### PR TITLE
Update atext to 2.23

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,10 +1,10 @@
 cask 'atext' do
-  version '2.22.3'
-  sha256 '553957237e7dbbcc25208ba030f2efc1ce428efef93766b12141ba665f528edd'
+  version '2.23'
+  sha256 'b2ffbb94fcfea5668bd55d137f8607c6cfee77a11c0eae5d0fd21bc091de74b3'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml',
-          checkpoint: '01816bad0f3226f4d9941b5c889f7042717486b5aeb5e3847b8538d90ea939a9'
+          checkpoint: 'f5a2b13581a691f1a0fa43f5abc5cc21f3bd0655205f5c17787493d792a4e744'
   name 'aText'
   homepage 'https://www.trankynam.com/atext/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.