### PR TITLE
Update blocs to 2.5.2

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,11 +1,11 @@
 cask 'blocs' do
-  version '2.5.0'
-  sha256 '5b9619925926c930efb60c0cbc40ddb5ccd127636cc7bdc0456b4907ad413d7e'
+  version '2.5.2'
+  sha256 'a3488866a28e8b36cc856df0de85044fa5f6975ff0f0f9f86b4e3c66f5073964'
 
   # uistore.io was verified as official when first introduced to the cask
   url "http://downloads.uistore.io/blocs/version-#{version.major}/Blocs.zip"
   appcast "https://uistore.io/blocs/#{version.major}.0/info.xml",
-          checkpoint: '27d21a3b913b3fbd4a26edc34aa5d129ad6e47f6ccd118451ffc1d34340ade1d'
+          checkpoint: 'ef341b2eb12b43da9231b216c377af66a2c5e0b9c1749979dc8af40099617b5a'
   name 'Blocs'
   homepage 'https://blocsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.