### PR TITLE
Update netron to 1.7.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.2'
-  sha256 '1ea3b312a331148dde599fd57ede2355217764c63bef0ad9e829fb3a3532be12'
+  version '1.7.3'
+  sha256 'efb68a5d226a65b49de5606be4faa7d0ce6fa0d07814bc815bc0e97d0d1ffbd8'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '494c35076ac847c80b9fef2e8e0f7b7502a9192758a7b9088607e8a91cd188b5'
+          checkpoint: '3308d38cbcd9cb4a4419ae40eef66a00dbdb0d1866f77abe4e0ff558ce1e375e'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.