### PR TITLE
Update zotero to 5.0.38

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.37'
-  sha256 '1d16e09a64b9b48988e6f1c72b8642a721c1788cf89fc474a96d275672ec03be'
+  version '5.0.38'
+  sha256 'dc6629182015822ace8170c21498e9aa0a420386f39f05cb01c16ea9420eeb09'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '9dea5763d67c720b2a36a6fcf666f55a966110b6e470dcaf6d761e7f8029b038'
+          checkpoint: '02fbad90c178d6f4a212b0c18d094db6911701e30f863beadb31d3e3be55c103'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.