### PR TITLE
Update nwjs to 0.28.3

### DIFF
--- a/Casks/nwjs.rb
+++ b/Casks/nwjs.rb
@@ -1,10 +1,10 @@
 cask 'nwjs' do
-  version '0.28.2'
-  sha256 'b01ca673630ec0a3c5b1a81386bff4bb781a097f6c95ac6c7f1fe992dfd6d734'
+  version '0.28.3'
+  sha256 '10f822747f47dbdb2e1bebe3912bc3f38c5f14f9e5a18fa7e63d89624dfbe86f'
 
   url "https://dl.nwjs.io/v#{version}/nwjs-sdk-v#{version}-osx-x64.zip"
   appcast 'https://github.com/nwjs/nw.js/releases.atom',
-          checkpoint: 'c329586162b5c11fd7f0a1acf95a2e845ddc19865b4b38c46e108ee97f81ced7'
+          checkpoint: '1f4a1b2c975ab463889eb56256b1508fc6c12782d23ca68254886a5e534326c2'
   name 'NW.js'
   homepage 'https://nwjs.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.