### PR TITLE
Update iffmpeg to 6.7.0

### DIFF
--- a/Casks/iffmpeg.rb
+++ b/Casks/iffmpeg.rb
@@ -1,10 +1,10 @@
 cask 'iffmpeg' do
-  version '6.5'
-  sha256 'a00f27f78249435a059fffd9ec2568489365de893222b704b051059d3cbad36c'
+  version '6.7.0'
+  sha256 '9de2dd1d0b06f6f93b14c6c6d8cd1153465bad8d5da9d887520bdfab0c6b2a24'
 
-  url 'http://www.iffmpeg.com/iFFmpeg.dmg'
+  url "http://www.iffmpeg.com/iFFmpeg#{version.no_dots}.dmg"
   appcast 'http://www.iffmpeg.com/download.html',
-          checkpoint: '6dacd24364098f3c2baa90056c07c3abf676f1210aee66dbcd032138931c64a8'
+          checkpoint: '2f030e6e89b2aead00fc2c20cc82334d9785baeb32e78b794db684c61b7af258'
   name 'iFFmpeg'
   homepage 'http://www.iffmpeg.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.