### PR TITLE
Update vfuse to 2.0.3

### DIFF
--- a/Casks/vfuse.rb
+++ b/Casks/vfuse.rb
@@ -1,10 +1,10 @@
 cask 'vfuse' do
-  version '2.0.0'
-  sha256 '5818e292500427a968b17007315e45de9bce3319248298e5f361fd3940704994'
+  version '2.0.3'
+  sha256 'a69e7357bea014f4c14ac9699274f559086844ffa46563c4619bf1addfd72ad9'
 
   url "https://github.com/chilcote/vfuse/releases/download/#{version}/vfuse-#{version}.pkg"
   appcast 'https://github.com/chilcote/vfuse/releases.atom',
-          checkpoint: '796026ea80a5adc3846abab852d5342f87c8203524ef2923fb7617f2fa47b61d'
+          checkpoint: '56d1707d3065bf0c75d75d7738571285273b7bf366d8f0f5a53eb8b457ad2453'
   name 'vfuse'
   homepage 'https://github.com/chilcote/vfuse'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.