### PR TITLE
Update bisq to 0.6.3

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.6.2'
-  sha256 '4b774299d0fe8f2da5e3bd09b90bc1d72d21f203dadc80fdc3c5475e1f8cb3eb'
+  version '0.6.3'
+  sha256 '844912d358fb903e88c14c099c7b6c94d98c3535f22b0da343de6d1513895dae'
 
   # github.com/bisq-network/exchange was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/exchange/releases.atom',
-          checkpoint: 'bffb806705ece1331ee2fd351698f0b922daed3695178c5eaf60baa5e3e5bfb2'
+          checkpoint: '5aa3f8d4a5114250b3afdd66e4d4e9160c337c78c3a138d06afa7c4e8573d0ef'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.