### PR TITLE
Update dotnet-sdk to 2.1.103

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk' do
-  version '2.1.102'
-  sha256 '73cec981bffae416b8c985031abfbcefc408ad750eda84ddeabfffabcf709d3b'
+  version '2.1.103'
+  sha256 '6781eb5a7e45b1ad7fc6f2836db0b0fb7eeaf758d0cdc8af54db19eb25e2443f'
 
-  url "https://download.microsoft.com/download/1/2/E/12E2BC14-7A9F-4497-A351-02B7C2DDD599/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-#{version}-osx-x64.pkg"
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'
 


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
