### PR TITLE
Update telegram to 3.8-118923

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,10 +1,10 @@
 cask 'telegram' do
-  version '3.7.5-115423'
-  sha256 '43f65f4bd25f2f74b5f15f33a7e2b0fd0eeac1de8ece678dde10d7794427d10e'
+  version '3.8-118923'
+  sha256 'cb0a870e6afe147d31f1475d3a87cdb5bb3aa3082dd5543162bf80a2aaa56f1a'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml',
-          checkpoint: '406b0620c003b94c0c9a9b4cd28d3235711a9a5e284870a54e63e95814e18ddf'
+          checkpoint: '0d10c69eb35bc6d29600522330debeda38d898923f981ba8b50bf2a98bb72f78'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.