### PR TITLE
Update clamxav to 2.18.1_3610

### DIFF
--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -1,10 +1,10 @@
 cask 'clamxav' do
-  version '2.18_3608'
-  sha256 '76527f129fa1d695e4635366d008e0683a9ea195a5ad04a4693ffbb0a3d190bc'
+  version '2.18.1_3610'
+  sha256 'a51284f640a1e0b95cce95d90df6031c4d3e543f1d6e109b980102a26fbb30e9'
 
   url "https://www.clamxav.com/downloads/ClamXAV_#{version}.zip"
   appcast 'https://www.clamxav.com/sparkle/appcast.xml',
-          checkpoint: 'b375f71ee431356819bcce4bf01298b60e01ee486fc79991997ea014c172a8fb'
+          checkpoint: 'c0b3e67fba1246d43d60a05490777e8a8a7a73af3a50c7521b48d3b2f3fcdd8e'
   name 'ClamXAV'
   homepage 'https://www.clamxav.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.