### PR TITLE
Update the-unarchiver to 3.11.5,118:1522141689

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,11 +1,11 @@
 cask 'the-unarchiver' do
-  version '3.11.4,116:1520347991'
-  sha256 '0b65ed1af57766c9ce4db9207390f31ffc3a2c1c274616ac20749739661e4929'
+  version '3.11.5,118:1522141689'
+  sha256 '3829e2ce028f767b7cd342214594a1cbb6350144ad09cc88a638a1632348112b'
 
   # devmate.com/cx.c3.theunarchiver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/cx.c3.theunarchiver/#{version.after_comma.before_colon}/#{version.after_colon}/TheUnarchiver-#{version.after_comma.before_colon}.zip"
   appcast 'https://updates.devmate.com/cx.c3.theunarchiver.xml',
-          checkpoint: 'f0af10046b5de56a0de92d6be04aca3dea66afabab0b06dc58914d85828bc326'
+          checkpoint: 'ec3bf702256de4ef8d1b301927794f46a97695d09b1d7a6a9f994d25f9d15ff0'
   name 'The Unarchiver'
   homepage 'https://theunarchiver.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.