### PR TITLE
Update transmission-remote-gui to 5.14.0

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,10 +1,10 @@
 cask 'transmission-remote-gui' do
-  version '5.13.0'
-  sha256 '6e91ab6e9a8c8d704fb38bdb6b37647f05635a2d75dd3a3738d5ddf5097fb712'
+  version '5.14.0'
+  sha256 '6213845c24243cdd24bef5010fb65a63244899be84ed73158874c32eb9f88854'
 
   url "https://github.com/transmission-remote-gui/transgui/releases/download/v#{version}/transgui-#{version}.dmg"
   appcast 'https://github.com/transmission-remote-gui/transgui/releases.atom',
-          checkpoint: '07003f14d0c8962865be85459fe5acf625175db1a69c3ca1f27d851d186bf09c'
+          checkpoint: 'e83a537a586f875e6a0cb62b43477aef5a6e492732e77207c3b9fc12d9ed3ae1'
   name 'Transmission Remote GUI'
   homepage 'https://github.com/transmission-remote-gui/transgui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.