### PR TITLE
Update openttd to 1.8.0

### DIFF
--- a/Casks/openttd.rb
+++ b/Casks/openttd.rb
@@ -1,6 +1,6 @@
 cask 'openttd' do
-  version '1.7.2'
-  sha256 '3d2d92a1870e68a3b88b069a940703292cda5b8cfd6c059d2d2f8755bc95e414'
+  version '1.8.0'
+  sha256 'fb5ac81ddec5a62efcf3cc44fde983e20a0ca61820ae6ee72b67323f45f5494e'
 
   url "http://binaries.openttd.org/releases/#{version}/openttd-#{version}-macosx-universal.zip"
   name 'OpenTTD'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.