### PR TITLE
Update exodus to 1.44.1

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.44.0'
-  sha256 '1982f72dfc67312175bdb4efb291fb2d78e2456ce0325c12f538c0d1a8861b34'
+  version '1.44.1'
+  sha256 'fa1c2ff2df970a90776962695be19c2ccd42b9ff59cc4b7749873a231b0fda5c'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '05e22800f98e10a4b71386a88337af7f67255b7772102aff67053e2472e8111a'
+          checkpoint: '17ab627cb9e09f9f6a70da8fac5a51be69092a0d9f097ae2154d51373aec9764'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.