### PR TITLE
Update TablePlus to build 90.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
-  version '1.0,89'
-  sha256 'fe8ad23d9b7ecb2d1c2da02e6bd643e3d284342dbbe9cf892c54271c486a4cdc'
+  version '1.0,90'
+  sha256 '0fae8a64648a41603a3830e25f1afb72fe93ebff6c1560a76d9bd5565df8011a'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: 'e4df533e0e4987317d6704252a0c810c2a4c4963071d2901c259a443d79d9977'
+          checkpoint: '576186ff3f47c1a4bb05d5ed6c8fea5ca0c2e4eea3b3574a6f9b6dd40a196a2b'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download tableplus.rb` is error-free.
- [x] `brew cask style --fix tableplus.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.