### PR TITLE
Update now to 3.8.16

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.15'
-  sha256 '78295ba2bb080a051cb78e68b1bef7ca21e6188e2699d78e71cdad1b0bb7a2c8'
+  version '3.8.16'
+  sha256 '54133d8005907b321f1ade5852e17a451cb7485a92789bd4f720746ea06f2c96'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '67b374ec16e9da81581fd83547e2dfff4c1b90901e1e0531d353accc1dae0065'
+          checkpoint: '87b6f87cf6b35c03879683b8c1412d6d5e6b21541f9e372932fbca91ed6630a0'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.