### PR TITLE
Update parallels-virtualization-sdk to 13.3.0-43321

### DIFF
--- a/Casks/parallels-virtualization-sdk.rb
+++ b/Casks/parallels-virtualization-sdk.rb
@@ -1,6 +1,6 @@
 cask 'parallels-virtualization-sdk' do
-  version '13.2.0-43213'
-  sha256 '07e1a4cc36f167735b3ed891c61f8286d00ca61acf7181f96fbf8ac27fa8abdf'
+  version '13.3.0-43321'
+  sha256 '55789180b93ced4b62f41da80392d2f3b7376a8ea0ba8f40a2ebd281ec417057'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsVirtualizationSDK-#{version}-mac.dmg"
   name 'Parallels Virtualization SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.