### PR TITLE
Update nitroshare to 0.3.4

### DIFF
--- a/Casks/nitroshare.rb
+++ b/Casks/nitroshare.rb
@@ -1,6 +1,6 @@
 cask 'nitroshare' do
   version '0.3.4'
-  sha256 'c76fc72f25dca27b371e8ed37488a11da625063a339452702d350f5ec6e557f7'
+  sha256 '64a3c62631ea8676ec2fc4f011aabf119ad5b4916de5c1ef969138096584b808'
 
   url "https://launchpad.net/nitroshare/#{version.major_minor}/#{version}/+download/nitroshare-#{version}-osx.dmg"
   appcast 'https://github.com/nitroshare/nitroshare-desktop/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.