### PR TITLE
Update lingon-x to 5.2.7

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.2.6'
-  sha256 'dcda364a338b19b4af7387a595a302eaebbae1f7725b42ddae07ed1bf56c3e5b'
+  version '5.2.7'
+  sha256 '0dc92c414f87cb15912ebd280b0171c5c69c619c40df775b43aa4b26eb971372'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: 'e9ca1425752c701f252e5a0a63d0a509fd7afeb32311d56f94f3eb266bc11706'
+          checkpoint: '2ced583891406edaf17f6bc69dbfc5f9d53ac15d8e11df4ba20af48dc0101045'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.