### PR TITLE
Update jaxx to 1.3.15

### DIFF
--- a/Casks/jaxx.rb
+++ b/Casks/jaxx.rb
@@ -1,11 +1,11 @@
 cask 'jaxx' do
-  version '1.3.12'
-  sha256 '1e19563f4f7c5a9d045b3a3fd6357107559ab54a994ba714058953300cefe166'
+  version '1.3.15'
+  sha256 'b054de8f5fe423c2c671494ac53acef4c25a310fddcb3088fdc34e15f4d95759'
 
   # github.com/Jaxx-io/Jaxx was verified as official when first introduced to the cask
   url "https://github.com/Jaxx-io/Jaxx/releases/download/v#{version}/Jaxx-#{version}.dmg"
   appcast 'https://github.com/Jaxx-io/Jaxx/releases.atom',
-          checkpoint: '2351faee636501193391d62e1e4b29f7dcc07acfeda00389af944fac746edc01'
+          checkpoint: '8e47b7e7b92e53145c3d3864cad1e0351ce0b02e2e8d8d641ab84a277a30cf94'
   name 'Jaxx Blockchain Wallet'
   homepage 'https://jaxx.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.