### PR TITLE
Update libreoffice-language-pack to 6.0.2

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,565 +1,565 @@
 cask 'libreoffice-language-pack' do
-  version '6.0.1'
+  version '6.0.2'
 
   language 'af' do
-    sha256 '83fbf25ba3a0055912f8a6f3c130a244c797b1cd5698c7c3ed4de000274f1a69'
+    sha256 '74f9e0ebfbf88aa4dbf4393ae22d2f3cf298f0fc3a378ca00dcbdf426e409e48'
     'af'
   end
 
   language 'am' do
-    sha256 'b82ba377129bf99d7ddf195f0922689041d051505442b5dda755b89d470334dd'
+    sha256 '6e04a1a7d2e1d319905c472e6c8b84db08431bbfa6b1c0ecede67b67ea7615d0'
     'am'
   end
 
   language 'ar' do
-    sha256 '7dc83841e740d9735985cc73c67e2d5e5806dae1a56e9a400936bd2fe27a6db5'
+    sha256 '7f57a39d26f10b3feeb1c44d380659dee31765dfc249826377fbd0edd10dc616'
     'ar'
   end
 
   language 'as' do
-    sha256 'e8857fcd5da3c461ff402575489f72128a67a530057bf94ce65bc50d91f4e323'
+    sha256 '5de90931098d94e6d9ed799c76f77b7b626d1cc81a025f63e4a14cd0ade18ea4'
     'as'
   end
 
   language 'ast' do
-    sha256 'a2fc66405ab3c232ab77a842f7bd10e36cbe702144b4c38f5ba876a6e1efa853'
+    sha256 '931e53e08c6ec17de0370d697bb5c0a61dd996650f48f3dac7bffa259849dba9'
     'ast'
   end
 
   language 'be' do
-    sha256 'd8c0c0a3661a3c862bc269d07fc38609148cf2521c3894691189d76a3347b937'
+    sha256 'a732f7243c27a1cadd62bac6b244a52ef52b0f342d97687a275c73a924ac19df'
     'be'
   end
 
   language 'bg' do
-    sha256 'bde077da7f1c34d638e0c2c2afaa7a146b03bd386bfce33a6b2b0ad66c34d126'
+    sha256 'd42a3611e4bb932063891b8ef039c57faddaf3f54a35ad82148bce4f92d507a7'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 'c92b074fa57239463aa351f3f1743f4b71d23081822e951d98df5539c22cdb79'
+    sha256 '7eb7005ceb0bb748cdf804e9c6d933297bf87cb8c681005afd9317c7ecf2362f'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '1da5ad945b1807b7b6d6d1a48df2ac89df611dc82d10a501cbde5b827299ad8f'
+    sha256 '6b50b37171836c94b505b69243fdc9ab544cf587588225649560941e224d9198'
     'bn'
   end
 
   language 'bo' do
-    sha256 'bedffb2948ae8d7a8a7ec26bd0bd842cb24d76ce70ad48e722bc32a4883c98f8'
+    sha256 '2357a14f5fcd0e628f88292f7bc0f930b5acc4635a3ace365d72a5e71619b8e2'
     'bo'
   end
 
   language 'br' do
-    sha256 '5c9f81ed34e97c448ba3a2bfc3b06a70099af7e96bf5bf74e643b52ac6817516'
+    sha256 '96859f4ad1b50d856711efa3b9aba1392f8a88a3f423cc70864579656814aec8'
     'br'
   end
 
   language 'brx' do
-    sha256 '402588655f46f7546f86fe26e0bff74a60f5d8e507c44c05e9b98483af5cd9d4'
+    sha256 '198acd49ab7776e69ad8fa04d03e75d43f22014f35d98bcf35fc81ac52744b57'
     'brx'
   end
 
   language 'bs' do
-    sha256 '10dfbc0708d3a2c0affe5f22940f41ae05d4f344059fddcfc20d17c8f41e5c0c'
+    sha256 'c0c538b2c0fc9d0364adae0f40897a90a2540ce7988df804320845a75d33be3c'
     'bs'
   end
 
   language 'ca' do
