### PR TITLE
Update noejectdelay to 7.1.4

### DIFF
--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -8,13 +8,14 @@ cask 'noejectdelay' do
   name 'NoEjectDelay'
   homepage 'https://pqrs.org/osx/karabiner/noejectdelay.html'
 
-  pkg 'NoEjectDelay.sparkle_guided.pkg'
-
   depends_on macos: '<= :el_capitan'
-  caveats do
-    discontinued
-  end
+
+  pkg 'NoEjectDelay.sparkle_guided.pkg'
 
   uninstall kext:    'org.pqrs.driver.NoEjectDelay',
             pkgutil: 'org.pqrs.driver.NoEjectDelay'
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -1,14 +1,19 @@
 cask 'noejectdelay' do
-  version '7.1.4'
-  sha256 '6a263c59efaaffb200db7d9ee6fe817f414e148053e610ccdcf37186fed27cc0'
+  version '7.1.0'
+  sha256 'cfaeed50aa7ed9eac04716ab0e34c5ef10658802e691732f7589f9454e96aa94'
 
   url "https://pqrs.org/osx/karabiner/files/NoEjectDelay-#{version}.dmg"
   appcast 'https://github.com/tekezo/NoEjectDelay/releases.atom',
           checkpoint: '8cf6b036077bd9db8bd105ec548f60866403c2986e760dcc6d0c8b5b99916710'
   name 'NoEjectDelay'
-  homepage 'https://pqrs.org/osx/karabiner/noejectdelay.html.en'
+  homepage 'https://pqrs.org/osx/karabiner/noejectdelay.html'
 
   pkg 'NoEjectDelay.sparkle_guided.pkg'
+
+  depends_on macos: '<= :el_capitan'
+  caveats do
+    discontinued
+  end
 
   uninstall kext:    'org.pqrs.driver.NoEjectDelay',
             pkgutil: 'org.pqrs.driver.NoEjectDelay'

--- a/Casks/noejectdelay.rb
+++ b/Casks/noejectdelay.rb
@@ -1,10 +1,10 @@
 cask 'noejectdelay' do
-  version '7.1.0'
-  sha256 'cfaeed50aa7ed9eac04716ab0e34c5ef10658802e691732f7589f9454e96aa94'
+  version '7.1.4'
+  sha256 '6a263c59efaaffb200db7d9ee6fe817f414e148053e610ccdcf37186fed27cc0'
 
   url "https://pqrs.org/osx/karabiner/files/NoEjectDelay-#{version}.dmg"
   appcast 'https://github.com/tekezo/NoEjectDelay/releases.atom',
-          checkpoint: '4475b83ad5927875fbc16e19c890dbaba1e466a758afcc0351ec86bb0e00468d'
+          checkpoint: '8cf6b036077bd9db8bd105ec548f60866403c2986e760dcc6d0c8b5b99916710'
   name 'NoEjectDelay'
   homepage 'https://pqrs.org/osx/karabiner/noejectdelay.html.en'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.