### PR TITLE
Update aquaskk to 4.4.6

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -10,5 +10,5 @@ cask 'aquaskk' do
 
   pkg 'AquaSKK.pkg'
 
-  uninstall pkgutil: 'jp.sourceforge.inputmethod.aquaskk.pkg'
+  uninstall pkgutil: 'org.codefirst.aquaskk.pkg'
 end

--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,10 +1,10 @@
 cask 'aquaskk' do
-  version '4.4.5'
-  sha256 'a0d3c21abc914da4b81a93b7af4a4c8d26a3afbc49bb7af3b24376356d3d0a18'
+  version '4.4.6'
+  sha256 'c6635e2f34672dfaa1ca3fc5f1eb831d21997c5baa278a8840e6358be4c6c563'
 
-  url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
+  url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK.pkg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom',
-          checkpoint: 'ea74f92ede5616588852b9b38b4a5b10a3ee75892a167a48b39a6c0134aaf429'
+          checkpoint: 'e88cfab393d7724d48ff5f0cc19433db68d921e65c1cdd83efc24c89f6e02106'
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.