### PR TITLE
Update downie to 3.2.2,1776

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.2.1,1774'
-  sha256 '4ad2cca93c920521dccfde516b84dfefcfd540e05da2ff9909fc0dd26914beba'
+  version '3.2.2,1776'
+  sha256 'e6218195bb071c08ee030e8b5cd6ae3fd709d62496b57240a1f0315c59fd5b95'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: 'd2791dee38ccf5e052b8606720e5e576a8647a27ac5019cf1873f186fb594316'
+          checkpoint: 'b2a053aeeef465361989edc9a5be132ed6ade856b4e674db2e5d208d635b5e8c'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.