### PR TITLE
Update gns3 to 2.1.5

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,12 +1,12 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.4'
-  sha256 '19c511b56def69252f67d8504c11f931eed62d13374b5653b60ee42f58e8f356'
+  version '2.1.5'
+  sha256 'cc1e56de0efe417670ff9ef4eaebd53732ded97c70863b56ca851c5ce1cb1aa3'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"
   appcast 'https://github.com/GNS3/gns3-gui/releases.atom',
-          checkpoint: '25929630a91c34a5e2013252bf76a8d287df28598206993aacccb014295dfe17'
+          checkpoint: '9132a534d462a23c0c6b11ed8e7497c7837993969925eb5d40159667f4b5bf9a'
   name 'GNS3'
   homepage 'https://www.gns3.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.