### PR TITLE
Update powerphotos to 1.3.8

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,13 +8,13 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.3.7'
-    sha256 'bee7dfbd86549372c8530858419ff619cc0e574088f5f7da1c085c30324f7254'
+    version '1.3.8'
+    sha256 '075b828c72bb8d8615eb86293441ec57a6eb330261f9cf49a0553f45d91aca5d'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 
   appcast 'https://www.fatcatsoftware.com/powerphotos/powerphotos_appcast.xml',
-          checkpoint: 'b8e1110e5018ba82e078a7ef40a69f19afbc590b65a6ea1f9cd9905ce0c6c587'
+          checkpoint: 'bb8963351c84927f79a3568e9d64dfae28c1e006dd8ad281a531bb7adb2e534d'
   name 'PowerPhotos'
   homepage 'https://www.fatcatsoftware.com/powerphotos/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.