### PR TITLE
Update simply-fortran to 2.41

### DIFF
--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -1,6 +1,6 @@
 cask 'simply-fortran' do
-  version '2.40'
-  sha256 '438be530ed56888c09ceee1f76f93124bf98fec8d0355766943eaf35d0a23523'
+  version '2.41'
+  sha256 '355340df3167b993807f90c8c3d51cec7eb1e246cadfe7377585fc3ab2c308a2'
 
   # download.approximatrix.com/simplyfortran was verified as official when first introduced to the cask
   url "http://download.approximatrix.com/simplyfortran/#{version}/SimplyFortran-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.