### PR TITLE
Remove travis buddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ notifications:
   webhooks:
     urls:
       - "https://webhooks.gitter.im/e/712d699360b239db14a5"
-      - "https://www.travisbuddy.com/"
     on_success: never
     on_failure: always
     on_start: never


### PR DESCRIPTION
With the high volume of traffic we have in Caskroom combined with Casks that fail with unfixable errors make the notifications somewhat annoying.

Improving our build scripts to collect and handle errors might help but that is a separate issue that will require a reasonable amount of work.