### PR TITLE
Update go-agent to 18.3.0-6540

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,11 +1,11 @@
 cask 'go-agent' do
-  version '18.2.0-6228'
-  sha256 '05d6f927ad8d473367f84cfd3b93832cdad18da97c13d18d6fe89e6fcb747272'
+  version '18.3.0-6540'
+  sha256 '52530a3f759c3f1a3cedb5eebc55bf8eeae509c9a97c070205f246910c9c6650'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: '85c4b79e99a44ff61809c6a72d2953d2654c02140e04200a5d1bda2a3e235f81'
+          checkpoint: 'd00e4e6848947d154dde8fd401343a233eab949f9021ba9ba509a7903fd823bb'
   name 'Go Agent'
   homepage 'https://www.gocd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.