### PR TITLE
Update cacher to 1.3.2

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.1'
-  sha256 '7b9af384b88d94376685255093e43d73f94c273b5f9c2d94bd9470a52bb51703'
+  version '1.3.2'
+  sha256 'a18a6ef713460439f7c61f422f5b52669bee6902d667ad8eced231f45f1411b2'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'cbee57ab09af2ff98d5237e18c4efde403637a71c5f752d43708d0e4249adc85'
+          checkpoint: '26fe985798db0753ea600ffa90d4c5b32e40c4e73d1ed0bf8a9b7437fc5208ad'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.