### PR TITLE
Update displaycal to 3.5.0.0

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,11 +1,11 @@
 cask 'displaycal' do
-  version '3.4.0.0'
-  sha256 '2f6c8253b094df1f39ddfcff1d225e2aa9f6a32aecfa6ff610802dfeb0d46837'
+  version '3.5.0.0'
+  sha256 'e667c4a5e0abf1df82e041d6accd29e77c924dcdcb8ecbd07674d6cf979e6bb7'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/dispcalgui/rss?path=/release',
-          checkpoint: 'ffa0643ae7cdafe81d18fe3dd700547ff1a84386b04a2d81aecc47dfd25c93ee'
+          checkpoint: '1696a83eb611839bfaf6b49191ab51e775ec8a4d07c2ec5dca02a5f2977960c5'
   name 'DisplayCAL'
   homepage 'https://displaycal.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.