### PR TITLE
Update antconc to 3.5.2

### DIFF
--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -1,11 +1,6 @@
 cask 'antconc' do
-  if MacOS.version <= :snow_leopard
-    version '3.4.1'
-    sha256 '03c353c059b8c0762b01d9be83f435321f5396cbf203bd8b36c6a56682b6a240'
-  else
-    version '3.5.2'
-    sha256 'a7dcdd2473d6e07f3e8afffd9630a4232abcafac4ceef46b8f1a479aeabbec73'
-  end
+  version '3.5.2'
+  sha256 'a7dcdd2473d6e07f3e8afffd9630a4232abcafac4ceef46b8f1a479aeabbec73'
 
   url "http://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   appcast 'http://www.laurenceanthony.net/software/antconc/releases/',

--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -3,13 +3,13 @@ cask 'antconc' do
     version '3.4.1'
     sha256 '03c353c059b8c0762b01d9be83f435321f5396cbf203bd8b36c6a56682b6a240'
   else
-    version '3.4.4'
-    sha256 '2c346728c70dce3279647005f8dd704e48368c91aada684aaee4ce01017c1327'
+    version '3.5.2'
+    sha256 'a7dcdd2473d6e07f3e8afffd9630a4232abcafac4ceef46b8f1a479aeabbec73'
   end
 
   url "http://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   appcast 'http://www.laurenceanthony.net/software/antconc/releases/',
-          checkpoint: '004e394eaa707f9e54139e66f1fce95eb41aff62cd8cf4ef3b4911fca75c77f6'
+          checkpoint: '681d8baa01f5f99650baa9f64cb3ff496bce13bdb346c237441f207a02d7fd17'
   name 'AntConc'
   homepage 'http://www.laurenceanthony.net/software/antconc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.