### PR TITLE
Update cacher to 1.3.6

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.5'
-  sha256 'a1b958c3bb94138e1f317c8e8d63351cac3c75d508a0746c7ef55a257d42ce75'
+  version '1.3.6'
+  sha256 '64647f9ffd9801b67da0547d0d0f9417526ff52d17cf2038d21e0ddec69e5fb7'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '8a19619feeac7357426f00bbaf8bab2e90588eb9af2470f955b731019b2d5e61'
+          checkpoint: 'eccc9fa5629e75d86997da6a9b8e177232bf3195846f119e2e68c3ce0e22844c'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.