### PR TITLE
Update standard-notes to 2.1.0

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.0.42'
-  sha256 'aa3e88989b3b9c81fb3b1629fd9945fd8a09b7a83933f6bc2d81035871e61bc1'
+  version '2.1.0'
+  sha256 '329e8ccb14a10de2a6f59166f60498ec8bf09df6ffb55a8a010b6ea5bc0a2aa8'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'b03f5bd462074dbd0caf7c69065b9c79c25e79d93c6971ca4a9bafcb44a2e61f'
+          checkpoint: 'b7a7c39704a625af883076d217b4773d24af3eba5a7d4a7f7df470b003150ed7'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.