### PR TITLE
Update vimr to 0.21.2-271

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,11 +1,11 @@
 cask 'vimr' do
-  version '0.21.1-269'
-  sha256 '75b5d76ef3f11a9cba8a1fdd9859455887c3646d22dd47f26f59251d74047bb3'
+  version '0.21.2-271'
+  sha256 '292594594574dd513ec6b5b3dcceacbc3834345bc160fcb8a223aa2bc50efacb'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom',
-          checkpoint: 'abc07845149c1b0d93bd644737aa7885934c56e33d3aeb8746385df57cd19b83'
+          checkpoint: 'bce30a1057c6551c7f85734af42e6af1cc744465f762885d84e3a02dd0aa93d5'
   name 'VimR'
   homepage 'http://vimr.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.