### PR TITLE
Update sunlogin-remote to 2.1

### DIFF
--- a/Casks/sunlogin-remote.rb
+++ b/Casks/sunlogin-remote.rb
@@ -2,7 +2,7 @@ cask 'sunlogin-remote' do
   version '2.1'
   sha256 '046a64a68524bd526071acd695c5ee7de7b5c90b5709f3566575445a6e9a9530'
 
-  url "https://download.oray.com/sunlogin/mac/SunloginRemote_#{version}.dmg"
+  url "http://download.oray.com/sunlogin/mac/SunloginRemote_#{version}.dmg"
   name 'Sunlogin Remote'
   name '向日葵控制端'
   homepage 'https://sunlogin.oray.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Changed from HTTPS to HTTP because the download fails over HTTPS unless a client-side certificate is provided.