### PR TITLE
Update hsang to 1.8.6

### DIFF
--- a/Casks/hsang.rb
+++ b/Casks/hsang.rb
@@ -1,9 +1,9 @@
 cask 'hsang' do
-  version '1.8.2'
-  sha256 'a1e54fc34b5ca82ed1b3e24f4618b832ef2df8e9d1bdb918573ac6f3d339e449'
+  version '1.8.6'
+  sha256 '74a01e493ed8df166b95e1451a69dcf5ba988830a1f176855b67accd544bf263'
 
-  # nie.gdl.netease.com/lushi was verified as official when first introduced to the cask
-  url "http://nie.gdl.netease.com/lushi/HSAng_#{version}.dmg"
+  # opd.gdl.netease.com/ was verified as official when first introduced to the cask
+  url "http://opd.gdl.netease.com/HSAng_#{version}.dmg"
   name 'HSAng'
   homepage 'http://lushi.163.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.