### PR TITLE
Update dockstation to 1.4.1

### DIFF
--- a/Casks/dockstation.rb
+++ b/Casks/dockstation.rb
@@ -1,11 +1,11 @@
 cask 'dockstation' do
-  version '1.3.0'
-  sha256 'cc22247295e0714a888b8d5dae1cc53c1f95cfcf8345c35a8c7c05b12afd0b5b'
+  version '1.4.1'
+  sha256 'e95606d7d780acb0b663c168348ddd1eeaf2810ea3d4a6639f81bc63bfe68606'
 
   # github.com/DockStation/dockstation was verified as official when first introduced to the cask
   url "https://github.com/DockStation/dockstation/releases/download/v#{version}/dockstation-#{version}.dmg"
   appcast 'https://github.com/DockStation/dockstation/releases.atom',
-          checkpoint: '78a34cbf5e41f237e83c3ac7edb7d5f17819bb12b2f118c5f9dd4ecede62587c'
+          checkpoint: '044b265074f1ea1639186a1c316d3a341c4cb9c1a0946ece115d8aeab0437226'
   name 'DockStation'
   homepage 'https://dockstation.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.