### PR TITLE
Update signal to 1.2.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.1.0'
-  sha256 'd96f7557d91ecdc73c19fff5488d0f5cb315ae3b8a06cde201191e856142f197'
+  version '1.2.0'
+  sha256 '3cb3170e690c7686cae0574c5e435df6845b8049abf377d61aff4ad5f5724207'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/WhisperSystems/Signal-Desktop/releases.atom',
-          checkpoint: '004bd795c9fcc9aebc3a78952208b3f0cf6ceb63138013b35045b4c1294c9b78'
+          checkpoint: '41ae9ec6e0b6287bd5aa32e274f515daf9bf847dc599f8ce80224837d4e83374'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.