### PR TITLE
Update opensesame to 3.2.2

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,17 +1,11 @@
 cask 'opensesame' do
-  if MacOS.version <= :snow_leopard
-    version '0.26'
-    sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'
-    url "https://files.cogsci.nl/software/opensesame/opensesame_#{version}-macos-2.zip"
-  else
-    version '3.2.2'
-    sha256 '02fbe080c163cef1060f927a0d9fde9a2b787bf59e249be098de384cb58f6952'
-    # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
-    url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
-    appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: '313b8f7ef7123f624f4e38f60f89ac66b249834a714c79f4fc702731728594e0'
-  end
+  version '3.2.2'
+  sha256 '02fbe080c163cef1060f927a0d9fde9a2b787bf59e249be098de384cb58f6952'
 
+  # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
+  url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
+  appcast 'https://github.com/smathot/OpenSesame/releases.atom',
+          checkpoint: '313b8f7ef7123f624f4e38f60f89ac66b249834a714c79f4fc702731728594e0'
   name 'OpenSesame'
   homepage 'https://osdoc.cogsci.nl/'
 

--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -4,12 +4,12 @@ cask 'opensesame' do
     sha256 'b2a37cfd1c514b2ae8ddd0be09a274844420bfa432318ef87df308fdd3b6a770'
     url "https://files.cogsci.nl/software/opensesame/opensesame_#{version}-macos-2.zip"
   else
-    version '3.1.9'
-    sha256 '593664ae5b88f03e845a837cf0cd062a6ebca97fcfb47e7017adf00c5f44b274'
+    version '3.2.2'
+    sha256 '02fbe080c163cef1060f927a0d9fde9a2b787bf59e249be098de384cb58f6952'
     # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
     url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
     appcast 'https://github.com/smathot/OpenSesame/releases.atom',
-            checkpoint: 'dd285e93f1cfd611c42e135a837ee7239bf55819bf99f4f9a228d75ca9f0f68c'
+            checkpoint: '313b8f7ef7123f624f4e38f60f89ac66b249834a714c79f4fc702731728594e0'
   end
 
   name 'OpenSesame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.