### PR TITLE
Update netlogo to 6.0.3

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,10 +1,10 @@
 cask 'netlogo' do
-  version '6.0.2'
-  sha256 '952954567aeed7da12340e024718e4ff62e2ee3cfcb7d8270845e07de0f26e80'
+  version '6.0.3'
+  sha256 '6d3c9da4d1bffc79689666d6319fa9ff3d2cf7e779027a1c457b3395cc12582f'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml',
-          checkpoint: '3dee474eb1e89e0db506c115172b236f2c2b41b5d4d9c58238f6dd8cd5c1a3b8'
+          checkpoint: '1351f25e5c59bbf9f6a08cda8371fa2b7aec4f0d75c3736020cb408656833473'
   name 'NetLogo'
   homepage 'https://ccl.northwestern.edu/netlogo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.