### PR TITLE
Update indi-server to 2.6.0

### DIFF
--- a/Casks/indi-server.rb
+++ b/Casks/indi-server.rb
@@ -1,6 +1,6 @@
 cask 'indi-server' do
-  version '2.4.1'
-  sha256 'a7c1a0eb9701afcbe694bd0467385b890e3d5efc5d615351a2d89ad2692957ae'
+  version '2.6.0'
+  sha256 '6ccfba73c89ad4dbc46e20496015a5e481c4e0d03f2eae2f2ceb849734530b79'
 
   url "http://download.cloudmakers.eu/INDI_Server_#{version}.dmg"
   name 'INDI Server'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.