### PR TITLE
Update get-backup-pro to 3.4.3

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.4.2'
-  sha256 '01d7e4bd623ed7b079ec8bf0c38a418675e50de8396dfc3a453270c7a33dceeb'
+  version '3.4.3'
+  sha256 '76e7d49c5055607c5ac9efcc7a309a3c05a7d65263ef5f1db7cda8f84cf39329'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: 'd7762347d2ff3c6995fbf00ad36c7409126faad67706ccb17911bb6a55eeebaa'
+          checkpoint: 'c4177d351a4c4db0bb964a1345f5f24dbbca2bc48e3d82feea90a4dfdcf96a35'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.