### PR TITLE
Update bitpay to 3.14.0

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.9.1'
-  sha256 'f528d754e299a66dde1c09044ec65895e9175c1307209acd96765c18f6835d7a'
+  version '3.14.0'
+  sha256 'e00f3a557f5cc3b97e28c3c11e13be281d4a8e11299743abbe41b5c73d5c7614'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: '3497b2ab135e91925c0fb786ffab656fffe92e64331106971ba872af92e05bc3'
+          checkpoint: 'f558ac51ea5a6cf6a7c61347731b5221625c8fb871f9a5f415cdfd53124ccfcc'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.