### PR TITLE
Update xiami to 3.1.2-0102

### DIFF
--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -1,6 +1,6 @@
 cask 'xiami' do
-  version '3.1.1-621'
-  sha256 'de0112ffe4c0e6bc95777cc46f8addc3ef97b8df82d5a99bef031fb8de442f38'
+  version '3.1.2-0102'
+  sha256 '30ab65b97ecfa7f06ed5b9d5c20957c2dfee823d837331e7e7be6cec2b36ade2'
 
   # gxiami.alicdn.com/xiami-desktop was verified as official when first introduced to the cask
   url "https://gxiami.alicdn.com/xiami-desktop/update/%E8%99%BE%E7%B1%B3%E9%9F%B3%E4%B9%90-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.