### PR TITLE
Add parts-library caveats to Fritzing 0.9.3b

### DIFF
--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -8,6 +8,8 @@ cask 'fritzing' do
   name 'Fritzing'
   homepage 'http://fritzing.org/home/'
 
+  app 'Fritzing.app'
+
   caveats <<~EOS
     There's a known issue with Fritzing 0.9.3b, causing it to corrupt its own
     parts-library on first-launch. To avoid this, you must launch Fritzing
@@ -24,6 +26,4 @@ cask 'fritzing' do
 
     See: https://github.com/fritzing/fritzing-app/issues/3308 for more.
   EOS
-
-  app 'Fritzing.app'
 end

--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -8,24 +8,22 @@ cask 'fritzing' do
   name 'Fritzing'
   homepage 'http://fritzing.org/home/'
 
-  if version == '0.9.3b'
-    caveats <<~EOS
-      There's a known issue with Fritzing 0.9.3b, causing it to corrupt its own
-      parts-library on first-launch. To avoid this, you must launch Fritzing
-      *from the command-line* for the first time, like this:
+  caveats <<~EOS
+    There's a known issue with Fritzing 0.9.3b, causing it to corrupt its own
+    parts-library on first-launch. To avoid this, you must launch Fritzing
+    *from the command-line* for the first time:
 
       $ /Applications/Fritzing.app/Contents/MacOS/Fritzing
 
-      Once open, you'll need to explicitly update the parts-library:
+    Once open, you'll need to explicitly update the parts-library:
 
-        Help → Check for updates...
+      Help → Check for updates...
 
-      Thereafter, at least until the next time you want to update the
-      parts-library, you can safely launch it from the Finder.
+    Thereafter, at least until the next time you want to update the
+    parts-library, you can safely launch it from the Finder.
 
-      (See: <https://github.com/fritzing/fritzing-app/issues/3308>)
-    EOS
-  end
+    See: https://github.com/fritzing/fritzing-app/issues/3308 for more.
+  EOS
 
   app 'Fritzing.app'
 end

--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -8,5 +8,24 @@ cask 'fritzing' do
   name 'Fritzing'
   homepage 'http://fritzing.org/home/'
 
+  if version == '0.9.3b'
+    caveats <<~EOS
+      There's a known issue with Fritzing 0.9.3b, causing it to corrupt its own
+      parts-library on first-launch. To avoid this, you must launch Fritzing
+      *from the command-line* for the first time, like this:
+
+      $ /Applications/Fritzing.app/Contents/MacOS/Fritzing
+
+      Once open, you'll need to explicitly update the parts-library:
+
+        Help → Check for updates...
+
+      Thereafter, at least until the next time you want to update the
+      parts-library, you can safely launch it from the Finder.
+
+      (See: <https://github.com/fritzing/fritzing-app/issues/3308>)
+    EOS
+  end
+
   app 'Fritzing.app'
 end

--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -15,7 +15,7 @@ cask 'fritzing' do
     parts-library on first-launch. To avoid this, you must launch Fritzing
     *from the command-line* for the first time:
 
-      $ /Applications/Fritzing.app/Contents/MacOS/Fritzing
+      $ #{appdir}/Fritzing.app/Contents/MacOS/Fritzing
 
     Once open, you'll need to explicitly update the parts-library:
 


### PR DESCRIPTION
(No checkboxes; didn't change anything but a caveats clause.)