### PR TITLE
Update switchhosts to 3.3.9.5343

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.8.5338'
-  sha256 'a158abcf3a10c1d9c6ebfe3dd0a832157ec445fc050df5b9a5e3f949dc9093b4'
+  version '3.3.9.5343'
+  sha256 'f1bc05ac03d0cf4ae2f627c5b4352a954a9bd388e724c994cd43cf99b07af15c'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: 'b8a3e89d000cc0d08cea1348d7d985efccc618449dd7d9586efe5b19c2bee313'
+          checkpoint: '5427e2e4bd8d26fa6ab940e09064c5eef7e3fbd4bbf63293146d18ec5dc4614c'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.