### PR TITLE
Fix the uninstall script of "background-music"

### DIFF
--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -15,5 +15,5 @@ cask 'background-music' do
   uninstall launchctl: 'com.bearisdriving.BGM.XPCHelper',
             pkgutil:   'com.bearisdriving.BGM',
             quit:      'com.bearisdriving.BGM.App',
-            script:    '/Applications/Background Music.app/Contents/Resources/_uninstall-non-interactive.sh'
+            script:    '/Applications/Background\ Music.app/Contents/Resources/_uninstall-non-interactive.sh'
 end


### PR DESCRIPTION
I fixed the path to the uninstall script of cask "background-music" v0.1.1.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.

I weren't able to run `brew cask audit --download Casks/background-music.rb` because of the following error:
```
audit for background-music: warning
 - appcast checkpoint mismatch
Expected: ba1cfbe4e14dfa185f3de08e2bf4bab608ca015fb96f6369c4d556567a5b9b39
Actual: a6c1fc2825204c1a931dc9f4870d20919ea56469d911c2b5934dc2b3aaf7a2a9
Error: audit failed for casks: background-music
```
Which made the command exit without completing the audit, although there shouldn't be any issues with the audit since I only changed the uninstall script, which is a quite minor modification.

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.