### PR TITLE
Update cctalk to 1.0.1-576,2018-04-13

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,11 +1,11 @@
 cask 'cctalk' do
-  version '1.0.0-568,2018-03-16'
-  sha256 '4c0dc206774aafd99b46cd7ebb684ad7cd2c29cba5070eb06d8bc470ee7a04a9'
+  version '1.0.1-576,2018-04-13'
+  sha256 '75fddbc3dc5b4af0eb36a3a3f1445c047b9d8b2ddbb0929a9af2a32223e1e81d'
 
   # f1.ct.hjfile.cn was verified as official when first introduced to the cask
   url "http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/in/mac/cctalk/archive/#{version.before_comma.hyphens_to_dots}/CCtalk-#{version.before_comma}-xianghu-#{version.after_comma}.dmg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml',
-          checkpoint: '3980d6e2e5e4ff0577a63cc758fb4f48b90251821e8147a75c1b876f75140cd8'
+          checkpoint: 'bc478199318209caf7e3e9b2d482ad8975f6c0acec46ff3fa2cc652b34cb0050'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.