### PR TITLE
Update epic to 63.0.3239.108

### DIFF
--- a/Casks/epic.rb
+++ b/Casks/epic.rb
@@ -1,9 +1,9 @@
 cask 'epic' do
-  version '53.0.2785.143'
-  sha256 'd5182231a9cbecbe39ff3b562e876b3f03092c71c8ccfb7c71880c88bd271297'
+  version '63.0.3239.108'
+  sha256 'db70a27a4eaa3e9f504d1426bc2d3f6557ea6c4959e6a83114d015c8707a0753'
 
   # macepic-cbe.kxcdn.com was verified as official when first introduced to the cask
-  url "https://macepic-cbe.kxcdn.com/Epic_#{version}.dmg"
+  url "https://cdn.epicbrowser.com/epic_#{version}.dmg"
   appcast 'https://updates.epicbrowser.com/mac_updates/appcast.xml',
           checkpoint: 'baa4248683b2bde4cb5124bada0f5f7330ed865ef266ef7a7014729269debdf3'
   name 'Epic Privacy Browser'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.