### PR TITLE
Update tableflip to 1.1.7

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,11 +1,11 @@
 cask 'tableflip' do
-  version '1.1.6'
-  sha256 '6a2f67176bc545834c35eb247494373b14031c361189cd170933ea0a5ba6ca48'
+  version '1.1.7'
+  sha256 'b57c5b41ea34d7c570136efd53bedc0cba4412bf8bf6f4343ccdc4d9259c1018'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"
   appcast "https://update.christiantietze.de/tableflip/v#{version.major}/release.xml",
-          checkpoint: 'e881fb683ddad4ca7408759a2a59db55c08f775785d157e4ad6dde403d8d4a6c'
+          checkpoint: '21f265db64c8a82f461240c5b51769b31945b9f623b8860a78cd6481278a0900'
   name 'TableFlip'
   homepage 'https://tableflipapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.