### PR TITLE
Update pretzel to 0.0.18

### DIFF
--- a/Casks/pretzel.rb
+++ b/Casks/pretzel.rb
@@ -1,10 +1,10 @@
 cask 'pretzel' do
-  version '0.0.15'
-  sha256 '8cda79066234d2d4fc8c0a3078b72c6d61e433e706e3eb15452dba0b1b7bdce5'
+  version '0.0.18'
+  sha256 'fe5d9bc77531b56f0b7a072fde26ba5788a4a5ab85c41c2f5242d306067f18d1'
 
   url "https://download.pretzel.rocks/Pretzel-#{version}-mac.zip"
   appcast 'https://download.pretzel.rocks/latest-mac.json',
-          checkpoint: '9f748cc1233eceec6f7ab0d715ac0c8f04ffb2aca3a8081a0050114af3f77711'
+          checkpoint: '9fe404e57f4f357d8d68bf892ca47ca335f4e6fddbdc844d6bd5f9da70e8d5cf'
   name 'Pretzel'
   homepage 'https://www.pretzel.rocks/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.