### PR TITLE
Update kugoumusic to 2.5.6

### DIFF
--- a/Casks/kugoumusic.rb
+++ b/Casks/kugoumusic.rb
@@ -1,6 +1,6 @@
 cask 'kugoumusic' do
-  version '2.5.4'
-  sha256 'c8d4e40dab713d73a64762913f4b34819a31003a7042bae77125afbeb79151b1'
+  version '2.5.6'
+  sha256 'a94bee1eb2177e67537af6fbba03a25f43acf798c017112bcc27412265032ecc'
 
   url "http://downmini.kugou.com/mac/Kugou_V#{version}.dmg"
   name 'Kugou Music'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.