### PR TITLE
Update firefox to 58.0

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,120 +1,125 @@
 cask 'firefox' do
-  version '57.0.4'
+  version '58.0'
 
   language 'cs' do
-    sha256 '65199521e641ced30fcee36b163ede1fb7923042a15f00f663a1009712da05a0'
+    sha256 'd6ee21a01361dd8388d83389e7864a9e937f8e76be445339e825d01a9145ef91'
     'cs'
   end
 
   language 'de' do
-    sha256 '7286fb20d4a03d9e75b728b16d6d94e7c08145ca4f540fc167c54e7b57cd809a'
+    sha256 '653c61ae0037c22acf93d5a6b9115ff6461512ac035623c274fe3d7e088781df'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '48936096cc61352e5a9ce01295e325ee6ab270829cfabd3f58d68d0a695b0c9d'
+    sha256 '1aa91b1b0ac01c0b219615782f0dffdba36cb70248ce6ec1ec5d794d0ef1e1e7'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'eff6739bbb5f1ba425e52f1a4dc2c5aaf618f544ddca6a130ee6b46899b76b3f'
+    sha256 'a853eb20821a21c0bedeb0263d7b5975e7704f20b78edfef129c73804b1fb962'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 'c6dbed12b0a0d87b917a80641be8ab3a1c37cce8fb4bc19aace52ceb0e0c7a01'
+    sha256 '67b76f63ac467119f71528cf049f2beb52733059e349605fad168ba835e2003e'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 'eee378677b95238c687fef607293f2bf9e2e2ce8f525ed37ea28d150107e2a96'
+    sha256 '5ac8edc86287f0309f1cd914dc508e7ea424556cc50c130fffa7a8f5789a6558'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '11e1bccd2b694b6ef8cc23ac50eb26791ede05d710006faf92fd4e29683a279d'
+    sha256 '163a537da955e4aa8a8adb984d8cc6f0c30b10db40450d7d122b40b4d7de2eb7'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '9ccb83fffbaeef1f23bdd98f5aeda9c215b20f8541b5894b58ddbc0eed4c1a49'
+    sha256 'c76f65ce46f288e7ae0a26c11f98bb72bc390faba1d0e31e1e2fe3549328a79f'
     'fi'
   end
 
   language 'fr' do
-    sha256 '048e8ff512a8bf0e6469649e6dedc6c055555bd9912055098035f78c64bb38b3'
+    sha256 '39a15c409de3fa5c9ce9bfcfc2ea21f97aeb33e1c2944d2a026ebdc0f5b8b6c7'
     'fr'
   end
 
   language 'gl' do
-    sha256 '7dfa1a4a28e3fbb9677764beaad3291c3177b42b7923b180c6a1e5f235f02a97'
+    sha256 '392bc3242c1c42de02b0e9ab675a85058b8d2f8c8d2ffb41a78eb0f287d3fe8f'
     'gl'
   end
 
   language 'in' do
-    sha256 '1afc5d5363031c044bedae28432d34030594b733f7cf1164f50ab3559c63a4ed'
+    sha256 '33c82bbb2a12808d1e1c292fd59ed5debc3fc5b0f3706d13b573973e8d1dd0f5'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '17be0e2bbaf284cf1797d45f5a67e73ad3f7a6e3bbda4956eed7c328f3ffe590'
+    sha256 'a3c521971dd1777bd399194948a4d5af053e166af8fd996c37e911753b10aaf9'
     'it'
   end
 
   language 'ja' do
-    sha256 'df3807e7df049ad871402001c9d23aeab7eb404dce7fba2b27b74df8c69d297c'
+    sha256 '6bf4b90234bed68038b0981db8b554280228e768e282cd3b7eecb9f790f573b3'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 'e7984bbaee03acf61285feda0b2c7ca81eff76f4303ecb0dcfc8937ec7f800f5'
+    sha256 '58e217412ccc6a89ccb190b8678c211d11b78a2c91fa47e90706ef96a192fbbb'
     'ko'
   end
 
   language 'nl' do
-    sha256 'd15efe473833db1ccdbedcc455bb782e361955be3d470622308ecba31ddee010'
+    sha256 '8b4590928d60ddc08acdb75501632a8ecb822c40f878ceefb69363c145ec3150'
     'nl'
   end
 
   language 'pl' do
-    sha256 'e980ddb0f0997136d450d03f9908f45e1b2342524f44f9b69dee91599df6130e'
+    sha256 'aaf515954dbf71ecfa73a2266dff9e5783bea9cf029c2ea17a94ecb28ad5d40d'
     'pl'
   end
 
   language 'pt' do
-    sha256 'd0275f8602bf516e1bf55bb79e6afb0c370d042901e610c47a871dbe85186c96'
+    sha256 '7a326436638c3c02a113e3c3c724256e6c46369e70d0924f40857252b4cf34e9'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 'ea884bd95d46416d07e29a0f6e5b54a0ab7bdd902ab26f41a227545f0798edb4'
+    sha256 '364227905796dcf641ee5e8d3d190d56c84989deba367848d9195cd3bd8c49dd'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '54276f6093873688d98fa88f90fac2bfcf593a0409749faa192c93128e3fbb4b'
+    sha256 'a5a8a074f1df61d4e56fd3ef4fd5e6805fdc17913ac3f65793bbbe2744b221b0'
     'ru'
   end
 
+  language 'tr' do
+    sha256 '37756fcac54b7c98d311085e7282f0a6eab045041716ec86e91be32e70e01d7f'
+    'tr'
+  end
+
   language 'uk' do
-    sha256 'cfc1c1e1c6fddfd577a92c2ad593434b5f7ef63d6666f7c20136a5423719346f'
+    sha256 '6ffc143b6e9085e858bbc1a2bc14348c6c4d5d4bf5062671429739cde3b3c967'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '3f14be10147a050b551be5ee0d8f3de65a2f7518577ee4454e9b2575200b4271'
+    sha256 '1eeb5dbd9f7ddf64f2828dcf5bd14ddbb138566152229c4cee8bb8c1c7fdd402'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'e8cf292d80b7a04322880fb07b6e2f9ef171a0ff7715a7ff500397bc78962f1d'
+    sha256 '896ca06defc45bf9f5cef8ae2746865b2fcc9d26f6ae66e22ea47bc2de497d31'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/firefox/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '9291db943d95e36b5ead371b780e8e35868a89874c8339ed6d21dc3ce1a54deb'
+          checkpoint: '4603316c5b3dfba0857e1a969f7526f2ab4b4275d2d88081810441a7db367553'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
Updated to 58.0, added Turkish language option

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.