### PR TITLE
Update typora to 0.9.9.14

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.13.6'
-  sha256 'ecec9d5b2cf7ce7d39781f0eae9d4405f6d0bed228635f8dcb1b06fcf277e76a'
+  version '0.9.9.14'
+  sha256 'f49e01951cd3bf6fc8cd7ecb37bfc056cdd91c15da99f111d415793b5549d476'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '3cb24e4b8937703fad68e877b6cb6f3c35e9d66cdc3b96768804f59294731e2d'
+          checkpoint: '5bd5df016f0414cbc666c898c183512640f066c13178a4b62f9eb934a41fb8b4'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.