### PR TITLE
Update docker to 18.03.0-ce-mac59,23608

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '17.12.0-ce-mac55,23011'
-  sha256 'd943b47f5cd250dd1f9cf5c4f4252be1f7975bca4dce855592944353ceaed073'
+  version '18.03.0-ce-mac59,23608'
+  sha256 'ae3e1f43cbeb2479a5173cc8d0a164c3828fd0983583f5cf02ebbed2c16a9ab7'
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: '9dcd36f6ac85ea84f656e647f9093a7ffdd4b8f5cff48a36cb5b43021cce7586'
+          checkpoint: 'ba26b0a092146b582546657dc6e9c85165b2352cf600f4a79ffade443f21e2fb'
   name 'Docker Community Edition'
   name 'Docker CE'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.