### PR TITLE
Update unity: uninstall delete 'app'

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -9,5 +9,6 @@ cask 'unity' do
   pkg 'Unity.pkg'
 
   uninstall quit:    'com.unity3d.UnityEditor5.x',
-            pkgutil: 'com.unity3d.UnityEditor5.x'
+            pkgutil: 'com.unity3d.UnityEditor5.x',
+            delete:  '/Applications/Unity/Unity.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://travis-ci.org/caskroom/homebrew-cask/builds/340654986?utm_source=github_status&utm_medium=notification
```
>>> Leftover: apps
> /Applications/Unity/Unity.app
```