### PR TITLE
Update exodus to 1.45.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.44.1'
-  sha256 'fa1c2ff2df970a90776962695be19c2ccd42b9ff59cc4b7749873a231b0fda5c'
+  version '1.45.0'
+  sha256 'b3d38a1446c97d21b3e9bb45632b3cf556580853a24a9d6d60d37b1d09bf2ed4'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '17ab627cb9e09f9f6a70da8fac5a51be69092a0d9f097ae2154d51373aec9764'
+          checkpoint: 'b846d990802504b6c1f9e87b27e84cb978786ff86e9a8086bc975ba96d9caff3'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.