### PR TITLE
Update navicat-for-postgresql to 12.0.24

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.23'
-  sha256 '62688e97dace5bc9c91cebd32dc123fcb09191a5b232889f978c8e253e4690e9'
+  version '12.0.24'
+  sha256 '849636d08384d9625d9d811a3cca80f5f92ad3d242188d45dee9b64ee9e2baf0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-postgresql-release-note',
-          checkpoint: '290960db13b3dac7d3f795f945cae9ab6fca0ef90a65483663fcd57673619517'
+          checkpoint: '4d74131ba30bfde7255e864bf12ad112fedc2233e3962c8c3ace242b4e482024'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.