### PR TITLE
Update chromedriver to 2.38

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,11 +1,11 @@
 cask 'chromedriver' do
-  version '2.37'
-  sha256 'a1c4699cf12d51a5284971ba5ca2d8e354e422acd5151c920c5105339f4a5d29'
+  version '2.38'
+  sha256 'e87fa43af3fbcfd5b9e49e627f09ff780ce5adc5def6b13aa6380f32174ed898'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"
   appcast 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE',
-          checkpoint: '8d92c9c2d484524c60f4ad13fb9319a8045d45b960079907bce91b7b03cedae3'
+          checkpoint: '56cbe3c372f86dc281ca8b3107962d7c546a861bdf975a75c245fb46526c50ed'
   name 'ChromeDriver'
   homepage 'https://sites.google.com/a/chromium.org/chromedriver/home'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.