### PR TITLE
Update joplin to 1.0.83

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '1.0.82'
-  sha256 'b88d348ac1bc3bab8fb53b56d53eb85cdae031209422a5d05d69c8a009cdff08'
+  version '1.0.83'
+  sha256 '6cf91bc494af2e6ea058609b698c16148bd66313cd38e27667b982aa0849acc7'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '195f24c49f89ba94f7b67e549288f98fb03b3d42ed7a03a61996fd07fe3b684a'
+          checkpoint: '148a8f71dee57a69f4293c60b7ba72ea25de0e679250620f58f39715ed550a70'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.