### PR TITLE
Update find-any-file to 1.9.2

### DIFF
--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -1,11 +1,11 @@
 cask 'find-any-file' do
-  version '1.9'
-  sha256 'd01964c2a61df8c80ae925559025b21d95cd2436f528f14266c09ecd3382ed74'
+  version '1.9.2'
+  sha256 '2d56ee022617f1bf6f901f9437fae50d0e80aaaddd4493fc7eeda19461a3e242'
 
   # files.tempel.org.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.tempel.org.s3.amazonaws.com/FindAnyFile_#{version}.zip"
   appcast 'http://apps.tempel.org/FindAnyFile/appcast.xml',
-          checkpoint: '2b434e83f0c478ddd58e4b8864f5f5b3df276e6e892f4f6532c787f689073ff9'
+          checkpoint: 'fbc3c15a6e4a35a8fb73da18e696a0e1b7f8779f05c8c8e9b5981df170f95fc4'
   name 'Find Any File'
   homepage 'http://apps.tempel.org/FindAnyFile/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.