### PR TITLE
Update gramps to 4.2.8-1

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,11 +1,11 @@
 cask 'gramps' do
-  version '4.2.6-1'
-  sha256 'b38648187e2eae04d4e4012e64754c721960582118c05c4ae61726bafc1bad93'
+  version '4.2.8-1'
+  sha256 '0dcb09ec5d40c9e42b26223a30d74d57450572ececad8cb25a3d4ee8e1a3f80a'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"
   appcast 'https://github.com/gramps-project/gramps/releases.atom',
-          checkpoint: '381bfc19f192623005e03ce6a1b63e63bc3d7271c70d6b27c031ad3f287ab7b5'
+          checkpoint: 'eda1607f53fd34ff0dc4e535158800f9d29831a3270f273fb4f280f476388cfb'
   name 'Gramps'
   homepage 'https://gramps-project.org/introduction-WP/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.