### PR TITLE
Update yandex-disk cask

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
   version '3.0'
-  sha256 '4cc3faad156c7c8fcddece0233c8b4042d239b4fa61f9772f6ae2dd59b9cc0f2'
+  sha256 :no_check
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.no_dots}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Today, without this fix, installation was failing with `Error: Checksum for Cask 'yandex-disk' does not match`.
Unfortunately, they publish new versions under the same URL, so checksum breaks install.
Luckily, the image is downloaded over HTTPS.