### PR TITLE
Update burp-suite to 1.7.32

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,10 +1,10 @@
 cask 'burp-suite' do
-  version '1.7.30'
-  sha256 'abca4f8aaaf07b58692f3b12c5b3dd2e1d3e6e655c17691f99644bf799465f4d'
+  version '1.7.32'
+  sha256 'a9a52bdf51bb7585f92b9b437512de5de7b00dd981cc58f4a9173c32bace7195'
 
   url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=macosx"
   appcast 'https://portswigger.net/burp/releasesarchive/community',
-          checkpoint: '76124f8b68ee23f1ed61425318e497fc48a61ce4d56633ad3070ecb2499bbf6c'
+          checkpoint: '1587f7a55e88b9a40dfa61d3dfdf0022835545f1fcfd34021f2731445c4fb041'
   name 'Burp Suite'
   homepage 'https://portswigger.net/burp/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.