### PR TITLE
Update tankix to andromeda1-15620

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version 'hydra1-15154'
-  sha256 'a1d424639d64485b7192d04abadc41d8f45b44a9437dc0062e1b68afb8ecb2af'
+  version 'andromeda1-15620'
+  sha256 '3410dcbd1c6d446f2f976d03b8c011866577020b95393809efad5f1af433c379'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.