### PR TITLE
Update navicat-for-mysql to 12.0.22

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.19'
-  sha256 '1ff2c3c7755a8f3151e14cb3b1ab3b6911a2145cfc4f12a3d7696b76f2e5c6c5'
+  version '12.0.22'
+  sha256 'a9c29c3747f42992c9078432b9f2b1b84690e19e2a6e1e748a9e63940a3f3bd0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: '727d30bc018771deea10d6fb3480f7424ee6e41055bd7a2f5aa1a8bc88a7a4e3'
+          checkpoint: '0845dbb0629757f0fbc261404b1c1b139c2e1a6c201aac73ca75e0ebfe5daefc'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.