### PR TITLE
Update freesmug-chromium to 65.0.3325.162

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
   version '65.0.3325.162'
-  sha256 '125a726f6e8be66061975203427bcfd9747dcbde36a30072e805ebf664310009'
+  sha256 '34e35227a1764ad3f928e454807b727e2413da928d48a63f8ff72503f1627814'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '742430e18ea6d09fa3f89d9ec46b251e07587d41e3e757d80e1ed6479fb04ef2'
+          checkpoint: 'd334643ff735c9d9f2bb4fde6aab307ffb1a293a64d418013a1dcc59172e736f'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

> https://www.virustotal.com/#/file/34e35227a1764ad3f928e454807b727e2413da928d48a63f8ff72503f1627814/details

Rerelease because original was unsigned.