### PR TITLE
Update obs to 21.1.1

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -1,11 +1,11 @@
 cask 'obs' do
-  version '21.0.3'
-  sha256 '16c4f71a965b7f3d0dc04a58a64c49192aad455ce8fc971b0d253babfdefbafc'
+  version '21.1.1'
+  sha256 '52a422a6cc42c62911c2a8d2d3b569c8ac725d5fcd13ab1f7bcaa23863ef9926'
 
   # github.com/jp9000/obs-studio was verified as official when first introduced to the cask
   url "https://github.com/jp9000/obs-studio/releases/download/#{version}/obs-mac-#{version}-installer.pkg"
   appcast 'https://github.com/jp9000/obs-studio/releases.atom',
-          checkpoint: '11a5b29ea1a3e7ce3f03dbadb0ccfbcb3a29ee8359226f15dc96b2bf303e94d7'
+          checkpoint: 'f31aeaf114bdad2ebf5e27ff816243dc919f4f794e9c408e4fd24b167433bb71'
   name 'OBS'
   homepage 'https://obsproject.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.