### PR TITLE
Update veusz to 2.2.1

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,11 +1,11 @@
 cask 'veusz' do
-  version '2.1.1'
-  sha256 '61e705bafc9ffdc3a3170a5e89616ba3ea9d6f1651a4c59b382fefc4e98c68ad'
+  version '2.2.1'
+  sha256 'b1a74272bd87198843fabae8631fe97ab7fff8964012281ae7378678785ecb54'
 
   # github.com/veusz/veusz was verified as official when first introduced to the cask
   url "https://github.com/veusz/veusz/releases/download/veusz-#{version}/veusz-#{version}-AppleOSX.dmg"
   appcast 'https://github.com/veusz/veusz/releases.atom',
-          checkpoint: 'fb8670130f2ebbe93fd1388066445110e64b13900e2e7e56696dfa7e63a04526'
+          checkpoint: '31445859330d1b3697141a808cb3fbabd0a46ff5b23c89e3cf67ad6b972682ed'
   name 'Veusz'
   homepage 'https://veusz.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.