### PR TITLE
hex-fiend 2.8.0: add conflict

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -5,9 +5,11 @@ cask 'hex-fiend' do
   # github.com/ridiculousfish/HexFiend was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"
   appcast 'https://github.com/ridiculousfish/HexFiend/releases.atom',
-          checkpoint: '356d40d0edce7acc0a69f8113ed7a39a0eba16846d384f4b5907ae9498500755'
+          checkpoint: 'a08db7b7bd0ea6df35d193897ac5c5b11ed894703d9df5f67dfbd2d3828060de'
   name 'Hex Fiend'
   homepage 'http://ridiculousfish.com/hexfiend/'
+
+  conflicts_with cask: 'hex-fiend-beta'
 
   app 'Hex Fiend.app'
   binary "#{appdir}/Hex Fiend.app/Contents/Resources/hexf"


### PR DESCRIPTION
Pending caskroom/homebrew-version#5486

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
---
Pending caskroom/homebrew-versions#5486