### PR TITLE
Update mal-updater to 2.3.12

### DIFF
--- a/Casks/mal-updater.rb
+++ b/Casks/mal-updater.rb
@@ -1,11 +1,11 @@
 cask 'mal-updater' do
-  version '2.3.8'
-  sha256 '325914225fa4daea7a6c26a6f98c46ced9f4f1d32d537969f530747f40447a97'
+  version '2.3.12'
+  sha256 '1c6ffc428bfa94212f720a9fc5e7c7043e540792a3902e5454529820ee1ebba1'
 
   # github.com/Atelier-Shiori/malupdaterosx-cocoa was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases/download/#{version}/malupdaterosx-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases.atom',
-          checkpoint: '23d50521982c7bd3e58d3d205bc0eb24d3f650f1a9b0857b5ee96bcae5d06110'
+          checkpoint: '3106d18f413b26335ffad55779c7dfd608ef8df3621c57b78fb734a2b3f6418c'
   name 'MAL Updater OS X'
   homepage 'https://malupdaterosx.ateliershiori.moe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.