### PR TITLE
Update joplin to 1.0.72

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '1.0.70'
-  sha256 'b2b93171d77bc9af3c0da2c00f762c0765c45f9d4a74b2f42154c462b8bac873'
+  version '1.0.72'
+  sha256 '121e9d86b343ae8c92ce01eb4e15421ee393d76948d7015f6bd933cec7366bf6'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: 'da7b2b737db283f25c625ce7dd0b48bbd9bc85e62cb997fab4f83f0f7936fc2d'
+          checkpoint: 'b27b31014f2401bb894f8d07ee02e83c28e7d912a8fa53d35e3ece2fb8f06ae4'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
