### PR TITLE
Add new Cask for gitlab 'lab' cli tool v0.10.1

### DIFF
--- a/Casks/gitlab-lab.rb
+++ b/Casks/gitlab-lab.rb
@@ -1,0 +1,13 @@
+cask 'gitlab-lab' do
+  version '0.10.1'
+  sha256 '7a215ca4b039403fd127edc02f6b9fdf58a044a3c925bd4d0e1666d8dfef977c'
+
+  # Github releases url has been verified at the time of creating cask
+  url "https://github.com/zaquestion/lab/releases/download/v#{version}/lab_#{version}_darwin_amd64.tar.gz"
+  appcast 'https://github.com/zaquestion/lab/releases.atom',
+          checkpoint: '7096ee3f7ebd4495794a54479d236410471d760f6265a86322699bc40eec8f7e'
+  name 'lab'
+  homepage 'https://zaquestion.github.io/lab'
+
+  binary 'lab'
+end


### PR DESCRIPTION
Lab is a complementary tool, similar to Hub, that wraps git and allows
interacting with repositories hosted on a Gitlab server

After making all changes to the cask:

- [ X ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ X ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ X ] Named the cask according to the [token reference].
- [ X ] `brew cask install {{cask_file}}` worked successfully.
- [ X ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ X ] Checked there are no [open pull requests] for the same cask.
- [ X ] Checked the cask was not already refused in [closed issues].
- [ X ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Cask style fails with this warning I'm not sure how to resolve:
```
C:  5:  3: Cask/HomepageMatchesUrl: Github does not match github.com/zaquestion/lab/releases/download/v
```
However the hompage *is* hosted on github pages and everything else has been thoroughly tested.