### PR TITLE
Update subsurface to 4.7.6

### DIFF
--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,6 +1,6 @@
 cask 'subsurface' do
-  version '4.7.4'
-  sha256 '44c2b7ef5c687b6da06f3a75a88752aed0b082f07f68a13a3d851b576e664474'
+  version '4.7.6'
+  sha256 '8d91405ccbe59387e13e4986d28801d3bc82097e3d6f52a680defc2e7c29ef5e'
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   name 'Subsurface'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.