### PR TITLE
Update textadept to 9.6

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,10 +1,10 @@
 cask 'textadept' do
-  version '9.4'
-  sha256 '187c4de715b355934bf4ac25a8076f428f6c13039ff93bc0c3651adcaf584e22'
+  version '9.6'
+  sha256 '0e4612263654b07cc8edb978f4fd9806b37b76c085f5d39a10312c7a60b9d207'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
   appcast 'https://foicica.com/textadept/feed',
-          checkpoint: 'feade9c945b551c4b5a2aa992c280c5e872d5e7e33f7e315953ec561c09d3205'
+          checkpoint: '78f04804812bfcbcd187db0addf01ff69b9330008def73f14891649efea63192'
   name 'Textadept'
   homepage 'https://foicica.com/textadept/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.