### PR TITLE
Update quodlibet to 4.0.2

### DIFF
--- a/Casks/quodlibet.rb
+++ b/Casks/quodlibet.rb
@@ -1,11 +1,11 @@
 cask 'quodlibet' do
-  version '3.9.1'
-  sha256 '3f26a9ddd7659a3b29f9e04f522122ad077e900b2e30591404a649527254fbf4'
+  version '4.0.2'
+  sha256 '6f9a98926e7e62cb26a34b41689616d60f709877fe20984af018843e76274060'
 
   # github.com/quodlibet/quodlibet was verified as official when first introduced to the cask
   url "https://github.com/quodlibet/quodlibet/releases/download/release-#{version}/QuodLibet-#{version}.dmg"
   appcast 'https://github.com/quodlibet/quodlibet/releases.atom',
-          checkpoint: '07c8c61a85c2371138c696b28aa175857d84645a59d2a2d99dc9a73341d141ed'
+          checkpoint: 'dc693ef4c5916de3d359d5503dbb41daecd2c1c586931b5cfde48c80da3dd7bd'
   name 'Quod Libet'
   homepage 'https://quodlibet.readthedocs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.