### PR TITLE
Update instead to 3.2.0

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,11 +1,11 @@
 cask 'instead' do
-  version '3.1.2'
-  sha256 '880d2e8f77a99cab8bac110cfb8473acf951c87b2bc26f8ac81870537e4174ae'
+  version '3.2.0'
+  sha256 '1b3ef401dc3c4a2bcece09b74ad759bbc043b5f0ebc8f18ef29dc17e7b4f0593'
 
-  # sourceforge.net/instead was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/instead/instead/#{version}/Instead-#{version}.dmg"
-  appcast 'https://sourceforge.net/projects/instead/rss?path=/instead',
-          checkpoint: 'b0bb1b1c52f94f3661376bee867fea09f538a2ef0c5674b3f9acacc7364cdd0a'
+  # github.com/instead-hub/instead was verified as official when first introduced to the cask
+  url "https://github.com/instead-hub/instead/releases/download/#{version}/Instead-#{version}.dmg"
+  appcast 'https://github.com/instead-hub/instead/releases.atom',
+          checkpoint: '22bfb0a6ec9f5105740b4a377e772a373ff101b1e1a6198806cd7c1a3ffb4fbc'
   name 'INSTEAD'
   homepage 'https://instead.syscall.ru/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.