### PR TITLE
Update 4k-video-downloader to 4.4.5.2285

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,10 +1,10 @@
 cask '4k-video-downloader' do
-  version '4.4.4.2275'
-  sha256 'b04c496832be1faba443807391ed293987337d4c42953c11f6b1388a70b227f8'
+  version '4.4.5.2285'
+  sha256 '3b7fd422d1b49510d61fbafc546104e51d22ccbc1a7fecdb4497c886c84ec0ef'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '89c3a317a578aa5ef3291f295bb4ff1ffc73f87c026475924dbc3e9f50fe695b'
+          checkpoint: 'a246eca2ffdef26baf777f4f710ac692ecd57aec0a270a3f9986f9deb15962fc'
   name '4K Video Downloader'
   homepage 'https://www.4kdownload.com/products/product-videodownloader'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.