### PR TITLE
Update dmmbookviewer to 3.1.4

### DIFF
--- a/Casks/dmmbookviewer.rb
+++ b/Casks/dmmbookviewer.rb
@@ -1,6 +1,6 @@
 cask 'dmmbookviewer' do
-  version '3.1.1'
-  sha256 'b69c9f49a23ffa0e7c158ac97bd35f5b3e883c919a1a474b8f544bea456c018d'
+  version '3.1.4'
+  sha256 '7644addebc62e7d83be305955883d74386253b208f643f687af29af0a7e6a33b'
 
   # dmm.co.jp was verified as official when first introduced to the cask
   url "http://dl.aka.dmm.co.jp/dmmviewer/mac/DMMViewerSetup_Mac_#{version}.pkg"

--- a/Casks/dmmbookviewer.rb
+++ b/Casks/dmmbookviewer.rb
@@ -9,16 +9,17 @@ cask 'dmmbookviewer' do
 
   pkg "DMMViewerSetup_Mac_#{version}.pkg"
 
-  uninstall pkgutil: [
-                       'com.dmm.DMMbookviewer',
-                       'jp.co.cyphertec.installer.acwd.plist',
-                       'jp.co.cyphertec.installer.framework.CypherGuardAC',
-                       'jp.co.cyphertec.installer.info.CypherGuardAC',
-                       'jp.co.cyphertec.installer.kext.nosigned',
-                       'jp.co.cyphertec.installer.kext.signed',
-                     ],
-            kext:    [
-                       'jp.co.cyphertec.CypherGuardKa',
-                       'jp.co.cyphertec.CypherGuardAT',
-                     ]
+  uninstall pkgutil:   [
+                         'com.dmm.DMMbookviewer',
+                         'jp.co.cyphertec.installer.acwd.plist',
+                         'jp.co.cyphertec.installer.framework.CypherGuardAC',
+                         'jp.co.cyphertec.installer.info.CypherGuardAC',
+                         'jp.co.cyphertec.installer.kext.nosigned',
+                         'jp.co.cyphertec.installer.kext.signed',
+                       ],
+            kext:      [
+                         'jp.co.cyphertec.CypherGuardKa',
+                         'jp.co.cyphertec.CypherGuardAT',
+                       ],
+            launchctl: 'jp.co.cyphertec.acwd'
 end

--- a/Casks/dmmbookviewer.rb
+++ b/Casks/dmmbookviewer.rb
@@ -16,5 +16,9 @@ cask 'dmmbookviewer' do
                        'jp.co.cyphertec.installer.info.CypherGuardAC',
                        'jp.co.cyphertec.installer.kext.nosigned',
                        'jp.co.cyphertec.installer.kext.signed',
+                     ],
+            kext:    [
+                       'jp.co.cyphertec.CypherGuardKa',
+                       'jp.co.cyphertec.CypherGuardAT',
                      ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.