### PR TITLE
Update kstars to 2.9.4

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,9 +1,9 @@
 cask 'kstars' do
-  version :latest
-  sha256 :no_check
+  version '2.9.4'
+  sha256 '27c78fcccb3c96cd37f9c2a71f557a60ee6698c5baf170d1adfac3571d5ff9a6'
 
   # indilib.org/jdownloads/kstars was verified as official when first introduced to the cask
-  url 'http://www.indilib.org/jdownloads/kstars/kstars-latest.dmg'
+  url "http://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"
   name 'KStars'
   homepage 'https://edu.kde.org/kstars/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.