### PR TITLE
Update qcad to 3.20.1

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,10 +1,18 @@
 cask 'qcad' do
   version '3.20.1'
-  sha256 'e24fb8ef40bf1dac7c830bfe1ab2c41810961b72d6231dcec883dbc15b1f1d8c'
 
-  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.13.dmg"
+  if MacOS.version <= :mavericks
+    sha256 'e24fb8ef40bf1dac7c830bfe1ab2c41810961b72d6231dcec883dbc15b1f1d8c'
+    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.13.dmg"
+  else
+    sha256 '4363ee2e0ba6e92c7a9ecba25f49fa9fba3572330966c6a3ebea3c056cf83c7f'
+    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.10-10.13.dmg"
+  end
+
   name 'QCAD'
   homepage 'https://www.qcad.org/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'QCAD.app'
 end

--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,6 +1,6 @@
 cask 'qcad' do
-  version '3.20.0'
-  sha256 '656cc00a40a4fc142f990a1514b81a9725ed303cbe58c8166d8703e50a276495'
+  version '3.20.1'
+  sha256 'e24fb8ef40bf1dac7c830bfe1ab2c41810961b72d6231dcec883dbc15b1f1d8c'
 
   url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.13.dmg"
   name 'QCAD'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.