### PR TITLE
Update rightfont to 4.6

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,10 +1,10 @@
 cask 'rightfont' do
-  version '4.5'
-  sha256 '3d133ea2ba9db94c41abfc132b52a39783f28d78cef84a28bc3e4bf9901955dc'
+  version '4.6'
+  sha256 '7484e5b8a41084093766a0064037bd255b9ad5aae43cf035f8323eabb6efcd17'
 
   url "https://rightfontapp.com/downloads/#{version}/rightfont.zip"
   appcast 'https://rightfontapp.com/update/appcast.xml',
-          checkpoint: 'd1f93d47ccc0c270b0c5fae97efd7d7ceaadd784c04328fac98c8afd304c90f2'
+          checkpoint: 'fafefa8ff0d05f8e67a778beb15139e9f87e14d7e84b25f71e5f6f6a4ca972c7'
   name 'RightFont'
   homepage 'https://rightfontapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.