### PR TITLE
Update typora to 0.9.9.13

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.12.5'
-  sha256 '0fb77e602b29d74b82b1b0c895c33cee176cc3947dfbc616f027932f616f5566'
+  version '0.9.9.13'
+  sha256 '3b0882a4dcbb704584523648fe5f3fedeb8db9d19a4f909398a4ef1465dd2cc6'
 
   url 'https://typora.io/download/Typora.dmg'
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '3d8ab4698cc2608bdfa38eeed4cfc71d2dd5f2a88a1ac3bc9898cf1a3e3ad4c7'
+          checkpoint: 'b132e8186331d5675de1e664d313ccf779c74afcfcf898a710551e72faf61611'
   name 'Typora'
   homepage 'https://typora.io/'
 

--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -2,7 +2,7 @@ cask 'typora' do
   version '0.9.9.13'
   sha256 '3b0882a4dcbb704584523648fe5f3fedeb8db9d19a4f909398a4ef1465dd2cc6'
 
-  url 'https://typora.io/download/Typora.dmg'
+  url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml',
           checkpoint: 'b132e8186331d5675de1e664d313ccf779c74afcfcf898a710551e72faf61611'
   name 'Typora'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.