### PR TITLE
Update local-by-flywheel to 2.1.2

### DIFF
--- a/Casks/local-by-flywheel.rb
+++ b/Casks/local-by-flywheel.rb
@@ -1,6 +1,6 @@
 cask 'local-by-flywheel' do
-  version '2.0.8'
-  sha256 'ca0fc617dd1bf0f38d0274b54362c75f06d25411e3c7221aa198aab08cc7235d'
+  version '2.1.2'
+  sha256 '81b9251b600ff87edc5243ca63793ac0d424d001b53c78fed80cd836dd386842'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-by-flywheel-#{version.dots_to_hyphens}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.