### PR TITLE
Update kitty to 0.8.4

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,10 +1,10 @@
 cask 'kitty' do
-  version '0.8.2'
-  sha256 'b0fa3e4967822781891fa7cd1d9f2edaecd8b7c296fef35a8c60c38448ecbcc5'
+  version '0.8.4'
+  sha256 'a116197a8c1807455f53494674c28de33d09ca484709819a6d3f0a8f4e9e659e'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom',
-          checkpoint: '5367d74595e105c890d91d3afb76258a4d63dd5a1f587fd5bf861533a7abf01e'
+          checkpoint: '7749a4e546bd871aafbf7e5ee8b4598ee71191eff58736a93a531eed3000823e'
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.