### PR TITLE
Update thonny to 2.1.17

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,11 +1,11 @@
 cask 'thonny' do
-  version '2.1.13'
-  sha256 'bd3e162d5e95c50adae290565ad60e468f8d65e93e811aba9778033dd799021f'
+  version '2.1.17'
+  sha256 '79bc942c76dd957577f3c24fba1ee4f00d9a84fb3797f7a0b638e7624b4ffb47'
 
   # bitbucket.org/plas/thonny/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/plas/thonny/downloads/thonny-#{version}.dmg"
   appcast 'http://thonny.org/blog/categories/releases.html',
-          checkpoint: 'b5f3b66d7bbcd46a4b5b880e1e167c7dced47afa7bc14d4ff8f4a553a7776e00'
+          checkpoint: '4126f0fac27d9b5714a015b9ab41e03feda91a5cd48102edcb721aea560c77ee'
   name 'Thonny'
   homepage 'http://thonny.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.