### PR TITLE
Update papers to 3.4.15,555

### DIFF
--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -1,11 +1,11 @@
 cask 'papers' do
-  version '3.4.12,550'
-  sha256 '7825647a1a6a21594acbb643d664751dc727cf5238c0b7d35a01ba6778715971'
+  version '3.4.15,555'
+  sha256 'de4a61730a1a343ad06f0aa41fd9b9881d0cd11436db7aa8b61b11108c22a03e'
 
   # appcaster.papersapp.com/apps/mac/production/download was verified as official when first introduced to the cask
   url "http://appcaster.papersapp.com/apps/mac/production/download/#{version.after_comma}/papers_#{version.before_comma.no_dots}_#{version.after_comma}.dmg"
   appcast 'https://appcaster.papersapp.com/apps/mac/production/appcast.xml',
-          checkpoint: 'ef674d808bf92ee6f004af91bb6ba89c636c3336cfeaa5210bfb10fbc05f18bc'
+          checkpoint: '97c2077a60542c82a63f062d26ffdebd13c203ca88b670fdbe8b17fcb90dbca7'
   name 'Papers'
   homepage 'https://www.readcube.com/papers/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.