### PR TITLE
Update opera to 51.0.2830.34

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '51.0.2830.26'
-  sha256 '3900aa62ecea9c692a407ffc63a15a974c564f6fbcb80bb4974960a1bbed62ea'
+  version '51.0.2830.34'
+  sha256 '58c8d64a7299112f0893a0a404318518d88a79f282f7803d362114424bca736b'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.