### PR TITLE
Update trailer to 1.6.7

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,11 +1,11 @@
 cask 'trailer' do
-  version '1.6.6'
-  sha256 'f27222465372473980ed609a056cb955867f04464e63b78837f7e6e9632c2dc3'
+  version '1.6.7'
+  sha256 '1a4528d6d9ff3d9bf837dd8540bc3befa70fc620dcbd91655fbf05d82a7344ec'
 
   # github.com/ptsochantaris/trailer was verified as official when first introduced to the cask
   url "https://github.com/ptsochantaris/trailer/releases/download/#{version}/trailer#{version.no_dots}.zip"
   appcast 'https://github.com/ptsochantaris/trailer/releases.atom',
-          checkpoint: '65f0b39c3c645d14d16a5f4ec431f4ea11b6e1a30010a23a2e0f8d734f6e494b'
+          checkpoint: '27711012a8c7b48fbe0df732582624e310c6d28a9a16aa1d0ffc495741f165d6'
   name 'Trailer'
   homepage 'https://ptsochantaris.github.io/trailer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.