### PR TITLE
Update freesmug-chromium to 64.0.3282.186

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '64.0.3282.167'
-  sha256 'bce59dd979cf6368ba00459f6a7da0c898f062e52313b282bf4c2a8da9511c1c'
+  version '64.0.3282.186'
+  sha256 '3dca39ddc1e933138919118a1b00d48e6a44d383f3a556a0ab2b18e2d5806bd8'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: 'fcd1b20b94df1225ed374640f31432dda71f3f646583d80acc239d11cff4403c'
+          checkpoint: '6e174f206370bbdf6b13381b2ec79720b70f700338e28063deb0d13b8f6de205'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Current version on the homepage. http://www.freesmug.org/chromium