### PR TITLE
Update rsyncosx to 5.2.1

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '4.9.6'
-  sha256 'ed4970ff6a985f31145c3b08d06c9445a793021e9f1219d83c1e53dc4c926fa1'
+  version '5.2.1'
+  sha256 '1d7926ea5e5d1ac7c7fb1c5975dad35943206efcdb8dd98ba913901f9adf0082'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: 'eb9d4ad5e6bed25387745715eb339b8c4cf485a727c7021c5eb7a419ab2c5133'
+          checkpoint: 'f22a306df4ecf7756ab0bbb7e03bcfd9a09c1176691d47ef51de607b033e132a'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.