### PR TITLE
Update netron to 1.6.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.6.2'
-  sha256 '0453764d557ccfd47e5ad42c633f3db84a65168a853f47bb49b11fbc56bde0c9'
+  version '1.6.3'
+  sha256 'b5f7ee5387fcbaaf9fc10f72e0ad9a6c0dde93f3f308452f7decb7a1008939a0'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '09cdad3fc3921c4ce64ac2def277266bbaad3d5bc3157972c1330bb24948b713'
+          checkpoint: '0c741c34d87fb816b63392e1e595aa05e43699e8674fb7ff3304b4b6c2f88a2b'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.