### PR TITLE
Update mattermost to 4.0.0

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,10 +1,10 @@
 cask 'mattermost' do
-  version '3.7.1'
-  sha256 '348c9321ee81114794d098998490a64f99b511497cd6b95454420685301e115a'
+  version '4.0.0'
+  sha256 '94a21bfe4932ef7f55c1386e16a98de079653297129bbabcf6092b780e68ddd2'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: '547ac8a75d459980ae21a9fbd2de8188a04b9c6aefc6a6d987435a182f51dbf5'
+          checkpoint: '9caa98f39e36318ebdb2ce47e1de2e254adc61cac78644d5ddfe9ca4ef3c7dfe'
   name 'Mattermost'
   homepage 'https://about.mattermost.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.