### PR TITLE
Update teamsql to 3.2.195

### DIFF
--- a/Casks/teamsql.rb
+++ b/Casks/teamsql.rb
@@ -1,6 +1,6 @@
 cask 'teamsql' do
-  version '3.2.190'
-  sha256 'ab00986145f6b1c981856fb6c2da301a696cca4b37ca6fb315c519ff2e707a3c'
+  version '3.2.195'
+  sha256 'e4c0a92cba73c5c50f977a13538674ce8ca6af591d8e456fcbbc22c5611448b8'
 
   # dlpuop5av9e02.cloudfront.net/osx/stable was verified as official when first introduced to the cask
   url "https://dlpuop5av9e02.cloudfront.net/osx/stable/#{version}/TeamSQL-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.