### PR TITLE
Add docker-machine-driver-hyperkit v0.24.1

### DIFF
--- a/Casks/docker-machine-driver-hyperkit.rb
+++ b/Casks/docker-machine-driver-hyperkit.rb
@@ -1,0 +1,32 @@
+cask 'docker-machine-driver-hyperkit' do
+  version '0.24.1'
+  sha256 '2c355e637c7acfd1b87bf575833902cf124332b0637d640abf474f93423c9c3f'
+
+  url "https://storage.googleapis.com/minikube/releases/v#{version}/docker-machine-driver-hyperkit"
+  appcast 'https://github.com/kubernetes/minikube/releases.atom',
+          checkpoint: '955ebaedbcc424fd4d8089f875c39184a3a2caf56a25d7ecf3baa3eedf29689e'
+  name 'Docker Machine driver for HyperKit'
+  homepage 'https://github.com/kubernetes/minikube'
+
+  depends_on cask: 'minikube'
+  container type: :naked
+
+  binary 'docker-machine-driver-hyperkit'
+
+  postflight do
+    set_ownership "#{staged_path}/docker-machine-driver-hyperkit", user: 'root', group: 'wheel'
+    set_permissions "#{staged_path}/docker-machine-driver-hyperkit", '0755'
+  end
+
+  zap trash: '~./docker-machine-driver-hyperkit'
+
+  caveats <<~EOS
+    The hyperkit driver must be installed with setuid permission to work.
+    
+    To set the right permissions, execute:
+      sudo chmod 4755 #{staged_path}/docker-machine-driver-hyperkit
+
+    For more information, see:
+      https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver
+  EOS
+end


### PR DESCRIPTION
Adds the HyperKit Docker Machine driver, from the Minikube project. It
requires running as root, so sets root ownership during install and has
a caveat that it must be given setuid permission, as per the offical
installation instructions.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
