### PR TITLE
DHS cask can also zap saved app state

### DIFF
--- a/Casks/dhs.rb
+++ b/Casks/dhs.rb
@@ -11,5 +11,8 @@ cask 'dhs' do
 
   app 'DHS.app'
 
-  zap trash: '~/Library/Preferences/com.objective-see.DHS.plist'
+  zap trash: [
+               '~/Library/Preferences/com.objective-see.DHS.plist',
+               '~/Library/Saved Application State/com.objective-see.DHS.savedState',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This change just adds an additional zap path for cleanup. Similar to other object-see recipes like [KnockKnock](https://github.com/caskroom/homebrew-cask/blob/master/Casks/knockknock.rb)

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version. 
**(version number of current cask is unchanged)**

**not adding a new cask**

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
