### PR TITLE
Update istat-menus to 6.10

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,5 +1,5 @@
 cask 'istat-menus' do
-  version '6.0'
+  version '6.10'
   sha256 :no_check # required as upstream package is updated in-place
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Ed1t:  It's actual 6.1, but the URL states 6.10.