### PR TITLE
Update cloudytabs to 1.9

### DIFF
--- a/Casks/cloudytabs.rb
+++ b/Casks/cloudytabs.rb
@@ -1,10 +1,10 @@
 cask 'cloudytabs' do
-  version '1.8'
-  sha256 'fbaece85ea803f74fa6c1abf089445bd2722dae39649a1738d58cfeea03d5877'
+  version '1.9'
+  sha256 '55fd43096c708e859ad969533c4034ab00a6be2f6bab5a5ccde3069cd976f5d5'
 
   url "https://github.com/josh-/CloudyTabs/releases/download/v#{version}/CloudyTabs.zip"
   appcast 'https://github.com/josh-/CloudyTabs/releases.atom',
-          checkpoint: 'b1a3921bc8e07b1c932632b5bea35f3e10899640ee37088c5897564396c78e03'
+          checkpoint: '1b74a4bfb365fc8bbe49be719a85932220f292f5d3238bd938edbcde60ec540e'
   name 'CloudyTabs'
   homepage 'https://github.com/josh-/CloudyTabs/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.