### PR TITLE
Update abstract to 0.66.2

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '0.65.6'
-  sha256 '3fc866ef89636db1484aa9965696b3ddf7a84e977f976663adc93635112578ce'
+  version '0.66.2'
+  sha256 '56295d1b1f8f0a2a8631a942a0eebd3f99f87339bb0600372f01fc6ec8795f39'
 
   # s3.amazonaws.com/propeller-internal-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/propeller-internal-releases/Abstract-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.