### PR TITLE
update google-featured-photos to 1.0.0.208

### DIFF
--- a/Casks/google-featured-photos.rb
+++ b/Casks/google-featured-photos.rb
@@ -1,6 +1,6 @@
 cask 'google-featured-photos' do
-  version '1.0.0.152'
-  sha256 'b1dcae63a6144dedcabdb37106cd2f9990340b24a667c010d9345b8113a33c67'
+  version '1.0.0.208'
+  sha256 '4d4abc378b38278b0cd247e99a008c730a3b6b77824437b01db0bf8beaf24bfb'
 
   url "https://dl.google.com/featuredphotosscreensaver/GoogleFeaturedPhotos-#{version}.dmg"
   name 'Google Featured Photos'


### PR DESCRIPTION
fix 10.13 bug

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
