### PR TITLE
Update udeler to 1.3.2

### DIFF
--- a/Casks/udeler.rb
+++ b/Casks/udeler.rb
@@ -1,10 +1,10 @@
 cask 'udeler' do
-  version '1.2.0'
-  sha256 'eb7206a5877fa578622212a0ffd2f665855dbf15ae3e8d7634847218cafec382'
+  version '1.3.2'
+  sha256 '00ea11e1fd6604130762951b0d50960e870c0ebe002ce814ea3dfd083e8e677f'
 
   url "https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v#{version}/Udeler-#{version}-mac.zip"
   appcast 'https://github.com/FaisalUmair/udemy-downloader-gui/releases.atom',
-          checkpoint: 'a0b63a95453c3c1319eae5c3f7181ebf82598de3ae10a6543878061ac76fb5bd'
+          checkpoint: '5b74cac7bb5f8c984b8bc6a42ffacb5608521e224795e06b356f6405da186a03'
   name 'Udeler'
   homepage 'https://github.com/FaisalUmair/udemy-downloader-gui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.