### PR TITLE
Update journey to 2.6.6

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,11 +1,11 @@
 cask 'journey' do
-  version '2.6.3'
-  sha256 'e3d501b1cbb7dd342544e2745053b45a5b59eae560c1fbe5dd1721fca6d0b53b'
+  version '2.6.6'
+  sha256 '9d7f99ca53f7c22ad97c804674bebb21df960db7a9364e99f5eaee1e749386cc'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
   url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-x64-#{version}.dmg"
   appcast 'https://github.com/2-App-Studio/journey-releases/releases.atom',
-          checkpoint: '53b3fe139d98e53790678aa4e5c1c1b77840e99cac4c76954b95cf11299817c1'
+          checkpoint: '201e76435d2d0dbc4dd48ec4a84b1e1521f79f38eba14421e2608a8cf58c4400'
   name 'Journey'
   homepage 'https://2appstudio.com/journey/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.