### PR TITLE
Update metabase-app to 0.28.6.0

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,11 +1,11 @@
 cask 'metabase-app' do
-  version '0.28.5.1'
-  sha256 '15d0a19a14f51e5de6607041f7bf3e42c44686b6a43da270609ba6065c32def0'
+  version '0.28.6.0'
+  sha256 '441cca34b727ad368f0294952664462c0994e5a50ec869123538dd8723304c70'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"
   appcast 'https://s3.amazonaws.com/downloads.metabase.com/appcast.xml',
-          checkpoint: '657c3a93f0146c3c0a90cc3f8733d469e7f99b737664ba1f60cef5d3be52830b'
+          checkpoint: '03ac38391d9e19f7fef0a612d23ca666722e86236e62a694483b3d0168787070'
   name 'Metabase'
   homepage 'https://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.