### PR TITLE
Update fly to 3.9.1

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,10 @@
 cask 'fly' do
-  version '3.9.0'
-  sha256 'ce4a12e136cff4c2c55bee9a7ded7b05ac6ef867369e947ddd525c61392e2051'
+  version '3.9.1'
+  sha256 '527c60a5e33a23f5ca43c5cf62061e49be192fcda5fd6daf293e9c4b5150a9fb'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom',
-          checkpoint: '8df2559bb7359c4419ba477e9d2211dae1ecbca2656d6e869694a566ebfe796a'
+          checkpoint: 'c20eeb5d47cb9dc26ecbe1fd0ff00835dbdcf75c3e9eba84451692582dcfcd1a'
   name 'fly'
   homepage 'https://github.com/concourse/fly'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.