### PR TITLE
Update farrago to 1.0.3

### DIFF
--- a/Casks/farrago.rb
+++ b/Casks/farrago.rb
@@ -1,10 +1,10 @@
 cask 'farrago' do
-  version '1.0.2'
-  sha256 '96bfd671aed96583a9cd11020fa5575f3b148492da690978ff7b04ba48892a11'
+  version '1.0.3'
+  sha256 'f3ea06b27162dbfb9461e463d241c2ab747cf5a15104a9e27c3c1d0ce8480372'
 
   url 'https://rogueamoeba.com/farrago/download/Farrago.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Farrago',
-          checkpoint: '0ab82edd3438ab53f8171ae3f58bcb42a5f99b07e800db8d6ea873d581ef17ff'
+          checkpoint: 'c0eff5944eb2f89cd1ddf9ac03e2b10c20ce1652372104201a4a6a249dfd0c0f'
   name 'Farrago'
   homepage 'https://rogueamoeba.com/farrago/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.