### PR TITLE
Update standard-notes to 2.1.26

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.1.1'
-  sha256 '76371d289adf6ddd0e5bfac2c52fe2fe6fa4532cab54a08fc1decdcdff95d3f6'
+  version '2.1.26'
+  sha256 '4475e747eba093b1475ef0b0ed63646d6fc4eb9d72630ee6f80b9c33d745d55b'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'a3f273cfafa35b496be8a96bc5c16aa6698985646780bd483ecf3deb8e05a2bb'
+          checkpoint: '6061888344c20c7fbb64cc42f6b5bff99de276b211f01fc8ba7fa0c791444a33'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.