### PR TITLE
Bump GraphiQL app to 0.7.2

### DIFF
--- a/Casks/graphiql.rb
+++ b/Casks/graphiql.rb
@@ -1,10 +1,10 @@
 cask 'graphiql' do
-  version '0.7.1'
-  sha256 '2487789d47e35eb47cdb75a0906fb67db703595e39f4c0e5ca6cb9bdf684a4d7'
+  version '0.7.2'
+  sha256 '204dd3db5c11bf265700d8d57defc4798cd0040651f751f35e2a646cb4846ac7'
 
   url "https://github.com/skevy/graphiql-app/releases/download/v#{version}/graphiql-app-#{version}-mac.zip"
   appcast 'https://github.com/skevy/graphiql-app/releases.atom',
-          checkpoint: '1ccb10a783911d622d739e706ddfe58b32374036f460c9e2b6518050f16f3041'
+          checkpoint: 'd91f8f51431a799905b0c52fc2e4d4496923cfe775362ff5a2887ec003d607fb'
   name 'GraphiQL App'
   homepage 'https://github.com/skevy/graphiql-app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
