### PR TITLE
Update onlyoffice to 4.8.8

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,10 +1,10 @@
 cask 'onlyoffice' do
-  version '4.4'
-  sha256 'ef98728c2b644e025d75c4abb722da71627e9d56169e4cd8ff95487e9ae27ce6'
+  version '4.8.8'
+  sha256 'bdaeac372b42920f6b6d0523d833aab3681adcd87b3d2bac589304d6111ba7b7'
 
   url "http://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'http://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml',
-          checkpoint: '3ba11ef937106e8a2cbc29434efb68419b8f3c49abc288f5dbb295a005c5a019'
+          checkpoint: 'ee4031cd3c52d4a2605f87ebfcba8afb3b4a8ef20f9c8a6b255702f703c2b1ee'
   name 'ONLYOFFICE'
   homepage 'https://www.onlyoffice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.