### PR TITLE
Update station to 1.8.1

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.7.2'
-  sha256 '9a927ee95838cf584864108834f41b859dc7be99c9d2da02c9ebaf6ecf39a984'
+  version '1.8.1'
+  sha256 'a81011617b030fa167a71dc20df2345456c688b7ac22f0e04bf415241d64474d'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: 'b447b4741c9624b445c5c84bcdca65203b445b52add1ed5ee820fd6b8571238c'
+          checkpoint: 'f59a39da7f958f176f2ac912595930ca0665e1b22a4882d517d9081ec9bef419'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.