### PR TITLE
Update canary to 2.03,411

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,11 +1,11 @@
 cask 'canary' do
-  version '1.8.1,396'
-  sha256 'c1950673c9975584dfa478867d1299c5ff78e3d296e97326d2674d88b593f460'
+  version '2.03,411'
+  sha256 'ef23fc92d412863a626d4f11bd0df2e67c5dc67a6884075fab5a9ac807d08df7'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050',
-          checkpoint: 'ab95777dfa75cacf26d1bce7d4f8290ee16e2cdee2a618cb44d8157c72cb60bb'
+          checkpoint: 'bd2342430e327ef03e185e0c7d67f8503f3e486b34b8a9e13ffa5d6d1e7d30ff'
   name 'Canary'
   homepage 'https://canarymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.