### PR TITLE
Update navicat-for-mysql to 12.0.24

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.23'
-  sha256 'c1abbddf926c65b70f731f3cde5686caef2e9619867b597f499747bb802b5bae'
+  version '12.0.24'
+  sha256 'd756542ba0bbe548ed3811b4f50115b33ad919dba58051b45d62f090425bd9bf'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: '17746fafc686102cf60bdf899339142305eb44a33576c0543ab4a3234c3b9c33'
+          checkpoint: 'd226beefb69d8f66801530be0a696417ee048c897d73c7a5d7d7d93ecffb4fa9'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.