### PR TITLE
Update pdfelement to 6.3.6

### DIFF
--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,5 +1,5 @@
 cask 'pdfelement' do
-  version '6.0.1.2654,2991'
+  version '6.3.6,2991'
   sha256 '36461546dcb7c853ecdac6257f356d4091134e79addd94bd383cb3e77283652b'
 
   url "http://download.wondershare.com/cbs_down/mac-pdfelement#{version.major}_full#{version.after_comma}.dmg"

--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,6 +1,6 @@
 cask 'pdfelement' do
   version '6.0.1.2654,2991'
-  sha256 '1b19380155f0606caeae45fe2f7e2294ba9645a79ca0af7648229cfe345a9b93'
+  sha256 '36461546dcb7c853ecdac6257f356d4091134e79addd94bd383cb3e77283652b'
 
   url "http://download.wondershare.com/cbs_down/mac-pdfelement#{version.major}_full#{version.after_comma}.dmg"
   name 'Wondershare PDFelement for Mac'


### PR DESCRIPTION
Only sha was updated, here is a link to VT scan-
https://www.virustotal.com/#/file/36461546dcb7c853ecdac6257f356d4091134e79addd94bd383cb3e77283652b/details

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
