### PR TITLE
update ogdesign-eagle version to 1.5.1 build2

### DIFF
--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -1,9 +1,9 @@
 cask 'ogdesign-eagle' do
-  version '1.4.0_build3'
-  sha256 '903994156896dcd95501cff009f00f22ec35b70eec3eabfe43a776c2e718dc85'
+  version '1.5.1-build2'
+  sha256 'ab5c9d49cf7de1ea84604005128c7ea918ee168e4db9ca24b19ce092bc954f44'
 
   # eagle-1253434826.file.myqcloud.com was verified as official when first introduced to the cask
-  url "http://eagle-1253434826.file.myqcloud.com/releases/Eagle_#{version}.dmg"
+  url "http://eagle-1253434826.file.myqcloud.com/releases/Eagle-#{version}.dmg"
   name 'Eagle'
   homepage 'https://eagle.cool/macOS'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

![](https://cl.ly/qllr/Image%202018-04-10%20at%207.22.25%20PM.png)
![](https://cl.ly/qlqk/Image%202018-04-10%20at%207.22.46%20PM.png)