### PR TITLE
Update TouchSwitcher download URL

### DIFF
--- a/Casks/touchswitcher.rb
+++ b/Casks/touchswitcher.rb
@@ -2,7 +2,7 @@ cask 'touchswitcher' do
   version :latest
   sha256 :no_check
 
-  url 'https://hazeover.com/touchswitcher/TouchSwitcher.zip'
+  url 'https://hazeover.com/touchswitcher/TouchSwitcher.tar.bz2'
   name 'TouchSwitcher'
   homepage 'https://hazeover.com/touchswitcher.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- ~~The commit message includes the cask’s name and version.~~

**Note:** Somewhere along the way, the URL to the installer changed from a `*.zip` to a `*.tar.bz` file. This PR resolves the error caused by that change.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
