### PR TITLE
Update track-o-bot to 0.9.0

### DIFF
--- a/Casks/track-o-bot.rb
+++ b/Casks/track-o-bot.rb
@@ -1,11 +1,11 @@
 cask 'track-o-bot' do
-  version '0.8.6'
-  sha256 '050ad7eda093d9eb3c44f9033291f0928512721162c8a2474b2fb55b52067eb2'
+  version '0.9.0'
+  sha256 'b1e7eeea98b869e1526ad2babcc01b818e177bbe129acb361029a5477c43b409'
 
   # github.com/stevschmid/track-o-bot was verified as official when first introduced to the cask
   url "https://github.com/stevschmid/track-o-bot/releases/download/#{version}/Track-o-Bot_#{version}.dmg"
   appcast 'https://github.com/stevschmid/track-o-bot/releases.atom',
-          checkpoint: '2d0e7b3d56f1ddf9ca07cea3a3ff473bc7a3cebf769c024dc7ad8df6ee79ed42'
+          checkpoint: '48df135240023aaf90a27ba89429853409947748019c9a42979242460ebf7473'
   name 'Track-o-Bot'
   homepage 'https://trackobot.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.