### PR TITLE
Update URL of fastlane.zip installer

### DIFF
--- a/Casks/fastlane.rb
+++ b/Casks/fastlane.rb
@@ -2,8 +2,7 @@ cask 'fastlane' do
   version :latest
   sha256 :no_check
 
-  # kits-crashlytics-com.s3.amazonaws.com/fastlane/ was verified as official when first introduced to the cask
-  url 'https://kits-crashlytics-com.s3.amazonaws.com/fastlane/standalone/fastlane.zip'
+  url 'https://fastlane.tools/fastlane.zip'
   name 'fastlane'
   homepage 'https://fastlane.tools/'
 


### PR DESCRIPTION
I'm the author of fastlane, working at Google. We recently moved all fastlane related infra services away from crashlytics/fabric, so the URL changed from AWS to the official website.

Let me know if you need any other kind of proof or verification