### PR TITLE
Update hab to 0.52.0-20180119184453

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.51.0-20171218220542'
-  sha256 'aece1e1e503b039a3180052763698157f3e981c0a8da9a867415ff83d6c630ae'
+  version '0.52.0-20180119184453'
+  sha256 '60849d39be265c05814d7be93798f9355f49cb4401d499405fdde83f1161c4e4'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '81deb90de6c8ce04568fbc1937aedaa1456c3b8ec2f121a57b5e490beb6752e3'
+          checkpoint: '415881ea7c8292f968172a486fab8b9e5036ecbda60a7e6435db37b5d25e03e2'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.