### PR TITLE
Update tankix to 13205

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version '13100'
-  sha256 '657c7e44bd4c2602262d3e3a9eccc0bd935970ae8c5803af36b3f36d9bd993de'
+  version '13205'
+  sha256 '7c27e75b6115576fb269ae5c05ec6cd97c490599630ad07d81b9201ca3d7f290'
 
   url "https://static.tankix.com/app/StandaloneOSXIntel64/master-#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.