### PR TITLE
Update quip to 5.2.53

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.2.39'
-  sha256 '561a2bcec79436ee5223f4c6cfac7ec929a7ae9889d2b6d5703974aa9a166961'
+  version '5.2.53'
+  sha256 '7c632e9a20639eca5c7c10092726ecfef372235a8c7ccef4ac148808b053d43f'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.