### PR TITLE
Update jamf-migrator to 2.7.1

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,10 +1,10 @@
 cask 'jamf-migrator' do
-  version '2.6.2'
-  sha256 '2c52e92493ce465490c749f1f29b1bdb48d20ea0fadf1f85800b5beeeb8ab2a1'
+  version '2.7.1'
+  sha256 '86529ef9d9d0dcc659c1b5e5a7a35f0ee4ef4454537ff590168521ab5210d599'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom',
-          checkpoint: '30dd7a5e724c655d5655440f7bc35aa8f0a67b7e048b0050cc4b47b893c638a8'
+          checkpoint: 'a55817d73874f77e2a5056ab402054a6f288a939bb9c3874f0f0d8f8be7c2f64'
   name 'JamfMigrator'
   homepage 'https://github.com/jamfprofessionalservices/JamfMigrator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.