### PR TITLE
Update buttercup to 1.3.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '1.2.2'
-  sha256 'fe444aa2faf0bd68e04eabf15ca32d6d3768974bc70af6f6bfc8b6756cdecaaf'
+  version '1.3.0'
+  sha256 'fb3b707afe1dd2883601cba20331e1e6b57456eb859307c40892271bafb30018'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: 'bec9ccec95d18ba2fd2ac82bbfc5e9a008c51fe618a9a986d58904dd10e43404'
+          checkpoint: '25595bf9644035944a933ee23df8503fc0e44710e6836d3f8a8d3f5f5360a777'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.