### PR TITLE
Update padlock to 2.4.2

### DIFF
--- a/Casks/padlock.rb
+++ b/Casks/padlock.rb
@@ -1,11 +1,11 @@
 cask 'padlock' do
-  version '2.3.1'
-  sha256 '47f9b07bef7c30e61ef8fb933a7e3c1f0a636507a831b2ba1ebf95a8c371b2ce'
+  version '2.4.2'
+  sha256 '3c42470bd6fa53aae2e9699d6ef4b43b0f19a5639256de37fb8b015adf77225e'
 
   # github.com/MaKleSoft/padlock was verified as official when first introduced to the cask
   url "https://github.com/MaKleSoft/padlock/releases/download/v#{version}/Padlock-#{version}.dmg"
   appcast 'https://github.com/MaKleSoft/padlock/releases.atom',
-          checkpoint: 'dbce66e8b2c155a2087b0ded43d76dd7ef6448a09c02e7ff4155352ef8b3402f'
+          checkpoint: '03bb2528ab052d5ffbeef6dbde8b7ccc2dc10ae806a7164939e5957f07dea36e'
   name 'Padlock'
   homepage 'https://padlock.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.