### PR TITLE
Update airfoil to 5.7.4

### DIFF
--- a/Casks/airfoil.rb
+++ b/Casks/airfoil.rb
@@ -1,10 +1,10 @@
 cask 'airfoil' do
-  version '5.7.3'
-  sha256 '1dec5efd01e50f3266f4f12d8e1655254924d21c172a1dfbc6de505ae4b0447e'
+  version '5.7.4'
+  sha256 '344206308e0ee96296a55c8a39ca270b67e66c9028702bf34a780ba0aadeea6d'
 
   url 'https://rogueamoeba.com/airfoil/download/Airfoil.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Airfoil&platform=osx',
-          checkpoint: '1338bc20ff2dc18506a9d566dd17ddc90c7fee71b532faca91072f69dca95eb1'
+          checkpoint: '587696c4070a586228ba6062c0c707315ef82a1315ecba7e48ed8935c2be75de'
   name 'Airfoil'
   homepage 'https://www.rogueamoeba.com/airfoil/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.