### PR TITLE
Update eclipse-platform to 4.7.3a,201803300640

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.7.3,201803010715'
-  sha256 '0f60150d42b2b3cf3f7acb172ce8c9b30359927250df6ba4383eb967dc8e6f88'
+  version '4.7.3a,201803300640'
+  sha256 'c7ca985ffaf604508371945d46f4af5de86aceea722034100ec1280202111f8d'
 
   url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.