### PR TITLE
Update blockstack to 0.23.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.22.1'
-  sha256 '0279e8b2b558e943d3a479e91e208af5445abe80689c635bced3785dc88ed8fa'
+  version '0.23.0'
+  sha256 '9e2a465976796223bcdb0c306e3460412fe3ac48e5064b473f4c2db2ef8cd7a0'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '1da1a7eb8f65e5d9573519cc5d728afe6f63f2d61686605031450e80414adee9'
+          checkpoint: '529039990d1567e5aa3232b8608f07be2fa708ab7e473acb06bb067b05fa3f69'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.