### PR TITLE
Update kite to 0.20180329.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20180322.0'
-  sha256 '3f05e9c5da1bac0f4920f228fdd37fb834af425a58b08616b2676c459dc7d430'
+  version '0.20180329.1'
+  sha256 'b03fe9355aa37502e6bdad3744d7069afc6e16c767be9d2e77052bbc948be300'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: 'e957c86f6616fa1f359d7287a37d2942b679215ae5dde2115749950a4c08bc68'
+          checkpoint: 'c47cf74ffc7cdd181a0e864b405beec4213da1c88bc62f99f199dcd569e7172c'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.