### PR TITLE
Update netron to 1.7.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.6.9'
-  sha256 'efa00a7e93b32fe31ced91e9a7bd87b433f0340e87f400c7866524f0dd59b027'
+  version '1.7.0'
+  sha256 '0b2f1c5859245c3c1b1013fb84a39130281fc17df91f1a36d673a992205746c9'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '8774f8ede98f2b1b0038310ca85ab4ccee22269bc3ca1bfade5c1c5822fa2ad0'
+          checkpoint: '0f5ac5805172b3c54e8dff091f1ab37c55a3de39adc66f444fb511f8f5fc100a'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.