### PR TITLE
Update crunch to 1.1.0

### DIFF
--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -1,10 +1,10 @@
 cask 'crunch' do
-  version '1.0.1'
-  sha256 'e5ddb785ffb7173e0a11e6813f3926da9f0dd85e99ed7b4188f86287f678bd87'
+  version '1.1.0'
+  sha256 'b34e48d695ceed3a3e1be1c713e51374fbc1678f73aff25abb64c48243f43396'
 
   url "https://github.com/chrissimpkins/Crunch/releases/download/v#{version}/Crunch-Installer.dmg"
   appcast 'https://github.com/chrissimpkins/Crunch/releases.atom',
-          checkpoint: '8bbb2f6218e2e4e2dff086970b8d2d58a946c27f668d01cbb5b9116f68737657'
+          checkpoint: 'a853ab2501078bf7623dd015f0406092bea9c172c815aa9213df39a50486db13'
   name 'Crunch'
   homepage 'https://github.com/chrissimpkins/Crunch'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.