### PR TITLE
Update script-debugger to 6.0.8-6A225

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,11 +1,11 @@
 cask 'script-debugger' do
-  version '6.0.7-6A217'
-  sha256 'b4c234e77dcf6b04427888eabaffaceefcbf99030729f4c6cfb45038912aed6f'
+  version '6.0.8-6A225'
+  sha256 '1f3ad8a2842c78ec4f504f4a596a9d237179ae93515457798ffa90a5f8183f07'
 
   # s3.amazonaws.com/latenightsw.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg"
   appcast "https://www.latenightsw.com/versions/com.latenightsw.ScriptDebugger#{version.major}.php",
-          checkpoint: '36f8c4638dd2281f170026d8c3fc5154b1ce7d8c9de33798097d5312a25ed56b'
+          checkpoint: '97015bd999ef3fd6643464375af35feaefce12a96b099427cf4e29184fffd2aa'
   name 'Script Debugger'
   homepage 'http://latenightsw.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.