### PR TITLE
Update netron to 1.4.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.4.2'
-  sha256 '906acfd98f4fed2b7983bc70553cdd85d6d3eb0a7cbca7824fedbdfd5fca473f'
+  version '1.4.3'
+  sha256 '7ddc4e28ba50d32fb5554006bac7ecdcca240fc6126b48956e222c87e3263a8a'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '1b80e1475ffd53adbbd707081bb93b6907a2639e99476f27bfae7622624e267c'
+          checkpoint: 'bfb3794e66d5103599f832df48c9ebd58b0b3d4b1d374666ed2589cf7b0a2d5e'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.