### PR TITLE
Update brackets to 1.12

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,11 +1,11 @@
 cask 'brackets' do
-  version '1.11'
-  sha256 '67a4a1d3eb394c838f14d65348858649927cc8811f1db275f2160fc514e614c3'
+  version '1.12'
+  sha256 '11805e056d01964c0a4226203db5e7bf55819294020c1a9194ed8e6e2fb60f7b'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"
   appcast 'https://github.com/adobe/brackets/releases.atom',
-          checkpoint: '95a55c07f04ad09125640a48c75833498aafb719fb61d001bd10530a9fc8ed80'
+          checkpoint: 'b231daac3fbba80810f29cf89634545e7313e0a439b71157abc8f268246d5253'
   name 'Brackets'
   homepage 'http://brackets.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.