### PR TITLE
Update airflow to 2.3.7

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,11 +1,11 @@
 cask 'airflow' do
-  version '2.3.1-u1'
-  sha256 'f6cecbc2865238c775f2a83656c3efcdc9443783bf613624b4ac908e9ef87811'
+  version '2.3.7'
+  sha256 '67d1bd9c08031f321512c2ad41980abf296803d29c3a097bf9674e9a3112033c'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.zip"
   appcast 'https://s3.amazonaws.com/Airflow/Updates/appcast-osx.xml',
-          checkpoint: '426092153bedb33ba0c3c8cc81ede2e32c6cf4463f94dc51f052dbfbecf87ae8'
+          checkpoint: '012c22c7bce1061485202a328111f2e7cb51188b90d009ccab884e5dcc8aa61c'
   name 'Airflow'
   homepage 'https://airflowapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.