### PR TITLE
Update vienna to 3.2.0

### DIFF
--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,11 +1,11 @@
 cask 'vienna' do
-  version '3.1.16'
-  sha256 'ba200fe0efe9e43025f8511b48af102e753dfc7f7c0a850e55a1b87f513dd882'
+  version '3.2.0'
+  sha256 '4f960fe4bdb7503f2f05af470b2241c8b131d54960c4e1bdc54d7f4d1ab4f296'
 
   # bintray.com/viennarss was verified as official when first introduced to the cask
-  url "https://dl.bintray.com/viennarss/vienna-rss/Vienna#{version}.tar.gz"
+  url "https://dl.bintray.com/viennarss/vienna-rss/Vienna#{version}.tgz"
   appcast 'https://viennarss.github.io/sparkle-files/changelog.xml',
-          checkpoint: 'c37abdea3b2b7ada796973930202066c5465e379f677931f231e52526018c029'
+          checkpoint: 'ec3cc4371a4f4c46c4ea2de94df491f29882fcc6df8bf7028d8448d348e80884'
   name 'Vienna'
   homepage 'http://www.vienna-rss.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.