### PR TITLE
Update bettertouchtool to 2.332

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -18,13 +18,13 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.320'
-    sha256 '4510d896d01626a6283d360ad1aaa606e3caaf48f8a3cb40673b5e76db56ec09'
+    version '2.332'
+    sha256 'cdb4fd0c8d232cb0b1750a58a7bb32f899a9f9c681f8e3d865ecb72c0a1f6a05'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"
     appcast 'https://updates.bettertouchtool.net/appcast.xml',
-            checkpoint: 'eda00f89e778b40380b3d9b332bdaf7a5f57669f37f21f3345dd29d814ec51e2'
+            checkpoint: '41c982b4b87381e0af4076285f41e1550e2c82b0090a69a49457426021b6066f'
   end
 
   name 'BetterTouchTool'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.