### PR TITLE
Update nteract to 0.8.0

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,10 +1,10 @@
 cask 'nteract' do
-  version '0.7.1'
-  sha256 'a03f8d8373a182f0b87b194db1eb1924e089cdb975bd0ee5c4bdbc79bd940795'
+  version '0.8.0'
+  sha256 '3a62a4b77e55b082eebc001c477380658a780c26e514c58198336d24e51a3c0c'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: '318bc16a2cf76ed4f341c3a00e9a793e3b65a5d8c1dfa28923c56e3070d46990'
+          checkpoint: 'e6b272fcedef05ea2a7fe44f5e6e0b4bfb7f1615cc8d6c35e256c76750ca11dd'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.