### PR TITLE
Update keybase to 1.0.47-20180410052738,f705a9510f

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,10 +1,10 @@
 cask 'keybase' do
-  version '1.0.47-20180403021644,19ebebe08b'
-  sha256 '8d16c7614ce0b6b332c06bfb34a49425aeb92c6c337e0b18afd490ccf85a761c'
+  version '1.0.47-20180410052738,f705a9510f'
+  sha256 '1f919cc2ef8d52d9e54a0e0b31383e42c6142994304271e3ac8a20d0a3c18802'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json',
-          checkpoint: 'de1a7999d87f2b1e2beb95a119d0c5f0330796348092d35ed45762995aff1051'
+          checkpoint: '75b6d0ab6dfe8c1b1eaabe49cdee004320e2f9fd4579993c9795faae8f8c71e3'
   name 'Keybase'
   homepage 'https://keybase.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.