### PR TITLE
Update xit to 1.0b8

### DIFF
--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -10,10 +10,10 @@ cask 'xit' do
 
   app 'Xit.app'
 
-  zap delete: [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uncommonplace.xit.sfl*',
-                '~/Library/Caches/com.uncommonplace.Xit',
-                '~/Library/Preferences/com.uncommonplace.Xit.plist',
-                '~/Library/Saved Application State/com.uncommonplace.Xit.savedState',
-              ]
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uncommonplace.xit.sfl*',
+               '~/Library/Caches/com.uncommonplace.Xit',
+               '~/Library/Preferences/com.uncommonplace.Xit.plist',
+               '~/Library/Saved Application State/com.uncommonplace.Xit.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.