### PR TITLE
Update libreoffice-language-pack to 6.0.3

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,565 +1,565 @@
 cask 'libreoffice-language-pack' do
-  version '6.0.2'
+  version '6.0.3'
 
   language 'af' do
-    sha256 '74f9e0ebfbf88aa4dbf4393ae22d2f3cf298f0fc3a378ca00dcbdf426e409e48'
+    sha256 '281ee7da47d629d64d4eb80d009f8c84af9b0c15142989d80c28da46183d4e57'
     'af'
   end
 
   language 'am' do
-    sha256 '6e04a1a7d2e1d319905c472e6c8b84db08431bbfa6b1c0ecede67b67ea7615d0'
+    sha256 '748e71e3b31fbbf871bda0a9fb526748e3d577beb6dae5348a81b356fc5ec7ae'
     'am'
   end
 
   language 'ar' do
-    sha256 '7f57a39d26f10b3feeb1c44d380659dee31765dfc249826377fbd0edd10dc616'
+    sha256 '45e400ccdfcf3cde4b5dac29159bfe47fd62b45846725962d9436021b5472b6b'
     'ar'
   end
 
   language 'as' do
-    sha256 '5de90931098d94e6d9ed799c76f77b7b626d1cc81a025f63e4a14cd0ade18ea4'
+    sha256 '0d5e2bd15abc6c2937e8a8acaabb61ac3c601271b26d438d33562570cb39a496'
     'as'
   end
 
   language 'ast' do
-    sha256 '931e53e08c6ec17de0370d697bb5c0a61dd996650f48f3dac7bffa259849dba9'
+    sha256 '60919e8bb151be4b9400ff0985cc478c74a4668aaeba75c22ddb0cf14b597f7a'
     'ast'
   end
 
   language 'be' do
-    sha256 'a732f7243c27a1cadd62bac6b244a52ef52b0f342d97687a275c73a924ac19df'
+    sha256 'dd9b2f7327435ddabb6a3ed6bc8f3a9cf1249d71a11f0f599e872983208cccd7'
     'be'
   end
 
   language 'bg' do
-    sha256 'd42a3611e4bb932063891b8ef039c57faddaf3f54a35ad82148bce4f92d507a7'
+    sha256 '253ec4b14e728a1913fbfb9b7cc17958e6806a256a36bd97f139d38e138f3975'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '7eb7005ceb0bb748cdf804e9c6d933297bf87cb8c681005afd9317c7ecf2362f'
+    sha256 'be242598023442748acc74dd9bc3f0008a81bb7d7975b41f180c1b25f447dde8'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '6b50b37171836c94b505b69243fdc9ab544cf587588225649560941e224d9198'
+    sha256 '6bb3afb518f4e2b05c577b57c6c2a4943c155cf07005bcc5df1fb175b86be4ab'
     'bn'
   end
 
   language 'bo' do
-    sha256 '2357a14f5fcd0e628f88292f7bc0f930b5acc4635a3ace365d72a5e71619b8e2'
+    sha256 'f0ad20af74b9a61791d7949467c500507eef969c557edfdea482ad3b8ca905a4'
     'bo'
   end
 
   language 'br' do
-    sha256 '96859f4ad1b50d856711efa3b9aba1392f8a88a3f423cc70864579656814aec8'
+    sha256 '0911bd47026bb83c892c1981c249b66a17a98af0634d14a85cd6ce0290b270cf'
     'br'
   end
 
   language 'brx' do
-    sha256 '198acd49ab7776e69ad8fa04d03e75d43f22014f35d98bcf35fc81ac52744b57'
+    sha256 '2295dd15be95f01eeb0a7286a7ef96a5c759937e808b8ac9171e25dcca29b01c'
     'brx'
   end
 
   language 'bs' do
-    sha256 'c0c538b2c0fc9d0364adae0f40897a90a2540ce7988df804320845a75d33be3c'
+    sha256 '2203798bdd0974bb1aa82ad18d5d8801f6da8b3d1f32ed3d8f1b01115470cbc8'
     'bs'
   end
 
   language 'ca' do
