### PR TITLE
Update istopmotion to 3.8.2-16057

### DIFF
--- a/Casks/istopmotion.rb
+++ b/Casks/istopmotion.rb
@@ -3,8 +3,8 @@ cask 'istopmotion' do
   sha256 'eb31319488346e12d6f95b7be9d61d911eaaf0228f22b6053ee0be8f6902f520'
 
   url "https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_#{version}.app.zip"
-  appcast 'https://www.boinx.com/d/connect/histories/istopmotion',
-          checkpoint: '27df05aa9511e2bdfa3b70434664de287efabcc6e80d316eb5b8acf63093c456'
+  appcast 'https://boinx.com/d/connect/histories/istopmotion',
+          checkpoint: '5f4e9953b712b4bf3b53c7e963dec51652a4fc72fa6bffebb2eca3ae0d96c9a2'
   name 'iStopMotion'
   homepage 'https://boinx.com/istopmotion/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.