### PR TITLE
Update canary to 1.8.1,396

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '1.8.1,392'
-  sha256 '530006d36d58693c7f1f964d184d01facf159375aea73a3ff44ade291d8b3833'
+  version '1.8.1,396'
+  sha256 'c1950673c9975584dfa478867d1299c5ff78e3d296e97326d2674d88b593f460'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: '0f221a1d55db589f50b768d6c2a18a7ab661d7014ea01bd134c815ce03377205'
+          checkpoint: 'ab95777dfa75cacf26d1bce7d4f8290ee16e2cdee2a618cb44d8157c72cb60bb'
   name 'Canary'
   homepage 'https://canarymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.