### PR TITLE
Update handshaker to 2.5.5

### DIFF
--- a/Casks/handshaker.rb
+++ b/Casks/handshaker.rb
@@ -1,11 +1,11 @@
 cask 'handshaker' do
-  version '2.5.4'
-  sha256 '96843644bf01c83883226ed9108419a2b76dd33f1b00ce6efd7648370b60d0aa'
+  version '2.5.5'
+  sha256 'de34c82254033d58511a107d98916a31f4d5b8e270b4431f01c664b243d99adf'
 
   # dl2.smartisan.cn was verified as official when first introduced to the cask
   url "http://dl2.smartisan.cn/app/HandShaker.v#{version}.dmg"
   appcast 'https://sf.smartisan.com/update.plist',
-          checkpoint: '6cdb44644195de046cb5b1ec50c724178062991585da8ab9fa11d59d45b641e4'
+          checkpoint: 'dadfb68ba230f8a4f85c6965d883c98add9a3bb6987e3e9af860158c6c52753d'
   name 'HandShaker'
   homepage 'http://www.smartisan.com/apps/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.