### PR TITLE
Update vrep to 3.5.0

### DIFF
--- a/Casks/vrep.rb
+++ b/Casks/vrep.rb
@@ -1,10 +1,10 @@
 cask 'vrep' do
-  version '3.4.0'
-  sha256 '1046549e3cc9d8820981a82431b43a5cb06f76d5a505c6bbb603b85a144525b2'
+  version '3.5.0'
+  sha256 '751dcc1200803395358e788ffa42ad3f998278e380da15feb37f31fd88f3517c'
 
   url "http://coppeliarobotics.com/files/V-REP_PRO_EDU_V#{version.dots_to_underscores}_Mac.zip"
   appcast 'http://www.coppeliarobotics.com/helpFiles/en/versionInfo.htm',
-          checkpoint: 'bd307d5da0329fd2d2783688e6959381afc4d973abb15cb197c10ca747140125'
+          checkpoint: 'cd7f357c87479c3832127ba84e32c74eb4b47af4e95e55ca6aee9fdadc8093c2'
   name 'V-REP'
   homepage 'http://www.coppeliarobotics.com/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.