### PR TITLE
Update cacher to 1.3.5

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.4'
-  sha256 '7b3f8ef28ef0dfd9370730edd66b4b7bff45e83fae11e91796576632b3f57f55'
+  version '1.3.5'
+  sha256 'a1b958c3bb94138e1f317c8e8d63351cac3c75d508a0746c7ef55a257d42ce75'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '118fcb16dfb6beda8e67ba5a44aece164cb9d1e10de75f4b4359a9b8f8a44386'
+          checkpoint: '8a19619feeac7357426f00bbaf8bab2e90588eb9af2470f955b731019b2d5e61'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.