### PR TITLE
Add Godot Mono.app v3.0.2

### DIFF
--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -1,0 +1,13 @@
+cask 'godot-mono' do
+  version '3.0.2'
+  sha256 '6451722d8154b878acd516f8e12fe53f5cf05fd12bc31c0017c3408fc9f5bba7'
+
+  # downloads.tuxfamily.org/godotengine was verified as official when first introduced to the cask
+  url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_osx64.zip"
+  appcast 'https://github.com/godotengine/godot/releases.atom',
+          checkpoint: '1f75e2ac01a411812c9cee3d4db561728b6eba1baed5186b92b659a6a938db15'
+  name 'Godot Engine Mono'
+  homepage 'https://godotengine.org/'
+
+  app 'Godot_v3.0.2-stable_mono_osx64.app', target: 'Godot Mono.app'
+end


### PR DESCRIPTION
Godot has a separated build which supports C# Mono runtime, add a new cask which supports the stable version of it.