### PR TITLE
Update graphicconverter to 10.5.5,2998

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,11 +1,11 @@
 cask 'graphicconverter' do
-  version '10.5.4,2971'
-  sha256 'c6901a343c02800cf9a72cfa1c2a3642a539f1c036382ccdcf1f046cd616c36c'
+  version '10.5.5,2998'
+  sha256 'efb03b6487f04addf057f53228c910dd30b29dd14bb0c97bc7bcf70b85f53096'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
   appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml",
-          checkpoint: '7b983b030452997e5e2d3aacbe84219c707bd73eff2b7f65946feb8e03b72026'
+          checkpoint: '8919c6ff98af50edd7829d8795cbdb7d3bbd119ba3d3b921855f371f14f97c7f'
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.