### PR TITLE
Update arq to 5.11.1

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,10 +1,10 @@
 cask 'arq' do
-  version '5.11'
-  sha256 '71282640881500607f97a4f0ccfdb46457c1582cd54e83ca47c2abf2620e83da'
+  version '5.11.1'
+  sha256 'c100dc14d680b29a01381b9892731399e8cebcbe23f232cf6925d4dc6b3f0d17'
 
   url "https://www.arqbackup.com/download/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arq#{version.major}.xml",
-          checkpoint: 'd16b129cffc1503703ff2be63c8202348f58dddba15de21ffefd00486388264f'
+          checkpoint: 'd0eb47f743c6349eeb998e702524114f600cdbc7a5e0503591ff6a77444afe2d'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.