### PR TITLE
Update obs to 21.0.3

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -1,11 +1,11 @@
 cask 'obs' do
-  version '21.0.2'
-  sha256 'dc67f301aa4956f0b14645fc3d8d4055f4b82397ac156dfe6378082b485690c3'
+  version '21.0.3'
+  sha256 '16c4f71a965b7f3d0dc04a58a64c49192aad455ce8fc971b0d253babfdefbafc'
 
   # github.com/jp9000/obs-studio was verified as official when first introduced to the cask
   url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-mac-#{version}-installer.pkg"
   appcast 'https://github.com/jp9000/obs-studio/releases.atom',
-          checkpoint: 'd585d7d76b11d0408ad060e250b2072ca64e0763799a3ac0f148d9d0ae0a9cf2'
+          checkpoint: '11a5b29ea1a3e7ce3f03dbadb0ccfbcb3a29ee8359226f15dc96b2bf303e94d7'
   name 'OBS'
   homepage 'https://obsproject.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.