-    sha256 '804ee2bcf1b5d4c477bf229d07967a6e1782a8dada2cd1f5721db4a5043961c6'
+    sha256 '499fcdc0403fbe94b10449db377190b37e174a52ac45acd09f900f74e0aed1a3'
     'ca'
   end
 
   language 'cs' do
-    sha256 'd97e4b09c01c69d778c7e8dd9fb475d25c0c88a4a02799518dfe0e61f216d5e1'
+    sha256 '10ca1849b3d0836cab9d220164ff90613edb4f7b463c265220c84615de5fb13c'
     'cs'
   end
 
   language 'cy' do
-    sha256 '497f2aa2121fceb953a217c9ce5e4d3201e6de77827ba0335cb09355481d4f2b'
+    sha256 '95c3da901889a2b96bda04b55cb3a52e7c02414eddc2ff6d66b8a924b8ed2fe1'
     'cy'
   end
 
   language 'da' do
-    sha256 '9ca7fcbb28136556fc8de46c0e982ad7e3502f20f18398210b3193777f8f96cd'
+    sha256 '8b22c6972f7de03b97934339b9522c04a005bc4e177c29276c0be59db5b6e0fc'
     'da'
   end
 
   language 'de' do
-    sha256 '5ae95952c3dd1c56c3b99d30ad299691eec3fdb50423c2624d40bb270e456847'
+    sha256 '97d2dbd0598a8ddab8f8a5f1c0654a789110561e8f505b5f18e29585dddea614'
     'de'
   end
 
   language 'dgo' do
-    sha256 'ad6aace20fc2a8b918967f4e0178ab80ab957e6cc39193d6bd1fa1e154350661'
+    sha256 '46f15ccc7a87866aa4f26ae84643f104e60858fecb5e55c363c2c1f7ae6aeb2c'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '2e05330332798daf1ef0e0f231598c7b4db8b1a00e428b935ba566b69d539474'
+    sha256 'fc0b290d7ff425b6ef9eaf3df877b174572caea11560e192c2d76b0e5acc9615'
     'dz'
   end
 
   language 'el' do
-    sha256 '978b189f13007d1671c939db0fc93f55443d817d9773b2a2bc3c8427461547c6'
+    sha256 'b1765f653b82c89766e30c576526b1c366062b7cf5a37ee9ca27397ac8603e8e'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '6f24edd37c2d1bf9b87b5d06c6ca1b1e5759e03c72adb56018e3687ae8faab11'
+    sha256 '45a705589f39ea50e8e8d57506ef19f24182e3325c7b6b3e3c2d4c26c4799d69'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 'dc01ebbbe7aee132ec396c71afe4ccaab3eaa87e7dabd06dcad914d895f657c1'
+    sha256 '1d915fbae842ab423ed8373089e1f0ac7367fcc6759a015f8f769b7b3e877d11'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '1a8383f15afa3885c2b77ea30bb0c526e5e7a83675272ea267614c5109ca08b0'
+    sha256 '07939824d5770ba8563bdf59e66ef5ed662630a915f0d71626c2fc01866c5671'
     'eo'
   end
 
   language 'es' do
-    sha256 'c81d23d25cdc4c8dedc0aba1c3a0b6fe6afbf655359e062da46a0f1435345279'
+    sha256 '8e79c365fa814b7e67e9f83dc90e5536f5d4bdbae6bbf067678d4235febe965b'
     'es'
   end
 
   language 'et' do
-    sha256 '399e07fc4db671582e369887aa1ad0532463fa9039b8ba46780fe264f3c26fc7'
+    sha256 '571c0f987c0ec19b74f72f5b16a2c9f3052bfad7d0248ca9b52fdb69a0a43c92'
     'et'
   end
 
   language 'eu' do
-    sha256 '288d0ac00434cdac35958e1168e48486bb62aac316ff57d9f908adedf79e16df'
+    sha256 'bbb1e6c0006cf78800433c470ebd44fd256387466e81acdac524557140dc10cd'
     'eu'
   end
 
   language 'fa' do
-    sha256 '33794e1193670d29ba2fafbaf7e726acaf4611c8e582bef459fa683ab45a1745'
+    sha256 'ff3089bf68f318a0ad6970b3c72e2df679f1ebbaeb0c2387d7bfa299f6820c69'
     'fa'
   end
 
   language 'fi' do
