### PR TITLE
Update dropzone to 3.6.6

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,10 +1,10 @@
 cask 'dropzone' do
-  version '3.6.5'
-  sha256 '2807a2b1d963b6a93f95a05839e962b39809e78d8319951d434f2e5799a1e5df'
+  version '3.6.6'
+  sha256 '2111a895d444e110890d5f4096bf0a58f257a267bdb9d2b9362313a79c6b3bc4'
 
   url "https://aptonic.com/dropzone3/sparkle/Dropzone-#{version}.zip"
   appcast 'https://aptonic.com/sparkle/updates.xml',
-          checkpoint: '36c621138ad2cd6703eb16d508f73fcf08e4610c6e84fa022014978bbb51a593'
+          checkpoint: '841ef8b654a5a210dcbae7286b7264735c0e567881d1daf091ee02555ebbbe63'
   name 'Dropzone'
   homepage 'https://aptonic.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.