### PR TITLE
Update double-commander to 0.8.2-8010

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,10 +1,10 @@
 cask 'double-commander' do
-  version '0.8.1-7950'
-  sha256 '0767fbfd1e416223cdf3fb42336da0ef490fec2c2220cb330ed5dbc5c01b1ca1'
+  version '0.8.2-8010'
+  sha256 '7b18802679e4fe94d91df90f97c1e077c694ad9833141b534a2ef6cc21e64598'
 
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg"
   appcast 'https://sourceforge.net/projects/doublecmd/rss',
-          checkpoint: '8dbc2807af6a44ab20b7960756fc54675347687ce2377f8fc5883e1f8651b51d'
+          checkpoint: 'ade8fd861cb5565bae8fcccec5a4b96c10782ee198976a5d72f6e81ee4d04282'
   name 'Double Commander'
   homepage 'http://doublecmd.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.