### PR TITLE
Update stretchly to 0.16.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.15.0'
-  sha256 '24a5f972617826fe6f1db748019c3161062452d2e79c2b891fa6834dcb7f66fb'
+  version '0.16.0'
+  sha256 'b87e7cc798effc8ac5ca948679f1de693556893c6b44e6c42d99ea4a3d12eaf3'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: 'ed45690ec09e6b916b1df9170a49b74120f6562d06f16cb59bf049a23d1166cf'
+          checkpoint: '1835820d39bcdb08dc371830f798d2169db3bde1341fdebabbf85a2ef7f74d30'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.