### PR TITLE
Update namechanger to 3.3.1

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -1,10 +1,10 @@
 cask 'namechanger' do
-  version '3.3.0'
-  sha256 '77a328f2947cd01c37a9181556c9e9d044b131075e72b514af0d01f7da35188d'
+  version '3.3.1'
+  sha256 'd00f9d9eaaa9d228f686dc313e9c5f8978d2d35fc9e598d759e8a2c9ca993198'
 
   url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.dots_to_underscores}.zip"
   appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
-          checkpoint: 'bc5602d20c7b88ad517282a8d1ae96327dd2c074fafd9ba36b76679c52b56e07'
+          checkpoint: '3caded5e8f5c07e6ec260322176151019a091a429d46af9ea3230ab00b6d13cd'
   name 'NameChanger'
   homepage 'https://mrrsoftware.com/namechanger/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.