### PR TITLE
Update 4k-stogram to 2.6.11.1557

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,10 +1,10 @@
 cask '4k-stogram' do
-  version '2.6.7.1517'
-  sha256 'ffe74804e1a0cd0acd104e89e75b7bb827e6abb7ee6f56352c56723404f3d116'
+  version '2.6.11.1557'
+  sha256 '8035c50a7d9dfa7cb3824206d9dd7f849162ed93e3c2d89da08f4e1cd5c81d9b'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '89c3a317a578aa5ef3291f295bb4ff1ffc73f87c026475924dbc3e9f50fe695b'
+          checkpoint: '6976352a19a6acbaf5953cb3db8d18a88d5258e9d05fd2a0d5018be457741204'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.