### PR TITLE
Update losslesscut to 1.10.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,12 +1,18 @@
 cask 'losslesscut' do
-  version '1.9.0'
-  sha256 '4a67572e031b6f240718160df6c5e942f7b8187cd76b79aeaf90447528aca40a'
+  version '1.10.0'
+  sha256 'b6ed8776c1bc0bf1172c39e1d76dab65b5d5a2acbd9249aeb043b4bd98954d56'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-darwin-x64.zip"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom',
-          checkpoint: '3a0d1ac2fe29edb13f3423762425921f124e03af7e7b51a9c79338eba3289d38'
+          checkpoint: 'aaa022ad5a986476e3a182bf7d732b378fe48454d64953bc6918fa4bdd24be07'
   name 'Loslesscut'
   homepage 'https://github.com/mifi/lossless-cut'
 
   app 'LosslessCut-darwin-x64/LosslessCut.app'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.losslesscut.sfl*',
+               '~/Library/Preferences/com.electron.losslesscut.helper.plist',
+               '~/Library/Preferences/com.electron.losslesscut.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.