### PR TITLE
Update goldencheetah to 3.4,3957:551

### DIFF
--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -5,9 +5,11 @@ cask 'goldencheetah' do
   # github.com/GoldenCheetah/GoldenCheetah was verified as official when first introduced to the cask
   url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V3.4/GoldenCheetah_V#{version.major_minor}_build_#{version.after_comma.before_colon}_Qt#{version.after_colon}_64bit.dmg"
   appcast 'https://github.com/GoldenCheetah/GoldenCheetah/releases.atom',
-          checkpoint: 'ae7917bdb6f3e20dd63435046002366931135f1c77667460d98201b8d165b86d'
+          checkpoint: '3bcf97f4be2aad76e915db03c070cf86a2812278921d043fec5129109ed95461'
   name 'GoldenCheetah'
   homepage 'http://www.goldencheetah.org/'
+
+  depends_on macos: '>= :lion'
 
   app 'GoldenCheetah.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.