### PR TITLE
Update vimr to 0.20.6-261-261

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.20.5-259'
-  sha256 '17c67b74207c0d7dfff5dfd2b1a298fe4cb06022f035aa9268cb92ab95f455a6'
+  version '0.20.6-261-261'
+  sha256 'c75b6c2b76570a4411b10858ee1eec3a5a4f9c25b8fd58c040568b835c787fc3'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: '7a735885c4090b05ade472e4a2fb69a51f5b1954322f296dffd371559ae6fdc5'
+          checkpoint: '229674c37ad5b56aa10ef4cc94f052f188664bf875c6897677f2bffe66efbcf7'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.