### PR TITLE
Update ctivo to 3.1.2

### DIFF
--- a/Casks/ctivo.rb
+++ b/Casks/ctivo.rb
@@ -1,10 +1,10 @@
 cask 'ctivo' do
-  version '3.1.1'
-  sha256 'ccf1f0445219c10cb4af82021fa1b338f16e85d4aefde304f99a74791a1f6f69'
+  version '3.1.2'
+  sha256 '707ae733121c295bb404a1bb2c81e3f4ac4d5e2dbe8b9fd3e2d685872d1d3047'
 
   url "https://github.com/dscottbuch/cTiVo/releases/download/#{version}/cTiVo.zip"
   appcast 'https://github.com/dscottbuch/cTiVo/releases.atom',
-          checkpoint: '9f1a5a4b16d21f3f02f481d4712833b0b603106a404a208230842ecbc40ec7e4'
+          checkpoint: 'c364ab3ba067eadbe7d6eb7d1ba0c89488e9716c6684e94e5984c171e8907f82'
   name 'cTiVo'
   homepage 'https://github.com/dscottbuch/cTiVo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.