### PR TITLE
Update mplayer-osx-extended to rev16

### DIFF
--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -1,13 +1,15 @@
 cask 'mplayer-osx-extended' do
-  version 'rev15'
-  sha256 '7979f2369730d389ceb4ec3082c65ffa3ec70f812f0699a2ef8acbae958a5c93'
+  version 'rev16'
+  sha256 'a52eae9a685a4d9854a5f989c4eb1e94b3f97b8c25a0e36ad4cdbc610fdf1023'
 
   # github.com/sttz/MPlayer-OSX-Extended was verified as official when first introduced to the cask
   url "https://github.com/sttz/MPlayer-OSX-Extended/releases/download/#{version}/MPlayer-OSX-Extended_#{version}.zip"
   appcast 'https://github.com/sttz/MPlayer-OSX-Extended/releases.atom',
-          checkpoint: '0a27d2b111abfe68462e7ef0cb71e9efe1ea34921b8a7a2dc208713208242dba'
+          checkpoint: '4c05f3c71bb35d180ae4b5821a5f50820ebd76f3293adda729b605e79d396ea6'
   name 'MPlayer OSX Extended'
   homepage 'https://mplayerosx.ch/'
+
+  depends_on macos: '>= :lion'
 
   app 'MPlayer OSX Extended.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.