### PR TITLE
Add adium-beta 1.5.11b3

### DIFF
--- a/Casks/adium-beta.rb
+++ b/Casks/adium-beta.rb
@@ -1,0 +1,19 @@
+cask 'adium-beta' do
+  version '1.5.11b3'
+  sha256 '999e1931a52dc327b3a6e8492ffa9df724a837c88ad9637a501be2e3b6710078'
+
+  url "http://download.adium.im/Adium_#{version}.dmg"
+  name 'Adium-beta'
+  homepage 'https://www.adium.im/'
+
+  auto_updates true
+
+  app 'Adium.app'
+
+  zap trash: [
+               '~/Library/Application Support/Adium 2.0',
+               '~/Library/Caches/Adium',
+               '~/Library/Caches/com.adiumX.adiumX',
+               '~/Library/Preferences/com.adiumX.adiumX.plist',
+             ]
+end


### PR DESCRIPTION
I create the cask because the stable current version of Adium doesn't allow to connect though Google Talk when you activate 2FA on your Google Account.

After making all changes to the cask:

- [x] `brew cask audit --download adium-beta` is error-free.
- [x] `brew cask style --fix adium-beta` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install adium-beta` worked successfully.
- [x] `brew cask uninstall adium-beta` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
