### PR TITLE
Update audio-hijack to 3.3.8

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -1,10 +1,10 @@
 cask 'audio-hijack' do
-  version '3.3.7'
-  sha256 '8ec65d645e85f8517e286bc63934526b474e265854796b1fa7380380bd573b42'
+  version '3.3.8'
+  sha256 'afb5288a11e4a503acf4d044c72537e036a7de7af36e8d670c558b97ad7c89bb'
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   appcast "https://www.rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.audiohijack#{version.major}",
-          checkpoint: 'e8626be322fc61e50c980b1b3d9ec846eee59fd463147c8e7d70c8f3c4855c09'
+          checkpoint: '5b28cb7b88a54355125216bccb8abf5446b10c29e8d31e90ea4b5851b77739fd'
   name 'Audio Hijack'
   homepage 'https://www.rogueamoeba.com/audiohijack/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.