### PR TITLE
Update drawbot to 3.112

### DIFF
--- a/Casks/drawbot.rb
+++ b/Casks/drawbot.rb
@@ -1,11 +1,11 @@
 cask 'drawbot' do
-  version '3.97'
-  sha256 'cc3ae6468fdec93a5177ae938d9747fa71fa9eebae8ef5c345b57b0c1a6244a2'
+  version '3.112'
+  sha256 '5ceb7ac8ee5a94fca235c653becc71f4916a7bb1626985133dd91c0cb219e238'
 
   # typemytype.com/drawBot was verified as official when first introduced to the cask
   url 'http://static.typemytype.com/drawBot/DrawBot.dmg'
   appcast 'https://raw.githubusercontent.com/typemytype/drawbot/master/drawBot/drawBotSettings.py',
-          checkpoint: '64c0b2764844891141610cbf22251d6d91fb7869192e808d3ec6038eb1049e0e'
+          checkpoint: 'c79e3fb9b5c6705cc587d7288740d4971f6710bf82e733061dd7ce5ca9a54a42'
   name 'DrawBot'
   homepage 'http://www.drawbot.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.