### PR TITLE
Update station to 1.9.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.8.2'
-  sha256 'f1a951940c83d9abd9a0aec1461a2536e66702bd6b9187f1caa44d8fcbc31f9a'
+  version '1.9.0'
+  sha256 '22bbc2d15d8b3b6c97f89cc278921c295e5c61a3b9cc03b479139a8c843d44e7'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '24cc00f2627bf8cbaff2874b6686ae07868e13332dc51a2f139c842a4268cceb'
+          checkpoint: 'b072464fc1ef2311567c49ddb8cdbec6396fc39ae0b2eb434cbc6f0b22ce51a8'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.