### PR TITLE
Update version of packetsender to 5.6.2

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,11 +1,11 @@
 cask 'packetsender' do
-  version '5.4.2,2017-09-01'
-  sha256 'b65428cda04eadcf956976fe30e9eb78e422c13602ff66f3134e7b6aa48fba7c'
+  version '5.6.2'
+  sha256 '9ad99a69466e741858a2a4276a16537b01f87c3e4accbb4316d5361b1ed43564'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
-  url "https://github.com/dannagle/PacketSender/releases/download/v#{version.before_comma}/PacketSender_v#{version.before_comma.dots_to_underscores}_#{version.after_comma}.dmg"
+  url "https://github.com/dannagle/PacketSender/releases/download/v#{version}/PacketSender_v#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom',
-          checkpoint: '272e1505776fff4d212eb4f3dd468fb595d3712973cd077e834f99f89baa4055'
+          checkpoint: '242c7a7b8d23e1e0fc76176852b91a491445e26b99aff872c0a0b0034566befe'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
