### PR TITLE
Update donut to 2.4.0

### DIFF
--- a/Casks/donut.rb
+++ b/Casks/donut.rb
@@ -2,12 +2,12 @@ cask 'donut' do
   version '2.4.0'
   sha256 '03d46d2701cf340675cc57d1bd1b6c769ae67516fb33466d507142317f84bd10'
 
-  # github.com/harshjv/donut was verified as official when first introduced to the cask
-  url "https://github.com/harshjv/donut/releases/download/#{version}/donut-#{version}.dmg"
-  appcast 'https://github.com/harshjv/donut/releases.atom',
-          checkpoint: '51dbb61af89a2dd2d170623a81a7d121facd4532130ae3ca6743b5d9ded49be4'
+  # github.com/EtherbitHQ/donut was verified as official when first introduced to the cask
+  url "https://github.com/EtherbitHQ/donut/releases/download/#{version}/donut-#{version}.dmg"
+  appcast 'https://github.com/EtherbitHQ/donut/releases.atom',
+          checkpoint: 'dbf5e29c7e259c8cc72a3a664106b10d032070da9e7c45cedc26fdd914730db2'
   name 'donut'
-  homepage 'https://harshjv.github.io/donut/'
+  homepage 'https://www.etherbit.in/pages/donut'
 
   app 'donut.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.