### PR TITLE
Update addaps to 0.4.38

### DIFF
--- a/Casks/addaps.rb
+++ b/Casks/addaps.rb
@@ -1,6 +1,6 @@
 cask 'addaps' do
-  version '0.4.31'
-  sha256 '8feddc813f8006bd588b40077ce2548087141a1fda4e34e23419496202298788'
+  version '0.4.38'
+  sha256 'e1b29370d68483703d236964592cedea8b1f95eee354245887d52e7904d3bd37'
 
   # s3.amazonaws.com/addaps-beta was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/addaps-beta/Addap's+beta-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.