### PR TITLE
Update lehreroffice to 2017.19.5

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice' do
-  version '2017.19.4'
-  sha256 '28bfb4f2030113c7be71eacd526a9409d363b3b9a8524d31af4252d1298a8d8b'
+  version '2017.19.5'
+  sha256 'e7a422b4eac3cba7e349809d26ea741216288e322d84a9f6ecfb055af2f041cc'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop',
-          checkpoint: 'cbe9319b16e5fc667c36ca4790cae5cf9ab250b4573248e9440039ca367c5ada'
+          checkpoint: '1c68708536535a5524c319a194d438624fba1517613f216379280c32e48db248'
   name 'LehrerOffice'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.