### PR TITLE
Update avocode to 2.21.0

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '2.20.1'
-  sha256 'a447bb235f53eb3a17094e505b6bc6903ab4f10a4c9ac15744ddf705ee809dbc'
+  version '2.21.0'
+  sha256 '0a058af744d85a0be00f031a9678598794d3f7816101a26242418ca198158d87'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   name 'Avocode'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.