### PR TITLE
Update transmission-remote-gui to 5.15.3

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,10 +1,10 @@
 cask 'transmission-remote-gui' do
-  version '5.15.2'
-  sha256 '56014943e1f070604b651b972ee754b9692e1d9993c7dd7edeff93e9b2492d26'
+  version '5.15.3'
+  sha256 '04dd013200c0c34677411b2972f43251514c17db2b1bc888f502ee54fa150f37'
 
   url "https://github.com/transmission-remote-gui/transgui/releases/download/v#{version}/transgui-#{version}.dmg"
   appcast 'https://github.com/transmission-remote-gui/transgui/releases.atom',
-          checkpoint: '11acace4862e1b33a3460a745c3f6c2d96297a877fe573b3419d415fafbf9ee0'
+          checkpoint: '65861990d1582bcd871d4510c886ff677c7aae248b1e225f47d3e1b6c8e62a6b'
   name 'Transmission Remote GUI'
   homepage 'https://github.com/transmission-remote-gui/transgui'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.