### PR TITLE
Update iris to 0.9.3.4

### DIFF
--- a/Casks/iris.rb
+++ b/Casks/iris.rb
@@ -1,6 +1,6 @@
 cask 'iris' do
-  version '0.9.2.5'
-  sha256 '4c93b0c9391302470ad53940cec32f7ce6f9f67b74aadec498c6368e344f44c3'
+  version '0.9.3.4'
+  sha256 'd223992e2726106ff27329d7a5dc63f4b7c6e115fe0b9c96dbe95ae5926c0c4e'
 
   # raw.github.com/danielng01/Iris-Builds/master/OSX was verified as official when first introduced to the cask
   url "https://raw.github.com/danielng01/Iris-Builds/master/OSX/Iris-#{version}-OSX.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.