### PR TITLE
Update qutebrowser to 1.1.1

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,11 +1,11 @@
 cask 'qutebrowser' do
-  version '1.1.0'
-  sha256 '35a60f169b2d9da7dd047a275d092ace143a5e9f6580ec84bbff7be8340deb7e'
+  version '1.1.1'
+  sha256 'd1f9aa22f9c4e83e93839124be85224a13e940724def49441236e73c7c148371'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
-          checkpoint: '7a527d1e8f8121d19243d14fe34b3fe444a2c9b31f30e74111b6b1ed9d79a092'
+          checkpoint: '9238b54864d15db556421bedffd30726bc9e707ddaaa20a8fd6bded838aa03ff'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.