### PR TITLE
Update provisionql to 1.4.0

### DIFF
--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -1,10 +1,10 @@
 cask 'provisionql' do
-  version '1.3.0'
-  sha256 '2b7ff935d8f4fa813f0cdac895ff9e4284e0090559e5f9c3f0bd7aadcd68e4b1'
+  version '1.4.0'
+  sha256 'c2d4b48f3e6f191fc9daafad67941caadf60b4023085849d2bce3d5fbb0b5193'
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
   appcast 'https://github.com/ealeksandrov/ProvisionQL/releases.atom',
-          checkpoint: '8de3dd53a45de649968cc684f123d7172538dedb01f553fd078931b07717abc3'
+          checkpoint: '5507bd7000949ff464ccfcad67f244d6109d42cd759942c43802eb96dafbe3f2'
   name 'ProvisionQL'
   homepage 'https://github.com/ealeksandrov/ProvisionQL'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.