### PR TITLE
Update graphql-playground to 1.4.3

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.4.2'
-  sha256 'ef655ed4771a10092fd02240fc3b7230bd4bcde518401029c9dab03e366ce7dc'
+  version '1.4.3'
+  sha256 '8b4ad069dfe763003db51742b74a46aeb40ae74b6496bad5dc47088f7b546e59'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: 'bc0d773a1ed173c6b7fc892be16348c77991e5fa90baf0a4f1148e96fad85848'
+          checkpoint: '890a86b8a84aef86d5d87a0c4e7f863e701580834c5d689510930c1c8c35e793'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.