### PR TITLE
Update bibdesk to 1.6.14

### DIFF
--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -1,11 +1,11 @@
 cask 'bibdesk' do
-  version '1.6.13'
-  sha256 'b544c04589410f10dc0f0e536b477b4a71cd8191dba3dd5a39a1b97e29c36246'
+  version '1.6.14'
+  sha256 'c66b062a63cb1c6dd9f3f3f52241a98052fb4822e79247eecb7b61faa4ea7067'
 
   # downloads.sourceforge.net/bibdesk was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bibdesk/BibDesk/BibDesk-#{version}/BibDesk-#{version}.dmg"
   appcast 'https://bibdesk.sourceforge.io/bibdesk.xml',
-          checkpoint: 'cad07e8830709b79092fe69c3488bfa842a5ba17c63dc08e4492d3cf4066e01b'
+          checkpoint: 'abcb339618af9c3bbf3a9250d824c9d99be8ed543f5a657e7091e3aacd5fd080'
   name 'BibDesk'
   homepage 'https://bibdesk.sourceforge.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.