### PR TITLE
Added Jonathan Levin's 'joker' iOS kernelcache manipulation utility

### DIFF
--- a/Casks/joker.rb
+++ b/Casks/joker.rb
@@ -1,0 +1,10 @@
+cask 'joker' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://newosxbook.com/tools/joker.tar'
+  name 'Joker iOS kernelcache handling utility'
+  homepage 'http://newosxbook.com/tools/joker.html'
+
+  binary 'joker.universal', target: 'joker'
+end


### PR DESCRIPTION
This utility claims to handle and manipulate the kernelcache extracted
from an iOS firmware update image, or from a jailbroken iOS device.

A source listing is available on the utility's homepage, but joker is
not suitable for a source-based distribution in Homebrew for the
following reasons:
- Building the source requires non-open source dependencies not
available in a standard macOS/Xcode installation.
- There is not version-controlled public repository or a means of
submitting bug reports or patches.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
