### PR TITLE
Update vuescan to 9.6.07

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,10 +1,10 @@
 cask 'vuescan' do
-  version '9.6.06'
-  sha256 'fa1d8e95d99f8fbda9d7b15ce58b2400d439bd5ee3ee6e1919aacac8e12ab177'
+  version '9.6.07'
+  sha256 'ff8d3e1ddf02c4c2d440407c94cf357983ecc380c778c47c64857adffb768cef'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html',
-          checkpoint: 'e7bc97e4e018ab349a7d4cfc7d4f03328bd372955d587c5bb32bcde94445db4f'
+          checkpoint: '2868d502d8b23ea2568c23adc821bbbaf8813200b1b8c59f66d2642188da0e10'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.