### PR TITLE
set auto_updates to true for various casks

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -7,6 +7,8 @@ cask 'carbon-copy-cloner' do
   name 'Carbon Copy Cloner'
   homepage 'https://bombich.com/'
 
+  auto_updates true
+
   app 'Carbon Copy Cloner.app'
 
   uninstall login_item: 'CCC User Agent',

--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -8,6 +8,8 @@ cask 'cyberduck' do
   name 'Cyberduck'
   homepage 'https://cyberduck.io/'
 
+  auto_updates true
+
   app 'Cyberduck.app'
 
   zap trash: [

--- a/Casks/portfolioperformance.rb
+++ b/Casks/portfolioperformance.rb
@@ -9,6 +9,8 @@ cask 'portfolioperformance' do
   name 'Portfolio Performance'
   homepage 'http://www.portfolio-performance.info/portfolio/'
 
+  auto_updates true
+
   app 'PortfolioPerformance.app'
 
   caveats do


### PR DESCRIPTION
The applications Portfolioperformance, Cyberduck and Carbon Copy Cloner come with integrated auto updaters and should be excluded from `brew cask outdated`. This pull requests sets their `auto_updates` property to `true`.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.