### PR TITLE
Update ganttproject to 2.8.6,r2233

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,11 +1,11 @@
 cask 'ganttproject' do
-  version '2.8.5,r2179'
-  sha256 '0f8a752c03e29196d38b1874239c4e8e048b3b8360c82d8da3262ec9e1160ad9'
+  version '2.8.6,r2233'
+  sha256 'ec7f11f057329ebeb9545103b7821871d2737caed4dcfdf248adc4b3f0f35946'
 
   # github.com/bardsoftware/ganttproject/releases/download was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/bardsoftware/ganttproject/releases.atom',
-          checkpoint: '3bf25b7d2739eace46496219d2955bfcf420a00c9a315a9ff948267d40b7c9d9'
+          checkpoint: '4d1a804b315baa3a7e690aa4933fe7462d551659b5bc0f23bfc2ba6657d0101c'
   name 'GanttProject'
   homepage 'https://www.ganttproject.biz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.