### PR TITLE
Update supercollider to 3.9.3

### DIFF
--- a/Casks/supercollider.rb
+++ b/Casks/supercollider.rb
@@ -1,11 +1,11 @@
 cask 'supercollider' do
-  version '3.9.1'
-  sha256 '5b13cdc6d1fe9a6a947406fb22852d72f1ec623367f1cea0065b63ed86d5bdde'
+  version '3.9.3'
+  sha256 '84cdad611aca022ff218aff46e92021a334c5bb8e6ac3dbbe0051fe7f57bae07'
 
   # github.com/supercollider/supercollider was verified as official when first introduced to the cask
   url "https://github.com/supercollider/supercollider/releases/download/Version-#{version}/SuperCollider-#{version}-macOS.zip"
   appcast 'https://github.com/supercollider/supercollider/releases.atom',
-          checkpoint: 'e59593baaa6ede02f4abfc079e0e144b49fad2b103acc5f332385be6626b3d1e'
+          checkpoint: '72ee8bd7b4c3325c616a0eca42db28464b46904434215af74addfcad5f2a19f0'
   name 'SuperCollider'
   homepage 'https://supercollider.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.