### PR TITLE
Update cityofzion-neon to 0.1.0

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,10 +1,10 @@
 cask 'cityofzion-neon' do
-  version '0.0.9'
-  sha256 '5e76baeb7ae51a233270364a50886500b5ccfb5e5f6bd4c72eb0c49a344992c3'
+  version '0.1.0'
+  sha256 '4017bcc1a9972501c97fbe8e99825faf255c1eee7a10a84cf891d04685e6d96a'
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: '6b1d962ba9941f2063cba44e7dc6346efe2e9d641397038ff4e9c027a8675d99'
+          checkpoint: '6d853ecc6479460a85515bc3e8803ab873e6dd530c1b9bc8866888f809b4c978'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.