### PR TITLE
Update transmission-remote-gui to 5.15.2

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,10 +1,10 @@
 cask 'transmission-remote-gui' do
-  version '5.15.0'
-  sha256 '91da842ad8701bb253e999ca7614b9a2d5483d1d85120cd9d18cdceb6e42f26b'
+  version '5.15.2'
+  sha256 '56014943e1f070604b651b972ee754b9692e1d9993c7dd7edeff93e9b2492d26'
 
   url "https://github.com/transmission-remote-gui/transgui/releases/download/v#{version}/transgui-#{version}.dmg"
   appcast 'https://github.com/transmission-remote-gui/transgui/releases.atom',
-          checkpoint: '46c3417c57b7cb424b770f2dd22a8e73cbbb3adaf31b6d5728aeafa1101eb402'
+          checkpoint: '11acace4862e1b33a3460a745c3f6c2d96297a877fe573b3419d415fafbf9ee0'
   name 'Transmission Remote GUI'
   homepage 'https://github.com/transmission-remote-gui/transgui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.