### PR TITLE
Update zotero to 5.0.40

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.38'
-  sha256 'dc6629182015822ace8170c21498e9aa0a420386f39f05cb01c16ea9420eeb09'
+  version '5.0.40'
+  sha256 '9a41227e529cb8186df95d30bcfb6998c070ce2834e9a7f44aa15f540219e2ec'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '02fbad90c178d6f4a212b0c18d094db6911701e30f863beadb31d3e3be55c103'
+          checkpoint: '39afdac688d4bead9238a2a95a8121837b53850183594983e4d59026e5debb9d'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.