### PR TITLE
Update brave to 0.19.139

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -5,7 +5,7 @@ cask 'brave' do
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'cdd67a18e4ec9c167cca40ba3477a10ce1cf0b89c1b0887c0274ade2b8183346'
+          checkpoint: '10e9482d50631b343ce7f8adeb1f235bdfbd1604a983d75e7cf8cd3c08a4fecc'
   name 'Brave'
   homepage 'https://brave.com/'
 

--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.19.134'
-  sha256 '57d71d0220af6a8da3c75de92a255421aea0873a79d369ac147377cf5148be2f'
+  version '0.19.139'
+  sha256 '82b6eb258aa4bd3a34bdda7c3094b2d137f5cf1cbfdb6a43aa98f17f0270d82b'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '43432aa7719bbddd9ef10a8b366c23c2e1d2eebd4f49033ff9ef495bbb78c643'
+          checkpoint: 'cdd67a18e4ec9c167cca40ba3477a10ce1cf0b89c1b0887c0274ade2b8183346'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.