### PR TITLE
Upgrade Blockstack.app to v0.26.2

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.26.1'
-  sha256 '27e9e74a1f2fc202f23bf01626b14e739eab84bde5ee8f24a4fbfa8dd80c6542'
+  version '0.26.2'
+  sha256 'e9d35f26ed6e5a5f3793b3886c73153684a37293f835e6d1b5e871c0cfcdf167'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '756e90a915d6d91aa13c92220f9844d3cc21695efed559dc02e8536b92cd92f6'
+          checkpoint: '4ea0071e37bd7ab29f5cb66a572e30ff6c9b3b04045f333d506b8445655cf116'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
