### PR TITLE
Update now to 3.8.20

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,11 +1,11 @@
 cask 'now' do
-  version '3.8.18'
-  sha256 'b92769896b3bea22f1442f7a8d40dc8a30cf84dc88c8191968ef3143a03ba226'
+  version '3.8.20'
+  sha256 '641a9255f72e4ac114df76dfc12b0d664985a0fa6ecec7de1a02319e463138bd'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/now-desktop-#{version}-mac.zip"
   appcast 'https://github.com/zeit/now-desktop/releases.atom',
-          checkpoint: '9f88a3cdff107cb303defe41cd32cc5b9cb0599ca979fc529ef8ce9e7176c40f'
+          checkpoint: 'd1d70c8605000209fb79d4075940a5eec60736c2d6fcc5835e04486b77cb4c2e'
   name 'Now'
   homepage 'https://zeit.co/now'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.