### PR TITLE
Update netron to 1.3.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.3.8'
-  sha256 '2d2027188042bc09c3f5e2151c367af37dea88436e05fbe67dad0783d91264b7'
+  version '1.3.9'
+  sha256 '982fe0088c48c5f46b32ed2942cc20b05f7f31b19deb20ab91e9e77b6fef2fe8'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '314e6a51d7ba6d93ca8fcd3c85b9794de37de05447908ae0b17d3220e02e5001'
+          checkpoint: '924551fc5c6704bdfe7680302511948c20a8e9415e7af1306d19ebf80e3d6865'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.