### PR TITLE
Update rstudio to 1.1.419

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,6 +1,6 @@
 cask 'rstudio' do
-  version '1.1.414'
-  sha256 '68b8597ef8b4625805e90cda6a214bff4c3d8e15434ce99868465da57936bbc9'
+  version '1.1.419'
+  sha256 '3af70da34340a9d10eda4f0b765610cbd5d6bfa94236b23692d056361cf8c7b2'
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.