### PR TITLE
Added sha256sum for iStat menus

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,6 +1,6 @@
 cask 'istat-menus' do
   version '6.10'
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 'ed62915fbace4478cdf8941490e893b3a5851c3f27c3ad8d7d1f62cd4cbea5c8'
 
   # amazonaws.com/bjango was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

I added `sha256sum` for istat-menus 6.10.

After making all changes to the cask:

- [x] `brew cask audit --download istat-menus` is error-free.
- [x] `brew cask style --fix istat-menus` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

The result of virustotal is here
https://www.virustotal.com/#/url/32bc004351113d418343b4bdc52a64bc2afa842bb7d712c715f450bccdd4e8f9/details