### PR TITLE
Update lego-mindstorms-ev3 to 1.3.1

### DIFF
--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -1,7 +1,7 @@
 cask 'lego-mindstorms-ev3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '1.3.0'
-  sha256 'ce5e0b047c096886d1a74540b306e704d6249c0c7eb09c76f58389841abe3528'
+  version '1.3.1'
+  sha256 '15ea0a61d87aa5172a0fd1587c904470287fa750ad9d47a3abf53233872808b2'
 
   # le-www-live-s.legocdn.com/downloads/LMS-EV3 was verified as official when first introduced to the cask
   url "https://le-www-live-s.legocdn.com/downloads/LMS-EV3/LMS-EV3_Full-setup_#{version}_en-us_osx.dmg"

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -14,11 +14,11 @@ cask 'lego-mindstorms-ev3' do
                        "com.ni.pkg.lego.ev3.Eng.#{version.major_minor_patch}",
                        "com.ni.pkg.lego.x3.#{version.major_minor_patch}.core",
                        "com.ni.pkg.lego.x3.#{version.major_minor_patch}.update",
-                       "com.ximian.mono-2.10.9"
                      ]
 
   zap pkgutil:  [
                   'com.ni.pkg.legodriver',
-                  'com.microsoft.silverlight.plugin'
+                  'com.microsoft.silverlight.plugin',
+                  'com.ximian.mono-*',
                 ]
 end

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -14,10 +14,10 @@ cask 'lego-mindstorms-ev3' do
                        "com.ni.pkg.lego.ev3.Eng.#{version.major_minor_patch}",
                        "com.ni.pkg.lego.x3.#{version.major_minor_patch}.core",
                        "com.ni.pkg.lego.x3.#{version.major_minor_patch}.update",
+                      'com.ni.pkg.legodriver',
                      ]
 
   zap pkgutil:  [
-                  'com.ni.pkg.legodriver',
                   'com.microsoft.silverlight.plugin',
                   'com.ximian.mono-*',
                 ]

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -11,9 +11,9 @@ cask 'lego-mindstorms-ev3' do
   pkg 'LEGO MINDSTORMS EV3 Home Edition.pkg'
 
   uninstall pkgutil: [
-                       "com.ni.pkg.lego.ev3.Eng.#{version.major_minor_patch}",
-                       "com.ni.pkg.lego.x3.#{version.major_minor_patch}.core",
-                       "com.ni.pkg.lego.x3.#{version.major_minor_patch}.update",
+                       "com.ni.pkg.lego.ev3.Eng.#{version}",
+                       "com.ni.pkg.lego.x3.#{version}.core",
+                       "com.ni.pkg.lego.x3.#{version}.update",
                      ]
 
   zap pkgutil:  [

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -14,10 +14,10 @@ cask 'lego-mindstorms-ev3' do
                        "com.ni.pkg.lego.ev3.Eng.#{version.major_minor_patch}",
                        "com.ni.pkg.lego.x3.#{version.major_minor_patch}.core",
                        "com.ni.pkg.lego.x3.#{version.major_minor_patch}.update",
-                      'com.ni.pkg.legodriver',
                      ]
 
   zap pkgutil:  [
+                  'com.ni.pkg.legodriver',
                   'com.microsoft.silverlight.plugin',
                   'com.ximian.mono-*',
                 ]

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -16,9 +16,9 @@ cask 'lego-mindstorms-ev3' do
                        "com.ni.pkg.lego.x3.#{version}.update",
                      ]
 
-  zap pkgutil:  [
-                  'com.ni.pkg.legodriver',
-                  'com.microsoft.silverlight.plugin',
-                  'com.ximian.mono-*',
-                ]
+  zap pkgutil: [
+                 'com.ni.pkg.legodriver',
+                 'com.microsoft.silverlight.plugin',
+                 'com.ximian.mono-*',
+               ]
 end

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -17,7 +17,8 @@ cask 'lego-mindstorms-ev3' do
                        "com.ximian.mono-2.10.9"
                      ]
 
-  zap pkgutil: [
-                'com.ni.pkg.legodriver',
-                'com.microsoft.silverlight.plugin'
+  zap pkgutil:  [
+                  'com.ni.pkg.legodriver',
+                  'com.microsoft.silverlight.plugin'
+                ]
 end

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -11,10 +11,13 @@ cask 'lego-mindstorms-ev3' do
   pkg 'LEGO MINDSTORMS EV3 Home Edition.pkg'
 
   uninstall pkgutil: [
-                       "com.ni.pkg.lego.ev3.Eng.#{version.major_minor}",
-                       "com.ni.pkg.lego.x3.#{version.major_minor}.core",
-                       "com.ni.pkg.lego.x3.#{version.major_minor}.update",
+                       "com.ni.pkg.lego.ev3.Eng.#{version.major_minor_patch}",
+                       "com.ni.pkg.lego.x3.#{version.major_minor_patch}.core",
+                       "com.ni.pkg.lego.x3.#{version.major_minor_patch}.update",
+                       "com.ximian.mono-2.10.9"
                      ]
 
-  zap pkgutil: 'com.ni.pkg.legodriver'
+  zap pkgutil: [
+                'com.ni.pkg.legodriver',
+                'com.microsoft.silverlight.plugin'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.