### PR TITLE
Update joplin to 1.0.64

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '0.10.61'
-  sha256 'f9b2cb25e03785ad3c501f8d8296a178d4df3c307cbd0602f9d776cc6dd64e5e'
+  version '1.0.64'
+  sha256 '1c95d5d992efbe86c04e7aa078b07e14ec48459341aedfbf7bfd8727109af4e5'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '289b543c7a8345eab3a0b688ddb6727d7306870f05303562b1c84a82de5dd5ec'
+          checkpoint: '303f434baff9307a61b5138991665e6e71c627ceb65f9118c0f5223cd2d1ae73'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 

--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -5,7 +5,7 @@ cask 'joplin' do
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '303f434baff9307a61b5138991665e6e71c627ceb65f9118c0f5223cd2d1ae73'
+          checkpoint: 'fb1cf317972b3ca588ddc4e4c14b22f1aa9b24cd1643c446f729e80fdf53069e'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.