### PR TITLE
Update evernote to 7.0.2_456266

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -9,13 +9,13 @@ cask 'evernote' do
     version '6.12.3_455520'
     sha256 'fdda9701f1d8ff56a5e8bcadcf5b04dba66ad7e08511700de4675d20fda2bc71'
   else
-    version '7.0.1_456247'
-    sha256 'fde3080d7d96a377961d8f490784130d3b88deba544239b0e9afb1cc04e0f116'
+    version '7.0.2_456266'
+    sha256 '4cd9b3bd9f87fe3f067a06a391e1d4cd5a32863baf2f07a910861ee7cf1aca64'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
   appcast 'https://update.evernote.com/public/ENMacSMD/EvernoteMacUpdate.xml',
-          checkpoint: '2ea9b4dcc699a6cacfbc02f39e9eb044413a9858d4440492513c800c20eb87c0'
+          checkpoint: 'f3536b229dd2dbc79781955c33d4a8808b80e990a34eb7713ee064f6ec1488eb'
   name 'Evernote'
   homepage 'https://evernote.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.