### PR TITLE
Update vectoraster to 7.2.4

### DIFF
--- a/Casks/vectoraster.rb
+++ b/Casks/vectoraster.rb
@@ -1,10 +1,10 @@
 cask 'vectoraster' do
-  version '7.1.3'
-  sha256 'f5544a33ade247d414a78e03ee28d31cedc47a53124fc7ba70f3e1d24ed01da1'
+  version '7.2.4'
+  sha256 'c0106135c408d80236e6901899e6e9e4a3b808dfcf747f248af2861d9e7cd207'
 
   url "https://www.lostminds.com/downloads/vectoraster#{version.major}.dmg"
   appcast "https://www.lostminds.com/vectoraster#{version.major}/version_history.php",
-          checkpoint: 'de4fac08ec06a435e29ae46e1ea07321d6f721a2baef7bfcdbca775f5c4f181e'
+          checkpoint: 'd6a4c659d08fed92c43d59b189321b12b7b66b7ca11cff8c4599f66af2d53020'
   name 'Vectoraster'
   homepage "https://www.lostminds.com/vectoraster#{version.major}/"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.