### PR TITLE
Update pgweb to 0.9.11

### DIFF
--- a/Casks/pgweb.rb
+++ b/Casks/pgweb.rb
@@ -1,10 +1,10 @@
 cask 'pgweb' do
-  version '0.9.10'
-  sha256 '223800dbee563c1ff7848b837057c0035bd9af62d90afc2858177c2406b5f4f9'
+  version '0.9.11'
+  sha256 '13b6b2e91959f4b2e3389864b8afd2447ec69ba9b13d763468e3bfc9aaa7b023'
 
   url "https://github.com/sosedoff/pgweb/releases/download/v#{version}/pgweb_darwin_amd64.zip"
   appcast 'https://github.com/sosedoff/pgweb/releases.atom',
-          checkpoint: '3b6c5fcd579c27bc5cfd4ade4f90a87da82728ae3d2f8965eefd016872c347c8'
+          checkpoint: 'da379eb2ed5806d88b17a91f8b201b03716e37cc91ca6625d09d499daba9853b'
   name 'pgweb'
   homepage 'https://github.com/sosedoff/pgweb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.