### PR TITLE
Update blockstack to 0.28.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,11 +1,11 @@
 cask 'blockstack' do
-  version '0.26.2'
-  sha256 'e9d35f26ed6e5a5f3793b3886c73153684a37293f835e6d1b5e871c0cfcdf167'
+  version '0.28.0'
+  sha256 'ca7c03ab34a7f73d6df8d6247f943fdf06631c1d1566cd99e11562d5583ecb81'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom',
-          checkpoint: '4ea0071e37bd7ab29f5cb66a572e30ff6c9b3b04045f333d506b8445655cf116'
+          checkpoint: '31928ff4bb3424e7a8001c3e2f2dff7974fca180fca50d2e8bad7d960b04e6d0'
   name 'Blockstack'
   homepage 'https://blockstack.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.