### PR TITLE
Update cacher to 1.3.7

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.6'
-  sha256 '64647f9ffd9801b67da0547d0d0f9417526ff52d17cf2038d21e0ddec69e5fb7'
+  version '1.3.7'
+  sha256 '251b58147e29f8fd9885725a3a2546d73fa0def0135a5f54c5e9e415c4edb07e'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'eccc9fa5629e75d86997da6a9b8e177232bf3195846f119e2e68c3ce0e22844c'
+          checkpoint: '1807ec0ed4a1228dc98202baf694bd1acfcbb1fe5a6a99ffb379c6f55c41f07c'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.