### PR TITLE
Update netron to 1.6.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.6.0'
-  sha256 '0ef9adce67fae2216ae49fb9e21eabe3711c991c3600e734591218a0ff064980'
+  version '1.6.1'
+  sha256 '281e7296aa34d81eeafc94c81e91b6ed838f950f787b61feb26219fd7ea10d17'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '9d391dd05ecc95f1d8f998e5d011a2d63d55fd8b314b9b39f862927240098057'
+          checkpoint: '151f85b5819c0d5416ff7e6ba5dff2828a872ce4f147aa7f011f0d7d1d5ef25d'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.