-    sha256 '499fcdc0403fbe94b10449db377190b37e174a52ac45acd09f900f74e0aed1a3'
+    sha256 'c1cfab3475135ddaf6bab5f9fca41e0ef4f7f8ea4e4c298c959b4ae2797ce22b'
     'ca'
   end
 
   language 'cs' do
-    sha256 '10ca1849b3d0836cab9d220164ff90613edb4f7b463c265220c84615de5fb13c'
+    sha256 '9a7771b125370bfe305dc430f01168c4ea949636d928c9e4ae28c8644220179b'
     'cs'
   end
 
   language 'cy' do
-    sha256 '95c3da901889a2b96bda04b55cb3a52e7c02414eddc2ff6d66b8a924b8ed2fe1'
+    sha256 '65adc60e6400f70c56edd2d43a078d293c8c8da402996171a57f7bfded6facec'
     'cy'
   end
 
   language 'da' do
-    sha256 '8b22c6972f7de03b97934339b9522c04a005bc4e177c29276c0be59db5b6e0fc'
+    sha256 '2f99c0e0e254ecbe734d5b6820a547feb0ba6bb69da128bb6d5248f52d4ab34b'
     'da'
   end
 
   language 'de' do
-    sha256 '97d2dbd0598a8ddab8f8a5f1c0654a789110561e8f505b5f18e29585dddea614'
+    sha256 'e3bcd1a21929c2ed87e0c86e68deb69772d1f7a4dfa2eac5a8db126a8739da93'
     'de'
   end
 
   language 'dgo' do
-    sha256 '46f15ccc7a87866aa4f26ae84643f104e60858fecb5e55c363c2c1f7ae6aeb2c'
+    sha256 '4df8b6c3b1a697855ef82efbf6b94d6ceacf46bc2f7e85ea5114dd9a7a47bc4b'
     'dgo'
   end
 
   language 'dz' do
-    sha256 'fc0b290d7ff425b6ef9eaf3df877b174572caea11560e192c2d76b0e5acc9615'
+    sha256 'ce851746c806caff21c54e3d3d3d462537999712c41e2e4f7f8d569bbe4a773e'
     'dz'
   end
 
   language 'el' do
-    sha256 'b1765f653b82c89766e30c576526b1c366062b7cf5a37ee9ca27397ac8603e8e'
+    sha256 'be2da224065081beeec48fac51ea90deb55d4e3c9ff23ea7eb5fc8673c302987'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '45a705589f39ea50e8e8d57506ef19f24182e3325c7b6b3e3c2d4c26c4799d69'
+    sha256 '54e7004bcfdc319acd4a4c89a326cc437f0d1a2ae4ffc2d634a48c725f2ffebb'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '1d915fbae842ab423ed8373089e1f0ac7367fcc6759a015f8f769b7b3e877d11'
+    sha256 'b896a8cba38de42a78c51fce954db98ff5babb597aa5a7811ed8b64872868c58'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '07939824d5770ba8563bdf59e66ef5ed662630a915f0d71626c2fc01866c5671'
+    sha256 '23e0d3caeb6f46f3fdb982d61a03bd5021eda27eafcd7adb03684ac1ed4f8704'
     'eo'
   end
 
   language 'es' do
-    sha256 '8e79c365fa814b7e67e9f83dc90e5536f5d4bdbae6bbf067678d4235febe965b'
+    sha256 '3da01608d1519315db309c9f2b14dbc8bc3e699ca705e1f9dad1f6a46c42f9af'
     'es'
   end
 
   language 'et' do
-    sha256 '571c0f987c0ec19b74f72f5b16a2c9f3052bfad7d0248ca9b52fdb69a0a43c92'
+    sha256 'f7c222c1789623dcb6bdca07189e57b05908b9109a0e579e660095a4cb7c2c16'
     'et'
   end
 
   language 'eu' do
-    sha256 'bbb1e6c0006cf78800433c470ebd44fd256387466e81acdac524557140dc10cd'
+    sha256 '091f7ec7703f9dfd5d8d8400fe7584df10bf396c448d1a5076c95751176e44a1'
     'eu'
   end
 
   language 'fa' do
