### PR TITLE
Update omegat to 3.6.0_09

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,11 +1,11 @@
 cask 'omegat' do
-  version '3.6.0_07'
-  sha256 'd6f1a60f5270efcbb1bd494824cc276b595e44b32fa01cbcaeaef6dce53f3d0b'
+  version '3.6.0_09'
+  sha256 '62274f144ff14c1a11d0bb2995006d06b8b3215807d620f735e248f5b87dda2c'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}%20update%204/OmegaT_#{version}_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard',
-          checkpoint: '9b605bfd9a498c9175151e05860be306fc956aa3a651bdc4eb5785cbc5fe211f'
+          checkpoint: '922c7a77f0831f858ef6854339d911fbba41e42f084f6032da325fccbffb4151'
   name 'OmegaT'
   homepage 'https://omegat.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.