### PR TITLE
Fix logisim-evolution 2.14.4 sha256

### DIFF
--- a/Casks/logisim-evolution.rb
+++ b/Casks/logisim-evolution.rb
@@ -1,6 +1,6 @@
 cask 'logisim-evolution' do
   version '2.14.4'
-  sha256 '5b659436dc719862a3c9815ebf6f8deb2499e31d2e91574c8dea789578d83908'
+  sha256 '3ca55caac762ca63d928e52f0f92013fb2a14d8d7031e378ef187c5969aef4f9'
 
   url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution.jar"
   appcast 'https://github.com/reds-heig/logisim-evolution/releases.atom',


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.