### PR TITLE
Update 4k-video-downloader to 4.4.6.2295

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,10 +1,10 @@
 cask '4k-video-downloader' do
-  version '4.4.5.2285'
-  sha256 '3b7fd422d1b49510d61fbafc546104e51d22ccbc1a7fecdb4497c886c84ec0ef'
+  version '4.4.6.2295'
+  sha256 '821979eeb980351c253bc49e5d103ad6791d0520e406bf582a97565974a428f6'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: 'a246eca2ffdef26baf777f4f710ac692ecd57aec0a270a3f9986f9deb15962fc'
+          checkpoint: 'e0ccc86a09b343e9f5f55be129817dfc7e03a974379c8c1ec0202f59a3badf64'
   name '4K Video Downloader'
   homepage 'https://www.4kdownload.com/products/product-videodownloader'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.