### PR TITLE
Update github to 1.1.0-cfbf44c8

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,11 +1,11 @@
 cask 'github' do
-  version '1.0.13-edec4470'
-  sha256 '0dca4b8155af7e45f410542a9dcf6f05a8c4491d91c925a10c392679f7a7fbf1'
+  version '1.1.0-cfbf44c8'
+  sha256 '17736d91835d98e851cbc373ddb29a73b0602f175c99ae577810a42c4c31c205'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: '0e87db894baafbdd3d4decd641518f7fde3babd01ef2a631f11ae090b6dda20a'
+          checkpoint: 'b0bb22cc168b5970bb0b577afb7803d3fc7b128a9c001363b30a4e3c8b58d6c0'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.