### PR TITLE
Update cacher to 1.3.9

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.8'
-  sha256 '8721dfb7e66428d8f238234b804ce89c3ec5af4484b8c77dab323149a83dd8df'
+  version '1.3.9'
+  sha256 'f9419d9419ada2451ad46e09ed598b48059e79420f23dbcf4435a6f9459f7a15'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'a10ffbda4d593145046bdebb4278c80ae820d20c6b77c76ed2c48ba80ed7d95b'
+          checkpoint: '3b8b9779cea270fd6115358b768a4d574f1a0ae96e84206ed6fe86c60ffdc88a'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.