### PR TITLE
Update bitshares to 2.0.180402

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.180306'
-  sha256 '4ddfb8ee7ba2ff5c8684bfb952d94a9cd9f6190f3a3b8f707a44bf276752732f'
+  version '2.0.180402'
+  sha256 'ac1efff629fbdd97e07396c81d111276072e4d5301441d977b2b798985f40627'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: 'c1788e76969824ee4973ca8b2d283a42e9f91d0922417792d29162efe845b576'
+          checkpoint: 'af65e8b84c6d90debf210c2ba6f7627430b71065548acb8211ace92c4e2c8900'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.