### PR TITLE
Update qldds to 1.33

### DIFF
--- a/Casks/qldds.rb
+++ b/Casks/qldds.rb
@@ -10,5 +10,6 @@ cask 'qldds' do
 
   pkg "QLdds_#{version.no_dots}.pkg"
 
-  uninstall pkgutil: 'uk.org.marginal.qldds'
+  uninstall pkgutil:   'uk.org.marginal.qldds',
+            launchctl: 'uk.org.marginal.qldds.mdimporter'
 end

--- a/Casks/qldds.rb
+++ b/Casks/qldds.rb
@@ -1,10 +1,10 @@
 cask 'qldds' do
-  version '1.32'
-  sha256 '790e28919fe353834a85d3418bfd91583e593fe1aacf556e0481215e449568a8'
+  version '1.33'
+  sha256 '7342f788f750bf4f40e84f6fcbfefb4603e78d00c99d55fae4ba65a78f9ff20f'
 
   url "https://github.com/Marginal/QLdds/releases/download/rel-#{version.no_dots}/QLdds_#{version.no_dots}.pkg"
   appcast 'https://github.com/Marginal/QLdds/releases.atom',
-          checkpoint: 'e3b021c381331a745d5192f8a406093bbbd06643bb6d6341ccb35c922fefcda6'
+          checkpoint: '27823a9808e826a1ced536feeac0816913c2e8d228a7af058f7b8122632f81f3'
   name 'QuickLook DDS'
   homepage 'https://github.com/Marginal/QLdds'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.