### PR TITLE
Update avocode to 2.19.2

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '2.19.1'
-  sha256 '4c5b8b094646ca3f8bfba826194a71d73b2f747084b8c2a67358509ccb58c64e'
+  version '2.19.2'
+  sha256 '73da411047261c9a3557327b6d50068c0b0ccbafba91b639c030e368f9c1fa59'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   name 'Avocode'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.