### PR TITLE
Update altair to 1.6.5

### DIFF
--- a/Casks/altair.rb
+++ b/Casks/altair.rb
@@ -1,11 +1,11 @@
 cask 'altair' do
-  version '1.6.3'
-  sha256 '776d6f5e4e67f8c92012c068607bac23f3ebdcd96658db908d6d9e6fa32fdcb5'
+  version '1.6.5'
+  sha256 '41fae8be4565bb3a2beefa85761ca004c44ac9ef6ca893076ed615257768fae1'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"
   appcast 'https://github.com/imolorhe/altair/releases.atom',
-          checkpoint: '01056b96ed2a2fde084d246ccb4a02f38362fc0b57b462d81b703e7aa793d545'
+          checkpoint: '76822cfd18acc8d4b7d3bf5de0063df0a85d63f121578bf5f64827f458bce759'
   name 'Altair GraphQL Client'
   homepage 'https://altair.sirmuel.design/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.