### PR TITLE
Update and rename tiddlywiki to tiddly 0.0.12

### DIFF
--- a/Casks/tiddly.rb
+++ b/Casks/tiddly.rb
@@ -1,4 +1,4 @@
-cask 'tiddlywiki' do
+cask 'tiddly' do
   version '0.0.12'
   sha256 'c75d8a68360ab10ebe15917eea3c570094f5adf23411435fd53190ab509785f5'
 
@@ -8,5 +8,5 @@ cask 'tiddlywiki' do
   name 'TiddlyWiki'
   homepage 'https://github.com/Jermolene/TiddlyDesktop'
 
-  app "TiddlyDesktop-mac64-v#{version}/TiddlyWiki.app"
+  app "TiddlyDesktop-mac64-v#{version}/TiddlyDesktop.app"
 end

--- a/Casks/tiddlywiki.rb
+++ b/Casks/tiddlywiki.rb
@@ -1,10 +1,10 @@
 cask 'tiddlywiki' do
-  version '0.0.9'
-  sha256 '85ca27b3819643f46c20fea16bcdc1c426bdf691fa124d49d96a71e76982b34c'
+  version '0.0.12'
+  sha256 'c75d8a68360ab10ebe15917eea3c570094f5adf23411435fd53190ab509785f5'
 
   url "https://github.com/Jermolene/TiddlyDesktop/releases/download/v#{version}/tiddlydesktop-mac64-v#{version}.zip"
   appcast 'https://github.com/Jermolene/TiddlyDesktop/releases.atom',
-          checkpoint: '2b31415d87ec8d870bf0fdf39f1b27f9f8b60e28eac39dd050175d7caa29cc4e'
+          checkpoint: '985ae77d9351beb2c4cb57eb8255fb08d166c170c09e03a2f01bab24e582da54'
   name 'TiddlyWiki'
   homepage 'https://github.com/Jermolene/TiddlyDesktop'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.