### PR TITLE
Update bilibili to 2.54

### DIFF
--- a/Casks/bilibili.rb
+++ b/Casks/bilibili.rb
@@ -1,10 +1,10 @@
 cask 'bilibili' do
-  version '2.53'
-  sha256 '0eac011e84dde2726526452ee575945e0b73db9c63e1d739489df85daa70a3d6'
+  version '2.54'
+  sha256 'a6ca7634095fc637867648c3484cb30823b7b01878d3fcd011122f6b68762410'
 
   url "https://github.com/typcn/bilibili-mac-client/releases/download/#{version}/Bilibili.dmg"
   appcast 'https://github.com/typcn/bilibili-mac-client/releases.atom',
-          checkpoint: 'ace8b3261e55172bf2fecaa11a90c756fc939f94407f9b5df6352820d9b05ded'
+          checkpoint: 'a7ac8087fb617be85ca39bdacd8d9fd8ecf761e77becf7032b6ba0b15394cccf'
   name 'Bilibili'
   homepage 'https://github.com/typcn/bilibili-mac-client/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.