### PR TITLE
Update voodoopad to 5.2.0

### DIFF
--- a/Casks/voodoopad.rb
+++ b/Casks/voodoopad.rb
@@ -1,11 +1,11 @@
 cask 'voodoopad' do
-  version '5.1.8'
-  sha256 '42da5a41c1759f2d2b66a5395decf5fc3a8a6f441bbd34f8afdececeb32de337'
+  version '5.2.0'
+  sha256 '2aee788f666b7b1109f173914e0cce1d40b991c79c1500af8e749c6abee65d37'
 
   # voodoopad.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://voodoopad.s3.amazonaws.com/VoodooPad-#{version}.zip"
   appcast 'https://www.voodoopad.com/download/',
-          checkpoint: '41636efe3ee458a3f6fb06ad08d589bed545a6a1cab46832dfd0652f6c1916cf'
+          checkpoint: '3d4dc6d9679d7dff6744c4f7bfa1300705071df0393272e42e67ce9619e09b94'
   name 'VoodooPad'
   homepage 'https://www.voodoopad.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.