### PR TITLE
Update MAL-Updater checksums for v2.4.3

### DIFF
--- a/Casks/mal-updater.rb
+++ b/Casks/mal-updater.rb
@@ -1,6 +1,6 @@
 cask 'mal-updater' do
   version '2.4.3'
-  sha256 '1664ec9acd283270d17d861983bf35a9455c2fab937ed126cd19e2377bf612bd'
+  sha256 '682540991b701896a4c664d930690e99f8acc0d4527369a9620332d2ba586df7'
 
   # github.com/Atelier-Shiori/malupdaterosx-cocoa was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases/download/#{version}/malupdaterosx-#{version}.dmg"

--- a/Casks/mal-updater.rb
+++ b/Casks/mal-updater.rb
@@ -5,7 +5,7 @@ cask 'mal-updater' do
   # github.com/Atelier-Shiori/malupdaterosx-cocoa was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases/download/#{version}/malupdaterosx-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases.atom',
-          checkpoint: 'b2c751aae00799924f68b05b6aed17af4c64cfed969b026c0703dbbc1ffa2ed4'
+          checkpoint: '4e4d5e15393454b3944ebeb27b971e1f79f8d227e423f38c7312dbfe05afff34'
   name 'MAL Updater OS X'
   homepage 'https://malupdaterosx.ateliershiori.moe/'
 


### PR DESCRIPTION
With version 2.4.3, the checksums were incorrect and it was impossible to update.
<img width="614" alt="screen shot 2018-04-17 at 08 26 37" src="https://user-images.githubusercontent.com/1688389/38852196-258bc6d4-4219-11e8-8395-56a97a3387f0.png">

I downloaded it manually from their repository and got the checksum.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
Though this made me change the app cast checksum for it to pass (I don't know if it's good).
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256