### PR TITLE
Update typinator to 7.4

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,11 +1,11 @@
 cask 'typinator' do
-  version '7.3'
-  sha256 '654de96328eb766b3879ebed83b2f6479b19614f3978958f054fd1fb227f802d'
+  version '7.4'
+  sha256 '1309f6758aea7d52c760cd7fcf0101795be295600c02870de533f7c0d61660d4'
 
   url "http://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake
   appcast 'http://www.ergonis.com/products/typinator/history.html',
-          checkpoint: '3af9687b6004c0ba8a71f3b1a227ad70544428189abdccdd44d260b153f1e707'
+          checkpoint: '9ee68c5c8d1e1ac1bd386e67c878caf615bf9a33376e535867efa46056eb8f45'
   name 'Typinator'
   homepage 'http://www.ergonis.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.