### PR TITLE
Update pd-l2ork to 2.5.0

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,11 +1,11 @@
 cask 'pd-l2ork' do
-  version '2.4.9'
-  sha256 '5e380d987a6f259f2441117858703b5e0053c4f96f0defbdf03ba89ac11fc3e5'
+  version '2.5.0'
+  sha256 '84986de234df55facdfc84afbd746eb101e7bbd3f7e0d4b2d4c5b3592c91b444'
 
   # github.com/agraef/purr-data was verified as official when first introduced to the cask
   url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-x86_64.zip"
   appcast 'https://github.com/agraef/purr-data/releases.atom',
-          checkpoint: '2b142a316395fa34411d623883de2fa1d580d161c74d2ad46f9cb09b8ae1eda0'
+          checkpoint: '1c2c9ece7b00a5f95bc3c745b9c1b15128c2f98a263a951b4f5990d5025d1d5f'
   name 'Pd-l2ork'
   name 'Purr Data'
   homepage 'https://agraef.github.io/purr-data/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.