### PR TITLE
Update cocktail to 11.3

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -28,12 +28,12 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/elcapitan/elcapitan.xml',
             checkpoint: '7d3fd5bf0b5816bc3971adfea9e571619e589ee6c30c6fcd6f0c5a1de21026da'
   elsif MacOS.version == :sierra
-    version '10.6'
-    sha256 '1f4537d47ddbf6f8611d34f26389dc402146ca79782e876cb5a637ee13d93c59'
+    version '10.6.1'
+    sha256 '7b7d357c948070e69bfe3fec7803e3c46826c7a8dd572cff5c01f3c5edb0272b'
 
     url "https://www.maintain.se/downloads/sparkle/sierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml',
-            checkpoint: '857abd14b79507e364a006d51d05b90b1ccaafaa35d2504dbd12d550f65e00f5'
+            checkpoint: 'e6fc28eafb6b4e1e0bc8364f8b9db3aeb7bb4398f438e8c485086ffb60a2e1a0'
   else
     version '11.3'
     sha256 '195b24d69dde555a5dc1c716dab0e38efa9f1030705b1379fae554cbd3f483c5'

--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -35,12 +35,12 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml',
             checkpoint: '857abd14b79507e364a006d51d05b90b1ccaafaa35d2504dbd12d550f65e00f5'
   else
-    version '11.2.1'
-    sha256 '0537f51b3145b88c5ac09e6f07c50f8dd0c868ff1e8c89c48ec8158580f099e0'
+    version '11.3'
+    sha256 '195b24d69dde555a5dc1c716dab0e38efa9f1030705b1379fae554cbd3f483c5'
 
     url "https://www.maintain.se/downloads/sparkle/highsierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/highsierra/highsierra.xml',
-            checkpoint: 'd08d5eb1c9bdb14ceeda0cfa591a2f90f13b06639690d1ef45c46f203211f0b5'
+            checkpoint: 'f42f46a81172be7b6cce6a0a4573bedf70a191e9bb4e6b8e6bdc8e5dfc6c762f'
   end
 
   name 'Cocktail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.