### PR TITLE
Update lingon-x to 6.0

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '5.2.8'
-  sha256 '1d8326b5a87817c94f8dd1be2c496d56abe34aa9336af06de8fc28e747c5591f'
+  version '6.0'
+  sha256 '8168b2a9ae37694dd65f3b17b978c445af4f1d916e6a4d449206a486b559d097'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '2fa4943c7d6d9301804c97fecf6da189adf07ab1522dbe4c01820a919c3a9f08'
+          checkpoint: '94b77fbea675529c2fd3d2c0cb578f0a32b2a599a2e1c0f0dcd425c12a79ce32'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 

--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -8,7 +8,7 @@ cask 'lingon-x' do
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   app 'Lingon X.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.