-    sha256 'ae38d8f5c623e5e1c9389a3013bd9a9217ca5fcccb53aa08364c47f0d781a080'
+    sha256 '62617c67d2fb9870e190d5f48001d13392b5ee3dd8dcd4e0a97718bb007457b0'
     'fi'
   end
 
   language 'fr' do
-    sha256 '24a46b51d4b8cbbbf468166452ed11bb80612bb261d74e582142905d0af4dc69'
+    sha256 '6bdd966b0bf0ed20e7d682e979f5b6b7a8a3582a62af5e3382065b845ecfd5f2'
     'fr'
   end
 
   language 'ga' do
-    sha256 'da57b93672c6aa4bb8de67a49fdbbf9367d4d82daeb53cffe96f41dd4c1f4944'
+    sha256 'f566db51b107538df650bdacf4583eef84e1f6b6b14cfc0e22559845f5b9056b'
     'ga'
   end
 
   language 'gd' do
-    sha256 'f0dd86b800ae555a1f493645990118bc3137c174974a670313501c8ff03b3b4d'
+    sha256 'cf693ba35a78b81bfcd2e6db92bf0577591b63284b0f93c94e8c0f2778320f6e'
     'gd'
   end
 
   language 'gl' do
-    sha256 '080e07f23bf6b627aa84e4341dc3d05ff4a96e4e45e0d53fd70c33c1aa891b46'
+    sha256 '54bf7d3ca11f0688bc837c23ca905ae2a8b4a678fc8fcb464463055f8879f8e9'
     'gl'
   end
 
   language 'gu' do
-    sha256 'facbfd40f2fffab2b809d1a0e17b3fb85bd7a075ae96d3e0895032a3303ea5e9'
+    sha256 '76f95b916f37a6388f09f156aa4a61dea60f3df222d3d034b4e24b2af8ea6e50'
     'gu'
   end
 
   language 'gug' do
-    sha256 '90243cf934d17bcb6c709a2ef601cf0d9b563fb5e39fbdd79259e6883a17eae6'
+    sha256 '59ad397362ce2e0492152d55dbf099f8c668eaa5b300e9d6f633b8ffd51e4095'
     'gug'
   end
 
   language 'he' do
-    sha256 'b8f4e49f63445cbefcc03db8a10a353acda78aeded26a8456f40bfa6e70f68e0'
+    sha256 '5bdc9fb7ba4c868fd645c4f55267e17c92e6c0b7c86ac1f72a40fb774d72002b'
     'he'
   end
 
   language 'hi' do
-    sha256 'e0554f6eb3995ea7e47a463c1c34e343c948e03d9a49b2e760b5e6004ece19da'
+    sha256 'cce0f57d720af08ffdaa68143bcf8722feea6c605fee87a8ebfc2bd0e314ce72'
     'hi'
   end
 
   language 'hr' do
-    sha256 '6739af2a2eafd8a09e17a3d67833731dec83d61b37871b4f3f741884bf4a9184'
+    sha256 '69d84eae7f4a80133d4c36e5a60ef43cf1fe0ca2fdf7a6019699738e30023e3c'
     'hr'
   end
 
   language 'hsb' do
-    sha256 'e8b0261bdc7435aa3e98ad4b18eb855960ffc5f914fdb23537a8b2be46888db4'
+    sha256 '66a4e849868ddf18257f341ea4349342af1a4da05401d103f378e69c23c664a9'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '2808f0c170fa2d1f3a2f4c32a9f5adbc723162af43b835869b3cace886fafb27'
+    sha256 '25b8199686fd6968d578946eb53adc4726baffa0298fe28ad66fd4a7a9541a08'
     'hu'
   end
 
   language 'id' do
-    sha256 '144ac4c394cfd6874368d4d9308bf46fd494fe4ccf8920b3d7c028e0a5809ca6'
+    sha256 '5e18c9414819d9bb994fdae4911119cfee4af76d6472c541bc21043febd10e84'
     'id'
   end
 
   language 'is' do
