### PR TITLE
Update brave to 0.22.21

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.22.13'
-  sha256 'a7224be024df312c2bb8b482a364e53900e11ce274598674164746f8f0d29a02'
+  version '0.22.21'
+  sha256 '157f4eedfa1e5ea4f48fe2b046c830e432b69e1ef0c5450f137a86a5ac4b9fe1'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'dba8561ea8d0811fc075d60d06f5a67f853956f83ffdd357581a7b6a2844efff'
+          checkpoint: '595a5bbc22ff4a037ce24ce274613f726080c48e3aaa9ffc62e18f2cbf9e7b0b'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.