### PR TITLE
Update powerphotos to 1.3.6

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,13 +8,13 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.3.5'
-    sha256 '0672fd3743ce9905ba742003b86ea188b60628ccacd301bfbabc75bb7869205f'
+    version '1.3.6'
+    sha256 'a205d06a4a26c736b1e6069c4d6a083d4c18e8431c07a54571a6d05c9f3fc64b'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: '6a3b876929b2491630f6b14f3156455d4054ce4484c6b17802034b90d0ad1222'
+          checkpoint: '51b170d10154183268573085a50c26cb168f92b7eae9d1ad9381a3536ed92a91'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.