### PR TITLE
Update Screaming Frog SEO Spider to 8.3

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -3,13 +3,13 @@ cask 'screaming-frog-seo-spider' do
     version '2.40'
     sha256 'f37a517cb1ddb13a0621ae2ef98eba148027b3a2b5ce56b6e6b4ca756e40329b'
   else
-    version '7.2'
-    sha256 'd3654be1c66e4c8fb4a5530a35eff62582a5272a2064243679795cc7d2f1d3ad'
+    version '8.3'
+    sha256 'd5b0123c57f6294cd1aed83a9a4efd48549177de700b5832d1730a6970838e4c'
   end
 
-  url "https://www.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
+  url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php',
-          checkpoint: '4741066c7036d2499b440c4528a3b2d1416c296e620bbb08fa3a942d628dc7ab'
+          checkpoint: '25054900a5f73770ce702561681f366552b070932c63a1ae582459650c9a82ff'
   name 'Screaming Frog SEO Spider'
   homepage 'https://www.screamingfrog.co.uk/seo-spider/'
 


### PR DESCRIPTION
Update screaming-frog-seo-spider version from 7.2 to 8.3.
Update download url for dmg.
Update appcast url checkpoint.
Verified ScreamingFrogSEOSpider-8.3.dmg sha256 on virustotal.com:
https://www.virustotal.com/#/file/d5b0123c57f6294cd1aed83a9a4efd48549177de700b5832d1730a6970838e4c/details

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
