### PR TITLE
Update station to 1.7.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.6.0'
-  sha256 '1ba2a0ceab7647c40bdada1670455522ffb8147b7fc3cecbe4853d00952e73d1'
+  version '1.7.0'
+  sha256 '6ae15c7bcf65fe6bdae9ec05955a55afc99611cad130b77a37036b59a6088c7d'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '924b5134d34166d20c88109974b10c4c1e699d9e3b0d94c643eca716ea37330e'
+          checkpoint: '21f40a6d7974489d97a2496859d883c955decd65bf000a14dc1318105a00d276'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.