### PR TITLE
Update NVIDIA GeForce NOW.app name

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -8,7 +8,8 @@ cask 'nvidia-geforce-now' do
 
   depends_on macos: '>= :yosemite'
 
-  app 'NVIDIA GeForce NOW.app'
+  # Renamed for consistency: app name is different in the Finder and in a shell.
+  app 'GeForceNOW.app', target: 'NVIDIA GeForce NOW.app'
 
   zap trash: [
                '~/Library/Application Support/NVIDIA/GeForceNOW',

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -8,7 +8,7 @@ cask 'nvidia-geforce-now' do
 
   depends_on macos: '>= :yosemite'
 
-  app 'GeForceNOW.app'
+  app 'NVIDIA GeForce NOW.app'
 
   zap trash: [
                '~/Library/Application Support/NVIDIA/GeForceNOW',


### PR DESCRIPTION
Updated the application name from `GeForceNOW.app` to `NVIDIA GeForce NOW.app`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.