### PR TITLE
Update etcher to 1.4.3

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,11 +1,11 @@
 cask 'etcher' do
-  version '1.3.1'
-  sha256 'c5609c7e9aaa4d8d28b45f6758ad5b9711ec1eeae9f752a6f64413bc1e97016a'
+  version '1.4.3'
+  sha256 'a13792e06f82ad8b1ed0dcf25d2f8cfaf335628512a4483dbf34a5dc602eeadf'
 
   # github.com/resin-io/etcher/releases/download was verified as official when first introduced to the cask
   url "https://github.com/resin-io/etcher/releases/download/v#{version}/Etcher-#{version}.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: '1d20d1b2b191d122b08196b0d125bf26e57e3f8336ccedbb1fa097f8f529f4ea'
+          checkpoint: '4e63969ab9821eccd300d41697ce7c6445456a482dcbda07fd60183a5833f1ba'
   name 'Etcher'
   homepage 'https://etcher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.