### PR TITLE
Update netron to 1.3.7

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.5'
-  sha256 '03633f6d21a3b5300daea8c43e45ee4a54fc7a259836853fd21fce92c817c850'
+  version '1.3.7'
+  sha256 '197618191cd63f1aa9257f7557b65d5dcc6e3639cd97bfb90bc7e427a8e30caf'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '8482496c090863985214bd2ef19fc695200f75e6e5e24a296e54fd4ffd37deae'
+          checkpoint: '6d7ffbc0376512dfe3128b8120042b767059dbc9e15452e6cb9c64d596f8993a'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.