### PR TITLE
Update netron to 1.5.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.5.5'
-  sha256 '4ca9e2ab4fe3474827d07fd57f02dbf3347cb96fbbf93f3ae9cb21e1b7b5b5b4'
+  version '1.5.6'
+  sha256 'd66ada7f088691a3d8312a4ea36ee4aae44f6a28ec3a20ac0f8370ead40b98d7'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'c0e91ceb2ddd816a28e8580e60ee36e64c720be06d2bbd6cc2fd14c8ab7bc368'
+          checkpoint: '82555a8775d79d39e8ce4928ddbe85da2e5ffd20d6c02cc3f218f49fec9d87d8'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.