### PR TITLE
Update coteditor to 3.3.5

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -9,14 +9,14 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.3.4'
-    sha256 '48587a7d7c2e28e4a6c33f3bda25d64c4b53b8db38fa5ac66911db19bf4301a6'
+    version '3.3.5'
+    sha256 '1e779c830409c622a02b8a57a6581f8d1f89d16e1472edc52dd93dd20a81540c'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
   url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   appcast 'https://github.com/coteditor/CotEditor/releases.atom',
-          checkpoint: 'cedc656d75a021e2bbf8aa2d3a2165a6a89506f48e09ef8aad0965441a0a9948'
+          checkpoint: '97684407d1d6dc6a858d9376ead6e6906a1d65ed7ba00b118d5aac37437943a3'
   name 'CotEditor'
   homepage 'https://coteditor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.