### PR TITLE
Update tankix to 12453

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '12339'
-  sha256 '21d23bbae8257936c91de808543c7947391615cc7adfb5a7d559273480f163a6'
+  version '12453'
+  sha256 'fc1098545816ca1ea80e810e41c5dd8836f25b8faa57a224e280153d340f6c73'
 
   url "https://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.