### PR TITLE
Update noti to 0.3.1

### DIFF
--- a/Casks/noti.rb
+++ b/Casks/noti.rb
@@ -1,11 +1,11 @@
 cask 'noti' do
-  version '0.3'
-  sha256 '3063d4889cd41c4c0411f1e27fbd80497a3c9e40bc437e6c436c918493a4385a'
+  version '0.3.1'
+  sha256 '7ce31dfc0a177bc21591d18b7f3b96f72f7105c132641e7d3a296ec02eaf23db'
 
   # github.com/jariz/Noti was verified as official when first introduced to the cask
   url "https://github.com/jariz/Noti/releases/download/#{version}/Noti.dmg"
   appcast 'https://github.com/jariz/Noti/releases.atom',
-          checkpoint: '085086d6b394f4a495ecfce21c0b9691a81939364409d9a163096a953a471bb3'
+          checkpoint: '6914874cca39d8d5a1957a7481b562d5599d9688171d54aa373a9765a2c17732'
   name 'Noti'
   homepage 'https://noti.center/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.