### PR TITLE
Update munki to 3.2.0.3476

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,11 +1,11 @@
 cask 'munki' do
-  version '3.1.1.3447'
-  sha256 '5a888db4b2cb014bc63bf2ec7a29abb44e27fb63c3b014fe74a0ba05aee63a40'
+  version '3.2.0.3476'
+  sha256 '845f129dc33a0624f4ff526107294285355b597bf701e3d7888ae7a77b8106fb'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: '1d2a6cb58fd43adad349714d8caf9f7ff108935f82333362521a934f2da56727'
+          checkpoint: '9668f7e2a4a576c5772f78041af6266a1be6a7501e0736cfd0c2cf6561d3ff7b'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.