### PR TITLE
Update capture-one to 11.0.1

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '11.0.0'
-  sha256 'f8ae1f05aadbe446344862f7b2494a8da7994f371dd81bdc6b82d114e0b3e2bc'
+  version '11.0.1'
+  sha256 'f87c9b1e0a72901464732fca68f06e46c1fe21878d31a99a671b42b7904573e8'
 
   url "http://downloads.phaseone.com/73bc2bdb-c7e0-45ec-bffc-3b2ec2adeb03/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.