### PR TITLE
Update cacher to 1.3.10

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.9'
-  sha256 'f9419d9419ada2451ad46e09ed598b48059e79420f23dbcf4435a6f9459f7a15'
+  version '1.3.10'
+  sha256 '83ab6c0b2cf8d5c53012873c7996e99a537dd591be923446fef8f26b5ee3a676'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '3b8b9779cea270fd6115358b768a4d574f1a0ae96e84206ed6fe86c60ffdc88a'
+          checkpoint: '63df46e31a77af9aefb646455984b5cfc1a12173d77906fbd3ae33f022a9680f'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.