### PR TITLE
Update omniplan to 3.9.2

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -9,9 +9,9 @@ cask 'omniplan' do
   app 'OmniPlan.app'
 
   zap trash: [
-               '~/Library/Application Scripts/com.omnigroup.OmniPlan3',
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.omnigroup.omniplan3.sfl*',
-               '~/Library/Containers/com.omnigroup.OmniPlan3',
-               '~/Library/Preferences/com.omnigroup.OmniPlan3.plist',
+               "~/Library/Application Scripts/com.omnigroup.OmniPlan#{version.major}",
+               "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.omnigroup.omniplan#{version.major}.sfl*",
+               "~/Library/Containers/com.omnigroup.OmniPlan#{version.major}",
+               "~/Library/Preferences/com.omnigroup.OmniPlan#{version.major}.plist",
              ]
 end

--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,8 +1,8 @@
 cask 'omniplan' do
-  version :latest
-  sha256 :no_check
+  version '3.9.2'
+  sha256 'a96ac0fcb37f1c48f2160ad0c7658535573a089a84786d6d3a489636736c4498'
 
-  url 'https://www.omnigroup.com/download/latest/omniplan'
+  url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
   name 'OmniPlan'
   homepage 'https://www.omnigroup.com/omniplan/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.