### PR TITLE
Update dropshare to 4.8,4693

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,11 +1,11 @@
 cask 'dropshare' do
-  version '4.7,4688'
-  sha256 '326063a600aeabfb94aa4df46445d89f2ca4e01570ae6fe7a791e4159fd7782f'
+  version '4.8,4693'
+  sha256 'df366b7c90e9d2fdc03c956fda11ca26c001ea660df96aaf3c687ba8fd608c1b'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml",
-          checkpoint: 'fd3514295d1980b0c8184e3d221f6a873ae18924d17931d160ed165c60d9407c'
+          checkpoint: '07f95e01339197f3d9ff6f22224d275dd8af2dcaf3fb1424f9016968d7f01a85'
   name 'Dropshare'
   homepage 'https://getdropsha.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.