### PR TITLE
Add cask_pr_manual_check

### DIFF
--- a/developer/bin/cask_pr_manual_check
+++ b/developer/bin/cask_pr_manual_check
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+require 'open-uri'
+require 'json'
+require 'tmpdir'
+
+pr_url = ARGV[0]
+
+abort 'You need to give the script exactly one argument, the URL to a pull request on the Caskroom organisation' if ARGV[0].empty?
+abort 'URL is not from the Caskroom organization' if pr_url !~ %r{^https://github.com/caskroom/}
+
+pr_api = pr_url.sub(%r{^https://github.com/([^/]+)/([^/]+)/pull/([^/]+).*}, 'https://api.github.com/repos/\1/\2/pulls/\3/files')
+pr_json = JSON.parse(open(pr_api).read)
+
+abort 'PR needs to have a single file' if pr_json.count != 1
+
+file_raw_url = pr_json[0]['raw_url']
+file_name = File.basename(file_raw_url)
+local_file = "#{Dir.mktmpdir}/#{file_name}"
+IO.copy_stream(open(file_raw_url), local_file)
+
+system('brew', 'cask', 'audit', '--download', local_file)
+system('brew', 'cask', 'style', local_file)


### PR DESCRIPTION
I’ve built this quick script during the last time Travis had an issue and we accumulated a huge backlog. You call it with one argument, the link to a PR, and it’ll get the cask in the PR and verify it with `audit` and `style`.

It’s quick and dirty, but works. If I were to improve upon it, it would be to auto-merge (with [`climergebutton`](https://github.com/vitorgalvao/tiny-scripts/blob/master/climergebutton)) on success and post a “Verified locally.” message with [`ghi`](https://github.com/stephencelis/ghi).

The script may be useful to other maintainers when Travis craps itself again.