### PR TITLE
Update tortoisehg to 4.5.2

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.5.0'
-  sha256 '0866e62f1cae87587a9d81b8699f446549e0352793375b1add7b51b3b6908b3a'
+  version '4.5.2'
+  sha256 '16696fe90096c4aa614665e204e10f03aab1d3f0bff474bde409fb5a1acf4c30'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64-qt5.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.