### PR TITLE
Update leanote to 2.6

### DIFF
--- a/Casks/leanote.rb
+++ b/Casks/leanote.rb
@@ -1,11 +1,11 @@
 cask 'leanote' do
-  version '2.5'
-  sha256 'c309051728fcc99519556d95ff7b4685aaa701e06dcd058fa544877bdd708e4a'
+  version '2.6'
+  sha256 'c11a4170e6fab48c8ad37c2f5959a1c6571b2ebd63e7b6e54de30a8db208ee86'
 
   # sourceforge.net/leanote-desktop-app was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/leanote-desktop-app/#{version}/leanote-desktop-mac-v#{version}.zip"
   appcast 'https://sourceforge.net/projects/leanote-desktop-app/rss?path=/',
-          checkpoint: '4b74a02e2d34988d94a9df01af233f97057c2ef639e02c88d9aeebfaa3646941'
+          checkpoint: 'f34c49f5116c4d1399c9e4abe91dfd83b9e349dc9c3698dfdd6e7f7c43a72d9e'
   name 'Leanote'
   homepage 'http://leanote.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.