### PR TITLE
Add zap and appcast for monero-wallet

### DIFF
--- a/Casks/monero-wallet.rb
+++ b/Casks/monero-wallet.rb
@@ -9,4 +9,11 @@ cask 'monero-wallet' do
   homepage 'https://getmonero.org/'
 
   app 'monero-wallet-gui.app'
+
+  zap trash: [
+               '~/.bitmonero',
+               '~/Monero',
+               '~/Library/Preferences/org.getmonero.monero-core.plist',
+               '~/Library/Saved Application State/com.yourcompany.monero-wallet-gui.savedState',
+             ]
 end

--- a/Casks/monero-wallet.rb
+++ b/Casks/monero-wallet.rb
@@ -3,6 +3,8 @@ cask 'monero-wallet' do
   sha256 '4f63ac3e9c5f87f8d8318ff89cdbfa954716e8addbdc8fcd0352fe678b84f8e2'
 
   url "https://downloads.getmonero.org/gui/monero-gui-mac-x64-v#{version}.tar.bz2"
+  appcast 'https://github.com/monero-project/monero-gui/releases.atom',
+          checkpoint: '8103e0f7aff022cf6d8ae8aff8c82dc2174f1a766a2b02de5c382e56a8564588'
   name 'Monero Wallet'
   homepage 'https://getmonero.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

<!--
Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

-->

---

I'd like to mention that ideally I'd like to use the app target to rename the application to something more sensible like "Monero Wallet.app", however this would break backwards compatibility for people who have already installed this cask. Is there any way to deal with this? Do you agree that a renaming would be a good idea?
