### PR TITLE
Update netron to 1.7.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.0'
-  sha256 '0b2f1c5859245c3c1b1013fb84a39130281fc17df91f1a36d673a992205746c9'
+  version '1.7.1'
+  sha256 'b0fc8bbf098d802b68c81e2abf572678806d32faa225e863008d3dbd316d7f5b'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '0f5ac5805172b3c54e8dff091f1ab37c55a3de39adc66f444fb511f8f5fc100a'
+          checkpoint: '5c2b2d67fc3232837eb5785a444122f1fc2686b5af412394bba096c1b08baf95'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.