### PR TITLE
Update netron to 1.6.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.6.3'
-  sha256 'b5f7ee5387fcbaaf9fc10f72e0ad9a6c0dde93f3f308452f7decb7a1008939a0'
+  version '1.6.4'
+  sha256 '0b828dc4f305644fb7ffca49f3d9e574916aef87ec8e5050c1c84fc159abd670'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '0c741c34d87fb816b63392e1e595aa05e43699e8674fb7ff3304b4b6c2f88a2b'
+          checkpoint: 'eef9fcf03b5d1a48196b9a82fc5f1fb2f4d714deae4fce5ffce9026c42f842e0'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.