### PR TITLE
Update freesmug-chromium to 66.0.3359.117

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '65.0.3325.181'
-  sha256 'dd1d4a72a8ea7ac4fc110ef1852929192c55948a486a447fb63eb0f8c7740dc8'
+  version '66.0.3359.117'
+  sha256 '85e4320708bebdc26c5597c48d54d46f07005d89c873aa36eed7dd1f94e24785'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '21cc0005151ef3ab5e53cf134308f3460d90f931552ba1cfc539430b740687b4'
+          checkpoint: 'e109d61870ff005524d5e2d191fea23a8ee2cb48caf50a9715b894a727341721'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.