### PR TITLE
Add OpenSC v.0.17.0

### DIFF
--- a/Casks/opensc.rb
+++ b/Casks/opensc.rb
@@ -1,0 +1,17 @@
+cask 'opensc' do
+  version '0.17.0'
+  sha256 'b35a56cafa4403fcb941422e4975c843018965282571d05a660485a21fde1bbe'
+
+  url "https://github.com/OpenSC/OpenSC/releases/download/#{version}/OpenSC-#{version}.dmg"
+  appcast 'https://github.com/github/SoftU2F/releases.atom',
+          checkpoint: 'b574f1d88aedca7b114cd5e473d66cd35180d04d5a9877d5088bad1b0bdb1992'
+  name 'opensc'
+  homepage 'https://github.com/OpenSC/OpenSC'
+
+  pkg "OpenSC #{version}.pkg"
+
+  uninstall script: {
+                      executable: '/usr/local/bin/opensc-uninstall',
+                      sudo:       true,
+                    }
+end

--- a/Casks/opensc.rb
+++ b/Casks/opensc.rb
@@ -5,7 +5,7 @@ cask 'opensc' do
   url "https://github.com/OpenSC/OpenSC/releases/download/#{version}/OpenSC-#{version}.dmg"
   appcast 'https://github.com/OpenSC/OpenSC/releases.atom',
           checkpoint: '064e2a4870fa8f8989661fc602f396220906cea5c4d4e1383f92108a757bdeef'
-  name 'opensc'
+  name 'OpenSC'
   homepage 'https://github.com/OpenSC/OpenSC/wiki'
 
   pkg "OpenSC #{version}.pkg"

--- a/Casks/opensc.rb
+++ b/Casks/opensc.rb
@@ -3,10 +3,10 @@ cask 'opensc' do
   sha256 'b35a56cafa4403fcb941422e4975c843018965282571d05a660485a21fde1bbe'
 
   url "https://github.com/OpenSC/OpenSC/releases/download/#{version}/OpenSC-#{version}.dmg"
-  appcast 'https://github.com/github/SoftU2F/releases.atom',
-          checkpoint: 'b574f1d88aedca7b114cd5e473d66cd35180d04d5a9877d5088bad1b0bdb1992'
+  appcast 'https://github.com/OpenSC/OpenSC/releases.atom',
+          checkpoint: '064e2a4870fa8f8989661fc602f396220906cea5c4d4e1383f92108a757bdeef'
   name 'opensc'
-  homepage 'https://github.com/OpenSC/OpenSC'
+  homepage 'https://github.com/OpenSC/OpenSC/wiki'
 
   pkg "OpenSC #{version}.pkg"
 


### PR DESCRIPTION
The [`opensc` formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/opensc.rb) seems to just download the source and run `./bootstrap && ./configure ${some_args} && make install`. The actual installer distributed by OpenSC does quite a bit more though (see [`build-package.in`](https://github.com/OpenSC/OpenSC/blob/master/MacOSX/build-package.in)).

More specifically, when installing OpenSC with hombrew `OpenSC.tokend` is not installed. This is a major component of OpenSC and is what allows it to interact with the macOS keychain.

I [asked in the forums](https://discourse.brew.sh/t/opensc-formula-is-missing-the-opensc-tokend-component/1683) if we should update the homebrew formula or add a new cask formula. @MikeMcQuaid said that a new cask formula would be better, so here we are.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
