### PR TITLE
Update dungeon-crawl-stone-soup-console to 0.21.1

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -1,10 +1,10 @@
 cask 'dungeon-crawl-stone-soup-console' do
-  version '0.21.0'
-  sha256 'fc0ba232b8728122b0912c4ef06b37000c17176a935d7a08d6b067df60ef1560'
+  version '0.21.1'
+  sha256 '43c3b8fbef69f801b223d2c8a0d9bcbd23e04369e8462d0f4bf389f84cdc9638'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-console-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom',
-          checkpoint: 'dd96d66f02bc77ccf322d3031ca3b8a59f3870901cd6013b9e2c915ecce7e1b6'
+          checkpoint: '87d8536b2af9d3adeb1aeec0d72397767b80d96cc144ed912a1bbb3863cd5cd4'
   name 'Dungeon Crawl Stone Soup'
   homepage 'https://crawl.develz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.