### PR TITLE
Update typora to 0.9.9.13.6

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.13.4'
-  sha256 'cf4f5d031a87ab0a40ef09e88fd4b4456d3d4aa84caf090443ad3324b8b453b9'
+  version '0.9.9.13.6'
+  sha256 'ecec9d5b2cf7ce7d39781f0eae9d4405f6d0bed228635f8dcb1b06fcf277e76a'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '02dd30f57e9dd55122524e80bceba0b78160e2f27a76f8ff4cb07dc669b7b5ca'
+          checkpoint: '3cb24e4b8937703fad68e877b6cb6f3c35e9d66cdc3b96768804f59294731e2d'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.