### PR TITLE
tableplus 1.0,87 checksum fix

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
   version '1.0,87'
-  sha256 '85eb319819aa270a5506524cfa22af0593e35b0afc1dd746b1a01faea381a1e1'
+  sha256 '6efc0060db4ccee39cb51873a41b8d04f421f6685390d9a8964f2b241e95e9e3'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: '98ad9a69f82b6bdcfa76a8091bfe0ad4b951a5023cec049359a15219cc12f985'
+          checkpoint: '5376bfe303b26320689a147cbc26ec14577cbf6f816629101afe5c5b94d4fc78'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
Checksum for Cask 'tableplus' does not match

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.