### PR TITLE
Update fluxcenter to 1.2.13.47658

### DIFF
--- a/Casks/fluxcenter.rb
+++ b/Casks/fluxcenter.rb
@@ -1,11 +1,12 @@
 cask 'fluxcenter' do
-  version '1.2.11.47267'
-  sha256 '6a3e9ef041c99ffbf2fa3674bc49769511a3200e27c6522c2a305a8088e6d6e5'
+  version '1.2.13.47658'
+  sha256 'c28ae7d6185e86c22cb3d293d33ba2dd9a696f1221fc254ad47a074e4da28486'
 
-  # files.flux.to was verified as official when first introduced to the cask
-  url "http://files.flux.to/files/Center/MacOS/Flux_FluxCenter_MacOS_Installer_(#{version}).dmg"
+  url "https://fluxhome.com/wp-content/uploads/files/Center/MacOS/Flux_FluxCenter_MacOS_Installer_(#{version}).dmg"
   name 'FluxCenter'
   homepage 'http://www.fluxhome.com/'
+
+  depends_on macos: '>= :lion'
 
   app 'FluxCenter.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.