### PR TITLE
Update freac to 1.1-alpha-20171119

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,11 +1,11 @@
 cask 'freac' do
-  version '1.1-alpha-20170902'
-  sha256 '31e591e88e3540b102e8f2606ec06a73af3b7a5b30980cae22e84e7f915ea6c9'
+  version '1.1-alpha-20171119'
+  sha256 '265d6a9304c947b866d36191e9820810a02f4696a66f68828603c86d434ce86e'
 
   # sourceforge.net/bonkenc was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/bonkenc/rss',
-          checkpoint: '4939b8a5daf8bce38ddb7ec635408f75396d109b0d8f0f936130b28c2ef8f848'
+          checkpoint: '1af0978fed96f9747bcf6adccd9eeaae474d16544bf49c26b37ce74e502cb162'
   name 'fre:ac'
   homepage 'https://www.freac.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.