### PR TITLE
Update droplr to 5.0.0,206

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version '4.7.1,104'
-  sha256 '58ce39d1f786f8430040e0cfe166d62c311f7724cbe965fc9f44e3f2a2f13284'
+  version '5.0.0,206'
+  sha256 '4362d360173a1bec7501055883a3edbf4253eea790059087d9174774284d52f4'
 
   # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.