### PR TITLE
Update cacher to 1.3.11

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.10'
-  sha256 '83ab6c0b2cf8d5c53012873c7996e99a537dd591be923446fef8f26b5ee3a676'
+  version '1.3.11'
+  sha256 'faa3aae71fda207f8921aaf273bb363a1cb6d31e225347f338165c5512669a8e'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '63df46e31a77af9aefb646455984b5cfc1a12173d77906fbd3ae33f022a9680f'
+          checkpoint: '86ecaf6358b9877601766385ab33f5cb84a91d09fc71336df45d526a0bfba1fa'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.