-    sha256 '7deadae36b33e8307acc13b0034be31da669f173e075bf76111f1f9abe5de234'
+    sha256 '5e0dd41824c10e103989aaea8fa9d040deb8075a535f454bdd96b75cf23331d4'
     'is'
   end
 
   language 'it' do
-    sha256 '6063fa85cc21bafce9af14ee2bc9d0f68b6c53ed0d51fab36d662ca44c96b02a'
+    sha256 '953ab29e916c7cd4d7ac0a85bc853e8e7f96277b81ed8ec4ac5cc95d9eb0a9dd'
     'it'
   end
 
   language 'ja' do
-    sha256 'd27a7cacfbe1b31afa157cb632e9031e0ae8006453258b07e211cf6fe7ba667a'
+    sha256 'c45a00ba14a02dbf3103c2796e321e6fca0a272df9eb8fc599b180f4dce1cbef'
     'ja'
   end
 
   language 'ka' do
-    sha256 'e566f6187312d9c5876a586e80bfb602ee61529fc13e8f8530a55cf27c428355'
+    sha256 '5dd3761e22286e70d06d3479e9b0011a61b0b73c2f2500935fc11137267bb515'
     'ka'
   end
 
   language 'kk' do
-    sha256 'b6cb5c56dfc863fc657922213721f477d3e18e2f7e17060154686b98a21be44b'
+    sha256 '8a0dc2faf7b6e580e8cd7decca77d552d37cdd3eea6507602c67e3c7ac0c8412'
     'kk'
   end
 
   language 'km' do
-    sha256 'edd23f40fcadb3e1498c3c455f4c41b067d69f4284666b3b0325a95041c01e55'
+    sha256 '1de200105ff640cdab608321a1a6dca1f38e50e419bda4a73360bfc756b7d1aa'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '6255d32867726cb067db811dc4873f27b85169c621f2b10aae413d9ba90ac846'
+    sha256 '2fbe672619c189430d9576ba91f0f6623339bb6102759be9dec927e70d31f45a'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 '0bf3b714bb78c56b631395c3536b77d3f3ea1d5150aa54f60ce24ad5d128d655'
+    sha256 '88ee74e8f769666abaf96ebc4e59ecddb6f9b773d6f7c12d3b07c42c32241006'
     'kn'
   end
 
   language 'ko' do
-    sha256 '0841a1bc18c8f4e68f0559216cddb7f0aa6090b256673e068c0dc1d82f9a53c2'
+    sha256 '84fd87dbb76118085318a3d011e90f5fbeafbbdc55058a419bb6f9fdc50f4632'
     'ko'
   end
 
   language 'kok' do
-    sha256 '852ae12369ae3c75aee1a531dc9483157ecc5c0b5e5d3fd05234cdbf32813d3c'
+    sha256 '35073691c4770d7e4602ca6c5c1383640bece46bc27f50826f5857b9a15a405e'
     'kok'
   end
 
   language 'ks' do
-    sha256 '1510d918f75e356dba75a915d6021421271b6c58f95cd5ae65619e5ced1f8a2c'
+    sha256 '0d5b692fc20549531e63d9c2a33bf7ff4f1b00c723ae99c3d3342d21e40fe6d3'
     'ks'
   end
 
   language 'lb' do
-    sha256 '1bbc4141a3de7c966b7f23f18b4c3c7f22067fe721e912ea9900ba55a5ffcc34'
+    sha256 '07c41fcce6786861f48c75008da7fd8749ae0caa8a642d8a4ea671500857ec05'
     'lb'
   end
 
   language 'lo' do
-    sha256 '1b8c6acc189717884da16caaff882a23c73c6d23e80f9780e918cbb15a832f59'
+    sha256 'de275c22d16687c84c626dc2304c0b70c9ee99aa9cdef49196fbef17acb6ea7a'
     'lo'
   end
 
   language 'lt' do
-    sha256 'c3b96d6e0cf1cb476062582f4a6369397fe69281b910e1407e8cd1be3d102469'
+    sha256 '9d0d34f954ed47e10f6b2985584d9083594cd6d4dc6fe82a8aca318400b03f97'
     'lt'
   end
 
   language 'lv' do
