### PR TITLE
Update webrecorder-player to 1.0.9

### DIFF
--- a/Casks/webrecorder-player.rb
+++ b/Casks/webrecorder-player.rb
@@ -1,10 +1,10 @@
 cask 'webrecorder-player' do
-  version '1.0.8'
-  sha256 '0bf5a72be2683995530b531114fc95338a798de4e49a9bebcfe839f2ea199ced'
+  version '1.0.9'
+  sha256 '4583299762d426eea22ef9b4c3a4985992e7da00cc39f5e6df64215b0d461c66'
 
   url "https://github.com/webrecorder/webrecorderplayer-electron/releases/download/v#{version}/webrecorderplayer-electron-osx-#{version}.dmg"
   appcast 'https://github.com/webrecorder/webrecorderplayer-electron/releases.atom',
-          checkpoint: 'c1090fe8bed42cd599b321694ccb14962a370b8c79caad18006ab722f14cc84e'
+          checkpoint: '070af3a0f8992330d3d311108754786c22480bc09f7cd02283bba6d338d9fc55'
   name 'Webrecorder Player'
   homepage 'https://github.com/webrecorder/webrecorderplayer-electron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.