### PR TITLE
Update lehreroffice-zusatz to 2018.1

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2017.19.5'
-  sha256 'cb068563740cd900f2804748074e09589f7ae3fd42e1fb33fa9a5d64f4295341'
+  version '2018.1'
+  sha256 '10f6aa6063a9d690b8620e694a5b8f86e4c59ed0fb55fbea051a345f41b52272'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '1c68708536535a5524c319a194d438624fba1517613f216379280c32e48db248'
+          checkpoint: '6fe4f5161c743ebd123751643531c2d1b4e78f578dc1b5bed3ca094501c44cde'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.