### PR TITLE
Update inboxer to 1.0.2

### DIFF
--- a/Casks/inboxer.rb
+++ b/Casks/inboxer.rb
@@ -1,11 +1,11 @@
 cask 'inboxer' do
-  version '1.0.1'
-  sha256 '9cd1ca70a0c4748a70510f7669682d109deec2801ff9bf131c86d2cdcd07c70e'
+  version '1.0.2'
+  sha256 'd60a7f25209602041cfb6e66c09c839a7068894daab7edc6205dbd10847c57bd'
 
   # github.com/denysdovhan/inboxer was verified as official when first introduced to the cask
   url "https://github.com/denysdovhan/inboxer/releases/download/v#{version}/inboxer-#{version}-mac.zip"
   appcast 'https://github.com/denysdovhan/inboxer/releases.atom',
-          checkpoint: 'ddc3401c7075c5402b246601ea40cc96f83a5655068bb2b55bba59277d0a8f85'
+          checkpoint: '2c7ba053eab9a808222369960b35deac26569c4f38f2933f9b13a87fd35b6f7f'
   name 'inboxer'
   homepage 'https://denysdovhan.com/inboxer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.