### PR TITLE
Update whatroute to 2.1.1

### DIFF
--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,10 +1,10 @@
 cask 'whatroute' do
-  version '2.1.0'
-  sha256 'd6ad1307eee75180d71868861f33a72c59674d528622032069f85fdb12792f29'
+  version '2.1.1'
+  sha256 'f9723fd293ab40be6cb89edac138252c7666987d655b0b95b72224ffb298b1a3'
 
   url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   appcast "https://www.whatroute.net/whatroute#{version.major}appcast.xml",
-          checkpoint: '81c8d6f6622081747b86a8998e24091cec3e4f3f20a05843605995ce56f97a12'
+          checkpoint: '309b8cf398dc462902975deabb5f745c4b3230e2f9a477a5a64e554f863cd9f0'
   name 'WhatRoute'
   homepage 'https://www.whatroute.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.