### PR TITLE
Update latexit to 2.10.1

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,11 +1,11 @@
 cask 'latexit' do
-  version '2.10.0'
-  sha256 '92294df74806617891ac483d494ed76572994c22fec0aedfb687fc867ff88650'
+  version '2.10.1'
+  sha256 '13e8cad21d51cb466c1d48e2f1b03a5dd541928c534fc5022e7d4e4cb2425895'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake
   appcast 'https://pierre.chachatelier.fr/latexit/downloads/latexit-sparkle-en.rss',
-          checkpoint: '85cd7de12a1bd57a0a5f196be3aa2de3125145aec42a96aa75e220cbe966cc50'
+          checkpoint: 'cc4dd3469b0bbc90d0dd61bbacf4a726295c9919c066c622ae6fd3712b1a7667'
   name 'LaTeXiT'
   homepage 'https://www.chachatelier.fr/latexit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.