### PR TITLE
Update android-platform-tools to 27.0.1

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -12,5 +12,6 @@ cask 'android-platform-tools' do
   binary "#{staged_path}/platform-tools/etc1tool"
   binary "#{staged_path}/platform-tools/fastboot"
   binary "#{staged_path}/platform-tools/hprof-conv"
+  binary "#{staged_path}/platform-tools/mke2fs"
   binary "#{staged_path}/platform-tools/sqlite3"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #42806.