### PR TITLE
Update adobe-acrobat-reader to 18.011.20035

### DIFF
--- a/Casks/adobe-acrobat-reader.rb
+++ b/Casks/adobe-acrobat-reader.rb
@@ -11,7 +11,11 @@ cask 'adobe-acrobat-reader' do
 
   pkg "AcroRdrDC_#{version.no_dots}_MUI.pkg"
 
-  uninstall pkgutil: 'com.adobe.acrobat.DC.reader.*',
+  uninstall pkgutil: [
+                       'com.adobe.acrobat.DC.reader.*',
+                       'com.adobe.RdrServicesUpdater',
+                       'com.adobe.armdc.app.pkg',
+                     ],
             delete:  '/Applications/Adobe Acrobat Reader DC.app',
             quit:    [
                        'com.adobe.Reader',

--- a/Casks/adobe-acrobat-reader.rb
+++ b/Casks/adobe-acrobat-reader.rb
@@ -11,17 +11,22 @@ cask 'adobe-acrobat-reader' do
 
   pkg "AcroRdrDC_#{version.no_dots}_MUI.pkg"
 
-  uninstall pkgutil: [
-                       'com.adobe.acrobat.DC.reader.*',
-                       'com.adobe.RdrServicesUpdater',
-                       'com.adobe.armdc.app.pkg',
-                     ],
-            delete:  '/Applications/Adobe Acrobat Reader DC.app',
-            quit:    [
-                       'com.adobe.Reader',
-                       'com.adobe.AdobeRdrCEFHelper',
-                       'com.adobe.AdobeRdrCEF',
-                     ]
+  uninstall pkgutil:   [
+                         'com.adobe.acrobat.DC.reader.*',
+                         'com.adobe.RdrServicesUpdater',
+                         'com.adobe.armdc.app.pkg',
+                       ],
+            delete:    '/Applications/Adobe Acrobat Reader DC.app',
+            quit:      [
+                         'com.adobe.Reader',
+                         'com.adobe.AdobeRdrCEFHelper',
+                         'com.adobe.AdobeRdrCEF',
+                       ],
+            launchctl: [
+                         'com.adobe.ARMDC.Communicator',
+                         'com.adobe.ARMDC.SMJobBlessHelper',
+                         'com.adobe.ARMDCHelper.cc24aef4a1b90ed56a725c38014c95072f92651fb65e1bf9c8e43c37a23d420d',
+                       ]
 
   zap trash: [
                '~/Library/Preferences/com.adobe.Reader.plist',

--- a/Casks/adobe-acrobat-reader.rb
+++ b/Casks/adobe-acrobat-reader.rb
@@ -1,6 +1,6 @@
 cask 'adobe-acrobat-reader' do
-  version '18.009.20044'
-  sha256 '7cedf7def4554b167b55322b1351a3a470463066a6e338070de57e2b00cb3409'
+  version '18.011.20035'
+  sha256 '57d4a5a255f8a714aaa34e0ccb2862303d60f1a8b77afb961959212fcdec3d47'
 
   url "http://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.no_dots}/AcroRdrDC_#{version.no_dots}_MUI.dmg"
   name 'Adobe Acrobat Reader DC'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.