### PR TITLE
Update cockatrice to 2.5.0,2018-03-02:Decked_Out

### DIFF
--- a/Casks/cockatrice.rb
+++ b/Casks/cockatrice.rb
@@ -1,11 +1,11 @@
 cask 'cockatrice' do
-  version '2.4.0,2017-11-19:Unwrapped'
-  sha256 'bd422d2ed42a1d15b7f83e1be9ace6b6b99b0e3130357dc087a9d554c54fecba'
+  version '2.5.0,2018-03-02:Decked_Out'
+  sha256 '500d28c24b5cb4e0128a67e153948b2dff59906d816827ec3a56b692bf598cce'
 
   # github.com/Cockatrice/Cockatrice was verified as official when first introduced to the cask
   url "https://github.com/Cockatrice/Cockatrice/releases/download/#{version.after_comma.before_colon}-Release-#{version.before_comma}/Cockatrice-#{version.after_colon}-#{version.before_comma}.dmg"
   appcast 'https://github.com/Cockatrice/Cockatrice/releases.atom',
-          checkpoint: '590f24d47778ff6abff0335f427c540a574b8553219add1d85876d01235a5713'
+          checkpoint: '4b0fde9f61b984516c01c9ae379518e40dd56a2891ff3d39a8fdaba543a0d824'
   name 'Cockatrice'
   homepage 'http://www.woogerworks.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.