### PR TITLE
Update cmpl to 1.12.0

### DIFF
--- a/Casks/cmpl.rb
+++ b/Casks/cmpl.rb
@@ -1,10 +1,10 @@
 cask 'cmpl' do
-  version '1.11.0'
-  sha256 'fbb54e6f69cb72d6e1ecdb12e2950ec7adc44a542aea1e748a7710c72c132dac'
+  version '1.12.0'
+  sha256 '7e7598cbacc31e609013b533ee080a489acdbbe4e84d9423a0bdecedcc6da432'
 
-  url "http://www.coliop.org/_download/Cmpl-#{version.dots_to_hyphens}-osx.tar.gz"
+  url "http://www.coliop.org/_download/Cmpl-#{version.dots_to_hyphens}-macOS.dmg"
   appcast 'http://www.coliop.org/download.html',
-          checkpoint: 'fce3e8cbdee735ffc9364e387753518f0781f10a71d13183c13ca1376acb4ac7'
+          checkpoint: '95517cd00d8ae7408ededa88884e7b26e9fd0f905eddc2b8b4b9655e1a4d9969'
   name 'CMPL'
   homepage 'http://www.coliop.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.