### PR TITLE
Update hachidori to 2.2.1

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,13 +1,15 @@
 cask 'hachidori' do
-  version '2.0b12'
-  sha256 'e22551430945ffce90232485fc4fe89964207b900bcaa09c88243dfc12d05f15'
+  version '2.2.1'
+  sha256 '51db575dd65bdcea29d554cea35bd1a6606281356e877e20d549521c5e1cbc28'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
-  url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/Hachidori-#{version}.dmg"
+  url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/hachidori/releases.atom',
-          checkpoint: 'a37270b79c8f43a3a62e286e55562b3b7e1432fb5a394fc0eec918f29ef9e169'
+          checkpoint: '993b1c9eeaa17bfb35697a8b5c09e76b518b463dc312fdb5c7c10083234ecfeb'
   name 'Hachidori'
   homepage 'https://hachidori.ateliershiori.moe/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'Hachidori.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.