### PR TITLE
Update mos to 2.0.0

### DIFF
--- a/Casks/mos.rb
+++ b/Casks/mos.rb
@@ -1,11 +1,11 @@
 cask 'mos' do
-  version '1.7.0'
-  sha256 '84002cd43e682adf6c04643260b64ebd44d0e2af50117541a6ae7c7b89cf7391'
+  version '2.0.0'
+  sha256 '04d3dda5f598994354d2c2c09191cc5cffad4a066a2dac4e546782f58c053361'
 
   # github.com/Caldis/Mos was verified as official when first introduced to the cask
   url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Version.#{version}.dmg"
   appcast 'https://github.com/Caldis/Mos/releases.atom',
-          checkpoint: '0824522cc30c9cd5e3923392828d7039c35d03bab5cd7d78335b8b0b32cd1d27'
+          checkpoint: 'be74629b2b97a2e4f13e502c8609777a211ad2f42b502df8a193e1541b7921ce'
   name 'Mos'
   homepage 'http://mos.u2sk.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.