### PR TITLE
Update qmapshack to 1.10.0

### DIFF
--- a/Casks/qmapshack.rb
+++ b/Casks/qmapshack.rb
@@ -1,10 +1,12 @@
 cask 'qmapshack' do
-  version '1.9.1'
-  sha256 'c0907b1dcbfe54c9054e80430a5faf01308dbdf8674e7ad58c744a85755074ad'
+  version '1.10.0'
+  sha256 '8f37941c32d987d42f9d2d5ab80e3eee786c687a3cbbbd0d064d8a0b15a49d39'
 
   url "https://bitbucket.org/maproom/qmapshack/downloads/QMapShack-MacOSX_#{version}.tar.gz"
   name 'QMapShack'
   homepage 'https://bitbucket.org/maproom/qmapshack/wiki/Home'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'QMapShack.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.