### PR TITLE
Update tabula to 1.2.0

### DIFF
--- a/Casks/tabula.rb
+++ b/Casks/tabula.rb
@@ -1,11 +1,11 @@
 cask 'tabula' do
-  version '1.1.1'
-  sha256 '7b02fa0cc00719316332785c116cdae815b33c5dab2157da27cec44ccacf7593'
+  version '1.2.0'
+  sha256 '14de2ac043fa6bb1180eb2217c3405e49c0f01cc2142a422e880522a30374e67'
 
   # github.com/tabulapdf/tabula was verified as official when first introduced to the cask
   url "https://github.com/tabulapdf/tabula/releases/download/v#{version.major_minor_patch}/tabula-mac-#{version}.zip"
   appcast 'https://github.com/tabulapdf/tabula/releases.atom',
-          checkpoint: '3d3f2d52a9ee3feb890d2f7594fcdaac2555cba78179552790fe184f56da1b91'
+          checkpoint: 'fa8aab834c95eff1d8408dbb299722fcbb32c4916231ff8ea798eabc83caff69'
   name 'Tabula'
   homepage 'http://tabula.technology/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.