### PR TITLE
Update robo-3t to 1.2.1,3e50a65

### DIFF
--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -1,6 +1,6 @@
 cask 'robo-3t' do
-  version '1.1.1,c93c6b0'
-  sha256 'b536ca099c200d80a4173c4aa2726fa3eaeaef8ddd17968e2326bd8d2ec9f3b4'
+  version '1.2.1,3e50a65'
+  sha256 'd57940bf81ee812bd49d2b9d7468f33c9a9d39004a0867cef5465ffb6a6d3844'
 
   url "https://download.robomongo.org/#{version.before_comma}/osx/robo3t-#{version.before_comma}-darwin-x86_64-#{version.after_comma}.dmg"
   name 'Robo 3T (formerly Robomongo)'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.