### PR TITLE
Update inspec to 2.0.17-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '1.51.0-1'
-  sha256 'b8007d337987cfd97dd63709fb8869357554009e6f56ff6079b67440104ab554'
+  version '2.0.17-1'
+  sha256 'e42a9e2c1de402692a012e2ca57b990fa9bf5a60cd8360071a2f929eff2947f8'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.13/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'efe4d78c3e64f629b0afa195b650082f001cf10c15f43bd37bd0249fd518b8a6'
+          checkpoint: '5cac4dd83d3c199f3f45e3932f0c45a1b68065a7839f3e9d3671f72fc0bd0895'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.