### PR TITLE
Update navicat-for-sqlite to 12.0.24

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sqlite' do
-  version '12.0.23'
-  sha256 'a08ae3f687d3b01aad1e2d55638da7a3d471e004a816e53a9977c00f6340b6d7'
+  version '12.0.24'
+  sha256 '04be3bdb6bff8ac0b4eaf7eb701ab6266d479a5f5c03b9ab4b8435e32d5721d9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlite-release-note',
-          checkpoint: 'f6d6841789e7bbf0e597e9cbe7c914f33192d55b79292e307b76851037c547f6'
+          checkpoint: 'fb73e63b981a356abd81935213e3162f03c623fdd777df0f27a725b2ed8e874f'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.