### PR TITLE
Update airflow to 2.3.1-u1

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,9 +1,9 @@
 cask 'airflow' do
-  version '2.2.0'
-  sha256 '19877d9483abe7f8c843cba474d6f3da1e853e5526592fc7f850d49d8b3b6854'
+  version '2.3.1-u1'
+  sha256 'f6cecbc2865238c775f2a83656c3efcdc9443783bf613624b4ac908e9ef87811'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.dmg"
+  url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.zip"
   appcast 'https://s3.amazonaws.com/Airflow/Updates/appcast-osx.xml',
           checkpoint: '426092153bedb33ba0c3c8cc81ede2e32c6cf4463f94dc51f052dbfbecf87ae8'
   name 'Airflow'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.