### PR TITLE
Add Spek.app(spek-alternative) v0.8.2.3

### DIFF
--- a/Casks/spek-alternative.rb
+++ b/Casks/spek-alternative.rb
@@ -1,0 +1,12 @@
+cask 'spek-alternative' do
+  version '0.8.2.3'
+  sha256 '6426c4c34ac8bcb2fa1020cb295e3c105ca912c853cbbe84d1d196a32bba361b'
+
+  url "https://github.com/withmorten/spek-alternative/releases/download/#{version}/spek-alternative-#{version}.dmg"
+  appcast 'https://github.com/withmorten/spek-alternative/releases.atom',
+          checkpoint: '02b1d685ab571f66cbe42ec638466034afe5c3b0016ba119a2922ca12197ba14'
+  name 'spek-alternative'
+  homepage 'https://github.com/withmorten/spek-alternative'
+
+  app 'Spek.app'
+end

--- a/Casks/withmorten-spek.rb
+++ b/Casks/withmorten-spek.rb
@@ -1,4 +1,4 @@
-cask 'spek-alternative' do
+cask 'withmorten-spek' do
   version '0.8.2.3'
   sha256 '6426c4c34ac8bcb2fa1020cb295e3c105ca912c853cbbe84d1d196a32bba361b'
 


### PR DESCRIPTION
Original spek(https://github.com/alexkay/spek) seems not maintaining anymore
So I add the fork version of spek which can work properly as a new cask

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ 👌] `brew cask audit --download {{cask_file}}` is error-free.
- [ 👌] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ 👌] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ 👌] Named the cask according to the [token reference].
- [ 👌] `brew cask install {{cask_file}}` worked successfully.
- [ 👌] `brew cask uninstall {{cask_file}}` worked successfully.
- [ 👌] Checked there are no [open pull requests] for the same cask.
- [ 👌] Checked the cask was not already refused in [closed issues].
- [ 👌] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
