### PR TITLE
Update feeder to 3.5.9

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,10 +1,10 @@
 cask 'feeder' do
-  version '3.5.8'
-  sha256 '1f6cdd8bff9b5863c85b8e3566b29e0f579dd595b69ea0b2be29e082cf206099'
+  version '3.5.9'
+  sha256 '03e3cdb567b6a023b3694e89e7f8061cd51f66f30b9603f6be4b69e94136b111'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml",
-          checkpoint: '072f99047e4f177e6b9f2c5e838ad828f6fe5c5d8f60f2331b628472eba5edf1'
+          checkpoint: '1005915612df1be9b1ce4d99d19ab2ad3c317e0759e38697abf6283ab6b5a06d'
   name 'Feeder'
   homepage 'https://reinventedsoftware.com/feeder/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.