### PR TITLE
Update lehreroffice to 2018.4.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice' do
-  version '2018.2.0'
-  sha256 '5b1db19466ee31f451ac5de32ca7fa1387187f4b76311ec6effd9e534a3cf45a'
+  version '2018.4.0'
+  sha256 '2aa71874bc3300761360a9bb953f99e2429349718b78adfe1588b7256e5f628a'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop',
-          checkpoint: '96aab4a8f7d62edade54ceb5a82d24e4710dab28af25be8b1ef4cbe68d1d6d58'
+          checkpoint: '259a12f7fe89e686b1edcad440f4b88ce677539693f89ec20f31c60a87b76ed8'
   name 'LehrerOffice'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.