### PR TITLE
Update cacher to 1.3.12

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.11'
-  sha256 'faa3aae71fda207f8921aaf273bb363a1cb6d31e225347f338165c5512669a8e'
+  version '1.3.12'
+  sha256 '2b494d21939e4d8082623a458bd2cf9c0ad57314c64f3acd23041cfceb7aac9f'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '86ecaf6358b9877601766385ab33f5cb84a91d09fc71336df45d526a0bfba1fa'
+          checkpoint: '715821e6e4636486e3ebb99fc1ada81b1559ad7775b79ecba91d5db7c5403518'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.