### PR TITLE
Update vivaldi to 1.14.1077.45

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi' do
-  version '1.14.1077.41'
-  sha256 'd882821249a6e9cbca90858a34e023a0c9ab59d084715b623ebea62d7bacc5ce'
+  version '1.14.1077.45'
+  sha256 '595e8d160a698dbe151fcc8671a527ee6bd81ae83b03b7c3bf4bcedd8944cf8e'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml',
-          checkpoint: '45e52cb6e93594bffc756ed3ee8a586f2691cf1b4f0efe7d4a5cb524e32c6181'
+          checkpoint: '1e0cf4d178e8b73fa920633bae80ecc799f9d7cbfff3262d112eb35a8b94ea8e'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.