### PR TITLE
Update bitpay to 3.15.2

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '3.14.2'
-  sha256 '5f7da8dfb9e8944d696cded33fbfa18115f01a151aed385f4e5fb04be7a6dd6e'
+  version '3.15.2'
+  sha256 '793961e1b1e0a2cdf1b9a770191399531cff5c5388e38461ffc72b0f1dc5c7d4'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: '0dc73ed919aa9337dad13787c755303b86945bc293ff3265014585283ae2b31d'
+          checkpoint: '95aff0b7be3e2ad3406cd086886c8c22c31540c358875e1e52f45c039d917ffb'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.