### PR TITLE
Update nteract to 0.7.0

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,10 +1,10 @@
 cask 'nteract' do
-  version '0.6.2'
-  sha256 'ef1e3a15cace72fef2df9ba72861d0b1318f2cec5369a22b3dc7858dc869e971'
+  version '0.7.0'
+  sha256 'c0080ca1447a0ff595d4d9fcae23edb64d2d8f5b8d9c8704c0c4642154de6b68'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: '5322852157274f404bbd3d18537af9d2d809246fee197c9186d4a2d7255d611b'
+          checkpoint: '134339cee7260132a626da5eb729647159746326af07c5ab3ef14712a7436bad'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.