### PR TITLE
Update qt-creator to 4.5.1

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.5.0'
-  sha256 'cb3aac65ddadaccef1bf62a95120f8d74d3e4454f7afcdcb5425f20051d24b5b'
+  version '4.5.1'
+  sha256 '0e2fa581aeaf9b2fb502f613c2e9e2fb705cf1565945326b97bd8539822faa7f'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.