### PR TITLE
Update bitpay to 3.14.2

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.14.1'
-  sha256 '8e6ef2860f7d7dd5952d9599865256202eb85e05b5052890902add7cdc2bc7fb'
+  version '3.14.2'
+  sha256 '5f7da8dfb9e8944d696cded33fbfa18115f01a151aed385f4e5fb04be7a6dd6e'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'b431beb451e59a79ab660d86f85a40a51db36a2e05cff0053abe31089a208e03'
+          checkpoint: '0dc73ed919aa9337dad13787c755303b86945bc293ff3265014585283ae2b31d'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.