### PR TITLE
Update docker to 18.03.0-ce-mac60,23751

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,10 +1,10 @@
 cask 'docker' do
-  version '18.03.0-ce-mac59,23608'
-  sha256 'ae3e1f43cbeb2479a5173cc8d0a164c3828fd0983583f5cf02ebbed2c16a9ab7'
+  version '18.03.0-ce-mac60,23751'
+  sha256 'cd2970d062d5ffb714f22a8595660646cbd7f3130874df1217f460b40f5e5a93'
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/stable/appcast.xml',
-          checkpoint: 'ba26b0a092146b582546657dc6e9c85165b2352cf600f4a79ffade443f21e2fb'
+          checkpoint: 'e65a38751dd883f1467c5799b39bfba42f8d823ce28f89763f700137d8ac621d'
   name 'Docker Community Edition'
   name 'Docker CE'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.