### PR TITLE
Update prusa-slic3r to 1.39.1,201803010854

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,11 +1,11 @@
 cask 'prusa-slic3r' do
-  version '1.37.2,201710211402'
-  sha256 'ef68fe1e5665dd08fd624c5415859a86ae0986ebdc67e1d037d40cafc58fa574'
+  version '1.39.1,201803010854'
+  sha256 '745a156f366c06e0863383d2e661e970443905a10370bbbcb44ad9167332f1b0'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3r-#{version.before_comma}-prusa3d-full-#{version.after_comma}.dmg"
   appcast 'https://github.com/prusa3d/Slic3r/releases.atom',
-          checkpoint: '75f9ef2abcf48d0425ed06dd1f99acd0a265fc47b75de9fe945173e74e76c6af'
+          checkpoint: '7043d27fe21072d2e88e3580f51e068c60ddc649d878e30ef4406c651ee83d37'
   name 'Slic3r - Prusa Edition'
   homepage 'https://www.prusa3d.com/slic3r-prusa-edition/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.