### PR TITLE
Update pagico to 8.8.2225

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,8 +1,8 @@
 cask 'pagico' do
-  version '8.8.2213'
-  sha256 '006b08d6c1f4cbc5a46bfdb71a663aedf11707bc1e4648b1bfcacbf29868d28b'
+  version '8.8.2225'
+  sha256 'f1f73bb56293e21514c7973bec6f519bdaaf9cf0d36986daa4ba26e1bb81778e'
 
-  url "https://www.pagico.com/downloads/Pagico_Desktop_r#{version.patch}.dmg"
+  url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   name 'Pagico'
   homepage 'https://www.pagico.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.