### PR TITLE
Update quip to 5.2.62

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.2.53'
-  sha256 '7c632e9a20639eca5c7c10092726ecfef372235a8c7ccef4ac148808b053d43f'
+  version '5.2.62'
+  sha256 '7ef0530f2023a099780dc1ba14f59522839921dc7ecb09fdcf7595d9b0047f67'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.