### PR TITLE
Update macdive to 2.9.2

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,10 +1,10 @@
 cask 'macdive' do
-  version '2.9.1'
-  sha256 '9e4ce5eed7f3cb6257ce172864575b96d51e963395b34502fff5c3e28f30584d'
+  version '2.9.2'
+  sha256 'bfd8e7ee70a9c58908c163dc69263aaa72326a05d1c810296be8e42fe2ff2ac7'
 
   url "http://mac-dive.com/shimmer/?download&appName=MacDive&appVariant=&appVersion=#{version}"
   appcast 'https://mac-dive.com/shimmer/?appcast&appName=MacDive',
-          checkpoint: '8d33fd928204c0fdf7f6350befcbdf532e73ae676de3d90ddb8ec40ddb5dd1c6'
+          checkpoint: '74973b8d594c898ae6ed5377d78db55023a31839c8e07af045caf2c37e888d39'
   name 'MacDive'
   homepage 'https://www.mac-dive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.