### PR TITLE
Update cityofzion-neon to 0.1.2

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,10 +1,10 @@
 cask 'cityofzion-neon' do
-  version '0.1.1'
-  sha256 '814200bfe0523a387f89a71b27716b4f023359ff61053d824d46ba234919e036'
+  version '0.1.2'
+  sha256 'd21f571a42c6f25df422507108a5d3433ecb0b1d7e5da9f65e1e4cf7ab5a090d'
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: '3fabfe5bd66c8b4a81930f6a37fd2f5cc436f1482786e93371ad8981e175ed9b'
+          checkpoint: 'f96d396012c6f25e2c2d1fed3e78b09ad9404afc34b998a8dd33980f576cb162'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.