### PR TITLE
Update chatology to 1.1.3

### DIFF
--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,10 +1,10 @@
 cask 'chatology' do
-  version '1.1.2'
-  sha256 '133bd7c2d13bcad042b0c885d916edcf88073bfb2a0d340d1243184ca55e8370'
+  version '1.1.3'
+  sha256 'c00918bc330bcdfd385f006e624dabfc98bce2815b21b4d44d1b64a2fa9e343b'
 
   url "http://cdn.flexibits.com/Chatology_#{version}.zip"
   appcast 'https://flexibits.com/chatology/appcast.php',
-          checkpoint: '5572a3834d8dbf929f111a3184824624e62b35f3346ed898c8d6b9b35014991f'
+          checkpoint: '9f246d374e887d6252a0c0092286dc86a69844e80609b0cb26e21e27f4220318'
   name 'Chatology'
   homepage 'https://flexibits.com/chatology'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.