### PR TITLE
Update ios-app-signer to 1.10

### DIFF
--- a/Casks/ios-app-signer.rb
+++ b/Casks/ios-app-signer.rb
@@ -1,11 +1,11 @@
 cask 'ios-app-signer' do
-  version '1.9'
-  sha256 '5130b0748115d2d4b54f29a65b86e82f60f630124fec6bbd1fc5677eee6e6f08'
+  version '1.10'
+  sha256 '0263f1185fc1a4d1b5e1bddb11be82e6a12d8a54845f5e5ace1780da75368190'
 
   # github.com/DanTheMan827/ios-app-signer was verified as official when first introduced to the cask
   url "https://github.com/DanTheMan827/ios-app-signer/releases/download/#{version}/iOS.App.Signer.app.zip"
   appcast 'https://github.com/DanTheMan827/ios-app-signer/releases.atom',
-          checkpoint: '180b0e34e5af5fe688180b1760cefd5d3c0fa5d845a7e578d5a24a7d3d8377a2'
+          checkpoint: '10b65a2a66f4ac45edd059fbba84a5dba673bc301af951d97c19e0d8bda6eb72'
   name 'iOS App Signer'
   homepage 'https://dantheman827.github.io/ios-app-signer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.