### PR TITLE
Update tankix to 12014

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '12000'
-  sha256 '4c7c557be6c96f61f3540a2c60660c905111f47e44cba82d6e87834a916f3926'
+  version '12014'
+  sha256 'a3d392ed4432cf24652de07bfd0980f9f48dd7c256d2d10b3a893b76f9b7168f'
 
   url "https://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.