### PR TITLE
Update astro to 3.0.2,3706

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '3.0.1,3698'
-  sha256 'd2b81e8f7d5248f836cc69bbdcba20eac20b21171ed88591c3e7ead42e6e8feb'
+  version '3.0.2,3706'
+  sha256 '52790a06ad13510365fc199b797558d1325d4071eff6557ad9564615047bf199'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: '9a14a28b34f42f5acede2cb256df75c1843e64e86d1cb02ea80b3937fd84920d'
+          checkpoint: '9f0a903a00e9e4c7e7c336ec5adc6ed1e53d3b251a534d704a58dcabd154df3b'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.