### PR TITLE
Update twine to 2.2.1

### DIFF
--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -4,7 +4,7 @@ cask 'twine' do
 
   # github.com/klembot/twinejs was verified as official when first introduced to the cask
   url "https://github.com/klembot/twinejs/releases/download/#{version}/twine_#{version}_osx.zip"
-  appcast 'https://github.com/klembot/twinejs/releases.atom'
+  appcast 'https://github.com/klembot/twinejs/releases.atom',
           checkpoint: 'f294c0940f5ae844f73b1c49cf867a7ff84f30c6ee17a28ffda8c1f5c1270981'
   name 'Twine'
   homepage 'https://twinery.org/'

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -2,7 +2,7 @@ cask 'twine' do
   version '2.2.1'
   sha256 '0282c9e21167c51fb57d1b276447d6560fa22f5489e87aac215a3616edc5887f'
 
-  # github.com/klembot/twinejs/releases/download/ was verified as official when first introduced to the cask
+  # github.com/klembot/twinejs/ was verified as official when first introduced to the cask
   url "https://github.com/klembot/twinejs/releases/download/#{version}/twine_#{version}_osx.zip"
   name 'Twine'
   homepage 'https://twinery.org/'

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -5,7 +5,7 @@ cask 'twine' do
   # github.com/klembot/twinejs was verified as official when first introduced to the cask
   url "https://github.com/klembot/twinejs/releases/download/#{version}/twine_#{version}_osx.zip"
   appcast 'https://github.com/klembot/twinejs/releases.atom'
-    checkpoint: 'f294c0940f5ae844f73b1c49cf867a7ff84f30c6ee17a28ffda8c1f5c1270981'
+          checkpoint: 'f294c0940f5ae844f73b1c49cf867a7ff84f30c6ee17a28ffda8c1f5c1270981'
   name 'Twine'
   homepage 'https://twinery.org/'
 

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -2,7 +2,7 @@ cask 'twine' do
   version '2.2.1'
   sha256 '0282c9e21167c51fb57d1b276447d6560fa22f5489e87aac215a3616edc5887f'
 
-  # github.com/klembot/twinejs/ was verified as official when first introduced to the cask
+  # github.com/klembot/twinejs was verified as official when first introduced to the cask
   url "https://github.com/klembot/twinejs/releases/download/#{version}/twine_#{version}_osx.zip"
   name 'Twine'
   homepage 'https://twinery.org/'

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -4,6 +4,8 @@ cask 'twine' do
 
   # github.com/klembot/twinejs was verified as official when first introduced to the cask
   url "https://github.com/klembot/twinejs/releases/download/#{version}/twine_#{version}_osx.zip"
+  appcast 'https://github.com/klembot/twinejs/releases.atom'
+    checkpoint: 'f294c0940f5ae844f73b1c49cf867a7ff84f30c6ee17a28ffda8c1f5c1270981'
   name 'Twine'
   homepage 'https://twinery.org/'
 

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -2,8 +2,8 @@ cask 'twine' do
   version '2.2.1'
   sha256 '0282c9e21167c51fb57d1b276447d6560fa22f5489e87aac215a3616edc5887f'
 
-  # bitbucket.org/klembot/twinejs was verified as official when first introduced to the cask
-  url "https://bitbucket.org/klembot/twinejs/downloads/twine_#{version}_osx.zip"
+  # github.com/klembot/twinejs/releases/download/ was verified as official when first introduced to the cask
+  url "https://github.com/klembot/twinejs/releases/download/#{version}/twine_#{version}_osx.zip"
   name 'Twine'
   homepage 'https://twinery.org/'
 

--- a/Casks/twine.rb
+++ b/Casks/twine.rb
@@ -1,6 +1,6 @@
 cask 'twine' do
-  version '2.1.3'
-  sha256 'f99eafcf3d70f6851016e350705aca563520b204cec13f86c353569f6ab362a4'
+  version '2.2.1'
+  sha256 '0282c9e21167c51fb57d1b276447d6560fa22f5489e87aac215a3616edc5887f'
 
   # bitbucket.org/klembot/twinejs was verified as official when first introduced to the cask
   url "https://bitbucket.org/klembot/twinejs/downloads/twine_#{version}_osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.