### PR TITLE
Update comic-life to 3.5.8

### DIFF
--- a/Casks/comic-life.rb
+++ b/Casks/comic-life.rb
@@ -1,10 +1,10 @@
 cask 'comic-life' do
-  version '3.5.7'
-  sha256 '6b1ba855f3738e103411d9595e2e67008de85ec25bd91b99659c674182b3fa1d'
+  version '3.5.8'
+  sha256 '1c5dca65928e8107879575114854e2acd9228bf4c23e107a756021bef091d4b1'
 
   url "http://downloads.plasq.com/comiclife#{version.major}.zip"
   appcast "https://s3.amazonaws.com/updater.plasq.com/comiclife#{version.major}-appcast.xml",
-          checkpoint: 'afe438be5128c6d6beb9204df5c874e74381459800f7a8c431bf1a032c43fcd6'
+          checkpoint: 'e1b29f0f99cacf73ceb631f704ff6d180eb9e46872a3315b02520d3c94c843d2'
   name 'Comic Life'
   homepage 'https://plasq.com/apps/comiclife/macwin/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.