### PR TITLE
Update daedalus to 1.1.1.952

### DIFF
--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -1,15 +1,16 @@
 cask 'daedalus' do
-  version '1.0.3619'
-  sha256 'fd644fe565e92adc13bc004bf18d4ec9591d79aa7f69fa63ee008def47fa1770'
+  version '1.1.1.952'
+  sha256 'f5262107b30f5617018fec7bff42982484f3af3623f8169d98500dfb7d495b84'
 
-  # amazonaws.com/daedalus-travis was verified as official when first introduced to the cask
-  url "https://s3.eu-central-1.amazonaws.com/daedalus-travis/Daedalus-installer-#{version}.pkg"
+  # amazonaws.com/update-cardano-mainnet.iohk.io was verified as official when first introduced to the cask
+  url "https://s3-ap-southeast-1.amazonaws.com/update-cardano-mainnet.iohk.io/Daedalus-installer-#{version}.pkg"
   name 'Daedalus'
   homepage 'https://daedaluswallet.io/'
 
   pkg "Daedalus-installer-#{version}.pkg"
 
-  uninstall pkgutil: 'org.daedalus.pkg'
+  uninstall pkgutil: 'org.daedalus.pkg',
+            trash:   '/Applications/Daedalus.app'
 
   zap trash: [
                '~/Library/Application Support/Daedalus',

--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -10,7 +10,7 @@ cask 'daedalus' do
   pkg "Daedalus-installer-#{version}.pkg"
 
   uninstall pkgutil: 'org.daedalus.pkg',
-            trash:   '/Applications/Daedalus.app'
+            delete:  '/Applications/Daedalus.app'
 
   zap trash: [
                '~/Library/Application Support/Daedalus',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.