### PR TITLE
Update gns3 to 2.1.4

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.3'
-  sha256 'c85068e09a4a926b7707c663beb7f226844018cc239bd2bb655e2e19cc307937'
+  version '2.1.4'
+  sha256 '19c511b56def69252f67d8504c11f931eed62d13374b5653b60ee42f58e8f356'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: 'acc96a409e008e3e008718141f51233ebc91cdc6bfba6c34897363acd87cecd7'
+          checkpoint: '25929630a91c34a5e2013252bf76a8d287df28598206993aacccb014295dfe17'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.