### PR TITLE
Update frostwire to 6.6.2

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.6.0'
-  sha256 'd6cc9ba8dc514eaed2092db29ea6a2ddae79bad1df9d4ffd6e76b45eeea8baa0'
+  version '6.6.2'
+  sha256 '73c25b793b50130136ab937749f6e0b2b4a943ea90dda8d28ae415ca4b81da66'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: 'eab124727e648e21235cb2ec584816311d41c2bacbf43292025084a75a4ef103'
+          checkpoint: 'a5673d497684b33cfcb334a961daad2a873812e09bff8611c11c78f569f05e3c'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.