### PR TITLE
Update netron to 1.5.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.4.9'
-  sha256 '8d7b4678fc95c55cd39080a3cced30bc6cd4ac989ecbceebb40d4d48c0805cce'
+  version '1.5.0'
+  sha256 '2da952300b39d2ead951932c724b120b1bf6d7c1c23661c2a1b593aed7271948'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '91d3d66045ed0c6247edacbc5a9ca86bff337211b037beedb0dd5b78bf7d1bbb'
+          checkpoint: '8ac121eeb1b9ad71c319e5e782d299121399a82c5c54e659126e08402a5386b1'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.