### PR TITLE
Update neofinder to 7.2.1

### DIFF
--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,11 +1,11 @@
 cask 'neofinder' do
-  version '7.1.3'
-  sha256 '86fd8716f36bbae309355cf61f219335e68bfc1cda677e8c462f6f55a3a24a45'
+  version '7.2.1'
+  sha256 'e916fb4ab4eece97f3ce0b743af662756876421171cae2e1caf266fa5412f154'
 
   # wfs-apps.de was verified as official when first introduced to the cask
   url "https://www.wfs-apps.de/updates/neofinder.#{version}.zip"
   appcast 'https://www.wfs-apps.de/updates/neofinder-appcast-64.xml',
-          checkpoint: '916ebab0a87a38ba361548d487c00427a7b45f222a0e470b1a94a038dd7db554'
+          checkpoint: 'd1a2fc760eeb3128a2361f782e61ccf6d864d53e1dd5b7610cbdb1affbe35399'
   name 'NeoFinder'
   homepage 'https://www.cdfinder.de/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.