### PR TITLE
Update tla-plus-toolbox to 1.5.6

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,11 +1,11 @@
 cask 'tla-plus-toolbox' do
-  version '1.5.4'
-  sha256 '33b122e20b4b6474a2b4de6a8634ce5b090660f363bdde2e7990bd75f4366c63'
+  version '1.5.6'
+  sha256 'bd8419ceffd82a848ff28cad34c825720a677c58b9eae443d9e529727abbf4cf'
 
   # github.com/tlaplus/tlaplus/releases/download was verified as official when first introduced to the cask
   url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/tlaplus/tlaplus/releases.atom',
-          checkpoint: '189b5da1be2bfb55c188c83f42953aba71eb346895f09881ea93f35c02872065'
+          checkpoint: '85dc89cebceb8215158c150f9efefd15c9c4557f7f1164fc80435405b209c701'
   name 'TLA+ Toolbox'
   homepage 'https://lamport.azurewebsites.net/tla/toolbox.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.