### PR TITLE
Update brave to 0.22.22

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.22.21'
-  sha256 '157f4eedfa1e5ea4f48fe2b046c830e432b69e1ef0c5450f137a86a5ac4b9fe1'
+  version '0.22.22'
+  sha256 '3edd06d9410adb527b5396ccd869cfad57f684a92361809a441f9486c2f41a54'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '595a5bbc22ff4a037ce24ce274613f726080c48e3aaa9ffc62e18f2cbf9e7b0b'
+          checkpoint: '831cd1240606e5df4bb61b9f95136238a815eaa023628f85579af768d1d1f8ba'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.