### PR TITLE
Update mplayer-osx-extended to rev16-test3

### DIFF
--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -1,11 +1,11 @@
 cask 'mplayer-osx-extended' do
-  version 'rev15'
-  sha256 '7979f2369730d389ceb4ec3082c65ffa3ec70f812f0699a2ef8acbae958a5c93'
+  version 'rev16-test3'
+  sha256 'eda6f5e7d508d54755c3b600ac4083d797314d81f78f24a8fd5decc25c60ac3d'
 
   # github.com/sttz/MPlayer-OSX-Extended was verified as official when first introduced to the cask
   url "https://github.com/sttz/MPlayer-OSX-Extended/releases/download/#{version}/MPlayer-OSX-Extended_#{version}.zip"
   appcast 'https://github.com/sttz/MPlayer-OSX-Extended/releases.atom',
-          checkpoint: '0a27d2b111abfe68462e7ef0cb71e9efe1ea34921b8a7a2dc208713208242dba'
+          checkpoint: '5df7951d912b70a47dbb4533726f85679fe372895b61d1e11da267334193294d'
   name 'MPlayer OSX Extended'
   homepage 'https://mplayerosx.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.