### PR TITLE
Update WebStorm to 2018.1,181.4203.535

### DIFF
--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -1,10 +1,10 @@
 cask 'webstorm' do
-  version '2017.3.5,173.4674.32'
-  sha256 '83ae6eb85696dbb64fcc0c1c77a12c6a040d6db71dedf34ef469b5404f870f99'
+  version '2018.1,181.4203.535'
+  sha256 '0db07163e893ba1493453c31646783d765863322a050555298870dd78bae387f'
 
   url "https://download.jetbrains.com/webstorm/WebStorm-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=WS&latest=true&type=release',
-          checkpoint: '70d369dc1fa3b04856ba4ec3c86ac3db6313d3f86dd582d566570c6a46b69a4a'
+          checkpoint: '3b71d79fe384abcc72552eff5a7617562eafc7193a92f37d70656c2a83542c73'
   name 'WebStorm'
   homepage 'https://www.jetbrains.com/webstorm/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.