### PR TITLE
Update jetbrains-toolbox to 1.8.3678

### DIFF
--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -1,10 +1,10 @@
 cask 'jetbrains-toolbox' do
-  version '1.7.3593'
-  sha256 '7ce704754c7eddee812c138146714ad03b3e0db75d798b7f3513440d7c1b8e9d'
+  version '1.8.3678'
+  sha256 '739bade6ff02f2ed97295ebe61ea65dfc07a63ff23c317342fd98a28e967fc96'
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release',
-          checkpoint: '5eb3acc1031e3ee96c81fe5ffd7ec58d59d52f037286c35f7120dfe81fc51adb'
+          checkpoint: 'db94980024e2da02d22514929cc31d64ebee3298bf05ba9a0c61ec4bceb689c9'
   name 'JetBrains Toolbox'
   homepage 'https://www.jetbrains.com/toolbox/app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.