### PR TITLE
Update netron to 1.7.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.3'
-  sha256 'efb68a5d226a65b49de5606be4faa7d0ce6fa0d07814bc815bc0e97d0d1ffbd8'
+  version '1.7.4'
+  sha256 'a8771f95650a13fac96903bfbf44336b39d06f273701b86026a9dadcf548fc9f'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '3308d38cbcd9cb4a4419ae40eef66a00dbdb0d1866f77abe4e0ff558ce1e375e'
+          checkpoint: '4a5f996fa4000d03d61d0bb366e9affda57f38e70e6ee26c226de4043995d4e8'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.