### PR TITLE
Update jaxx to 1.3.12

### DIFF
--- a/Casks/jaxx.rb
+++ b/Casks/jaxx.rb
@@ -1,11 +1,11 @@
 cask 'jaxx' do
-  version '1.3.11'
-  sha256 'f0d3657c7de3217c2db57eafd370d7df80f367dfd33a47570c15da96eea2e799'
+  version '1.3.12'
+  sha256 '1e19563f4f7c5a9d045b3a3fd6357107559ab54a994ba714058953300cefe166'
 
   # github.com/Jaxx-io/Jaxx was verified as official when first introduced to the cask
   url "https://github.com/Jaxx-io/Jaxx/releases/download/v#{version}/Jaxx-#{version}.dmg"
   appcast 'https://github.com/Jaxx-io/Jaxx/releases.atom',
-          checkpoint: 'b3a999f051714320af674e6175c18ee283be63ec917e6424579729e4cd68e338'
+          checkpoint: '2351faee636501193391d62e1e4b29f7dcc07acfeda00389af944fac746edc01'
   name 'Jaxx Blockchain Wallet'
   homepage 'https://jaxx.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.