### PR TITLE
Update lehreroffice-zusatz to 2018.2.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.1.2'
-  sha256 '39e3b4565c7a28ebf56a1fe3a6d72f52e695cee254e9e290bdfb8eaf84ab1351'
+  version '2018.2.0'
+  sha256 '15cfb0720ff1eff329b5adfbe7982b926b51648f94d62a081ee458455d3f5af7'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '3f6abfaa7a0af13d02b27553e85584cdb9130c2e07bcb549afae2bffdffb9c14'
+          checkpoint: '96aab4a8f7d62edade54ceb5a82d24e4710dab28af25be8b1ef4cbe68d1d6d58'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.