### PR TITLE
Update warsow to 2.1.2

### DIFF
--- a/Casks/warsow.rb
+++ b/Casks/warsow.rb
@@ -1,9 +1,9 @@
 cask 'warsow' do
-  version '2.1'
-  sha256 '347c47b029dc706ab43b754ec7422c3766dde2b2ed9a3ce0f40cd0d52c64f94d'
+  version '2.1.2'
+  sha256 '176b037186e4d8a1c0fc740fe8660cd960339fc4eeca5e5eaaec4028b9bd6aba'
 
   # sebastian.network/warsow was verified as official when first introduced to the cask
-  url "http://sebastian.network/warsow/warsow_#{version.no_dots}.dmg"
+  url "http://sebastian.network/warsow/warsow-#{version}.dmg"
   name 'Warsow'
   homepage 'https://www.warsow.net/'
 


### PR DESCRIPTION
I'm kinda confused what the change is, but the site tells me it has been
updated and the download works and all. However, the version ingame
doesn't seem to have been changed. But I guess it's better to just stay
on the same version as upstream, in case I missed something.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.