### PR TITLE
Update appcode to 2018.1,181.4203.561

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -1,10 +1,10 @@
 cask 'appcode' do
-  version '2017.3.3,173.4674.5'
-  sha256 '32a8181127f2c0d359f42881c9275554f509e87eb0d4bbf912ef083358df543b'
+  version '2018.1,181.4203.561'
+  sha256 '40c5b1065cc70c2b29f426683e8de133e7572589ba50a002fadfeed701cf9ecc'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=AC&latest=true&type=release',
-          checkpoint: '63cbe43505df0ea931c306f52c49c7bd0040c3f6c68d3ef53a88b2d0fa6f1288'
+          checkpoint: '473b365fa1fa9a5e407cb6059f8444c10fea21dd62061f0974336ff3a16d0dfe'
   name 'AppCode'
   homepage 'https://www.jetbrains.com/objc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.