### PR TITLE
Update clipgrab to 3.6.8

### DIFF
--- a/Casks/clipgrab.rb
+++ b/Casks/clipgrab.rb
@@ -1,6 +1,6 @@
 cask 'clipgrab' do
-  version '3.6.7'
-  sha256 '8e0593b69c293c86f14fbd4f736f1453a84faf2ea0b6c92ae09a8ff10638094b'
+  version '3.6.8'
+  sha256 '2266da071cba1a802526508f2cf65154dcc2a6eeb5de78a31eefb01af3ec573b'
 
   url "https://download.clipgrab.org/ClipGrab-#{version}.dmg"
   name 'ClipGrab'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.