### PR TITLE
Update rhodes-kite to 1.9.1

### DIFF
--- a/Casks/rhodes-kite.rb
+++ b/Casks/rhodes-kite.rb
@@ -1,10 +1,10 @@
 cask 'rhodes-kite' do
-  version '1.7.6'
-  sha256 '8b6bd2031e816f758e202b4b5e0b346374bbc6f6e4407311241a97d3cd5427a9'
+  version '1.9.1'
+  sha256 '4f2632857ce98240bd4ec5c5c48b6c8de318575a3b9169c9e1ffe3e3b8617378'
 
   url "https://kiteapp.co/downloads/Kite-#{version}.zip"
   appcast 'https://api.kiteapp.co/kite_appcast.xml',
-          checkpoint: '704dba0129215d79283c17e3b67611708acc3ff98475ae8ce3942ceb1d1d8f27'
+          checkpoint: '59e44a50e3b523c9d0ab8d6a58bfb34cc4f870bd635674a329af730a10c17ea0'
   name 'Kite Compositor'
   homepage 'https://kiteapp.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.