### PR TITLE
Update proxifier to 2.21

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -3,8 +3,8 @@ cask 'proxifier' do
   sha256 '139887d2f4468af222af2b8a1b806169918f359113547a918078792b47471540'
 
   url 'https://www.proxifier.com/distr/ProxifierMac.dmg'
-  appcast 'https://www.proxifier.com/mac/new.htm',
-          checkpoint: '602cadf245901c60c6fd178f80f5e0771ce290a1b03446f1d949ed310f7b97a2'
+  appcast 'https://www.proxifier.com/changelog/mac.html',
+          checkpoint: 'af05a525c7e3128fc3c6c82f0f9ba94e2a7cb34a5f14a5592e57c3ca986ba263'
   name 'Proxifier'
   homepage 'https://www.proxifier.com/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.