### PR TITLE
Update kitty to 0.7.1

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,10 +1,10 @@
 cask 'kitty' do
-  version '0.7.0'
-  sha256 '9e1176ffcced51ea5e631af64c8205f86243562c76943b35008d5880d808c52f'
+  version '0.7.1'
+  sha256 'db84d8bcc09c89bcf889caecef313c5034e0945fd2abe1fc50449b6b605694bb'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom',
-          checkpoint: 'bc2298eebb5cac180a54d6386f0f22f0dbe1fe6480a97b889146a81b64e5a7e7'
+          checkpoint: '211e54fdd1e18f33049d9e0ac4a2f4cc95765d393764025e5d1e26418badd784'
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.