### PR TITLE
Update blockstack to 0.25.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.23.0'
-  sha256 '9e2a465976796223bcdb0c306e3460412fe3ac48e5064b473f4c2db2ef8cd7a0'
+  version '0.25.0'
+  sha256 '71a168ac9cf8f35b36e90e28a57eccf705155fac47541a06a17ecb390727c98b'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '529039990d1567e5aa3232b8608f07be2fa708ab7e473acb06bb067b05fa3f69'
+          checkpoint: '468c21800f6eeee09113e70a1df3d23cc8cfc8445e4fdf9f933cec0d5da02ca4'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.