### PR TITLE
Update inboxer to 1.0.4

### DIFF
--- a/Casks/inboxer.rb
+++ b/Casks/inboxer.rb
@@ -1,11 +1,11 @@
 cask 'inboxer' do
-  version '1.0.2'
-  sha256 'd60a7f25209602041cfb6e66c09c839a7068894daab7edc6205dbd10847c57bd'
+  version '1.0.4'
+  sha256 '708aa5e6394b869efca1d99b3d03d5936a8599c1d4d864d157e13982d93b424e'
 
   # github.com/denysdovhan/inboxer was verified as official when first introduced to the cask
   url "https://github.com/denysdovhan/inboxer/releases/download/v#{version}/inboxer-#{version}-mac.zip"
   appcast 'https://github.com/denysdovhan/inboxer/releases.atom',
-          checkpoint: '2c7ba053eab9a808222369960b35deac26569c4f38f2933f9b13a87fd35b6f7f'
+          checkpoint: '3c36ee31f7aa39052adbbf6376891cccf14e302b05f8c973f75e47b0295bced3'
   name 'inboxer'
   homepage 'https://denysdovhan.com/inboxer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.