### PR TITLE
Update oryoki to 0.2.2

### DIFF
--- a/Casks/oryoki.rb
+++ b/Casks/oryoki.rb
@@ -1,11 +1,11 @@
 cask 'oryoki' do
-  version '0.2.1'
-  sha256 '08ae4ef31e8d4712ff4159ea81c087db03be6ea51e51185051959992aee9ed82'
+  version '0.2.2'
+  sha256 '419a251b1be83c1f11763d4713920f5e7676a2cb23fc9e359e0d2d4fd349e23f'
 
   # github.com/thmsbfft/oryoki was verified as official when first introduced to the cask
   url "https://github.com/thmsbfft/oryoki/releases/download/#{version}/Oryoki-#{version}.zip"
   appcast 'https://github.com/thmsbfft/oryoki/releases.atom',
-          checkpoint: 'ee8d0b12e4b14ff2e03e3f162552d89c2d9aa4430d645987702c9e68bdcbc2c5'
+          checkpoint: '5cf035ce9c0df5957ebdc566e7c2a6bd8cf78e1107f83f6fc3f4abcdeaf31dfa'
   name 'Oryoki'
   name 'Ōryōki'
   name '応量器'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.