### PR TITLE
Update jettison to 1.6

### DIFF
--- a/Casks/jettison.rb
+++ b/Casks/jettison.rb
@@ -1,10 +1,10 @@
 cask 'jettison' do
-  version '1.5.3'
-  sha256 'fdd4a4357b94732c3129cd01af23ce18169b274351c2b5dedba63aa3cb732390'
+  version '1.6'
+  sha256 '2dae3d80a35a6eb9013b053eb98ec8f082168ad9c8a1041bd173fb6ec9892a6b'
 
   url "https://stclairsoft.com/download/Jettison-#{version}.dmg"
   appcast 'https://stclairsoft.com/cgi-bin/sparkle.cgi?JT',
-          checkpoint: '6319301b4f7de64553226a1f22044eecd9bfcad0f401f091696b115ceaa950d4'
+          checkpoint: '19d162dbe3a48351efbf2712d9f41acdff593d5e3a1e37a2f20c5d896010ee61'
   name 'Jettison'
   name 'St. Clair Software Jettison'
   homepage 'https://stclairsoft.com/Jettison/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.