### PR TITLE
Update clipgrab to 3.6.7

### DIFF
--- a/Casks/clipgrab.rb
+++ b/Casks/clipgrab.rb
@@ -1,6 +1,6 @@
 cask 'clipgrab' do
-  version '3.6.6'
-  sha256 'e9d1afed9ee2cf047e7a8df3eeaa13ec7900c48dd98723a28a9bb4dfa10ad2d7'
+  version '3.6.7'
+  sha256 '8e0593b69c293c86f14fbd4f736f1453a84faf2ea0b6c92ae09a8ff10638094b'
 
   url "https://download.clipgrab.org/ClipGrab-#{version}.dmg"
   name 'ClipGrab'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.