### PR TITLE
Update handshaker to 2.5.4

### DIFF
--- a/Casks/handshaker.rb
+++ b/Casks/handshaker.rb
@@ -1,11 +1,11 @@
 cask 'handshaker' do
-  version '2.5.3'
-  sha256 '753bafec261c1e9a4e63160f06970e79afac0fd56e3a71bf5665ac6b054c79cd'
+  version '2.5.4'
+  sha256 '96843644bf01c83883226ed9108419a2b76dd33f1b00ce6efd7648370b60d0aa'
 
   # dl2.smartisan.cn was verified as official when first introduced to the cask
   url "http://dl2.smartisan.cn/app/HandShaker.v#{version}.dmg"
   appcast 'https://sf.smartisan.com/update.plist',
-          checkpoint: '47a208f3481f017df96bc28d0b9e9c6a4617054a1aeb81f8086b9590b8a17c8c'
+          checkpoint: '6cdb44644195de046cb5b1ec50c724178062991585da8ab9fa11d59d45b641e4'
   name 'HandShaker'
   homepage 'http://www.smartisan.com/apps/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.