### PR TITLE
Update mightytext to 3.88.20

### DIFF
--- a/Casks/mightytext.rb
+++ b/Casks/mightytext.rb
@@ -1,6 +1,6 @@
 cask 'mightytext' do
-  version '3.88.18'
-  sha256 '9bece607493ef5997eda9ab11261217bece836ceafa9ae90291653028d3326dc'
+  version '3.88.20'
+  sha256 '03c4dff76d6894f185cdde8fa9b601e0d9037eacdaf9589dd8ac78d28125389c'
 
   url "https://dl-desktop.mightytext.net/MightyText-#{version}.dmg"
   name 'MightyText'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.