### PR TITLE
Upgrade puppet-agent to 5.4.0-1

### DIFF
--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -34,8 +34,15 @@ cask 'puppet-agent' do
 
   pkg "puppet-agent-#{version}-installer.pkg"
 
-  uninstall launchctl: ['puppet', 'pxp-agent', 'mcollective'],
+  uninstall launchctl: [
+                         'puppet',
+                         'pxp-agent',
+                         'mcollective',
+                       ],
             pkgutil:   'com.puppetlabs.puppet-agent'
 
-  zap trash: ['~/.puppetlabs', '/etc/puppetlabs']
+  zap trash: [
+               '~/.puppetlabs',
+               '/etc/puppetlabs',
+             ]
 end

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -1,24 +1,34 @@
 cask 'puppet-agent' do
-  version '1.10.9-1'
+  version '5.4.0-1'
 
   if MacOS.version == :yosemite
-    sha256 '05af4e30856de5b012e9e219872391d56b99e6966f874258fb2285269eebff09'
+    sha256 'f58df568221c54d22345367b129af2027da49bf898a3fcb740bf2567aacac8c1'
     # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
-    url "https://downloads.puppetlabs.com/mac/10.10/PC1/x86_64/puppet-agent-#{version}.osx10.10.dmg"
+    url "https://downloads.puppetlabs.com/mac/puppet/10.10/x86_64/puppet-agent-#{version}.osx10.10.dmg"
+    appcast 'https://downloads.puppetlabs.com/mac/puppet/10.10/x86_64/',
+            checkpoint: '98908c8146c5a8dc74c1dd4e9edc7fbe3fa0e377e37f2ecc22d05c4b8d12e04c'
   elsif MacOS.version == :el_capitan
-    sha256 '4c7274ab07c82328d47d2365baa1f866687b3fcf04ac88e9bbb743fc6bfee7a2'
+    sha256 '142602889c389a997d7a4f722ed22cc9070b52f47dfe87a2613b5aaef484b383'
     # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
-    url "https://downloads.puppetlabs.com/mac/10.11/PC1/x86_64/puppet-agent-#{version}.osx10.11.dmg"
+    url "https://downloads.puppetlabs.com/mac/puppet/10.11/x86_64/puppet-agent-#{version}.osx10.11.dmg"
+    appcast 'https://downloads.puppetlabs.com/mac/puppet/10.11/x86_64/',
+            checkpoint: 'bf5e8da65789f667913a4f6eb933995d82196dc6d9fb17bf9187d0b598636438'
+  elsif MacOS.version == :sierra
+    sha256 '7deaa981a1e9a898b9a8c9f6a95c9518694681f7b65db53a02de402739e9c2d9'
+    # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
+    url "https://downloads.puppetlabs.com/mac/puppet/10.12/x86_64/puppet-agent-#{version}.osx10.12.dmg"
+    appcast 'https://downloads.puppetlabs.com/mac/puppet/10.12/x86_64/',
+            checkpoint: '8524abe2cc62de4b6bddea8aa99ec2b5728b2067750517bd220bd47bf8f9d572'
   else
-    sha256 '8657902ca7aaffeebc16465a68f1b583844214fb874513f43e9f27fb49f775f7'
+    sha256 '9ad5d205fe8979beb93a75a18f1d70beb873ad73355ddfb362a6283965b2cac7'
     # downloads.puppetlabs.com/mac was verified as official when first introduced to the cask
-    url "https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/puppet-agent-#{version}.osx10.12.dmg"
-    appcast 'https://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/',
-            checkpoint: '65fd80d62d954ecf8f13e309eb7721a385c1299740421f57c1c35bac6eee78bb'
+    url "https://downloads.puppetlabs.com/mac/puppet/10.13/x86_64/puppet-agent-#{version}.osx10.13.dmg"
+    appcast 'https://downloads.puppetlabs.com/mac/puppet/10.13/x86_64/',
+            checkpoint: 'dd42205bf01e8063855d35a7d6828289f7be6b2ab6ea7efb2aa18a601c51104e'
   end
 
   name 'Puppet Agent'
-  homepage 'https://docs.puppet.com/puppet/4.5/about_agent.html'
+  homepage 'https://docs.puppet.com/puppet/5.4/about_agent.html'
 
   depends_on macos: '>= :yosemite'
 
@@ -27,5 +37,5 @@ cask 'puppet-agent' do
   uninstall launchctl: ['puppet', 'pxp-agent', 'mcollective'],
             pkgutil:   'com.puppetlabs.puppet-agent'
 
-  zap trash: '~/.puppetlabs'
+  zap trash: ['~/.puppetlabs', '/etc/puppetlabs']
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.