-    sha256 '94e78e2dcdd8e94d054b3aae8c6980c842a399c4af8b6346e7a9b06986f0a1f7'
+    sha256 '56f9f5b50c1ff123bf571f715193d17451b77f8fabffe97f0f9b1f4967ef51fb'
     'lv'
   end
 
   language 'mai' do
-    sha256 '5c33fa9187ba91bb7beb20665f058b12f61e09e7a8a19867fb8c60fac6473892'
+    sha256 'ddcde3a1bfda6a46378f5e783c38caa19177673954c093f20b76537a09ad430b'
     'mai'
   end
 
   language 'mk' do
-    sha256 '5c96eb59f997e16e80969bcfa2089a56c9e04ce1045025ca2c16484b54f1d2d3'
+    sha256 '63216d3e76473552d2fdec28a14299322a65867d3de5f6af788a2cdb38a520ac'
     'mk'
   end
 
   language 'ml' do
-    sha256 'e79223b75e5b65b54e5ff74a9bdeef5093a6667c45d6009a4aa84184c1970bfe'
+    sha256 '414873e04a8dda1a7f6b21669321f6217ade1c61f4685f825fb2775ac6f77063'
     'ml'
   end
 
   language 'mn' do
-    sha256 'f0fbdaf438337bffc99ba8abe6146a0c80624c1e3f81d044bf7a512bcddf8629'
+    sha256 '75ae95dbf1384d4fb83c14aa85b234cf29213b6e138e6b9e15c627769196370c'
     'mn'
   end
 
   language 'mni' do
-    sha256 'c03502bd1c6ed63e5e6c8161b87e8b3ba07aba581d4b27279f4bc93962dfe2c3'
+    sha256 'c9d7571ea9b00216ce642a6c1656e1c4ccb8e729a3f200818535f34202e93234'
     'mni'
   end
 
   language 'mr' do
-    sha256 '8f5df78456bb2e317a9577d22cafb1a86b9807626841ae9bee678526514cd6e4'
+    sha256 '926e45f345ae4f65a587d58ceddcca18062621d49c8ad4aaa485f49fd9f10e18'
     'mr'
   end
 
   language 'my' do
-    sha256 'b1030856c21ac3a29ec47bb262f6627adb1c56132ae30052f3db3fdd85e99b1a'
+    sha256 '0ba9be12fbe9912f8da278989501826461acc534e523dbfe6bd50c5ec8e25a22'
     'my'
   end
 
   language 'nb' do
-    sha256 '6f23d6509ead600084eb69b9f1e046fc30e7fe7a018916264d1f22d9a433591f'
+    sha256 '76c9abcb7d5ce31e8f71671fd1ca86ec1d08d5b9e0e0106eef1e2345a0dcc56a'
     'nb'
   end
 
   language 'ne' do
-    sha256 'eabc0ffed7b98b0f3260dd012d2d1caa6e804e1d3f078073f13905d16ee2f789'
+    sha256 '9151dc09f665f4d6866f5994223a84b05f7e26d9a1a3c78209a15b2f6be2e397'
     'ne'
   end
 
   language 'nl' do
-    sha256 'df8f347809ae77b96c0f416305f28dc91575a36706c164e836dedde1ac43708b'
+    sha256 '146be5ebde23e42a788eb1d600dcfb20441ee646cf72d70efeb1c6bced9162af'
     'nl'
   end
 
   language 'nn' do
-    sha256 'da0657dfc1174a1f8c528fdf3eb3192d8797ff8aa57ef7fbe90541c6f5110b93'
+    sha256 '40f82dca5b4d40ca5a0f1228240142090cd4dd4511a0f9d978186898db782b99'
     'nn'
   end
 
   language 'nr' do
-    sha256 '097d2063e00c5f3de07076acb355ad951181ff0beb65914aee27015378c9c6c1'
+    sha256 'e80d24ffbc87977bdc269e956f8885752109bbe73980932b4ad14e2355c8b9f4'
     'nr'
   end
 
   language 'nso' do
-    sha256 'fbcf19c8c29788d9f8ac5ccd5080e81072b1b1b6b61d7288099881d760219ee9'
+    sha256 '001cd01414719a86b5e8d992cc9f68f2bd5dd4a7f9ca1b85ca1a1e8e07e00179'
     'nso'
   end
 
   language 'oc' do
