### PR TITLE
Update mark-text to 0.8.12

### DIFF
--- a/Casks/mark-text.rb
+++ b/Casks/mark-text.rb
@@ -1,11 +1,11 @@
 cask 'mark-text' do
-  version '0.7.17'
-  sha256 '3985a2ad8352c37c4202c9b2d61df92649ed0bf8f4bde15edd6ba9e1213787a7'
+  version '0.8.12'
+  sha256 '332bd8ced0cc31ab33c0f52d8a748930a47a3312f01571e4e61fe1a0ac6f1d56'
 
   # github.com/marktext/marktext was verified as official when first introduced to the cask
   url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext-#{version}.dmg"
   appcast 'https://github.com/marktext/marktext/releases.atom',
-          checkpoint: 'e8945da0456a433193c119a773d86a2424ebbc2f23b76f201c516d51c40e540c'
+          checkpoint: 'e0064ac52d33edc0d44e46092719d0a627ebe109af0f7bc35bed6d54bc3f7a3a'
   name 'Mark Text'
   homepage 'https://marktext.github.io/website/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.