### PR TITLE
Update aether to 1.2.3

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -2,10 +2,10 @@ cask 'aether' do
   version '1.2.3'
   sha256 '04ca7fbd693bda438436b46315616660ff123ec9d817d802c8c14dcb13711338'
 
-  # github.com/nehbit/aether-public was verified as official when first introduced to the cask
-  url "https://github.com/nehbit/aether-public/releases/download/v#{version}-OSX/Aether.#{version}.dmg"
-  appcast 'https://github.com/nehbit/aether-public/releases.atom',
-          checkpoint: 'cfd1eeab50243955ebb52c7710fddeb08d8cbbfef751d0108273ca58e3ccbd38'
+  # github.com/nehbit/aether was verified as official when first introduced to the cask
+  url "https://github.com/nehbit/aether/releases/download/v#{version}-OSX/Aether.#{version}.dmg"
+  appcast 'https://github.com/nehbit/aether/releases.atom',
+          checkpoint: 'e04d1d483f3a095bca996c29d6023b3f28453a8a2badc84807c45426dabab94f'
   name 'Aether'
   homepage 'http://getaether.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.