### PR TITLE
Add emacsclient app v1.0 (for use with org-protocol links)

### DIFF
--- a/Casks/emacsclient.rb
+++ b/Casks/emacsclient.rb
@@ -1,6 +1,6 @@
 cask 'emacsclient' do
-  version '1.0'
-  sha256 '865c5779d37ee750abf75f8f57f4b2ad7532337b04e9be660a7644d2cd5aa6e4'
+  version :latest
+  sha256 :no_check
 
   url 'https://github.com/sprig/org-capture-extension/raw/master/EmacsClient.app.zip'
   name 'emacsclient'

--- a/Casks/emacsclient.rb
+++ b/Casks/emacsclient.rb
@@ -1,0 +1,10 @@
+cask 'emacsclient' do
+  version '1.0'
+  sha256 '865c5779d37ee750abf75f8f57f4b2ad7532337b04e9be660a7644d2cd5aa6e4'
+
+  url 'https://github.com/sprig/org-capture-extension/raw/master/EmacsClient.app.zip'
+  name 'emacsclient'
+  homepage 'https://github.com/sprig/org-capture-extension'
+
+  app 'EmacsClient.app'
+end


### PR DESCRIPTION
This is the tiny wrapper around an AppleScript (`Contents/Resources/Scripts/main.scpt` in the package) that lets you send `org-protocol` links through to emacs with emacsclient from browser extensions like [org-capture](https://github.com/sprig/org-capture-extension). I had been shuttling this around in my dotfiles long enough that I figured I'd submit it for inclusion.

However, I'm not sure whether it should go into this repo or homebrew-versions. The maintainer technically provides this build, and that is where it is sourced from, but there is no hard version or tag attached. If this is not correct, or it doesn't merit being in here at all, I apologise for the inconvenience.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
