### PR TITLE
Update callnote-premium to 2.3.8

### DIFF
--- a/Casks/callnote-premium.rb
+++ b/Casks/callnote-premium.rb
@@ -1,6 +1,6 @@
 cask 'callnote-premium' do
-  version '2.3.7'
-  sha256 '968c61f2cd1e71f91ec45b9f69023765210010e3d28256eeb65942ee075e756b'
+  version '2.3.8'
+  sha256 '3c053acf7c77e38dc76d8593a0499991a5191103cd3b21941c44578c50ce3e17'
 
   url "http://callnote.kandasoft.com/callnote-premium-install-#{version}.pkg"
   name 'Callnote Premium'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.