### PR TITLE
Update expandrive to 6.1.11

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,6 +1,6 @@
 cask 'expandrive' do
-  version '6.1.9'
-  sha256 'dd45795ff94012e9efd778db9bf80c8b22cd691626b938f3ac2ec0279c0cee02'
+  version '6.1.11'
+  sha256 'dee8c4e0254fa36242a922f40bcb3b774ce206bcd50bc925c51783c7153bb7d3'
 
   url "https://updates.expandrive.com/apps/expandrive/v/#{version.dots_to_hyphens}/download.dmg"
   name 'ExpanDrive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.