### PR TITLE
Update neo4j to 1.0.18

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,7 +1,7 @@
 cask 'neo4j' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '1.0.17'
-  sha256 'c12eaf9d457b13790881781696d4b507051dd4166fed1a652060e81311d8d0c1'
+  version '1.0.18'
+  sha256 'e1e8657c8adb661a01ea47534d0fe9e0c200c58e4f475e6788b1d6c967af74c6'
 
   url "https://neo4j.com/artifact.php?name=neo4j-desktop-offline-#{version}.dmg"
   name 'Neo4j Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.