### PR TITLE
Update milkytracker to 1.02.00

### DIFF
--- a/Casks/milkytracker.rb
+++ b/Casks/milkytracker.rb
@@ -1,11 +1,11 @@
 cask 'milkytracker' do
-  version '1.01.00'
-  sha256 'bfaa71fddd41aa0b9220eca3b0de6953061aa60b730dbea80a79a4c42ca33e9b'
+  version '1.02.00'
+  sha256 'b526497dc957454a4150e77b1f2f835ce564122e56f49bbe7b494dc984be076d'
 
   # github.com/milkytracker/MilkyTracker was verified as official when first introduced to the cask
   url "https://github.com/milkytracker/MilkyTracker/releases/download/v#{version}/milkytracker-#{version}.dmg"
   appcast 'https://github.com/milkytracker/MilkyTracker/releases.atom',
-          checkpoint: '8505703fe680236448c273062676dc530af227958f3fb00c7803c4953b76ca84'
+          checkpoint: 'e2b2d0a0d1f755e77a3ff467cb5e91b1bdc69a5851ed31d1dbde341684fd9568'
   name 'MilkyTracker'
   homepage 'http://milkytracker.titandemo.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.