### PR TITLE
Add Cask for mactex-no-gui 20170524

### DIFF
--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -60,8 +60,4 @@ cask 'mactex-no-gui' do
                '/usr/local/texlive',
                '~/Library/texlive',
              ]
-
-  caveats <<~EOS
-    This Cask does not install any of the gui apps packaged with MacTeX.
-  EOS
 end

--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -1,0 +1,67 @@
+cask 'mactex-no-gui' do
+  version '20170524'
+  sha256 '0caf76027c9e0534a0b636f2b880ace4a0463105a7ad5774ccacede761be8c2d'
+
+  # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
+  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
+  appcast 'https://www.tug.org/mactex/downloading.html',
+          checkpoint: '2dd3e7c71fe586512a5241f2b26c24f93af3510d2bda2f56da1a404098b894ee'
+  name 'MacTeX'
+  homepage 'https://www.tug.org/mactex/'
+
+  conflicts_with cask: [
+                         'mactex',
+                         'mactex-no-ghostscript',
+                         'basictex',
+                       ]
+  depends_on macos: '>= :yosemite'
+  depends_on formula: 'ghostscript'
+
+  pkg "mactex-#{version}.pkg",
+      choices: [
+                 {
+                   # TeXLive
+                   'choiceIdentifier' => 'choice1',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   # GUI-Applications
+                   'choiceIdentifier' => 'choice2',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   # Ghostscript
+                   'choiceIdentifier' => 'choice3',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+               ]
+
+  uninstall pkgutil: [
+                       'org.tug.mactex.gui2017',
+                       'org.tug.mactex.texlive2017',
+                     ],
+            delete:  [
+                       '/usr/local/texlive/2017',
+                       '/Applications/TeX',
+                       '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
+                       '/Library/TeX',
+                       '/etc/paths.d/TeX',
+                       '/etc/manpaths.d/TeX',
+                     ]
+
+  zap trash: [
+               '/usr/local/texlive/texmf-local',
+               '~/Library/texlive/2017',
+             ],
+      rmdir: [
+               '/usr/local/texlive',
+               '~/Library/texlive',
+             ]
+
+  caveats <<~EOS
+    This Cask does not install any of the gui apps packaged with MacTeX.
+  EOS
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Well, I'm a GitHub newbie so I'm not sure about if it's all right. 
I made this cask b/c I would like to install my own editors for latex, without all the gui applications included. It can feel as bloat when you uses separate editors from TeXShop and not use other applications like LaTeXit. I wanted a solution for home-brew cask.
 It also uses home-brew Ghostscript. I referenced caskroom/homebrew-cask#38190 very much, but I wasn't sure about the commit message thingie, so I didn't tick the checkbox about that. (Sorry for the bad English / GitHub skills;;)