### PR TITLE
Update timely to 0.4.8

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,11 +1,11 @@
 cask 'timely' do
-  version '0.4.5'
-  sha256 '732ca8669ce3390d5b9404bfb3ce06b30e0a20ef0a60da081624d22a1955c341'
+  version '0.4.8'
+  sha256 '2184d8ed6e951e2cf1d5da22626740c8825d2bfea4fd9f7b83e771d219e86622'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/osx64-v#{version}/Timely-#{version}.dmg"
   appcast 'https://github.com/Timely/desktop-releases/releases.atom',
-          checkpoint: '10058dde6d53d6ab0fa626266ffbe9ee7ab53172ed41bde843d700ea9eb5a5d4'
+          checkpoint: 'aff78e8f2a95417fc33a88004d49b3dad213a2dfc72bdbe3e0d18177bc3fed6e'
   name 'Timely'
   homepage 'https://timelyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.