### PR TITLE
Update tex-live-utility to 1.34

### DIFF
--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -1,10 +1,10 @@
 cask 'tex-live-utility' do
-  version '1.33'
-  sha256 '8b8ac5cb9c4a8450e0fadfdf7d653f5a428eb8b4e4c1484cacd625b3f8acca8e'
+  version '1.34'
+  sha256 '57f34bec3802bae73509b817479aa7f0456abc67d509064080612227527233cb'
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
   appcast 'https://github.com/amaxwell/tlutility/releases.atom',
-          checkpoint: 'c4e0ce62618c3c67cdf81425d379a4bda6bc3507ab82429da7f36a7fa3801249'
+          checkpoint: '295f8beecdc100b82dff5e1e00098316e7fcddad08d2fcb386033cb9b6134603'
   name 'TeX Live Utility'
   homepage 'https://github.com/amaxwell/tlutility'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.