### PR TITLE
Update hands-off to 3.2.6

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,10 +1,10 @@
 cask 'hands-off' do
-  version '3.2.5'
-  sha256 'a7395508749c7decc40d98e0b435233128f79970d31841c0973ed65669cc0455'
+  version '3.2.6'
+  sha256 '5d87db60eb69e7d4ff23de60a785607775c0a7b355bda322f9dfac3369993ad2'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml",
-          checkpoint: 'ed3c97f0c4529e8747df3bf881c9245d2fbb3076abda9c530c022585386c564d'
+          checkpoint: '724cd6190abb2f91affac55868725810b2e29bb4751e3b91d2cb5bab18e9b476'
   name 'Hands Off!'
   homepage 'https://www.oneperiodic.com/products/handsoff/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.