### PR TITLE
Update jaxx to 1.3.11

### DIFF
--- a/Casks/jaxx.rb
+++ b/Casks/jaxx.rb
@@ -1,11 +1,11 @@
 cask 'jaxx' do
-  version '1.3.9'
-  sha256 '0e1756d95c68e7d44e4faeba916ba27608584692dd2f67f89aa19d73c5109e05'
+  version '1.3.11'
+  sha256 'f0d3657c7de3217c2db57eafd370d7df80f367dfd33a47570c15da96eea2e799'
 
   # github.com/Jaxx-io/Jaxx was verified as official when first introduced to the cask
   url "https://github.com/Jaxx-io/Jaxx/releases/download/v#{version}/Jaxx-#{version}.dmg"
   appcast 'https://github.com/Jaxx-io/Jaxx/releases.atom',
-          checkpoint: '2670f07ef7e62cf6752333fbcef16a6be192ff340099eb64a071582fe86470b4'
+          checkpoint: 'b3a999f051714320af674e6175c18ee283be63ec917e6424579729e4cd68e338'
   name 'Jaxx Blockchain Wallet'
   homepage 'https://jaxx.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.