### PR TITLE
Update inpad to 0.1.0

### DIFF
--- a/Casks/inpad.rb
+++ b/Casks/inpad.rb
@@ -2,12 +2,12 @@ cask 'inpad' do
   version '0.1.0'
   sha256 'a66a0be66bc98d31f36232ab9b5ea5a47fdb644e4234673d8ccc26bd637841f1'
 
-  # github.com/ManoCurry/Inpad was verified as official when first introduced to the cask
-  url "https://github.com/ManoCurry/Inpad/releases/download/v#{version}/Inpad-#{version}.dmg"
-  appcast 'https://github.com/ManoCurry/Inpad/releases.atom',
-          checkpoint: '853830cd514b300be9c46ee2afdc1c522d942a86249a16e660b83e9f5836acaf'
+  # github.com/BoostIO/Boost was verified as official when first introduced to the cask
+  url "https://github.com/BoostIO/Boost/releases/download/v#{version}/Inpad-#{version}.dmg"
+  appcast 'https://github.com/BoostIO/Boost/releases.atom',
+          checkpoint: 'cc8f63649c914eb792a14de4666f0671c869aa265de95496470157b19cd09299'
   name 'Inpad'
-  homepage 'https://manocurry.github.io/Inpad/'
+  homepage 'https://sarah-seo.github.io/Inpad/'
 
   app 'Inpad.app'
 end

--- a/Casks/inpad.rb
+++ b/Casks/inpad.rb
@@ -2,12 +2,11 @@ cask 'inpad' do
   version '0.1.0'
   sha256 'a66a0be66bc98d31f36232ab9b5ea5a47fdb644e4234673d8ccc26bd637841f1'
 
-  # github.com/BoostIO/Boost was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/Boost/releases/download/v#{version}/Inpad-#{version}.dmg"
   appcast 'https://github.com/BoostIO/Boost/releases.atom',
           checkpoint: 'cc8f63649c914eb792a14de4666f0671c869aa265de95496470157b19cd09299'
   name 'Inpad'
-  homepage 'https://sarah-seo.github.io/Inpad/'
+  homepage 'https://github.com/BoostIO/Boost'
 
   app 'Inpad.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.