### PR TITLE
Update tex-live-utility to 1.32

### DIFF
--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -3,8 +3,8 @@ cask 'tex-live-utility' do
   sha256 '6e587b646ba1f6b74ceb42eaeaf03f21ac92457f263c098155b942bf171f6073'
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
-  appcast 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml',
-          checkpoint: '80246f0d1b0ffccd1b025d77f4331df40e31fd6698a03d5d9cade7d892ea346e'
+  appcast 'https://github.com/amaxwell/tlutility/releases.atom',
+          checkpoint: '982731a785be11020da9aee3d2814e08061a599d197cc394f2047f36deb23095'
   name 'TeX Live Utility'
   homepage 'https://github.com/amaxwell/tlutility'
 

--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -1,10 +1,10 @@
 cask 'tex-live-utility' do
-  version '1.30'
-  sha256 '212ab760f9fe5262a919200b408a91592228f71fd3b41dc0087b17dd16ceae29'
+  version '1.32'
+  sha256 '6e587b646ba1f6b74ceb42eaeaf03f21ac92457f263c098155b942bf171f6073'
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
   appcast 'https://raw.githubusercontent.com/amaxwell/tlutility/master/appcast/tlu_appcast.xml',
-          checkpoint: 'f72413da7375733f1b78981163da5aa7dc0b69d151d80ab649d1af29775fa242'
+          checkpoint: '80246f0d1b0ffccd1b025d77f4331df40e31fd6698a03d5d9cade7d892ea346e'
   name 'TeX Live Utility'
   homepage 'https://github.com/amaxwell/tlutility'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.