### PR TITLE
Update soundcleod to 1.3.2

### DIFF
--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -1,11 +1,11 @@
 cask 'soundcleod' do
-  version '1.3.0'
-  sha256 '15215156a85848b23034857d64768a94a1f7a866e5eca4dd0efc9ddaf2bb2ae6'
+  version '1.3.2'
+  sha256 '11933d97317184c87c822dbcbfc8dac76bc70fd7ee509907f83428e2199c516e'
 
   # github.com/salomvary/soundcleod was verified as official when first introduced to the cask
   url "https://github.com/salomvary/soundcleod/releases/download/v#{version}/SoundCleod-#{version}.dmg"
   appcast 'https://github.com/salomvary/soundcleod/releases.atom',
-          checkpoint: '776c533e7f56d078cd42c08cfe0d569c5ad4c7a9679c4afa4257879e51ec3430'
+          checkpoint: '43f512e286815d229501fa5905f2b105c3cb9738b26a6da6ccb4de2708fc6469'
   name 'SoundCleod'
   homepage 'https://soundcleod.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.