### PR TITLE
java 9.0.4 link MacOS

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -57,6 +57,7 @@ cask 'java' do
                          "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
                          '/Library/PreferencePanes/JavaControlPanel.prefPane',
                          '/Library/Java/Home',
+                         '/Library/Java/MacOS',
                        ]
 
   zap trash: [

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -29,6 +29,9 @@ cask 'java' do
     system_command '/bin/ln',
                    args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
                    sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/MacOS", '/Library/Java/MacOS'],
+                   sudo: true
     system_command '/bin/mkdir',
                    args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
                    sudo: true


### PR DESCRIPTION
Adds MacOS link to /Library/Java

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
