### PR TITLE
Fix Factor 0.97 install by switching to a suite

### DIFF
--- a/Casks/factor.rb
+++ b/Casks/factor.rb
@@ -6,9 +6,9 @@ cask 'factor' do
   name 'Factor'
   homepage 'https://factorcode.org/'
 
-  app 'factor/Factor.app'
+  suite 'factor'
 
   caveats do
-    path_environment_variable "#{staged_path}/factor/"
+    path_environment_variable "#{staged_path}/factor"
   end
 end


### PR DESCRIPTION
The Factor Listener expects to find factor.image and other files included in its disk image to be alongside the application.

Switch from a standalone app stanza to a suite so that all required files are installed.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
