### PR TITLE
Update molotov to 2.0.5

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '2.0.0'
-  sha256 '1c37b387d08f3019f953dd2ddad1e6123e4ac9a5710a3c14741d29f7b58aa84b'
+  version '2.0.5'
+  sha256 'ee37bc3724bacfeb7880af67865d5b446b03bd23856ee78a8e00f596cc4b58e9'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.