### PR TITLE
Update bettertouchtool to 2.405

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -23,8 +23,8 @@ cask 'bettertouchtool' do
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"
-    appcast 'https://updates.bettertouchtool.net/highsierra_new.xml',
-            checkpoint: '1c3a66a8fb4f1b9c2b8db6b14cead596110d4efc90e766e094e1d9f5e8cdaf80'
+    appcast 'https://updates.bettertouchtool.net/bettertouchtool_release_notes.html',
+            checkpoint: '4520ee4fcee23c2367b2262ac827e548ca635ac33000cfb9becf4f4fc663c16a'
   end
 
   name 'BetterTouchTool'

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -18,13 +18,13 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.403'
-    sha256 '61abb82673442d95aa8f7b95ae78fb1eb363d12b7689211de3ab5e6f3ee8ddb6'
+    version '2.405'
+    sha256 '268ef79817a02623bce4ff2290135567100e6b4e0700a11720909f80fbe47534'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"
-    appcast 'https://updates.bettertouchtool.net/appcast.xml',
-            checkpoint: '6af441c57231d96750f1a6d4122fba5690b0d3920594a6c36cee1b7545e187f9'
+    appcast 'https://updates.bettertouchtool.net/highsierra_new.xml',
+            checkpoint: '1c3a66a8fb4f1b9c2b8db6b14cead596110d4efc90e766e094e1d9f5e8cdaf80'
   end
 
   name 'BetterTouchTool'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.