### PR TITLE
Update hstracker to 1.3.3

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.3.2'
-  sha256 '3af4589d56a7693573e7ea67a5a97f5cc2b645086a76cc39c9667f4a272127cf'
+  version '1.3.3'
+  sha256 '9ffd18712ef1431a09f4d86922ed4073bebccf79ee1f89ac5d6e3c9282177d33'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: 'b85e2c04ac1a8b66099727c539592d7c4a8b0c6008f9a892a0614e1ae568fa0d'
+          checkpoint: '6511d137f4071ef2358b28bd693a8abcf258b62be8d90b0c3b2eb2c8152ceffe'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.