### PR TITLE
Update metabase-app to 0.28.5.1

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,11 +1,11 @@
 cask 'metabase-app' do
-  version '0.28.4.0'
-  sha256 '46f08fef5054e6aa3c3d4169842d3eb7ba91817b5aa9cc16da6ba626f044dd20'
+  version '0.28.5.1'
+  sha256 '15d0a19a14f51e5de6607041f7bf3e42c44686b6a43da270609ba6065c32def0'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"
   appcast 'https://s3.amazonaws.com/downloads.metabase.com/appcast.xml',
-          checkpoint: 'e3525f4922b4beb50a0277093978be5f97b10f3a95b6bdbae85bdc0ab93b2dd4'
+          checkpoint: '657c3a93f0146c3c0a90cc3f8733d469e7f99b737664ba1f60cef5d3be52830b'
   name 'Metabase'
   homepage 'https://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.