### PR TITLE
Update encryptme to 4.1.1.1

### DIFF
--- a/Casks/encryptme.rb
+++ b/Casks/encryptme.rb
@@ -1,10 +1,10 @@
 cask 'encryptme' do
-  version '4.1.0.8'
-  sha256 '977e7eacf448cb3d14e01cdb2b536e0eff2e8a18dad29275efe88bf553026469'
+  version '4.1.1.1'
+  sha256 'e71529d161824166f06f794e7d01dac2283125c4b0994352a8f6ff0ab4247baf'
 
   url "https://static.encrypt.me/downloads/osx/updates/Release/EncryptMe-#{version}.dmg"
   appcast 'https://www.getcloak.com/updates/osx/public/',
-          checkpoint: 'b8ee09684565fd0dbe7449941bddc3acc09188996ffa265a3ed72697d9589304'
+          checkpoint: '1236e9d10bdf2bd01fc8af564c405c3cb0e4e9dc8497ab7c28b1bacaed90653b'
   name 'EncryptMe'
   name 'Cloak'
   homepage 'https://encrypt.me/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.