### PR TITLE
Update copay to 3.14.2

### DIFF
--- a/Casks/copay.rb
+++ b/Casks/copay.rb
@@ -1,11 +1,11 @@
 cask 'copay' do
-  version '3.14.1'
-  sha256 '829f0cacce2e53f361c36d0f6a471073fd525d236775dfd10929ff90fa4b7b29'
+  version '3.14.2'
+  sha256 '9c983e794547263f2c3198248b42fc048beba23a711c5a2fbeae1ec022e4062c'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/Copay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: 'b431beb451e59a79ab660d86f85a40a51db36a2e05cff0053abe31089a208e03'
+          checkpoint: '0dc73ed919aa9337dad13787c755303b86945bc293ff3265014585283ae2b31d'
   name 'Copay'
   homepage 'https://copay.io/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.