### PR TITLE
Update flash-decompiler-trillix to 5.3.1301

### DIFF
--- a/Casks/flash-decompiler-trillix.rb
+++ b/Casks/flash-decompiler-trillix.rb
@@ -3,8 +3,8 @@ cask 'flash-decompiler-trillix' do
   sha256 '5b1313197c1e311db7aefc1764785187a5f5fd39ea5aa689587761ff42232d9e'
 
   url 'http://www.flash-decompiler.com/download/flash_decompiler.dmg'
-  appcast 'https://www.eltima.com/download/fd-mac-update/fd-mac.xml',
-          checkpoint: '4d828404e0e754bce1c5fc7fcfe9d9011c45bd9327ffb4dcf03dfdff1eabf0d0'
+  appcast 'https://cdn.eltima.com/download/fd-mac-update/fd-mac.xml',
+          checkpoint: '19ab6533a9bd666360a1810c9237f8336d4fffaf7e15aadf82d396df362fd8a7'
   name 'Flash Decompiler Trillix'
   homepage 'http://www.flash-decompiler.com/mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.