### PR TITLE
Update tinymediamanager to 2.9.8_6644bb9

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -1,10 +1,10 @@
 cask 'tinymediamanager' do
-  version '2.9.7_8513bee'
-  sha256 '5efc8c2ac5ea52f515c6a9bc3bb168190d337e79f85e1d7e2c2559dd4f11f766'
+  version '2.9.8_6644bb9'
+  sha256 '02687a49ae252c30a96e467b4286d1783c23377662e9504fef7f6bee1dbb64cc'
 
   url "https://release.tinymediamanager.org/dist/tmm_#{version}_mac.zip"
   appcast 'https://release.tinymediamanager.org/',
-          checkpoint: '2f3d4f22d255adbad6220670675b4c8390cab776edbd80d9281f83bccabb6cbb'
+          checkpoint: 'daaa35bd818ca2d7412abca29079af4ffde5bdb833ae87f843c6136ada4c4239'
   name 'tinyMediaManager'
   homepage 'https://www.tinymediamanager.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.