### PR TITLE
Update Sound Control to 2.2.0

### DIFF
--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -1,8 +1,9 @@
 cask 'sound-control' do
-  version '2.1.6,4297'
-  sha256 '33feccad185a1cc53ac5e8e89202484254ca2f737ebf3ea86a988296f93c44a9'
+  version '2.2.0'
+  sha256 '6b5c30e51713351679d052f9d315f48b77e04e7e95a01fec1fba53e7424c0c31'
 
-  url "https://staticz.com/download/#{version.after_comma}/"
+  # staticz.net was verified as official when first introduced to the cask
+  url "http://staticz.net/downloads/SoundControlInstaller_#{version}.dmg"
   name 'Sound Control'
   homepage 'https://staticz.com/soundcontrol/'
 


### PR DESCRIPTION
Been maintaining my [tap](https://github.com/sscotth/homebrew-sound-control) for several months, and noticed it was in core now.

Changed back to staticz.net because it is direct to the S3 download with all prior releases. Using the `#{version.after_comma}` method is not checksum consistent and would require `:latest` & `:no_check`.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
