### PR TITLE
Update tortoisehg to 4.5.0

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,9 +1,9 @@
 cask 'tortoisehg' do
-  version '4.4.2'
-  sha256 'd38633707ff9c4e0c8971ddfba4c85c730b8ba2d3478d72c00baace34cb244b0'
+  version '4.5.0'
+  sha256 '0866e62f1cae87587a9d81b8699f446549e0352793375b1add7b51b3b6908b3a'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
-  url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64.dmg"
+  url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64-qt5.dmg"
   name 'TortoiseHg'
   homepage 'https://tortoisehg.bitbucket.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.