### PR TITLE
Use version number for beaker-browser, starting at 0.7.11

### DIFF
--- a/Casks/beaker-browser.rb
+++ b/Casks/beaker-browser.rb
@@ -1,9 +1,11 @@
 cask 'beaker-browser' do
-  version :latest
-  sha256 :no_check
+  version '0.7.11'
+  sha256 '78f988186e3668aa1e6e4459f3e5f3c045ef9fd291e0a790f9c595eb73874ee9'
 
-  # download.beakerbrowser.net/download was verified as official when first introduced to the cask
-  url 'https://download.beakerbrowser.net/download/latest/osx'
+  # github.com/beakerbrowser/beaker was verified as official when first introduced to the cask
+  url 'https://github.com/beakerbrowser/beaker/releases/download/0.7.11/beaker-browser-0.7.11.dmg'
+  appcast 'https://github.com/beakerbrowser/beaker/releases.atom',
+          checkpoint: '81c94a620c59bd5ea85e1d562381d7f709d55edd33356947024015c7033d98a3'
   name 'Beaker Browser'
   homepage 'https://beakerbrowser.com/'
 

--- a/Casks/beaker-browser.rb
+++ b/Casks/beaker-browser.rb
@@ -3,7 +3,7 @@ cask 'beaker-browser' do
   sha256 '78f988186e3668aa1e6e4459f3e5f3c045ef9fd291e0a790f9c595eb73874ee9'
 
   # github.com/beakerbrowser/beaker was verified as official when first introduced to the cask
-  url 'https://github.com/beakerbrowser/beaker/releases/download/0.7.11/beaker-browser-0.7.11.dmg'
+  url "https://github.com/beakerbrowser/beaker/releases/download/#{version}/beaker-browser-#{version}.dmg"
   appcast 'https://github.com/beakerbrowser/beaker/releases.atom',
           checkpoint: '81c94a620c59bd5ea85e1d562381d7f709d55edd33356947024015c7033d98a3'
   name 'Beaker Browser'


### PR DESCRIPTION
Also use download url [from official website](https://beakerbrowser.com/docs/install) and add appcast.

---
After making all changes to the cask:

- [x] `brew cask audit --download beaker-browser` is error-free.
- [x] `brew cask style --fix beaker-browser` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---
I couldn't pass the style check because my comment above `url`

> does not match the expected comment format

and I didn't really know what to do about it because simply putting the wanted

> was verified as official when first introduced to the cask

just to let it pass felt wrong.