### PR TITLE
Update crunch.rb v1.0.0 to include new dependencies

### DIFF
--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -7,6 +7,8 @@ cask 'crunch' do
           checkpoint: '32a4d6304199eec025b2bbcecc1984e51558816e14cc0efbeac37c796bf5f0e4'
   name 'Crunch'
   homepage 'https://github.com/chrissimpkins/Crunch'
+  
+  depends_on formula: [ 'libpng', 'little-cms2' ]
 
   app 'Crunch.app'
 end

--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -7,8 +7,11 @@ cask 'crunch' do
           checkpoint: '163804ec141e7f909a6707cf74f3bd0b0a07944e5c4e18fd4fecde781dfad0b0'
   name 'Crunch'
   homepage 'https://github.com/chrissimpkins/Crunch'
-  
-  depends_on formula: [ 'libpng', 'little-cms2' ]
+
+  depends_on formula: [
+                        'libpng',
+                        'little-cms2',
+                      ]
 
   app 'Crunch.app'
 end

--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -4,7 +4,7 @@ cask 'crunch' do
 
   url "https://github.com/chrissimpkins/Crunch/releases/download/v#{version}/Crunch-Installer.dmg"
   appcast 'https://github.com/chrissimpkins/Crunch/releases.atom',
-          checkpoint: '32a4d6304199eec025b2bbcecc1984e51558816e14cc0efbeac37c796bf5f0e4'
+          checkpoint: '163804ec141e7f909a6707cf74f3bd0b0a07944e5c4e18fd4fecde781dfad0b0'
   name 'Crunch'
   homepage 'https://github.com/chrissimpkins/Crunch'
   


### PR DESCRIPTION
Addresses issues reported on repository in https://github.com/chrissimpkins/Crunch/issues/7.  Application requires two new library dependencies as homebrew formulae.  They are added in this pull request using the `depends_on formula` idiom.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
 
Updated to appcast checkpoint reported through the command: 

```
$ brew cask _appcast_checkpoint --calculate crunch
```

- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
