### PR TITLE
Update emby-server to 3.2.70.0

### DIFF
--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -1,11 +1,11 @@
 cask 'emby-server' do
-  version '3.2.60.0'
-  sha256 'e85a86a82fb6cc1324fc5de341f7e3672e575f55da5c8dea4452e991eefbd382'
+  version '3.2.70.0'
+  sha256 '5cad78024d4e9a4f6a396a5a670215665d91e009a0d1e27184d7ed6926666fdd'
 
   # github.com/MediaBrowser/Emby was verified as official when first introduced to the cask
   url "https://github.com/MediaBrowser/Emby/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"
   appcast 'https://github.com/MediaBrowser/Emby/releases.atom',
-          checkpoint: '58677b8443e6cb1c671425c197954279a217dc70e385b212365d63ed997452e4'
+          checkpoint: 'e199120a28828be9b51304d873e1b1064230c57020712372cee673afcabed663'
   name 'Emby Server'
   homepage 'https://emby.media/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.