### PR TITLE
Update mark-text to 0.9.25

### DIFF
--- a/Casks/mark-text.rb
+++ b/Casks/mark-text.rb
@@ -1,11 +1,11 @@
 cask 'mark-text' do
-  version '0.8.12'
-  sha256 '332bd8ced0cc31ab33c0f52d8a748930a47a3312f01571e4e61fe1a0ac6f1d56'
+  version '0.9.25'
+  sha256 'd49e14ef72ae5443b717139c8851cf2cc4d0c557c530c9ed36d389e942013a48'
 
   # github.com/marktext/marktext was verified as official when first introduced to the cask
   url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext-#{version}.dmg"
   appcast 'https://github.com/marktext/marktext/releases.atom',
-          checkpoint: 'e0064ac52d33edc0d44e46092719d0a627ebe109af0f7bc35bed6d54bc3f7a3a'
+          checkpoint: '0b4e404117b748cd10ad870a2c970d3d2e02f2a99dd9874705e21da901d0d862'
   name 'Mark Text'
   homepage 'https://marktext.github.io/website/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.