### PR TITLE
Update minikube to 0.26.0

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,11 +1,11 @@
 cask 'minikube' do
-  version '0.25.2'
-  sha256 'dc5b00c4a06e8160bd607732c9a2294598d803716e353293b4463cc2c9539eec'
+  version '0.26.0'
+  sha256 '0b2c63c6f5a00525e679b01948edffcb16e3bdb37ea0db3ed89431dd0e4c3b3c'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"
   appcast 'https://github.com/kubernetes/minikube/releases.atom',
-          checkpoint: 'ce48a5c392fb7b35a106ae78ca225bc3c01e4afcb99d96957d3f8d0dcf55d910'
+          checkpoint: '31fb88014af1058d557bbcc5b9bcb0484ad34dd5327ea5c9ecac075d85b1a69e'
   name 'Minikube'
   homepage 'https://github.com/kubernetes/minikube'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.