### PR TITLE
Update exfalso to 4.0.2

### DIFF
--- a/Casks/exfalso.rb
+++ b/Casks/exfalso.rb
@@ -1,11 +1,11 @@
 cask 'exfalso' do
-  version '3.9.1'
-  sha256 'b438f771a6063788bad4c359bb89b09dfce0dbd698caa485caddf6ed50a94a07'
+  version '4.0.2'
+  sha256 'aea8192a089affc58f955400029a936b579bc1ee06bddc5b6f839cfb696ce9e9'
 
   # github.com/quodlibet/quodlibet was verified as official when first introduced to the cask
   url "https://github.com/quodlibet/quodlibet/releases/download/release-#{version}/ExFalso-#{version}.dmg"
   appcast 'https://github.com/quodlibet/quodlibet/releases.atom',
-          checkpoint: '9efb0435388c948603147c16f6b1f4f3e8ee9ca92f73e3dd4549e5fe5b9edf26'
+          checkpoint: 'dc693ef4c5916de3d359d5503dbb41daecd2c1c586931b5cfde48c80da3dd7bd'
   name 'Ex Falso'
   homepage 'https://quodlibet.readthedocs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.