### PR TITLE
Update iridient-developer to 3.2.2

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,10 +1,10 @@
 cask 'iridient-developer' do
-  version '3.2.1'
-  sha256 '43382713f0941e0a5a44f4bfc9a8b41f0fa0e1c8c1c761ef04e5e6350f367c37'
+  version '3.2.2'
+  sha256 'a2c15afb957c48582cbbccbba8d579267a82ba9370064f5493cc9a6c8f8046f8'
 
   url "http://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'http://www.iridientdigital.com/products/rawdeveloper_history.html',
-          checkpoint: 'c39f874e22e9051235d7422f91fb51f276ab6d52e3109a90f01b71c2f254a1f3'
+          checkpoint: '13900534c0dcc07df80b62203f5e60001d3e1235b606cb6793d1c7cf727c26a0'
   name 'Iridient Developer'
   homepage 'http://www.iridientdigital.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.