### PR TITLE
Update astro to 3.0.5,3773

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '3.0.4,3745'
-  sha256 '6bcb35c466a15700bceaeb2af95120e02353997b225598d21f25efd2ecc02afb'
+  version '3.0.5,3773'
+  sha256 'b212edd96c7d23a39cf2bdaa5532ad6b54d4dcae3a57d416869b35e718091fad'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: '77938345d5b29395b377ca1a19b343977b6897e18ebabd7eaf54a5df949a4419'
+          checkpoint: '8b8e715519dfcd5a6d09ea41d5ece825e7607a689bdc61b5fba9adae3ae0d790'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.