### PR TITLE
Update rambox to 0.5.15

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -3,9 +3,9 @@ cask 'rambox' do
   sha256 '75c15d6a87494660b1ca5dc3910909c539ac1cd3312b11a150c6f26ea4b4b057'
 
   # github.com/saenzramiro/rambox was verified as official when first introduced to the cask
-  url "https://github.com/saenzramiro/rambox/releases/download/v#{version}/Rambox-#{version}-mac.zip"
+  url "https://github.com/saenzramiro/rambox/releases/download/#{version}/Rambox-#{version}-mac.zip"
   appcast 'https://github.com/saenzramiro/rambox/releases.atom',
-          checkpoint: '57314273c3e4162e5a43ed403fe21cb255f2778f0232acfa0a4e650ab8b9f867'
+          checkpoint: 'd3d4a831bf6b37877e4d86e19328f35fa1b47144992d5a1cb8e59a160a7c716a'
   name 'Rambox'
   homepage 'http://rambox.pro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
URL and appcast change.