### PR TITLE
Update mirador to 1.5.0

### DIFF
--- a/Casks/mirador.rb
+++ b/Casks/mirador.rb
@@ -1,11 +1,11 @@
 cask 'mirador' do
-  version '1.4.2'
-  sha256 '39980fc8e391d9e832fb56c862e7177dcb33c16e571338dce058f3dd74e8e753'
+  version '1.5.0'
+  sha256 'bb65824a703a812b658f3956148500137be00de85e26d7045fdd5d10c998428f'
 
   # github.com/mirador/mirador was verified as official when first introduced to the cask
   url "https://github.com/mirador/mirador/releases/download/latest-macos/mirador-#{version}-macos.zip"
   appcast 'https://github.com/mirador/mirador/releases.atom',
-          checkpoint: 'd941f12631b7d90773a77e345d03def8bde1b36a963d2079e9083778e06283d6'
+          checkpoint: '6e4c5ccf5b625b75b1b525a2f4cc526cf3bdca22f2971033ce813a9499bf6d73'
   name 'Mirador'
   homepage 'https://fathom.info/mirador/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.