### PR TITLE
Update fastonosql to 1.17.4

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,10 +1,10 @@
 cask 'fastonosql' do
-  version '1.16.3'
-  sha256 '9b60d88fcd5fa860a7260bb1a7471ebead5fedb4fe6cfadd6248de8f6be98497'
+  version '1.17.4'
+  sha256 '249e60716acf94c00d2049a14da411e5985ca2cfe7f3ed42462c45edee422684'
 
-  url "https://www.fastonosql.com/trial_users_downloads/macosx/fastonosql-#{version}-x86_64.dmg"
+  url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom',
-          checkpoint: '0aa5af5f704c186fe0c948108df9d2f4cb42421db7718301ced7e737da9c195c'
+          checkpoint: '41f72610c3d64b529b092c1f587fbe2ef4eb79fdfbb1d03a72ff0ebc0663f621'
   name 'FastoNoSQL'
   homepage 'https://www.fastonosql.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.