### PR TITLE
Fix soda-player (latest) download url

### DIFF
--- a/Casks/soda-player.rb
+++ b/Casks/soda-player.rb
@@ -2,7 +2,7 @@ cask 'soda-player' do
   version :latest
   sha256 :no_check
 
-  url 'https://releases.sodaplayer.com/mac/Soda%20Player.dmg'
+  url 'https://www.sodaplayer.com/mac/download'
   name 'Soda Player'
   homepage 'https://www.sodaplayer.com/'
 


### PR DESCRIPTION
Existing url is failing:

```
==> Downloading https://releases.sodaplayer.com/mac/Soda%20Player.dmg

curl: (22) The requested URL returned error: 403 Forbidden
Error: Download failed on Cask 'soda-player' with message: Download failed: https://releases.sodaplayer.com/mac/Soda%20Player.dmg
```

This is the url provided on the soda player homepage now.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

**Note**: I don't have homebrew-cask set up for development locally right now, so I haven't been able to run the tests below yet.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.