### PR TITLE
Update VLC.app to 3.0.1

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,6 +1,6 @@
 cask 'vlc' do
-  version '3.0.0'
-  sha256 'e6f7179cb06809b6101803da3ac4191edb72ecf82f31b8ae7dbf010e1a78ba26'
+  version '3.0.1'
+  sha256 'ceea37fb888b810c1b11c558471f10fa35500c047d6eca5733f038eefb16d926'
 
   url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
   appcast 'http://update.videolan.org/vlc/sparkle/vlc-intel64.xml',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

---

new `version`
new `sha256`

---

Note `appcast` is broken, the last entry in the official VLC XML file is for version `2.2.8`
http://update.videolan.org/vlc/sparkle/vlc-intel64.xml
