### PR TITLE
Update overture to 2.6.0

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.5.6'
-  sha256 '3e4b992fc52b5e0aee5e5cddb2c6d562b51161bd8f49e2c082e4f3e261f76971'
+  version '2.6.0'
+  sha256 '9ecdaa3aee858459c9383c9277c82d7f2d28b1a6fba989d49c18223909f77ef6'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: 'af3f9817a721c2ad81fd5d776dd891c5cda37e5b7b96a886213e7b068cca1161'
+          checkpoint: '60e51d8d7b605de42480aba89cd6dadaa3e514fd90b27aabf8d9715cabfabd03'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.