### PR TITLE
Update mono-mdk to 5.4.1.7

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,10 +1,10 @@
 cask 'mono-mdk' do
-  version '5.4.1.6'
-  sha256 '6b5129bf9457b54b442497caa0a5d4272d973db75b4470eb69da4327dbcbca1f'
+  version '5.4.1.7'
+  sha256 '7b5c24d3528e63e82446fb94bf6b8465000202ea6e95b50a83b60c8192ac9542'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: '72454391ed3476126473c324f16b31b54518d0ab05c30aeb6c452b1ea1c61dce'
+          checkpoint: '6d5b8d721663b5d513dc940cb0872b9822da2a8f66ff74da551af4457fb885d9'
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.