### PR TITLE
Update preform to 2.15.1,160

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '2.11.3,646'
-  sha256 '98e9fdcab645e0cfcbec6a5c486725069799472881e2c9862ee4cccea1dfa977'
+  version '2.15.1,160'
+  sha256 'fefb279f62c2b7354c293de759d9180550ebf511e131bdf3f1587f205ebf1e50'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.