### PR TITLE
Update switchhosts to 3.3.11.5347

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -1,11 +1,11 @@
 cask 'switchhosts' do
-  version '3.3.10.5345'
-  sha256 '6034494edaba30c843f83ec0d0490052bcf4081ed30bcfab3c146ceea49169e0'
+  version '3.3.11.5347'
+  sha256 '198519b5aa8fb8d567a6fcb51609d434df08c444623c7350a2d1b4b62dd48c8a'
 
   # github.com/oldj/SwitchHosts was verified as official when first introduced to the cask
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts-macOS-x64_v#{version}.zip"
   appcast 'https://github.com/oldj/SwitchHosts/releases.atom',
-          checkpoint: '08d0f3523776776bea7a170ba24d3369ead3583f8f60ef6756fcac8f9509bbdf'
+          checkpoint: 'cf200f9f79455a6b611bec86249a14137ad9aad3dbb0c057376043615f6636ea'
   name 'SwitchHosts!'
   homepage 'https://oldj.github.io/SwitchHosts/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.