### PR TITLE
Update iridium to 2017.11-1

### DIFF
--- a/Casks/iridium.rb
+++ b/Casks/iridium.rb
@@ -1,12 +1,14 @@
 cask 'iridium' do
-  version '61.0.0'
-  sha256 '1fcd109ceda9674e0627f48f97bbb54a4abd8918cdcb8435e0ea1913a8dba038'
+  version '2017.11-1'
+  sha256 'c60de6ccd8de35b3cf2f75b0f00274c50ced0eeb2a5eb0525b1905fb1039b61c'
 
-  url "https://downloads.iridiumbrowser.de/macosx/#{version}/iridium_browser_#{version}_osx_x64.dmg"
-  appcast 'https://downloads.iridiumbrowser.de/macosx/',
-          checkpoint: '79e5b67739fa063b09bc512e0621114a7544ee46e76bc49875fcd94f049823a1'
+  url "https://downloads.iridiumbrowser.de/macos/#{version}/iridium_browser_#{version}_macos_x64.dmg"
+  appcast 'https://downloads.iridiumbrowser.de/macos/',
+          checkpoint: '8030b33d6c451429d6098e802548c1f47dc8fbe12851ba1b55cb54502b434cbf'
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'Iridium.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.