### PR TITLE
add Family Tree Builder 7.0.2.155

### DIFF
--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -1,0 +1,11 @@
+cask 'family-tree-builder' do
+  version '7.0.2,155'
+  sha256 '67e346320510ee1e0be3ad5d10b3a68e68f29c63693e67470160be4da9140623'
+
+  # mhcache-myheritage.netdna-ssl.com was verified as official when first introduced to the cask
+  url "https://mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/family_tree_builder_#{version.major}#{version.after_comma}.dmg"
+  name 'Family Tree Builder'
+  homepage 'https://www.myheritage.com/'
+
+  app 'Family Tree Builder.app'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].


Note some of my installs failed:
```
curl: (56) Unexpected EOF
Error: Download failed on Cask 'family-tree-builder' with message: Download failed: https://mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/family_tree_builder_7155.dmg
```

But I believe this is an issue with curl: https://github.com/curl/curl/issues/1618

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
