### PR TITLE
Update visual-studio-code to 1.21.1,79b44aa704ce542d8ca4a3cc44cfca566e7720f1

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code' do
-  version '1.21.0,9a199d77c82fcb82f39c68bb33c614af01c111ba'
-  sha256 '532b5a64cf5ad94a89d555cb77dadf71dbefbb99c87378c9aaaa4c44d487b44a'
+  version '1.21.1,79b44aa704ce542d8ca4a3cc44cfca566e7720f1'
+  sha256 '312c498b673574785eb632890a98d6e38877a3a77ee1ace2f50f203b18d13c34'
 
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/stable/VERSION',
-          checkpoint: '8cd50c8953a425acf570f08fd7dc97e0b4939db3af331fe85f37c05a36c2ccc1'
+          checkpoint: '0ef3f19695586f49a0e8031f2df23251c856109aee63b67509df21d31d3d2179'
   name 'Microsoft Visual Studio Code'
   name 'VS Code'
   homepage 'https://code.visualstudio.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.