### PR TITLE
Update workcraft to 3.1.8

### DIFF
--- a/Casks/workcraft.rb
+++ b/Casks/workcraft.rb
@@ -1,6 +1,6 @@
 cask 'workcraft' do
-  version '3.1.7'
-  sha256 'b87911235218a6f329e4487fc20aa22c7c07d19f37f53a442ed499452dc20fcc'
+  version '3.1.8'
+  sha256 'd3d23dcd66f6f2118b67a2a570dcd154eef2756613e0bf47f29aa84f990f8dd8'
 
   url "https://www.workcraft.org/_media/download/workcraft-v#{version}-osx.tar.gz"
   name 'Workcraft'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.