### PR TITLE
Update socket-io-tester to 1.2.2

### DIFF
--- a/Casks/socket-io-tester.rb
+++ b/Casks/socket-io-tester.rb
@@ -1,11 +1,11 @@
 cask 'socket-io-tester' do
-  version '1.1.1'
-  sha256 'd0d24270be25fdfc5f5ec703fbf57c5a88595540f0d4ee38d79bd49cee258ba1'
+  version '1.2.2'
+  sha256 '41f9ecde7b503c7f1e30f8d3c58a6b78d320eabc024627ec2fb9b55b01e997d1'
 
   # github.com/AppSaloon/socket.io-tester was verified as official when first introduced to the cask
   url "https://github.com/AppSaloon/socket.io-tester/releases/download/v#{version}/socket-io-tester-darwin-x64.zip"
   appcast 'https://github.com/AppSaloon/socket.io-tester/releases.atom',
-          checkpoint: 'bd60343db134474587b697365fe1e0863454048e17a42da22a30180505f62a90'
+          checkpoint: '93192654f585c55656e4b4e3fe36cf9276a8ce432f01e2fafe7b7e85314692ad'
   name 'socket-io-tester.app'
   homepage 'https://appsaloon.github.io/socket.io-tester/'
 

--- a/Casks/socket-io-tester.rb
+++ b/Casks/socket-io-tester.rb
@@ -9,5 +9,5 @@ cask 'socket-io-tester' do
   name 'socket-io-tester.app'
   homepage 'https://appsaloon.github.io/socket.io-tester/'
 
-  app 'socket-io-tester.app'
+  app 'socket-io-tester-darwin-x64/socket-io-tester.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.