### PR TITLE
Update copay to 3.14.0

### DIFF
--- a/Casks/copay.rb
+++ b/Casks/copay.rb
@@ -1,11 +1,11 @@
 cask 'copay' do
-  version '3.9.1'
-  sha256 '1300dd42e801c7e82754a601fb9e1953242e41f25e29ab4d9bf43376ff288ec6'
+  version '3.14.0'
+  sha256 '524b6259e67640add384b6d9a133db8b6a424c7d4698257c5f73bde9fcb62e51'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/Copay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: '3497b2ab135e91925c0fb786ffab656fffe92e64331106971ba872af92e05bc3'
+          checkpoint: 'f558ac51ea5a6cf6a7c61347731b5221625c8fb871f9a5f415cdfd53124ccfcc'
   name 'Copay'
   homepage 'https://copay.io/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.