### PR TITLE
Update google-earth-pro to 7.3.1.4505

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask 'google-earth-pro' do
-  version '7.3.0.3832'
-  sha256 'a55a7f97ea498cb0e5704681b0e4f33af73c97d5813a239bbece57f1f5bb23aa'
+  version '7.3.1.4505'
+  sha256 '7b29eddc19bc2df91a279db4642eabb9a92055f1bcfe90ace733a8c02a64fcec'
 
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg'
   name 'Google Earth Pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.