### PR TITLE
Update bzflag to 2.4.12

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -2,11 +2,13 @@ cask 'bzflag' do
   version '2.4.12'
   sha256 '5bf28fab219bae32cdfd32765289b3454b7e658ffe49d05ea49c2c03d6749fe7'
 
-  url "https://download.bzflag.org/bzflag/osx/#{version}/BZFlag-#{version}-macOS.zip"
+  url "https://download.bzflag.org/bzflag/macos/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom',
-          checkpoint: 'bd9b9100c950397795323125b82cf5b21c789cb6defa9ded7962892b24a71df0'
+          checkpoint: '6e4b261035541185c5cbe2932845df390d71010942d06eb8e94775630620810c'
   name 'BZFlag'
   homepage 'https://www.bzflag.org/'
+
+  depends_on macos: '>= :lion'
 
   app "BZFlag-#{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.