### PR TITLE
Update resilio-sync to 2.5.12(1191)

### DIFF
--- a/Casks/resilio-sync.rb
+++ b/Casks/resilio-sync.rb
@@ -1,6 +1,6 @@
 cask 'resilio-sync' do
-  version :latest
-  sha256 :no_check
+  version '2.5.12(1191)'
+  sha256 'f6c7a0b0e0b11399cbe5f3250b4067293d0c8a80b8a5ea3a938476e7923b0dba'
 
   url 'https://download-cdn.resilio.com/stable/osx/Resilio-Sync.dmg'
   name 'Resilio Sync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.