### PR TITLE
Update karabiner-elements to 11.6.0

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -18,6 +18,7 @@ cask 'karabiner-elements' do
                        ['TERM', 'karabiner_console_user_server'],
                      ],
             pkgutil: 'org.pqrs.Karabiner-Elements',
+            kext:    'org.pqrs.driver.Karabiner.VirtualHIDDevice.v050000',
             script:  {
                        executable: '/Library/Application Support/org.pqrs/Karabiner-Elements/uninstall_core.sh',
                        sudo:       true,

--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,10 +1,10 @@
 cask 'karabiner-elements' do
-  version '11.5.0'
-  sha256 '73195dabd21fe516b99dee87d32f0dde44615cfb00e1055e9e310fa5ee3eea47'
+  version '11.6.0'
+  sha256 'c1b06252ecc42cdd8051eb3d606050ee47b04532629293245ffdfa01bbc2430d'
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
   appcast 'https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml',
-          checkpoint: 'e532046785a9be31edcec6146694dbc60dc2290320f0e6592bb02ed6bc3d76e5'
+          checkpoint: '90f290396b38c82fe24547572781fa4ed695cf79cd3fb95ca8139d0f893b3dc7'
   name 'Karabiner Elements'
   homepage 'https://pqrs.org/osx/karabiner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.