### PR TITLE
Update osculator to 3.1.2-63-gb9634423,2356a19f-47c4-4689-9f3b-5f5c83d6c85f

### DIFF
--- a/Casks/osculator.rb
+++ b/Casks/osculator.rb
@@ -1,13 +1,13 @@
 cask 'osculator' do
-  version '3.1.1-7-g064b670,8f8c7fe3-196c-44c2-8b93-e7507b749fdf'
-  sha256 '960bc3536cbf27fd0307d8e08d5d855f0f796f14b2016df4e6835818ffac2817'
+  version '3.1.2-63-gb9634423,2356a19f-47c4-4689-9f3b-5f5c83d6c85f'
+  sha256 '5868d7dcc1a6121945ee69286fc26e1c70a04e4e118e5ec05a877d74a8a2c722'
 
   # distribution.wildora.net was verified as official when first introduced to the cask
   url "https://distribution.wildora.net/products/osculator-v#{version.major}/revisions/#{version.after_comma}/osculator-#{version.before_comma}.dmg"
   appcast 'https://osculator.net/downloadthanks.php?stable',
-          checkpoint: 'f05f25b4bdc6e493e45619036b4037e5fb2918a61803b7cfd27912b10dba8843'
+          checkpoint: '6ee719500cb0df48815239eb88f9740218e6b9b14e8d25992825f387fb64578c'
   name 'OSCulator'
   homepage 'https://osculator.net/'
 
-  app 'OSCulator ƒ/OSCulator.app'
+  app 'OSCulator.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.