### PR TITLE
Update the Amethyst cask to 0.12.0

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -6,13 +6,15 @@ cask 'amethyst' do
     version '0.10.1'
     sha256 '9fd1ac2cfb8159b2945a4482046ee6d365353df617f4edbabc4e8cadc448c1e7'
   else
-    version '0.11.4'
-    sha256 '60239205a4376ff624e48e94d894d2967b93b1edd35c9542952e4185cab1f1e7'
+    version '0.12.0'
+    sha256 '7425304f643b67b88b7e851595cdd89bbc58bb7361f7c2dc35239d2ee5569af4'
   end
 
-  url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
+  # This is GitHub.com URL instead of an ianyh URL because
+  # https://ianyh.com/amethyst/versions/ (as previously used) 404s.
+  url "https://github.com/ianyh/Amethyst/releases/download/v#{version}/Amethyst-#{version}.zip"
   appcast 'https://ianyh.com/amethyst/appcast.xml',
-          checkpoint: 'adfbc2e1cab357a3a1b84984e6c49113bbb16da91c0cf08de7ea5a24af1e1da4'
+          checkpoint: '4bfc1fb4b264b2508b3f33dca188a22264ef196598dcd16c08219f1c55f8f0c6'
   name 'Amethyst'
   homepage 'https://ianyh.com/amethyst/'
 

--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -2,17 +2,18 @@ cask 'amethyst' do
   if MacOS.version <= :mavericks
     version '0.9.10'
     sha256 '82adf42ce6031ab59a3072e607788e73f594ad5f21c7118aabc6c5dafe3d0b47'
+    url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   elsif MacOS.version <= :el_capitan
     version '0.10.1'
     sha256 '9fd1ac2cfb8159b2945a4482046ee6d365353df617f4edbabc4e8cadc448c1e7'
+    url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   else
     version '0.12.0'
     sha256 '7425304f643b67b88b7e851595cdd89bbc58bb7361f7c2dc35239d2ee5569af4'
+    # github.com/ianyh/Amethyst was verified as official when first introduced to the cask
+    url "https://github.com/ianyh/Amethyst/releases/download/v#{version}/Amethyst-#{version}.zip"
   end
 
-  # This is GitHub.com URL instead of an ianyh URL because
-  # https://ianyh.com/amethyst/versions/ (as previously used) 404s.
-  url "https://github.com/ianyh/Amethyst/releases/download/v#{version}/Amethyst-#{version}.zip"
   appcast 'https://ianyh.com/amethyst/appcast.xml',
           checkpoint: '4bfc1fb4b264b2508b3f33dca188a22264ef196598dcd16c08219f1c55f8f0c6'
   name 'Amethyst'


### PR DESCRIPTION
- I installed this via `brew cask install` and when I launched it it
  offered me an update. I thought I'd give this update back to Cask as
  well.
- The `amethyst/versions` path appears to have changed to be
  `Amethyst/releases/download/v[version]`, so I updated that too and
  left a comment. The `cask audit` step is unhappy with this, as it
  doesn't like the homepage and download URLs to be different. The
  homepage URL links to the download URL for the specific version,
  though.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
