### PR TITLE
Update all Eclipse casks to 4.7.3 (Oxygen.3)

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-cpp' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '33cde50429482369078bb7ccc5a74c3d8a206f140cc8fa2b0c04b11cbea61fb3'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-cpp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-ide' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '8657a0a8bda888bd9287e92d26f3744bf2f9a2d0a95265a260d92f09372d3f6c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-installer' do
-  version '4.7.0,oxygen:R'
+  version '4.7.3,oxygen:R2'
   sha256 '610b28ad30fc9ba044c87cca87ef66abdbe938d3ea50d112a81e36f953a72c0e'
 
   url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-inst-mac64.tar.gz&r=1"

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-java' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '45ab1f3ab53cf457c723818e2198e1b5d82479f4e8c7539a018dfb2934268d7d'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-jee' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '30412262e4fe6a0db5f03ee2dbbcd7635c88f8ad75af99a89ab25f4065f65ff7'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-modeling' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '6f22d51abd8ad012bdf8fb5716021a8edbf4a34da573df8052e020584f2c56ca'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-modeling-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-php' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '56aab2c6aea889b24882bcbc2b898ec3b6cd01b6f91fc90656fa82bdaa49c22e'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-php-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-ptp' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '400e176bfe0e7463c6c17af1d2eb852ab739a57c9b41f71755009b1e844bcbfe'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-parallel-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-rcp' do
-  version '4.7.2,oxygen:2'
+  version '4.7.3,oxygen:3'
   sha256 '0b88bfa67d55314ff8f9d150ace2aa2808587fad3f87dbf6b738c3a8d75f4d8e'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-rcp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the casks:

- [x] `brew cask audit --download {{cask_files}}` is error-free.
- [x] `brew cask style --fix {{cask_files}}` reports no offenses.
- [ ] The commit message includes the casks’ name and version.
  - I included all eight of the Eclipse casks as one commit, so fitting all of them in the commit message would be a bit excessive.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
