### PR TITLE
Update flash-player-debugger to 28.0.0.161

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger' do
-  version '28.0.0.137'
-  sha256 '59fe96ba72b9e3a94c054d853754c7de5cee4250346b636c426aefebb95b1439'
+  version '28.0.0.161'
+  sha256 'c78179b37e8e685e0a179ab9ea9b9d90d7d8b8fd1c3730887ec9efc73ce38043'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml',
-          checkpoint: '0e62296da997de154e620ca99f77fd9842641dbaf5970a8dc41dc927fedcc2cc'
+          checkpoint: '9328b81a03aa632970cd96be9f1d58a573a5e376debed48a59ab76e186e9786f'
   name 'Adobe Flash Player projector content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.