### PR TITLE
Update Synergy app to version 2.0.9-stable

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '2.0.8,b1659-a99bf78e'
-  sha256 '7e600945b3f4281569323da6ddc3eeafc0907b6eb1b557de8c4a5d94f1776cf7'
+  version '2.0.9,b1697-4a1bbebe'
+  sha256 '8d9fd724a590b3fcbd38d0cef4ff732045e20a023586fb738963c028b2bbe3d7'
 
   url "https://binaries.symless.com/v#{version.before_comma}/Synergy_v#{version.before_comma}-stable_#{version.after_comma}.dmg"
   name 'Synergy'


### PR DESCRIPTION
Updated the synergy app to version 2.0.9-stable. 

After making all changes to the cask:

- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} reports no offenses.
- [x] The commit message includes the cask’s name and version.