### PR TITLE
Update veracrypt to 1.22

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,11 +1,11 @@
 cask 'veracrypt' do
-  version '1.21'
-  sha256 'cbd3f80eca753edce40be134ccbd288805c93643b21d8cf21fd72c0fd544f377'
+  version '1.22'
+  sha256 'c72257380f5653e6130d4efdd88297b328f29819f4bad82f5563cb906679e2b7'
 
   # launchpad.net/veracrypt/trunk/ was verified as official when first introduced to the cask
   url "https://launchpad.net/veracrypt/trunk/#{version}/+download/VeraCrypt_#{version}.dmg"
   appcast 'https://github.com/veracrypt/VeraCrypt/releases.atom',
-          checkpoint: 'fffe46cc3d4758cb1066693e84a4349a2b9c618700571541c446959adc7a95da'
+          checkpoint: '45f2781dc568f6801994fe77ff2492296622e7437c12594f667f71a9335d08c9'
   name 'VeraCrypt'
   homepage 'https://www.veracrypt.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.