### PR TITLE
Update postman to 6.0.9

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,6 +1,6 @@
 cask 'postman' do
-  version '6.0.8'
-  sha256 'de0f4180be6a2ca9349be30836506f25138965d137bb156ec79a77e26023249d'
+  version '6.0.9'
+  sha256 '0922608591e78aa4f0750a4906dd62311e93cd733825ee8cd5b92ed165954976'
 
   # dl.pstmn.io/download/version/ was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.