### PR TITLE
Update go-server to 18.2.0-6228

### DIFF
--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,11 +1,11 @@
 cask 'go-server' do
-  version '18.1.0-5937'
-  sha256 '1ab51326ae3109e90375a55ae27be21e7f8652c6d777ab9abe18ed86350da445'
+  version '18.2.0-6228'
+  sha256 'bff9894962ba6e2cba29d89406998e1ab26f5f90648f4fb8d7f5e20b3cfa734f'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: '379c3238931056d4232f6422ef965db0a870b6aad8b2ccee09df16f584bb7155'
+          checkpoint: '85c4b79e99a44ff61809c6a72d2953d2654c02140e04200a5d1bda2a3e235f81'
   name 'Go Server'
   homepage 'https://www.gocd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.