### PR TITLE
Update quip to 5.2.39

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.2.31'
-  sha256 '2ce1de6dd533f9f070125270cf84c4128f1e4dca63723b9e90404be17a63c47f'
+  version '5.2.39'
+  sha256 '561a2bcec79436ee5223f4c6cfac7ec929a7ae9889d2b6d5703974aa9a166961'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.