### PR TITLE
Updated BBEdit to 12.1

### DIFF
--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -1,11 +1,11 @@
 cask 'bbedit' do
-  version '12.0.2'
-  sha256 '9a1d18e5b722380591d175edf7bfdbea0ec65aba4384e61e3b135442ed498d91'
+  version '12.1'
+  sha256 '06fdabbd8d4f55771cbafc322542e12b29b51fabcd624af88bea19befc9078ff'
 
   # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "http://s3.amazonaws.com/BBSW-download/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml',
-          checkpoint: '6f47f2a80842d0dcd158d11fbea25ca06992eb134367e5888a60396963a16bea'
+          checkpoint: 'a0b4110f1b3812f7c93f12a8b414074d0c9fd641a9c1c1c51c2d2806a5ede827'
   name 'BBEdit'
   homepage 'https://www.barebones.com/products/bbedit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.