### PR TITLE
Update molotov to 2.1.2

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '2.1.0'
-  sha256 '95ce31a86764f92dc6a6e1123c6b8ca91699f3c2350c97741fbf4cceaeeb0738'
+  version '2.1.2'
+  sha256 '6cc00e22616c60e298cd3dd991378770da1e8528a199bf9a249d44176409dd45'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.