### PR TITLE
Update eagle to 8.6.3

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,10 +1,10 @@
 cask 'eagle' do
-  version '8.6.0'
-  sha256 'ff3b3f87fd10a6bf0295a281fd5b98940341c5f25a11ed24a25e376cca9616ca'
+  version '8.6.3'
+  sha256 '9559c951775e206f561de5e13941d5a8dc50516374fa52c656c5b78435d7e450'
 
-  url "https://trial2.autodesk.com/NET17SWDLD/2017/EGLPRM/ESD/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
+  url "https://eagle-updates.circuits.io/downloads/#{version.gsub('.', '_')}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   name 'Autodesk EAGLE'
-  homepage 'https://www.autodesk.com/products/eagle/overview'
+  homepage 'https://circuits.io/eagle/'
 
   pkg "Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
 

--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -2,7 +2,7 @@ cask 'eagle' do
   version '8.6.3'
   sha256 '9559c951775e206f561de5e13941d5a8dc50516374fa52c656c5b78435d7e450'
 
-  url "https://eagle-updates.circuits.io/downloads/#{version.gsub('.', '_')}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
+  url "https://eagle-updates.circuits.io/downloads/#{version.dots_to_underscores}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   name 'Autodesk EAGLE'
   homepage 'https://circuits.io/eagle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.