### PR TITLE
Update nodebox to 3.0.51

### DIFF
--- a/Casks/nodebox.rb
+++ b/Casks/nodebox.rb
@@ -1,12 +1,15 @@
 cask 'nodebox' do
-  version '3.0.47'
-  sha256 '5ecff567f031fea456e2b8dc3eae3f23e29160cda4623dd048e18e5860d54d3b'
+  version '3.0.51'
+  sha256 '2187ebaa849de93f54c5550529678a8a160b06cf6186e8d21a66fc43f395e629'
 
-  url "https://secure.nodebox.net/downloads/NodeBox-#{version}.zip"
+  # github.com/nodebox/nodebox was verified as official when first introduced to the cask
+  url "https://github.com/nodebox/nodebox/releases/download/v#{version}/NodeBox-#{version}.zip"
   appcast 'https://www.nodebox.net/node/release-notes.html',
-          checkpoint: '3611b14bb85d5c4ecd914bb5b03eb9b38ad7225b524b3a63f26913b1cfc2217b'
+          checkpoint: '50038e9f76f0ca9a5dd0860240969ea736fbb70ca12137270f5a4dbbd960c3f9'
   name 'NodeBox'
   homepage 'https://www.nodebox.net/node/'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'NodeBox.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.