### PR TITLE
Update omnifocus to 2.12.1

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -12,13 +12,13 @@ cask 'omnifocus' do
     sha256 'e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8'
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
   else
-    version '2.12'
-    sha256 'c6206f9366f4369f509ed9b232c7e0a5b29ca1a45b8820f7498e6c9d0cc85bf1'
+    version '2.12.1'
+    sha256 '9cf156c8a96cfb47f931701efa2a395fca7ccf4baecd26f216e70b011c3c7f0f'
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
   end
 
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniFocus#{version.major}",
-          checkpoint: '1dad34cd67a57ecd80c5d70404b4e6e6d2b714c69d640254ea09359dafa9c4e1'
+          checkpoint: '2870a5fc1ba17bae60451999bc0dba8157200de9d39cb762b99c0728588261a1'
   name 'OmniFocus'
   homepage 'https://www.omnigroup.com/omnifocus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.