### PR TITLE
Update graphql-playground to 1.5.0

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.4.3'
-  sha256 '8b4ad069dfe763003db51742b74a46aeb40ae74b6496bad5dc47088f7b546e59'
+  version '1.5.0'
+  sha256 'd5018aeab61547e9de5c31acc12771590cb99c7803c7374c57cb07725feb431f'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: '890a86b8a84aef86d5d87a0c4e7f863e701580834c5d689510930c1c8c35e793'
+          checkpoint: '7a717783084dd305e7aea3a3c257b3c556764fe743054337262d4474fde667b6'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.