### PR TITLE
Update pyzo to 4.5.1

### DIFF
--- a/Casks/pyzo.rb
+++ b/Casks/pyzo.rb
@@ -1,11 +1,11 @@
 cask 'pyzo' do
-  version '4.5.0'
-  sha256 '45803003a51d5d1d8dd9a114ce34e2fa5da6d40213450ce93faa863b5792db6f'
+  version '4.5.1'
+  sha256 'a2fdf72305a9ba7600e1bfa34781c212891eaa23ea08ecd071d1f14dcf0d0a84'
 
   # github.com/pyzo/pyzo was verified as official when first introduced to the cask
   url "https://github.com/pyzo/pyzo/releases/download/v#{version}/pyzo-#{version}-osx64.dmg"
   appcast 'https://github.com/pyzo/pyzo/releases.atom',
-          checkpoint: 'cd706d1dd49c7198fc67c2db665cdd956c3427fc92e6581128dcf5433e4b223b'
+          checkpoint: '975fff49a5a76855abb7a6dad04851dba6d86ebe5f0562a35951178da84e3ecb'
   name 'Pyzo'
   homepage 'http://www.pyzo.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.