### PR TITLE
Update dollydrive to 3.99,39996

### DIFF
--- a/Casks/dollydrive.rb
+++ b/Casks/dollydrive.rb
@@ -1,10 +1,10 @@
 cask 'dollydrive' do
-  version '3.99,39993'
-  sha256 '187680f85ccb29cdb5bc790102f2f8e233e8499e0d73cd00f050b3a7bddaa6d0'
+  version '3.99,39996'
+  sha256 '5bdc7492102302684c4cb1b6f5c1673afc1ef432073a911b4f3dd8a4aa3a232d'
 
   url "http://dollydrive.com/download-center/dollydrive/DollyDrive_#{version.before_comma}_#{version.after_comma}_CERTIFIED.zip"
   appcast "http://www.dollydrive.com/dolly#{version.major}.xml",
-          checkpoint: '4e410d256c5e9ae0ed3f51ae889b8b10eae644d0f52184206abfe9951379362c'
+          checkpoint: '054f899600656ad6e38548c31994edffbc1dbb589ed7db58dbcb9ae8fc503de5'
   name 'DollyDrive'
   homepage 'http://www.dollydrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.