### PR TITLE
script.sh: sleep 5

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -55,7 +55,7 @@ else
   ohai 'No Casks modified, skipping'
 fi
 
-sleep 5
+sleep 5 # Rerunning the checks too soon can result in false positives
 
 for check in "${checks[@]}"; do
   "${check}" > "${HOME}/cask-checks/after/${check}"

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -55,6 +55,8 @@ else
   ohai 'No Casks modified, skipping'
 fi
 
+sleep 5
+
 for check in "${checks[@]}"; do
   "${check}" > "${HOME}/cask-checks/after/${check}"
 


### PR DESCRIPTION
Sleep for 5 seconds because running the checks too soon can result in false positives.

https://travis-ci.org/caskroom/homebrew-cask/builds/340827295#L1577
```
>>> brew cask uninstall --verbose Casks/squirrelsql.rb
==> Uninstalling Cask squirrelsql
==> Purging files for version 3.8.1 of Cask squirrelsql

>>> Leftover: apps
> /Applications/SQuirreLSQL.app
```
https://travis-ci.org/caskroom/homebrew-cask/builds/340860167#L1578
```
>>> brew cask uninstall --verbose Casks/squirrelsql.rb
==> Uninstalling Cask squirrelsql
==> Purging files for version 3.8.1 of Cask squirrelsql

The command ". ci/travis/script.sh" exited with 0.
```