### PR TITLE
Update eagle to 8.6.0

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,6 +1,6 @@
 cask 'eagle' do
-  version '8.5.2'
-  sha256 'bccdee6fb322d87372374ede5917ef1ab03d8b444c0b7aa1d4bab74cd4eabfec'
+  version '8.6.0'
+  sha256 'ff3b3f87fd10a6bf0295a281fd5b98940341c5f25a11ed24a25e376cca9616ca'
 
   url "https://trial2.autodesk.com/NET17SWDLD/2017/EGLPRM/ESD/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   name 'Autodesk EAGLE'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.