### PR TITLE
Update now to 3.8.18

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.17'
-  sha256 '5d046ae898c0cfc91c3cbd95047831440e0c63b4c32ecf2bc5acda66c68910f0'
+  version '3.8.18'
+  sha256 'b92769896b3bea22f1442f7a8d40dc8a30cf84dc88c8191968ef3143a03ba226'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: 'ba5c5746be42c44f2058ff9039e518bdad34d1fae5fa790292bf0d977ca53fa9'
+          checkpoint: '9f88a3cdff107cb303defe41cd32cc5b9cb0599ca979fc529ef8ce9e7176c40f'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.