### PR TITLE
Update wordservice to 2.8.2

### DIFF
--- a/Casks/wordservice.rb
+++ b/Casks/wordservice.rb
@@ -1,6 +1,6 @@
 cask 'wordservice' do
-  version '2.8.1'
-  sha256 'c8085d93400ee60d103225fbaa53409fe66b8c92afe6cda05ca74916562c3a92'
+  version '2.8.2'
+  sha256 'bf2a982702d922b984639b372510ee73cdfc28f5c5fbbb5fa540bb2702beab7a'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/freeware/wordservice/#{version}/WordService.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.