### PR TITLE
Update flixster-video to 2.7.1.637

### DIFF
--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -1,11 +1,11 @@
 cask 'flixster-video' do
-  version '2.7.0.610'
-  sha256 '6ebddd7540244ea2fb8ae89bfbf403758dfec805d5207e303eca8b428db016be'
+  version '2.7.1.637'
+  sha256 'eef953f1b4636d158a594728a9bed6ded61f5af1402bd7432cce817e836f1346'
 
   # d1rtylazwb77ux.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
   appcast 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
-          checkpoint: '36972a98c844df356b2d2ceb2f08ac71441fdacfe99b9a93b24ccab193f0d9fd'
+          checkpoint: '7486cfdc8e89809389fa19117d196149086788eed99798948443892633a540a1'
   name 'Flixster Video'
   homepage 'https://www.flixstervideo.com/apps'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.