### PR TITLE
Update handshaker to 2.5.6

### DIFF
--- a/Casks/handshaker.rb
+++ b/Casks/handshaker.rb
@@ -1,11 +1,11 @@
 cask 'handshaker' do
-  version '2.5.5'
-  sha256 'de34c82254033d58511a107d98916a31f4d5b8e270b4431f01c664b243d99adf'
+  version '2.5.6'
+  sha256 'a263e0713a2d6d41b7fb9323fa0b145e35a8fc9086b6ff6253f9b9abda7ede16'
 
   # dl2.smartisan.cn was verified as official when first introduced to the cask
   url "http://dl2.smartisan.cn/app/HandShaker.v#{version}.dmg"
   appcast 'https://sf.smartisan.com/update.plist',
-          checkpoint: 'dadfb68ba230f8a4f85c6965d883c98add9a3bb6987e3e9af860158c6c52753d'
+          checkpoint: '652bf99baae7e0a9c0da1bde3a86ad2fd7df318912e24e8323bf9475a28a309c'
   name 'HandShaker'
   homepage 'http://www.smartisan.com/apps/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.