### PR TITLE
Update jgrasp to 2.0.4_04

### DIFF
--- a/Casks/jgrasp.rb
+++ b/Casks/jgrasp.rb
@@ -1,6 +1,6 @@
 cask 'jgrasp' do
-  version '2.0.4_03'
-  sha256 '24c7b053e1a0072581e58934ba9232124db1827e86022c424100fbae179dd507'
+  version '2.0.4_04'
+  sha256 '5ece62ccdb6ee38b24e1727ea3674c059dbe512226eb60670773609536defa7b'
 
   url "http://www.jgrasp.org/dl4g/jgrasp/jgrasp#{version.no_dots}.pkg"
   name 'jgrasp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.