### PR TITLE
Update lehreroffice-zusatz to 2018.5.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.2.0'
-  sha256 '15cfb0720ff1eff329b5adfbe7982b926b51648f94d62a081ee458455d3f5af7'
+  version '2018.5.0'
+  sha256 '807d3c47c73d3b0dbd82bd9c810ce764ce819c7abb6b99d39c90f83523ea8aa2'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '96aab4a8f7d62edade54ceb5a82d24e4710dab28af25be8b1ef4cbe68d1d6d58'
+          checkpoint: '56468370af51073f2261b475ca6387f3ac9cb9725819e9c7fe80c5c2da5ac0d7'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.