### PR TITLE
Update smartgit to 17.1.4 and fix the download URL

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,10 +1,10 @@
 cask 'smartgit' do
-  version '17.1.3'
-  sha256 '01b409a3e3ab6b43c2876084294f9919e03ee6bf394406b019e6052083aaef9f'
+  version '17.1.4'
+  sha256 '502d4383b0c7bb35d75664314263d38edadcd7a10ee400f3e21176a575e5c505'
 
-  url "https://www.syntevo.com/static/smart/download/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
+  url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',
-          checkpoint: '2d0842a34f992b8edf8bf61caef1d155b7898e9b2feb2b2ddb95a34c16e8c810'
+          checkpoint: 'ac063796a8db1a234286aa9e3d1bae901ca459ba9662d801af0b8d2445a45f62'
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 


### PR DESCRIPTION
Download URL was wrong and also new version was available.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
