### PR TITLE
update towerim-tower to 0.6.2

### DIFF
--- a/Casks/towerim-tower.rb
+++ b/Casks/towerim-tower.rb
@@ -1,6 +1,6 @@
 cask 'towerim-tower' do
-  version '0.6.1'
-  sha256 'ac1bcc7375d95392c0c3eebec58fa8910dc5dadde6cbf07d779c6d2c7e95a9a5'
+  version '0.6.2'
+  sha256 '89f030324e1372199b1017267cd9e4cc83b3c385fa24d7451dde65378b58b9d6'
 
   # towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac was verified as official when first introduced to the cask
   url "https://towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac/Tower-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.