### PR TITLE
Update cave.rb for Unidata AWIPS-Cave 17.1.1 (correcting sha256) 

### DIFF
--- a/Casks/cave.rb
+++ b/Casks/cave.rb
@@ -1,6 +1,6 @@
 cask 'cave' do
   version '17.1.1'
-  sha256 '20c8b6a0d3f71bcdb8735af75898ccfa58dc5eeacfe424b5a3b7a804120f5cf6'
+  sha256 'a1039ee4c4a71f344071e0e8ea03718680376855ccd638e3bf9ca0130313ac75'
 
   url "https://www.unidata.ucar.edu/downloads/awips2/awips2-cave-#{version}.dmg"
   name 'AWIPS Cave'


### PR DESCRIPTION
Minor change to accommodate emerging error in the sha256 code.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
