### PR TITLE
Update ableton-live-lite to 10.0.1

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '9.7.5'
-  sha256 'c91876c86e06717c86b4e1df7168c9916c789a7e0eb2ea2d43fec3abe892c183'
+  version '10.0.1'
+  sha256 'b4c0d7dfc4e05eddf1cab6a831962f8aad355fafc36c512112dc0e820a2f2c61'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   name 'Ableton Live Lite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.