### PR TITLE
Update prepros to 6.2.2

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,11 +1,11 @@
 cask 'prepros' do
-  version '6.2.1'
-  sha256 '3c0ae453abcb2a729c11b8cfb0d0923d28d0e7ccafcd76e3d4a74b684d69233a'
+  version '6.2.2'
+  sha256 '103322a9bc12d4b3b274bde9fa1fb91b67fcc00b7b36ba3225dd515e93a36f03'
 
   # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog',
-          checkpoint: '18a3f3017f3d828f0495af07c8bf8d787842882defea9f67c933c156e72e9d1b'
+          checkpoint: '2d0b72d112ea81cce8a2293e6c487886e227da150b9531f54bd24259263a89af'
   name 'Prepros'
   homepage 'https://prepros.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.