### PR TITLE
Upgrade Dropbox.app to v41.4.80

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,8 +1,9 @@
 cask 'dropbox' do
-  version :latest
-  sha256 :no_check
+  version '41.4.80'
+  sha256 'bb69e170803c85e7fb2b9fdfcc99a2d1f3d2ce5cef605225dc79855e5409cb3a'
 
-  url 'https://www.dropbox.com/download?plat=mac&full=1'
+  # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
+  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox%20#{version}.dmg"
   name 'Dropbox'
   homepage 'https://www.dropbox.com/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.