### PR TITLE
Update clamxav to 2.18_3608

### DIFF
--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -1,10 +1,10 @@
 cask 'clamxav' do
-  version '2.17_3603'
-  sha256 '55849ec74a97283710699d62ed8fbbc421045ffd01bd1778b33dbc6002d6328f'
+  version '2.18_3608'
+  sha256 '76527f129fa1d695e4635366d008e0683a9ea195a5ad04a4693ffbb0a3d190bc'
 
   url "https://www.clamxav.com/downloads/ClamXAV_#{version}.zip"
   appcast 'https://www.clamxav.com/sparkle/appcast.xml',
-          checkpoint: 'fcb7e4e4e7189baf1f1a78f248a4183c0edfb7ce66f8429f86c552dafc63e884'
+          checkpoint: 'b375f71ee431356819bcce4bf01298b60e01ee486fc79991997ea014c172a8fb'
   name 'ClamXAV'
   homepage 'https://www.clamxav.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.