### PR TITLE
Update bitmessage to 0.6.3.2

### DIFF
--- a/Casks/bitmessage.rb
+++ b/Casks/bitmessage.rb
@@ -1,11 +1,11 @@
 cask 'bitmessage' do
-  version '0.6.2'
-  sha256 '79c02e7d42e0b313baacaee31a4d6df2650f83726fe759705cd88d1038256dcb'
+  version '0.6.3.2'
+  sha256 '40a78384a7a0613333dd76aaafc8ebeb08eb1ef02fceb0925763ce289ec5888b'
 
   # github.com/Bitmessage/PyBitmessage was verified as official when first introduced to the cask
-  url "https://github.com/Bitmessage/PyBitmessage/releases/download/v#{version}/bitmessage-v#{version}.dmg"
+  url "https://github.com/Bitmessage/PyBitmessage/releases/download/#{version}/bitmessage-v#{version}.dmg"
   appcast 'https://github.com/Bitmessage/PyBitmessage/releases.atom',
-          checkpoint: '2616f7341b2d3f00152e31f56953c8692f6c349ee3591570a70699c83c88722b'
+          checkpoint: '57d6ff89a3322acbbdfc91a66cb9c8d24bbd7e88d07b069d089ff2623e021823'
   name 'Bitmessage'
   homepage 'https://bitmessage.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.