### PR TITLE
Update tableflip to 1.1.8

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,11 +1,11 @@
 cask 'tableflip' do
-  version '1.1.7'
-  sha256 'b57c5b41ea34d7c570136efd53bedc0cba4412bf8bf6f4343ccdc4d9259c1018'
+  version '1.1.8'
+  sha256 '4b9e19c22b49594b88226648f5ac23c780a214aaead6bfd777a59b76c498bf9f'
 
   # s3.amazonaws.com/tableflip was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableflip/TableFlip-v#{version}.zip"
   appcast "https://update.christiantietze.de/tableflip/v#{version.major}/release.xml",
-          checkpoint: '21f265db64c8a82f461240c5b51769b31945b9f623b8860a78cd6481278a0900'
+          checkpoint: 'b8f9c377f51ec89e771370776136c0e3b0ffa9cc00ed071d93bb3786135246cc'
   name 'TableFlip'
   homepage 'https://tableflipapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.