### PR TITLE
Update wordpresscom to 3.2.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,10 +1,10 @@
 cask 'wordpresscom' do
-  version '3.1.0'
-  sha256 '794184637abe04bee5a193b3b085c29c25d632b26b1a53413d0085d65733f48f'
+  version '3.2.0'
+  sha256 'dc7c8c7d901f46b5b4c7cc95b77dde2ef7edb47d0a084853e6c37e8270f66e5d'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable',
-          checkpoint: 'f8651571a5797bc35fb9ace9feae6ca25c8253d277ae650c287971fada15dfbc'
+          checkpoint: '42bc81c9b3bce7d8e10eeae6bb45edb3291ea8e7810aebff12b50df6117500ef'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.