### PR TITLE
Updated cevelop to v1.9.1

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,10 +1,10 @@
 cask 'cevelop' do
-  version '1.9.0-201802051526'
-  sha256 'e2236ab25b8af60d8328c825942e1f77dd8ecae5891fb2b9e57ea739574fe493'
+  version '1.9.1-201802220948'
+  sha256 '5273f0d409c6393f2fc1402541676972ec7e42531b927ddf0a5034180fd141c0'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/',
-          checkpoint: '028df297be15a0d8f7078370fa55c9e23401868e3893433b36be2aeac4c285e6'
+          checkpoint: 'ed6e2ffba529f57118b6d102edeb5dd7e27d101d33ef0976d24ff1ac4cd9d4a6'
   name 'Cevelop'
   homepage 'https://www.cevelop.com/'
 


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.9.1.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.