### PR TITLE
Update Texpad to 1.8.0

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -5,8 +5,8 @@ cask 'texpad' do
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.dots_to_underscores}.zip"
   else
-    version '1.7.45,237,1487350'
-    sha256 '5973da0e221a9f9168228d628e25b1f788bcdc9ca8cae86cb02089804f3240f5'
+    version '1.8.0,365,f27f248'
+    sha256 'e6657161f8df77bff4e6e2a8561ba99dca15dd400fdb971c8bc7b85594c1cd9f'
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"
     appcast 'https://www.texpad.com/static-collected/upgrades/texpadappcast.xml',

--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -10,7 +10,7 @@ cask 'texpad' do
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"
     appcast 'https://www.texpad.com/static-collected/upgrades/texpadappcast.xml',
-            checkpoint: '3dca6764839ba976aa0504b0ad2c506fb044c16e756d5bbd41b1f5412bde8038'
+            checkpoint: '30c0dcf110015f71d53d2b2dc1ea85fff51177efb1ddbe8830df600aeab3c3e3'
   end
 
   name 'Texpad'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
