### PR TITLE
Update stack-exchange-notifier to 1.1

### DIFF
--- a/Casks/stack-exchange-notifier.rb
+++ b/Casks/stack-exchange-notifier.rb
@@ -2,11 +2,11 @@ cask 'stack-exchange-notifier' do
   version '1.1'
   sha256 '849b543bc724e735e9a951721159b45a5284fde44c4cd8caa74c0e7eefb7e30c'
 
-  url "https://hewgill.com/senotifier/stack-exchange-notifier-#{version}.dmg"
-  appcast 'https://hewgill.com/senotifier/',
+  url 'http://hewgill.com/senotifier/stack-exchange-notifier-1.1.dmg'
+  appcast 'http://hewgill.com/senotifier/',
           checkpoint: '398a6bc54240d120edc773b81471ca4b58ad206a2690f7499b7b7462fae402a6'
   name 'Stack Exchange Notifier'
-  homepage 'https://hewgill.com/senotifier/'
+  homepage 'http://hewgill.com/senotifier/'
 
   app 'Stack Exchange Notifier.app'
 end

--- a/Casks/stack-exchange-notifier.rb
+++ b/Casks/stack-exchange-notifier.rb
@@ -2,7 +2,7 @@ cask 'stack-exchange-notifier' do
   version '1.1'
   sha256 '849b543bc724e735e9a951721159b45a5284fde44c4cd8caa74c0e7eefb7e30c'
 
-  url 'http://hewgill.com/senotifier/stack-exchange-notifier-1.1.dmg'
+  url "http://hewgill.com/senotifier/stack-exchange-notifier-#{version}.dmg"
   appcast 'http://hewgill.com/senotifier/',
           checkpoint: '398a6bc54240d120edc773b81471ca4b58ad206a2690f7499b7b7462fae402a6'
   name 'Stack Exchange Notifier'


### PR DESCRIPTION
- This Download is not available in HTTPS anymore.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.