### PR TITLE
Update lingon-x to 5.2.6

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.2.5'
-  sha256 '4b4e05f89d5f42e1d2b2fb3531a1b7cf5ed8341db018984f65bd19ff16249953'
+  version '5.2.6'
+  sha256 'dcda364a338b19b4af7387a595a302eaebbae1f7725b42ddae07ed1bf56c3e5b'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'b051ee79a9bf3c267546607d27367adb6842991f389d3354a07692038f23e0ef'
+          checkpoint: 'e9ca1425752c701f252e5a0a63d0a509fd7afeb32311d56f94f3eb266bc11706'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.