### PR TITLE
Update keka to 1.0.14

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,11 +1,11 @@
 cask 'keka' do
-  version '1.0.13'
-  sha256 '4f24d0f88f7c4e0852c452f948ecc549df7ce44b7e529aadb51ef353a71e24c6'
+  version '1.0.14'
+  sha256 '9b546a71eadc90ff9e8be15c86cbea21ffd53ba5f640e8a1000dcf57393c930c'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: '0008beedbd97ca62d68af13b49fbedad5a68faacc194639f288a310251dde2cf'
+          checkpoint: '229d2d4868b0801738f73f9a7a44ffca493297d6db6d7060bf37014180da5dcb'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.