### PR TITLE
Update alfred to 3.6.1_910

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -1,6 +1,6 @@
 cask 'alfred' do
-  version '3.6_903'
-  sha256 'd128389caeba552cb297e72dfc889379db50f003e43872dc91d09eb2080511e7'
+  version '3.6.1_910'
+  sha256 'fdefdb35047e193e1d06f5a441f4aabd4b45b24fd43c63d223d8508ad11a131e'
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.dmg"
   name 'Alfred'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.