### PR TITLE
Update textmate to 2.0-rc.9

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,11 +1,11 @@
 cask 'textmate' do
-  version '2.0-rc.8'
-  sha256 '55e8142f97622c52d1efbf09201b6abbfdf4501c46d8df0846d09926022e9043'
+  version '2.0-rc.9'
+  sha256 '305cbcff17fd75b71ab64136e61f73d7a171d63383e650153763b0c27bff7158'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
   appcast 'https://github.com/textmate/textmate/releases.atom',
-          checkpoint: '5983d646dd88065cd61ee95c2127765a6056621c23a1662a9c3dcf4cb5c6765c'
+          checkpoint: '95e7403180471619a8d7c2bbc02acf71b2bab034010af753ee8eada5d95b9789'
   name 'TextMate'
   homepage 'https://macromates.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.