### PR TITLE
Update jet to 2.4.0

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,6 +1,6 @@
 cask 'jet' do
-  version '2.3.1'
-  sha256 '4bb1f1892a29582ac61f770ca89975462bc3c30e00d89d032096da600897dbff'
+  version '2.4.0'
+  sha256 'a479444c82055c98616ed1abc9602804763a36b8559d04f60027ecb8ef4363a0'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.