### PR TITLE
Update snapndrag to 4.2.8

### DIFF
--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -1,10 +1,10 @@
 cask 'snapndrag' do
-  version '4.2.7'
-  sha256 'e53d5a3f596fea2c46eca52cee7f54e40ccb2cbb417ed26cc1e159fde08dac7f'
+  version '4.2.8'
+  sha256 '113664b9616fff224aba6d3cb8006cd302f3089b1a93b6f3b5e9f7d0daf00daa'
 
   url "http://yellowmug.com/download/SnapNDrag_#{version}.dmg"
   appcast 'http://yellowmug.com/snapndrag/appcast-1012.xml',
-          checkpoint: 'd5b63cfb058ed514c2579b6376a6cb3aa04c1ba05a48292c66e8556d4e19a53f'
+          checkpoint: '9a7a4be2351013794d4dbc8fe869493f0336cb16361237e0b194ce9b87ecd220'
   name 'SnapNDrag'
   homepage 'http://www.yellowmug.com/snapndrag/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.