### PR TITLE
Update graphiql to 0.7.0

### DIFF
--- a/Casks/graphiql.rb
+++ b/Casks/graphiql.rb
@@ -1,10 +1,10 @@
 cask 'graphiql' do
-  version '0.6.3'
-  sha256 'db0bd648e89f8a97b38e8a818538a037b5f5e193891a323383f89ce06c1a05be'
+  version '0.7.0'
+  sha256 '625da5f42acb58f5caf98ca3581d8f2c2d3b728592ae2f72c181cebefe0c0ee9'
 
   url "https://github.com/skevy/graphiql-app/releases/download/v#{version}/GraphiQL-app-#{version}-mac.zip"
   appcast 'https://github.com/skevy/graphiql-app/releases.atom',
-          checkpoint: '0a2c95ee8e5b359e420c90e4f07e7b4529e8733667d93e33ccdc0f3ec1152453'
+          checkpoint: '7f75917adf6738b6c5d8c4637917d1dd03db065014c11fe08f8c58ad78cfdab4'
   name 'GraphiQL App'
   homepage 'https://github.com/skevy/graphiql-app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.