### PR TITLE
Update MAMP to 4.3

### DIFF
--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -4,7 +4,7 @@ cask 'mamp' do
     sha256 'b935d118b6e14d43cf2570be2a05166a15b824c3edc0ede98cc30e6ab5af3697'
   else
     version '4.3'
-    sha256 'abca495b9b4c1861d0baff8c869b7025306b5006d25c3c8ab7d0a1523973d20c'
+    sha256 '2fb215c6ae5718796f53b4380c2807a7f78836cf6aac9d08aa81e6bac5921203'
   end
 
   url "https://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -3,8 +3,8 @@ cask 'mamp' do
     version '3.5.2'
     sha256 'b935d118b6e14d43cf2570be2a05166a15b824c3edc0ede98cc30e6ab5af3697'
   else
-    version '4.2.1'
-    sha256 '9428a3cf494d02d94ecaec302042822f54273ba9d412ecde25d1155ab07db56e'
+    version '4.3'
+    sha256 'abca495b9b4c1861d0baff8c869b7025306b5006d25c3c8ab7d0a1523973d20c'
   end
 
   url "https://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"


### PR DESCRIPTION
There is still one problem, similar to the one for 4.2.1. The SHA I have now is different than the one on the MAMP downloads page (https://www.mamp.info/en/downloads/). I have contacted their support. The last time they changed the actual download file and forgot to update the SHA on the downloads page AND to flush their caches. So maybe it's worthwhile to hold off on merging this.

Just wanted to get this ready cause I had 5 min to spare and it's worthwhile stuff like this has SOME history, so people can look these people up.

After making all changes to the cask:

- [ X ] `brew cask audit --download {{cask_file}}` is error-free.
- [ X ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ X ] The commit message includes the cask’s name and version.
