### PR TITLE
Update feeder to 3.5.8

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.5.7'
-  sha256 'ce0ff58e504854314fddefffefa571fb3ca3be346ca0e4a8a69752ff6d49311d'
+  version '3.5.8'
+  sha256 '1f6cdd8bff9b5863c85b8e3566b29e0f579dd595b69ea0b2be29e082cf206099'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: '4ff6f7fa424ddfcaf2aed5311ae298835917545a2276d59acd63fdf39f8f8812'
+          checkpoint: '072f99047e4f177e6b9f2c5e838ad828f6fe5c5d8f60f2331b628472eba5edf1'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.