### PR TITLE
Update paintcode to 3.3.8

### DIFF
--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,11 +1,11 @@
 cask 'paintcode' do
-  version '3.3.6'
-  sha256 '0e97da6713685c28e8ca198514933ead6401dd6d4963a2eed0c0b8e27cc05de6'
+  version '3.3.8'
+  sha256 '070b9f220693fb195501449e68460f26114d2208b45473f51977567aec941396'
 
   # pixelcut.com/paintcode was verified as official when first introduced to the cask
   url "https://www.pixelcut.com/paintcode#{version.major}/paintcode.zip"
   appcast "https://www.pixelcut.com/paintcode#{version.major}/appcast.xml",
-          checkpoint: '78737eb412de8b34c038eced33553dac44f569fabb98b42b7a1852e1ae20e377'
+          checkpoint: 'c69924e71b543d06f24da680ebb621deabc29db6a8ef4f29b2025500765ce8e5'
   name 'PaintCode'
   homepage 'https://www.paintcodeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.