### PR TITLE
Update latexit to 2.9.1

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,11 +1,11 @@
 cask 'latexit' do
-  version '2.9.0'
-  sha256 'ce6b9945fc9afb8fe820552f862ecc3ed0a69b15cda9c62f7780b219333f9b23'
+  version '2.9.1'
+  sha256 '8352728814e3824abd19b351495c7ca4a5aa0f4b597fcadbd32590183c38365f'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake
   appcast 'https://pierre.chachatelier.fr/latexit/downloads/latexit-sparkle-en.rss',
-          checkpoint: '946ab8e24300a0dbbb909d1253f395ca01727e9da797b97c05c73a8fc4212d52'
+          checkpoint: 'b269cd9141accea8a161668409c246a48944e07e08079d67df247466936e854c'
   name 'LaTeXiT'
   homepage 'https://www.chachatelier.fr/latexit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.