### PR TITLE
Update handshaker to 2.5.3

### DIFF
--- a/Casks/handshaker.rb
+++ b/Casks/handshaker.rb
@@ -1,11 +1,11 @@
 cask 'handshaker' do
-  version '2.1.1'
-  sha256 '35f77d7991b30f8bbd062ea23644c1a45e61058722ee43f2885c2eaa2cae7022'
+  version '2.5.3'
+  sha256 '753bafec261c1e9a4e63160f06970e79afac0fd56e3a71bf5665ac6b054c79cd'
 
   # dl2.smartisan.cn was verified as official when first introduced to the cask
   url "http://dl2.smartisan.cn/app/HandShaker.v#{version}.dmg"
   appcast 'https://sf.smartisan.com/update.plist',
-          checkpoint: '6acfae4d43e92c8314b76a685d37452ea7477230de6405f54c331eec15274c00'
+          checkpoint: '47a208f3481f017df96bc28d0b9e9c6a4617054a1aeb81f8086b9590b8a17c8c'
   name 'HandShaker'
   homepage 'http://www.smartisan.com/apps/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.