### PR TITLE
Update stargazer to 1.5.4

### DIFF
--- a/Casks/stargazer.rb
+++ b/Casks/stargazer.rb
@@ -1,11 +1,11 @@
 cask 'stargazer' do
-  version '1.5.3'
-  sha256 '2fae109e6e3440f7189b3bbd4d0a0dd31657cb2d4d43b54d9492f80d49b7b8df'
+  version '1.5.4'
+  sha256 '3ae4f03d76219292e6babf468d44ab0e7ed2502b2ab6d3ebde6dabcfec725755'
 
   # github.com/johansten/stargazer was verified as official when first introduced to the cask
   url "https://github.com/johansten/stargazer/releases/download/v#{version}/Stargazer-#{version}.dmg"
   appcast 'https://github.com/johansten/stargazer/releases.atom',
-          checkpoint: 'eb24e83176b839818a64a9e5e7b9d0ffa3cbd9d43bd52a781863112a3fd06bf2'
+          checkpoint: '42ec9c5752a9f76c5adcb16e2a17985ff8c328f21c140f41243c098392fb4d0d'
   name 'Stargazer'
   homepage 'https://getstargazer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.