### PR TITLE
Update subsmarine to 1.2.4

### DIFF
--- a/Casks/subsmarine.rb
+++ b/Casks/subsmarine.rb
@@ -1,11 +1,11 @@
 cask 'subsmarine' do
-  version '1.2.3'
-  sha256 '8cdaec741029dec8a45fe55679009fa4a30ede35704b313888388618c331f000'
+  version '1.2.4'
+  sha256 '7afbad7d12a9e3ea4ff414dc7351cd9d8ae612063e1b5cf0d48b28d04f401c9d'
 
   # amazonaws.com/cwcbucket/subsmarine was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/cwcbucket/subsmarine/subsmarine.#{version}.zip"
   appcast 'https://www.cocoawithchurros.com/shine/appcast.php?id=7',
-          checkpoint: '40d2a45c63120bcfe9b0ec15c60c2f2b5b6753c98daa58c3042c6660761b57d5'
+          checkpoint: '71c0b06a7dec716e04091eca2b0ae7b9de48b19b08c570722887aaf89c932444'
   name 'SubsMarine'
   homepage 'https://www.cocoawithchurros.com/subsmarine.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.