### PR TITLE
Update yandex-disk 3.0 checksum

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
   version '3.0'
-  sha256 '4cc3faad156c7c8fcddece0233c8b4042d239b4fa61f9772f6ae2dd59b9cc0f2'
+  sha256 'd5f9c1b43faeb99e30e203c612d678cbe6d2f08d187c74e7cf1c6e7efac5c53c'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.no_dots}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
Initial PR: https://github.com/caskroom/homebrew-cask/pull/45778

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

There's no post about update of 3.0, only about initial release of 3.0: https://yandex.ru/blog/disk/novoe-prilozhenie-disk-3-0-dlya-kompyutera

VirusTotal (container is not signed): https://www.virustotal.com/#/file/d5f9c1b43faeb99e30e203c612d678cbe6d2f08d187c74e7cf1c6e7efac5c53c/detection