### PR TITLE
Update emby-server to 3.3.0.0

### DIFF
--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -1,11 +1,11 @@
 cask 'emby-server' do
-  version '3.2.70.0'
-  sha256 '5cad78024d4e9a4f6a396a5a670215665d91e009a0d1e27184d7ed6926666fdd'
+  version '3.3.0.0'
+  sha256 'b91d88ae4bece00e1c06143d64ebc2633b75c601514832eaf5c85242bbeee683'
 
   # github.com/MediaBrowser/Emby was verified as official when first introduced to the cask
   url "https://github.com/MediaBrowser/Emby/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"
   appcast 'https://github.com/MediaBrowser/Emby/releases.atom',
-          checkpoint: 'e199120a28828be9b51304d873e1b1064230c57020712372cee673afcabed663'
+          checkpoint: '855d87bb4463f298d68a8bf8f36a90b5681e22060b889588967cdcc15f5b06f7'
   name 'Emby Server'
   homepage 'https://emby.media/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.