### PR TITLE
Update cycling74-max to 7.3.5_180307

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '7.3.4_171023'
-  sha256 'dd262487d15cc0eab9ec1b1aeab734ef79935dad35c67af23d73537a94a271b1'
+  version '7.3.5_180307'
+  sha256 '53dc94069c4493856cf33ed6051366f3fa5250134cff93a9557c63b141884bd2'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.