### PR TITLE
Update fldigi to 4.0.14

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,10 +1,10 @@
 cask 'fldigi' do
-  version '4.0.13'
-  sha256 '3c73f1d09c9dac4c9c9285f02e4f3bc7d0a59f44c014b2ae5b3ec9a82af5328c'
+  version '4.0.14'
+  sha256 'c893bb8c28e8d3064b890e5d59f2e6dc48305ee67c99d314973d3437c04012f1'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}.64bit.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi',
-          checkpoint: '6f3dfb43aca05a45ba4eb31100260d294c82770db55e112b89c68ea9b2d6345a'
+          checkpoint: 'a7a4c03a665efa3abfb1bcd3afe57ec9f86e4f5e34a602317bfdac8061627bd5'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.