### PR TITLE
Update opera to 51.0.2830.26

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '50.0.2762.67'
-  sha256 '834e1fad0a23baf5c80d2497f7ee687536e069407ee3306de1bd244e108c4652'
+  version '51.0.2830.26'
+  sha256 '3900aa62ecea9c692a407ffc63a15a974c564f6fbcb80bb4974960a1bbed62ea'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.