### PR TITLE
Update toggl to 7.4.129

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,11 +1,11 @@
 cask 'toggl' do
-  version '7.4.84'
-  sha256 '22ef7b89f9ce04a24621f25e4d1f025c6391ec690ec773b74a244e5f8b425466'
+  version '7.4.139'
+  sha256 '0eb9fec43fa4343de06c7cb6c57a7c9e3d29a75cbd010227db600d6c39231f71'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml',
-          checkpoint: 'f76871b13b18b13ae223a3ba5bc9463311e57d69977d895ffac0c4f223f687d8'
+          checkpoint: '0aa1336cd987d2db2b4e88008de0b7824ef665d3975962049d37212757035d77'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 

--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.139'
-  sha256 '0eb9fec43fa4343de06c7cb6c57a7c9e3d29a75cbd010227db600d6c39231f71'
+  version '7.4.129'
+  sha256 '1eb1f0dc3baed9e293040f9e77946c055376339802f967beb1266f8e8bfe22c2'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.