### PR TITLE
Update station to 1.0.14

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.0.13'
-  sha256 '387f672c10947460f8abc9c517e56a7655e31400156fa6c4e4a985e8c91c6710'
+  version '1.0.14'
+  sha256 '8125d5341f64637f1f1c975f11a3e97ccba8e24e1e0e80bebe78fce27b36ec26'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '88ae2da611a1308b0e39e19971ceb4b659ae8e64bf05057f3885dd5d07356823'
+          checkpoint: '85fcfd9f8e586d85cbe00c2e6d5222c7dc9dde516661c5490988173adaf1098a'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.