### PR TITLE
Update dollydrive to 3.99,39987

### DIFF
--- a/Casks/dollydrive.rb
+++ b/Casks/dollydrive.rb
@@ -1,10 +1,10 @@
 cask 'dollydrive' do
-  version '3.98,39850'
-  sha256 'c9c74636485ebd6c2f6377ae0ca3b60c50b2082b545d3a6309795c940fc1419d'
+  version '3.99,39987'
+  sha256 '3644739ed8dece5c2f9f1ff6d50bd184907599566e7a4c20a789959d86b03e3c'
 
   url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.before_comma}_#{version.after_comma}_CERTIFIED.zip"
   appcast "http://www.dollydrive.com/dolly#{version.major}.xml",
-          checkpoint: '306c616fa81dda21d26b26af52ff14bef91cea308a6585bcf23d9dec16d16922'
+          checkpoint: '69c3bbbc40c30294e9c2522add974a59ded347b23a87036b722aacb8e61a91c5'
   name 'DollyDrive'
   homepage 'http://www.dollydrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.