### PR TITLE
Update ghost to 1.5.2

### DIFF
--- a/Casks/ghost.rb
+++ b/Casks/ghost.rb
@@ -1,11 +1,11 @@
 cask 'ghost' do
-  version '1.5.1'
-  sha256 'b49c1775d606a88469b6795104ae193266785f71626624fbdd85614206889c86'
+  version '1.5.2'
+  sha256 '775f45ba458f457a453b51783297b0354bf76d48c4ff7403bd2d8b50ab58f087'
 
   # github.com/TryGhost/Ghost-Desktop was verified as official when first introduced to the cask
-  url "https://github.com/TryGhost/Ghost-Desktop/releases/download/v#{version}/ghost-desktop-#{version}-osx.zip"
+  url "https://github.com/TryGhost/Ghost-Desktop/releases/download/v#{version}/ghost-desktop-#{version}-osx.dmg"
   appcast 'https://github.com/TryGhost/Ghost-Desktop/releases.atom',
-          checkpoint: '46ded7109c5c93f70b937a029d85060ea45d105c52513a946030b63a50812de2'
+          checkpoint: 'ecc58393423feca65bdf5573c3cf337d24e581a5b39d99daa381e0159e20b327'
   name 'Ghost Desktop'
   homepage 'https://ghost.org/downloads/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.