### PR TITLE
Update latexit to 2.10.0

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,11 +1,11 @@
 cask 'latexit' do
-  version '2.9.1'
-  sha256 '8352728814e3824abd19b351495c7ca4a5aa0f4b597fcadbd32590183c38365f'
+  version '2.10.0'
+  sha256 '92294df74806617891ac483d494ed76572994c22fec0aedfb687fc867ff88650'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake
   appcast 'https://pierre.chachatelier.fr/latexit/downloads/latexit-sparkle-en.rss',
-          checkpoint: 'b269cd9141accea8a161668409c246a48944e07e08079d67df247466936e854c'
+          checkpoint: '85cd7de12a1bd57a0a5f196be3aa2de3125145aec42a96aa75e220cbe966cc50'
   name 'LaTeXiT'
   homepage 'https://www.chachatelier.fr/latexit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.