-    sha256 'ff3089bf68f318a0ad6970b3c72e2df679f1ebbaeb0c2387d7bfa299f6820c69'
+    sha256 '1c944754f56f6d85d96727e6de39ccd0979815a48f10dd584404d8b3388e953b'
     'fa'
   end
 
   language 'fi' do
-    sha256 '62617c67d2fb9870e190d5f48001d13392b5ee3dd8dcd4e0a97718bb007457b0'
+    sha256 '02dc26f30511950ab0fd0620e1ea33b3e15a81fb2f5d06f4650b041037bbb20a'
     'fi'
   end
 
   language 'fr' do
-    sha256 '6bdd966b0bf0ed20e7d682e979f5b6b7a8a3582a62af5e3382065b845ecfd5f2'
+    sha256 'f194f88f6906f401f21aa4cdfacebb191d2b5a36dd4fd16c22f3aee5a6d362c9'
     'fr'
   end
 
   language 'ga' do
-    sha256 'f566db51b107538df650bdacf4583eef84e1f6b6b14cfc0e22559845f5b9056b'
+    sha256 '8759d29daa2fdfaa9bf28942af61a594f233381278968f522f2d4a878dd257c3'
     'ga'
   end
 
   language 'gd' do
-    sha256 'cf693ba35a78b81bfcd2e6db92bf0577591b63284b0f93c94e8c0f2778320f6e'
+    sha256 'a163cbe5a2eb2da06ff5dffa64d5abddab3e5db3fda35800f7ed3014bcbc0841'
     'gd'
   end
 
   language 'gl' do
-    sha256 '54bf7d3ca11f0688bc837c23ca905ae2a8b4a678fc8fcb464463055f8879f8e9'
+    sha256 '60ae3735ac65b5841745e9a1339f67b7952b1b65ccea8e7a46d619ea5bc237a5'
     'gl'
   end
 
   language 'gu' do
-    sha256 '76f95b916f37a6388f09f156aa4a61dea60f3df222d3d034b4e24b2af8ea6e50'
+    sha256 '8034affda9dfff0557a0d4f94e61b1ff6308cde63eb9ca32c3776e3a04313958'
     'gu'
   end
 
   language 'gug' do
-    sha256 '59ad397362ce2e0492152d55dbf099f8c668eaa5b300e9d6f633b8ffd51e4095'
+    sha256 '19be5917542a4401e7982dedfdb50ddb4b74c3c97f7b49b1173002826cf25d7f'
     'gug'
   end
 
   language 'he' do
-    sha256 '5bdc9fb7ba4c868fd645c4f55267e17c92e6c0b7c86ac1f72a40fb774d72002b'
+    sha256 'de8304ce5355778dc8aa70c30e1b43971c600e32405c955d7a0f7afde1f5113b'
     'he'
   end
 
   language 'hi' do
-    sha256 'cce0f57d720af08ffdaa68143bcf8722feea6c605fee87a8ebfc2bd0e314ce72'
+    sha256 '09b7d1c92080de97367b6120dc6694be57c12bde0710fcc8bf5f017cb25bf8e7'
     'hi'
   end
 
   language 'hr' do
-    sha256 '69d84eae7f4a80133d4c36e5a60ef43cf1fe0ca2fdf7a6019699738e30023e3c'
+    sha256 'a23744f307f66553bcdf248ae599eeb9237b4345a72f05cdefe4bb7c8e327553'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '66a4e849868ddf18257f341ea4349342af1a4da05401d103f378e69c23c664a9'
+    sha256 '489c129913c493e3435787b4be03a468400cde77d86f90fb09c3c56e00373944'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '25b8199686fd6968d578946eb53adc4726baffa0298fe28ad66fd4a7a9541a08'
+    sha256 '7f0a72898518502dc68c56dbbc0b467a743481c0dd5427ff039cb661242d4ca1'
     'hu'
   end
 
   language 'id' do
-    sha256 '5e18c9414819d9bb994fdae4911119cfee4af76d6472c541bc21043febd10e84'
+    sha256 'ec3c2b30a701441aa86c62bce907a4d906adc7df2c0883b1e309cd6f6f868fb5'
     'id'
   end
 
   language 'is' do
