### PR TITLE
Update lifesize to 10.3.7-235

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,11 +1,11 @@
 cask 'lifesize' do
-  version '10.3.6-229'
-  sha256 'e33c7ebca28735fee44a11e5f7251bf5a1bc0d8fabff610eab956cb3e56e357c'
+  version '10.3.7-235'
+  sha256 '7924c29dd00057f3417fb000b700d333a6cf36869ef2637b76e077ebfc813f7d'
 
   # cdn.lifesizecloud.com was verified as official when first introduced to the cask
   url "https://cdn.lifesizecloud.com/LifesizeCloud-#{version}-signed.pkg"
   appcast 'https://cdn.lifesizecloud.com/OSX_Clients/Sparkle_Upgrades/LifesizeAppcast.xml',
-          checkpoint: 'c2483ecac9f8e27beb660acb55ec9162c7d70894dbab3b5b1873e12b07625de7'
+          checkpoint: '632a8d4a035d6aa7184dd98f6448d3d09f5ce9da6acd155912e7cd0f4d60148a'
   name 'lifesize'
   homepage 'https://www.lifesize.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.