### PR TITLE
Update qfinder-pro to 2.5.0.1228

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,10 +1,10 @@
 cask 'qfinder-pro' do
-  version '2.4.5.1030'
-  sha256 '0a8eb9c709053cce94d469597a86634ccfcfa2adeeb8de068389c7579a3ae6b5'
+  version '2.5.0.1228'
+  sha256 'b31c60368c95e82c5f1e4d604bce3bdaa7cc7330a9058f712192d8bf114e318a'
 
   url "http://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'http://update.qnap.com/SoftwareRelease.xml',
-          checkpoint: 'fec331a4d3860734eb0806f06f632b94366430ed1ede024703ca6fa5c761ed0b'
+          checkpoint: 'fc69d5d12b4c7ff159272f6cf44cadfe4788bb1480b1e5672d47bdd6699c6911'
   name 'Qnap Qfinder Pro'
   homepage 'https://www.qnap.com/en/utilities#utliity_5'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.