### PR TITLE
Add Screenotate Latest

### DIFF
--- a/Casks/screenotate.rb
+++ b/Casks/screenotate.rb
@@ -1,10 +1,22 @@
 cask 'screenotate' do
-  version :latest
-  sha256 :no_check
+  version '2.1.0'
+  sha256 '51a434ad6ee8f64da23f48dcab19c8709008ac6b8f95f18fb90a8c1756d27e2e'
 
   url 'https://screenotate.com/download/Screenotate-latest.dmg'
+  appcast 'https://screenotate.com/download/appcast.xml',
+          checkpoint: '756cf1fee8e6efd5d9ec2a496143d3ef4021c6bc3931662c9fc40b54023b627e'
   name 'Screenotate'
   homepage 'https://screenotate.com/'
 
   app 'Screenotate.app'
+
+  uninstall login_item: 'Screenotate',
+            quit:       'com.rsnous.Screenotate'
+
+  zap trash: [
+               '~/Library/Application Support/Screenotate',
+               '~/Library/Caches/com.rsnous.Screenotate',
+               '~/Library/Cookies/com.rsnous.Screenotate.binarycookies',
+               '~/Library/Preferences/com.rsnous.Screenotate.plist',
+             ]
 end

--- a/Casks/screenotate.rb
+++ b/Casks/screenotate.rb
@@ -1,0 +1,10 @@
+cask 'screenotate' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://screenotate.com/download/Screenotate-latest.dmg'
+  name 'Screenotate'
+  homepage 'https://screenotate.com/'
+
+  app 'Screenotate.app'
+end


### PR DESCRIPTION
Screenotate (https://screenotate.com/) is a screenshot-taking tool which
works just like macOS's screenshot tool – one keyboard shortcut and drag
– and it uses OCR (Optical Character Recognition) to recognize text in
your screenshots.

The app has a fremium pricing model and can be unlocked without any
extra downloads. Based on the guides, I believe it should be accepted
into the main repository.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256