### PR TITLE
Update airdroid to 3.6.1.0

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
-  version '3.6.0.0'
-  sha256 'a32117be6cd3a6fad5004fd32988d52c7ed69f88cb09196f957389afe6d1e901'
+  version '3.6.1.0'
+  sha256 '2f660e8d9159b8041dce81737a1b02c864a2918dd9f7eb49c60eb9b9f5550320'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.