### PR TITLE
Update netron to 1.4.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.4.1'
-  sha256 '6e38384b10341197450f875c43caf809f6d7d64bbfba83f95fe73d6bf7a4e10c'
+  version '1.4.2'
+  sha256 '906acfd98f4fed2b7983bc70553cdd85d6d3eb0a7cbca7824fedbdfd5fca473f'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'dd2fea80e25966456002f1b1fd24744580222778e0388ebabd4ed9971ecb2db1'
+          checkpoint: '1b80e1475ffd53adbbd707081bb93b6907a2639e99476f27bfae7622624e267c'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.