### PR TITLE
Update netron to 1.5.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.5.2'
-  sha256 '604ac305832ce73dd18d42cb0c2761e4f0acf0eda6dd08926da907511a8c12be'
+  version '1.5.3'
+  sha256 '8b752eaf2dab6519209df8d49d95d93184c1eea19d4d38807f4bf1f33e56c617'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '74d6208762582ff039dfa268909032d1c3853bc32e485c4e2c8691744e4dcdf3'
+          checkpoint: '027a4cc27d216d715d901b3b1baf15044b1353f35b764e55ee04f96ae9ae3b0a'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.