### PR TITLE
Update ticktick to 2.1.00,56

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '1.9.52,53'
-  sha256 '7ad7a48ec81bb955426b0a057d72a0273668176c5a01bfa91618c559bfda4426'
+  version '2.1.00,56'
+  sha256 'd9bed721e65d1d8b6c309b5e16197c84cfea9ffbd74178334adf61a541bd6cad'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.