### PR TITLE
Update altair to 1.6.3

### DIFF
--- a/Casks/altair.rb
+++ b/Casks/altair.rb
@@ -1,11 +1,11 @@
 cask 'altair' do
-  version '1.6.2'
-  sha256 '2952d7f5d70ccd58ba69aac35751584b67ca117f482305c57359a056c112ece7'
+  version '1.6.3'
+  sha256 '776d6f5e4e67f8c92012c068607bac23f3ebdcd96658db908d6d9e6fa32fdcb5'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"
   appcast 'https://github.com/imolorhe/altair/releases.atom',
-          checkpoint: 'ef224046b692f8ba969c9601377dc2b3ca8b95a439e5ac4975395fac7f807473'
+          checkpoint: '01056b96ed2a2fde084d246ccb4a02f38362fc0b57b462d81b703e7aa793d545'
   name 'Altair GraphQL Client'
   homepage 'https://altair.sirmuel.design/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.