### PR TITLE
Update ticktick to 2.2.00,57

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.1.00,56'
-  sha256 'd9bed721e65d1d8b6c309b5e16197c84cfea9ffbd74178334adf61a541bd6cad'
+  version '2.2.00,57'
+  sha256 'fd00f83560bece399c804d5dfa194fecee49db3629d4b713cbb7c9f2d3e64de5'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.