### PR TITLE
Update minitube to 2.9

### DIFF
--- a/Casks/minitube.rb
+++ b/Casks/minitube.rb
@@ -1,12 +1,12 @@
 cask 'minitube' do
-  version '2.8'
-  sha256 '982f89c34ac425b50ffc79c2a586bacb1a6c3b501ec8294ddca6595ea2baa08e'
+  version '2.9'
+  sha256 'b1e2db72731974f4314461eac245d67e6a8a7991ff5a54e310b59fab74ce3ff2'
 
-  url 'http://flavio.tordini.org/files/minitube/minitube.dmg'
-  appcast 'http://flavio.tordini.org/minitube-ws/appcast.xml',
-          checkpoint: '9135952d27429f3e81c1aaea2546a194df9cb29abfe180ad805ab3f9b18c6b9c'
+  url 'https://flavio.tordini.org/files/minitube/minitube.dmg'
+  appcast 'https://flavio.tordini.org/minitube-ws/appcast.xml',
+          checkpoint: 'dbba6cb37544ab549f5dc7103c5aabc07a70ec4571a3b0b6815140795093b1a3'
   name 'Minitube'
-  homepage 'http://flavio.tordini.org/minitube'
+  homepage 'https://flavio.tordini.org/minitube'
 
   app 'Minitube.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.