### PR TITLE
Update radarr to 0.2.0.995

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,11 +1,11 @@
 cask 'radarr' do
-  version '0.2.0.870'
-  sha256 '2b071f7e32595a06f4d22fa523aa1c3a5850244347bffa0890774a3b7b45eec9'
+  version '0.2.0.995'
+  sha256 '28119d8e5e32e8039278c094a22d33a30c98c48239dc79643532d5b0b7e444ef'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"
   appcast 'https://github.com/Radarr/Radarr/releases.atom',
-          checkpoint: '4f99bfc047db51333fa4e58da7edf5a946306e39a10faa4911eac1e915b1aa76'
+          checkpoint: '1220385ac520d66ebab3c7c83f7d42fc892df41ca4a901df437f223ba1ed9583'
   name 'Radarr'
   homepage 'https://radarr.video/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.