### PR TITLE
Update hipchat to 4.30.1-754

### DIFF
--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -1,11 +1,11 @@
 cask 'hipchat' do
-  version '4.30.1-749'
-  sha256 'd690e6b4dd000dee0e849c73b202944b9bb2bcbe998b047b0ce113c1a4eec5ee'
+  version '4.30.1-754'
+  sha256 'bf4456465f04a815093cb3a343fd6a09a54a32d6fb034143df54a36942a63e03'
 
   # amazonaws.com/downloads.hipchat.com/osx was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.hipchat.com/osx/HipChat-#{version}.zip"
   appcast 'https://www.hipchat.com/release_notes/appcast/mac',
-          checkpoint: '106da2f4326989a86526e767404a2c41d19c4c8ca4064e81636c967dba788e1a'
+          checkpoint: '94dc2e3919fda990932c99ac99d01695e0c4a34db5a36174168e9f66020aae8b'
   name 'HipChat'
   homepage 'https://www.hipchat.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
