### PR TITLE
Update nteract to 0.8.4

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,10 +1,10 @@
 cask 'nteract' do
-  version '0.8.3'
-  sha256 '7ca00bfa01e66613df5bfd10f238fa179ac88b59b8476dccd96eee6a8ad2239f'
+  version '0.8.4'
+  sha256 'dcc993ac35e1b3e58057f0eb73240a695c681e7501c0454728b53550f6ebe160'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom',
-          checkpoint: 'e6b272fcedef05ea2a7fe44f5e6e0b4bfb7f1615cc8d6c35e256c76750ca11dd'
+          checkpoint: '1b1402e6093e6d5a02e19951625ecbd2369792c30ebe4e2d743f434cceb020d9'
   name 'nteract'
   homepage 'https://github.com/nteract/nteract'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.