### PR TITLE
Update impactor to 0.9.44

### DIFF
--- a/Casks/impactor.rb
+++ b/Casks/impactor.rb
@@ -1,11 +1,11 @@
 cask 'impactor' do
-  version '0.9.42'
-  sha256 '367ee0dde296ee44c4d4474aeedd03000537c425429ac52eaf58aa35fc4c56eb'
+  version '0.9.44'
+  sha256 '119f45f4e082304589aa0891aa0613c977059194539c69974ace0ad91444ca48'
 
   # cache.saurik.com/impactor was verified as official when first introduced to the cask
   url "https://cache.saurik.com/impactor/mac/Impactor_#{version}.dmg"
   appcast 'https://cydia.saurik.com/api/appcast/1',
-          checkpoint: '50b4d0401be38b412868f9cca690365c11f6e1497359b08cf773e336c7b4fa93'
+          checkpoint: '59a66c701e6195ae3b491b938f30df9285e61bc2b6d649f37444890eaf4cba7d'
   name 'Impactor'
   homepage 'http://www.cydiaimpactor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.