### PR TITLE
Update cacher to 1.3.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.2'
-  sha256 'a18a6ef713460439f7c61f422f5b52669bee6902d667ad8eced231f45f1411b2'
+  version '1.3.3'
+  sha256 'dd34d2be35256542dcd73f341c73f7068756f1dd3a84f210f7a9784bd13c4765'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '26fe985798db0753ea600ffa90d4c5b32e40c4e73d1ed0bf8a9b7437fc5208ad'
+          checkpoint: 'ba1e2b5364cd5d3792b1b355b0b67224d685bcec3074149699510197c42405a4'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.