### PR TITLE
Update formular-designer to 2018.1.0

### DIFF
--- a/Casks/formular-designer.rb
+++ b/Casks/formular-designer.rb
@@ -1,10 +1,10 @@
 cask 'formular-designer' do
-  version '2016.1.0'
-  sha256 'e0aa68784586cda45c2f253432dee5ffff784b63e2fbaa7ba4e6c6780aa781c2'
+  version '2018.1.0'
+  sha256 'f40f0c8b5e1259ad8cd575102ec36393e3c296534ffb477c50f32398d115b307'
 
-  url 'https://www.lehreroffice.ch/lo/dateien/designer/lo_designer_mac.dmg'
+  url 'https://www.lehreroffice.ch/lo/dateien/designer/lo_designer_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Designer',
-          checkpoint: '3ed41774545c3c4d19ceb71cedfb8eb7f8231a16b61ca36e1d7f0b21a32a8316'
+          checkpoint: '6fe4f5161c743ebd123751643531c2d1b4e78f578dc1b5bed3ca094501c44cde'
   name 'Formular-Designer'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.