-    sha256 '2be94b10c5e0a51745ac3ac7e6d8c457e56e0590d1ce505d1c752d914561117d'
+    sha256 '2df7805504134cf5de2d7b34b830d7b5da5afacf0b534d324a684525996e5774'
     'oc'
   end
 
   language 'om' do
-    sha256 'ef2cb3f310cf0a50c6d0d944ba1ae3398e5d8d41a12cb43f762b02c011e5825c'
+    sha256 'fc257c7e2c7c072f3c025ceef4dc1c74770e4254be80396cda070491cd87f36e'
     'om'
   end
 
   language 'or' do
-    sha256 '7179d955440168d097dc22f88ba05b5ed59e5f0e57f664d711ead9284bcf23d3'
+    sha256 '27de80085501f32a4b04756918b71afa0c22027c4fb142eea5d148a086297ce2'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '9b138fc8d545be45acd4d3176a23100895b2d9dd4e963f79f1406d1646eb16c8'
+    sha256 '4ace4885a006b2e4c0087d53c845d276faa84cb9df7933a35c6e185ff3ac2859'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 'c3e22485ee8a7219c0e7d493d9349d03b7a31c15b2c31879129dabfa6ce3f80b'
+    sha256 '59f9678c561ed74a8ca30e12b53125d54459a67e4cf8d28a432284184b9f85ee'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'f45e09db103420ca40e84c684747f055d9abcce628e50eeaed8fbb3d6946f2a1'
+    sha256 '69b7a425e4b61c7d05e6595f5e8d214976b762eaf11b621f7103936059200acf'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '014a919191a27424dd5c74a32a35fbcec8ae178ee2cc8c7e26fd1e0c776f5963'
+    sha256 'bccd52a73a3e8a28bbf6e38d05247237da2fdfb1c011b22a4068fd047c3ec963'
     'pt'
   end
 
   language 'ro' do
-    sha256 'c71aa27238c53ec6b8988d6da3412a9d0695c4f36faf80aed9d985f59964ece6'
+    sha256 '610519ba377b92a910434ec65f5498c6db49db54d065794ce84c55038ebfbc92'
     'ro'
   end
 
   language 'ru' do
-    sha256 '34e746d669401073441eaeeb57f745a141e0f2d97f265d94c4fa806241f47da4'
+    sha256 'a9e04a90deabdeb866fac1c9129622bc16b7aaa48e41ddc17894c8413d060777'
     'ru'
   end
 
   language 'rw' do
-    sha256 'c7fd9b6ee4e5e56301b1b91d95ca303019e8862243c8e3f5c7cb8f5c0a252ebc'
+    sha256 '74adc46e6a093c9e3e3f5b4c47337ad447652fd4f93f22c7d67083643bd37afc'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 'ee0a12ce491a320ad31deae6478a04a6393632666c305be83787f897279b6d07'
+    sha256 '0393ff7c01acc0e1e3d5e0682441b410401001eb6e011fe925af51043247de69'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 'a389b9993002152c548869f6be6d2222b4ca6af6cc0c136ed72876b1b3797c58'
+    sha256 '81a6d089b120f0867d104e44389c679d0f43f7056bc22a8b6ea36a5f8c4ace17'
     'sat'
   end
 
   language 'sd' do
-    sha256 '523bc4905725046461f8cad70b09f72de67dc9f6ca2760eafd77f58ec075a224'
+    sha256 'ecf64070ace9607d3a16b35d5ca3da0f611d73f398be45c658d243c50f994664'
     'sd'
   end
 
   language 'si' do
-    sha256 '69aa9b67293eb284619b7462c9e435b898c65acde0dc71d2a3913ba1c21a734c'
+    sha256 '3bf9aebd838fbe7318559ea3599bdeee1d22d5a4e30d6dc24267618a9304a419'
     'si'
   end
 
   language 'sid' do
-    sha256 '6829359982a212c01dc31a17f57e7b9b1cfc37351f89d43873ad918ff4a52ae5'
+    sha256 '0ef2979585d19a0d8d39d1fd25e03da09ed7003a28726a0000764db94fcf78ef'
     'sid'
   end
 
   language 'sk' do
