### PR TITLE
Update webponize to 2.3.0

### DIFF
--- a/Casks/webponize.rb
+++ b/Casks/webponize.rb
@@ -1,11 +1,11 @@
 cask 'webponize' do
-  version '2.1.0'
-  sha256 'ce394e91d07f636571a2a21cf183993ad9170794877e6744148ff1faf0ded2b3'
+  version '2.3.0'
+  sha256 '490d39d212c71b077a9bc65cc0657bb9ba030ab7ed55f0b79fb6330dafdf24df'
 
   # github.com/webponize/webponize was verified as official when first introduced to the cask
   url "https://github.com/webponize/webponize/releases/download/v#{version}/WebPonize.app.zip"
   appcast 'https://github.com/webponize/webponize/releases.atom',
-          checkpoint: '23acecb403ea619bcce7df816eefe9dea35d543958e1b339cee2d3d3081a6ca8'
+          checkpoint: '139670e55ade776738ac9bfee428e6d8623ef83093311cfbcc86b0af61cc58f5'
   name 'WebPonize'
   homepage 'https://webponize.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.