### PR TITLE
Update itubedownloader to 6.3.4,1516650380

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,13 +1,15 @@
 cask 'itubedownloader' do
-  version '6.3.2,1509417770'
-  sha256 'dfdf21331a24da4f2e85532112c13b3d88b354d3fdc3b6afa01fb02061a5a651'
+  version '6.3.4,1516650380'
+  sha256 'f816ada880aabe7731f49141fc8265b4a5ba69e94a0d5d11987ac6a1a0fa91bb'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/#{version.before_comma.no_dots}/#{version.after_comma}/iTubeDownloader-#{version.before_comma.no_dots}.zip"
   appcast 'https://updates.devmate.com/com.AlphaSoft.iTubeDownloader.xml',
-          checkpoint: 'd534df0b9b617b025c1243aef2c743cf59faac2807a0b59967fcd7964ba90459'
+          checkpoint: 'd04a9f42fc2e9a223db149079f7850f990267765407e3428d9ff46da427c5d2e'
   name 'iTubeDownloader'
   homepage 'http://alphasoftware.co/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'iTubeDownloader.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.