### PR TITLE
Update little-snitch to 4.0.5

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -1,10 +1,10 @@
 cask 'little-snitch' do
-  version '4.0.4'
-  sha256 '54d6261aa77754f8b86beb51ae442e8001c93bd0f3c520f2c736293089e3fbee'
+  version '4.0.5'
+  sha256 'a954a269596c9a8e9efb3efadf843a6ae419fe218145c5b8d877e2acb0692981'
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html',
-          checkpoint: '8e17472e6ded5ea372da822ecda88abef0dd018ecfcdfb4b33e622b355afdf64'
+          checkpoint: 'd05379db49626643c029d8fb0abd9a7d85fd4107e03717ff999781d33d71f1b5'
   name 'Little Snitch'
   homepage 'https://www.obdev.at/products/littlesnitch/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.