### PR TITLE
Update astro to 3.0.8,3845

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '3.0.7,3818'
-  sha256 '9fa7591bf5e39666fcaf18bc1668304e547ded27f82156798106ba876e069a76'
+  version '3.0.8,3845'
+  sha256 'fda7047d9a633253129b3e6cc5a49d1bd9986faebaa1270d677e3df9f21ecd3e'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: '135d27ab349f3c939700ea0de5d6bbc9522bef52ae237c8e003ec5fb7ade0c36'
+          checkpoint: '7691e364086651297cc41260b5e8ff86e0c90daf99d7635898c2bf927f4a7f95'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.