### PR TITLE
Update latexdraw to 3.3.8

### DIFF
--- a/Casks/latexdraw.rb
+++ b/Casks/latexdraw.rb
@@ -1,10 +1,10 @@
 cask 'latexdraw' do
-  version '3.3.7'
-  sha256 '7a4db698767e74ca9548d26caec385faf12c8565535c1c108d9ec450193b25e5'
+  version '3.3.8'
+  sha256 '92f25a620d25af07281d8941174cf6420fde8ce8050938e05c65e1f13a83d2fa'
 
   url "https://downloads.sourceforge.net/latexdraw/LaTeXDraw-#{version}.app.zip"
   appcast 'https://sourceforge.net/projects/latexdraw/rss?path=/latexdraw',
-          checkpoint: '37de4623cbf3183c9fa9a7304d5bb489d8690f81c6c4eb88c24b10f49e25df86'
+          checkpoint: '21df34f659d84c4e3008757fbd327f940626ff0cc135daf406a16db841d4015b'
   name 'LaTexDraw'
   homepage 'http://latexdraw.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.