### PR TITLE
Update managenameext to 1.6.3

### DIFF
--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -6,7 +6,7 @@ cask 'managenameext' do
   appcast 'throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html',
           checkpoint: '48c241c749d43463b4f829520a97a22019cdbbef9389292636c262d3aab6ea2b'
   name 'ManageNameExt'
-  homepage 'throb.pagesperso-orange.fr/site/ind_JS.html?Prg_S.html&Prg_ApplisRB.html#ManageNameExt'
+  homepage 'http://throb.pagesperso-orange.fr/site/ind_JS.html?Prg_S.html&Prg_ApplisRB.html#ManageNameExt'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -3,7 +3,7 @@ cask 'managenameext' do
   sha256 '57f34571293b525ea7d9c0068f784c9684ac26f8da54f93b2fd3dd0f2c1d2aa1'
 
   url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
-  appcast 'throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html',
+  appcast 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html',
           checkpoint: '48c241c749d43463b4f829520a97a22019cdbbef9389292636c262d3aab6ea2b'
   name 'ManageNameExt'
   homepage 'http://throb.pagesperso-orange.fr/site/ind_JS.html?Prg_S.html&Prg_ApplisRB.html#ManageNameExt'

--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -1,11 +1,14 @@
 cask 'managenameext' do
-  version :latest
-  sha256 :no_check
+  version '1.6.3'
+  sha256 '57f34571293b525ea7d9c0068f784c9684ac26f8da54f93b2fd3dd0f2c1d2aa1'
 
-  # tom.25.free.fr was verified as official when first introduced to the cask
-  url 'http://tom.25.free.fr/prg/Xojo/ManageNameExt_c.zip'
+  url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
+  appcast 'throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html',
+          checkpoint: '48c241c749d43463b4f829520a97a22019cdbbef9389292636c262d3aab6ea2b'
   name 'ManageNameExt'
-  homepage 'http://throb.pagesperso-orange.fr/site/ind_JS.html?Prg_S.html&Prg_AutresRB.html#ManageNameExt'
+  homepage 'throb.pagesperso-orange.fr/site/ind_JS.html?Prg_S.html&Prg_ApplisRB.html#ManageNameExt'
+
+  depends_on macos: '>= :mavericks'
 
   app 'ManageNameExt.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.