### PR TITLE
Update framer to 17919,1519228836

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '17676,1516724546'
-  sha256 '06c26efc76f0b8ca79d96e3bd54e4f68971316cb3d0040781cd4ee780a198659'
+  version '17919,1519228836'
+  sha256 '2619c398b7107c6ba4db467a84b3df6685237a309ede26b3f5352fc166819b6c'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.motif.framer/#{version.before_comma}/#{version.after_comma}/FramerStudio-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '4ce23bfe350d509df35265faad8f51aee2d75016d3f96fe1a32f8478ac0d94f1'
+          checkpoint: '617837e1f58f1ba25599c723fc83aa0381e433b7dc22cd7070b9916241126a6b'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.