### PR TITLE
Update signal to 1.3.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.2.0'
-  sha256 '3cb3170e690c7686cae0574c5e435df6845b8049abf377d61aff4ad5f5724207'
+  version '1.3.0'
+  sha256 '16464c0a3fa6f1cbf13f5163bb1cce5a413374056f84e8b3466bdcd5afbc1261'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
-  appcast 'https://github.com/WhisperSystems/Signal-Desktop/releases.atom',
-          checkpoint: '41ae9ec6e0b6287bd5aa32e274f515daf9bf847dc599f8ce80224837d4e83374'
+  appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom',
+          checkpoint: '0750ef434cd950cef8f1a36dbaa9ccec337c901ebaec22eb79e7ef2642d47049'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.