### PR TITLE
Update netron to 1.3.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.5'
-  sha256 '03633f6d21a3b5300daea8c43e45ee4a54fc7a259836853fd21fce92c817c850'
+  version '1.3.6'
+  sha256 'a94e30f4efa2c99e83c3acd0d36bb47a17f80b8624762842fe05f905dc5d3b0a'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '8482496c090863985214bd2ef19fc695200f75e6e5e24a296e54fd4ffd37deae'
+          checkpoint: '85ccba814a664fff405c7cf65291d47b810b897fb52f1867bcccf80c12868d4f'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.