### PR TITLE
Fix CI `<<-EOS deprecated` for java Cask

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -10,10 +10,9 @@
 
 header 'Running script.sh...'
 
-# fix `Calling <<-EOS.undent is deprecated` for `java`
-# can be removed for `java` > 9.0.1 and/or `java8` > 1.8.0_152
-# this was added when `java` == 1.8.0_112
-run /bin/rm -rf "$(brew --prefix)"/Caskroom/java/.metadata
+run brew pull https://github.com/Homebrew/brew/pull/3801
+
+run brew cask reinstall java
 
 apps () { /usr/bin/find /Applications -type d -name '*.app' -maxdepth 2 ; }
 kexts () { "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_loaded_kext_ids" ; }

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -10,6 +10,11 @@
 
 header 'Running script.sh...'
 
+# fix `Calling <<-EOS.undent is deprecated` for `java`
+# can be removed for `java` > 9.0.1 and/or `java8` > 1.8.0_152
+# this was added when `java` == 1.8.0_112
+run /bin/rm -rf "$(brew --prefix)"/Caskroom/java/.metadata
+
 apps () { /usr/bin/find /Applications -type d -name '*.app' -maxdepth 2 ; }
 kexts () { "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_loaded_kext_ids" ; }
 launchjob_install () { "$(brew --repository)/Library/Taps/caskroom/homebrew-cask/developer/bin/list_installed_launchjob_ids" ; }


### PR DESCRIPTION
`java` is the only Cask installed on the CI image with `<<-EOS.undent`

```
>>> brew cask reinstall --verbose Casks/java.rb
==> Caveats
This Cask makes minor modifications to the JRE to prevent issues with
packaged applications, as discussed here:
  https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
If your Java application still asks for JRE installation, you might need
to reboot or logout/login.
Installing this Cask means you have AGREED to the Oracle Binary Code
License Agreement for Java SE at
  https://www.oracle.com/technetwork/java/javase/terms/license/index.html
==> Satisfying dependencies
==> Downloading http://download.oracle.com/otn-pub/java/jdk/9.0.4+11/c2514751926b4512b076cc82f959763f/jdk-9.0.4_osx-x64_bin.dmg
/usr/bin/curl --show-error --user-agent Homebrew/1.5.2-37-g701ecb4 (Macintosh; Intel Mac OS X 10.12.6) curl/7.54.0 --fail --silent --location --remote-time --continue-at - --output /Users/travis/Library/Caches/Homebrew/Cask/java--9.0.4,11:c2514751926b4512b076cc82f959763f.dmg.incomplete http://download.oracle.com/otn-pub/java/jdk/9.0.4+11/c2514751926b4512b076cc82f959763f/jdk-9.0.4_osx-x64_bin.dmg -b oraclelicense=accept-securebackup-cookie
==> Verifying checksum for Cask java
Error: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:104:in `block in load'
```