### PR TITLE
Update byteball to 2.2.0

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,11 +1,11 @@
 cask 'byteball' do
-  version '2.1.0'
-  sha256 '60e1d4adade4b3a38a930ee70a5c24397aba5be93950d39141a5792df1abde2b'
+  version '2.2.0'
+  sha256 '436f81611ace2722016228c2f3313e89567231d2ae9d4b0fbb2b2c80030090da'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"
   appcast 'https://github.com/byteball/byteball/releases.atom',
-          checkpoint: 'bc766ea84b52d2f54a8965fe229c349293a4c925fe33de07da4452ff209ce219'
+          checkpoint: '6bd833dc2ad35e2a02b16b96c7b8a6128ce3345965806e2895ac1dc8586d672f'
   name 'Byteball'
   homepage 'https://byteball.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.