### PR TITLE
Rename eldeveloper-macfusion to macfusion-ng

### DIFF
--- a/Casks/eldeveloper-macfusion.rb
+++ b/Casks/eldeveloper-macfusion.rb
@@ -3,8 +3,8 @@ cask 'eldeveloper-macfusion' do
   sha256 '3e6e356f36623dde805aa3de941e29f6256b02cfe0720bcbd70df4526e2a7198'
 
   url "https://github.com/ElDeveloper/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
-  appcast "https://github.com/ElDeveloper/macfusion#{version.major}/releases.atom",
-          checkpoint: '4f19fdf3855e04e508dec355554487deaba49414556e6f93bc947d054703808b'
+  appcast 'https://github.com/macfusion-ng/macfusion2/releases.atom',
+          checkpoint: '501d54473744c385e7a060ff5890907ada340ce0f95ca48c2dd45c58947d3b53'
   name 'Macfusion'
   homepage "https://github.com/ElDeveloper/macfusion#{version.major}/"
 

--- a/Casks/macfusion-ng.rb
+++ b/Casks/macfusion-ng.rb
@@ -1,8 +1,8 @@
-cask 'eldeveloper-macfusion' do
+cask 'macfusion-ng' do
   version '2.1.1-dev.3'
   sha256 '3e6e356f36623dde805aa3de941e29f6256b02cfe0720bcbd70df4526e2a7198'
 
-  url "https://github.com/ElDeveloper/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
+  url "https://github.com/macfusion-ng/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
   appcast 'https://github.com/macfusion-ng/macfusion2/releases.atom',
           checkpoint: '501d54473744c385e7a060ff5890907ada340ce0f95ca48c2dd45c58947d3b53'
   name 'Macfusion'

--- a/Casks/macfusion-ng.rb
+++ b/Casks/macfusion-ng.rb
@@ -3,7 +3,7 @@ cask 'macfusion-ng' do
   sha256 '3e6e356f36623dde805aa3de941e29f6256b02cfe0720bcbd70df4526e2a7198'
 
   url "https://github.com/macfusion-ng/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
-  appcast 'https://github.com/macfusion-ng/macfusion2/releases.atom',
+  appcast 'https://github.com/macfusion-ng/macfusion#{version.major}/releases.atom',
           checkpoint: '501d54473744c385e7a060ff5890907ada340ce0f95ca48c2dd45c58947d3b53'
   name 'Macfusion'
   homepage "https://github.com/ElDeveloper/macfusion#{version.major}/"

--- a/Casks/macfusion-ng.rb
+++ b/Casks/macfusion-ng.rb
@@ -3,7 +3,7 @@ cask 'macfusion-ng' do
   sha256 '3e6e356f36623dde805aa3de941e29f6256b02cfe0720bcbd70df4526e2a7198'
 
   url "https://github.com/macfusion-ng/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
-  appcast 'https://github.com/macfusion-ng/macfusion#{version.major}/releases.atom',
+  appcast "https://github.com/macfusion-ng/macfusion#{version.major}/releases.atom",
           checkpoint: '501d54473744c385e7a060ff5890907ada340ce0f95ca48c2dd45c58947d3b53'
   name 'Macfusion'
   homepage "https://github.com/macfusion-ng/macfusion#{version.major}/"

--- a/Casks/macfusion-ng.rb
+++ b/Casks/macfusion-ng.rb
@@ -6,7 +6,7 @@ cask 'macfusion-ng' do
   appcast 'https://github.com/macfusion-ng/macfusion#{version.major}/releases.atom',
           checkpoint: '501d54473744c385e7a060ff5890907ada340ce0f95ca48c2dd45c58947d3b53'
   name 'Macfusion'
-  homepage "https://github.com/ElDeveloper/macfusion#{version.major}/"
+  homepage "https://github.com/macfusion-ng/macfusion#{version.major}/"
 
   depends_on formula: 'sshfs'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.