### PR TITLE
Update lehreroffice to 2018.5.1

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice' do
-  version '2018.5.0'
-  sha256 'fd61efcb433d6952399e295104624b36572a4c1e6afb9b38615f888d8ec60928'
+  version '2018.5.1'
+  sha256 '022670f56c78a183c92e79e83e33c8e3c92c0d62c35f103271b5e3465ae50111'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop',
-          checkpoint: '56468370af51073f2261b475ca6387f3ac9cb9725819e9c7fe80c5c2da5ac0d7'
+          checkpoint: 'b133f3b525a4a99a6c9be4b6307d8ecb4897c0e48e60a9cc9ad99153d1b940b9'
   name 'LehrerOffice'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.