### PR TITLE
Update inspec to 1.51.0-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.45.13-1'
-  sha256 'c9b01a7c2a856d8e8490076e515eb47311d326eca168922b8752c41c55eda8e3'
+  version '1.51.0-1'
+  sha256 'b8007d337987cfd97dd63709fb8869357554009e6f56ff6079b67440104ab554'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.13/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'e08cb507c408d3ad24dfb681d16507c8806f26350a5b79accd4d93551cae1e50'
+          checkpoint: 'efe4d78c3e64f629b0afa195b650082f001cf10c15f43bd37bd0249fd518b8a6'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.