### PR TITLE
Update bisq to 0.6.5

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.6.4'
-  sha256 'af68aa7944a3a4168cd6a402da5da8cef474bc07d95376b7d22168f3006c1540'
+  version '0.6.5'
+  sha256 'd3cefc59327f7e4e6d0f56d8cec642355086694475b2143a9fec10ade8960475'
 
   # github.com/bisq-network/exchange was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/exchange/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/exchange/releases.atom',
-          checkpoint: '937e2d0341514104d193cb753966b28602e7f91ea79bc98eed3c20a5b087d8c1'
+          checkpoint: '65eb6995084605e36fe7c146c264e7c93dff580fd82a8140bcd0333c303b4114'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.