### PR TITLE
Fix krita 4.0.0 install for case-sensitive filesystems.

### DIFF
--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -9,7 +9,7 @@ cask 'krita' do
 
   depends_on macos: '>= :el_capitan'
 
-  app 'Krita.app'
+  app 'krita.app'
 
   zap trash: [
                '~/Library/Application Support/krita',


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.