### PR TITLE
Update acorn to 6.1.2

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,10 +1,10 @@
 cask 'acorn' do
-  version '6.1.1'
-  sha256 'd23f311dde006a201c75ea6bd92ede665edb13d2f69104cf5d27f7256f6e854c'
+  version '6.1.2'
+  sha256 '0a69736c71f1b46206986cd1ae8aab9e9b732ddeed817648e2accb46bdd37148'
 
   url 'https://secure.flyingmeat.com/download/Acorn.zip'
   appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml",
-          checkpoint: 'e7ddc66a889b9ebb3e2905354717ab971219a4945ecd8800cbcfc55e6e754c02'
+          checkpoint: 'ef4b645d3cd13bfe689206f40fbc34c69c204e4fb3aeea878f12975abb7d43b7'
   name 'Acorn'
   homepage 'https://flyingmeat.com/acorn/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.