### PR TITLE
Update cacher to 1.4.4

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.4.3'
-  sha256 '9dfc8770be577632fd902a20bbd6009a269544bbb676db2fa8c908463222be16'
+  version '1.4.4'
+  sha256 '17a64e9d4b8b5774c4c449c0dc73cfd08e7f6993385e86ba99b46a2762bb1cc9'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'ae05a8700eb297ea87aedba46431a73965667fe3d231c7572c705ae4328e199d'
+          checkpoint: 'fb0df71ff68e4462a9ec4872b116f9cc2c3b58fe419bde3f61ba40b0cce0925f'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.