-    sha256 '18fbe9139c7356c55b472aa9e37d5d1ea031f13644939a22bddc2f01738ae981'
+    sha256 '8ecaae6b91ca6274668b7aec2199e8d6b9b6603778efaaef1c917cf225179423'
     'sk'
   end
 
   language 'sl' do
-    sha256 '292ccb60ebf82af5b8e5f0f3972bbde2ce3abc4f6be92be20334f4e22aa996f6'
+    sha256 'e7b1fc844792be4534da3ec68b0e0ee1a996f8d1514a034535bdb61bd4eff82b'
     'sl'
   end
 
   language 'sq' do
-    sha256 '9b02d63486d8ef534e520359db9a715b58712a60f6689488f34469db179fee2b'
+    sha256 '79b4d13c473943f58f17046097c9bc6a7e733b0c99c39fffc45bf9e8f5ce95b1'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '9f683ea93e5629d7249703ab3e331cc5484a6d2c8733ce257560bd984e5af8de'
+    sha256 '9c806a5c3d2d7bc3625f3bfe029f3c6c9a795c6407627dc21fa28793194f0377'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'faf2a970b360e7af29b4da24eb210ff076812eff55ce47852572bf666ffbf44f'
+    sha256 'cd76f4ba697a5e02642d524b4ca07a9b5e4b00adc869fbc8ac6e8ee501541d82'
     'sr'
   end
 
   language 'ss' do
-    sha256 '017412a35fd5528ce1e5fc193eb8b541d7c38890f0b2eb67111909ecae7cf52e'
+    sha256 '2c080f7889125066e466e19a0de0a0c7f010bc5a4135e5356ea4852873ac43f0'
     'ss'
   end
 
   language 'st' do
-    sha256 'd4b54e241fd200c7b7554ea1358b1c830c286949b6745bce48d2d48c1c509235'
+    sha256 '14915e60c6dcbaee4cf65977f3c228f9a58e919e21ac8cfcdcf4b9cb8b0bc2b3'
     'st'
   end
 
   language 'sv' do
-    sha256 '36dc12ac81d948fa9fc5b549820ad647a14fe0834a6181c252b3f2280bd507fa'
+    sha256 '55c8160654647bafc4222ad7540faebe4b621902ac4929f2c14a72ac645b3ff0'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 '72b32e88ef3d8ad98d74b204529ab8fafbd5d22c653ca14734d73011c785bf6a'
+    sha256 'fb24ab8dd23efa6a5708df82329c64f23800069a19a2c6031d860fa6c923d47a'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '304458a89259f140ab53ad1772a63ce55f0d576cd9c858b6da6ec17566617e7c'
+    sha256 'a3e148e7bdfc4e24677416487299ea91254d44861c614481c0b20661547765d1'
     'ta'
   end
 
   language 'te' do
-    sha256 'd61d1ab7ba186855794c3719c7d7800a5237dfaa54f705af621f40b0c2d00609'
+    sha256 '352470c50fa411e4f2598b18aab88b0aae170facc11d40781e4852a6e4bc41d7'
     'te'
   end
 
   language 'tg' do
-    sha256 '9f2d85cbab95689b2685507b8aa78b0bb418026925cb81c8c3df859e13570ec7'
+    sha256 'a13ee7d304643753a7f04fbb7e5ea190c3784c38c4ac0a14a2cbee7ecefd5942'
     'tg'
   end
 
   language 'th' do
-    sha256 'c0447f3641d4fa275bff79f5095a312f75ed51b5384c7e5fc1f1141ffce334db'
+    sha256 '2a2c3761ca8d81402904ae34b309a6409417b02f97e5abc6b4e6c683a7230dc0'
     'th'
   end
 
   language 'tn' do
-    sha256 'dd5185d5cef97b0034335a35c8428e3293d5b45fbc5749360d4d5b17dbcd4b12'
+    sha256 '6f1ed4e694ee083af1905d48ec6cab9245fd8b6aeb707b3b0330fcd69e0c7ed9'
     'tn'
   end
 
   language 'tr' do
