### PR TITLE
Fix Factor 0.97 path environment variable caveat

### DIFF
--- a/Casks/factor.rb
+++ b/Casks/factor.rb
@@ -9,6 +9,6 @@ cask 'factor' do
   suite 'factor'
 
   caveats do
-    path_environment_variable "#{staged_path}/factor"
+    path_environment_variable "#{appdir}/factor"
   end
 end


### PR DESCRIPTION
As Factor is now installed as a suite, its staged path will be empty and
cannot be used in an environment variable. Instead, users should be
directed to add the installed application directory to their PATH in
order to use the "factor" binary command.

Note that we cannot add a "binary" stanza for "factor" as it does not
work as a symlink and requires its surrounding files to be in the same
directory.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
