### PR TITLE
Update chalk to 1.3.2

### DIFF
--- a/Casks/chalk.rb
+++ b/Casks/chalk.rb
@@ -1,11 +1,11 @@
 cask 'chalk' do
-  version '1.3.1'
-  sha256 '6b83946890b27631bf08ec3d87d9dd12aeb7f19701eb8483ea88e990ca94aa46'
+  version '1.3.2'
+  sha256 'f8eb490889e908bae4d8be614295e0a99891da147d0e0c21efaeceb91b91b32b'
 
   url "https://www.chachatelier.fr/chalk/downloads/Chalk-#{version.dots_to_underscores}.dmg",
       user_agent: :fake
   appcast 'https://pierre.chachatelier.fr/chalk/downloads/chalk-sparkle-en.rss',
-          checkpoint: 'b17fd895a90434cd08f03c413ba3f39ba1937d1941cf6f50bc6f50d31037e072'
+          checkpoint: '164c4a75f74eabaf6e6af148bbd7f7f77af5466dbeedf1d0f217b20258618847'
   name 'Chalk'
   homepage 'https://www.chachatelier.fr/chalk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.