### PR TITLE
Update castbridge to 1.0.5

### DIFF
--- a/Casks/castbridge.rb
+++ b/Casks/castbridge.rb
@@ -1,11 +1,11 @@
 cask 'castbridge' do
   version '1.0.5'
-  sha256 'c04b8d8ceb9a0cf31891ea3e4bd5bc2325c8830b6665fd81dd9542798892628a'
+  sha256 '1df0898d856e0743f0c871199c8e71847706185dacf305576cb53b4f136394c3'
 
   # s3.amazonaws.com/updates.castbridge.io was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/updates.castbridge.io/Castbridge-#{version}.dmg"
+  url "https://s3.amazonaws.com/updates.castbridge.io/Castbridge-#{version}-mac.zip"
   appcast 'https://s3.amazonaws.com/updates.castbridge.io/latest-mac.json',
-          checkpoint: '9f844f5c59f36bac9ab794d150c6d1302d344ce575905040f669ef6523a699e1'
+          checkpoint: '878a480ac7b53f0166d33a2c95da9cf0501ed75c6c6cf7241268945b232f496d'
   name 'Castbridge'
   homepage 'https://castbridge.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.