### PR TITLE
Update gitmoji to 1.0.1

### DIFF
--- a/Casks/gitmoji.rb
+++ b/Casks/gitmoji.rb
@@ -2,11 +2,11 @@ cask 'gitmoji' do
   version '1.0.1'
   sha256 '7961f9be82688c98cc62d0df70b59251d94848c9b6669a6a39d6ae4fc7ad10d1'
 
-  url "https://github.com/Meadowcottage/gitmoji/releases/download/#{version}/Gitmoji-#{version}.dmg"
-  appcast 'https://github.com/Meadowcottage/gitmoji/releases.atom',
-          checkpoint: '61237d048c9f1a59aa553afd7d9b633b9efe9af17be1bdea8f9242c3248cc0f7'
+  url "https://github.com/NuroDev/gitmoji/releases/download/#{version}/Gitmoji-#{version}.dmg"
+  appcast 'https://github.com/NuroDev/gitmoji/releases.atom',
+          checkpoint: '30ef1a869bc8db533e3f53d83f2195c4a81775b9fb966810458ef38e335fad26'
   name 'gitmoji'
-  homepage 'https://github.com/Meadowcottage/gitmoji'
+  homepage 'https://github.com/NuroDev/gitmoji'
 
   app 'gitmoji.app'
 

--- a/Casks/gitmoji.rb
+++ b/Casks/gitmoji.rb
@@ -16,4 +16,8 @@ cask 'gitmoji' do
                '~/Library/Preferences/com.Meadowcottage.Gitmoji.plist',
                '~/Library/Saved Application State/com.Meadowcottage.Gitmoji.savedState',
              ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.