### PR TITLE
Update kodelife to 0.5.3.1

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,10 +1,10 @@
 cask 'kodelife' do
-  version '0.5.2.0'
-  sha256 '2ea60e0da71bec3e6633a3235847221d3ff014ef31a93b846cc9dc143bf63fc6'
+  version '0.5.3.1'
+  sha256 '78c2f741cb21d1c6d69e673f51422dbdcbf96bb591e6b0a546c8a6d288450ef1'
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-osx.zip"
   appcast 'https://hexler.net/pub/kodelife/appcast.hex',
-          checkpoint: '9346742e456ba6e8de55b4aa9abea56fd8b4922a6a9b09b5945801c78c76bcb5'
+          checkpoint: '70f544743019d596b3f9f2a0bd0c2f36edb947029375c5b443350d06bf708902'
   name 'KodeLife'
   homepage 'https://hexler.net/software/kodelife'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.