### PR TITLE
Update datagrip to 2017.3.7,173.4674.7

### DIFF
--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -1,10 +1,10 @@
 cask 'datagrip' do
-  version '2017.3.6,173.4652.3'
-  sha256 '1c5fc9f9f7079ac82417fd5406fbf723215a340a04411a171da225d0bfdedf6b'
+  version '2017.3.7,173.4674.7'
+  sha256 'cac7b834618cc14d4a8da92f72202ab60127eb020438f1232276fdcc5dbfccd5'
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release',
-          checkpoint: 'fb63bda34cb9fd969354a632b54dbfcf9ff296501c81edb77f9254b69b48c9c8'
+          checkpoint: '939499163e71e9744e61e48a4d96d3a140575826a417c6772dfb927be1e87cdc'
   name 'DataGrip'
   homepage 'https://www.jetbrains.com/datagrip/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.