### PR TITLE
Update netron to 1.3.8

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.7'
-  sha256 '197618191cd63f1aa9257f7557b65d5dcc6e3639cd97bfb90bc7e427a8e30caf'
+  version '1.3.8'
+  sha256 '2d2027188042bc09c3f5e2151c367af37dea88436e05fbe67dad0783d91264b7'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '6d7ffbc0376512dfe3128b8120042b767059dbc9e15452e6cb9c64d596f8993a'
+          checkpoint: '314e6a51d7ba6d93ca8fcd3c85b9794de37de05447908ae0b17d3220e02e5001'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.