### PR TITLE
Update blockblock to 0.9.9.1

### DIFF
--- a/Casks/blockblock.rb
+++ b/Casks/blockblock.rb
@@ -1,24 +1,24 @@
 cask 'blockblock' do
   version '0.9.9.1'
-  sha256 'f51f8cf4120a6714c710e1a9d06dd2f7ad19f198910f9092c7822413e6a953ff'
+  sha256 'e3c3043a6628e6fc455edc39068d59e91d11186a30a08cd3e505a5d65c26e964'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/BlockBlock_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/BlockBlock.txt',
-          checkpoint: 'f0abfa845ad922e4e5b645f65a52a90a75fb81fc1c27916fb24ba79b37aa1ea0'
+          checkpoint: 'c6b1c0717efd633e59199878fdb509e811ac7ae47bc7ed79d23e8f40042ccc63'
   name 'BlockBlock'
   homepage 'https://objective-see.com/products/blockblock.html'
 
   depends_on macos: '>= :mavericks'
 
   installer script: {
-                      executable: "#{staged_path}/BlockBlock.app/Contents/MacOS/BlockBlock",
+                      executable: "#{staged_path}/BlockBlock_Installer.app/Contents/MacOS/BlockBlock",
                       args:       ['-install'],
                       sudo:       true,
                     }
 
   uninstall script: {
-                      executable: "#{staged_path}/BlockBlock.app/Contents/MacOS/BlockBlock",
+                      executable: "#{staged_path}/BlockBlock_Installer.app/Contents/MacOS/BlockBlock",
                       args:       ['-uninstall'],
                       sudo:       true,
                     }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.