### PR TITLE
Update teamdrive to 4.5.5.1833

### DIFF
--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -1,6 +1,6 @@
 cask 'teamdrive' do
-  version '4.3.2.1681'
-  sha256 '1948a032861d3efd615ec3af3dd2099dc95380a872fa75d92a6b5f3ea93077c5'
+  version '4.5.5.1833'
+  sha256 '908ac820af13010111057b8e3a8d6811307296ecc09b9c90becb50e8a71feecf'
 
   # s3download.teamdrive.net.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.