### PR TITLE
Update gotofile to 1.1.3

### DIFF
--- a/Casks/gotofile.rb
+++ b/Casks/gotofile.rb
@@ -1,10 +1,10 @@
 cask 'gotofile' do
-  version '1.0.3'
-  sha256 '2baf82a8ac3a01f5751f8049327c4f4f63a923155d828d633ba39c3b34dbbb7c'
+  version '1.1.3'
+  sha256 'a646cfec1eff2f9d2f021acf4841143b219d255ba4ef5bc492a159b0940091aa'
 
   url "http://www.soma-zone.com/download/files/GoToFile_#{version}.tbz"
   appcast 'https://somazonecom.ipage.com/soma-zone.com/GoToFile/a/appcast_update.xml',
-          checkpoint: '588d3935e336cd644f9a133634c8a357071691922091bda3f9028219d7828da9'
+          checkpoint: '6695d30c7ce2cfddc35c6231c637feee403a19bfd825ee863874571a52d549c3'
   name 'GoToFile'
   homepage 'http://www.soma-zone.com/GoToFile/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.