### PR TITLE
Update buttercup to 1.6.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '1.4.0'
-  sha256 'b08de949cd8487541fca955ecd58526e327b1132b3e7bf184ed8f606f529f57b'
+  version '1.6.1'
+  sha256 '0ce076efe304f1d68f31906b428bb80a72b0a2c04572890c312fe8c605eb4d3a'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: 'd00b142d19efa589a158a67ceceab6599fc6807160d88f8295fbde87e123caed'
+          checkpoint: 'b09503f840f848bdb171bb131ff30550d490b7ed535f47ef08361ec0e70a5f31'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.