### PR TITLE
Update amazon-chime to 4.13.6123

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,10 +1,10 @@
 cask 'amazon-chime' do
-  version '4.12.6094'
-  sha256 'a384ac895ecac4e54e918fddee6f0a45fd5317e86762e633759c526039063b99'
+  version '4.13.6123'
+  sha256 'e26bab9d4e4a56fc16425cb76ae0338faa28378e8ede05990d10c0194983f937'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast',
-          checkpoint: '96c3655a818cc0d2db436e217103e45f460601946d38b286e0d840586b20d926'
+          checkpoint: '6ef4eb2d6e1e083009387f61f926528baf867a48b1b27fb2935c8350cccb4b85'
   name 'Amazon Chime'
   homepage 'https://chime.aws/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.