### PR TITLE
Update coqide to 8.7.2

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,11 +1,11 @@
 cask 'coqide' do
-  version '8.7.1-1'
-  sha256 '16c05be6de9094f140dd9659c65d83e3a10f701ae33be8eb3cda354da78496ce'
+  version '8.7.2'
+  sha256 'ad3e7239c3bd157bc8a14d3b5fa7c8bf34e2c9c5db83703330591610e845d35f'
 
   # github.com/coq/coq was verified as official when first introduced to the cask
   url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version}-installer-macos.dmg"
   appcast 'https://github.com/coq/coq/releases.atom',
-          checkpoint: '91af0d574c77ef0997d1f23eb594a1eed4889185ebb4d48db0ff267cd0894d13'
+          checkpoint: '96ab2db426f4a4e9c5bb0f35cb45b8d4ad03fafdf4f2e52af7e3547d2c242579'
   name 'Coq'
   homepage 'https://coq.inria.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.