### PR TITLE
Update overture to 2.5.6

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.5.4'
-  sha256 '8dc6b714ce3bc811e5f3c83bf689b164f7101956cf5a6a3615b4b1e87d94a8ef'
+  version '2.5.6'
+  sha256 '3e4b992fc52b5e0aee5e5cddb2c6d562b51161bd8f49e2c082e4f3e261f76971'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: '45f8c70a788dd81c8c1938af50bca548c6b2f9c4f1d9af4358b0108e11820077'
+          checkpoint: 'af3f9817a721c2ad81fd5d776dd891c5cda37e5b7b96a886213e7b068cca1161'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.