### PR TITLE
Update lehreroffice-zusatz to 2018.5.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.4.0'
-  sha256 'b7c717ed20de5ea1ed5e4bd16f7534c69fb29dd8158715327f91e6cf7d07ab61'
+  version '2018.5.0'
+  sha256 '807d3c47c73d3b0dbd82bd9c810ce764ce819c7abb6b99d39c90f83523ea8aa2'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '259a12f7fe89e686b1edcad440f4b88ce677539693f89ec20f31c60a87b76ed8'
+          checkpoint: '56468370af51073f2261b475ca6387f3ac9cb9725819e9c7fe80c5c2da5ac0d7'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.