### PR TITLE
Update pocket-casts to 0.9.6

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,10 +1,10 @@
 cask 'pocket-casts' do
-  version '0.9.5'
-  sha256 'af22a56f8392a5265fb026005a8a242c8024da835826a1d677885eef266a2024'
+  version '0.9.6'
+  sha256 '3c8d9b38976a730173c7f8b3a52a62fa239116e903a1fe6202bc0f04947b24ab'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
   appcast 'https://static2.pocketcasts.com/mac/appcast.xml',
-          checkpoint: 'fe5c0164713ef586e7996fa33ff28555dd8e3c3ecb37a6acd1461b62393e4ff2'
+          checkpoint: '6f522f26c59e1d5fb2576ee203123a4316386a438f2f353b90cb7a88c6eb6e86'
   name 'Pocket Casts'
   homepage 'https://play.pocketcasts.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.