### PR TITLE
update towerim-tower to 0.6.4

### DIFF
--- a/Casks/towerim-tower.rb
+++ b/Casks/towerim-tower.rb
@@ -1,6 +1,6 @@
 cask 'towerim-tower' do
-  version '0.6.3'
-  sha256 '666e58cc2ba8dfae1147f92b34ab59826b4b59d9b4fc3e3c3d4899d94966db02'
+  version '0.6.4'
+  sha256 'b776b2d71ce0b2ccdc6093979b80239adc387177765381276ffc160a7ebbe863'
 
   # towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac was verified as official when first introduced to the cask
   url "https://towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac/Tower-#{version}.dmg"

--- a/Casks/towerim-tower.rb
+++ b/Casks/towerim-tower.rb
@@ -1,6 +1,6 @@
 cask 'towerim-tower' do
-  version '0.6.2'
-  sha256 '89f030324e1372199b1017267cd9e4cc83b3c385fa24d7451dde65378b58b9d6'
+  version '0.6.4'
+  sha256 'b776b2d71ce0b2ccdc6093979b80239adc387177765381276ffc160a7ebbe863'
 
   # towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac was verified as official when first introduced to the cask
   url "https://towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac/Tower-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.