### PR TITLE
Update metasploit to 4.16.31+20180114130927

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.31+20180106131746'
-  sha256 'b2e60d75921df8f0f72f7700e5db0735153c0a43a63a1737021fcd51131523d6'
+  version '4.16.31+20180114130927'
+  sha256 '44f6cb3fb6064cf4cd4947cd5669f5d966112853dc1bc669cf40e1e045c7768c'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '7940bb51d24e8ce4c940aff34970acf25762139eb7cd86c858aadeb52d11aae6'
+          checkpoint: '769b19debe093d48a9b795b51bd188d40a0b48c728c8296e32b945aa853a590d'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.