### PR TITLE
Update simplenote to 1.1.3

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,10 +1,10 @@
 cask 'simplenote' do
-  version '1.1.2'
-  sha256 '59092b964afdb8ba6bd335f8b0cb05a4bba3c87282d06c7d46394cf87d031342'
+  version '1.1.3'
+  sha256 '6152ad389f0296c2715b9d916b816a2dc108a897ce97b457cfa48ef4c1ccdc1c'
 
   url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.zip"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom',
-          checkpoint: '6f8a954c631476a564c6093524636fefc8fd71bc1ae97d135922aef05c5bbd1c'
+          checkpoint: 'a1628ee71cf2948c90f95307cef4151b6b91acbdbc8e33e01ac26eb48fd55255'
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.