### PR TITLE
Update navicat-for-sqlite to 12.0.22

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.19'
-  sha256 '21235a891909177423b2b5403f9890a57f0525524f9f4576e4ceec46b6be988a'
+  version '12.0.22'
+  sha256 'd11e00c90ee1e0cf0d411970be66b3af5d7017b7d8254f74c9df12ea00294bbf'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlite-release-note',
-          checkpoint: '9ad09b2d459e8e9dd8e3574857ed3e8dbef0725d03bd288bb38248a3a904525b'
+          checkpoint: '79128b1df6372153ba6f2638bbaa7f1ca9048f3531e1751fe674257051eda311'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.