### PR TITLE
Update pikopixel to 1.0-b9

### DIFF
--- a/Casks/pikopixel.rb
+++ b/Casks/pikopixel.rb
@@ -1,11 +1,11 @@
 cask 'pikopixel' do
-  version '1.0-b8'
-  sha256 'b99a077a3ab3cb2f06af70d145977c5c7339d81e861a9b8c3fa2ba39c690181d'
+  version '1.0-b9'
+  sha256 'fb5a495a9284c9ea435f4d48e6572c1e1e673e11fe020e52ac0bf98b73a6f4ce'
 
   url "http://twilightedge.com/downloads/PikoPixel.#{version}.dmg",
       user_agent: :fake
   appcast 'http://twilightedge.com/mac/pikopixel/history.html',
-          checkpoint: '083969e644e961cfe61696bc5bec560608bbb5d60374216e05407fb9ad404eb1'
+          checkpoint: '5ab5fa990651cedc8bee56abdf2490bb987480b9aeaf524e744a6694b76ec60d'
   name 'PikoPixel'
   homepage 'http://twilightedge.com/mac/pikopixel/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.