### PR TITLE
Update iota-wallet to 2.5.7

### DIFF
--- a/Casks/iota-wallet.rb
+++ b/Casks/iota-wallet.rb
@@ -1,11 +1,11 @@
 cask 'iota-wallet' do
-  version '2.5.6'
-  sha256 '78aadca2d4f9127e7f7a1ff2611e75cd7dfa127dc65d852fc453651344b4a4af'
+  version '2.5.7'
+  sha256 'dfb4219c68e97a0056df6a59c5ba98684086c4f5347357c14143842eb33ecea9'
 
   # github.com/iotaledger/wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/wallet/releases/download/v#{version}/IOTA.Wallet-#{version}.dmg"
   appcast 'https://github.com/iotaledger/wallet/releases.atom',
-          checkpoint: '3c2fd80c80721898f551cb0950b8f33d83ed9e12b5626bd79892e9fbc1733c76'
+          checkpoint: '401d14351e8a5f8c5cf47b844c32ace43b02dfb69cc353294b9951f2a70cf02c'
   name 'IOTA Wallet'
   homepage 'https://iota.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.