### PR TITLE
Update fontbase to 2.3.4

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,8 +1,8 @@
 cask 'fontbase' do
-  version '2.2.3'
-  sha256 '258d6d021de3a2ef2cef7a3fb15a69fc6dacc5f4cb75f0d580dc108057a9f0c8'
+  version '2.3.4'
+  sha256 '2a4c4d358fcc8ff30d49fab38213d88a2c535146403fa62fdf46faebba8aee1d'
 
-  url "http://releases.fontba.se/mac/#{version}/FontBase-#{version}.dmg"
+  url "http://releases.fontba.se/mac/FontBase-#{version}.dmg"
   name 'FontBase'
   homepage 'http://fontba.se/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.