### PR TITLE
Update flash-npapi to 28.0.0.161

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -13,8 +13,9 @@ cask 'flash-npapi' do
 
   pkg 'Install Adobe Flash Player.app/Contents/Resources/Adobe Flash Player.pkg'
 
-  uninstall pkgutil: 'com.adobe.pkg.FlashPlayer',
-            delete:  '/Library/Internet Plug-Ins/Flash Player.plugin'
+  uninstall pkgutil:   'com.adobe.pkg.FlashPlayer',
+            launchctl: 'com.adobe.fpsaud',
+            delete:    '/Library/Internet Plug-Ins/Flash Player.plugin'
 
   zap trash: [
                '~/Library/Caches/Adobe/Flash Player',

--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-npapi' do
-  version '28.0.0.137'
-  sha256 '5d70c1c4767886b6cf60a4f9c064f9a54eb3eda280beb09546b3ff8d82b9dafc'
+  version '28.0.0.161'
+  sha256 '14ddafcba6efe9e7cc61bc4f8068618662d2909a4b9bb8ac8d709aa949c1e361'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '0e62296da997de154e620ca99f77fd9842641dbaf5970a8dc41dc927fedcc2cc'
+          checkpoint: '9328b81a03aa632970cd96be9f1d58a573a5e376debed48a59ab76e186e9786f'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox)'
   homepage 'https://get.adobe.com/flashplayer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.