### PR TITLE
Update station to 1.1.1

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.1.0'
-  sha256 '8e294c91e4eb5f301be6c15aa90d76aed2093e2da17a7a09cdba22d63e814ddb'
+  version '1.1.1'
+  sha256 'ebdd38da79ff121066bc3413e50ce4d24c45d0b840d6c22d4c56aadf5ba7f607'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: 'fb159ddfabaa6f61d952f0375aaed52822521af737bf1a30529f7d4465afcc44'
+          checkpoint: 'be5d0dcda0edcc10f8cba2d31d0a885f91196025cfa706ed3e84ac1b734aaa09'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.