### PR TITLE
Update nozbe to 3.7.2

### DIFF
--- a/Casks/nozbe.rb
+++ b/Casks/nozbe.rb
@@ -1,8 +1,8 @@
 cask 'nozbe' do
-  version '3.6.3'
-  sha256 'ab15029f51d0bd92645b64e04ceb503f1797728a25a934d604e1189a697bc348'
+  version '3.7.1'
+  sha256 'fbbd86ee96037dc7e3ef289d12c547b1d25edf5baf51011ec1310d058bc8ca33'
 
-  url "https://files.nozbe.com/#{version.no_dots}/Nozbe.app.zip"
+  url 'https://nozbe.com/mac'
   name 'Nozbe'
   homepage 'https://nozbe.com/'
 

--- a/Casks/nozbe.rb
+++ b/Casks/nozbe.rb
@@ -1,8 +1,8 @@
 cask 'nozbe' do
-  version '3.7.1'
+  version '3.7.2'
   sha256 'fbbd86ee96037dc7e3ef289d12c547b1d25edf5baf51011ec1310d058bc8ca33'
 
-  url 'https://nozbe.com/mac'
+  url "https://files.nozbe.com/#{version.no_dots}/release/Nozbe.app.zip"
   name 'Nozbe'
   homepage 'https://nozbe.com/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

I can download v3.7.1 Nozbe.app.zip, but I can't download from "https://files.nozbe.com/371/Nozbe.app.zip".

I'm waiting some week that versioned download url, but maybe Nozbe stop it.
