### PR TITLE
Update postman to 6.0.8

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,6 +1,6 @@
 cask 'postman' do
-  version '6.0.7'
-  sha256 'f34cbc5c0646eba6c4e234b7d5b031b9845f1075ea1e7604fa4a15b878a84b07'
+  version '6.0.8'
+  sha256 'de0f4180be6a2ca9349be30836506f25138965d137bb156ec79a77e26023249d'
 
   # dl.pstmn.io/download/version/ was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.