### PR TITLE
Update listen1 to 1.5.2

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,12 +1,12 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '1.2.2'
-  sha256 '5f420bb15062ef77b0e3d7f57b729957acedff5d66f23945f941c293a324aa1b'
+  version '1.5.2'
+  sha256 '69b1c07a91a0a2e3ff90ecebe54faf021978248cfe016fd821d02fd1ca437f89'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
-  url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/listen1_mac_v#{version.no_dots}.dmg"
+  url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"
   appcast 'https://github.com/listen1/listen1_desktop/releases.atom',
-          checkpoint: '897bf2723ca2742603b8aa0b734fcd55acd886e37a7be7e85a1a57237f9fae94'
+          checkpoint: '75c58a7854e9bbd5a371a34b8793a5c7ead5ee83cc5efdebad3e8006074b723a'
   name 'Listen 1'
   homepage 'https://listen1.github.io/listen1/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.