### PR TITLE
Update script-debugger to 7.0-7A40

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,11 +1,11 @@
 cask 'script-debugger' do
-  version '6.0.8-6A225'
-  sha256 '1f3ad8a2842c78ec4f504f4a596a9d237179ae93515457798ffa90a5f8183f07'
+  version '7.0-7A40'
+  sha256 '284f6d3a5506f5f996e371d9cbf1ac93f9611ec227e90b59fc4a67b5cc896d4c'
 
   # s3.amazonaws.com/latenightsw.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg"
   appcast "https://www.latenightsw.com/versions/com.latenightsw.ScriptDebugger#{version.major}.php",
-          checkpoint: '97015bd999ef3fd6643464375af35feaefce12a96b099427cf4e29184fffd2aa'
+          checkpoint: '598dfae5f421535329a211069183f4a6f0e919d476247232a9f7b99f502f6a65'
   name 'Script Debugger'
   homepage 'http://latenightsw.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.