### PR TITLE
Update envkey to 1.2.8

### DIFF
--- a/Casks/envkey.rb
+++ b/Casks/envkey.rb
@@ -1,11 +1,11 @@
 cask 'envkey' do
-  version '1.2.7'
-  sha256 'b11fc60d19e94f1eb282fce2a2a9d1dc695e7a451492b236c7dfcfb4221c0aeb'
+  version '1.2.8'
+  sha256 'c26d55b27781060b910a124821d6d3662c448b9b2d52817e4ca02698bd8798ff'
 
   # github.com/envkey/envkey-app was verified as official when first introduced to the cask
   url "https://github.com/envkey/envkey-app/releases/download/darwin-x64-prod-v#{version}/EnvKey-#{version}-mac.zip"
   appcast 'https://github.com/envkey/envkey-app/releases.atom',
-          checkpoint: '8c2acb6120135929b5af0464ed8a2301bc83c96cef20e8d19f83f159adfec131'
+          checkpoint: 'b62623b612b51255b2456ae63579190029fb94cee1ca056dbe0c78d84c645ecf'
   name 'EnvKey'
   homepage 'https://www.envkey.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.