### PR TITLE
new cask for EPI2ME Agent v2.52.1202033

### DIFF
--- a/Casks/epi2me-agent.rb
+++ b/Casks/epi2me-agent.rb
@@ -1,0 +1,11 @@
+cask 'epi2me-agent' do
+  version '2.52.1202033'
+  sha256 '06b94d9d11e31b44b28bd4e52fd68327aa59d8e3a07953527c6192b099620e44'
+
+  # oxfordnanoportal.com was verified as official when first introduced to the cask
+  url 'https://mirror.oxfordnanoportal.com/software/metrichor-agent/epi2me-agent-2.52.1202033.dmg'
+  name 'EPI2ME Agent'
+  homepage 'https://epi2me.nanoporetech.com/'
+
+  app 'EPI2MEAgent.app'
+end

--- a/Casks/epi2meagent.rb
+++ b/Casks/epi2meagent.rb
@@ -1,4 +1,4 @@
-cask 'epi2me-agent' do
+cask 'epi2meagent' do
   version '2.52.1202033'
   sha256 '06b94d9d11e31b44b28bd4e52fd68327aa59d8e3a07953527c6192b099620e44'
 


### PR DESCRIPTION
EPI2ME is a cloud analytics platform for data from genetic
sequencing devices made by Oxford Nanopore Technologies Ltd.
This cask is for the latest stable release of the EPI2ME desktop app.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
