### PR TITLE
Update keystore-explorer to 5.3.2

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,11 +1,11 @@
 cask 'keystore-explorer' do
-  version '5.3.1'
-  sha256 '172afbb9a2c47d9f549ed8efc3a6751da0b8659c2602594a107ee7c0d282354a'
+  version '5.3.2'
+  sha256 'd06c1300dea98c1188b0ffb34cac6653bd3e08048f860f56f51e142fea9aaced'
 
   # github.com/kaikramer/keystore-explorer was verified as official when first introduced to the cask
   url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version}/kse-#{version.no_dots}.dmg"
   appcast 'https://github.com/kaikramer/keystore-explorer/releases.atom',
-          checkpoint: 'a3a5556f83c974e9d36a9aec59d7f4a8358d159f7f3241c303714463444ff6af'
+          checkpoint: '9b91815d3deb31a4e834bd482ab8bb3446e5d1d59c91c6c6ef948b9bd9a2e64c'
   name 'KeyStore Explorer'
   homepage 'http://keystore-explorer.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.