### PR TITLE
Update lab to 0.0.73

### DIFF
--- a/Casks/lab.rb
+++ b/Casks/lab.rb
@@ -1,11 +1,11 @@
 cask 'lab' do
-  version '0.0.71'
-  sha256 'ab6f4a61560c193d65edf6df19f99d7209dbd78c3857ffcf06557620738862cd'
+  version '0.0.73'
+  sha256 '0c9e35fbca8b43bfe5287e772ccff8627e18112a85f93de720e51914c08f8fb6'
 
   # github.com/c8r/lab was verified as official when first introduced to the cask
   url "https://github.com/c8r/lab/releases/download/v#{version}/Lab-#{version}-mac.zip"
   appcast 'https://github.com/c8r/lab/releases.atom',
-          checkpoint: '83127ae76c94af2569b140b28c51fbd90fcca6b5f63aefb705bdbfa1db911b4d'
+          checkpoint: 'a3e6ae0ac48a5bbe0fe09eb5feae00298b0083cdc1ea06ffe4c638040141fc67'
   name 'Lab'
   homepage 'https://compositor.io/lab/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.