### PR TITLE
Update noteplan to 1.6.22

### DIFF
--- a/Casks/noteplan.rb
+++ b/Casks/noteplan.rb
@@ -1,11 +1,11 @@
 cask 'noteplan' do
-  version '1.6.18'
-  sha256 '0427cc19a1e4c0705d1f0c8dc8fea720f474100c5f951ef4eaf79075a1582b9d'
+  version '1.6.22'
+  sha256 '3ff81f6baa6bf05cd855f44f5e4a02c920abebbd2ef34a10e31a8e2bb7f1f357'
 
   # rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380/?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380',
-          checkpoint: '5ccfecc72b7c1f398c209db3ab4c124b223e04bc4ca262c237a241507adb79c4'
+          checkpoint: '0caae80a6559a75db979b162062871823576e38c83b5e8e555ada878e512f724'
   name 'NotePlan'
   homepage 'http://noteplan.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.