-    sha256 '5e0dd41824c10e103989aaea8fa9d040deb8075a535f454bdd96b75cf23331d4'
+    sha256 '4cfd23137ba44a6a7bbc9929d8a090da2e54086f80115e0c31112fdaa79087d7'
     'is'
   end
 
   language 'it' do
-    sha256 '953ab29e916c7cd4d7ac0a85bc853e8e7f96277b81ed8ec4ac5cc95d9eb0a9dd'
+    sha256 '40ec3bc9a9291eafd26d26884119e8e731f3b00650736dd3fe6e754ae565c3a1'
     'it'
   end
 
   language 'ja' do
-    sha256 'c45a00ba14a02dbf3103c2796e321e6fca0a272df9eb8fc599b180f4dce1cbef'
+    sha256 '59a99ecdb18aa3f48ba9d6463dec0a4c8b047c99fd893b6ebeb4b617e1979b93'
     'ja'
   end
 
   language 'ka' do
-    sha256 '5dd3761e22286e70d06d3479e9b0011a61b0b73c2f2500935fc11137267bb515'
+    sha256 '768ef34c936192ebbb5a61e7c1c87011d0ac15f56b7f6239a4f726be00cc3c4b'
     'ka'
   end
 
   language 'kk' do
-    sha256 '8a0dc2faf7b6e580e8cd7decca77d552d37cdd3eea6507602c67e3c7ac0c8412'
+    sha256 '1ce707697294d0fe30b472c78ba0f9a3325bbfb279223900b1c8b8b029d316ba'
     'kk'
   end
 
   language 'km' do
-    sha256 '1de200105ff640cdab608321a1a6dca1f38e50e419bda4a73360bfc756b7d1aa'
+    sha256 '4d3cd290eed178eadaa0580d46b5cb2618f3a07f40ae043585869a3cbfdd1daa'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '2fbe672619c189430d9576ba91f0f6623339bb6102759be9dec927e70d31f45a'
+    sha256 '0b575259f801635e1f9ba69c9226df19dd24edf56bd04f4fcc03c96046d38249'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 '88ee74e8f769666abaf96ebc4e59ecddb6f9b773d6f7c12d3b07c42c32241006'
+    sha256 'd37f332fa265a72626d13d8112fedfae2e1c2f1928265054e9945a54e395c771'
     'kn'
   end
 
   language 'ko' do
-    sha256 '84fd87dbb76118085318a3d011e90f5fbeafbbdc55058a419bb6f9fdc50f4632'
+    sha256 '837a4725c8c8e7fcc497d81140086224589d6cc5a3094e1afd2cf3bce52588bc'
     'ko'
   end
 
   language 'kok' do
-    sha256 '35073691c4770d7e4602ca6c5c1383640bece46bc27f50826f5857b9a15a405e'
+    sha256 'a2d567c8393db2e000e351baf378c49c5d35ac3a29e0847260fb5d53149dfea0'
     'kok'
   end
 
   language 'ks' do
-    sha256 '0d5b692fc20549531e63d9c2a33bf7ff4f1b00c723ae99c3d3342d21e40fe6d3'
+    sha256 '83a749df21bace6c1f20a9448c8d836a31dc664e30b1f74c7758aa4c03394a6f'
     'ks'
   end
 
   language 'lb' do
-    sha256 '07c41fcce6786861f48c75008da7fd8749ae0caa8a642d8a4ea671500857ec05'
+    sha256 '6ca86420d4ae449817cfc1629fc91797b81e5291644b7ac26ac5e53113255dcc'
     'lb'
   end
 
   language 'lo' do
-    sha256 'de275c22d16687c84c626dc2304c0b70c9ee99aa9cdef49196fbef17acb6ea7a'
+    sha256 '779db629b372796715c2b3d3b9d67709e99b736b9acc3a7fdb524a2c8b9b75ef'
     'lo'
   end
 
   language 'lt' do
-    sha256 '9d0d34f954ed47e10f6b2985584d9083594cd6d4dc6fe82a8aca318400b03f97'
+    sha256 '40c61a9488284ed945f90706dab8dfb2fbbf2e6ec70c112a2fa54e3389641121'
     'lt'
   end
 
   language 'lv' do
