### PR TITLE
Update knockknock to 1.9.3

### DIFF
--- a/Casks/knockknock.rb
+++ b/Casks/knockknock.rb
@@ -1,11 +1,11 @@
 cask 'knockknock' do
   version '1.9.3'
-  sha256 '8f45d5dc56e39e3eea5aed1fc0798728971cfb918e75c02864c3ba43758c5be9'
+  sha256 '37f59fbeaa7e80fe92bd1a25bd6342d7b3f78778a248c307336e24cfebd3dbf8'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/KnockKnock_#{version}.zip"
   appcast 'https://objective-see.com/products/changelogs/KnockKnock.txt',
-          checkpoint: 'f5d04e72277c4e36f225e3365cf28d711ddf0ad0c28cef0a23717487e6ee4bd3'
+          checkpoint: '2df38711440d62d4504ad9007a20452ee4448227e011230a3d2934a764f06f02'
   name 'KnockKnock'
   homepage 'https://objective-see.com/products/knockknock.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #45332.