### PR TITLE
Update wavebox to 3.10.0

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.9.0'
-  sha256 '7fe76b4f7c28e1f2ab31e77a37adaaeabc9d4737b23c404448baf1d6f65ff6bf'
+  version '3.10.0'
+  sha256 '177031e0c34838ca6f9d3a3a811a92474180ccab88ed69aed9011bdb92f23cc6'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: 'a9687b732511324b99a6ec4e6cdedf0c4210da5683fd013d0f9cf9ba6fb8f93a'
+          checkpoint: '29b5b14955f2462f28284ed5906b7e6f38d49088e04a98cf7cd6b3b54d48339f'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.