### PR TITLE
Update powershell.rb 6.0.0  with new Shasum

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -4,7 +4,7 @@ cask 'powershell' do
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx.10.12-x64.pkg"
   appcast 'https://github.com/PowerShell/PowerShell/releases.atom',
-          checkpoint: '74c4d1ba68958df7630327c3ea0c3b9c40181fd748b82738b54941a6863e3859'
+          checkpoint: '55056d894283db7a07b0aa5b90011dc85b6f90cef094bdc53b0c273336faf737'
   name 'PowerShell'
   homepage 'https://github.com/PowerShell/PowerShell'
 

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -1,10 +1,10 @@
 cask 'powershell' do
   version '6.0.0'
-  sha256 '396bbb5907fd0ec0bdfbfe0bf01961b52b4f1f1ceddc95467dd9ecd4fa5281df'
+  sha256 '74c4d1ba68958df7630327c3ea0c3b9c40181fd748b82738b54941a6863e3859'
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx.10.12-x64.pkg"
   appcast 'https://github.com/PowerShell/PowerShell/releases.atom',
-          checkpoint: '339de99aebfd66bc07b2bb82fed802c3a37af3af480d47c2b5d1162f43350fba'
+          checkpoint: '74c4d1ba68958df7630327c3ea0c3b9c40181fd748b82738b54941a6863e3859'
   name 'PowerShell'
   homepage 'https://github.com/PowerShell/PowerShell'
 


### PR DESCRIPTION
According to the Powershell release notes [here](https://github.com/PowerShell/PowerShell/releases/tag/v6.0.0), they re-relased the OSX binary as it wasn't properly signed, and now has a different checksum.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
