### PR TITLE
Update fork to 1.0.63.3

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,10 +1,10 @@
 cask 'fork' do
-  version '1.0.63.2'
-  sha256 'f44dcc7c46b59915e8eb559791f27decd35ae9fad07ffe8953882c8f9c3af31c'
+  version '1.0.63.3'
+  sha256 'c263e62225c15c3b2409f016facfa7e23cd3188a4255ad8ca65f09c9495d60b5'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: 'ab0ca52ac62306bc33221c00b5e1a803c82c9cf2252d3a32f790cb25eba85078'
+          checkpoint: '8523064bbe376feef2ab6e31a060f380e04da907fdc217f44ebd4e104a6c346f'
   name 'Fork'
   homepage 'https://git-fork.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.