### PR TITLE
Update qgroundcontrol to 3.2.7

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,11 +1,11 @@
 cask 'qgroundcontrol' do
-  version '3.2.5'
-  sha256 '246ab87302945861782230ddc5f171e5f226d728ff7974a2628230045f6c860f'
+  version '3.2.7'
+  sha256 '14d2cd2487554b89461e60a0bff4f335ae847927a40918944092a4ed09fe1e77'
 
   # github.com/mavlink/qgroundcontrol/releases/download was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
   appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom',
-          checkpoint: '74f3d5dd1fc403aeef01d151d8960d0db72ea24c3a7e0cd1957adff2f033c43e'
+          checkpoint: 'd60cb67da1483476a59806fe7a8b45ba6d1d9fb54f9508f875c933f6d253d396'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.