### PR TITLE
Update dupin to 2.12.3

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,11 +3,11 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.12.2'
-    sha256 '1fae6ff10ddedb8af2b561f6ca63f8d9206a351cee21c2f8e3cb2c4ced0347dc'
+    version '2.12.3'
+    sha256 'b50e2a0bccb5ce42f612c3d2f8aac932206b0882903579c078ce841ce0fe4056'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml',
-            checkpoint: '06e50594f42c9eb59d9cb156221108587de57197769356b972989fd2f7f6c1f3'
+            checkpoint: '868b8eeedfbded97a26abcb664940c9f7ef2bc0790653a72462f2aec7465a59b'
   end
 
   url "https://dougscripts.com/itunes/scrx/dupinv#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.