### PR TITLE
Update standard-notes to 2.1.1

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.1.0'
-  sha256 '329e8ccb14a10de2a6f59166f60498ec8bf09df6ffb55a8a010b6ea5bc0a2aa8'
+  version '2.1.1'
+  sha256 '76371d289adf6ddd0e5bfac2c52fe2fe6fa4532cab54a08fc1decdcdff95d3f6'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'b7a7c39704a625af883076d217b4773d24af3eba5a7d4a7f7df470b003150ed7'
+          checkpoint: 'a3f273cfafa35b496be8a96bc5c16aa6698985646780bd483ecf3deb8e05a2bb'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.