### PR TITLE
Update otter-browser to 0.9.97-rc7

### DIFF
--- a/Casks/otter-browser.rb
+++ b/Casks/otter-browser.rb
@@ -1,11 +1,11 @@
 cask 'otter-browser' do
-  version '0.9.94'
-  sha256 '655e7078483dbedf7d3a99ea2ba9df1eb30bfb5e5ad656a1a34fb6b6c65ec5f9'
+  version '0.9.97-rc7'
+  sha256 '71af2a3de43bffc059030f50a9f90d882df10713d0e8bed0e54be1a5f6f378c8'
 
   # sourceforge.net/otter-browser was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/otter-browser/otter-browser-#{version}-setup.dmg"
   appcast 'https://sourceforge.net/projects/otter-browser/rss',
-          checkpoint: '0229f008fe06822195c01a46c8c29a515c1e6c01a3f9050b756390f65de6b70d'
+          checkpoint: '88fce898da990c99de75b194fb39fd57e22c80666cfc7d8bf1d47ac95e172a5d'
   name 'Otter Browser'
   homepage 'https://otter-browser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.