### PR TITLE
Update ukelele to 3.2.7

### DIFF
--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -1,6 +1,6 @@
 cask 'ukelele' do
-  version '3.2.5'
-  sha256 '07978444b295950b08c0533c403e79c63c67d18ebcd11563d1ee213e57f77ef9'
+  version '3.2.7'
+  sha256 '5fd6a3123e1e1967098fffa216a6becf34dbc3df4bdfc9767bd889f28dd7443d'
 
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_#{version}&filename=Ukelele_#{version}.dmg"
   name 'Ukelele'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.