### PR TITLE
Update flash-ppapi to 28.0.0.161

### DIFF
--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -12,8 +12,9 @@ cask 'flash-ppapi' do
 
   pkg 'Install Adobe Pepper Flash Player.app/Contents/Resources/Adobe Flash Player.pkg'
 
-  uninstall pkgutil: 'com.adobe.pkg.PepperFlashPlayer',
-            delete:  '/Library/Internet Plug-Ins/PepperFlashPlayer'
+  uninstall pkgutil:   'com.adobe.pkg.PepperFlashPlayer',
+            launchctl: 'com.adobe.fpsaud',
+            delete:    '/Library/Internet Plug-Ins/PepperFlashPlayer'
 
   zap trash: [
                '~/Library/Caches/Adobe/Flash Player',

--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,10 +1,10 @@
 cask 'flash-ppapi' do
-  version '28.0.0.137'
-  sha256 '46ed55fe6e464cdb2de97244cec77a26234ecb6c8de2e9a8d41a1e81e55ac5c6'
+  version '28.0.0.161'
+  sha256 '5738b58c3a6a1ff612d054529dab6137af30ed329abaf769b92359ae4f07204d'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',
-          checkpoint: '0e62296da997de154e620ca99f77fd9842641dbaf5970a8dc41dc927fedcc2cc'
+          checkpoint: '9328b81a03aa632970cd96be9f1d58a573a5e376debed48a59ab76e186e9786f'
   name 'Adobe Flash Player PPAPI (plugin for Opera and Chromium)'
   homepage 'https://get.adobe.com/flashplayer/otherversions/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.