### PR TITLE
Update dollydrive to 3.99,39993

### DIFF
--- a/Casks/dollydrive.rb
+++ b/Casks/dollydrive.rb
@@ -1,10 +1,10 @@
 cask 'dollydrive' do
-  version '3.99,39987'
-  sha256 '3644739ed8dece5c2f9f1ff6d50bd184907599566e7a4c20a789959d86b03e3c'
+  version '3.99,39993'
+  sha256 '187680f85ccb29cdb5bc790102f2f8e233e8499e0d73cd00f050b3a7bddaa6d0'
 
   url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.before_comma}_#{version.after_comma}_CERTIFIED.zip"
   appcast "http://www.dollydrive.com/dolly#{version.major}.xml",
-          checkpoint: '69c3bbbc40c30294e9c2522add974a59ded347b23a87036b722aacb8e61a91c5'
+          checkpoint: '4e410d256c5e9ae0ed3f51ae889b8b10eae644d0f52184206abfe9951379362c'
   name 'DollyDrive'
   homepage 'http://www.dollydrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.