### PR TITLE
Update vnote to 1.14

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,11 +1,11 @@
 cask 'vnote' do
-  version '1.12'
-  sha256 '9ac3c687466faf60864a5610394f0b9b01fa4ad9a480483c7198303edd0872f0'
+  version '1.14'
+  sha256 'f6a576fcb14990ded7c58fdba9d8f97a8e26c2b47602270af2efb4ba0b6f25d8'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote_X64_#{version}.dmg"
   appcast 'https://github.com/tamlok/vnote/releases.atom',
-          checkpoint: '17fe06d597fe9bb104c8bdb5a650a21021b0e7b473e81199e4c1ab47e71ab8a1'
+          checkpoint: '5b65722928f42af4f8c1fb06a3258a60e9e266d89993dcdc5e21bb566d26923d'
   name 'VNote'
   homepage 'https://tamlok.github.io/vnote/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.