### PR TITLE
Update pyfa to 1.35.1,yc120.2-1.2

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.35.0,yc120.2-1.1'
-  sha256 '0ebd34fa6d74c85470b9669d4b0caa6a08b9bdc134270b812e132747dce32379'
+  version '1.35.1,yc120.2-1.2'
+  sha256 '52648b7d35f56953a198f3cb495bde4651e61c86546b7bd448f5316ea3a1bc22'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '698aa80a9b224094e5ecb71d332e547308789d9bd3fcb7f7d20e0a9e68e1720b'
+          checkpoint: '6df0e91d93781a9dd0f6d1a3631ce002798f6bc5fb02eaf31d6325590b8a76b7'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.