### PR TITLE
Update omnidb to 2.6.0

### DIFF
--- a/Casks/omnidb.rb
+++ b/Casks/omnidb.rb
@@ -1,6 +1,6 @@
 cask 'omnidb' do
-  version '2.5.0'
-  sha256 '61467b79b746ad682098c55525321f03de2218c64deb177abea45943f7567ed3'
+  version '2.6.0'
+  sha256 '77bd1cd3f3c071562011fef124d64cda93800ebbc77af9a55f1dd81fcfea4b15'
 
   url "https://omnidb.org/dist/#{version}/omnidb-app_#{version}-mac.dmg"
   name 'OmniDB'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.