### PR TITLE
Update deespeaker-vst to 1.0.5

### DIFF
--- a/Casks/deespeaker-vst.rb
+++ b/Casks/deespeaker-vst.rb
@@ -1,10 +1,12 @@
 cask 'deespeaker-vst' do
-  version :latest
-  sha256 :no_check
+  version '1.0.5'
+  sha256 'a90ee658d0f17032d8534734ff6150505d7d6391a3aacb982cd58051cbb4038e'
 
-  url 'https://dotec-audio.com/release/DeeSpeaker/latest/mac/DeeSpeakerMac.zip'
+  url "https://dotec-audio.com/release/DeeSpeaker/DeeSpeakerMacA_#{version}.zip"
   name 'DOTEC-AUDIO DeeSpeaker (VST)'
   homepage 'https://dotec-audio.com/deespeaker.html'
+
+  depends_on macos: '>= :lion'
 
   vst_plugin 'DeeSpeaker.vst'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.