### PR TITLE
Update react-native-debugger (0.7.15)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,6 +1,6 @@
 cask 'react-native-debugger' do
   version '0.7.15'
-  sha256 '3926eda0f5afb395119fa7812846b17de50aec5012aec7'
+  sha256 '3926eda0f5afb395119fa7812846b17de50aec5012aec779d0e8594f06b8140c'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',

--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.14'
-  sha256 '89b380b8f848d2e4e79f3781c396df39abd1d40268c6863cbee57446fc6d2651'
+  version '0.7.15'
+  sha256 '3926eda0f5afb395119fa7812846b17de50aec5012aec7'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: 'f207e16517f5d998e2ec29da54d8f2ba8b068a27ea4203aaedb3e7873c1a3fc8'
+          checkpoint: '3732307f9f30034db7b611e8b3b7827ef32453bc7b32767518c4736c5eed4b32'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
