### PR TITLE
Update persepolis-download-manager to 3.0.1

### DIFF
--- a/Casks/persepolis-download-manager.rb
+++ b/Casks/persepolis-download-manager.rb
@@ -1,11 +1,11 @@
 cask 'persepolis-download-manager' do
-  version '2.4.2'
-  sha256 '855756ae23ff672890f05c38bd1e146ee2d4ec218a920026ac26f286a98422a4'
+  version '3.0.1'
+  sha256 '7ba0a50ebb6c911fa32e87842e5aab191d375d5215ca89fad2b8c3f0739c37be'
 
   # github.com/persepolisdm/persepolis was verified as official when first introduced to the cask
   url "https://github.com/persepolisdm/persepolis/releases/download/#{version}/persepolis_#{version.dots_to_underscores}_mac.dmg"
   appcast 'https://github.com/persepolisdm/persepolis/releases.atom',
-          checkpoint: '691d6a7e5af0135e95912ee8119af7f23a1293b2b4337920dc3c63b2ac146737'
+          checkpoint: '7c540321e4b2c1e268a8a148d2b87f2e2d1e41d74c0e87ffe2853a103a3a7f0d'
   name 'Persepolis'
   homepage 'https://persepolisdm.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.