### PR TITLE
Update cloudlibrary to 2.3.1708230907

### DIFF
--- a/Casks/cloudlibrary.rb
+++ b/Casks/cloudlibrary.rb
@@ -7,12 +7,12 @@ cask 'cloudlibrary' do
 
     app '3MCloudLibrary.app'
   else
-    version '2.2.1706151134'
-    sha256 'd84ab4416933f33eb46617d11dde2a8efd0db04a0b0131d2e9cd677e00926bba'
+    version '2.3.1708230907'
+    sha256 'f8424b1bcf209d01c80da1b1452dd140c8d7306572c76726fcc6c0244a5f5bc1'
 
     url "http://download.yourcloudlibrary.com/apps/mac/cloudLibrary-#{version}.pkg"
-    appcast 'http://www.yourcloudlibrary.com/index.php/en-us/downloads/software?format=rss',
-            checkpoint: '6b8ef699b4bfa6d53abd56031b04f09a121c547b6e892a7ac5cb18c98877792a'
+    appcast 'https://www.yourcloudlibrary.com/index.php/en-us/downloads/software?format=rss',
+            checkpoint: '49cccbcaa582ec8b81f29869bcc0e4d4ab8147cd5e82c70dbd15f9a69ace2856'
 
     pkg "cloudLibrary-#{version}.pkg"
 
@@ -20,5 +20,5 @@ cask 'cloudlibrary' do
   end
 
   name '3M Cloud Library'
-  homepage 'http://www.yourcloudlibrary.com/index.php/en-us/get-the-app/mac'
+  homepage 'https://www.yourcloudlibrary.com/mac/'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.