### PR TITLE
Update fly to 3.9.0

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.8.0'
-  sha256 'fe00de8aadc09c8a4395fd03fa99d1e371eb26214a3ffc7aa79df94d4d8dad91'
+  version '3.9.0'
+  sha256 'ce4a12e136cff4c2c55bee9a7ded7b05ac6ef867369e947ddd525c61392e2051'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: 'ca61b5b64d280d6c83a22631d981071a67f6a7115eda6da506fe6f09def66fac'
+          checkpoint: '8df2559bb7359c4419ba477e9d2211dae1ecbca2656d6e869694a566ebfe796a'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.