### PR TITLE
Update exodus to 1.47.2

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.47.1'
-  sha256 '5a3903c8e3c72d2931c12dded22403caf6fffbfcad92d36eceae4a1e88992235'
+  version '1.47.2'
+  sha256 'bfdaf57e53c13c58cf324b0b5314d426ff10bbd89cae9e4fce04f29b84964dcf'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '608262dfeca90cfd38244cdec7b890a0a59a306483a00e0a27103f83672d7cc9'
+          checkpoint: '3659c6095faa1d9f23ca4ff208e3b9fa48f8776500ad759f4b39698715a6f81e'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.