### PR TITLE
Update hedgewars to 0.9.23

### DIFF
--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -1,6 +1,6 @@
 cask 'hedgewars' do
-  version '0.9.22'
-  sha256 'adc0b6dd3b47de115e85db1cb72841836444c0ebc77caee8139bfd6561e28fe8'
+  version '0.9.23'
+  sha256 '2a5fbfa005ec6aeea172270397025c17a2c117224dd21db5214b8cbbeade411b'
 
   url "http://www.hedgewars.org/download/releases/Hedgewars-#{version}.dmg"
   appcast 'https://www.hedgewars.org/download/appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.