### PR TITLE
Add pgmanage v10.1.1

### DIFF
--- a/Casks/pgmanage.rb
+++ b/Casks/pgmanage.rb
@@ -1,0 +1,11 @@
+cask 'pgmanage' do
+  version '10.1.1'
+  sha256 'f8607023373e4cea55c6d1a889e92942bcdb6b386dba087f86d5aa5e376ce06a'
+
+  # github.com/pgManage/pgManage was verified as official when first introduced to the cask
+  url "https://github.com/pgManage/pgManage/releases/download/v#{version}/pgManage-#{version}.dmg"
+  name 'pgManage'
+  homepage 'https://www.workflowproducts.com/services.html#software'
+
+  app 'pgManage.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

This is the renamed version of the cask `postage`. I wasn't able to test the success of installation/uninstallation because every time I ran `brew cask install pgmanage`, I automatically checked out of my `pgmanage` branch into the `master` branch, then was told that the cask `pgmanage` doesn't exist. I'm not sure if that is intended behaviour, or if it's just something wrong with my system.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
