### PR TITLE
Update superproductivity to 1.10.14

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,11 +1,11 @@
 cask 'superproductivity' do
-  version '1.10.8'
-  sha256 '4bd98eec162924dbb719763e55a2505780d5e58698b77433e20562b0967c66f7'
+  version '1.10.14'
+  sha256 'fa0631f72bd1e3d8884661b5c824298315270609368bb9341ed146be8f61a6e1'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"
   appcast 'https://github.com/johannesjo/super-productivity/releases.atom',
-          checkpoint: '2b692d28063a99035e339aa57f1e8086c70e50d81520648195af6b7348c43bd1'
+          checkpoint: 'a12a674e331deed8e2cd3b271a282b89b645be0e2e9da66069a479ef4c3fe99c'
   name 'Super Productivity'
   homepage 'https://super-productivity.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.