### PR TITLE
Update chalk to 1.3.1

### DIFF
--- a/Casks/chalk.rb
+++ b/Casks/chalk.rb
@@ -1,11 +1,11 @@
 cask 'chalk' do
-  version '1.3.0'
-  sha256 '8c87ec406790274a3422facc995819e9c1b95a76c4e848fa243f0d7eabcd15f5'
+  version '1.3.1'
+  sha256 '6b83946890b27631bf08ec3d87d9dd12aeb7f19701eb8483ea88e990ca94aa46'
 
   url "https://www.chachatelier.fr/chalk/downloads/Chalk-#{version.dots_to_underscores}.dmg",
       user_agent: :fake
   appcast 'https://pierre.chachatelier.fr/chalk/downloads/chalk-sparkle-en.rss',
-          checkpoint: 'c802affdbe9e90f1a8b2cb529e822780440b89b6596de18a90c8bc3a01cbe109'
+          checkpoint: 'b17fd895a90434cd08f03c413ba3f39ba1937d1941cf6f50bc6f50d31037e072'
   name 'Chalk'
   homepage 'https://www.chachatelier.fr/chalk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.