### PR TITLE
Update graphicconverter to 10.5.4,2971

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,11 +1,11 @@
 cask 'graphicconverter' do
-  version '10.5.2,2911'
-  sha256 'cf705720d3ab710300376e1114029c1eb276724e9ef9a275fe36df626c9d8926'
+  version '10.5.4,2971'
+  sha256 'c6901a343c02800cf9a72cfa1c2a3642a539f1c036382ccdcf1f046cd616c36c'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
   appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml",
-          checkpoint: 'd81276fa9cce65c47078aa20516134d573a2c4b670073b2fc94e108d25c695e8'
+          checkpoint: '7b983b030452997e5e2d3aacbe84219c707bd73eff2b7f65946feb8e03b72026'
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.