### PR TITLE
Update frostwire to 6.6.4

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.6.3'
-  sha256 '861150255cdc042bcb953bc73f2b1307a92981f3b9fbf747c23186659592ab12'
+  version '6.6.4'
+  sha256 'afcbb87b0f9aae14a95e0ce020bf60f8dd4c5ac8d3a73690350717629b4ddb9e'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: 'd301b9e4067329d507c7a1ca6d9f2d3964b3dacdd2054f79a2919246385f8705'
+          checkpoint: 'e4bcd06a3a615aa792595bd76ce1f50813f4389316df20cbf84687518b0a670f'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.