### PR TITLE
Update cacher to 1.3.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.0'
-  sha256 'c003fa0c6b733c0bd9640bf6d8e5faf6f798a5e8e3ab161cdd813f35d939ee88'
+  version '1.3.1'
+  sha256 '7b9af384b88d94376685255093e43d73f94c273b5f9c2d94bd9470a52bb51703'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '7c6c8bcd7c06d273c722436a61a3943df165814d57b3629c984d34230a96cad1'
+          checkpoint: 'cbee57ab09af2ff98d5237e18c4efde403637a71c5f752d43708d0e4249adc85'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.