### PR TITLE
Update camunda-modeler to 1.13.1

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.13.0'
-  sha256 '352002ddb2b6c59630103e40087592d2f3be4427fbee3a6379c746bb29777811'
+  version '1.13.1'
+  sha256 'fe67b3c006f99ddb9e126d0c77cef52bcc14ba58636bddb461c389ee281a2f65'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.