### PR TITLE
Update gurps-character-sheet to 4.10.0

### DIFF
--- a/Casks/gurps-character-sheet.rb
+++ b/Casks/gurps-character-sheet.rb
@@ -2,9 +2,10 @@ cask 'gurps-character-sheet' do
   version '4.10.0'
   sha256 'eaf10a4eb4577d876c64702bb3b70335e46b92860251cf83833a1cf244c51bc1'
 
-  url "http://gurpscharactersheet.com/downloads/#{version}/gcs-#{version}-mac.zip"
+  # github.com/richardwilkes/gcs/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/richardwilkes/gcs/releases/download/gcs-#{version}/gcs-#{version}-mac.zip"
   appcast 'https://github.com/richardwilkes/gcs/releases.atom',
-          checkpoint: '94cf2a5172fd549caabd889f8e75f98064a92281f2d3cd1d658e4a47ff2320ee'
+          checkpoint: '0ecd208e6c435d965fb3fecd035d23b141b6cd323e2fef786e7925dafdda5e47'
   name 'GURPS Character Sheet'
   homepage 'http://gurpscharactersheet.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.