### PR TITLE
Upgrade Tiled.app to v1.1.1

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,11 +1,11 @@
 cask 'tiled' do
-  version '1.0.3'
-  sha256 '4086f611debbf793e986be7defc55b481f35d52c7607bb4f3e48efd8732ed9d4'
+  version '1.1.1'
+  sha256 'cf4104d342f57e89c9763560f620dbdde9cf8194fb0d7908aecf43d93a7b69ec'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
-  url "https://github.com/bjorn/tiled/releases/download/v#{version}/tiled-#{version}.dmg"
+  url "https://github.com/bjorn/tiled/releases/download/v#{version}/Tiled-#{version}-macos.zip"
   appcast 'https://github.com/bjorn/tiled/releases.atom',
-          checkpoint: '4762e77bcd9e2f41c9ad72635ace6dfb7d83dd295bf28c6bb33014c150714387'
+          checkpoint: '917a431f8fe507c9af98bc89fd844ab535a191891ab3c11dcfee15db6ba409ad'
   name 'Tiled'
   homepage 'http://www.mapeditor.org/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
