### PR TITLE
Update mos to 2.2.0

### DIFF
--- a/Casks/mos.rb
+++ b/Casks/mos.rb
@@ -1,11 +1,11 @@
 cask 'mos' do
-  version '2.0.0'
-  sha256 '04d3dda5f598994354d2c2c09191cc5cffad4a066a2dac4e546782f58c053361'
+  version '2.2.0'
+  sha256 'fc8f5359f9d6e826741ef59c975a8ffe9be1cadda22933e6d0f40929e2413da3'
 
   # github.com/Caldis/Mos was verified as official when first introduced to the cask
-  url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Version.#{version}.dmg"
+  url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.dmg"
   appcast 'https://github.com/Caldis/Mos/releases.atom',
-          checkpoint: '227c55156ad8d2ce6376806cb25f7c6aeef4e5f33ff2cdd1576eb9ffc4ef56a1'
+          checkpoint: '3ddaddac825c26ac3cb4dd57826770e524a498bd4d7d364627fac510baa20459'
   name 'Mos'
   homepage 'https://mos.caldis.me/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.