### PR TITLE
Update knockknock to 1.9.1

### DIFF
--- a/Casks/knockknock.rb
+++ b/Casks/knockknock.rb
@@ -1,11 +1,11 @@
 cask 'knockknock' do
-  version '1.9.0'
-  sha256 '3af57a0689d9a6c28b1cb3a0c9624b832b1d77a17d9af5c2d3df9b05c709072e'
+  version '1.9.1'
+  sha256 '4adfba2ac018ab99200b57c4e2dbe9cbb7681b4af9384500e19a6e0c2dedf698'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/KnockKnock_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/KnockKnock.txt',
-          checkpoint: '81ac609807675f5159467d8bb0c6caea39a3196ebd6e05b6a165411044b87cf2'
+          checkpoint: 'bb686927f517b0ccdfb89e46d09dfe3d087203c5d63fc719bb075e41667a3c19'
   name 'KnockKnock'
   homepage 'https://objective-see.com/products/knockknock.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.