### PR TITLE
Update tuxera-ntfs to 2018

### DIFF
--- a/Casks/tuxera-ntfs.rb
+++ b/Casks/tuxera-ntfs.rb
@@ -1,6 +1,6 @@
 cask 'tuxera-ntfs' do
-  version '2016.1'
-  sha256 'd957b207b13b705f9ef5e4f54942af0b41fb335219ca0833c34627ce95e968f9'
+  version '2018'
+  sha256 '84af4075f0ceaf42040928447d9f77240e4c3ae4359837e113cf35115400a19a'
 
   url "https://www.tuxera.com/mac/tuxerantfs_#{version}.dmg"
   name 'Tuxera NTFS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.