### PR TITLE
Update quip to 5.2.26

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.2.18'
-  sha256 'c068bc1a2f1e8cd0f73c122e99a8425d56dfe917cd22c6d17046be079b276d92'
+  version '5.2.26'
+  sha256 '811f2681ff98c2bbf9032643f32d4f7877b5e51b4d792b86aaf62bc8482086d9'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.