### PR TITLE
Update lbry to 0.21.2

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,11 +1,11 @@
 cask 'lbry' do
-  version '0.20.0'
-  sha256 'd67d6d44e4f30df1a3050a3228a9c0e656d4d1bfb87d30f7697b5fe13a4d3b16'
+  version '0.21.2'
+  sha256 'e6f5af33929484fb27f76761c24c901fe651f5dd389b87c4c09c867edbb33221'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"
   appcast 'https://github.com/lbryio/lbry-app/releases.atom',
-          checkpoint: 'f09f598f481acc85bac012f9d370ba8f10ca5c43056b1f400b7e367077ccca3c'
+          checkpoint: '24b688185291edad7e006b36e7faa281f13d1c0c3daa96214538c6406c1c3c93'
   name 'LBRY'
   homepage 'https://lbry.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.