### PR TITLE
Update neo4j to 1.0.22

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,7 +1,7 @@
 cask 'neo4j' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '1.0.21'
-  sha256 '6365de793fa275fd875e672a700eb8d3a14b584206da7247d3f6864a2882d8ff'
+  version '1.0.22'
+  sha256 'c7f307258d170e340f5cf301af1d70b442cd4192ef4519850b28e60093016941'
 
   url "https://neo4j.com/artifact.php?name=neo4j-desktop-offline-#{version}.dmg"
   name 'Neo4j Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.