### PR TITLE
Update wey to 0.1.1

### DIFF
--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,10 +1,10 @@
 cask 'wey' do
-  version '0.1.0'
-  sha256 'ca6126b815e9b0a04422ae52fa890e3167b3eab0d2a1216bce7a1e2df2dd0f31'
+  version '0.1.1'
+  sha256 '64375ec21d286b9be0af9a863cc53cd0159f9b27c03540fd275455998a780498'
 
   url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom',
-          checkpoint: '7c22dcae0c9a1a70699b36170d57ec04bae77737cf2374e7c7842d7050c538ae'
+          checkpoint: '6910598e1ac593f9ecf163782b88e03b36711e516847a2dddc888cffc06cd062'
   name 'Wey'
   homepage 'https://github.com/yue/wey'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.