### PR TITLE
Update mountain-duck to 2.3.0.9118

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '2.2.2.8962'
-  sha256 '0bbb2a2760313990c634b9f544b6c972dc5c15a2e112d99781d339d69de4f880'
+  version '2.3.0.9118'
+  sha256 'bb5ee46091d9d91b87daafbdb3d68dfc54bf1e8b02aa62cd744ef41ccf31d5ad'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '8946be3129a65fe5e7c6ab420d8c07a8d1a1d98a2bec0e1408295122d1f9ffc9'
+          checkpoint: 'c0b1ce0d7e8af2dbb4b4259fd6ef91ef9e05e4971e378ff814cff75594ef0f9c'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.