### PR TITLE
Update mark-text to 0.10.21

### DIFF
--- a/Casks/mark-text.rb
+++ b/Casks/mark-text.rb
@@ -1,11 +1,11 @@
 cask 'mark-text' do
-  version '0.9.25'
-  sha256 'd49e14ef72ae5443b717139c8851cf2cc4d0c557c530c9ed36d389e942013a48'
+  version '0.10.21'
+  sha256 'c65b64c46ce30d522608927a827417e37687f0cee7c96570ac942bb1c2b0cd36'
 
   # github.com/marktext/marktext was verified as official when first introduced to the cask
   url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext-#{version}.dmg"
   appcast 'https://github.com/marktext/marktext/releases.atom',
-          checkpoint: '0b4e404117b748cd10ad870a2c970d3d2e02f2a99dd9874705e21da901d0d862'
+          checkpoint: '93a9a60b21bfc925c2165b8832a5559553d6cc079c177b3b55c104268aab82c6'
   name 'Mark Text'
   homepage 'https://marktext.github.io/website/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.