### PR TITLE
Added AppGrid.app v1.0.4

### DIFF
--- a/Casks/appgrid.rb
+++ b/Casks/appgrid.rb
@@ -1,0 +1,12 @@
+cask 'appgrid' do
+  version '1.0.4'
+  sha256 'e89280465b4a3dc580b026f25f2ade04ab1cd9b15a476e327110a1d91bd7da77'
+
+  url "https://github.com/sdegutis/AppGrid/releases/download/#{version}/AppGrid-#{version}.zip"
+  appcast 'https://github.com/sdegutis/AppGrid/releases.atom',
+          checkpoint: '16074ddd44ba518efb255a3808340acf76940cc08342933cf6b026dd9242644a'
+  name 'AppGrid'
+  homepage 'https://github.com/sdegutis/AppGrid'
+
+  app 'AppGrid.app'
+end

--- a/Casks/appgrid.rb
+++ b/Casks/appgrid.rb
@@ -9,4 +9,9 @@ cask 'appgrid' do
   homepage 'https://github.com/sdegutis/AppGrid'
 
   app 'AppGrid.app'
+
+  uninstall login_item: 'AppGrid',
+            quit:       'com.sdegutis.AppGrid'
+
+  zap trash: '~/Library/Preferences/com.sdegutis.AppGrid.plist'
 end


### PR DESCRIPTION
A new Cask for AppGrid has been created. This application is described
by the developer as "a macOS window manager with Vim-like hotkeys", allowing the user to
"move and resize windows along an invisible "grid" of your screen".

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
