### PR TITLE
Bump TablePlus build to 102.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
-  version '1.0,101'
-  sha256 '99931e674c4f8c65587cd1ea86723fed923d6f9219dda531b16669f03ac89e44'
+  version '1.0,102'
+  sha256 '2d414ae1bdb022f4ae33be3dd139c9c39dcce1eddfec13b7f667c420718cb7ae'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: '07fc48a6227d6df353619b7b50565c40971a891509f3cace0920fbee0f2a23d6'
+          checkpoint: '66c6ed440ff097821662c4a29513719c18accce616fe4a194d4b9b1443febac5'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Sorry for the frequent update, I need to release this build asap to support MySQL 8.0.
Thank you so much.