### PR TITLE
Update sysdig-inspect to 0.3.0

### DIFF
--- a/Casks/sysdig-inspect.rb
+++ b/Casks/sysdig-inspect.rb
@@ -1,11 +1,11 @@
 cask 'sysdig-inspect' do
-  version '0.2.0'
-  sha256 '1c4d8dd87c44362603bcee752d31f3f3f7b2b6677eef6f5d8219dfcfa0607900'
+  version '0.3.0'
+  sha256 'b7a0a8f988f6d188c8ecea5a673fc61135973e21d0e20ae11727ea8ddbaeaec7'
 
   # download.sysdig.com/stable/sysdig-inspect was verified as official when first introduced to the cask
   url "https://download.sysdig.com/stable/sysdig-inspect/sysdig-inspect-#{version}-mac.dmg"
   appcast 'https://github.com/draios/sysdig-inspect/releases.atom',
-          checkpoint: 'fcdc73d10fc08b495dac33350230e7f4df1903856c4695be14716f0709bbdadf'
+          checkpoint: 'd48ffed8b8d0f100488a2cbf4a04adbd1eb5ce000bfa0baab2c0991f3d093f9b'
   name 'Sysdig Inspect'
   homepage 'https://github.com/draios/sysdig-inspect'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.