### PR TITLE
Update vuescan to 9.6.06

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
   version '9.6.06'
-  sha256 'b0e769f71c685b59e724953dddc513b58bc559a47e207c2d8243ef9d4f744523'
+  sha256 'fa1d8e95d99f8fbda9d7b15ce58b2400d439bd5ee3ee6e1919aacac8e12ab177'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.