### PR TITLE
Update onionshare to 1.2

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,11 +1,11 @@
 cask 'onionshare' do
-  version '1.1'
-  sha256 'a9a377590a09c98e821b15c20f9ddd34a13c83b4d8a85e966a0ec4adc31bca52'
+  version '1.2'
+  sha256 '1a9b0d5019a2b664535b4219b87caaaf676b0430b9816e86df2993bdaf9fb8ff'
 
   # github.com/micahflee/onionshare was verified as official when first introduced to the cask
   url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom',
-          checkpoint: '278463a88f6461ee37dcd0c66304a1212adf7243da9bbcaf38cda972cca82eb9'
+          checkpoint: '97ede8041dcfcf92e58aec8f4cca01ed036dcd191790bde56efaf333ca7b16f5'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
   gpg "#{url}.sig", key_url: 'https://onionshare.org/signing-key.asc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.