### PR TITLE
Update shiftit to 1.6.4

### DIFF
--- a/Casks/shiftit.rb
+++ b/Casks/shiftit.rb
@@ -1,10 +1,10 @@
 cask 'shiftit' do
-  version '1.6.3'
-  sha256 '3b01d74cc39e4efad64b2c9b135bea528730cb750c55a386bf74e1203b92ca68'
+  version '1.6.4'
+  sha256 '20db9e67f70b77bf1be325b0fb6705ac469c79595348da83e5ae180fe3193773'
 
   url "https://github.com/fikovnik/ShiftIt/releases/download/version-#{version}/ShiftIt-#{version}.zip"
   appcast 'https://github.com/fikovnik/ShiftIt/releases.atom',
-          checkpoint: 'ce84bfdc0d373f8fc0eb8a97f23934ca2cf7e7d075bc5b4ff07bc2d68d7ad947'
+          checkpoint: '643bc93d3db52d965d0cc9022f12b8194db46b99eb04530b618f3620a4ab9107'
   name 'ShiftIt'
   homepage 'https://github.com/fikovnik/ShiftIt/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.