### PR TITLE
Update minergate to 8.0

### DIFF
--- a/Casks/minergate.rb
+++ b/Casks/minergate.rb
@@ -1,6 +1,6 @@
 cask 'minergate' do
-  version '7.2'
-  sha256 '9e65d63c366fe7bd0093899d7a0e8082dfbcf05d4667f1a1ca7d0d72f0012be8'
+  version '8.0'
+  sha256 '2211c1be48c09225dcd27e6223a8243d40334932951fba6257e53220a55afbe7'
 
   url "https://download.minergate.com/mac/#{version}"
   name 'MinerGate'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closed in favor of https://github.com/caskroom/homebrew-cask/pull/45481. 👍 