### PR TITLE
Update macvim to 8.0.146

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,10 +1,10 @@
 cask 'macvim' do
-  version '8.0.145'
-  sha256 '4182cbf0cd6158f4515d3a7af96140d6069e01542e9250410cbeb66452779460'
+  version '8.0.146'
+  sha256 'd25327c789db35ff24e3702ddfcc1e101c0383043f08b100a818d3422a2e31bc'
 
   url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.patch}/MacVim.dmg"
   appcast 'https://github.com/macvim-dev/macvim/releases.atom',
-          checkpoint: 'a2011f44bc946d193b9195a1ba8a030bd53c08f9cfdcb44a1f7eb297023183b5'
+          checkpoint: 'e39fbfb481c7cf28b2e03563e0dffb64e0d82007fc8ada2dab83c75eba75a07e'
   name 'MacVim'
   homepage 'https://github.com/macvim-dev/macvim'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.