### PR TITLE
Update air-video-server-hd to 2.3.0-beta1u1

### DIFF
--- a/Casks/air-video-server-hd.rb
+++ b/Casks/air-video-server-hd.rb
@@ -1,11 +1,11 @@
 cask 'air-video-server-hd' do
-  version '2.2.4-beta2'
-  sha256 'f3578a21f537a04756c0f8af8f8a5ca845baa034e75477f766d78be92977607f'
+  version '2.3.0-beta1u1'
+  sha256 '1e45abf868349f1ad43b6f3a1234a254d31e943ef5c7d72b84eff9f955a15a33'
 
   # amazonaws.com/AirVideoHD was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/AirVideoHD/Download/Air+Video+Server+HD+#{version}.dmg"
   appcast 'https://s3.amazonaws.com/AirVideoHD/Download/appcast.xml',
-          checkpoint: '5bac1596a893cf4ac74db81a40404b6a98a0b8d14c3163cee14882b3557673f8'
+          checkpoint: '2edab1e42ef53acc10dc26be789885edeb737bc83fd75b987c3642a5c533fb5a'
   name 'Air Video Server HD'
   homepage 'http://www.inmethod.com/airvideohd'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.