### PR TITLE
Update mailbutler to 2.0.4-9086

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -4,7 +4,7 @@ cask 'mailbutler' do
 
   # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-data.s3.amazonaws.com/downloads/Mailbutler_#{version}.zip"
-  appcast 'https://www.mailbutler.io/appcast2.php',
+  appcast "https://www.mailbutler.io/appcast#{version.major}.php",
           checkpoint: 'a5c5085d09e66f9ee23f6ea56f27248b7b063a2acf82175f9702972ec377e411'
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.