### PR TITLE
Update wavebox to 3.11.0

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.10.0'
-  sha256 '177031e0c34838ca6f9d3a3a811a92474180ccab88ed69aed9011bdb92f23cc6'
+  version '3.11.0'
+  sha256 '7c4d452cdbdbabb050d617da4ec3c94f2f04fcbc4b6541f5e5ca86b1e19d17ea'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: '29b5b14955f2462f28284ed5906b7e6f38d49088e04a98cf7cd6b3b54d48339f'
+          checkpoint: '896a7ca9a8ea3c9283560e3c4e38be8523c8a1c478bf90b8d4a2c031c2b26f18'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.