### PR TITLE
Update papers to 3.4.16,555

### DIFF
--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -1,5 +1,5 @@
 cask 'papers' do
-  version '3.4.15,555'
+  version '3.4.16,555'
   sha256 'de4a61730a1a343ad06f0aa41fd9b9881d0cd11436db7aa8b61b11108c22a03e'
 
   # appcaster.papersapp.com/apps/mac/production/download was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.