### PR TITLE
Update obs to 21.0.2

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -1,15 +1,15 @@
 cask 'obs' do
-  version '20.1.0'
-  sha256 '8eb490f749b3717002fd55b0ee14e082191cc921c5913070890e95af8776445d'
+  version '21.0.2'
+  sha256 'f2b7369a16b42fd8e73345c964a2b68130d55478bd5adb1dc207fb2d90b99b7d'
 
   # github.com/jp9000/obs-studio was verified as official when first introduced to the cask
-  url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-mac-#{version.major_minor}-installer.pkg"
+  url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-mac-#{version}-installer.pkg"
   appcast 'https://github.com/jp9000/obs-studio/releases.atom',
-          checkpoint: 'bce365214c203a68f6978094931f9748ddac61be3b8de71adbb55a6cdf0f584e'
+          checkpoint: '66148fae44e816f788ade0d4d40bc60ffbd6bf89abf756a3a1541c93fb864d63'
   name 'OBS'
   homepage 'https://obsproject.com/'
 
-  pkg "obs-mac-#{version.major_minor}-installer.pkg"
+  pkg "obs-mac-#{version}-installer.pkg"
 
   uninstall pkgutil: [
                        'org.obsproject.pkg.obs-studio',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

Running ```brew cask style --fix obs.rb``` outputs:
```
Error: The 'rubocop-cask' gem is installed but couldn't find 'rubocop' in the PATH:
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin:/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/Homebrew/Library/Homebrew/shims/scm
```