### PR TITLE
Update now to 3.8.11

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.10'
-  sha256 '647a24aff6f5ab250dae961a70e34ed17fc84234db1c5371b40e8bea2edd561c'
+  version '3.8.11'
+  sha256 '9f87b919c1981d680c3d205c5714973d706117a5ddc2e81414974c88ba73491f'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '835b7acf873f6a9ce319c57ea3d777654f180dfb3a3d09676f7ecde792782cd5'
+          checkpoint: '8f622cace581dfeb33c9b9a1911fa27bcee0506f02cbf5d4e51f0808710d6d08'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.