### PR TITLE
Update screenflick to 2.7.30

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,10 +1,10 @@
 cask 'screenflick' do
-  version '2.7.27'
-  sha256 '12fa339ded27f11c444e421ec688f94ac14ae3f276cbfdb3952456badc53de6a'
+  version '2.7.30'
+  sha256 '2b1c2993aa5af1072d153308ef91cf9ccf74c096d3d8188d449fb797d8f544d9'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml",
-          checkpoint: '950fb37bb1bbcf0abef5a7518d1f67de79951b7417f121e0cdd47f5dd8e6ef04'
+          checkpoint: 'c4c35cb76288f67b9baab5f8ac5f594a9dd8b59b98a3900fe86f6b1d8ef236c3'
   name 'Screenflick'
   homepage 'https://www.araelium.com/screenflick/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.