### PR TITLE
Update navicat-for-sql-server to 12.0.22

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.19'
-  sha256 'da221fe7ad7c8c236874dc9d21674fafa633e30fa96865052566b151b968083f'
+  version '12.0.22'
+  sha256 '660c5d33f133976389a0a1751b6c25035cd621bcae7293a605607a60141dfee9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlserver-release-note',
-          checkpoint: 'dd1a89fef14a734ee841556207f0319801ff4d65695fffccc6c77a2a17bccc41'
+          checkpoint: 'ce7e26ac5415db0e5b188cb43b5a578f909fcc1fb33f04b30ba62172e2ec72a4'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.