### PR TITLE
Update mountain-duck to 2.3.3.9245

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '2.3.1.9206'
-  sha256 'bff5e5fe3d2931dd901ad6c8b30a925655452c2015cc92aabdfcd42d3dcac017'
+  version '2.3.3.9245'
+  sha256 'dc00f673b087d117cb5881c1bfe16f31c4de6b41e4a5d8534d847b1b33cc7c55'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '78e74f97c3c3a0278457639af4d41022a24f3f321b571cdd7774c15dbd4fef59'
+          checkpoint: '478ba8c2f78938fa9e2fc8374317097645d6afcc7777c2ea02aefe6f14268488'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.