### PR TITLE
Update viscosity to 1.7.7

### DIFF
--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,10 +1,10 @@
 cask 'viscosity' do
-  version '1.7.6'
-  sha256 'f34b3d2bcf8e57e33db2e678a17bbef029b0175faaae3373fa29a929fbc4df84'
+  version '1.7.7'
+  sha256 '19f3650e9ac7e781c0ac11ff2a2704c9c79cc5c38b7fcf7f978b97a298919467'
 
   url "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%20#{version}.dmg"
   appcast 'https://swupdate.sparklabs.com/appcast/mac/release/viscosity/',
-          checkpoint: '496aa5e3dcb5c19ebda7aed2a8a9c5053e6a24b77941c3db5e7653161915dfa7'
+          checkpoint: 'a588977c3dbf8bb0b5c9d1adde6b665b51eb0799772c58714035f4dc57341055'
   name 'Viscosity'
   homepage 'https://www.sparklabs.com/viscosity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.