### PR TITLE
Update borgbackup to 1.1.5

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,11 +1,11 @@
 cask 'borgbackup' do
-  version '1.1.4'
-  sha256 'ed205a17eb2c881b421317f76b35f2800a743455ee1b81d4f47451e42f690826'
+  version '1.1.5'
+  sha256 'bf71ee7d5aa46a47b8fd5d2105d523da279e6c438198def3b9988d169c92351d'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"
   appcast 'https://github.com/borgbackup/borg/releases.atom',
-          checkpoint: '5a573388701b1016807563c5f925ecebb0db52235803ed91a2b89d6556b1ec92'
+          checkpoint: 'eb322dddad67aa477b0d7006707aaec4950d8c146a63292bdccecd3a43124bce'
   name 'BorgBackup'
   homepage 'https://borgbackup.readthedocs.io/en/stable/'
   gpg "#{url}.asc", key_id: '51F78E01'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
