### PR TITLE
Update debt-quencher to 1.2.3:7847,495929

### DIFF
--- a/Casks/debt-quencher.rb
+++ b/Casks/debt-quencher.rb
@@ -1,8 +1,9 @@
 cask 'debt-quencher' do
-  version '1.2.3'
-  sha256 '2083fdb28d3138998a0d6b4b5c4405a18a2e8dd7b71554786386623313c166ad'
+  version '1.2.3:7847,495929'
+  sha256 'c2cdb6161176d7417078bdbdccd88cd4eb553d95b8630c1d2374acdf4bef247e'
 
-  url "http://downloads.nothirst.com/DebtQuencher_#{version.sub(%r{^(\d+)\.(\d+).*}, '\1.\2')}.zip"
+  # paddle.s3.amazonaws.com/fulfillment_downloads was verified as official when first introduced to the cask
+  url "https://paddle.s3.amazonaws.com/fulfillment_downloads/#{version.after_colon.before_comma}/#{version.after_colon.after_comma}/Debt_Quencher.zip"
   appcast 'http://nothirst.com/feeds/DebtQuencherAppcast.xml',
           checkpoint: 'e9dfeda02779bfceea5fb34278f5d28f97d2c6403242d6ba0520c8850a910195'
   name 'Debt Quencher'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.