### PR TITLE
Update vox to 3.2.1

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,11 +1,11 @@
 cask 'vox' do
-  version '3.1'
-  sha256 '0d2388b9da421032ae9aa0f6b23c47d1d14deec8a8e21829ba7fdd36deeb34f7'
+  version '3.2.1'
+  sha256 '0000761ec5d874b374945a2ad54aeb41a3d637a483d3ebd813647f053ea96ebf'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'
   appcast 'https://updates.devmate.com/com.coppertino.Vox.xml',
-          checkpoint: '6a6fefd1083763d3776b280410b6b284513bd0de4bb4563f85d5055118c27b71'
+          checkpoint: '027278951864ae54578aef216bfda8abbe68afdd5bca42632cfed19edae65b35'
   name 'VOX'
   homepage 'https://vox.rocks/mac-music-player'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.