### PR TITLE
Update jedit to 5.5.0

### DIFF
--- a/Casks/jedit.rb
+++ b/Casks/jedit.rb
@@ -1,11 +1,11 @@
 cask 'jedit' do
-  version '5.4.0'
-  sha256 '5bef965e267a13cbac8dae12d4f3b1428298fb769c759cedd9d75be96a82c96a'
+  version '5.5.0'
+  sha256 '2573720e6b36dca2105d3b16bc2245b3d1dadcd7e84d40f2c41c3c285386d122'
 
   # sourceforge.net/jedit was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jedit/jedit#{version}install.dmg"
   appcast 'https://sourceforge.net/projects/jedit/rss',
-          checkpoint: '5ef477fd6b9583423dc6fca1816255d1e2c4da3057f8cd88d7783b904dcb8567'
+          checkpoint: 'c701cc0e0af7cddf29beaea544309fe356c3fd134a17bfb7b2f42f05604316ac'
   name 'jEdit'
   homepage 'http://www.jedit.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.