### PR TITLE
Bump TablePlus to build 100.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
-  version '1.0,99'
-  sha256 '431ea1ffd051101e288ea423f3adf11d1c6ae7f5d9fbf531201bd261fdd148af'
+  version '1.0,100'
+  sha256 '41519521846328d56d46e700390294bccfbe6f5227291aaac819839ae78e1207'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: 'f7ae2f0ca3b04a80493506b8c567e877f17fd7f554acaedf347ee2b6be25415f'
+          checkpoint: 'b7780cc05739c13e1a437bc6bbe5ed4ab0a92ed46502cc75fba313c8712bd3a3'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download tableplus.rb` is error-free.
- [x] `brew cask style --fix tableplus.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.