### PR TITLE
Update netron to 1.4.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.4.3'
-  sha256 '7ddc4e28ba50d32fb5554006bac7ecdcca240fc6126b48956e222c87e3263a8a'
+  version '1.4.4'
+  sha256 'a9e897683e5ba0d8fd4b1e1a1a7dae14244e2df0976959920e0fb6e1594f0970'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'bfb3794e66d5103599f832df48c9ebd58b0b3d4b1d374666ed2589cf7b0a2d5e'
+          checkpoint: 'bdbfabe867d98e64b80683030df585ab47839cbb4c5fbb2966e06b9957b4b8f4'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.