### PR TITLE
Update navicat-for-mysql to 12.0.23

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.22'
-  sha256 'a9c29c3747f42992c9078432b9f2b1b84690e19e2a6e1e748a9e63940a3f3bd0'
+  version '12.0.23'
+  sha256 'c1abbddf926c65b70f731f3cde5686caef2e9619867b597f499747bb802b5bae'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: '0845dbb0629757f0fbc261404b1c1b139c2e1a6c201aac73ca75e0ebfe5daefc'
+          checkpoint: '17746fafc686102cf60bdf899339142305eb44a33576c0543ab4a3234c3b9c33'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.