### PR TITLE
Update mono-mdk to 5.8.0.108

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,10 +1,10 @@
 cask 'mono-mdk' do
-  version '5.4.1.7'
-  sha256 '7b5c24d3528e63e82446fb94bf6b8465000202ea6e95b50a83b60c8192ac9542'
+  version '5.8.0.108'
+  sha256 '478e362c22c3f095ed2d28a53180e923b0bc1c9909cf6305cb5628798f6df6aa'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: '6d5b8d721663b5d513dc940cb0872b9822da2a8f66ff74da551af4457fb885d9'
+          checkpoint: '542ba80a1f656ec9f0985528ec22648ea8036dff1f4c75e8a1c5a95de281b233'
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.