### PR TITLE
Add uninstall_preflight and _postflight to Virtualbox 5.2.8,121009

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -10,6 +10,31 @@ cask 'virtualbox' do
 
   pkg 'VirtualBox.pkg'
 
+  uninstall_preflight do
+    def get_process_list_array(filter = nil)
+      psaux = system_command('/usr/bin/env', args: ['ps', 'aux'], sudo: true).stdout.split("\n")
+      filter.nil? ? psaux : psaux.select { |line| line.match(filter) }
+    end
+
+    vbox_users = get_process_list_array('VirtualBoxVM').map { |process| process.split("\s")[0] }.uniq
+    running_vms_full_list = vbox_users.map { |user| system_command '/usr/bin/env', args: ['su', user.to_s, '/usr/local/bin/VBoxManage', 'list', 'runningvms'], sudo: true }.map { |vboxmanage| vboxmanage.stdout.split("\n") }
+    running_vms_guids_only = running_vms_full_list.map { |vmlist| vmlist.map { |vmlistitem| vmlistitem.match(%r{\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}})[0] } }
+    Hash[vbox_users.zip running_vms_guids_only].each { |user, vmlist| vmlist.each { |vm| system_command '/usr/bin/env', args: ['su', user.to_s, '/usr/local/bin/VBoxManage', 'controlvm', vm.to_s, 'savestate'], sudo: true, must_succeed: true, print_stdout: true } }
+
+    vbox_app_process_list = get_process_list_array('VirtualBox.app/Contents/MacOS/VirtualBox').map { |process| process.split("\s")[1] }.uniq
+    vbox_app_process_list.each { |process| system_command '/usr/bin/env', args: ['kill', '-HUP', process.to_s], sudo: true, must_succeed: true }
+
+    10.times do
+      break if get_process_list_array('VirtualBox.app').count.zero?
+      sleep 1
+    end
+    get_process_list_array('VirtualBox.app').map { |process| process.split("\s")[1] }.each { |process_id| system_command '/usr/bin/env', args: ['kill', '-9', process_id.to_s], sudo: true, must_succeed: true }
+  end
+
+  uninstall_postflight do
+    system_command '/usr/bin/env', args: ['bash', '-c', '$HOMEBREW_BREW_FILE cask uninstall virtualbox-extension-pack --force'], must_succeed: false, print_stdout: true
+  end
+
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',
                        args:       ['--unattended'],


### PR DESCRIPTION
Virtualbox cask installation and uninstallation will fail if the
application or any virtual machines are running. This commit adds an
uninstall_preflight stanza to the cask that saves the state of all
running VMs for all users, then cleanly closes the application with a
ten second timeout, after which it will kill -9 any still-running
VirtualBox binaries.

Currently, uninstalling the virtualbox cask deletes the extension pack
binaries, leaving the associated cask in an inconsistent state. This
commit adds an uninstall_postflight stanza that forces uninstallation of
the virtualbox-extension-pack cask when the virtualbox cask is
uninstalled.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.