### PR TITLE
Update mullvad to 2018.1

### DIFF
--- a/Casks/mullvad.rb
+++ b/Casks/mullvad.rb
@@ -2,9 +2,10 @@ cask 'mullvad' do
   version '2018.1'
   sha256 '9a0c912ed0cf2222649f9367c6cfea338e02c737865bd556f230353096c49f37'
 
-  url "https://www.mullvad.net/media/client/MullvadVPN-#{version}.dmg"
-  appcast 'https://mullvad.net/media/CHANGES.rst',
-          checkpoint: '0f8edb7e8d4287a38402b6ab26f08947403782cf01f0a64d4711ca44df8faf68'
+  # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
+  url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.dmg"
+  appcast 'https://github.com/mullvad/mullvadvpn-app/releases.atom',
+          checkpoint: '5d66d4df8faea62e8321f04655c6d12c624409104d26395263a524d7bbe0d148'
   name 'Mullvad'
   homepage 'https://mullvad.net/'
   gpg "#{url}.asc", key_id: 'a1198702fc3e0a09a9ae5b75d5a1d4f266de8ddf'

--- a/Casks/mullvad.rb
+++ b/Casks/mullvad.rb
@@ -9,5 +9,5 @@ cask 'mullvad' do
   homepage 'https://mullvad.net/'
   gpg "#{url}.asc", key_id: 'a1198702fc3e0a09a9ae5b75d5a1d4f266de8ddf'
 
-  app 'Mullvad.app'
+  app 'MullvadVPN.app'
 end

--- a/Casks/mullvad.rb
+++ b/Casks/mullvad.rb
@@ -1,8 +1,8 @@
 cask 'mullvad' do
-  version '67'
-  sha256 '6bf7727467755eb0f1247721ce651fa35c8e485e57e244967495a343890cc44f'
+  version '2018.1'
+  sha256 '9a0c912ed0cf2222649f9367c6cfea338e02c737865bd556f230353096c49f37'
 
-  url "https://www.mullvad.net/media/client/Mullvad-#{version}.dmg"
+  url "https://www.mullvad.net/media/client/MullvadVPN-#{version}.dmg"
   appcast 'https://mullvad.net/media/CHANGES.rst',
           checkpoint: '0f8edb7e8d4287a38402b6ab26f08947403782cf01f0a64d4711ca44df8faf68'
   name 'Mullvad'

--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -1,4 +1,4 @@
-cask 'mullvad' do
+cask 'mullvadvpn' do
   version '2018.1'
   sha256 '9a0c912ed0cf2222649f9367c6cfea338e02c737865bd556f230353096c49f37'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

#### **Read edit at the end.**
---
While I added the appcast in the previous commit, it has not been updated for this release. As of this moment, none of the other versions, including their source code, has been updated to version 2018.1. I believe this is the new naming scheme because their beta version of the Mac app was versioned this way.

My suggestion would be to either put it on hold or just remove the appcast. I'll leave it up to a maintainer to decide the next course of action.

---
**Edit:** So it appears that Mullvad has moved to GitHub for hosting their macOS application. I have updated all references in 56bc33b to point there.