### PR TITLE
Update iridient-developer to 3.2.1

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,10 +1,10 @@
 cask 'iridient-developer' do
-  version '3.2.0'
-  sha256 '8e6c183776cb984364136881f8fba2323c5dd22f206d6fffba268924cdb2fd15'
+  version '3.2.1'
+  sha256 '43382713f0941e0a5a44f4bfc9a8b41f0fa0e1c8c1c761ef04e5e6350f367c37'
 
   url "http://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'http://www.iridientdigital.com/products/rawdeveloper_history.html',
-          checkpoint: '2a1b16663ae1efb0b8d1484da4dc5b6e2ac6cfedf6232cb052c95b9ba1a91b4f'
+          checkpoint: 'c39f874e22e9051235d7422f91fb51f276ab6d52e3109a90f01b71c2f254a1f3'
   name 'Iridient Developer'
   homepage 'http://www.iridientdigital.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.