### PR TITLE
Update brave to 0.21.24

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.21.18'
-  sha256 'c507e928485ec3fb9cb227a027bd9096936c99cb5d8288cd4443a61d01559457'
+  version '0.21.24'
+  sha256 '8d014874e7dfc86dfdfc7344b0e1aa2b490d5e806b6c6d9aa30e5f66f9715fb2'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'ccac84a9b82c68e68667ce459e7ce4ef9fcc3b58837c71a92e5074f5345d382a'
+          checkpoint: '609d50c515741fdfac1ccd8209f1d39b9113efba6c4b88a529089cb5330b6db2'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.