### PR TITLE
Update rambox to 0.5.16

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,11 +1,11 @@
 cask 'rambox' do
-  version '0.5.15'
-  sha256 '75c15d6a87494660b1ca5dc3910909c539ac1cd3312b11a150c6f26ea4b4b057'
+  version '0.5.16'
+  sha256 'bf5da49c53579137e9904d10460313041d0c9698cac564e40033bcf08dc3cb0e'
 
   # github.com/saenzramiro/rambox was verified as official when first introduced to the cask
   url "https://github.com/saenzramiro/rambox/releases/download/#{version}/Rambox-#{version}-mac.zip"
   appcast 'https://github.com/saenzramiro/rambox/releases.atom',
-          checkpoint: 'd3d4a831bf6b37877e4d86e19328f35fa1b47144992d5a1cb8e59a160a7c716a'
+          checkpoint: 'd5852eacbf3084a759b0d4675af8fc2da11164d914155eb69df10561539ae477'
   name 'Rambox'
   homepage 'http://rambox.pro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.