### PR TITLE
Update ckan-app to 1.25.0

### DIFF
--- a/Casks/ckan-app.rb
+++ b/Casks/ckan-app.rb
@@ -1,10 +1,10 @@
 cask 'ckan-app' do
-  version '1.24.0'
-  sha256 '4c116febeeaf4ed95cc6327ca3b220d22f16c8c601d878627367606573c205f8'
+  version '1.25.0'
+  sha256 '59931b28c91d456d400091a78c29cb8ac99ad9a8cf7019c2a1275f61133fe8df'
 
   url "https://github.com/KSP-CKAN/CKAN/releases/download/v#{version}/CKAN.dmg"
   appcast 'https://github.com/KSP-CKAN/CKAN/releases.atom',
-          checkpoint: 'ec64ae33f2ab43d9324749aa536b066f7cc1679b28035065d9a5d7a3df4ce5b9'
+          checkpoint: '7332163f6416402a6756bf0a08c57a3f948c3b6b94af20db5ec44fccc1c4e888'
   name 'Comprehensive Kerbal Archive Network client'
   homepage 'https://github.com/KSP-CKAN/CKAN'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.