### PR TITLE
Revert cerebro to 0.3.1

### DIFF
--- a/Casks/cerebro.rb
+++ b/Casks/cerebro.rb
@@ -1,6 +1,6 @@
 cask 'cerebro' do
-  version '0.3.2'
-  sha256 'a4df90aca836d6110ac65cd5c1427fb9121f93bdd36ed8527816befbda3dc833'
+  version '0.3.1'
+  sha256 '83fe4fa5baae56052eb44ae0a94a93880e2d99e52ad5d2e0d4201ddd2f960889'
 
   # github.com/KELiON/cerebro was verified as official when first introduced to the cask
   url "https://github.com/KELiON/cerebro/releases/download/v#{version}/cerebro-#{version}.dmg"


### PR DESCRIPTION
Reverts upgrade from commit 22cb81a, as Cerebro 0.3.2 is currently crashing, as per #43172. 

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
