### PR TITLE
Update bitshares to 2.0.180201

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.171219'
-  sha256 'b52681b75824eceaedf9068936e0afea50533747ecef1bf56e629f26b375fb52'
+  version '2.0.180201'
+  sha256 '59c1816176a87e7bd2bfda170eecd0a47a30f499868bfa13c9f22e08c2362e1e'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: 'b94c394a522a3507452749b57d1c01b6bba5ff875a6c5da1f077b695241cb717'
+          checkpoint: 'ea8f4ba5cf4778f6f9bf1950f2d7d4b1dee0814e12b2347b0a2d72553130ba91'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.