### PR TITLE
Update mattermost to 4.0.1

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,10 +1,10 @@
 cask 'mattermost' do
-  version '4.0.0'
-  sha256 '94a21bfe4932ef7f55c1386e16a98de079653297129bbabcf6092b780e68ddd2'
+  version '4.0.1'
+  sha256 'c09ccf29aeb56eda53ca037dfde2233d0969c337ccf8f7b0077993e1fc2786d2'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-osx.tar.gz"
   appcast 'https://github.com/mattermost/desktop/releases.atom',
-          checkpoint: '9caa98f39e36318ebdb2ce47e1de2e254adc61cac78644d5ddfe9ca4ef3c7dfe'
+          checkpoint: '7c94663f026357847dba6d50e76d68cd4f5dc55f9810e1a4c61548ceab241dea'
   name 'Mattermost'
   homepage 'https://about.mattermost.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.