### PR TITLE
Update pokerstars to fix urls

### DIFF
--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -3,31 +3,7 @@ cask 'pokerstars' do
   sha256 :no_check
 
   language 'US', default: true do
-    ['.com', '']
-  end
-
-  language 'AT' do
-    ['.eu', 'EU']
-  end
-
-  language 'DK' do
-    ['.dk', 'DK']
-  end
-
-  language 'GR' do
-    ['.gr', 'GR']
-  end
-
-  language 'IT' do
-    ['.it', 'IT']
-  end
-
-  language 'RO' do
-    ['.ro', 'RO']
-  end
-
-  language 'UK' do
-    ['.uk', 'UK']
+    ['.net', '.net']
   end
 
   language 'PT' do

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -3,14 +3,30 @@ cask 'pokerstars' do
   sha256 :no_check
 
   language 'US', default: true do
-    ['.net', '.net']
+    ['.net', '.net', '.net']
+  end
+
+  language 'DK' do
+    ['.dk', '.net', '.net']
+  end
+
+  language 'GR' do
+    ['.gr', '.net', '.net']
+  end
+
+  language 'IT' do
+    ['.it', '.net', '.net']
+  end
+
+  language 'UK' do
+    ['.uk', '.net', '.net']
   end
 
   language 'PT' do
-    ['.pt', 'PT']
+    ['.pt', 'PT', '.pt']
   end
 
-  url "http://www.pokerstars#{language[0]}/PokerStars#{language[1]}.app.zip"
+  url "http://www.pokerstars#{language[2]}/PokerStars#{language[1]}.app.zip"
   name 'PokerStars'
   homepage "http://www.pokerstars#{language[0]}"
 


### PR DESCRIPTION
- Website changed from www.pokerstars.com to www.pokerstars.net.
- The following regions now use the same default .net download url instead of their own: AT, DK, GR, IT, RO, UK.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
