### PR TITLE
Update onionshare to 1.3

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,11 +1,11 @@
 cask 'onionshare' do
-  version '1.2'
-  sha256 '1a9b0d5019a2b664535b4219b87caaaf676b0430b9816e86df2993bdaf9fb8ff'
+  version '1.3'
+  sha256 '262d0653945a06737502fb78bf2a159dbfdc93de6ff020c9ff2252db5d1ecd25'
 
   # github.com/micahflee/onionshare was verified as official when first introduced to the cask
-  url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare.pkg"
+  url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare-#{version}.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom',
-          checkpoint: '97ede8041dcfcf92e58aec8f4cca01ed036dcd191790bde56efaf333ca7b16f5'
+          checkpoint: 'f230e50bf649344715d0b53668f059566f16cfe487deb61dddbd0583477f9952'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
   gpg "#{url}.sig", key_url: 'https://onionshare.org/signing-key.asc'

--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -10,7 +10,7 @@ cask 'onionshare' do
   homepage 'https://onionshare.org/'
   gpg "#{url}.sig", key_url: 'https://onionshare.org/signing-key.asc'
 
-  pkg 'OnionShare.pkg'
+  pkg "OnionShare-#{version}.pkg"
 
   uninstall pkgutil: 'com.micahflee.onionshare'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.