### PR TITLE
Update boostnote to 0.11.2

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,11 +1,11 @@
 cask 'boostnote' do
-  version '0.10.0'
-  sha256 '78d421c971322b7faefd03dfb2fb208cca54bbecf9019548c3f8165247f61684'
+  version '0.11.2'
+  sha256 '9d9149ee07b1cbf098af921f831ed97c904c63c7e2ab15744aae60d711f25597'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"
   appcast 'https://github.com/BoostIO/boost-releases/releases.atom',
-          checkpoint: '16bc71948a474eb969be43a69d2e1038e015ac4809c076145e9ee95549925f27'
+          checkpoint: 'a06ed4a43ec6089d45fca88eb4bac3514580beb4a0ab0bb1e58740143bdaf64e'
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.