### PR TITLE
Update master-pdf-editor to 4.3.89

### DIFF
--- a/Casks/master-pdf-editor.rb
+++ b/Casks/master-pdf-editor.rb
@@ -1,10 +1,10 @@
 cask 'master-pdf-editor' do
-  version '4.3.83'
-  sha256 'c46f891c8de779ea404f7a15984fcd2de0948b5625c6e898171350005108778f'
+  version '4.3.89'
+  sha256 '5537b89aa8ae54f3c642b0d94fc6244c6238bb293af3757d0c89d3d4250b4776'
 
   url 'https://code-industry.net/public/MasterPDFEditor.dmg'
   appcast 'https://code-industry.net/get-masterpdfeditor/',
-          checkpoint: 'fe58ad8c73ddb06671dffc9ebacccadf93ace7ddf27ceaf336c115e567651046'
+          checkpoint: '6466aa8fedfdd93b4f8b1d0dea2d49a05c4eeaae53a7fe791503523f9d5b3d58'
   name 'Master PDF Editor'
   homepage 'https://code-industry.net/masterpdfeditor/'
 
@@ -13,6 +13,7 @@ cask 'master-pdf-editor' do
   app 'Master PDF Editor.app'
 
   zap trash: [
+               '~/Library/Application Support/Master PDF Editor',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.code-industry.masterpdfeditor3.sfl*',
                '~/Library/Preferences/net.code-industry.Master PDF Editor.plist',
                '~/Library/Saved Application State/net.code-industry.MasterPDFEditor3.savedState',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.