### PR TITLE
Update championify to 2.1.5

### DIFF
--- a/Casks/championify.rb
+++ b/Casks/championify.rb
@@ -1,10 +1,10 @@
 cask 'championify' do
-  version '2.1.4'
-  sha256 '64db96b2d1dc0e6c5a208565a035d7948fbcddeb60ca22d769c7edaa9b28db78'
+  version '2.1.5'
+  sha256 '4069269c30c2aa2c150a1613bc7e55827ac6464a6d814be6a50c8e2404edb160'
 
   url "https://github.com/dustinblackman/Championify/releases/download/#{version}/Championify-OSX-#{version}.dmg"
   appcast 'https://github.com/dustinblackman/Championify/releases.atom',
-          checkpoint: 'c8ab08e38f553f47c264c72bcdcd40672161a3e663836cbb2f44174a359a095d'
+          checkpoint: '63d0db65b3ab75faf5c15ad7ac30971b73acbd6c210f5b3e1b36ca400bd20218'
   name 'Championify'
   homepage 'https://github.com/dustinblackman/Championify/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.