### PR TITLE
Update molotov to 2.1.0

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '2.0.5'
-  sha256 'ee37bc3724bacfeb7880af67865d5b446b03bd23856ee78a8e00f596cc4b58e9'
+  version '2.1.0'
+  sha256 '95ce31a86764f92dc6a6e1123c6b8ca91699f3c2350c97741fbf4cceaeeb0738'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.