### PR TITLE
Update navicat-for-postgresql to 12.0.23

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.22'
-  sha256 '74b94e5a76cdbd2b58cc532a7e17110e8c1eab49e75adcb1d7d20f5b1061353d'
+  version '12.0.23'
+  sha256 '62688e97dace5bc9c91cebd32dc123fcb09191a5b232889f978c8e253e4690e9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-postgresql-release-note',
-          checkpoint: 'e5030859f1b241cdd40dfb66b3668eac29ea6b7e41a8fe4fa839e7b5298f6794'
+          checkpoint: '290960db13b3dac7d3f795f945cae9ab6fca0ef90a65483663fcd57673619517'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.