### PR TITLE
Update cubicsdr to 0.2.3

### DIFF
--- a/Casks/cubicsdr.rb
+++ b/Casks/cubicsdr.rb
@@ -1,11 +1,11 @@
 cask 'cubicsdr' do
-  version '0.2.2'
-  sha256 'e0099a2c8fefc1a997057b95f72c74769c3e0f91b8821f1cd7f494f609c477cb'
+  version '0.2.3'
+  sha256 'de13d61843b81571710c9065e132ab7869fa01e711d947f0464428ba160ab9cd'
 
   # github.com/cjcliffe/CubicSDR was verified as official when first introduced to the cask
   url "https://github.com/cjcliffe/CubicSDR/releases/download/#{version}/CubicSDR-#{version}-Darwin.dmg"
   appcast 'https://github.com/cjcliffe/CubicSDR/releases.atom',
-          checkpoint: '6ca500dc8de9dafd9b142be8c3b40120b19809cd19d7bc610b19ee0ab7c9ae64'
+          checkpoint: '132db1cd1120d8fe64bba01cc863c1f04e4bbf9646b54398bf6c40016cfcb167'
   name 'CubicSDR'
   homepage 'http://cubicsdr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.