### PR TITLE
Update gitup to 1.0.11

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,11 +1,11 @@
 cask 'gitup' do
-  version '1.0.9'
-  sha256 'a9d43f6b7f99c8a559fd002766691fc9c2699a549eb1e721f4c4c726c7b8c07f'
+  version '1.0.11'
+  sha256 '3cd4b67bd76cdcec924895d69f6e867233bcc026fee5507fce43333e8b47fb4d'
 
   # s3-us-west-2.amazonaws.com/gitup-builds was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/gitup-builds/stable/GitUp.zip'
   appcast 'https://github.com/git-up/GitUp/releases.atom',
-          checkpoint: '75471345678b24c6cc76d263c43dc625b3f26305635f7a11fd576bd002067966'
+          checkpoint: '8af6cd118a5e855af3afa7468596b32319ed9a4b810c6ffe0145b57bdff6eaaa'
   name 'GitUp'
   homepage 'http://gitup.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #44475.