### PR TITLE
Update kactus to 0.3.2

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.3.1'
-  sha256 '1776d3fa8442199f0b71e5cd6be3eb84b67b89fc9bcaf3b49a5d92a64f11d246'
+  version '0.3.2'
+  sha256 'f240959b07636fd031ef49e20d9eb3c72bf89d787484316637f461954434f39a'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: '5c7736cf0a0fb9087e1d7b7770ccc84da48bb3712e45751ee01aa86fb298b419'
+          checkpoint: '1a65391fa900adccb3e1558ca399fe574b0bfbf07a0240f99cc943cbd20a536f'
   name 'Kactus'
   homepage 'https://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.