### PR TITLE
Update netron to 1.5.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.5.1'
-  sha256 'eeb044b862901b2fc2cf801dd5357bde91974e0832aebffc68a37eded13ca635'
+  version '1.5.2'
+  sha256 '604ac305832ce73dd18d42cb0c2761e4f0acf0eda6dd08926da907511a8c12be'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '5b443c72a2deab1602f3b3b80889e5107825c6122971b09354da143037c0e801'
+          checkpoint: '74d6208762582ff039dfa268909032d1c3853bc32e485c4e2c8691744e4dcdf3'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.