### PR TITLE
Update okapi to 0.35

### DIFF
--- a/Casks/okapi.rb
+++ b/Casks/okapi.rb
@@ -1,6 +1,6 @@
 cask 'okapi' do
-  version '0.32'
-  sha256 '5d63f1ef997b05b4faa896a10a2d35ae4998648fada60230e65757a240c62c5c'
+  version '0.35'
+  sha256 '94033a291df167172271aab8004974dfd84feb2c9023c0213056c0fe58124250'
 
   # bintray.com/okapi was verified as official when first introduced to the cask
   url "http://dl.bintray.com/okapi/Distribution/okapi-apps_cocoa-macosx-x86_64_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.