### PR TITLE
Update caprine to v2.10.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,10 +1,10 @@
 cask 'caprine' do
-  version '2.9.0'
-  sha256 'bd1286f69b6fde1cfc731d76985523776c35b4f082dda55ef8b5140d5ec3e454'
+  version '2.10.0'
+  sha256 'c13fbd3e4492dbe100f5594f4e6f2b38afb1e7dc9476d3a3096169225399463d'
 
-  url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/caprine-#{version}-mac.zip"
+  url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/Caprine-#{version}.dmg"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom',
-          checkpoint: '281c1a719acea0995bad6bce576fad3241d7b0c8a94c39dee41ebd96bd7f69d0'
+          checkpoint: '23607bbeb299f67402a719640f87c777f90947d8490736c99cd5f10a2c17e53d'
   name 'Caprine'
   homepage 'https://github.com/sindresorhus/caprine'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
