### PR TITLE
Update taskwarrior-pomodoro to 1.7.0

### DIFF
--- a/Casks/taskwarrior-pomodoro.rb
+++ b/Casks/taskwarrior-pomodoro.rb
@@ -1,11 +1,11 @@
 cask 'taskwarrior-pomodoro' do
-  version '1.5.0'
-  sha256 '196c38ec03758ff27a16d1341d4ed5475be8f00f3a1cc963ba321c2c3a502c4d'
+  version '1.7.0'
+  sha256 '5909e42e31a6b545d8e549f000433ca677708f0c4178e1fcd60b8f890ad61adf'
 
   # coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro was verified as official when first introduced to the cask
   url "https://coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro/releases/taskwarrior-pomodoro-#{version}.dmg"
   appcast 'https://github.com/coddingtonbear/taskwarrior-pomodoro/releases.atom',
-          checkpoint: '6b898b32196fc2ce0808efaa92d2a343fd0697aec7cffcc285d95c48c59a4a89'
+          checkpoint: '60001727db126f00c27daaa0d6df7472b5ba155b4b0153ac1f9b8baee7d8e251'
   name 'Taskwarrior-Pomodoro'
   homepage 'https://github.com/coddingtonbear/taskwarrior-pomodoro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.