### PR TITLE
Update antpconc to 1.2.1

### DIFF
--- a/Casks/antpconc.rb
+++ b/Casks/antpconc.rb
@@ -1,10 +1,10 @@
 cask 'antpconc' do
-  version '1.2.0'
-  sha256 'f36adc0b2d36c18c3415fefb6e0b58b669caac7938e0d75ec934ae83941c3b44'
+  version '1.2.1'
+  sha256 '8b3332c3a0f71070783b6c847f203b257bff32b3d5095285c07572dc29c1b9b9'
 
   url "http://www.laurenceanthony.net/software/antpconc/releases/AntPConc#{version.no_dots}/AntPConc.zip"
   appcast 'http://www.laurenceanthony.net/software/antpconc/releases/',
-          checkpoint: 'd7ddfaf52e277ab475b7fc3e9f3ba76c1dfd3a3021de2976f209a1565b284d62'
+          checkpoint: 'ba5c12cb250387a5fa61ff38b0f4f86493e441893f427ff743e95c83cbc4c82e'
   name 'AntPConc'
   homepage 'http://www.laurenceanthony.net/software/antpconc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.