### PR TITLE
Update vagrant to 2.0.3

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,11 +1,11 @@
 cask 'vagrant' do
-  version '2.0.2'
-  sha256 'c5dd5b8c7193844a6cc5b6f79b0c878cd144f1eebbac72ad70de0f3cfdb31d93'
+  version '2.0.3'
+  sha256 '4ccdd7530a4b0172339c84a61a22bf7868c9fd1d173e7b510cf21f6deb26776e'
 
   # hashicorp.com/vagrant was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"
   appcast 'https://github.com/hashicorp/vagrant/releases.atom',
-          checkpoint: '10e5c87eb8ace1e0df7b9b6f376cb145ff1292d9ad22da40f38409db458d3e27'
+          checkpoint: '15e49f1530c8501e14b361a4a2eba290bbcd2b32b402cc002035e30455938519'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.