### PR TITLE
Update padlock to 2.6.2

### DIFF
--- a/Casks/padlock.rb
+++ b/Casks/padlock.rb
@@ -1,11 +1,11 @@
 cask 'padlock' do
-  version '2.5.0'
-  sha256 'f5d367608160a6fbbe6007893ed64e2fb8ba86f72bdff964b18f9b855b61eb80'
+  version '2.6.2'
+  sha256 '95627f911298ceea84da35e6c17d12d97fcf17a1970edd062cd912ac3d59d026'
 
   # github.com/MaKleSoft/padlock was verified as official when first introduced to the cask
   url "https://github.com/MaKleSoft/padlock/releases/download/v#{version}/Padlock-#{version}.dmg"
   appcast 'https://github.com/MaKleSoft/padlock/releases.atom',
-          checkpoint: 'fce2adfe4c017e5b85c44686faebab2c54ade548eaa6d41d6386e3c943844efb'
+          checkpoint: '2fd8816baa2d588f5809d17185af186008fb6d3fa38bedf2be7365ffaae0b2ff'
   name 'Padlock'
   homepage 'https://padlock.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.