### PR TITLE
Update tex-live-utility to 1.33

### DIFF
--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -1,10 +1,10 @@
 cask 'tex-live-utility' do
-  version '1.32'
-  sha256 '6e587b646ba1f6b74ceb42eaeaf03f21ac92457f263c098155b942bf171f6073'
+  version '1.33'
+  sha256 '8b8ac5cb9c4a8450e0fadfdf7d653f5a428eb8b4e4c1484cacd625b3f8acca8e'
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
   appcast 'https://github.com/amaxwell/tlutility/releases.atom',
-          checkpoint: '982731a785be11020da9aee3d2814e08061a599d197cc394f2047f36deb23095'
+          checkpoint: 'c4e0ce62618c3c67cdf81425d379a4bda6bc3507ab82429da7f36a7fa3801249'
   name 'TeX Live Utility'
   homepage 'https://github.com/amaxwell/tlutility'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.