### PR TITLE
Update hstracker to 1.3.4

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.3.3'
-  sha256 '9ffd18712ef1431a09f4d86922ed4073bebccf79ee1f89ac5d6e3c9282177d33'
+  version '1.3.4'
+  sha256 '1c7fb69f5de42592d647c4fcf5665af0bbfc65363361e2b73507c307bf141d79'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: '6511d137f4071ef2358b28bd693a8abcf258b62be8d90b0c3b2eb2c8152ceffe'
+          checkpoint: '32fde260af3d782fd2be575e43b0b8c4ac59fafba2bc487b0b7eead1e7ea6068'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.