### PR TITLE
Update chemdoodle to 9.0.0

### DIFF
--- a/Casks/chemdoodle.rb
+++ b/Casks/chemdoodle.rb
@@ -1,6 +1,6 @@
 cask 'chemdoodle' do
-  version '8.1.0'
-  sha256 'e65e33724034f996ba5d8ed7a51ecce2e38d1efdc49dfd24d3be180521308e9d'
+  version '9.0.0'
+  sha256 'ab3c7ee5372d00cbd39440a27752ae52d0e9a02caeb750e087991be7d2811445'
 
   url "https://www.chemdoodle.com/downloads/ChemDoodle-osx-#{version}.dmg"
   name 'ChemDoodle'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.