### PR TITLE
Update cacher to 1.3.4

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.3'
-  sha256 'dd34d2be35256542dcd73f341c73f7068756f1dd3a84f210f7a9784bd13c4765'
+  version '1.3.4'
+  sha256 '7b3f8ef28ef0dfd9370730edd66b4b7bff45e83fae11e91796576632b3f57f55'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'ba1e2b5364cd5d3792b1b355b0b67224d685bcec3074149699510197c42405a4'
+          checkpoint: '118fcb16dfb6beda8e67ba5a44aece164cb9d1e10de75f4b4359a9b8f8a44386'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.