### PR TITLE
Update get-iplayer-automator to 1.10.0.b20180226001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.9.13.b20171126001'
-  sha256 '76f2d95274f304970a98ae9adad584ce2360fa428aae09c84ab582d9484a0e33'
+  version '1.10.0.b20180226001'
+  sha256 'e18fb10056f11b0f1bbf744ea5392873c81a8d261832f85b57ae40e17e627e80'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          checkpoint: '7cb9ac2896d1efdb580873cfe559ce6e3c01cf312e4c418c509449960036f33b'
+          checkpoint: '98b5fc7f387fb76612aee58f9d2b66328e536b94121b1ecf80cbbf5bbdb02088'
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.