### PR TITLE
Update prepros to 6.2.1

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.2.0'
-  sha256 'b4c2a7132369f445da57c519d8318d86fab43352da5028913251203d76534673'
+  version '6.2.1'
+  sha256 '3c0ae453abcb2a729c11b8cfb0d0923d28d0e7ccafcd76e3d4a74b684d69233a'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: '251ecfa574e1122fe514760c340e73d3f80329d406f97732152cee80e3673402'
+          checkpoint: '18a3f3017f3d828f0495af07c8bf8d787842882defea9f67c933c156e72e9d1b'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.