-    sha256 'a891053c077648ff614cf606f25f5066240ba971d7713dc818b454d3112ab698'
+    sha256 '65b9dd2cc5e70c1300228385eac79c616377ec53ab7d4b64e901607f0f27e898'
     'tr'
   end
 
   language 'ts' do
-    sha256 'b535062703fa934a8d7071c80f5f6611259b0ffe86e8a00e64f7040c5a8be7ed'
+    sha256 'b23c7060a8d605dcfb5b1683877e68d71cd0ff4ad9e6287c120c8cbcb0efce03'
     'ts'
   end
 
   language 'tt' do
-    sha256 'f1d895830e79fb2e12c465c6423b4b9e27713296fc47353a747e7cb372f31e18'
+    sha256 '2f650e40a70a18231471401e6d43a8b9e0e4dbafa02f0f54a85ea17774bb9e5c'
     'tt'
   end
 
   language 'ug' do
-    sha256 'dca5a9deaba924c043803a7f51814e5cf44e452e53a4f8f65a33127cb8a59939'
+    sha256 '90d645d5bce4557a1c22c12eca7236bf0d5a5ddd3ea442f8cd2515eeff2ab1fe'
     'ug'
   end
 
   language 'uk' do
-    sha256 '4664399ce4e42bebf521a675481b5dee0cb3dba22993883e2d5d8ecb14a6e64d'
+    sha256 '95cfdcbfffa87f4fadf5b1cea7dd0e7f2339a39580bccf1fe7082efdf1c0c76a'
     'uk'
   end
 
   language 'uz' do
-    sha256 'a3f60092db4f61b41453553d4c601528701279fc3f144c1e80f88dec2a713d36'
+    sha256 '7af64f6e1dfcffb134f0d74fe8c7df46da8378ab2dfbbda0433ddfb699303974'
     'uz'
   end
 
   language 've' do
-    sha256 'dcd96868f6fb8bfd6bd0ebcc6dd3bc97ad852372f0e56376f9d32f0ca2376dfe'
+    sha256 '374851153f5b13607da02e673ea8bb1dfd18dbbcb33c42764da75321b7c5ec94'
     've'
   end
 
   language 'vec' do
-    sha256 '91b1742523b7bbd01cc5807ac4ba14ef1a70bb67861d0fd0618314aec083075d'
+    sha256 'e3f299659c24f408b6066c5201b04a89d41cb99d87c1f2f68dc1c16ab16d9122'
     'vec'
   end
 
   language 'vi' do
-    sha256 '4bacd93536ee4762da282001b7fba34b2b4530e2ee4819cce70a169dc8f1786b'
+    sha256 '9a782939adf6d4934415e19dec665c7693b3e566afa2c74f8b19e4435948fed9'
     'vi'
   end
 
   language 'xh' do
-    sha256 'c0406a690e3ab05011b4803b006980aadb61be36d128710df622c148abb1a39b'
+    sha256 '086dd843c8a5fbc45e730333de562ab125aec1f3b610d5f25fc5816ccbdd6aec'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'bcf038d15858524f5928dd716af2ee7864c26c334f03af354ee2c02fb242efd7'
+    sha256 'b76613eaf9688023845491e01360321171d407c7514f59934f15c09b78a203ba'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '52f9d69a3ebddbd2eb09f25d8698ec11e8cc0b572ffdf285cef4db0af8cfa587'
+    sha256 '3e858bc0331a08b70da36713886cd94c4f129c7fff1c9737941f2451178803e6'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '94761cf2c1bd4e07657dab2254c14fa82b515315bb38c5ed9cd7701f9738655f'
+    sha256 'a27badc9ae020ce3db552472e360c45861eba400d8e41f916dab1d81db3ca9f4'
     'zu'
   end
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "http://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64_langpack_#{language}.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/stable/',
-          checkpoint: '35b9aa5600b2ca5de0ff0e75b9ee37511b8b82ccb4ade3daf2e00234315b90b8'
+          checkpoint: '94f0edd918fe7f81314a8c7ed858d39a7859a9af398ce8b49566c5fe9bd7ba83'
   name 'LibreOffice Language Pack'
   homepage 'https://www.libreoffice.org/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
