### PR TITLE
Update joplin to 0.10.60

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '0.10.59'
-  sha256 '77bce3c769fe0da2cf8cc8943e8e091ed2c25a7489e17116ce05600f6c142268'
+  version '0.10.60'
+  sha256 '6b2bbb87b04b09bcf62b441b87f8a92690d2e7c660f9b8b4c7bdbc8adec93ba1'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '70253687cef933433cb105fdeb2d131c4964b38c06275ec714db437eae5ebefc'
+          checkpoint: '223c89d493e034d07c4407a95fd58154fb99b097dfc66376ef1b58185872d1ab'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.