### PR TITLE
Update araxis-merge to 2018.4971

### DIFF
--- a/Casks/araxis-merge.rb
+++ b/Casks/araxis-merge.rb
@@ -8,25 +8,17 @@ cask 'araxis-merge' do
     sha256 '341b47242f30aca3ce3c0af9112c95f3bdac5f5ae262aa1894a9632b46fef6ab'
     url "https://www.araxis.com/download/Merge#{version}-OSX10.9.dmg"
   elsif MacOS.version <= :yosemite
-    version '2017.4855'
-    sha256 '7ba0fb79a0ef1a6e3c1f569e6b6c384d9d83d09a255faf4ed200252a8db85c8f'
+    version '2017.4884'
+    sha256 'abba11a92e1f50d913356d31123bed5bb08838ce39c4659206fd24c32432c4b3'
     url "https://www.araxis.com/download/Merge#{version}-OSX10.10.dmg"
-  elsif MacOS.version <= :el_capitan
-    version '2017.4937'
-    sha256 'a9a6ebfcf13a1fb30633dc5fe83633725052420fffb6743e85a8acea24909514'
-    url "https://www.araxis.com/download/Merge#{version}-OSX10.11.dmg"
-  elsif MacOS.version <= :sierra
-    version '2017.4937'
-    sha256 'e9e4cf7fed08a25327ca16ce18e799422b6c44cd5fc3a078844ca0ed6584e289'
-    url "https://www.araxis.com/download/Merge#{version}-macOS10.12.dmg"
   else
-    version '2017.4937'
-    sha256 '5173d6e2bf1a0f289ddb6bb07f7f5aebbf455cbf10f1c25958a2fbc43f5b4304'
-    url "https://www.araxis.com/download/Merge#{version}-macOS10.13.dmg"
+    version '2018.4971'
+    sha256 'f16f7aa874dab7fa3f48e7284f9613e0c8c872034ffa4ddce20f37b38c8200f4'
+    url "https://www.araxis.com/download/Merge#{version}-macOS.dmg"
   end
 
   appcast 'https://www.araxis.com/news-feed.atom',
-          checkpoint: 'c298dbcf8d6c2de5c2331c7569a6ad25795a0bb3efc696d95d9d1bfa17bfaf64'
+          checkpoint: '7c405cb5dcce28e0ee8da41c76bb2cd4a908f77bb81896c58257e526909c5341'
   name 'Araxis Merge'
   homepage 'https://www.araxis.com/merge/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://www.araxis.com/merge/documentation-os-x/release-notes.en

> A single installation disk-image download covers all supported versions of macOS and OS X. Previously, each version of the operating system required its own separate Merge download.