### PR TITLE
Update copay to 3.14.1

### DIFF
--- a/Casks/copay.rb
+++ b/Casks/copay.rb
@@ -1,11 +1,11 @@
 cask 'copay' do
-  version '3.14.0'
-  sha256 '524b6259e67640add384b6d9a133db8b6a424c7d4698257c5f73bde9fcb62e51'
+  version '3.14.1'
+  sha256 '829f0cacce2e53f361c36d0f6a471073fd525d236775dfd10929ff90fa4b7b29'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/Copay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'f558ac51ea5a6cf6a7c61347731b5221625c8fb871f9a5f415cdfd53124ccfcc'
+          checkpoint: 'b431beb451e59a79ab660d86f85a40a51db36a2e05cff0053abe31089a208e03'
   name 'Copay'
   homepage 'https://copay.io/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.