### PR TITLE
Update intel-haxm to 7.1.0

### DIFF
--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -2,6 +2,7 @@ cask 'intel-haxm' do
   version '7.1.0'
   sha256 'dbbf88dfad7c81abc2165d8db0bdaa42f8d48f4436dc27c02ed7556041122fdc'
 
+  # github.com/intel/haxm was verified as official when first introduced to the cask
   url "https://github.com/intel/haxm/releases/download/v#{version}/haxm-macosx_v#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/intel/haxm/releases.atom',
           checkpoint: '13601cec1e9129ef60537e7196e91df7880a33dfa7d48d5d28733219190bb3cb'

--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -1,8 +1,8 @@
 cask 'intel-haxm' do
-  version '6.2.1,a0:49'
-  sha256 '18a5c08a61f711ac1ce824feebfaa5819aabbe7e03ee4638f3edd6f0c34b69d9'
+  version '7.1.0'
+  sha256 'dbbf88dfad7c81abc2165d8db0bdaa42f8d48f4436dc27c02ed7556041122fdc'
 
-  url "https://software.intel.com/sites/default/files/managed/#{version.after_comma.before_colon}/#{version.after_colon}/haxm-macosx_v#{version.before_comma.dots_to_underscores}.zip"
+  url "https://github.com/intel/haxm/releases/download/v#{version}/haxm-macosx_v#{version.dots_to_underscores}.zip"
   name 'Intel HAXM'
   homepage 'https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager'
 

--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -3,6 +3,8 @@ cask 'intel-haxm' do
   sha256 'dbbf88dfad7c81abc2165d8db0bdaa42f8d48f4436dc27c02ed7556041122fdc'
 
   url "https://github.com/intel/haxm/releases/download/v#{version}/haxm-macosx_v#{version.dots_to_underscores}.zip"
+  appcast 'https://github.com/intel/haxm/releases.atom',
+          checkpoint: '13601cec1e9129ef60537e7196e91df7880a33dfa7d48d5d28733219190bb3cb'
   name 'Intel HAXM'
   homepage 'https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager'
 


### PR DESCRIPTION
Fixes #45851 but I'm not sure how to help resolve the actual uninstall of the older version. This pull request merely uses the newer intel-haxm which works on OSX 10.13.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
