### PR TITLE
Update kotori to 0.25

### DIFF
--- a/Casks/kotori.rb
+++ b/Casks/kotori.rb
@@ -1,10 +1,10 @@
 cask 'kotori' do
-  version '0.24'
-  sha256 '02b2cf71d5ff4138a768781c920232ab905d852e20b3db0e178c3d611f640636'
+  version '0.25'
+  sha256 'd834a47b864cda419f9f778a40c82c3c7a01cc0d802999f0ec5de614229b81f7'
 
   url "https://github.com/Watson1978/kotori/releases/download/v#{version}/kotori_#{version}.dmg"
   appcast 'https://github.com/Watson1978/kotori/releases.atom',
-          checkpoint: '32edd1fe702bc3121a92ce4cdad6152e25c4064e9494d9eeb47a89450e9f2cad'
+          checkpoint: 'dae5e202bd585b6e90060a3ba8e03bacca2345f489ea14854f35044b977230a9'
   name 'kotori'
   name '小鳥'
   homepage 'https://github.com/Watson1978/kotori'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.