### PR TITLE
Update cacher to 1.4.2

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.3.14'
-  sha256 'f4301e4be306956072940d7479ea8efec556203f96c59358153c376a0acc6e2f'
+  version '1.4.2'
+  sha256 '29002d9237bc34c2de5f718acc4958e0119e809a95729ca6aa8f1d5472041c4b'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '3b572f102aaf1803b2d0278a7297d879be86d60970d4032f7cdc3874786b9548'
+          checkpoint: '23aeaf76109f54134b36385b75422fef46b6a50a02056888e11bfd0a5b0791db'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.