### PR TITLE
Update kugoumusic to 2.5.4

### DIFF
--- a/Casks/kugoumusic.rb
+++ b/Casks/kugoumusic.rb
@@ -1,6 +1,6 @@
 cask 'kugoumusic' do
-  version '2.5.2'
-  sha256 '667f37741aa32fd49e521f8acdc9df9a50b6b6c426eb8729b0a76633e3f8deb3'
+  version '2.5.4'
+  sha256 'c8d4e40dab713d73a64762913f4b34819a31003a7042bae77125afbeb79151b1'
 
   url "http://downmini.kugou.com/mac/Kugou_V#{version}.dmg"
   name 'Kugou Music'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.