### PR TITLE
Update react-native-debugger (0.7.17)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,10 +1,10 @@
 cask 'react-native-debugger' do
-  version '0.7.16'
-  sha256 '5bf3559c03f3732c5e517a9b70554876bbfd757e0845d8cdebd6201cf240dff0'
+  version '0.7.17'
+  sha256 'a8545ceea5f0d68bf3f7362b3342f04581037a732014189ceefab1ab6b89a799'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom',
-          checkpoint: '32ad14050291de516d773d966b4ef65cbef87d899d2d01fec966b0785bb94f5b'
+          checkpoint: '332920a05393a804893da823a8795d5d816c2632833f9cf928943aece1d18330'
   name 'React Native Debugger'
   homepage 'https://github.com/jhen0409/react-native-debugger'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
