### PR TITLE
Update qlc-plus to 4.11.2

### DIFF
--- a/Casks/qlc-plus.rb
+++ b/Casks/qlc-plus.rb
@@ -1,6 +1,6 @@
 cask 'qlc-plus' do
-  version '4.11.1'
-  sha256 'd34804876fbac6fa6c1a5a4310d15cbdcf1423d460a9242b8f43453da4c964ec'
+  version '4.11.2'
+  sha256 '5d8b2c17d7be7f36d5ac18cb5ebfb09c0f57cfa6d0015a71e1ae488cb65b17b0'
 
   url "http://qlcplus.org/downloads/#{version}/QLC+_#{version}.dmg"
   name 'Q Light Controller+'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.