### PR TITLE
Update bloodhound to 1.5.2

### DIFF
--- a/Casks/bloodhound.rb
+++ b/Casks/bloodhound.rb
@@ -1,10 +1,10 @@
 cask 'bloodhound' do
-  version '1.4'
-  sha256 'b11b6028e75a3bcbe194770f9613181009aaf40bdd23892e12e0ce32bbe90cfb'
+  version '1.5.2'
+  sha256 'a2090197c5cf82c6799cf7f8f7f1d0d42436882c67814b70d458c4ae8e9c7e32'
 
   url "https://github.com/BloodHoundAD/BloodHound/releases/download/#{version}/BloodHound-darwin-x64.zip"
   appcast 'https://github.com/BloodHoundAD/BloodHound/releases.atom',
-          checkpoint: 'cd6df9e823b9434029f0ad50f819eb99335cbe3d2f87ac0533e92230107428e0'
+          checkpoint: '3043e8d3935e99c729b993b632ba3927ac31f357e03bc4e73b0675ceae45fa1b'
   name 'bloodhound'
   homepage 'https://github.com/BloodHoundAD/BloodHound'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.