### PR TITLE
Update studio-3t to 2018.2.4

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '2018.2.3'
-  sha256 '02b343b43a8c4cde133b3eabfa3f4e6edd8ceca6ea63bdaa02f66cfbfc1243ab'
+  version '2018.2.4'
+  sha256 'f5ee571326f821b69e917fc17ca7050c8c164966433d55cf67f053067f4fce66'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '1d2ff35bc2217778c011e561ec6a1df9cb3ebc5f384e1625a4978c3f4588f5a5'
+          checkpoint: '8c54aedcbf73463bf7b930c1f9a6584e40715faf81e1274de1e2b8243a60568f'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.