### PR TITLE
Update metasploit to 4.16.31+20180116130540

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.31+20180106131746'
-  sha256 'b2e60d75921df8f0f72f7700e5db0735153c0a43a63a1737021fcd51131523d6'
+  version '4.16.31+20180116130540'
+  sha256 'dd75675b4fd99e63349dcd160fb8bdd2b234e45afcc70796c850d0c5d56e05ed'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '7940bb51d24e8ce4c940aff34970acf25762139eb7cd86c858aadeb52d11aae6'
+          checkpoint: 'afc0698c391433b32aa772597ed2d83844e40f8db347a8d2e6a2c8da174bcaf3'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.