### PR TITLE
Update navicat-for-sql-server to 12.0.23

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.22'
-  sha256 '660c5d33f133976389a0a1751b6c25035cd621bcae7293a605607a60141dfee9'
+  version '12.0.23'
+  sha256 'b62ef46452db05e3ef9960b91538da7f8d71be63dbcb89f865bea0a8361c9f93'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlserver-release-note',
-          checkpoint: 'ce7e26ac5415db0e5b188cb43b5a578f909fcc1fb33f04b30ba62172e2ec72a4'
+          checkpoint: 'f0ed98261ce0906ae1c672560f5a6131175fb9c4e782517720e7a28c9e658e01'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.