### PR TITLE
Update qingg to 2.6.0

### DIFF
--- a/Casks/qingg.rb
+++ b/Casks/qingg.rb
@@ -1,10 +1,10 @@
 cask 'qingg' do
-  version '2.5.0'
-  sha256 '98f3eb1a56a38dd230aac44e571001859558e28feb9e756078998bf4b9a2cd7a'
+  version '2.6.0'
+  sha256 '4cb0f6399c4f59bcfd2ecb557702adce6a7d9ccf718019827ec54630a1d80ea9'
 
   url "https://qingg.im/download/Qingg-#{version}.dmg"
   appcast 'https://qingg.im/sparkle/appcast.php',
-          checkpoint: '751eb771d487c59dd6fafab1fd910807813f70d198c869081bcbb8d6f28066be'
+          checkpoint: '447bd53ca90a8a5d919c765f8a01f9d09c0c47d3ef10af5eab8b39e3ce9b724a'
   name 'QinggIM'
   name '清歌输入法'
   homepage 'https://qingg.im/mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.