### PR TITLE
Update name-mangler to 3.4.1

### DIFF
--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -1,10 +1,10 @@
 cask 'name-mangler' do
-  version '3.4'
-  sha256 '460f802b90e0e0123d397199600b68adf609e656e51a7b23f38bdf9eec05c91e'
+  version '3.4.1'
+  sha256 '040b98d0d0da0f4457b6186d9a3854165bf59dad3b45e61f5df6dbee4173c710'
 
   url 'https://manytricks.com/download/namemangler'
   appcast 'https://manytricks.com/namemangler/appcast/',
-          checkpoint: 'bd563ec5d011424d6f90b5b46a6d85e54fe1acc7ddb919ef96b5a3f96eb5f03b'
+          checkpoint: 'cec08158f7365b5652114c7109899e696fdab37df37597a1406c62d659312129'
   name 'Name Mangler'
   homepage 'https://manytricks.com/namemangler/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.