### PR TITLE
Update blockblock to 0.9.9.1

### DIFF
--- a/Casks/blockblock.rb
+++ b/Casks/blockblock.rb
@@ -1,11 +1,11 @@
 cask 'blockblock' do
-  version '0.9.9'
-  sha256 '133ebdffd9847e17af048cdeb069ba5d1978595f6855d7fabf0cface0e562609'
+  version '0.9.9.1'
+  sha256 'f51f8cf4120a6714c710e1a9d06dd2f7ad19f198910f9092c7822413e6a953ff'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/BlockBlock_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/BlockBlock.txt',
-          checkpoint: '143a59e168fcbdb4c391bf55d371ee09ea689246c25c005a2d2ffb0b7a62da11'
+          checkpoint: 'f0abfa845ad922e4e5b645f65a52a90a75fb81fc1c27916fb24ba79b37aa1ea0'
   name 'BlockBlock'
   homepage 'https://objective-see.com/products/blockblock.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.