### PR TITLE
Update react-native-debugger (0.7.16)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.15'
-  sha256 '3926eda0f5afb395119fa7812846b17de50aec5012aec779d0e8594f06b8140c'
+  version '0.7.16'
+  sha256 '5bf3559c03f3732c5e517a9b70554876bbfd757e0845d8cdebd6201cf240dff0'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '3732307f9f30034db7b611e8b3b7827ef32453bc7b32767518c4736c5eed4b32'
+          checkpoint: '32ad14050291de516d773d966b4ef65cbef87d899d2d01fec966b0785bb94f5b'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
