### PR TITLE
Update big-mean-folder-machine to 2.37

### DIFF
--- a/Casks/big-mean-folder-machine.rb
+++ b/Casks/big-mean-folder-machine.rb
@@ -1,12 +1,14 @@
 cask 'big-mean-folder-machine' do
-  version '2.36'
-  sha256 'a25385e4281a55efd36d6fff9ea641c36def1277bf18975dff9111f8c768034d'
+  version '2.37'
+  sha256 '8410146f1378ef33244dd2fa816fcc7a6c211d2f3b567526805fd43f0ffd4d59'
 
   url 'http://www.publicspace.net/download/BMFM.dmg'
   appcast "http://www.publicspace.net/app/bmfm#{version.major}.xml",
-          checkpoint: '947e1219de7f228bcca809fd0ffc3798188bbb1d2df0e6fa9a9b6efe41fef3b0'
+          checkpoint: '5a0128ad6e18f886a873dc2cb4b2082f1ff0ac1ead1a90bfb8f4a6077ee5d2b4'
   name 'Big Mean Folder Machine'
   homepage 'http://www.publicspace.net/BigMeanFolderMachine/'
+
+  depends_on macos: '>= :lion'
 
   app "Big Mean Folder Machine #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.