### PR TITLE
Update hammerspoon to 0.9.60

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -3,14 +3,14 @@ cask 'hammerspoon' do
     version '0.9.46'
     sha256 '20f7e81624b6f007d6fdd8944cab3d9ba48c36fd0b4f1405a590526b5d4859bc'
   else
-    version '0.9.59'
-    sha256 '8e9288aac1cdd4359b645fad530a771abd6acfad474544c668176925b9aaaf52'
+    version '0.9.60'
+    sha256 '70bc88973af7ab8f12d64e7408a94d59592e96518f67cb385bddef18ba14c4e9'
   end
 
   # github.com/Hammerspoon/hammerspoon was verified as official when first introduced to the cask
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip"
   appcast 'https://github.com/Hammerspoon/hammerspoon/releases.atom',
-          checkpoint: 'c6acea1292058e414546408b272ae3e8623f85520098d2e2696e5651ff475a33'
+          checkpoint: 'd74e7c78815ecf07071012f401f902f319fcfaef364ebbbb22b832b96419a061'
   name 'Hammerspoon'
   homepage 'http://www.hammerspoon.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.