### PR TITLE
Update qsync-client to 3.2.2.1121

### DIFF
--- a/Casks/qsync-client.rb
+++ b/Casks/qsync-client.rb
@@ -1,6 +1,6 @@
 cask 'qsync-client' do
-  version '3.2.1.1017'
-  sha256 '59b51e7aa8b5a42f60d6ddfa780e8753d748365f2086d22b62bd6332c8ac188c'
+  version '3.2.2.1121'
+  sha256 '75e81092805c38ef61609f038b66c323e58e41254e9f5c268e8e2378a3b95861'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQsyncClientMac-#{version}.dmg"
   name 'Qnap Qsync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.