### PR TITLE
Update freenettray to 2.2.0

### DIFF
--- a/Casks/freenettray.rb
+++ b/Casks/freenettray.rb
@@ -1,11 +1,11 @@
 cask 'freenettray' do
-  version '2.1.0'
-  sha256 '13c20619813d349a517906096068c6f0986ef6c36295bc7f4da3535022ce4e94'
+  version '2.2.0'
+  sha256 '1351ee80def91f0fd7bb0903921d1987070e38787eacdb0ae8801b8f52bf0dac'
 
   # github.com/freenet/mactray was verified as official when first introduced to the cask
   url "https://github.com/freenet/mactray/releases/download/v#{version}/FreenetTray_#{version}.zip"
   appcast 'https://github.com/freenet/mactray/releases.atom',
-          checkpoint: 'eec8e91d4369875d291545af99043499207bb5fd99e3de841a55d0e863662209'
+          checkpoint: '20c4293885850440d8e87ca055a2dcc5bb7ae8bc01869efd1e7611e55edcdfc9'
   name 'Freenet'
   homepage 'https://freenetproject.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.