### PR TITLE
Update banking-4x to 6.10.3.6676

### DIFF
--- a/Casks/banking-4x.rb
+++ b/Casks/banking-4x.rb
@@ -1,11 +1,11 @@
 cask 'banking-4x' do
   # note: "4x" is not a version number, but an intrinsic part of the product name
-  version '6.10.2.6649'
-  sha256 '747bf1c602e9bb752889773d8834e04a171ecba16a7445183ce8a3e89ac0b2de'
+  version '6.10.3.6676'
+  sha256 'ac9f05d4aaf1e176f873953fe2381ee2dbb0339f7275e8f388c45c4c8f92312a'
 
   url 'https://subsembly.com/download/MacBanking.pkg'
   appcast 'https://subsembly.com/banking4x-updates.php',
-          checkpoint: 'c70bb00ff1dafc4b217c4e8fa722a8d940d267a7a5567339e738284800f41e8b'
+          checkpoint: '6d974a6ca0eea918f7e0c4188eb0e457147811d64627815bab9810420b534f25'
   name 'Banking 4X'
   homepage 'https://subsembly.com/banking4.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.