### PR TITLE
Update mongodb-compass to 1.12.5

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.12.4'
-  sha256 'e847d9a7f479fb34aa53b99422d20edb74f5be0a122c8a18a647ebbbc7a243ba'
+  version '1.12.5'
+  sha256 '6e9ce59f2fd9d1bea3e8028c9970bfaccf76c5b36373c3f69d08401a207375ec'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.