### PR TITLE
Update drawbot to 3.114

### DIFF
--- a/Casks/drawbot.rb
+++ b/Casks/drawbot.rb
@@ -1,11 +1,11 @@
 cask 'drawbot' do
-  version '3.112'
-  sha256 '5ceb7ac8ee5a94fca235c653becc71f4916a7bb1626985133dd91c0cb219e238'
+  version '3.114'
+  sha256 'e63c5c7cb78c7c62ce2c588d5dcb332892e0dafa4102ff515fb93c10d98110b8'
 
   # typemytype.com/drawBot was verified as official when first introduced to the cask
   url 'http://static.typemytype.com/drawBot/DrawBot.dmg'
   appcast 'https://raw.githubusercontent.com/typemytype/drawbot/master/drawBot/drawBotSettings.py',
-          checkpoint: 'c79e3fb9b5c6705cc587d7288740d4971f6710bf82e733061dd7ce5ca9a54a42'
+          checkpoint: '221eff636e2e25ba8a15d67bcd2040ef83b58e7b9894753112f5ab444f46d69f'
   name 'DrawBot'
   homepage 'http://www.drawbot.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.