### PR TITLE
Update gotofile to 1.1.4

### DIFF
--- a/Casks/gotofile.rb
+++ b/Casks/gotofile.rb
@@ -1,10 +1,10 @@
 cask 'gotofile' do
-  version '1.1.3'
-  sha256 'a646cfec1eff2f9d2f021acf4841143b219d255ba4ef5bc492a159b0940091aa'
+  version '1.1.4'
+  sha256 '11369f519fe69a6f7a580a8f8762b6282a796570c4e8a4009ad08fe6f92bd921'
 
   url "http://www.soma-zone.com/download/files/GoToFile_#{version}.tbz"
   appcast 'https://somazonecom.ipage.com/soma-zone.com/GoToFile/a/appcast_update.xml',
-          checkpoint: '6695d30c7ce2cfddc35c6231c637feee403a19bfd825ee863874571a52d549c3'
+          checkpoint: '32d43e18ffbd7f3cf79de4af954845a92b37e76c2e0847fa95553bb53ba4f314'
   name 'GoToFile'
   homepage 'http://www.soma-zone.com/GoToFile/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.