### PR TITLE
Update protonmail-unofficial to 0.5.8

### DIFF
--- a/Casks/protonmail-unofficial.rb
+++ b/Casks/protonmail-unofficial.rb
@@ -1,10 +1,10 @@
 cask 'protonmail-unofficial' do
-  version '0.5.2'
-  sha256 '68049f1870461b0ad9df5840284837ce110afd094e943e76ac0bfbffaf267903'
+  version '0.5.8'
+  sha256 'e9a9583e629ca5762281f422ad7bebc2f7569de25e31eec69fe896af8e502023'
 
   url "https://github.com/protonmail-desktop/application/releases/download/v#{version}/protonmail-desktop-#{version}.dmg"
   appcast 'https://github.com/protonmail-desktop/application/releases.atom',
-          checkpoint: '35075ef1c1e48b4dab2188a1d01b9bf2da8a99d06b1fe79d31a02246b7a32abe'
+          checkpoint: 'a587fdec24fc068aa31d9852c4f6c9670e87c16486ea80b37003c82004ed9f62'
   name 'Protonmail Desktop'
   homepage 'https://github.com/protonmail-desktop/application'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.