### PR TITLE
Update navicat-for-oracle to 12.0.22

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.19'
-  sha256 'ad59ae84215fa0fa4eda34761a9ae93e763d83972695699d8711f5507c261a79'
+  version '12.0.22'
+  sha256 '3827ec1da162e97893b0c2ffa33641f0fa1eba4a05dc8e4e29fbe5c09e40b375'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-oracle-release-note',
-          checkpoint: '5235500c11211e2d4afc9bb0e42c18165c64bf6ccbdf12941e3c07c8e8578c79'
+          checkpoint: '826d769f2791695070b1fe0b3c38b3ddefe19ec108bd6f5e2d06587da12645ab'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.