### PR TITLE
travis: zap instead of uninstall

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -43,7 +43,7 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
     fi
     for cask in "${modified_casks[@]}"; do
       run brew cask reinstall --verbose "${cask}"
-      run brew cask uninstall --verbose "${cask}"
+      run brew cask zap --verbose "${cask}"
     done
     if [[ -f "${HOME}/Brewfile" ]]; then
       run brew bundle cleanup --force --file="${HOME}/Brewfile"


### PR DESCRIPTION
Sometimes `zap` has `pkg`s shared with other apps. If we don’t remove those as well, they’ll be shown as leftover packages.