### PR TITLE
Update superproductivity to 1.10.4

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,11 +1,11 @@
 cask 'superproductivity' do
-  version '1.9.1'
-  sha256 'a286fba6e7ca75bc9a8a6f7d9da29e3c3567826c29631f11eee360f6c20f1c6d'
+  version '1.10.4'
+  sha256 'a94598ac6cc12966b72531cd9ba922119411cf67a84dac78e60c2cd4d213c471'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"
   appcast 'https://github.com/johannesjo/super-productivity/releases.atom',
-          checkpoint: 'bb1c72a2875efdaeffd4907e84be0740272719b2f5ec4b79e2f6097009e20e76'
+          checkpoint: '6faa2f14286438f76e2ecf2f4c45c25f823f9a4ef32d8579791efbaf718106de'
   name 'Super Productivity'
   homepage 'https://super-productivity.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.