### PR TITLE
Update kullo to 56.0.0

### DIFF
--- a/Casks/kullo.rb
+++ b/Casks/kullo.rb
@@ -1,6 +1,6 @@
 cask 'kullo' do
-  version '53.0.0'
-  sha256 'dc43528a8615b5872c8a58004c40cf1af85c2bc29ce0e9750b599e6c3ea4c2c1'
+  version '56.0.0'
+  sha256 '4d8d9b8f86e5917ead6c50ea92a0021b5c014d2db3f30982c01141487e575536'
 
   url "https://www.kullo.net/download/files/osx/Kullo-#{version}.dmg"
   name 'Kullo'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.