### PR TITLE
Update hab to 0.54.0-20180221020527

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.52.0-20180119184453'
-  sha256 '60849d39be265c05814d7be93798f9355f49cb4401d499405fdde83f1161c4e4'
+  version '0.54.0-20180221020527'
+  sha256 '3eb8f6e1f8145bad9edf1ceceafd7a97a10d1cab78e6c7ebec6b05e2b5e36fe7'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '415881ea7c8292f968172a486fab8b9e5036ecbda60a7e6435db37b5d25e03e2'
+          checkpoint: 'dc64e5193123de97efd533e8af931faccd4a74f50068074e03a455d629032fdb'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.