### PR TITLE
Update lingon-x to 5.2.8

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.2.7'
-  sha256 '0dc92c414f87cb15912ebd280b0171c5c69c619c40df775b43aa4b26eb971372'
+  version '5.2.8'
+  sha256 '1d8326b5a87817c94f8dd1be2c496d56abe34aa9336af06de8fc28e747c5591f'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '2ced583891406edaf17f6bc69dbfc5f9d53ac15d8e11df4ba20af48dc0101045'
+          checkpoint: '2fa4943c7d6d9301804c97fecf6da189adf07ab1522dbe4c01820a919c3a9f08'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.