### PR TITLE
Update savoir-faire-linux-ring to 201802231805

### DIFF
--- a/Casks/savoir-faire-linux-ring.rb
+++ b/Casks/savoir-faire-linux-ring.rb
@@ -9,5 +9,7 @@ cask 'savoir-faire-linux-ring' do
   name 'Ring'
   homepage 'https://ring.cx/'
 
+  auto_updates true
+
   app 'Ring.app'
 end

--- a/Casks/savoir-faire-linux-ring.rb
+++ b/Casks/savoir-faire-linux-ring.rb
@@ -1,10 +1,10 @@
 cask 'savoir-faire-linux-ring' do
-  version '201710201455'
-  sha256 'df32a8cb54eca20fd2412521ba2b523afc27244941722676b0ff5397e090e305'
+  version '201802231805'
+  sha256 '0dd8605a408552faab7aa4f2cc29ee076ebac9bf95101b657d1842039ca0e6eb'
 
   url "https://dl.ring.cx/mac_osx/ring-#{version}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',
-          checkpoint: 'ec50e30a44406e82ff3daacfd7704ec155db1479dac83b1980ecb60269d44a6c'
+          checkpoint: '7803aa2cc88bf9357de9c9cc28d359baf3c93ba7a40787c7ceba6f44d81d612d'
   name 'Savoir-faire LINUX Ring'
   name 'Ring'
   homepage 'https://ring.cx/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.