### PR TITLE
Update gpxsee to 4.19

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,11 +1,11 @@
 cask 'gpxsee' do
-  version '4.16'
-  sha256 '62e6955e7a7189edaab8e23bb98e590aa7331f2eb72aa08873e2861840e478eb'
+  version '4.19'
+  sha256 '73079c39947a4c386bd5259482538679dfb8acdb3c1affdfb2b68e078fd6c72f'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/gpxsee/rss?path=/Mac%20OS%20X',
-          checkpoint: '74d489cb204aaa1a501ee4ac8884ce97c7c703c4a9874ffc7ced481b4eec4909'
+          checkpoint: '603494ac861bab6bbf950ba1333c0d33156ca5f64e421e14e76dbbacf699af12'
   name 'GPXSee'
   homepage 'http://www.gpxsee.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.