### PR TITLE
Update bitrix24 to 6.0.67.40

### DIFF
--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -1,11 +1,11 @@
 cask 'bitrix24' do
   # note: "24" is not a version number, but an intrinsic part of the product name
-  version '6.0.35.40'
-  sha256 '72a0b55a6e63757aba65c33e06f2308abe7bb342c355f30cc9cb509e3e8a16ce'
+  version '6.0.67.40'
+  sha256 'f7b4dd62dcd77d8573e04af56d967e7affd8e71a847ef3d9a44b2d547c160e45'
 
   url 'http://dl.bitrix24.com/b24/bitrix24_desktop.dmg'
   appcast 'https://www.bitrix24.com/osx_version.php',
-          checkpoint: '04e0f05ae026934eb4307a82f030678d2f0f4679639b2725e13a2e4a4e41a71c'
+          checkpoint: '56235ec33594314026ed3b0dd560f5cf923faf8c3d1cdb1fce71783fa1a89e54'
   name 'Bitrix24'
   homepage 'https://www.bitrix24.com/apps/mobile-and-desktop-apps.php#desktop_app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.