### PR TITLE
Fix MAMP 4.4.1 SHA256

### DIFF
--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -4,7 +4,7 @@ cask 'mamp' do
     sha256 'b935d118b6e14d43cf2570be2a05166a15b824c3edc0ede98cc30e6ab5af3697'
   else
     version '4.4.1'
-    sha256 'e7a83227a60d782d4ad8cea675834bb97cdd06718dc42f5f5e03e9c8944cac06'
+    sha256 '5eab5e3bcca0e7c9641d4cf21c7ee4a5698fa0c2ed7980cdb6a728de7857084b'
   end
 
   url "https://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}.pkg"


### PR DESCRIPTION
The SHA256 of MAMP is not correct.
See https://www.mamp.info/en/downloads/ for correct digest.
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256