### PR TITLE
Update bdash to 1.2.2

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,10 +1,10 @@
 cask 'bdash' do
-  version '1.2.1'
-  sha256 'c28cd5cc9c6c2a1d14552a1b14d07dceb5ada0769ea08d9ae85876d7dd72824c'
+  version '1.2.2'
+  sha256 '3fd4764e7454ff8861562ade2162e0a1d28ea7d80b1ba466f4a7aa6095ac84dd'
 
   url "https://github.com/bdash-app/bdash/releases/download/#{version}/Bdash-#{version}-macOS.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom',
-          checkpoint: '4e2beb620d57e15a407972b02d15a339cdbc3a9243edf717a55f0a25fd62af62'
+          checkpoint: '3f5cebce3e85be302157f59b86f6dd26c595c0f60948fcbeafcd065bc5b3983c'
   name 'Bdash'
   homepage 'https://github.com/bdash-app/bdash'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.