### PR TITLE
Fix hedgewars: use 0.9.22 on El Capitan

### DIFF
--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -1,6 +1,11 @@
 cask 'hedgewars' do
-  version '0.9.23'
-  sha256 '2a5fbfa005ec6aeea172270397025c17a2c117224dd21db5214b8cbbeade411b'
+  if MacOS.version <= :el_capitan
+    version '0.9.22'
+    sha256 'adc0b6dd3b47de115e85db1cb72841836444c0ebc77caee8139bfd6561e28fe8'
+  else
+    version '0.9.23'
+    sha256 '2a5fbfa005ec6aeea172270397025c17a2c117224dd21db5214b8cbbeade411b'
+  end
 
   url "http://www.hedgewars.org/download/releases/Hedgewars-#{version}.dmg"
   appcast 'https://www.hedgewars.org/download/appcast.xml',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Hedgewars requires Sierra as of version 0.9.23.