### PR TITLE
Update rubitrack-pro to 4.4.7

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '4.4.6'
-  sha256 'bdca80859c57e9dcaf5b6ddf685e729388e23d4be0ef3726ba14ca587fa3ce20'
+  version '4.4.7'
+  sha256 'f159c82225bd607d8fa41bcd766fa4f79859aa356942be91730c64f8081aab6d'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}_u.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: 'd9d4344855a45bebdc12d4b5f283852bf62bbee40b2ea552901783f81517af97'
+          checkpoint: 'bd8a93acbd69c1ebc09c86e2ca8d0ea91596b7200df9a5982ba2f26867ff0a3d'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.