### PR TITLE
Update coronasdk to 2017.3184

### DIFF
--- a/Casks/coronasdk.rb
+++ b/Casks/coronasdk.rb
@@ -1,6 +1,6 @@
 cask 'coronasdk' do
-  version '2017.3135'
-  sha256 '86654603f890edf2f27d54acdb97fac55e352b263c6950886860f27a3114ff22'
+  version '2017.3184'
+  sha256 '54fe7dfd2e9e67a948e08fc4f50c77136d22b4bdeb23f48b13ecb123da1098ae'
 
   url "https://developer.coronalabs.com/sites/default/files/Corona-#{version}.dmg"
   name 'Corona SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.