### PR TITLE
Update buttercup to 0.26.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '0.25.2'
-  sha256 '89b095ce0362f8f11e30d04626bc59520eb28626b6da3e48c449dc69323a449c'
+  version '0.26.0'
+  sha256 '168455ef1f31d81b53c0801e8f70ca912f92394bdc42d5e3eda683cc2c5dc441'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: '7f64039ae2de5852920e295b95b450ec267ad8daf59892c76841bf7f0c58f55c'
+          checkpoint: '687ecb97b94c0c456566bf92dde048daf80d2b8136e74a12ef21b8723ee4df18'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.