### PR TITLE
Update grandtotal to 5.1.1.4

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,10 +1,10 @@
 cask 'grandtotal' do
-  version '5.0.3'
-  sha256 '0afba805ad4137850886f9d37c865296811f2d36f856a16bacd70f2bc66b3401'
+  version '5.1.1.4'
+  sha256 'e35924df594fbbb69edbedf6545775dbe3cd35e4f5c245085437dfdfce69d4de'
 
   url "https://mediaatelier.com/GrandTotal#{version.major}/GrandTotal_#{version}.zip"
   appcast "https://mediaatelier.com/GrandTotal#{version.major}/feed.php",
-          checkpoint: '384b98383047955a26b608e0c579f3e092c13287c63fef015a5ed3abadf8a371'
+          checkpoint: '13b8c6eea5cb6b3e1c5e65dd9afc7e5492cf1deded57645c42492fc1097de0fc'
   name 'GrandTotal'
   homepage 'https://www.mediaatelier.com/GrandTotal4/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.