### PR TITLE
Update java to 10,46:76eac37278c24557a3c4199677f19b62

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,13 +1,13 @@
 cask 'java' do
-  version '9.0.4,11:c2514751926b4512b076cc82f959763f'
-  sha256 'f5c827ab4c3cf380827199005a3dfe8077a38c4d6e8b3fa37ec19ce6ca9aa658'
+  version '10,46:76eac37278c24557a3c4199677f19b62'
+  sha256 'df64b0d6c24e6a6006820b0073747e1c79ace714063f515cdcfb825b73558851'
 
   url "http://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_osx-x64_bin.dmg",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
   name 'Java Standard Edition Development Kit'
-  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.major}-downloads-3848520.html"
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.major}-downloads-4416644.html"
 
   depends_on macos: '>= :yosemite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.