### PR TITLE
Update joplin to 1.0.82

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '1.0.81'
-  sha256 '68345ac7aff7ae7fcf258f904908da8e02db05effa2f50d99ab12a7057f1c1b8'
+  version '1.0.82'
+  sha256 'b88d348ac1bc3bab8fb53b56d53eb85cdae031209422a5d05d69c8a009cdff08'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '98f7757d5945d63ae35c09549663807c16a35a159286f1d03b92d8853c288aec'
+          checkpoint: '195f24c49f89ba94f7b67e549288f98fb03b3d42ed7a03a61996fd07fe3b684a'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.