### PR TITLE
Update postgres to 2.1.3

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,11 +1,11 @@
 cask 'postgres' do
-  version '2.1.2'
-  sha256 '3fca874dfb9472bee547b82a40b0b3cca3a20df07349bf166aea372dd4a633f8'
+  version '2.1.3'
+  sha256 '1498a39a4383b8cc59cc9318e535e6e5be8128350b85ff45dab353f7c50915b6'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
-          checkpoint: '4225e77dc16360db31fa3757ebd705a733e40c84de494f5e0b76e48763582bf5'
+          checkpoint: 'c051d1096e47ad817205a65247b28ab71e382b8391b051a26771d107847ba67b'
   name 'Postgres'
   homepage 'https://postgresapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.