### PR TITLE
Update padlock to 2.5.0

### DIFF
--- a/Casks/padlock.rb
+++ b/Casks/padlock.rb
@@ -1,11 +1,11 @@
 cask 'padlock' do
-  version '2.4.2'
-  sha256 '3c42470bd6fa53aae2e9699d6ef4b43b0f19a5639256de37fb8b015adf77225e'
+  version '2.5.0'
+  sha256 'f5d367608160a6fbbe6007893ed64e2fb8ba86f72bdff964b18f9b855b61eb80'
 
   # github.com/MaKleSoft/padlock was verified as official when first introduced to the cask
   url "https://github.com/MaKleSoft/padlock/releases/download/v#{version}/Padlock-#{version}.dmg"
   appcast 'https://github.com/MaKleSoft/padlock/releases.atom',
-          checkpoint: '03bb2528ab052d5ffbeef6dbde8b7ccc2dc10ae806a7164939e5957f07dea36e'
+          checkpoint: 'fce2adfe4c017e5b85c44686faebab2c54ade548eaa6d41d6386e3c943844efb'
   name 'Padlock'
   homepage 'https://padlock.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.