### PR TITLE
Update praat to 6.0.38

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,11 +1,11 @@
 cask 'praat' do
-  version '6.0.36'
-  sha256 '5fe22254c0ce2a9ddea7de4d497fd3d5d620725ce690d123381dda44cccd7c30'
+  version '6.0.38'
+  sha256 'dc69203cddecf1c4dde441d2fd78e83b35b96b498fb7bc9d02a3a644299053ae'
 
   # github.com/praat/praat/releases was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom',
-          checkpoint: '2a347fbe3d6ae15184feaf71a2856fdca856cb7e06daabc26d0fd3f88ed76709'
+          checkpoint: '885c266f67baf05fff6d811f3470bf254b76b666758549823c4945abfd151377'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.