### PR TITLE
Update hugin to 2018.0.0

### DIFF
--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -1,10 +1,10 @@
 cask 'hugin' do
-  version '2017.0.0'
-  sha256 '4caa1f6d541c78e778d2689a90e1a641df1a51b40aa7246e0811a75f66ca0e2f'
+  version '2018.0.0'
+  sha256 '286812bb95e34c2dd8458d49878c54d919e1c0f37ed042d174e8cf0c651edb3e'
 
   url "https://downloads.sourceforge.net/hugin/Hugin-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/hugin/rss',
-          checkpoint: 'dc3cd74ac990811372b6c1605129e13100b97aed1483147f6fa52e4b394e153e'
+          checkpoint: '1165a4f3f2442ed955d005d25cfd043fb47fad3aa94701ead6f400d236c4e597'
   name 'Hugin'
   homepage 'http://hugin.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.