### PR TITLE
Update the-unarchiver to 3.11.4

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,11 +1,11 @@
 cask 'the-unarchiver' do
-  version '3.11.3,115:1507740941'
-  sha256 '04dc20b845171e25c7137e504cd5a5387a81bdfdc51d2ad810d5fdcf84cff8c6'
+  version '3.11.4'
+  sha256 '0b65ed1af57766c9ce4db9207390f31ffc3a2c1c274616ac20749739661e4929'
 
   # devmate.com/cx.c3.theunarchiver was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/cx.c3.theunarchiver/#{version.after_comma.before_colon}/#{version.after_colon}/TheUnarchiver-#{version.after_comma.before_colon}.zip"
+  url 'https://dl.devmate.com/cx.c3.theunarchiver/TheUnarchiver.zip'
   appcast 'https://updates.devmate.com/cx.c3.theunarchiver.xml',
-          checkpoint: '1c96c54e3a66a32152a075585833353b2a7973e4f3460c49f597dff60626f5cd'
+          checkpoint: 'f0af10046b5de56a0de92d6be04aca3dea66afabab0b06dc58914d85828bc326'
   name 'The Unarchiver'
   homepage 'https://theunarchiver.com/'
 

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -3,7 +3,7 @@ cask 'the-unarchiver' do
   sha256 '0b65ed1af57766c9ce4db9207390f31ffc3a2c1c274616ac20749739661e4929'
 
   # devmate.com/cx.c3.theunarchiver was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/cx.c3.theunarchiver/TheUnarchiver.zip'
+  url "https://dl.devmate.com/cx.c3.theunarchiver/#{version.after_comma.before_colon}/#{version.after_colon}/TheUnarchiver-#{version.after_comma.before_colon}.zip"
   appcast 'https://updates.devmate.com/cx.c3.theunarchiver.xml',
           checkpoint: 'f0af10046b5de56a0de92d6be04aca3dea66afabab0b06dc58914d85828bc326'
   name 'The Unarchiver'

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,5 +1,5 @@
 cask 'the-unarchiver' do
-  version '3.11.4'
+  version '3.11.4,116:1520347991'
   sha256 '0b65ed1af57766c9ce4db9207390f31ffc3a2c1c274616ac20749739661e4929'
 
   # devmate.com/cx.c3.theunarchiver was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.