### PR TITLE
Update netron to 1.6.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.6.0'
-  sha256 '0ef9adce67fae2216ae49fb9e21eabe3711c991c3600e734591218a0ff064980'
+  version '1.6.2'
+  sha256 '0453764d557ccfd47e5ad42c633f3db84a65168a853f47bb49b11fbc56bde0c9'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '9d391dd05ecc95f1d8f998e5d011a2d63d55fd8b314b9b39f862927240098057'
+          checkpoint: '09cdad3fc3921c4ce64ac2def277266bbaad3d5bc3157972c1330bb24948b713'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.