### PR TITLE
Update mal-updater to 2.4.2

### DIFF
--- a/Casks/mal-updater.rb
+++ b/Casks/mal-updater.rb
@@ -1,11 +1,11 @@
 cask 'mal-updater' do
-  version '2.4.1'
-  sha256 '4932ed81fb99098658fc8a988efa239157e214321bc652d16105bdbf17bc37e3'
+  version '2.4.2'
+  sha256 '45b98d6a7265e2156ae670843a8114d1866673a3295ba1bea55bcc78daeba564'
 
   # github.com/Atelier-Shiori/malupdaterosx-cocoa was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases/download/#{version}/malupdaterosx-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases.atom',
-          checkpoint: 'fb26cb1ea0de9841e1c6839bd395d3b419f57582134c8cc261e0c54a7fde3e87'
+          checkpoint: '529dd672ee82a7786fcb3536283271b2f19728e168896a77f70cdb16f7b3e330'
   name 'MAL Updater OS X'
   homepage 'https://malupdaterosx.ateliershiori.moe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.