### PR TITLE
Update mongodb-compass to 1.12.3

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.12.2'
-  sha256 '0a43d00e55de8842feb4736825c595ca200c3f8f7370e15daa609e551df0fbb8'
+  version '1.12.3'
+  sha256 '44a98463a064cc2bddee3b24aa90924536fe2d18baf7da5073d4c26ead4ed436'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.