### PR TITLE
Update backuploupe to 2.13.2

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,10 +1,10 @@
 cask 'backuploupe' do
-  version '2.13.1'
-  sha256 'f36f95de4e96088e3d023329f9e8cd0ae24e694a748b4567309457e49d0df374'
+  version '2.13.2'
+  sha256 '9518ace482429faf51a72aaf6431b004153a02430c5098df1b2cdf29a3c54ed8'
 
   url "http://www.soma-zone.com/download/files/BackupLoupe_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/BackupLoupe/a/appcast.xml',
-          checkpoint: '9a712ba4a09dd4563e6e915631a88bb22229ac6e32694d99efa905766c8784c8'
+          checkpoint: 'b9f37ec88c0ecbdcc119cdceb08e9fc9a92caf69f18c70264d967325bfda5ffd'
   name 'BackupLoupe'
   homepage 'http://www.soma-zone.com/BackupLoupe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.