### PR TITLE
Update station to 1.3.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.2.0'
-  sha256 'e2439392c919855f1c5fbf7c72de2a3e59e8f1f3f587ee161a6360b3f5d1b575'
+  version '1.3.0'
+  sha256 'e6b7b24f625a41bad553c7fa72584b6852b38ec19d91c2a5466246f7a5e82d78'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '95c9a5da3826ddf2eeb0fe5ee9425851fed4b34f9c9545d0100e1be5afef1aca'
+          checkpoint: 'e2749b650eb68431d17ab6be7351aa5ae3d722c2f95a2e1ca4b4d9f85acb5411'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.