### PR TITLE
Update filezilla to 3.32.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,10 +1,10 @@
 cask 'filezilla' do
-  version '3.31.0'
-  sha256 '188e8d9af77dbcdd6176fb7eeca19083fff6f22e41331a1927c78c73c1faa769'
+  version '3.32.0'
+  sha256 '97d1fc473fadbf4f63df5941f8ad3f04f59d95ba61dce206c01c36f4a8499aa8'
 
   url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client',
-          checkpoint: '9b1a081a82ba46468494ab610ca341f26790ccc431193bda585571cf9ca722e0'
+          checkpoint: '69a64a1c8fdf110662adeed59998ccf3c22ceeb13a2b65d6b6e5b31b9820d26a'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.