### PR TITLE
Update qqlive to 1.5.0.35292

### DIFF
--- a/Casks/qqlive.rb
+++ b/Casks/qqlive.rb
@@ -1,6 +1,6 @@
 cask 'qqlive' do
-  version '1.3.0.30662'
-  sha256 'd78bee2625bc4fb23c5914fd32952b6ba71fcb8d0250e62697eb1520f00ee15f'
+  version '1.5.0.35292'
+  sha256 '4453d7dbc148f0ce6324c86cee30291ae7c23bd3f77233564dbff335ff27837b'
 
   url "https://dldir1.qq.com/qqtv/mac/TencentVideo_V#{version}.dmg"
   name 'QQLive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.