### PR TITLE
Update controllermate to 4.10.6

### DIFF
--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,11 +1,11 @@
 cask 'controllermate' do
-  version '4.10.4'
-  sha256 'fdeb37ca8df145d927b9daef6dfa22ef6d1535f9ad1459c4f4ffcb52fbc19c3b'
+  version '4.10.6'
+  sha256 'f5093f29532e072e821758dd3cd3ef93bfafe8372b0db19342a15eb515422df7'
 
   # amazonaws.com/orderedbytes was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/orderedbytes/ControllerMate#{version.no_dots}.zip"
   appcast 'https://www.orderedbytes.com/sparkle/appcast_cm460.xml',
-          checkpoint: 'c28a14b30a4e7d0aa389f5bcf78736d29e79d19f409734eb624b30eccbe1a76a'
+          checkpoint: '85aed7061f3df8ea38953d37c2626fab1ce0857e8bc5737954fce5cc338f4373'
   name 'ControllerMate'
   homepage 'https://www.orderedbytes.com/controllermate/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.