### PR TITLE
Update wavebox to 3.14.3

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,11 +1,11 @@
 cask 'wavebox' do
-  version '3.14.2'
-  sha256 '28b1622eb19ee2285d4b18356a0583314ce2850d126b58a55ad53b503ac49899'
+  version '3.14.3'
+  sha256 'ca64f65d2640ab1081b6a8a6ad4881f8a73a7f158d8a635d3e391a48df9120a8'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"
   appcast 'https://github.com/wavebox/waveboxapp/releases.atom',
-          checkpoint: '05a6bef4c12a3ae2364d18d7932b9676e70899ce4448d834b087c78e341de677'
+          checkpoint: '16aaeed4b32c47e3401499a2486a936fde5fecadf1452db43b246731e563a953'
   name 'Wavebox'
   homepage 'https://wavebox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.