### PR TITLE
Update metabase-app to 0.28.4.0

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,11 +1,11 @@
 cask 'metabase-app' do
-  version '0.28.2.0'
-  sha256 '3947f17e215956687c0d5988049062e7c35aabdd1f265cfa712101f421d1772f'
+  version '0.28.4.0'
+  sha256 '46f08fef5054e6aa3c3d4169842d3eb7ba91817b5aa9cc16da6ba626f044dd20'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"
   appcast 'https://s3.amazonaws.com/downloads.metabase.com/appcast.xml',
-          checkpoint: '9242415687b295b8672ca43662f474b7d19909515ea0111b0b2884b6722fcc14'
+          checkpoint: 'e3525f4922b4beb50a0277093978be5f97b10f3a95b6bdbae85bdc0ab93b2dd4'
   name 'Metabase'
   homepage 'https://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.