### PR TITLE
Update plex-media-server to 1.12.0.4829-6de959918

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.11.3.4803-c40bba82e'
-  sha256 '26c00e66ec472f5e73d810c38b22749c9748cec48d5e145764445adb5cb50249'
+  version '1.12.0.4829-6de959918'
+  sha256 '4ec78933659336ba01c604e55e5d3816f3984bd8eedefc1c08bcd0663e7fd2ee'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   appcast 'https://plex.tv/api/downloads/1.json',


### PR DESCRIPTION
New version, new checksum, appcast unchanged, has not been incremented on Plex's end but is out on multiple platforms for days.

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.