### PR TITLE
Update cloudytabs to 1.9.1

### DIFF
--- a/Casks/cloudytabs.rb
+++ b/Casks/cloudytabs.rb
@@ -1,10 +1,10 @@
 cask 'cloudytabs' do
-  version '1.9'
-  sha256 '55fd43096c708e859ad969533c4034ab00a6be2f6bab5a5ccde3069cd976f5d5'
+  version '1.9.1'
+  sha256 'acbccf2172242b6cd5e702ad06293e616932889e75e1dbfdb3b6229a0dbf87e0'
 
   url "https://github.com/josh-/CloudyTabs/releases/download/v#{version}/CloudyTabs.zip"
   appcast 'https://github.com/josh-/CloudyTabs/releases.atom',
-          checkpoint: '1b74a4bfb365fc8bbe49be719a85932220f292f5d3238bd938edbcde60ec540e'
+          checkpoint: 'a57eba0c907758cc9d3c34ea1bfa8026e1eea5bbf9049feefd0a8d9715eb01d5'
   name 'CloudyTabs'
   homepage 'https://github.com/josh-/CloudyTabs/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.