### PR TITLE
Update endurance to 1.1r18

### DIFF
--- a/Casks/endurance.rb
+++ b/Casks/endurance.rb
@@ -1,8 +1,8 @@
 cask 'endurance' do
-  version :latest
-  sha256 :no_check
+  version '1.1r18'
+  sha256 'a20ceb5629de4b8785ebb6b4e0e86ca0be36de591c2dc6ed39f73e9cdd0c9884'
 
-  url 'http://enduranceapp.com/download'
+  url "https://enduranceapp.com/downloads/Endurance#{version}.zip"
   name 'Endurance'
   homepage 'https://enduranceapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.