### PR TITLE
Update alva to 0.7.0

### DIFF
--- a/Casks/alva.rb
+++ b/Casks/alva.rb
@@ -1,11 +1,11 @@
 cask 'alva' do
-  version '0.6.1'
-  sha256 'c9f17817e3d9b3d62086cd36bd85f4c26c82f2126e7f7aef4612f1ac8495c621'
+  version '0.7.0'
+  sha256 'a834429e38d4d3b7fc5805d58c76b7e141b64f9fbe57c032c7e9c5628a24892b'
 
   # github.com/meetalva/alva was verified as official when first introduced to the cask
   url "https://github.com/meetalva/alva/releases/download/v#{version}/Alva-#{version}-mac.zip"
   appcast 'https://github.com/meetalva/alva/releases.atom',
-          checkpoint: '6c3ff696b3084d5499e2e512bd050e2a1d42285b9cf3191b3f15dc31bef82c0f'
+          checkpoint: '345afc0994022649d69ad7a9d2b5e698122b987f7997610f46b9812d6574637b'
   name 'Alva'
   homepage 'https://meetalva.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.