### PR TITLE
Update macwinzipper to 2.5.3

### DIFF
--- a/Casks/macwinzipper.rb
+++ b/Casks/macwinzipper.rb
@@ -1,6 +1,6 @@
 cask 'macwinzipper' do
-  version '2.5.2'
-  sha256 'a0aa57ae29772df78a698eab8c2ac723877c0a34bee2e477e6ceb6c2b4f4b86f'
+  version '2.5.3'
+  sha256 'f9ac05daef780f8b79557af2a77600a17c97951051a43cf8c93860afd7855818'
 
   url "http://tidajapan.com/files/MacWinZipper-#{version}.dmg?download"
   name 'MacWinZipper'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.