### PR TITLE
Update virtualbox-extension-pack to 5.2.8,121009

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,10 +1,10 @@
 cask 'virtualbox-extension-pack' do
-  version '5.2.6,120293'
-  sha256 '70584a70b666e9332ae2c6be0e64da4b8e3a27124801156577f205750bdde4f5'
+  version '5.2.8,121009'
+  sha256 '355ea5fe047f751534720c65398b44290d53f389e0f5f66818f3f36746631d26'
 
   url "https://download.virtualbox.org/virtualbox/#{version.before_comma}/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack"
   appcast 'https://download.virtualbox.org/virtualbox/LATEST.TXT',
-          checkpoint: 'd4dc0eb9ab198f5250e794afc13c8129b1a171a906c03f2c7b3f93b9ff3e2bcc'
+          checkpoint: '96cbba0b6bc9a09d588b1a2de0a078ffcb35a31827e7ff1aaa9817df42caac88'
   name 'Oracle VirtualBox Extension Pack'
   homepage 'https://www.virtualbox.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.