### PR TITLE
Update studio-3t to 2018.2.5

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '2018.2.4'
-  sha256 'f5ee571326f821b69e917fc17ca7050c8c164966433d55cf67f053067f4fce66'
+  version '2018.2.5'
+  sha256 '3e84381adef8e207a18a740a87fb8ec26e22dd1ffc97ac83b7d7d6575feb9594'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: '8c54aedcbf73463bf7b930c1f9a6584e40715faf81e1274de1e2b8243a60568f'
+          checkpoint: 'a7674667e1071c8636d70555d8b27e83bf0b48956b796b78bbb307a847df698f'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.