### PR TITLE
Update navicat-for-sqlite to 12.0.23

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.22'
-  sha256 'd11e00c90ee1e0cf0d411970be66b3af5d7017b7d8254f74c9df12ea00294bbf'
+  version '12.0.23'
+  sha256 'a08ae3f687d3b01aad1e2d55638da7a3d471e004a816e53a9977c00f6340b6d7'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlite-release-note',
-          checkpoint: '79128b1df6372153ba6f2638bbaa7f1ca9048f3531e1751fe674257051eda311'
+          checkpoint: 'f6d6841789e7bbf0e597e9cbe7c914f33192d55b79292e307b76851037c547f6'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.