### PR TITLE
Update zotero to 5.0.45

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.44'
-  sha256 'b1b7c5bf1696d75cfd4b6b992751b7b87464873304771b5e4050cba7530b18a5'
+  version '5.0.45'
+  sha256 'eb9df6f01b68ff9363f057960e8c1804e60e9c946633ec3d91924dfa2d1a1c58'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '967904316f503acb2ed21df98df6d40e67665375f22a8b49390e9a13ba413108'
+          checkpoint: '92ae47cbfc519792b89c24aff896bec69fa568372154f5f54a380d46581d904a'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.