### PR TITLE
Update auristor-client to 0.168

### DIFF
--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -1,20 +1,20 @@
 cask 'auristor-client' do
-  version '0.167'
+  version '0.168'
 
   if MacOS.version == :mavericks
-    sha256 '50a605891a5d8e5262f33bc050fcf437ed630c54c7f931ed0d4d6cf691224a9a'
+    sha256 'b921aa93872a3f5dadcb8abbb94bc1ebbf97db44d64e96c5ab5880be54da2205'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.9/AuriStor-client-#{version}-Mavericks.dmg"
   elsif MacOS.version == :yosemite
-    sha256 '25072c42cb0e74b7d9f63e9248cad0851aa9566484f9f8f44a897b468e2f262a'
+    sha256 '4f44569cecf28b9e318c17a5801f2691ca78f5ee6c9665bc505ae28177b74547'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.10/AuriStor-client-#{version}-Yosemite.dmg"
   elsif MacOS.version == :el_capitan
-    sha256 '890ce742255b6c06be2bdedd93efc1de2f24ea1b25695b874399195236ab5f7f'
+    sha256 'a1d74ebab1ea9199afbc5675398c04ca877dc6eeb6ae71a808601023955dfa5e'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.11/AuriStor-client-#{version}-ElCapitan.dmg"
   elsif MacOS.version == :sierra
-    sha256 '3d9b1ddf4d2bcaad6a2fab9d35bc21a744ed08da5776b0579ed7e58a42264899'
+    sha256 '243ac6bc632c0070d5ffdfb93c49c8609b2842aac6d98b9d2bc562f01b70ed36'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.12/AuriStor-client-#{version}-Sierra.dmg"
   else
-    sha256 '9faef2ded9a89b0dfc697b9abd721af940b8ba865ae1404473319ce6e7df84c6'
+    sha256 '37f79fae30eb28a85d7da8983bfd036654000be1560356321c893fb8c6a91c66'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.13/AuriStor-client-#{version}-HighSierra.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.