### PR TITLE
Added 'hfsleuth' by Jonathan Levin for inspecting HFS+ filesystems.

### DIFF
--- a/Casks/hfsleuth.rb
+++ b/Casks/hfsleuth.rb
@@ -3,7 +3,7 @@ cask 'hfsleuth' do
   sha256 :no_check
 
   url 'http://newosxbook.com/files/hfsleuth.tar'
-  name 'HFSleuth − HFS+/HFSX file system inspection tool'
+  name 'HFSleuth'
   homepage 'http://newosxbook.com/tools/hfsleuth.html'
 
   binary 'hfsleuth.universal', target: 'hfsleuth'

--- a/Casks/hfsleuth.rb
+++ b/Casks/hfsleuth.rb
@@ -1,0 +1,11 @@
+cask 'hfsleuth' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://newosxbook.com/files/hfsleuth.tar'
+  name 'HFSleuth − HFS+/HFSX file system inspection tool'
+  homepage 'http://newosxbook.com/tools/hfsleuth.html'
+
+  binary 'hfsleuth.universal', target: 'hfsleuth'
+  artifact 'hfsleuth.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/hfsleuth.1"
+end


### PR DESCRIPTION
The `hfsleuth` tool is intended to inspect and manipulate Apple HFS+
filesystems, either in the form a a file (e.g., disk image) or a block
device, such as `/dev/block4s1`.

Note: Jonathan links to two different hfsleuth tarballs from his
website. This cask downloads and installs the tarball from the main
'downloads' page.

If Jonathan reconciles the two versions, this cask should be updated to
download and install the version from the hfsleuth page.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
