### PR TITLE
Update subler to 1.4.7

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,11 +1,11 @@
 cask 'subler' do
-  version '1.4.6'
-  sha256 '110a961df24ee8c9b23a050e98dfb77452487bf6f133af2afbde6b1ebcf8a40e'
+  version '1.4.7'
+  sha256 'df1b724d7c5dcafda24386014217c42b8d16994ce1aaed945fc06399bd9898b3'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"
   appcast 'https://subler.org/appcast/appcast.xml',
-          checkpoint: '86bbe748dffcab012b7f2c808afbf2c76d3d964d4aaa2b54460dfd39a0d1e5a2'
+          checkpoint: '1db302667b3b8082aa1567c04ec5f317b72003bd305fb48437222337d35a4ff5'
   name 'Subler'
   homepage 'https://subler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.