### PR TITLE
Update keybase to 1.0.44-20180223192708,9a9ccec79

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,10 +1,10 @@
 cask 'keybase' do
-  version '1.0.41-20180219090016,48b060172'
-  sha256 '5bcf4ef4e0180a245f0e8a8ff94a5713097daa96e654990345f3a30602465a6f'
+  version '1.0.44-20180223192708,9a9ccec79'
+  sha256 '93a53be0ed06c20b6e27324351c0017c157b868d0087648337964277fee46ead'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json',
-          checkpoint: 'f29cb82e31b04c95010eb0f2c55677486d57c4894fedb13a22fb0f8e39b93a9f'
+          checkpoint: 'b595d11c45bf6e94d4f42673e6f4690883cf9d23b56c4cc8d07a982edfc2717e'
   name 'Keybase'
   homepage 'https://keybase.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.