### PR TITLE
Update flixster-video to 2.7.1.638

### DIFF
--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -3,8 +3,8 @@ cask 'flixster-video' do
   sha256 'eef953f1b4636d158a594728a9bed6ded61f5af1402bd7432cce817e836f1346'
 
   # dtmmt9rxsy2no.cloudfront.net was verified as official when first introduced to the cask
-  url 'http://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
-  appcast 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
+  url 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
+  appcast 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
           checkpoint: '58614097c1c907f7a693ffd55ffcfc493a51d5ad1e176f80ba7deebe361f606d'
   name 'Flixster Video'
   homepage 'https://www.flixstervideo.com/apps'

--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -1,11 +1,11 @@
 cask 'flixster-video' do
-  version '2.7.1.637'
+  version '2.7.1.638'
   sha256 'eef953f1b4636d158a594728a9bed6ded61f5af1402bd7432cce817e836f1346'
 
-  # d1rtylazwb77ux.cloudfront.net was verified as official when first introduced to the cask
-  url 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
+  # dtmmt9rxsy2no.cloudfront.net was verified as official when first introduced to the cask
+  url 'http://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
   appcast 'https://d1rtylazwb77ux.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml',
-          checkpoint: '7486cfdc8e89809389fa19117d196149086788eed99798948443892633a540a1'
+          checkpoint: '58614097c1c907f7a693ffd55ffcfc493a51d5ad1e176f80ba7deebe361f606d'
   name 'Flixster Video'
   homepage 'https://www.flixstervideo.com/apps'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.