### PR TITLE
Update firefox to 59.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,125 +1,125 @@
 cask 'firefox' do
-  version '59.0.1'
+  version '59.0.2'
 
   language 'cs' do
-    sha256 'b18c092cde8ff115e20a368333d8cc22680c7b9561ff7d5982ae4bf0998cff4e'
+    sha256 '9bfc475796f0a7ce9c67e0d45ab02ce35d2bad1e42742c7d3df7e84b840d3d9e'
     'cs'
   end
 
   language 'de' do
-    sha256 '41556eb6e7b38ff0621cf38e46f0b6c06b02bfb7c5fd0c315f4d83a0e2a45de3'
+    sha256 '5c12e914c954efc5829c5925b31cd7e5efaac93186defea65e940386a4013e20'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '48579c6ffb2b4a0edc0123236af042f1aa68db2d8c36acfb1eda5316b40a4f22'
+    sha256 '642a87311a0f264a165c41a3599c681e7272c2dc43a3c1f71ea632223f9a5ad5'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'c833d8e65490a7cf87e8a66ad037b8590c036aebc39e1b01757d9b9d830d3402'
+    sha256 'de65a85080f8a9423aba4c1ae498687568ef948cf97dcc6dd666c6ee67480a0a'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 'aecf59db94efdfc45cd673b6b364a1f3019564178fcd24fc68ef10b07b4a5129'
+    sha256 'b2ffac92822345c22cf4a836a7515ed777ac45b40610088537b479abfa6b5da0'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 'a9b0daea6f00e12f354c4c09f53fe8126d44113886768249e0ae12f9fc37d6ce'
+    sha256 'b404cca27308da6a68c55cbe5717275ddec533773ca0ccfab055382d4f6344ef'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'aea072b2f030a57da145cb531f91f8b7541c472945ce946efefbddbcea5eef22'
+    sha256 'ead883c653103e05dcce0f45e214a1d577d192f2389cc331bf57939a9822abea'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 'aecae47596db3e8fe63362bf91342a215d4f91dcaf355cc11212ac6af146ac89'
+    sha256 '6615ff79b3df5f272ad9cb86ebec9513cbba039113469638c83adb5a79513d13'
     'fi'
   end
 
   language 'fr' do
-    sha256 'd2f29dcec15047911fdabe309088cac2fcb11b92c03582188ef111b8f0fbd6ca'
+    sha256 'a77916f283eb8dbb1bb262f3487776b90e4216605ad6fac3c23b18c4a91e9044'
     'fr'
   end
 
   language 'gl' do
-    sha256 'f900a1c010836b58d0b976849b73997de668be5cfb4b5a806c39d8547779f29a'
+    sha256 '6851d4bda928b1de1d30c8bb2b43abec15e355e1d9e4dccdee8d6e351abd5f82'
     'gl'
   end
 
   language 'in' do
-    sha256 '7468d76eca141cfefae364d3866ecfb16f4898fae77bb0e21bc16d66d0df03ac'
+    sha256 'd73e674203c2878477e2a32bed417d31c74d83b68bd65c4d0739925986ff294b'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 'd5dda2df2af0d5583fd06669885b73249cf48af1c9f702dc0a482b3ceed1f08a'
+    sha256 'cbb861febf46d577c69db78e89b0d99ae3b52c9e2e367f24a8f6bc4bef80083f'
     'it'
   end
 
   language 'ja' do
-    sha256 '25d63b70e3ace9a242399d51422afc60ca4dd557757ef098b413525106eef19d'
+    sha256 '1bc270c28297c510cd42da26d8908516ef78a41e8472eb37623554b81bbf27db'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '5f4119c8b821c714e38747b080153a33e6c198b04da9d437eb3abc462adfb4e7'
+    sha256 'dcd6aec3ee37741593cec63bf70aa058517ce4ed22293afb355114b308d7c6e3'
     'ko'
   end
 
   language 'nl' do
-    sha256 '946715dd76338786470d1aae92d56677d69266e96a1bd41023b5faf4c024cfff'
+    sha256 'd53356481bc5db1f541cb26872984dd68348f81c3aa19d185b1aaeba8459a6a3'
     'nl'
   end
 
   language 'pl' do
-    sha256 '9452ce084f8f71bfdc31f26d719946f3292ed07177b162ab9098c4b41fdf7944'
+    sha256 'd05c2474e49e0951bda965d721870d2b4030a636a5ba819d9ba7ef2f35e2b1f3'
     'pl'
   end
 
   language 'pt' do
-    sha256 'bf6c6d6f67024e2aac838edfc58deb472d5167ef068ec913a1c44c60fa1083ff'
+    sha256 '8aa511e5587fbc2b065d5e4763eac310a9f6164241120e96021cf64a0efc0eff'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '8873740ae5cab19825cda4495b1f2db37f9dd4d0db891dd89b114e264e960d52'
+    sha256 'c2ed1a853cf5200ff7ba63f0ba467f346c137d02ab14071be8dafcf4bd3af7f0'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '3e99d5781142c58edde5000e3c1e700b3dc00d16bf7eb713164a5454ea138b9e'
+    sha256 '420b845283a3a0059d540d41903807609c369aee8988361c60b50ce26414534d'
     'ru'
   end
 
   language 'tr' do
-    sha256 'b6718f0cb9ae88d99dcb0145123c8f270ea2694c19a941047c340c4826d5c387'
+    sha256 '0e60069e8e99d3c83da2c33bb8dcab42694c73bd87658baa348abdbbfc3e53ef'
     'tr'
   end
 
   language 'uk' do
-    sha256 '27e5d07a30c791d49ee04fc39ce32879febcaca6e004f9b892c5a9c0596f5ec7'
+    sha256 '558b51c5c9d8dc4a87760e852f75327a5fbdb6aaaf36347ee5572b5667600424'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'b8a929b74127d92acbf7a97327d1f3e07b8aa666e928341559a316b7ee778f1b'
+    sha256 '67484ec4860c9750fa3e2666980250c98f87e072bbe36cdb674b3c9913a08c4f'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'ff106dbdb25a10d7860ca77bd5289855ccd569e5a620b956f3fd43db112134f0'
+    sha256 '59dc5e0137cf50f994c8a5fb5e929a50493305e1e3429f6e1a8ea87d04bda77c'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/firefox/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '274a55a33ede0574afd2183d3873ee8476e6d37f6349e3949285065725afe7c0'
+          checkpoint: '88cdfa96ff4ee8de0423d48e434efa92a167fc1b53f88506a080362fdf4537eb'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
