### PR TITLE
Update electronic-wechat to 2.0

### DIFF
--- a/Casks/electronic-wechat.rb
+++ b/Casks/electronic-wechat.rb
@@ -4,9 +4,18 @@ cask 'electronic-wechat' do
 
   url "https://github.com/geeeeeeeeek/electronic-wechat/releases/download/V#{version}/mac-osx.tar.gz"
   appcast 'https://github.com/geeeeeeeeek/electronic-wechat/releases.atom',
-          checkpoint: 'c1ecc5779be1473be10667310df8d1a00790382af0ec0746cde056b737b5072f'
+          checkpoint: 'fcf75bf1c85650d594e46bfb8a50fa74546f7d77cc55eb189c6a9a0dda8cb1ae'
   name 'Electronic WeChat'
   homepage 'https://github.com/geeeeeeeeek/electronic-wechat'
 
   app 'Electronic WeChat-darwin-x64/Electronic WeChat.app'
+
+  zap trash: [
+               '~/Library/Application Support/electronic-wechat',
+               '~/Library/Application Support/electronic-wechat/Local Storage/https_web.wechat.com_0.localstorage',
+               '~/Library/Application Support/electronic-wechat/Local Storage/https_web.wechat.com_0.localstorage-journal',
+               '~/Library/Saved Application State/com.electron.electronic-wechat.savedState',
+               '~/Library/Preferences/com.electron.electronic-wechat.plist',
+               '~/Library/Preferences/com.electron.electronic-wechat.helper.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.