### PR TITLE
Update hbuilder to 9.0.1

### DIFF
--- a/Casks/hbuilder.rb
+++ b/Casks/hbuilder.rb
@@ -1,6 +1,6 @@
 cask 'hbuilder' do
-  version '8.1.0'
-  sha256 '2ca373a1cf9afb1de3d227946be41545c4bceca223b4f9f97e7b74480b158c15'
+  version '9.0.1'
+  sha256 'dc8bcc073fe40450ff7cad9f098ba668e2e21066ff0984c6514f3d338a25084c'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "http://download.dcloud.net.cn/HBuilder.#{version}.macosx_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.