### PR TITLE
Update ao to 5.5.0

### DIFF
--- a/Casks/ao.rb
+++ b/Casks/ao.rb
@@ -1,10 +1,10 @@
 cask 'ao' do
-  version '5.4.0'
-  sha256 '6068ca6a52c812d5744c5095c24ac43af17180f4823a575a01685d427d7835f6'
+  version '5.5.0'
+  sha256 '38e214c9b724cb4c3ca169d05d0bdb9f361d368a11ba6fbe1836d27e3a5c66f6'
 
   url "https://github.com/klauscfhq/ao/releases/download/v#{version}/ao-macos-#{version}.dmg"
   appcast 'https://github.com/klauscfhq/ao/releases.atom',
-          checkpoint: '12d547bfc877cbfb5d92315b2e1a4e5a87a48961c15863cbeaaae437d640edc5'
+          checkpoint: '00c1a110fdd709464d6a38dd869e3db91adb28c5a41dde4d339c9821271ba906'
   name 'Ao'
   homepage 'https://github.com/klauscfhq/ao'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.