### PR TITLE
Update the-mut to 4.0.0

### DIFF
--- a/Casks/the-mut.rb
+++ b/Casks/the-mut.rb
@@ -1,9 +1,9 @@
 cask 'the-mut' do
-  version '3.6.0'
-  sha256 '578ed3e13ef57238d0649e25f4fe523115e483cf2b22960eb07da81767df0b72'
+  version '4.0.0'
+  sha256 '95a805ae455aeae67f2d3a0db2210cf4a25adefe5a9d01ab724ced3d36d1a555'
 
   # m-lev.com/uploads was verified as official when first introduced to the cask
-  url "http://m-lev.com/uploads/TheMUT#{version.no_dots}.dmg"
+  url "http://m-lev.com/uploads/TheMUT_#{version.dots_to_underscores}.dmg"
   name 'The MUT'
   homepage 'https://jssmut.weebly.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.