### PR TITLE
Update minishift to 1.13.1

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.13.0'
-  sha256 '2ae2d05aabe3b8adf7add5cab51e53a3a3634bf87492a2dcf312efdf217b7339'
+  version '1.13.1'
+  sha256 'cfe006bcd1da0c4c119d25949cea368bb1055c520fbfc470623caf01860b6284'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: '59b745b38eec4777a1689e76345dd24547306a6dc8fd08ec35a75cdf2499774b'
+          checkpoint: '9732bb60963d6d6b26299ffd6e1430e4e8b7d5969c5782f0418ef09f602d7a0e'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.