### PR TITLE
Update geoda to 1.12.1.59

### DIFF
--- a/Casks/geoda.rb
+++ b/Casks/geoda.rb
@@ -1,11 +1,11 @@
 cask 'geoda' do
-  version '1.12.0.0'
-  sha256 '73c88679a1e51aabc634aa2cb42ba4de97f1ddedd41e6d8fe8e212fca34d94cc'
+  version '1.12.1.59'
+  sha256 'f9c96644b11f3aaa5aa12f4cfbeacc51fa01a29404d427d3ae1d9355dfe6f390'
 
   # s3-us-west-2.amazonaws.com/geodasoftware was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/geodasoftware/GeoDa#{version}-Installer.dmg"
   appcast 'https://github.com/GeoDaCenter/geoda/releases.atom',
-          checkpoint: 'cb0aab92920cfb28255679102b3e94f259611e9258fcf0f333cc9ce7ecc4ea1d'
+          checkpoint: '1b95843042e8f0197d607653065be7f2393f231cac42579f9c1175f3c9b78ce8'
   name 'GeoDa'
   homepage 'https://geodacenter.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.