### PR TITLE
Updated cevelop to v1.9.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,10 +1,10 @@
 cask 'cevelop' do
-  version '1.8.0-201707131430'
-  sha256 '5317b246223334c3c46a82ca35df852b518b7ecdc6ff715c3ff77124c2642a89'
+  version '1.9.0-201802051526'
+  sha256 'e2236ab25b8af60d8328c825942e1f77dd8ecae5891fb2b9e57ea739574fe493'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/',
-          checkpoint: '58bcd0acc6a5ea02c2d34834997f87379f2fc1dd8d1fa8017e395c6ba6875553'
+          checkpoint: '028df297be15a0d8f7078370fa55c9e23401868e3893433b36be2aeac4c285e6'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.9.0.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.