### PR TITLE
Update react-native-debugger (0.7.14)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.13'
-  sha256 'd90700e91f83e7ef058a9c969303436b283abd38c4350d3b8b713ae6daa4e3d6'
+  version '0.7.14'
+  sha256 '89b380b8f848d2e4e79f3781c396df39abd1d40268c6863cbee57446fc6d2651'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '36ddde5747147c1db9dbeed87f82278039cb8896f7ab79505dd1580c63513d95'
+          checkpoint: 'f207e16517f5d998e2ec29da54d8f2ba8b068a27ea4203aaedb3e7873c1a3fc8'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
