### PR TITLE
Update filezilla to 3.31.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,11 +1,11 @@
 cask 'filezilla' do
-  version '3.29.0'
-  sha256 'e7264da974dc95ffb36af0bbe2a0233fbbb876a11f67e69417fa3e15f52fc1c2'
+  version '3.31.0'
+  sha256 '188e8d9af77dbcdd6176fb7eeca19083fff6f22e41331a1927c78c73c1faa769'
 
   # sourceforge.net/filezilla was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/filezilla/FileZilla_Client/#{version}/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://sourceforge.net/projects/filezilla/rss?path=/FileZilla_Client',
-          checkpoint: 'ddb618d0a52162617c69b8f2036cbd006ae7127c17d21da1ae48d0f93edfeb77'
+          checkpoint: '098d16fde9aa950ea2989b0b2c51ff340eb1c05b997497f7512f37dd7c86f177'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 

--- a/Casks/pingendo.rb
+++ b/Casks/pingendo.rb
@@ -1,10 +1,11 @@
 cask 'pingendo' do
-  version '3'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '4.0'
+  sha256 '8bd102c73e98b4f5085b4908526b9af1b3dd24cbea9bb7d622674049258d1b69'
 
-  url "http://download.pingendo.com/v#{version}/Pingendo.dmg"
+  # pingendoauth.appspot.com was verified as official when first introduced to the cask
+  url "https://firebasestorage.googleapis.com/v0/b/pingendoauth.appspot.com/o/Pingendo%20#{version}.dmg?alt=media&amp;token=0621d7bf-a02b-4901-91ba-7d8a25f95395"
   name 'Pingendo'
   homepage 'https://pingendo.com/'
 
-  app "Pingendo#{version}.app"
+  app "Pingendo #{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.