### PR TITLE
Update cacher to 1.2.6

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.2.1'
-  sha256 '1788d7bf0a5bbb2ae43ec3adf81c4b021b69ba5addefe336523f2fc67b054517'
+  version '1.2.6'
+  sha256 'ec6a534f8766d664e6ce1abba19090e93d4c01e04e08543acdca2cfe90cb3459'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'b9f55e13a163da807aaa2c8b56b375679ea43d86200d99104ba782e83d697371'
+          checkpoint: '05daeb4cdd12464865ae467f904d4fcb1ed8d6c2524b5013f2453d583fa9b9ad'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.