### PR TITLE
Update devrant to 1.0.3

### DIFF
--- a/Casks/devrant.rb
+++ b/Casks/devrant.rb
@@ -2,11 +2,15 @@ cask 'devrant' do
   version '1.0.3'
   sha256 '9aea3cdd3f6cc89012baa0dfd2f82b213557e0e6d667e6a6cee594f8b3d50740'
 
-  url "https://github.com/Meadowcottage/devRant/releases/download/#{version}/devRant-#{version}.dmg"
-  appcast 'https://github.com/Meadowcottage/devRant/releases.atom',
-          checkpoint: '54943700e5e9c020a0e64c9a8eea7143d35f91b1840e8452d19a0527f72d33eb'
+  url "https://github.com/NuroDev/devRant/releases/download/#{version}/devRant-#{version}.dmg"
+  appcast 'https://github.com/NuroDev/devRant/releases.atom',
+          checkpoint: '8e6281dfc3871de661518aeac120d52d5e43f7759e03024a4ef1fcfc38df1aac'
   name 'devrant'
-  homepage 'https://github.com/Meadowcottage/devRant'
+  homepage 'https://github.com/NuroDev/devRant'
 
   app 'devrant.app'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.