### PR TITLE
Update knuff to 1.2

### DIFF
--- a/Casks/knuff.rb
+++ b/Casks/knuff.rb
@@ -1,10 +1,10 @@
 cask 'knuff' do
-  version '1.1'
-  sha256 'd954305fd0951d7d2697a55cd288c3d4af20b82293055ab0203f2a3518e92c27'
+  version '1.2'
+  sha256 '3e2aae3b80ec53d70a6f68fc309d6e54d09b38cdf97638885f70e3e8eb86ad53'
 
   url "https://github.com/KnuffApp/Knuff/releases/download/v#{version}/Knuff.app.zip"
   appcast 'https://github.com/KnuffApp/Knuff/releases.atom',
-          checkpoint: 'd736b6239009ee0d0c1eb2795d902859b66c7fb250a80705539add563b4363c4'
+          checkpoint: 'c19f26bcd5a18f030b8d790de5b16fc7ffcc1fd3ccb919121eadb97eed637c5f'
   name 'Knuff'
   homepage 'https://github.com/KnuffApp/Knuff'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.