### PR TITLE
Update lehreroffice-zusatz to 2017.19.5

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2017.19.4'
-  sha256 '64db16b20f27c891f1581ffa4902946ec872696c45887ace5e0232989b3a0de2'
+  version '2017.19.5'
+  sha256 'cb068563740cd900f2804748074e09589f7ae3fd42e1fb33fa9a5d64f4295341'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: 'cbe9319b16e5fc667c36ca4790cae5cf9ab250b4573248e9440039ca367c5ada'
+          checkpoint: '1c68708536535a5524c319a194d438624fba1517613f216379280c32e48db248'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.