### PR TITLE
Update patchwork to 3.8.10

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,10 +1,10 @@
 cask 'patchwork' do
-  version '3.8.8'
-  sha256 'c98a566f7fb3843048ce7d6ae17b6c6315a2f67c751827e97a4f0e2fe02b0bc4'
+  version '3.8.10'
+  sha256 'e25fafdf1b219a0d77ae2a5b24001fb46106b29a05d63b5a5d80da8c50194895'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom',
-          checkpoint: '7b12049462445401d19932e28d9512d3531ffa15047c31549bb331c7481d2ab8'
+          checkpoint: '952a6faed3af64e356ed3c8172cff3733511675e471b65a1c147dc5c8488c938'
   name 'Patchwork'
   homepage 'https://github.com/ssbc/patchwork'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.