### PR TITLE
Update textexpander to 6.2.5

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,11 +1,11 @@
 cask 'textexpander' do
-  version '6.2.4'
-  sha256 '9cbd0455bc4f67f1240d80a78988c750943e70cf9e749c6dfb4c852a5828110b'
+  version '6.2.5'
+  sha256 'a3bca4a50993f60d9bffa901e90709bbccb64a6667b216ce45eaba191956149d'
 
   # cdn.textexpander.com/mac was verified as official when first introduced to the cask
   url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"
   appcast "https://smilesoftware.com/appcast/TextExpander#{version.major}.xml",
-          checkpoint: 'c63a30d1119b5f61331a1de5038bfe1ee61fc72d32928d010d9f4998dede4c8c'
+          checkpoint: '1e80f157eb7bac6e3f1ef14ea4ce09f79ecf34c751983458d3b69e64948c8560'
   name 'TextExpander'
   homepage 'https://smilesoftware.com/TextExpander'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.