### PR TITLE
Update epoch-flip-clock to 0.0.4

### DIFF
--- a/Casks/epoch-flip-clock.rb
+++ b/Casks/epoch-flip-clock.rb
@@ -1,12 +1,12 @@
 cask 'epoch-flip-clock' do
-  version '0.0.3'
-  sha256 '837edfe5d498a014b0a580c52a36c7efc71812e9d6c2e582f6dd1f2c8a8262bb'
+  version '0.0.4'
+  sha256 '7a9fe06209a140ea86a6a37263e3476ce9080bc274d27b815e373a3f8352c45d'
 
-  url "https://github.com/chrstphrknwtn/epoch-flip-clock/releases/download/#{version}/Epoch.Flip.Clock.saver.zip"
-  appcast 'https://github.com/chrstphrknwtn/epoch-flip-clock/releases.atom',
-          checkpoint: '41a86464323f5fbaed984ba4bb930aaca4d458c10d4dc8b281c93183f2521942'
+  url "https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver/releases/download/#{version}/Epoch.Flip.Clock.#{version}.saver.zip"
+  appcast 'https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver/releases.atom',
+          checkpoint: 'a4cf50b673488297f98a27448b48dcdd789d9a0cca12da27ce5aa8a96af6e009'
   name 'Epoch Flip Clock Screensaver'
-  homepage 'https://github.com/chrstphrknwtn/epoch-flip-clock/'
+  homepage 'https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver/'
 
   screen_saver 'Epoch Flip Clock.saver'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.