-    sha256 '56f9f5b50c1ff123bf571f715193d17451b77f8fabffe97f0f9b1f4967ef51fb'
+    sha256 '51c7ad0dc1fbdedbefb5bb3f591bcc686048cae3d13aa1dd4cf2c002bc1bd528'
     'lv'
   end
 
   language 'mai' do
-    sha256 'ddcde3a1bfda6a46378f5e783c38caa19177673954c093f20b76537a09ad430b'
+    sha256 'da509b4b56c29e098b11625de20cd13c6f05bb898e2d0610130fddc5eed8c886'
     'mai'
   end
 
   language 'mk' do
-    sha256 '63216d3e76473552d2fdec28a14299322a65867d3de5f6af788a2cdb38a520ac'
+    sha256 'ff6cbc3dc0961e3d61fcc54ecd30d67b79ab59f95be3903176c05ddbd5fbe493'
     'mk'
   end
 
   language 'ml' do
-    sha256 '414873e04a8dda1a7f6b21669321f6217ade1c61f4685f825fb2775ac6f77063'
+    sha256 '07526287c101ce38565b16a545ecd2082bc5ea8fed7215a820d84928f42ee490'
     'ml'
   end
 
   language 'mn' do
-    sha256 '75ae95dbf1384d4fb83c14aa85b234cf29213b6e138e6b9e15c627769196370c'
+    sha256 'f9701cec08fd527f223c64feeac25c6e28603c328c9f905ecdf2635ce007022d'
     'mn'
   end
 
   language 'mni' do
-    sha256 'c9d7571ea9b00216ce642a6c1656e1c4ccb8e729a3f200818535f34202e93234'
+    sha256 '7a62c2c4ab6b372ee673ec1c0dc786ce3b604daf5a705a9a050882888c7ba4b2'
     'mni'
   end
 
   language 'mr' do
-    sha256 '926e45f345ae4f65a587d58ceddcca18062621d49c8ad4aaa485f49fd9f10e18'
+    sha256 'c1ec9b6ae5ea9e22b87f4188637b058142a6f02c70444baea748aa8f7e8e60a0'
     'mr'
   end
 
   language 'my' do
-    sha256 '0ba9be12fbe9912f8da278989501826461acc534e523dbfe6bd50c5ec8e25a22'
+    sha256 '2909a428e86f8a1b6a3997804f1feca1932c2d992d75448726bd7bdb392d8d82'
     'my'
   end
 
   language 'nb' do
-    sha256 '76c9abcb7d5ce31e8f71671fd1ca86ec1d08d5b9e0e0106eef1e2345a0dcc56a'
+    sha256 '43f8e734077c2454834bc6d589b5de1c47bccf05236752b00fa4808a4cc75fa0'
     'nb'
   end
 
   language 'ne' do
-    sha256 '9151dc09f665f4d6866f5994223a84b05f7e26d9a1a3c78209a15b2f6be2e397'
+    sha256 '0c6436b887e6097142631eeefccd6276ec2ca3befd93f01ea521ac173067ccfb'
     'ne'
   end
 
   language 'nl' do
-    sha256 '146be5ebde23e42a788eb1d600dcfb20441ee646cf72d70efeb1c6bced9162af'
+    sha256 '829a3954215eb446a01dba567dd90bd41637b949cb58695f64a2ccc300d72cc8'
     'nl'
   end
 
   language 'nn' do
-    sha256 '40f82dca5b4d40ca5a0f1228240142090cd4dd4511a0f9d978186898db782b99'
+    sha256 '7ded7847e5dffed07dfc77cc3b5932e9bbdc59c9ab35ff22e69e62023a7278fd'
     'nn'
   end
 
   language 'nr' do
-    sha256 'e80d24ffbc87977bdc269e956f8885752109bbe73980932b4ad14e2355c8b9f4'
+    sha256 '92181eabe724a81fed27cc6e2bb4c9ae9f0ff80dbd220253cd283c9e10488cb9'
     'nr'
   end
 
   language 'nso' do
-    sha256 '001cd01414719a86b5e8d992cc9f68f2bd5dd4a7f9ca1b85ca1a1e8e07e00179'
+    sha256 'ab7456f837b6aaaaefd25484ea1f231f98727cae44de984d18de3a02124ae38c'
     'nso'
   end
 
   language 'oc' do
