### PR TITLE
Update bisq to 0.6.4

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.6.3'
-  sha256 '844912d358fb903e88c14c099c7b6c94d98c3535f22b0da343de6d1513895dae'
+  version '0.6.4'
+  sha256 'af68aa7944a3a4168cd6a402da5da8cef474bc07d95376b7d22168f3006c1540'
 
   # github.com/bisq-network/exchange was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/exchange/releases.atom',
-          checkpoint: '5aa3f8d4a5114250b3afdd66e4d4e9160c337c78c3a138d06afa7c4e8573d0ef'
+          checkpoint: '937e2d0341514104d193cb753966b28602e7f91ea79bc98eed3c20a5b087d8c1'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.