### PR TITLE
Update wechatwebdevtools to 1.02.1801081

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.01.1712150'
-  sha256 '780d676e9197b18c669bf1c807130559e92892064c84512c815e73ff8f04ec4a'
+  version '1.02.1801081'
+  sha256 'c7e359f480a770bef33931a45c4c964c075e6fcef3e8aa70f358490524da3b56'
 
   url "https://dldir1.qq.com/WechatWebDev/1.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.