### PR TITLE
Update netron to 1.3.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.4'
-  sha256 '9bb8dd34b19c52c69eae351d8f6553809289407c92483e605ca01a9e4e250555'
+  version '1.3.5'
+  sha256 '03633f6d21a3b5300daea8c43e45ee4a54fc7a259836853fd21fce92c817c850'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '41153f2afbbf25014e3dd61c125a381a3bc1737a5c87128087b40c40c9e3d324'
+          checkpoint: '8482496c090863985214bd2ef19fc695200f75e6e5e24a296e54fd4ffd37deae'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.