### PR TITLE
Update mightytext to 3.90.2

### DIFF
--- a/Casks/mightytext.rb
+++ b/Casks/mightytext.rb
@@ -1,6 +1,6 @@
 cask 'mightytext' do
-  version '3.89.9'
-  sha256 'a23fbadeb6ad1b1c7a9fc1e5705421ce570ce7e7595f3ccdcf4262dad190d1b8'
+  version '3.90.2'
+  sha256 'c10f410492b323bd58c1ecd28cc6aa945e12e65a80042526055e7d86acc0fabe'
 
   url "https://dl-desktop.mightytext.net/MightyText-#{version}.dmg"
   name 'MightyText'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.