### PR TITLE
Update bilibili to 2.55

### DIFF
--- a/Casks/bilibili.rb
+++ b/Casks/bilibili.rb
@@ -1,10 +1,10 @@
 cask 'bilibili' do
-  version '2.54'
-  sha256 'a6ca7634095fc637867648c3484cb30823b7b01878d3fcd011122f6b68762410'
+  version '2.55'
+  sha256 'c211ccf4716d12e654bc2d8e82b46fd2692d971b6599cf67a6a9e6c9fa2181e9'
 
   url "https://github.com/typcn/bilibili-mac-client/releases/download/#{version}/Bilibili.dmg"
   appcast 'https://github.com/typcn/bilibili-mac-client/releases.atom',
-          checkpoint: 'a7ac8087fb617be85ca39bdacd8d9fd8ecf761e77becf7032b6ba0b15394cccf'
+          checkpoint: 'f6918fdc4fdd80b72c2893d12468f33dd7df7e8ccf96c2c79d0e414f3968a347'
   name 'Bilibili'
   homepage 'https://github.com/typcn/bilibili-mac-client/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.