### PR TITLE
Update adobe-photoshop-lightroom: uninstall preflight

### DIFF
--- a/Casks/adobe-photoshop-lightroom.rb
+++ b/Casks/adobe-photoshop-lightroom.rb
@@ -28,7 +28,7 @@ cask 'adobe-photoshop-lightroom' do
   end
 
   uninstall_preflight do
-    system_command 'brew', args: ['cask', 'uninstall', 'adobe-photoshop-lightroom600']
+    system_command "#{HOMEBREW_PREFIX}/bin/brew", args: ['cask', 'uninstall', 'adobe-photoshop-lightroom600']
   end
 
   zap trash: [


### PR DESCRIPTION
The `system_command` uninstall calling `brew` is broken.
