### PR TITLE
Update eclipse-ide to 4.7.2,oxygen:2

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.7.1,oxygen:1a'
-  sha256 '7beeec0531181da673086568cfe14151ac8b96e76b0bfeaf3880d7ca495b9068'
+  version '4.7.2,oxygen:2'
+  sha256 '8657a0a8bda888bd9287e92d26f3744bf2f9a2d0a95265a260d92f09372d3f6c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.