### PR TITLE
Update processing to 3.3.7

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,14 +1,18 @@
 cask 'processing' do
-  version '3.3.6'
-  sha256 '3d97f9835e0e3b42ef95f8fc2e89e123478ee0864d015c577f6d1d87dc6e735f'
+  version '3.3.7'
+  sha256 '4f076f6957b3c5e7df40d29864fa9fe6fdb944e00863bd3f534fe0dd234f4992'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: '3ca368a6d2a97a16ff2cff0435fb1968da78a8e8fda3d16519b46341c9f50e9f'
+          checkpoint: '2da872c8774ac8a0519516a83488dcf0b524e7af91b857ea9ac96957978c0658'
   name 'Processing'
   homepage 'https://processing.org/'
 
   app 'Processing.app'
 
-  zap trash: '~/Library/Processing/preferences.txt'
+  zap trash: [
+               '~/Library/Processing',
+               '~/Preferences/org.processing.app.plist',
+               '~/Preferences/processing.app.tools.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.