### PR TITLE
Update mark-text to 0.7.17

### DIFF
--- a/Casks/mark-text.rb
+++ b/Casks/mark-text.rb
@@ -1,11 +1,11 @@
 cask 'mark-text' do
-  version '0.6.14'
-  sha256 '04b8f78adbc4d7d3f11622516dde627ac7870c28220737ae546a4835b9265fe1'
+  version '0.7.17'
+  sha256 '3985a2ad8352c37c4202c9b2d61df92649ed0bf8f4bde15edd6ba9e1213787a7'
 
   # github.com/marktext/marktext was verified as official when first introduced to the cask
   url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext-#{version}.dmg"
   appcast 'https://github.com/marktext/marktext/releases.atom',
-          checkpoint: 'f6e600e962ea30715501d0fe7a5a862f06550120e4cf4e891473c1878e35ec2d'
+          checkpoint: 'e8945da0456a433193c119a773d86a2424ebbc2f23b76f201c516d51c40e540c'
   name 'Mark Text'
   homepage 'https://marktext.github.io/website/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.