### PR TITLE
Update netron to 1.6.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.6.4'
-  sha256 '0b828dc4f305644fb7ffca49f3d9e574916aef87ec8e5050c1c84fc159abd670'
+  version '1.6.5'
+  sha256 '3764e7fdd15744746fcc3088e331b7407ef78af08045b765abb5112f115c17da'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'eef9fcf03b5d1a48196b9a82fc5f1fb2f4d714deae4fce5ffce9026c42f842e0'
+          checkpoint: 'e844172d49fc4a535d1813eb2cc614446af15fea85ccddae2b0a13b6a372bb5f'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.