### PR TITLE
Update sbrowserq to 3.4

### DIFF
--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -1,11 +1,10 @@
 cask 'sbrowserq' do
-  version '3.3'
-  sha256 '45ea3b8887f84ae1e4cb3206ad2f7d466b34bdc292a16dc26df298a8c8066b86'
+  version '3.4'
+  sha256 '06e126cfcc80e2442260c291508b82d6a2d722246f51e7b795b15534ec4b7f93'
 
-  url "http://park.geocities.jp/sbrowser_q/SbrowserQ_V#{version}_mac.zip"
+  url "http://park.geocities.jp/sbrowser_q/SbrowserQ_V#{version}_mac.dmg"
   name 'SbrowserQ'
   homepage 'http://park.geocities.jp/sbrowser_q/'
 
-  app "SbrowserQ_V#{version}_mac/SbrowserQ.app"
-  app "SbrowserQ_V#{version}_mac/SbrowserQ_Bundle_Java8.app"
+  app 'SbrowserQ.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.