### PR TITLE
Update snapndrag to 4.2.7

### DIFF
--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -1,10 +1,10 @@
 cask 'snapndrag' do
-  version '4.2.6'
-  sha256 'd91037d537cef7148427b814f1114a9a2e19ac110d2330e3c31ee542fc5b963c'
+  version '4.2.7'
+  sha256 'e53d5a3f596fea2c46eca52cee7f54e40ccb2cbb417ed26cc1e159fde08dac7f'
 
   url "http://yellowmug.com/download/SnapNDrag_#{version}.dmg"
   appcast 'http://yellowmug.com/snapndrag/appcast-1012.xml',
-          checkpoint: '4a3e65ba7e4792b95d9adbbdcc5f40b9c91fe8dbf85983b9a69efc66af1b4cf4'
+          checkpoint: 'd5b63cfb058ed514c2579b6376a6cb3aa04c1ba05a48292c66e8556d4e19a53f'
   name 'SnapNDrag'
   homepage 'http://www.yellowmug.com/snapndrag/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.