### PR TITLE
Update milanote to 1.0.27

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.0.26'
-  sha256 '41adf4a0e4465fb9ee1c7a7fbfaea650272d5a2514b6f1502505144b7697176d'
+  version '1.0.27'
+  sha256 'fef6dbd4894c82993c2cabf468b665e88b621a991b5e2e34f05a4b833d267ccf'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.