### PR TITLE
Bump TablePlus to build 101.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
-  version '1.0,100'
-  sha256 '41519521846328d56d46e700390294bccfbe6f5227291aaac819839ae78e1207'
+  version '1.0,101'
+  sha256 '99931e674c4f8c65587cd1ea86723fed923d6f9219dda531b16669f03ac89e44'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: 'b7780cc05739c13e1a437bc6bbe5ed4ab0a92ed46502cc75fba313c8712bd3a3'
+          checkpoint: '07fc48a6227d6df353619b7b50565c40971a891509f3cace0920fbee0f2a23d6'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download tableplus.rb` is error-free.
- [x] `brew cask style --fix tableplus.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.
