### PR TITLE
Update play to 2.0.16

### DIFF
--- a/Casks/play.rb
+++ b/Casks/play.rb
@@ -1,11 +1,11 @@
 cask 'play' do
-  version '2.0.15'
-  sha256 'd1dc43949faf7ad88ea5ecb6004ca2b075272f51972916cb5b4b9a747cfc2a5c'
+  version '2.0.16'
+  sha256 '6554961e11bc78873a2ccf1bed33c387763f969541556d119f506c4eaee77c3f'
 
   # github.com/pmsaue0/play was verified as official when first introduced to the cask
   url "https://github.com/pmsaue0/play/releases/download/v#{version}/play_#{version}.dmg.zip"
   appcast 'https://github.com/pmsaue0/play/releases.atom',
-          checkpoint: 'bc659ebb278c9e035c1970c1f277ff225a5736c12fc91838d34fae76d0af2f36'
+          checkpoint: '19544fa2c74c79d9c56016dacf785749a09873bf0f00f7d239272bc73702955f'
   name 'Play'
   homepage 'https://pmsaue0.github.io/play/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.