### PR TITLE
Update oclint to 0.13.1,17.4.0

### DIFF
--- a/Casks/oclint.rb
+++ b/Casks/oclint.rb
@@ -1,11 +1,11 @@
 cask 'oclint' do
-  version '0.13,17.0.0'
-  sha256 '03ccf5c21abd705edfb254d037e0452490d8ce3bfb8d638cc2aa8e69e7283658'
+  version '0.13.1,17.4.0'
+  sha256 'c67f014a1ce997e62a242fe9154a9ac0a4ea50ad07b0417f3fb8b13f20e1ab90'
 
   # github.com/oclint/oclint was verified as official when first introduced to the cask
   url "https://github.com/oclint/oclint/releases/download/v#{version.before_comma}/oclint-#{version.before_comma}-x86_64-darwin-#{version.after_comma}.tar.gz"
   appcast 'https://github.com/oclint/oclint/releases.atom',
-          checkpoint: '939775f9b4876d24f3b9b7c897e6680cdc3347fa99ee55b62976d6606cb950d0'
+          checkpoint: 'd60b959ae35a0632d8f60e6234e19f425a04d924a31520753bd45643b25a1a6d'
   name 'OCLint'
   homepage 'http://oclint.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.