### PR TITLE
Update tribler to 7.0.1

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,11 +1,11 @@
 cask 'tribler' do
-  version '7.0.0'
-  sha256 '8ccdc62fc30609b092d83e029a48a0d6f8fc411c1b535c4e6c7aa422b7fe8dfd'
+  version '7.0.1'
+  sha256 '320e2d587cc9f4eb357f9e662e5a31fbadec55ea3f36f2868b32b785d2bb30a9'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
   appcast 'https://github.com/Tribler/tribler/releases.atom',
-          checkpoint: '4506b719939cab9856167b4e91bfb4d8d0bff515a178248175ea976335e6f1b5'
+          checkpoint: '4852b66079146e43ba608a52718694670a60e3862df10ef2cec129097b65ca4d'
   name 'Tribler'
   homepage 'https://www.tribler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.