### PR TITLE
Update brackets to 1.11

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,11 +1,11 @@
 cask 'brackets' do
-  version '1.12'
-  sha256 'a084a21754c5fa45d47e177be4d9820996098ac7b20a1ba8fb45a8799355d7d4'
+  version '1.11'
+  sha256 '67a4a1d3eb394c838f14d65348858649927cc8811f1db275f2160fc514e614c3'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
   appcast 'https://github.com/adobe/brackets/releases.atom',
-          checkpoint: '000e74860d02ed23d5ae0466e84567e48be2bf6ba0b12190d6b0210a6cb05b12'
+          checkpoint: '95a55c07f04ad09125640a48c75833498aafb719fb61d001bd10530a9fc8ed80'
   name 'Brackets'
   homepage 'http://brackets.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #43473.