### PR TITLE
Added 'simplistic' tool by Jonathan Levin for manipulating plist data.

### DIFF
--- a/Casks/simplistic.rb
+++ b/Casks/simplistic.rb
@@ -1,0 +1,12 @@
+cask 'simplistic' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://newosxbook.com/tools/simplist.tar'
+  name 'SimPLISTic - an alternate, cross-platform format for representing property lists'
+  homepage 'http://newosxbook.com/tools/simplistic.html'
+
+  binary 'jlutil.universal', target: 'jlutil'
+
+  caveats "The executable is for this cask is #{HOMEBREW_PREFIX}/bin/jlutil, even though the author named the project 'Simplistic'."
+end

--- a/Casks/simplistic.rb
+++ b/Casks/simplistic.rb
@@ -3,10 +3,9 @@ cask 'simplistic' do
   sha256 :no_check
 
   url 'http://newosxbook.com/tools/simplist.tar'
-  name 'SimPLISTic - an alternate, cross-platform format for representing property lists'
+  name 'SimPLISTic'
+  name 'jlutil'
   homepage 'http://newosxbook.com/tools/simplistic.html'
 
   binary 'jlutil.universal', target: 'jlutil'
-
-  caveats "The executable is for this cask is #{HOMEBREW_PREFIX}/bin/jlutil, even though the author named the project 'Simplistic'."
 end


### PR DESCRIPTION
Simplistic is intended as more powerful alternative for /usr/bin/plutil
and /usr/libexec/PlistBuddy.

Although the project is called "Simplistic" the actual executable is
named "jlutil," which may be confusing to the user. Hence the caveat.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
