### PR TITLE
Update scrivener to 3.0.2,1506

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,11 +1,11 @@
 cask 'scrivener' do
-  version '3.0.1,966'
-  sha256 '704ae6632026a6b18f4f84df383696ca7bda37ea79ce5f3a269cd04ef3c622d4'
+  version '3.0.2,1506'
+  sha256 '05e360e15931fbf2114d50d6b926b3c8c899257e5a514b3add8ed4f6edd313aa'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://scrivener.s3.amazonaws.com/mac_updates/Scrivener_1012_#{version.after_comma}.zip"
   appcast "https://www.literatureandlatte.com/downloads/scrivener-#{version.major}.xml",
-          checkpoint: '86ba4658751c0ebb95046ca0c836e81c6d21259da8c051f41c4986cd59b6302b'
+          checkpoint: '003e8dffe156aafbe056a8c0070373ca5ba99b82a0b098ffb86c41dbd891cb5c'
   name 'Scrivener'
   homepage 'https://literatureandlatte.com/scrivener.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.