### PR TITLE
Update mnemosyne to 2.6

### DIFF
--- a/Casks/mnemosyne.rb
+++ b/Casks/mnemosyne.rb
@@ -1,11 +1,11 @@
 cask 'mnemosyne' do
-  version '2.5'
-  sha256 'bc96a436f59e1f7f02a536679c8a811db844b5a267e88962c2159f90937ac9d4'
+  version '2.6'
+  sha256 'e4a965c4cdc8478baea0be940e333b83016deff3106b3d7f3fb993c479b45a20'
 
   # sourceforge.net/mnemosyne-proj was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/mnemosyne-proj/mnemosyne/mnemosyne-#{version}/Mnemosyne-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/mnemosyne-proj/rss?path=/mnemosyne',
-          checkpoint: '43fb5c0bf4be29f6e67f10a3cef5994da60864520723073c22f8280860546272'
+          checkpoint: '5c80600a3f49a12dc1db4aa65b048c306d04af6928b4027aa984f2cde627fb75'
   name 'Mnemosyne'
   homepage 'https://mnemosyne-proj.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.