### PR TITLE
update graphql-playground 1.4.0

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.3.23'
-  sha256 'b7215849c8f5fb8e0fe4ccd5a6bb6fbe4ba31cd633927bfe3edb29a68d1b6b5b'
+  version '1.4.0'
+  sha256 '8b5b13d71577f161d5257db919299a4f4ec3e9efd31547c5ed5f73a30dcbb4f4'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: '5f8475933c34ada20803b316798c686de15a3a41583baf996781934df6a71b9a'
+          checkpoint: 'f00c2e8909f701cf9244e1167d6cca23bac5cf81ed9c2e31963a55587e23b369'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.