### PR TITLE
Update flightgear to 2018.1.1

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,11 +1,11 @@
 cask 'flightgear' do
-  version '2017.3.1'
-  sha256 '902100088b1f572be919660779160414c6eaa6b3cf196fcff9f416fa8f017f13'
+  version '2018.1.1'
+  sha256 '473d4c54be9342861433189a87e2de9892f3d273a90969458427e2923052ce00'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss',
-          checkpoint: '0647d44d57b299e8f68e2157d01befc45138b97470eda127b7e72309607a8584'
+          checkpoint: '1f0c965acda11e42fa01a17c153da182e64312291844492e6e75d319164ba806'
   name 'FlightGear'
   homepage 'http://www.flightgear.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.