### PR TITLE
Update java-jdk-javadoc to 10,46:76eac37278c24557a3c4199677f19b62

### DIFF
--- a/Casks/java-jdk-javadoc.rb
+++ b/Casks/java-jdk-javadoc.rb
@@ -1,13 +1,13 @@
 cask 'java-jdk-javadoc' do
-  version '9.0.4,11:c2514751926b4512b076cc82f959763f'
-  sha256 '66a7e0948f109020bfb5483848e9998b2624043074d7aae974e89e85a6e14d37'
+  version '10,46:76eac37278c24557a3c4199677f19b62'
+  sha256 '3bd4c890f6bfaef61141f0720457d6c82a8c479b22a591631cc2b3d741a205bb'
 
   url "http://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
   name 'Java Standard Edition Development Kit Documentation'
-  homepage "http://www.oracle.com/technetwork/java/javase/documentation/jdk#{version.major}-doc-downloads-3850606.html"
+  homepage "http://www.oracle.com/technetwork/java/javase/documentation/jdk#{version.major}-doc-downloads-4417029.html"
 
   postflight do
     `/usr/libexec/java_home -v #{version.before_comma} -X | grep -B0 -A1 JVMHomePath | sed -n -e 's/[[:space:]]*<string>\\(.*\\)<\\/string>/\\1/p'`.split("\n").each do |path|


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.