### PR TITLE
Update zotero to 5.0.42

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.41'
-  sha256 '2119f127d10374862f834dc29abf7c4eee9918993e5cabcdfca66294d0dcdfaa'
+  version '5.0.42'
+  sha256 'c8e2c01e781a82d640dc45af92173bf430407a47b173641d89abd4a7bb484296'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: 'e3e5d149956d4b5ec73cd0655b02e4167860d2ebe6f040bc77582482ef711deb'
+          checkpoint: 'be7adf05dccfe994510381fd4508dc0c1c55e1c39d8ed1e5fd624e94fbef63d1'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.