### PR TITLE
Update dvdstyler to 3.0.4

### DIFF
--- a/Casks/dvdstyler.rb
+++ b/Casks/dvdstyler.rb
@@ -1,11 +1,11 @@
 cask 'dvdstyler' do
-  version '3.0.3'
-  sha256 'c7e603a09e8455464d047ebb89b1aa2e4d81c49ade7bb38ed546170cf056b5a6'
+  version '3.0.4'
+  sha256 '12d485facb37c8541585899237391a6b959cf8c9661d3600ca144cd9efc2bae2'
 
   # sourceforge.net/dvdstyler was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dvdstyler/DVDStyler-#{version}-MacOSX.dmg"
   appcast 'https://sourceforge.net/projects/dvdstyler/rss',
-          checkpoint: 'f5dcdcddef5bfa8da5cb8c688cd58e432d2cb5742b3193f99d9a34043c831eee'
+          checkpoint: '9290d747cb761e2ebc694879687daa3d01c0c609dcb72558f2c4400790ce4145'
   name 'DVDStyler'
   homepage 'https://www.dvdstyler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.