### PR TITLE
Update macpass to 0.7.3

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -2,12 +2,14 @@ cask 'macpass' do
   version '0.7.3'
   sha256 '1551b9db0e275827ab99e80a14980dcc1c1e20e47bdb65c0140e618407f150c2'
 
-  # github.com/mstarke/MacPass was verified as official when first introduced to the cask
-  url "https://github.com/mstarke/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
-  appcast 'https://github.com/mstarke/MacPass/releases.atom',
-          checkpoint: '15939b4b9530a717e6cdfda3a959f9a40b8cd2010a0a4246c251fcdb0ca92262'
+  # github.com/MacPass/MacPass was verified as official when first introduced to the cask
+  url "https://github.com/MacPass/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
+  appcast 'https://github.com/MacPass/MacPass/releases.atom',
+          checkpoint: 'ea1645fadb971b817c28d5743c123a2c8cb160b25cf99920516ec439014ed163'
   name 'MacPass'
-  homepage 'https://mstarke.github.io/MacPass/'
+  homepage 'https://macpass.github.io/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'MacPass.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.