### PR TITLE
Update captin to 1.0.12,84:1520071833

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,11 +1,11 @@
 cask 'captin' do
-  version '1.0.11,82:1516943455'
-  sha256 'c09431aef7ceb8b4c2eb0c758cd47af27673a29e302d5f143be583046b5ea938'
+  version '1.0.12,84:1520071833'
+  sha256 '6a84831ddd97e5a98215d9cd8b866a7093c4a55a97ee9b31d84e01f9ed231218'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"
   appcast 'https://updates.devmate.com/com.100hps.captin.xml',
-          checkpoint: '564e94f5e771ded9fb43db2380936cdc69d21d482cd0f8142c794ae550bdce3d'
+          checkpoint: '384a968ec3382d40df7c92dbc64e2dbf21dd4c53099c18d5ef4df118ed3c6d20'
   name 'Captin'
   homepage 'http://captin.strikingly.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.