### PR TITLE
Update audirvana-plus to 3.2.5

### DIFF
--- a/Casks/audirvana-plus.rb
+++ b/Casks/audirvana-plus.rb
@@ -1,10 +1,10 @@
 cask 'audirvana-plus' do
-  version '3.2.4'
-  sha256 '3655169b3cada7d0a034b844e22c4112daaa22d37cf31c9c9b8def39dd518c33'
+  version '3.2.5'
+  sha256 '18d5439246075fff16362b44b6c509db446b59b4bfde75597abe1a40068a0d43'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml",
-          checkpoint: '5a5ee6ef00147260ccdbb136c0fa3591f9ab4f3a0e07ce0e42149e56d7441d57'
+          checkpoint: '49d3df584d932f0772e4b21572538a18aa477cca8e700e9a6c4090f68ff1987d'
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.