### PR TITLE
Update mono-mdk to 5.8.0.127

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,10 +1,10 @@
 cask 'mono-mdk' do
-  version '5.8.0.108'
-  sha256 '478e362c22c3f095ed2d28a53180e923b0bc1c9909cf6305cb5628798f6df6aa'
+  version '5.8.0.127'
+  sha256 '9c743b3d48472427bd31b51dc56974e395514ed784ce633dafcc4491c07052d1'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
-          checkpoint: '542ba80a1f656ec9f0985528ec22648ea8036dff1f4c75e8a1c5a95de281b233'
+          checkpoint: 'dd09818c71e94eaf058af709a4d12795667d626973dbaeab18bb7314c5c5e5ab'
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.