### PR TITLE
Update cacher to 1.3.8

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.7'
-  sha256 '251b58147e29f8fd9885725a3a2546d73fa0def0135a5f54c5e9e415c4edb07e'
+  version '1.3.8'
+  sha256 '8721dfb7e66428d8f238234b804ce89c3ec5af4484b8c77dab323149a83dd8df'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '1807ec0ed4a1228dc98202baf694bd1acfcbb1fe5a6a99ffb379c6f55c41f07c'
+          checkpoint: 'a10ffbda4d593145046bdebb4278c80ae820d20c6b77c76ed2c48ba80ed7d95b'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.