### PR TITLE
Update juicebox to 1.8.8

### DIFF
--- a/Casks/juicebox.rb
+++ b/Casks/juicebox.rb
@@ -1,15 +1,15 @@
 cask 'juicebox' do
-  version :latest
-  sha256 :no_check
+  version '1.8.8'
+  sha256 'f3e825c062184dc11ef8f5a7ca3df3667b943663734d84e4cec86e93427dd1db'
 
   # s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox/Juicebox.dmg'
+  url "https://s3.amazonaws.com/hicfiles.tc4ga.com/public/juicebox/Juicebox_#{version}.dmg"
   name 'Juicebox'
   homepage 'http://aidenlab.org/juicebox/'
 
   app 'Juicebox.app'
 
   caveats do
-    depends_on_java('8')
+    depends_on_java('8+')
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.