### PR TITLE
Update irccloud to 0.6.0

### DIFF
--- a/Casks/irccloud.rb
+++ b/Casks/irccloud.rb
@@ -1,10 +1,10 @@
 cask 'irccloud' do
-  version '0.4.0'
-  sha256 '2b2fd80b8b982e158f6050f74ca81cb6fe9321d178f903589ea5adb5394d0cd6'
+  version '0.6.0'
+  sha256 'f3d791032171fed6cca9d95878514b6c315a0ec13f7c7482d1b7e6b43d818440'
 
   url "https://github.com/irccloud/irccloud-desktop/releases/download/v#{version}/IRCCloud-#{version}.dmg"
   appcast 'https://github.com/irccloud/irccloud-desktop/releases.atom',
-          checkpoint: '9b910adc87328ee270f764581af8db7e7699aa4001c39398dc03ea343002fc87'
+          checkpoint: '7d71a18d23d43899cfdb9d92695a35a387ae94b3d4e040db9972139023e78fb4'
   name 'IRCCloud Desktop'
   homepage 'https://github.com/irccloud/irccloud-desktop'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.