### PR TITLE
Update hammerspoon to 0.9.65

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -3,14 +3,14 @@ cask 'hammerspoon' do
     version '0.9.46'
     sha256 '20f7e81624b6f007d6fdd8944cab3d9ba48c36fd0b4f1405a590526b5d4859bc'
   else
-    version '0.9.64'
-    sha256 '65c84c885fc905615c350e42ee7916ca856b34a215f0b43d82cf2ccf0822602e'
+    version '0.9.65'
+    sha256 'be5868bcc9e77be51ab4fac0d07055ea499f804f89954f324d75f7f8843cf488'
   end
 
   # github.com/Hammerspoon/hammerspoon was verified as official when first introduced to the cask
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip"
   appcast 'https://github.com/Hammerspoon/hammerspoon/releases.atom',
-          checkpoint: 'c9279f2098d3c385000583f5ea9f28bc76836f3169446aa2375cb23664aa9b8b'
+          checkpoint: '08f731f72ca9c360012e1479b1cde972fba1b868a8b736fc3481e85c27a9c562'
   name 'Hammerspoon'
   homepage 'http://www.hammerspoon.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.