### PR TITLE
Update joplin to 0.10.61

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '0.10.60'
-  sha256 '6b2bbb87b04b09bcf62b441b87f8a92690d2e7c660f9b8b4c7bdbc8adec93ba1'
+  version '0.10.61'
+  sha256 'f9b2cb25e03785ad3c501f8d8296a178d4df3c307cbd0602f9d776cc6dd64e5e'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '223c89d493e034d07c4407a95fd58154fb99b097dfc66376ef1b58185872d1ab'
+          checkpoint: '289b543c7a8345eab3a0b688ddb6727d7306870f05303562b1c84a82de5dd5ec'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.