### PR TITLE
Update arkclient to 1.5.1

### DIFF
--- a/Casks/arkclient.rb
+++ b/Casks/arkclient.rb
@@ -1,11 +1,11 @@
 cask 'arkclient' do
-  version '1.5.0'
-  sha256 '915922096191bf6203ef797492e732c477499e99bb670fc7321755e2addfbd2c'
+  version '1.5.1'
+  sha256 'a33256df845f440763b3738168ba10951c16683fec37330a94ebb2637b612273'
 
   # github.com/ArkEcosystem/ark-desktop was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/ark-desktop/releases/download/#{version}/ArkClient-MacOS-#{version}.dmg"
   appcast 'https://github.com/ArkEcosystem/ark-desktop/releases.atom',
-          checkpoint: '24cb2e9886047d0f1b8134d4d1c80efe85e684dc78b03511bf960f3c038a6f13'
+          checkpoint: '001eb2cad60cdb8a76b729ac25fc7da871404b1ba0ca43e5e2686f50c71f402d'
   name 'Ark Client'
   homepage 'https://ark.io/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
