### PR TITLE
reMarkable upgraded to remarkable 1.2.1

### DIFF
--- a/Casks/remarkable.rb
+++ b/Casks/remarkable.rb
@@ -1,8 +1,8 @@
 cask 'remarkable' do
-  version '1.0.0'
-  sha256 '5135c6878ebc1d1816aac4bc822b7cd0da3bb05c14167c201aefe20def1e05cf'
+  version '1.2.1'
+  sha256 'a33aa4a6eb86ca146ae678148bc343a53f80731819504a205940e31a4ed5c244'
 
-  url "http://technology.remarkable.com/remarkable-#{version}.dmg"
+  url "https://storage.googleapis.com/remarkable-client-software-540221a9321a8a52ec61a06bfab53423/desktop/production/mac/reMarkable-1.2.1.dmg"
   name 'reMarkable'
   homepage 'https://remarkable.com/'
 


### PR DESCRIPTION
reMarkable macos client was upgraded from 1.0 to 1.2.1. The engineering.remarkable.com URL seems obsolete.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
The new download URL is not under the remarkable.com domain but hosted on Google.
This new URL is provided under my.remarkable.com

- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
