### PR TITLE
Update genome workbench to 2.12.5

### DIFF
--- a/Casks/genome-workbench.rb
+++ b/Casks/genome-workbench.rb
@@ -1,12 +1,12 @@
 cask 'genome-workbench' do
-  version '2.11.10'
+  version '2.12.5'
   sha256 '52b2f90d2feff1d048b21a359ad54a9e8bd0b545b97927285e4feaf1e0929516'
 
-  url "ftp://ftp.ncbi.nlm.nih.gov/toolbox/gbench/ver-#{version}/gbench-macos64-10.9-#{version}.dmg"
+  url "ftp://ftp.ncbi.nlm.nih.gov/toolbox/gbench/ver-#{version}/gbench-macos64-10.10-#{version}.dmg"
   name 'Genome Workbench'
   homepage 'https://www.ncbi.nlm.nih.gov/tools/gbench/'
 
-  depends_on macos: '>= :mavericks'
+  depends_on macos: '>= :yosemite'
 
   app 'Genome Workbench.app'
 end

--- a/Casks/genome-workbench.rb
+++ b/Casks/genome-workbench.rb
@@ -1,6 +1,6 @@
 cask 'genome-workbench' do
   version '2.12.5'
-  sha256 '52b2f90d2feff1d048b21a359ad54a9e8bd0b545b97927285e4feaf1e0929516'
+  sha256 'd6ef76f4133b9157c4c3d90f823d0a0d306b9ebc76dcc3fe21bbb46c7540dbae'
 
   url "ftp://ftp.ncbi.nlm.nih.gov/toolbox/gbench/ver-#{version}/gbench-macos64-10.10-#{version}.dmg"
   name 'Genome Workbench'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
