### PR TITLE
Update unity-linux-support-for-editor to 2017.3.1f1,fc1d3344e6ea

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2017.3.0f3,a9f86dcd79df'
-  sha256 '2bd298a2f5ab966ba7df702c9f173fda2fe762afd3ddb451ce8c077f28cab19a'
+  version '2017.3.1f1,fc1d3344e6ea'
+  sha256 '58e7166b0d354cfb82e37bbc07b790cf3d295416479f8ee52ec1b41bc5959da8'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Linux Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.