### PR TITLE
Update gpsdump to 0.43

### DIFF
--- a/Casks/gpsdump.rb
+++ b/Casks/gpsdump.rb
@@ -1,10 +1,10 @@
 cask 'gpsdump' do
-  version '0.42'
-  sha256 'b6778e44b7af4f2ac93f66c742b6d4d0170870ba2ab7579a485e035ee261a6d3'
+  version '0.43'
+  sha256 '1ee89de779d874e13e8c5a7d66696801ba5b2dca391297977d4bd9cb1194cbc2'
 
   url "http://www.gpsdump.no/GpsDumpMac#{version.no_dots}.zip"
   appcast 'http://www.gpsdump.no/body_mac.htm',
-          checkpoint: 'f800479a9918e3ef84f1b9099713eab2677a43296cc53cbbe65ca247556c9d34'
+          checkpoint: '3b1836292c7d1d738389101b99ee6a096c726601896d8618846034f5594826b1'
   name 'GpsDump'
   homepage 'http://www.gpsdump.no/body_mac.htm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.