### PR TITLE
Update skype to 8.18.0.6

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.17.0.2'
-  sha256 '8ad96b417f9ddde983ca944786a2d3232ede33bc3a9327460d03d74dd0b1465f'
+  version '8.18.0.6'
+  sha256 '88f037653a24b3547da152622fed23e8199b8693ebadb0662a0c0a734cbe3f76'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.