### PR TITLE
Update garagesale to 7.0.11

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,6 +1,6 @@
 cask 'garagesale' do
-  version '7.0.10'
-  sha256 'a3656e982a6a92519574ad8c5f9f80bd15b76de5c0f98b066e49958ea33d5a1c'
+  version '7.0.11'
+  sha256 '8f2ef6394908d8d361908bdf7a0d8302078a01ec81050cbb7eddec57beef5fa3'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   name 'GarageSale'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.