### PR TITLE
Update qtox to 1.14.0

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
-  version '1.13.0'
-  sha256 '0485ff362d3c14afc92ef34619f53824ca5a1652a0f7a3ea883c891526acd07a'
+  version '1.14.0'
+  sha256 '02865c13377fde03507c6a951f7a013b9b804a2fff84d6eab9ffdc5742ef4cd1'
 
   # github.com/qTox/qTox was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/qTox/qTox/releases.atom',
-          checkpoint: '7bddd2fe85e63620b6428ac275d6d55dfc194ccbcd3213aff8a891a364c6881c'
+          checkpoint: '0871516f88b8286ba747d0a92cd2018467b604c5cc3d70c2370fa6220e5fffe6'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.