### PR TITLE
Update opera to 52.0.2871.30

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '51.0.2830.62'
-  sha256 '224393d23342e6621ae8023b50866436019726130ac52861f161cb501a0215c9'
+  version '52.0.2871.30'
+  sha256 '21f381b37738c11e73d2de90fa981ac429b954e360d3e639806b4e4546fd9dbf'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.