### PR TITLE
Update hstracker to 1.4.0

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,11 +1,11 @@
 cask 'hstracker' do
-  version '1.3.5'
-  sha256 '610ff12a929d71f6ef2c17eb1b74b6a4cf198e59b0e195896756595c1534b1e2'
+  version '1.4.0'
+  sha256 '2fe9038d059bf63cc4a8a8a19c3561a06db97c6243c9769554ed16ff6cc5699f'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"
   appcast 'https://github.com/HearthSim/HSTracker/releases.atom',
-          checkpoint: 'a444c12b43cd494206b62aee8333b85a097bba7600ef2617d436ac2a5146a8bb'
+          checkpoint: 'de94f5a14129c212b09fceca9f151e53bc10295bac67d484044683c2ed39b8ee'
   name 'Hearthstone Deck Tracker'
   homepage 'https://hsdecktracker.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.