### PR TITLE
Update boostnote to 0.8.20

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.8.19'
-  sha256 '25fd1e37469e430075a0f06212b90bbd2a888c4b83382a434aaebe5de5352553'
+  version '0.8.20'
+  sha256 '8af83a061ed7246b72d2c2068495bf6272926e2d02cfecd724323f86e2f968f1'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '00226291f218a64789dfc281ac2c33ef459b6ad1fc3f1bbe1ae1a2a9389f6b2f'
+          checkpoint: 'd39a4058708011dc2943a7f8bc6d6828d0886453952338cd7df7c280f57ca016'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.