### PR TITLE
Update electorrent to 2.3.1

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,10 +1,10 @@
 cask 'electorrent' do
-  version '2.2.1'
-  sha256 '457a84edd541f2ac8b25e5312b589503354621d439c2bf75c6a615e1f06a04c0'
+  version '2.3.1'
+  sha256 '31bd50f59a77dd78b13fb951e43c0e5bb38ae5faa08908cae23e86cee2b465db'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom',
-          checkpoint: '0588cc358b25142872aaa3edbaabfa5e2b9425ab896cbe230246721c141450cc'
+          checkpoint: '00bdb30bfa1c237f871944e08b4f3bf7682ee225d9294fe77b048c20a34894d1'
   name 'Electorrent'
   homepage 'https://github.com/Tympanix/Electorrent'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.