### PR TITLE
Update cityofzion-neon to 0.2.2

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,10 +1,10 @@
 cask 'cityofzion-neon' do
-  version '0.2.1'
-  sha256 'c1e75ed0c81d78173ea403fbb35843b2ecc61dde366409d908479dd4016fc093'
+  version '0.2.2'
+  sha256 '117cfb457b100ff348e1f30b24b8740c6ae9c39535c4241043f6416900c08595'
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
-          checkpoint: 'afb12029c1eb93d130105f5cd314325a17996e6becefdc81dff108fc34f26aaa'
+          checkpoint: '354a1cb9e474650619d67f3a91e45afe719e6880315d78c346bbbae429f6f9b8'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.