### PR TITLE
Update pycharm-ce to 2018.1,181.4203.547

### DIFF
--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -1,10 +1,10 @@
 cask 'pycharm-ce' do
-  version '2017.3.4,173.4674.37'
-  sha256 '7f28b4f75600671c0d0f8d9153be0f5fbf64fb9616812e34569e06a30ebcbd55'
+  version '2018.1,181.4203.547'
+  sha256 '86a583fca38c70e092ea3c009231cd07d8cd9e6623589cf17d925fe2c2ce1ca7'
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release',
-          checkpoint: '2c73cff82d88d4ade97eb7c48cddf56bc5f76a1c23246206dac4e640ee5e52e8'
+          checkpoint: 'ac3e18ab4d7dfdaf35104c35edbde86385b42872ca6e9c657af8d8bab6199fe5'
   name 'Jetbrains PyCharm Community Edition'
   name 'PyCharm CE'
   homepage 'https://www.jetbrains.com/pycharm/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.