### PR TITLE
Update nucleo to 2.3.1

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,11 +1,11 @@
 cask 'nucleo' do
-  version '2.3.0'
-  sha256 '349a64f18a5a2dcf4f921b8c4a37203d2f8e24779581b0d2143a5eddde55e163'
+  version '2.3.1'
+  sha256 '33077671920dc6cd57fe1c4fb23e11dc96ba32ef7c6d42381e21ba2a5a466aa9'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"
   appcast 'https://nucleoapp.com/updates',
-          checkpoint: 'b10761baf63c0587fff9b7878286d18119a16ddf9c041eba32a081b938560017'
+          checkpoint: 'c0fda658f91aee8c9b85f440ca9dcf1d4139a8bd30804cc80cea4ca17d38a23b'
   name 'Nucleo'
   homepage 'https://nucleoapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.