### PR TITLE
Update rubitrack-pro to 4.4.6

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '4.4.5'
-  sha256 'eb29912f3511fad5175446395e84e8f15c5e9d13c3d1d04ba78cbb9617d1d6e0'
+  version '4.4.6'
+  sha256 'bdca80859c57e9dcaf5b6ddf685e729388e23d4be0ef3726ba14ca587fa3ce20'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}_u.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: 'ae47d04bcfdeaa6281c683e5f6c633c0b08dbc51552c90a0e583137c38963e0b'
+          checkpoint: 'd9d4344855a45bebdc12d4b5f283852bf62bbee40b2ea552901783f81517af97'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.