### PR TITLE
Update darktable to 2.4.2

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,11 +1,11 @@
 cask 'darktable' do
-  version '2.4.1'
-  sha256 '75077f17332a6fda144125ab0f1d3dd219c214bf7602b0b252208f1ec665d031'
+  version '2.4.2'
+  sha256 '2b0b456f6efbc05550e729a388c55e195eecc827b0b691cd42d997b026f0867c'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.before_comma}/darktable-#{version.before_comma}.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: '45ecafcfd9d2cacf2515fe69ba28e469085e2c6c9d536add38e45dae9dfeeaf1'
+          checkpoint: '69ab2ed06877928ab72c5b942d8a0b806460e34f828875c220455153dd637fdf'
   name 'darktable'
   homepage 'https://www.darktable.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
