### PR TITLE
Update qfinder-pro to 2.6.0.0214

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,10 +1,10 @@
 cask 'qfinder-pro' do
-  version '2.5.0.1228'
-  sha256 'b31c60368c95e82c5f1e4d604bce3bdaa7cc7330a9058f712192d8bf114e318a'
+  version '2.6.0.0214'
+  sha256 '84afbb7dbb5b309daf466bf74da588a16fa000d96c4b366be95b398317853fe7'
 
   url "http://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'http://update.qnap.com/SoftwareRelease.xml',
-          checkpoint: 'fc69d5d12b4c7ff159272f6cf44cadfe4788bb1480b1e5672d47bdd6699c6911'
+          checkpoint: '1ba97d1b6fda74f08a14e207f7a9a1bee01761f9cecea31fb9652bb2393636dc'
   name 'Qnap Qfinder Pro'
   homepage 'https://www.qnap.com/en/utilities#utliity_5'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.