### PR TITLE
Update and rename bluemix-cli to ibm-cloud-cli 0.6.5

### DIFF
--- a/Casks/bluemix-cli.rb
+++ b/Casks/bluemix-cli.rb
@@ -1,15 +1,16 @@
 cask 'bluemix-cli' do
-  version '0.6.2'
-  sha256 '383a920469908b2371651fa4e181d0d071d7f0590ac9e5594df77c7fc5e3f25e'
+  version '0.6.5'
+  sha256 '718a6dd70b3bc1af43c9371bf0f432ffb2918c8defb26b4de7a554aef9c8fdf4'
 
   # public.dhe.ibm.com was verified as official when first introduced to the cask
-  url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/Bluemix_CLI_#{version}.pkg"
-  appcast 'https://github.com/IBM-Bluemix/bluemix-cli-release/releases.atom',
-          checkpoint: 'a8b4534e53a5e92e1092fa12f436d3951ba33ecfd52eab99359790fa30543fb5'
+  url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/IBM_Cloud_CLI_#{version}.pkg"
+  appcast 'https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases.atom',
+          checkpoint: 'db99ee28d9d8bf308abe04b856c056488f84c3aac62e66bf2c87c632c1bc7c96'
   name 'Bluemix-CLI'
+  name 'IBM Cloud CLI'
   homepage 'https://clis.ng.bluemix.net/ui/home.html'
 
-  pkg "Bluemix_CLI_#{version}.pkg"
+  pkg "IBM_Cloud_CLI_#{version}.pkg"
 
   uninstall_postflight do
     if File.exist?('/etc/profile')
@@ -28,7 +29,7 @@ cask 'bluemix-cli' do
     system('/usr/bin/sed', '-E', '-i', '.bluemix_uninstall_bak', '-e', '/^### Added by the Bluemix CLI$/d', '-e', '/^source \/usr\/local\/Bluemix\/bx\/zsh_autocomplete$/d', "#{ENV['HOME']}/.zshrc") if File.exist?("#{ENV['HOME']}/.zshrc")
   end
 
-  uninstall pkgutil: 'com.ibm.bluemix.cli',
+  uninstall pkgutil: 'com.ibm.cloud.cli',
             delete:  [
                        '/usr/local/Bluemix',
                        '/usr/local/bin/bx',

--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -1,4 +1,4 @@
-cask 'bluemix-cli' do
+cask 'ibm-cloud-cli' do
   version '0.6.5'
   sha256 '718a6dd70b3bc1af43c9371bf0f432ffb2918c8defb26b4de7a554aef9c8fdf4'
 
@@ -25,14 +25,37 @@ cask 'bluemix-cli' do
                      sudo: true
     end
 
-    system('/usr/bin/sed', '-E', '-i', '.bluemix_uninstall_bak', '-e', '/^### Added by the Bluemix CLI$/d', '-e', '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d', "#{ENV['HOME']}/.bashrc") if File.exist?("#{ENV['HOME']}/.bashrc")
-    system('/usr/bin/sed', '-E', '-i', '.bluemix_uninstall_bak', '-e', '/^### Added by the Bluemix CLI$/d', '-e', '/^source \/usr\/local\/Bluemix\/bx\/zsh_autocomplete$/d', "#{ENV['HOME']}/.zshrc") if File.exist?("#{ENV['HOME']}/.zshrc")
+    if File.exist?("#{ENV['HOME']}/.bashrc")
+      system_command '/usr/bin/sed',
+                     args: [
+                             '-E',
+                             '-i', '.bluemix_uninstall_bak',
+                             '-e', '/^### Added by the Bluemix CLI$/d',
+                             '-e', '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
+                             "#{ENV['HOME']}/.bashrc"
+                           ]
+    end
+
+    if File.exist?("#{ENV['HOME']}/.zshrc")
+      system_command '/usr/bin/sed',
+                     args: [
+                             '-E',
+                             '-i', '.bluemix_uninstall_bak',
+                             '-e', '/^### Added by the Bluemix CLI$/d',
+                             '-e', '/^source \/usr\/local\/Bluemix\/bx\/zsh_autocomplete$/d',
+                             "#{ENV['HOME']}/.zshrc"
+                           ]
+    end
   end
 
   uninstall pkgutil: 'com.ibm.cloud.cli',
             delete:  [
                        '/usr/local/Bluemix',
-                       '/usr/local/bin/bx',
                        '/usr/local/bin/bluemix',
+                       '/usr/local/bin/bluemix-analytics',
                      ]
+
+  caveats do
+    files_in_usr_local
+  end
 end

--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -2,7 +2,7 @@ cask 'ibm-cloud-cli' do
   version '0.6.5'
   sha256 '718a6dd70b3bc1af43c9371bf0f432ffb2918c8defb26b4de7a554aef9c8fdf4'
 
-  # public.dhe.ibm.com was verified as official when first introduced to the cask
+  # public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli was verified as official when first introduced to the cask
   url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/IBM_Cloud_CLI_#{version}.pkg"
   appcast 'https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases.atom',
           checkpoint: 'db99ee28d9d8bf308abe04b856c056488f84c3aac62e66bf2c87c632c1bc7c96'

--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -18,7 +18,7 @@ cask 'ibm-cloud-cli' do
                      args: [
                              '-E',
                              '-i', '.bluemix_uninstall_bak',
-                             '-e', '/^### Added by the Bluemix CLI$/d',
+                             '-e', '/^### Added by IBM Cloud CLI$/d',
                              '-e', '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
                              '/etc/profile'
                            ],
@@ -30,7 +30,7 @@ cask 'ibm-cloud-cli' do
                      args: [
                              '-E',
                              '-i', '.bluemix_uninstall_bak',
-                             '-e', '/^### Added by the Bluemix CLI$/d',
+                             '-e', '/^### Added by IBM Cloud CLI$/d',
                              '-e', '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
                              "#{ENV['HOME']}/.bashrc"
                            ]
@@ -41,7 +41,7 @@ cask 'ibm-cloud-cli' do
                      args: [
                              '-E',
                              '-i', '.bluemix_uninstall_bak',
-                             '-e', '/^### Added by the Bluemix CLI$/d',
+                             '-e', '/^### Added by IBM Cloud CLI$/d',
                              '-e', '/^source \/usr\/local\/Bluemix\/bx\/zsh_autocomplete$/d',
                              "#{ENV['HOME']}/.zshrc"
                            ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.