### PR TITLE
Update cutter to 1.2

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,11 +1,11 @@
 cask 'cutter' do
-  version '1.1'
-  sha256 '0cf7d17b6edfff88967ac1979effdbba506dc80ef319d25114081a19118bbde1'
+  version '1.2'
+  sha256 '9d5cc522e2d571746c9df89bce5528a81b85e31ccaee3d8e79933ea1eb944892'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/cutter-v#{version}.dmg"
   appcast 'https://github.com/radareorg/cutter/releases.atom',
-          checkpoint: '8d37bfefc10e9e0f1861dee8a029cd4ae2d5f2afecaeabae9e62c6dc0021a600'
+          checkpoint: 'efac4ee3bcb6ecddaf748d3a86012553de50c366a09bfb54c6c137dc445651d5'
   name 'Cutter'
   homepage 'https://radare.org/cutter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.