### PR TITLE
Update franz to 5.0.0-beta.17

### DIFF
--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -1,11 +1,11 @@
 cask 'franz' do
-  version '5.0.0-beta.16'
-  sha256 '656376a36f510295eaf3c54eebe968abd426162427d8919147040d3183aa4ff7'
+  version '5.0.0-beta.17'
+  sha256 '2b388cb82da5bac7fb1bd71e17bab894523c6fce26631b297bb66d78387985c3'
 
   # github.com/meetfranz/franz was verified as official when first introduced to the cask
   url "https://github.com/meetfranz/franz/releases/download/v#{version}/franz-#{version}.dmg"
   appcast 'https://github.com/meetfranz/franz/releases.atom',
-          checkpoint: '62cd70cd039061bb6fc73a5b292f793380ccb0faadc78f01124f7e75172d3b0d'
+          checkpoint: 'f1a1b87b70a4f88c6075a36199e605ee9c398882e5be509958a3888fb453591a'
   name 'Franz'
   homepage 'https://meetfranz.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.