### PR TITLE
Update soundcleod to 1.3.4

### DIFF
--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -1,11 +1,11 @@
 cask 'soundcleod' do
-  version '1.3.3'
-  sha256 'eac858e725336dfe79af7df20fec04991ec8503a95e872a3f9c12545ce17cb0d'
+  version '1.3.4'
+  sha256 '8fb6ee8024d8773d4389227b0bfc0725ff2aae33b12064365bd32aba6ea5cc70'
 
   # github.com/salomvary/soundcleod was verified as official when first introduced to the cask
   url "https://github.com/salomvary/soundcleod/releases/download/v#{version}/SoundCleod-#{version}.dmg"
   appcast 'https://github.com/salomvary/soundcleod/releases.atom',
-          checkpoint: '50f8012639e8d52e3bb189d511f2a29fa5b039dffe1e17fa330fab2840c8a6f5'
+          checkpoint: '7d6ef0e71c5c6b80b063ae9076f3e88dc539fc6647e38cd4c2bfcad5d3f33b4e'
   name 'SoundCleod'
   homepage 'https://soundcleod.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.