### PR TITLE
Update liteide to 33.2

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,13 +1,13 @@
 cask 'liteide' do
   version '33.2'
-  sha256 '2b773c078f46d880d6f8f3980ff153c47790068e647d9a9f9fecb0ad7628c67f'
+  sha256 'abaf9492c156048bff09fb3c6dac7657fbc6fb73389264f24b2cd03d81ad2e47'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
   url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macosx-qt5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom',
-          checkpoint: 'dcc2fc7a31e3f829790c067b09ab80ccbe27ddbc96625091cdd619a5fe0f7e45'
+          checkpoint: 'c19004e6cdb7414f81805b957fc88d0ad1dffc265952ffcf17455407b2d6ec43'
   name 'LiteIDE'
   homepage 'http://liteide.org/'
 
-  app 'LiteIDE.app'
+  app 'liteide/LiteIDE.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.