### PR TITLE
Update quip to 5.2.12

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.2.06'
-  sha256 '80eb083ac5bfc5e9e84b22e3de3c0bf628420eb62190e2d150b95f170ccaa1dd'
+  version '5.2.12'
+  sha256 'bfad413211de36f23cd021c3a9ddbd82ccdeee0962198c3ef6a89acd7b32e41f'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.