-    sha256 '2df7805504134cf5de2d7b34b830d7b5da5afacf0b534d324a684525996e5774'
+    sha256 '57c3ea7fd1f38b4ede0a1e38e68d0e3baa60e2692c0cf676e5187331c5ce1ca2'
     'oc'
   end
 
   language 'om' do
-    sha256 'fc257c7e2c7c072f3c025ceef4dc1c74770e4254be80396cda070491cd87f36e'
+    sha256 'b08900d527c62f8764ef1e3a2935f282ae20b598f6d07c8ef164c1ea00f29c8d'
     'om'
   end
 
   language 'or' do
-    sha256 '27de80085501f32a4b04756918b71afa0c22027c4fb142eea5d148a086297ce2'
+    sha256 '79325fcfbd236b5f5f721f5a798ed783d63eb7ee40d8ac18eb5a151d01fd5438'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '4ace4885a006b2e4c0087d53c845d276faa84cb9df7933a35c6e185ff3ac2859'
+    sha256 'c1650fa19f7bb964a0c3120ce9d6faba36d8fb2a760aa7cf5ddfa01cab326e2c'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '59f9678c561ed74a8ca30e12b53125d54459a67e4cf8d28a432284184b9f85ee'
+    sha256 '1f60defaca9e053b02951ddd610087c9212f85a0475c3654d05d4723d0df07f1'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '69b7a425e4b61c7d05e6595f5e8d214976b762eaf11b621f7103936059200acf'
+    sha256 '438df4f0fd13d7666cd658f4f1556f0d750f346e816e2e61ef7592a66978da84'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'bccd52a73a3e8a28bbf6e38d05247237da2fdfb1c011b22a4068fd047c3ec963'
+    sha256 '96d488d1f062cfebed87233344f975e3d0d901c7373a0009e0b728ca2dbe2e3d'
     'pt'
   end
 
   language 'ro' do
-    sha256 '610519ba377b92a910434ec65f5498c6db49db54d065794ce84c55038ebfbc92'
+    sha256 '0f7b96c1eca7bd45f1de6c367b08e040d08ca0662a224f660b396aabe1d99cf6'
     'ro'
   end
 
   language 'ru' do
-    sha256 'a9e04a90deabdeb866fac1c9129622bc16b7aaa48e41ddc17894c8413d060777'
+    sha256 '4bb9d92dc18008478fe8e02545805eb6a60b6126ccaee5aa050517ec2cadb44d'
     'ru'
   end
 
   language 'rw' do
-    sha256 '74adc46e6a093c9e3e3f5b4c47337ad447652fd4f93f22c7d67083643bd37afc'
+    sha256 '10839995b7d0c317436f012d5978faa4d01e260a0b60e23a85e4430a739c0488'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '0393ff7c01acc0e1e3d5e0682441b410401001eb6e011fe925af51043247de69'
+    sha256 '71f55084ebf87b3ce4d2acbcfc15b30f4912e094972c568626899cb80deab738'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '81a6d089b120f0867d104e44389c679d0f43f7056bc22a8b6ea36a5f8c4ace17'
+    sha256 '55197a9b825e617d5d39bb87ca5a51f3cf4b49f279fda1e09c5976337f878c4b'
     'sat'
   end
 
   language 'sd' do
-    sha256 'ecf64070ace9607d3a16b35d5ca3da0f611d73f398be45c658d243c50f994664'
+    sha256 'af12baea8f41ec352b72886ddbb633fdff0fb551c55eded865374fcd0a7d5084'
     'sd'
   end
 
   language 'si' do
-    sha256 '3bf9aebd838fbe7318559ea3599bdeee1d22d5a4e30d6dc24267618a9304a419'
+    sha256 'be17986eecda7e0d74f3432e07eef87d3535ebb31b18318c563295cd93dbffd5'
     'si'
   end
 
   language 'sid' do
-    sha256 '0ef2979585d19a0d8d39d1fd25e03da09ed7003a28726a0000764db94fcf78ef'
+    sha256 'b4e6ed4e25c7224ae56972583815d68ac1952b72c548d9109c45ba6ceb8671cc'
     'sid'
   end
 
   language 'sk' do
