### PR TITLE
Update toggl to 7.4.84

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,11 +1,11 @@
 cask 'toggl' do
-  version '7.4.71'
-  sha256 'bfab01fe4f09017828d0c69bd3e4f11efc96abb417e1a1a766b92a218452f44a'
+  version '7.4.84'
+  sha256 '22ef7b89f9ce04a24621f25e4d1f025c6391ec690ec773b74a244e5f8b425466'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml',
-          checkpoint: 'ff775387a8c7946cc1ea804d1373d44e7cdabb00a674a70ef32e563d370e7fb2'
+          checkpoint: 'f76871b13b18b13ae223a3ba5bc9463311e57d69977d895ffac0c4f223f687d8'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.