### PR TITLE
Update filezilla to 3.31.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -2,10 +2,9 @@ cask 'filezilla' do
   version '3.31.0'
   sha256 '188e8d9af77dbcdd6176fb7eeca19083fff6f22e41331a1927c78c73c1faa769'
 
-  # sourceforge.net/filezilla was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
-  appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: '098d16fde9aa950ea2989b0b2c51ff340eb1c05b997497f7512f37dd7c86f177'
+  url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
+  appcast 'https://filezilla-project.org/versions.php?type=client',
+          checkpoint: '9b1a081a82ba46468494ab610ca341f26790ccc431193bda585571cf9ca722e0'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.