### PR TITLE
Changed battle-net app name to match downloaded package

### DIFF
--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -13,7 +13,9 @@ cask 'battle-net' do
   name 'Blizzard Battle.net'
   homepage 'https://www.battle.net/'
 
-  app 'Battle.net-Setup.app'
+  installer manual: 'Battle.net-Setup.app'
+
+  uninstall delete: '/Applications/Battle.net.app'
 
   zap trash: [
                '~/Library/Application Support/Battle.net',
@@ -29,4 +31,8 @@ cask 'battle-net' do
                '/Users/Shared/Blizzard',
              ],
       rmdir: '~/Blizzard'
+
+  caveats <<~EOS
+    If you pick an installation directory other than /Applications when installing this cask, you will need to uninstall it manually
+  EOS
 end

--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -13,7 +13,7 @@ cask 'battle-net' do
   name 'Blizzard Battle.net'
   homepage 'https://www.battle.net/'
 
-  app 'Battle.net.app'
+  app 'Battle.net-Setup.app'
 
   zap trash: [
                '~/Library/Application Support/Battle.net',


### PR DESCRIPTION
Problem:

```
▶ brew cask install battle-net
==> Satisfying dependencies
==> Downloading https://www.battle.net/download/getInstallerForGame?os=mac&locale=enUS&version=LIVE&gameProgram=BATTLENET_APP
==> No checksum defined for Cask battle-net, skipping verification
==> Installing Cask battle-net
==> Purging files for version latest of Cask battle-net
Error: It seems the App source '/usr/local/Caskroom/battle-net/latest/Battle.net.app' is not there.
```

Following [the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/reporting_bugs/source_is_not_there_fix.md), the unpacked app is now named "Battle.net-Setup.App".

```
▶ brew cask fetch battle-net
▶ mv /path/to/battle-net--latest .
▶ tar -xzvf battle-net--latest
▶ ls
Battle.net-Setup.app battle-net--latest
```