### PR TITLE
update malwarebytes to 3.2.35.1162

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '3.1.1.505'
-  sha256 '56f08d321b962d7c582192052330360d8af3096fc2e50a549fee8f6fb09e925b'
+  version '3.2.35.1162'
+  sha256 '789b340b707ae7c3cf978960192258c38839d133556641c255d0d5485a4a5a9a'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.