### PR TITLE
Update thunder to 3.1.9.3378

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '3.1.8.3304'
-  sha256 '9f410e1703cf9e376cfed5362b8efe75a8b4d937889fbdee88719c079fb2359f'
+  version '3.1.9.3378'
+  sha256 '7869ef18c5b30ace6aeac0da4b5f0ab19eaca3ae64096e1d6434b84dbbdbb823'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.