### PR TITLE
Update jmc to 0.3-beta

### DIFF
--- a/Casks/jmc.rb
+++ b/Casks/jmc.rb
@@ -1,10 +1,10 @@
 cask 'jmc' do
-  version '0.2-beta.5'
-  sha256 'bd524ce2cbb4c05d93d4e7fd362a9f68ac15d307fffe0241a96df2a716c035fc'
+  version '0.3-beta'
+  sha256 'b6e9303815d80948b80e1f94d797e1ee4ce1017940b236284930abc583ce6e41'
 
   url "https://github.com/jcm93/jmc/releases/download/v#{version}/jmc.app.zip"
   appcast 'https://github.com/jcm93/jmc/releases.atom',
-          checkpoint: 'f0d94b9ef85e4dce94a4a50ac22d1fad08c1030abf406d20cc4416560aa2d2e5'
+          checkpoint: 'e6caffd897c1dba961506df3a55b8f90c85b242cb7b3be1d937f0ab1c1004a4d'
   name 'jmc'
   homepage 'https://github.com/jcm93/jmc'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.