### PR TITLE
Update thingsmacsandboxhelper to 3.13

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -1,6 +1,6 @@
 cask 'thingsmacsandboxhelper' do
-  version '3.11'
-  sha256 'ae0face6c56b8da9aceaf157176d7ef2d4492be65471687740761b6b142e310c'
+  version '3.13'
+  sha256 '547d041ec327887d90d89a450d61c5c6fda538131c7590a924f003efc62753e6'
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.