### PR TITLE
Update milanote to 1.0.28

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.0.27'
-  sha256 'fef6dbd4894c82993c2cabf468b665e88b621a991b5e2e34f05a4b833d267ccf'
+  version '1.0.28'
+  sha256 '5e39964eb7425d8ec8de7b5c77d8683b8ebadfbcdfad291d890b8d46bca7c0f3'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.