### PR TITLE
Update studio-3t to 2018.2.3

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '5.7.4'
-  sha256 '9e161da134860f3822387b53cebc93280f0fb8aa96a9687547accab6d8fe5a36'
+  version '2018.2.3'
+  sha256 '02b343b43a8c4cde133b3eabfa3f4e6edd8ceca6ea63bdaa02f66cfbfc1243ab'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: 'ec3e9cf293487231d10099f081612914e76e353b0f450068003a63c2717f5512'
+          checkpoint: '1d2ff35bc2217778c011e561ec6a1df9cb3ebc5f384e1625a4978c3f4588f5a5'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.