### PR TITLE
Update graphql-playground to 1.5.2

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.5.0'
-  sha256 'd5018aeab61547e9de5c31acc12771590cb99c7803c7374c57cb07725feb431f'
+  version '1.5.2'
+  sha256 '7307364cfd8221fe7e7b91f146447bbbbbbe079f8a357c8aedd351dbee23cbfd'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: '7a717783084dd305e7aea3a3c257b3c556764fe743054337262d4474fde667b6'
+          checkpoint: '37aed50da2a0bedc710ec03a4a4dbedc4586b7cbad6dc74fdad6cd41bbfe2c9d'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.