### PR TITLE
Update jamf-migrator to 2.6.2

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,10 +1,10 @@
 cask 'jamf-migrator' do
-  version '2.2.8'
-  sha256 '5825c6e7d6146a876bc911af0eaaa835c038cb74578ef394c782a9986c2399fe'
+  version '2.6.2'
+  sha256 '2c52e92493ce465490c749f1f29b1bdb48d20ea0fadf1f85800b5beeeb8ab2a1'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom',
-          checkpoint: 'f37156fc086e1864577aa11a93b1915566ca9cb46a44837e7151b2ea17b7ade5'
+          checkpoint: '30dd7a5e724c655d5655440f7bc35aa8f0a67b7e048b0050cc4b47b893c638a8'
   name 'JamfMigrator'
   homepage 'https://github.com/jamfprofessionalservices/JamfMigrator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.