### PR TITLE
Update exodus to 1.47.0

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.46.1'
-  sha256 '24a32500b5f80e774a54556225990ec980841929c4b0e9c38ce47bd58dd30a5b'
+  version '1.47.0'
+  sha256 '47df69ff3a55ba57a4548d7811b4bed192e8828394006a3683936b0b79ccb1c1'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '2cd4cd510ee74a37b489f52104673d4b71f2ab872bc23daa6454274c800991f1'
+          checkpoint: '0f49b2909378ee7f3af530c913b99eee4b169f4cd578a4d7340d5fb009570ad7'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.