### PR TITLE
Added Google Chat Cask

### DIFF
--- a/Casks/google-chat.rb
+++ b/Casks/google-chat.rb
@@ -1,0 +1,17 @@
+cask 'google-chat' do
+  version '18.2.252'
+  sha256 '03207c6549f1055c6238633d8b3b49f89f296b4328b13c5209decc646ed2b5cb'
+
+  url "https://dl.google.com/chat/#{version}/InstallHangoutsChat.dmg"
+  name 'Chat'
+  homepage 'https://gsuite.google.com/products/chat/'
+
+  app 'Chat.app'
+
+  zap trash: [
+               '~/Library/Logs/Chat',
+               '~/Library/Saved Application State/com.google.chat.savedState',
+               '~/Library/Application Support/Chat',
+               '~/Library/Preferences/com.google.chat*',
+             ]
+end


### PR DESCRIPTION
Note: there is a conflicting cask, `chat`. As such, this has been vendor-prefixed `google-chat`. 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference]. 
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
