### PR TITLE
Update devonthink-pro to 2.9.17

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.16'
-  sha256 '15d7e7785fa0164ed765677ad80e22f1f31d075b1dc63539018ff40df257f25c'
+  version '2.9.17'
+  sha256 '3a01a261a8e5d9b452fbae7d2b22a1c1fd7b95fc0b81e28e5b00aeab79d77c14'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '5765140ac4a3c7a55f7a197ad636beb6181e739c5ebe60e0625dda1ddc2b0c11'
+          checkpoint: '34e525574a0e9dd88366dd3096ea60e07342a90aa0ba94d510d92536e429ba16'
   name 'DEVONthink Pro'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.