### PR TITLE
Update mini-vmac to 3.5.8

### DIFF
--- a/Casks/mini-vmac.rb
+++ b/Casks/mini-vmac.rb
@@ -1,6 +1,6 @@
 cask 'mini-vmac' do
-  version '3.4.1'
-  sha256 '1d3b6051c22d68033eb47da5c1ec4cc4b2474ca2095f087b085ceaa5effc19da'
+  version '3.5.8'
+  sha256 '09a4a2ffd4f44087bf929cec89ecacd3b775690f137b211627154076627ce4cf'
 
   url "http://www.gryphel.com/d/minivmac/minivmac-#{version}/minivmac-#{version}-imch.bin.tgz"
   name 'Mini vMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.