### PR TITLE
Update zotero to 5.0.41

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.40'
-  sha256 '9a41227e529cb8186df95d30bcfb6998c070ce2834e9a7f44aa15f540219e2ec'
+  version '5.0.41'
+  sha256 '2119f127d10374862f834dc29abf7c4eee9918993e5cabcdfca66294d0dcdfaa'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '39afdac688d4bead9238a2a95a8121837b53850183594983e4d59026e5debb9d'
+          checkpoint: 'e3e5d149956d4b5ec73cd0655b02e4167860d2ebe6f040bc77582482ef711deb'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.