### PR TITLE
Update lilypond to 2.18.2-1

### DIFF
--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -2,10 +2,9 @@ cask 'lilypond' do
   version '2.18.2-1'
   sha256 '0009bf234db6a598e30940ae9a5cef50ffe939992c9bf0c7959ecd9c0d179c80'
 
-  # linuxaudio.org/lilypond was verified as official when first introduced to the cask
-  url "https://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
+  url "http://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   appcast 'http://lilypond.org/macos-x.html',
-          checkpoint: '1b49752034aa258d4ff5dedbb2c09d73910d1dfe004b30801664e3e7f5b95871'
+          checkpoint: '0cfcdd3d1b94d208b7f2de42f949ef2e70452fbcf4c1e502582542f7fca47544'
   name 'LilyPond'
   homepage 'http://lilypond.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.