### PR TITLE
Update mactracker to 7.7.1

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -1,10 +1,10 @@
 cask 'mactracker' do
-  version '7.7'
-  sha256 '10e21078fea80f3d127beb322de2d84e4b32830bb7e584f78593617b0bb88438'
+  version '7.7.1'
+  sha256 '5f8c945d25c8511c66ce0c3fda595ac9d9534b3edff11c2be47a0f9bb99f0cb3'
 
   url "https://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
   appcast 'https://update.mactracker.ca/appcast-b.xml',
-          checkpoint: '1c5df6b4fae6b88cd7c0c1647fe4f36b57a81acaba7783edb774c8dce9a8dbb9'
+          checkpoint: '3c11dca8a1dbdc9f562d4ca3cb5c433de9edf61ee4acfa7b5889f05834f52029'
   name 'Mactracker'
   homepage 'https://mactracker.ca/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.