### PR TITLE
Update cacher to 1.4.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.4.2'
-  sha256 '29002d9237bc34c2de5f718acc4958e0119e809a95729ca6aa8f1d5472041c4b'
+  version '1.4.3'
+  sha256 '9dfc8770be577632fd902a20bbd6009a269544bbb676db2fa8c908463222be16'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '23aeaf76109f54134b36385b75422fef46b6a50a02056888e11bfd0a5b0791db'
+          checkpoint: 'ae05a8700eb297ea87aedba46431a73965667fe3d231c7572c705ae4328e199d'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.