### PR TITLE
kube-solo is deprecated in favor of minikube, add caveat

### DIFF
--- a/Casks/kube-solo.rb
+++ b/Casks/kube-solo.rb
@@ -11,4 +11,8 @@ cask 'kube-solo' do
   app 'Kube-Solo.app'
 
   zap trash: '~/kube-solo'
+
+  caveats <<~EOS
+    As of October 2017, this has been depricated in favof of minikube.
+  EOS
 end

--- a/Casks/kube-solo.rb
+++ b/Casks/kube-solo.rb
@@ -12,7 +12,7 @@ cask 'kube-solo' do
 
   zap trash: '~/kube-solo'
 
-  caveats <<~EOS
-    As of October 2017, this has been depricated in favof of minikube.
-  EOS
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Based on information at https://github.com/TheNewNormal/kube-solo-osx#kubernetes-solo-cluster-for-macos
```
Kubernetes Solo cluster for macOS
This project is not maintained anymore, please use minikube instead
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [] The commit message includes the cask’s name and version.