-    sha256 '8ecaae6b91ca6274668b7aec2199e8d6b9b6603778efaaef1c917cf225179423'
+    sha256 '6d5657a99a8b0dc847f86eb6cc96353c2b6c88a309e4a6b8628fe7e7da8a43b3'
     'sk'
   end
 
   language 'sl' do
-    sha256 'e7b1fc844792be4534da3ec68b0e0ee1a996f8d1514a034535bdb61bd4eff82b'
+    sha256 'e239dafaf00f8a3a7d02a0a05a5aca69c670eaa22c04f891527d597fcb443eca'
     'sl'
   end
 
   language 'sq' do
-    sha256 '79b4d13c473943f58f17046097c9bc6a7e733b0c99c39fffc45bf9e8f5ce95b1'
+    sha256 '99f2cdf41281964d817144c6d7e5ee46d9f7ae4494fbfe0d1e5fb5564f53be29'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '9c806a5c3d2d7bc3625f3bfe029f3c6c9a795c6407627dc21fa28793194f0377'
+    sha256 'e3609481a4afba0b8aa850232aeadaa1fd4b015c7c2d5e3a3dd794bb7b2e7b06'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'cd76f4ba697a5e02642d524b4ca07a9b5e4b00adc869fbc8ac6e8ee501541d82'
+    sha256 'fec969748ad52c766d730a5689279d23ac50e4368277caf0998172b9d22bac20'
     'sr'
   end
 
   language 'ss' do
-    sha256 '2c080f7889125066e466e19a0de0a0c7f010bc5a4135e5356ea4852873ac43f0'
+    sha256 '3f360505631e118f3c3bc803c76cbdf542a77895cd55c2318ec0022686ae14fa'
     'ss'
   end
 
   language 'st' do
-    sha256 '14915e60c6dcbaee4cf65977f3c228f9a58e919e21ac8cfcdcf4b9cb8b0bc2b3'
+    sha256 'c255b1dbd8105b6a2eae96718e398725570368778dc42623ec035a65279080ff'
     'st'
   end
 
   language 'sv' do
-    sha256 '55c8160654647bafc4222ad7540faebe4b621902ac4929f2c14a72ac645b3ff0'
+    sha256 '7f63a3ed6da8ba89854434f072be89388d40ff30b1df30ce3a0d4755fe53d90f'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'fb24ab8dd23efa6a5708df82329c64f23800069a19a2c6031d860fa6c923d47a'
+    sha256 'eb09b98a4f15123e9b5899fb7a105d80f8f2f5ce878694c473666c38537c3f99'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 'a3e148e7bdfc4e24677416487299ea91254d44861c614481c0b20661547765d1'
+    sha256 '0add829d9f7b069e41960161ae6f4eff3f103a88bb70eac3db159cbef9fc5cf2'
     'ta'
   end
 
   language 'te' do
-    sha256 '352470c50fa411e4f2598b18aab88b0aae170facc11d40781e4852a6e4bc41d7'
+    sha256 'cc5f7eaf0a0f28616e18ac14e338cdac1fbc3c55301307044ec58002411148fe'
     'te'
   end
 
   language 'tg' do
-    sha256 'a13ee7d304643753a7f04fbb7e5ea190c3784c38c4ac0a14a2cbee7ecefd5942'
+    sha256 '64991430703034ac25fc467e5285c035c961e1dcb0e338dfb20bb626c638c2e1'
     'tg'
   end
 
   language 'th' do
-    sha256 '2a2c3761ca8d81402904ae34b309a6409417b02f97e5abc6b4e6c683a7230dc0'
+    sha256 '595a185687a10483e4381fd37e2f3109f3a048db01be42c6e7328a91f51e47be'
     'th'
   end
 
   language 'tn' do
-    sha256 '6f1ed4e694ee083af1905d48ec6cab9245fd8b6aeb707b3b0330fcd69e0c7ed9'
+    sha256 'c9da40bc2ea19e94706a4343663bb06b4648a4e7c58a5c7a44b6951704ef6ac7'
     'tn'
   end
 
   language 'tr' do
