### PR TITLE
Update mongodb-compass-community to 1.12.8

### DIFF
--- a/Casks/mongodb-compass-community.rb
+++ b/Casks/mongodb-compass-community.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-community' do
-  version '1.12.7'
-  sha256 'a7b3e023a885f0456791d97d8df4697064ea297fe54479afe3d065cd8a82098b'
+  version '1.12.8'
+  sha256 'ec4613a7b40366020dbe36c1d585ea0bf5df80318f98509e9884c4ee0933f5ea'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-community-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass Community'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.