### PR TITLE
Update navicat-for-sql-server to 12.0.24

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.23'
-  sha256 'b62ef46452db05e3ef9960b91538da7f8d71be63dbcb89f865bea0a8361c9f93'
+  version '12.0.24'
+  sha256 'b8e09d96327e3106253bb6b17b7f066810b7933f586e4a3f33a5cfdb7012cc51'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlserver-release-note',
-          checkpoint: 'f0ed98261ce0906ae1c672560f5a6131175fb9c4e782517720e7a28c9e658e01'
+          checkpoint: '00c7d2bca50b01b9e8d9e369a432bda73465be8ac57376fffb317c37b9b3c3fd'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.