### PR TITLE
Update nucleo to 2.2.1

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,11 +1,11 @@
 cask 'nucleo' do
-  version '2.1.4'
-  sha256 'ad651aeb3203f590975884ceafbd8c985ec27b6096e89a481f0129176cd56701'
+  version '2.2.1'
+  sha256 '9510617ad020b25a967c14addae7b15da533a35f89e7573bfac68e59366c5e59'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"
   appcast 'https://nucleoapp.com/updates',
-          checkpoint: 'cc4fa5213a3131104cb2b71422c6ab434f7fe349f4ef2af526e25afc4354867f'
+          checkpoint: '44656517923ede804c1aa340c4f68fc72f35f9d983b47b552487e9c59566a5a6'
   name 'Nucleo'
   homepage 'https://nucleoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.