### PR TITLE
Update tropy to 1.1.0

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,11 +1,11 @@
 cask 'tropy' do
-  version '1.0.4'
-  sha256 '8a97c028a025581f92e28e2eb96f503efe00027787a665383c663b62ed26437e'
+  version '1.1.1'
+  sha256 '7999c453504e12de525cb2c6f51a3c0d7e8ab1d6636e93318734a534d12c2a2b'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"
   appcast 'https://github.com/tropy/tropy/releases.atom',
-          checkpoint: '743e9bada47c640bf57cd00f84ae7b11d55d0f7b773d90f8660cfb74078ef472'
+          checkpoint: '5158f64950cee9e470b8c323fe9e849d5ff524a4f48cb9fdc9997af21108e602'
   name 'Tropy'
   homepage 'https://tropy.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.