### PR TITLE
Add Google Play Music Desktop Player v4.5.0 (gpmdp).

### DIFF
--- a/Casks/gpmdp.rb
+++ b/Casks/gpmdp.rb
@@ -1,0 +1,19 @@
+cask 'gpmdp' do
+  version '4.5.0'
+  sha256 '2d43b0c69fa38d90a26cb711bcb952cb9be525d3ace9e8a5c5d7fe5e5a27db26'
+
+  # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
+  url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"
+  appcast 'https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases.atom',
+          checkpoint: '20c4bcba908bb7e9a4ad0f7fc021fc9de2c44406e72a0b8b9dadde818984fff4'
+  name 'Google Play Music Desktop Player'
+  homepage 'https://www.googleplaymusicdesktopplayer.com/'
+
+  app 'Google Play Music Desktop Player.app'
+
+  zap trash: [
+               '~/Library/Application Support/Google Play Music Desktop Player',
+               '~/Library/Caches/google-play-music-desktop-player',
+               '~/Library/Caches/google-play-music-desktop-player.ShipIt',
+             ]
+end


### PR DESCRIPTION
[Google Play Music Desktop Player](https://www.googleplaymusicdesktopplayer.com/) (GPMDP) is a popular unofficial Electron wrapper for Google Play Music that introduces new features and improves upon the Google Play Music website.

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
Since GPMDP is not an official Google application, the recommended token "google-play-music-desktop-player" was changed to "gpmdp" in order to avoid misleading users and to prevent any potential copyright or trademark issues.

- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
