### PR TITLE
Update nteract to 0.7.1

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,10 +1,10 @@
 cask 'nteract' do
-  version '0.7.0'
-  sha256 'c0080ca1447a0ff595d4d9fcae23edb64d2d8f5b8d9c8704c0c4642154de6b68'
+  version '0.7.1'
+  sha256 'a03f8d8373a182f0b87b194db1eb1924e089cdb975bd0ee5c4bdbc79bd940795'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: '134339cee7260132a626da5eb729647159746326af07c5ab3ef14712a7436bad'
+          checkpoint: '318bc16a2cf76ed4f341c3a00e9a793e3b65a5d8c1dfa28923c56e3070d46990'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.