### PR TITLE
Update buttercup to 1.6.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '1.6.1'
-  sha256 '0ce076efe304f1d68f31906b428bb80a72b0a2c04572890c312fe8c605eb4d3a'
+  version '1.6.2'
+  sha256 'e73748a31f8eda1fe74aeb38025f5aef314498e10049ffb48152118036f29b9a'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: 'b09503f840f848bdb171bb131ff30550d490b7ed535f47ef08361ec0e70a5f31'
+          checkpoint: 'ae5d4f2f2560672309a65359277815f140774e60bf15b6732a6b1aed70c0c84d'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.