### PR TITLE
Update mcedit to 1.5.6.0

### DIFF
--- a/Casks/mcedit.rb
+++ b/Casks/mcedit.rb
@@ -2,10 +2,10 @@ cask 'mcedit' do
   version '1.5.6.0'
   sha256 'e2026de3589e3e65086a385ee4e02d607337bc9da11357d1b3ac106e2ee843d7'
 
-  # github.com/Khroki/MCEdit-Unified was verified as official when first introduced to the cask
-  url "https://github.com/Khroki/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
-  appcast 'https://github.com/Khroki/MCEdit-Unified/releases.atom',
-          checkpoint: '6d45b83ded8e642ca2c53c5210f7dc45c52e4865cfe8d2c790c06838fa79aed0'
+  # github.com/Podshot/MCEdit-Unified was verified as official when first introduced to the cask
+  url "https://github.com/Podshot/MCEdit-Unified/releases/download/#{version}/MCEdit.v#{version}.OSX.64bit.zip"
+  appcast 'https://github.com/Podshot/MCEdit-Unified/releases.atom',
+          checkpoint: '8f31a11aee8b7dabc3c5f0479d66e5e4b8759d5769762955a86cb9f15e7edac5'
   name 'MCEdit-Unified'
   homepage 'https://www.mcedit-unified.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.