### PR TITLE
Update linkliar to 2.1.1

### DIFF
--- a/Casks/linkliar.rb
+++ b/Casks/linkliar.rb
@@ -3,13 +3,13 @@ cask 'linkliar' do
     version '1.1.3'
     sha256 '34c9baeaf1d6732c8ce9add689b281f9b71fddadd8f56cca614cba4f8c167962'
   else
-    version '2.1.0'
-    sha256 'ccb5d99a51a549367dde621102dd313f8da8cc46fed6a65d8e7bfdf4fb39c07a'
+    version '2.1.1'
+    sha256 '58cd56b7f53039d7c608bd4a6c5e6fcf2ade63c4a3e99df0510a4838c5ec57b0'
   end
 
   url "https://github.com/halo/LinkLiar/releases/download/#{version}/LinkLiar.app.zip"
   appcast 'https://github.com/halo/LinkLiar/releases.atom',
-          checkpoint: '02149724f71d7ba213a3bec2fd8cd744b86ae3524bb12fd24208d21e8577f941'
+          checkpoint: '193bc90972b6fd49fa43cc5ea5b5caf8bd5d79e2746c52f0c7388837655cf91f'
   name 'LinkLiar'
   homepage 'https://github.com/halo/LinkLiar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.