### PR TITLE
Update electorrent to 2.2.0

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.1.11'
-  sha256 'aa9d08dbfcb0ad0db13c7bc48f6edfc22b7d4ee38fa58e797fe0a9596ffdb8b7'
+  version '2.2.0'
+  sha256 'ab3ededadb0e183f68113505cd9b7f5cbe41d57d9834443314bdbde8e31ea73a'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '29d34fd944b71d90ac251f0ee91a1b094ea298a6b1db415bbbbdb3ca106e067d'
+          checkpoint: '9476e8803104ab062eb356ffe70ae4dcb1a2bff9c8857c419e406fd5b07446dd'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.