### PR TITLE
Update awa to 1.5.0

### DIFF
--- a/Casks/awa.rb
+++ b/Casks/awa.rb
@@ -1,6 +1,6 @@
 cask 'awa' do
-  version '1.4.2'
-  sha256 '3fbd1cc851d4157c6a8abc340a4200eff9e2d0d51764b41b12929df09da4ce8c'
+  version '1.5.0'
+  sha256 '97664b9ff891894cca55550671718171ee71dce05446de0271ed51e82debad50'
 
   # download-d.awa.io/mac/stable was verified as official when first introduced to the cask
   url "https://download-d.awa.io/mac/stable/AWASetup-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.