-    sha256 '65b9dd2cc5e70c1300228385eac79c616377ec53ab7d4b64e901607f0f27e898'
+    sha256 'a2fcad710f42cb5062c0305bf281b86b6139954c5c447b9fdb6bbc8c4acdfb41'
     'tr'
   end
 
   language 'ts' do
-    sha256 'b23c7060a8d605dcfb5b1683877e68d71cd0ff4ad9e6287c120c8cbcb0efce03'
+    sha256 '1a4dd2a2c5a1f10f3dd171b0773047112420a6997d393369bff04dc2ea199a40'
     'ts'
   end
 
   language 'tt' do
-    sha256 '2f650e40a70a18231471401e6d43a8b9e0e4dbafa02f0f54a85ea17774bb9e5c'
+    sha256 'ac7edf899cc4ed19d5b68043eec570940a2dc1a3280f7ac4bd54852b3448fa41'
     'tt'
   end
 
   language 'ug' do
-    sha256 '90d645d5bce4557a1c22c12eca7236bf0d5a5ddd3ea442f8cd2515eeff2ab1fe'
+    sha256 '53b64ea0a6189e1012809e732d549aa4b85018f470a01239a8fdf8f59104d724'
     'ug'
   end
 
   language 'uk' do
-    sha256 '95cfdcbfffa87f4fadf5b1cea7dd0e7f2339a39580bccf1fe7082efdf1c0c76a'
+    sha256 '5e89e9202c3eaea7609bb0f6a1240cc8a40066738fb2929f6fe2e1113a9359e8'
     'uk'
   end
 
   language 'uz' do
-    sha256 '7af64f6e1dfcffb134f0d74fe8c7df46da8378ab2dfbbda0433ddfb699303974'
+    sha256 '8fcb62c90d5a17b36ce75af6344c5cec790a5a6a40d4907f048c7d662079c85f'
     'uz'
   end
 
   language 've' do
-    sha256 '374851153f5b13607da02e673ea8bb1dfd18dbbcb33c42764da75321b7c5ec94'
+    sha256 'dd9123acdea01bd05956170c8a0a68697ce40f1ce06d29198bc598f98421f763'
     've'
   end
 
   language 'vec' do
-    sha256 'e3f299659c24f408b6066c5201b04a89d41cb99d87c1f2f68dc1c16ab16d9122'
+    sha256 '0f85bf12b84253a2345707ea2e1fb07b43837932da850f19d573e4688354efe3'
     'vec'
   end
 
   language 'vi' do
-    sha256 '9a782939adf6d4934415e19dec665c7693b3e566afa2c74f8b19e4435948fed9'
+    sha256 '30befa17d8f76667d41f259ac8d594ce076bc2bdbba32770e9d13f6ceed55ed8'
     'vi'
   end
 
   language 'xh' do
-    sha256 '086dd843c8a5fbc45e730333de562ab125aec1f3b610d5f25fc5816ccbdd6aec'
+    sha256 '66859c54638f9af854efe574dda998c4587d19b88be5278069f40ff7d8e3008c'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'b76613eaf9688023845491e01360321171d407c7514f59934f15c09b78a203ba'
+    sha256 'df881c039507b11c4fc6e63430091aaf215ec5b0ada8f30b9a8d347b3c8fe4f0'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '3e858bc0331a08b70da36713886cd94c4f129c7fff1c9737941f2451178803e6'
+    sha256 'd93c58af404518101a59e6774cdcc09081fe34c52a2725584c4b454374c0517e'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 'a27badc9ae020ce3db552472e360c45861eba400d8e41f916dab1d81db3ca9f4'
+    sha256 '2f567903cb6d08c2edf6870498f2aef58b92ec19a9e369c40e273084605ffd0d'
     'zu'
   end
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "http://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64_langpack_#{language}.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/stable/',
-          checkpoint: '94f0edd918fe7f81314a8c7ed858d39a7859a9af398ce8b49566c5fe9bd7ba83'
+          checkpoint: '9f0908b47721f0693147570d675a2b6006dcd94983e235ba361cb07c672483b5'
   name 'LibreOffice Language Pack'
   homepage 'https://www.libreoffice.org/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
