### PR TITLE
Update liteide to 33.2

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -9,5 +9,5 @@ cask 'liteide' do
   name 'LiteIDE'
   homepage 'http://liteide.org/'
 
-  app 'liteide/LiteIDE.app'
+  app 'LiteIDE.app'
 end

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,11 +1,11 @@
 cask 'liteide' do
-  version '33.1'
-  sha256 '8cdf02a057f802c14e6c70d88414930489c13c77a26427f3e1333e2e66ef9616'
+  version '33.2'
+  sha256 '2b773c078f46d880d6f8f3980ff153c47790068e647d9a9f9fecb0ad7628c67f'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
   url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macosx-qt5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom',
-          checkpoint: '8f33190cbde5cfb5d7387a74a7fd96b9883f7eaab015590a6d1f0270452cf0a9'
+          checkpoint: 'dcc2fc7a31e3f829790c067b09ab80ccbe27ddbc96625091cdd619a5fe0f7e45'
   name 'LiteIDE'
   homepage 'http://liteide.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.