### PR TITLE
Update outline-manager to 1.0.5

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,11 +1,11 @@
 cask 'outline-manager' do
-  version '1.0.4'
-  sha256 '2394fd17e730a9f2c131fac8ae1e2635d00cd70943f7a6c384d1dd3e19d1efa9'
+  version '1.0.5'
+  sha256 '4d5298ff1db0a012058e200891e8c0825b808b7d5a670199751c4d6cfce2aef3'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"
   appcast 'https://github.com/Jigsaw-Code/outline-server/releases.atom',
-          checkpoint: '1bf06af79dc83c160c1c8f79dfe6718502ea2a5c2ed1337873ad8d2dd76f8f11'
+          checkpoint: '9ff5eeb367e86a7c8f5c0c4fd4e725f843fe30475cb3bd0815da5202757ec180'
   name 'Outline Manager'
   homepage 'https://www.getoutline.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.