### PR TITLE
Update gprojector to 2.1.3

### DIFF
--- a/Casks/gprojector.rb
+++ b/Casks/gprojector.rb
@@ -1,6 +1,6 @@
 cask 'gprojector' do
-  version '2.1.0'
-  sha256 '1b12adefa6d9f7eb10e713fa95b63d1bea7b01026574d0fe1e0e442e82c4ff5f'
+  version '2.1.3'
+  sha256 '7ca67ed3c75b1f05ef2fc4857da7f475c0d383666daf3445423676b5e070a243'
 
   url "https://www.giss.nasa.gov/tools/gprojector/download/G.ProjectorMacOS-#{version}.dmg"
   name 'G.Projector'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.