### PR TITLE
Update nomachine to 6.1.6_10

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -9,15 +9,15 @@ cask 'nomachine' do
   pkg 'NoMachine.pkg'
 
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
-  uninstall delete: '/Applications/NoMachine.app',
-  # However, we duplicate the uninstall process manually just in case
-            script: '/Library/Application Support/NoMachine/nxuninstall.sh',
-            quit:         'com.nomachine.nxdock',
-            kext:         [
-                            'com.nomachine.driver.nxau',
-                            'com.nomachine.driver.nxtun',
-                            'com.nomachine.kext.nxfs',
-                          ],
-            pkgutil:      'com.nomachine.nomachine.NoMachine.*',
-            launchctl:    'com.nomachine.uninstall'
+  uninstall delete:    '/Applications/NoMachine.app',
+            # However, we duplicate the uninstall process manually just in case
+            script:    '/Library/Application Support/NoMachine/nxuninstall.sh',
+            quit:      'com.nomachine.nxdock',
+            kext:      [
+                         'com.nomachine.driver.nxau',
+                         'com.nomachine.driver.nxtun',
+                         'com.nomachine.kext.nxfs',
+                       ],
+            pkgutil:   'com.nomachine.nomachine.NoMachine.*',
+            launchctl: 'com.nomachine.uninstall'
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -19,5 +19,9 @@ cask 'nomachine' do
                          'com.nomachine.kext.nxfs',
                        ],
             pkgutil:   'com.nomachine.nomachine.NoMachine.*',
-            launchctl: 'com.nomachine.uninstall'
+            launchctl: [
+                         'com.nomachine.localnxserver',
+                         'com.nomachine.nxserver',
+                         'com.nomachine.uninstall',
+                       ]
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -8,21 +8,16 @@ cask 'nomachine' do
 
   pkg 'NoMachine.pkg'
 
-  # a launchctl job ordinarily manages uninstall once the app bundle is removed
-
-  uninstall delete: '/Applications/NoMachine.app'
-
-  # however, we duplicate the uninstall process manually in the zap stanza just in case
-  zap early_script: {
-                      executable: '/bin/rm',
-                      args:       ['-f', '--', '/Library/Application Support/NoMachine/nxuninstall.sh'],
-                    },
-      quit:         'com.nomachine.nxdock',
-      kext:         [
-                      'com.nomachine.driver.nxau',
-                      'com.nomachine.driver.nxtun',
-                      'com.nomachine.kext.nxfs',
-                    ],
-      pkgutil:      'com.nomachine.nomachine.NoMachine.*',
-      launchctl:    'com.nomachine.uninstall'
+  # A launchctl job ordinarily manages uninstall once the app bundle is removed
+  uninstall delete: '/Applications/NoMachine.app',
+  # However, we duplicate the uninstall process manually just in case
+            script: '/Library/Application Support/NoMachine/nxuninstall.sh',
+            quit:         'com.nomachine.nxdock',
+            kext:         [
+                            'com.nomachine.driver.nxau',
+                            'com.nomachine.driver.nxtun',
+                            'com.nomachine.kext.nxfs',
+                          ],
+            pkgutil:      'com.nomachine.nomachine.NoMachine.*',
+            launchctl:    'com.nomachine.uninstall'
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '6.0.78_4'
-  sha256 '84494bb89e7275c1b5fc39fe13068fb2a211f72cd2afbc8b39e3f8379df1f5b5'
+  version '6.1.6_10'
+  sha256 '7b7b0096364ee00b7b89156242997b58ac636bf3022e7c419e4f493963b26775'
 
   url "http://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -10,5 +10,5 @@ cask 'nomachine' do
 
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
-  uninstall delete:    '/Applications/NoMachine.app'
+  uninstall delete: '/Applications/NoMachine.app'
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -9,19 +9,6 @@ cask 'nomachine' do
   pkg 'NoMachine.pkg'
 
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
-  uninstall delete:    '/Applications/NoMachine.app',
-            # However, we duplicate the uninstall process manually just in case
-            script:    '/Library/Application Support/NoMachine/nxuninstall.sh',
-            quit:      'com.nomachine.nxdock',
-            kext:      [
-                         'com.nomachine.driver.nxau',
-                         'com.nomachine.driver.nxtun',
-                         'com.nomachine.kext.nxfs',
-                       ],
-            pkgutil:   'com.nomachine.nomachine.NoMachine.*',
-            launchctl: [
-                         'com.nomachine.localnxserver',
-                         'com.nomachine.nxserver',
-                         'com.nomachine.uninstall',
-                       ]
+  # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
+  uninstall delete:    '/Applications/NoMachine.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.