### PR TITLE
Update wechatwebdevtools to 1.02.1804120

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1803210'
-  sha256 '7390bc33d42d4d2392dea44448904f193fc392f550119c7cf09ec81e6933107a'
+  version '1.02.1804120'
+  sha256 '73c47fad32956afce280149e5e1f9db08223dc3de9857cee2ed087cb769ef397'
 
   url "https://dldir1.qq.com/WechatWebDev/1.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'

--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -2,7 +2,7 @@ cask 'wechatwebdevtools' do
   version '1.02.1804120'
   sha256 '73c47fad32956afce280149e5e1f9db08223dc3de9857cee2ed087cb769ef397'
 
-  url "https://dldir1.qq.com/WechatWebDev/1.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
+  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'
   name '微信web开发者工具'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.