### PR TITLE
Update focuswriter to 1.6.9

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,6 +1,6 @@
 cask 'focuswriter' do
-  version '1.6.8'
-  sha256 '0ccc581d6f895fc218f25abc5c91cc0de73af5e8cbac5bb8e2f0997e9a9d2c09'
+  version '1.6.9'
+  sha256 '4f3249bbf1f5525935dfd3f636e7a563a671293bce83f739d81b9730c072a1a6'
 
   url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   name 'FocusWriter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.