### PR TITLE
Update bitshares to 2.0.180306

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.180215'
-  sha256 '07e3992a7cb82424b498979f324ec4590a5bb6dfc8258d43f3b8b2acf5ce20c4'
+  version '2.0.180306'
+  sha256 '4ddfb8ee7ba2ff5c8684bfb952d94a9cd9f6190f3a3b8f707a44bf276752732f'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: '9d734ddfd2b917e0a9f907b049a92eda89fd115c3a2e2187e5f5119f4e6de2ac'
+          checkpoint: 'c1788e76969824ee4973ca8b2d283a42e9f91d0922417792d29162efe845b576'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.