### PR TITLE
Update alva to 0.6.1

### DIFF
--- a/Casks/alva.rb
+++ b/Casks/alva.rb
@@ -1,11 +1,11 @@
 cask 'alva' do
-  version '0.6.0'
-  sha256 'bd34da0102a993bb3340634a98341fdfb672a73adc6478b3297161b1db3f80b3'
+  version '0.6.1'
+  sha256 'c9f17817e3d9b3d62086cd36bd85f4c26c82f2126e7f7aef4612f1ac8495c621'
 
   # github.com/meetalva/alva was verified as official when first introduced to the cask
   url "https://github.com/meetalva/alva/releases/download/v#{version}/Alva-#{version}-mac.zip"
   appcast 'https://github.com/meetalva/alva/releases.atom',
-          checkpoint: 'b3a090d3729da0a8c705b218b1fb66a4204c4afecee300389930b464da96d8e9'
+          checkpoint: '6c3ff696b3084d5499e2e512bd050e2a1d42285b9cf3191b3f15dc31bef82c0f'
   name 'Alva'
   homepage 'https://meetalva.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.