### PR TITLE
Update abstract to 0.66.5

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '0.65.6'
-  sha256 '3fc866ef89636db1484aa9965696b3ddf7a84e977f976663adc93635112578ce'
+  version '0.66.5'
+  sha256 'e28b995824bc5326ba2de1ed0e4d1a190242e82660464b073288bf92b1585a81'
 
   # s3.amazonaws.com/propeller-internal-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/propeller-internal-releases/Abstract-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.