### PR TITLE
Update flux to latest

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,10 +1,8 @@
 cask 'flux' do
-  version '39.983'
-  sha256 '7b04effd88f4b12029cc929d9b3a5646e35be89bb5ea4404157133e9c96348e6'
+  version :latest
+  sha256 :no_check
 
-  url "https://justgetflux.com/mac/Flux#{version}.zip"
-  appcast 'https://justgetflux.com/mac/macflux.xml',
-          checkpoint: '4bf6d537d257ade71e07a188d635e5c92afeb043eb04f0d6b0927ba202839159'
+  url 'https://justgetflux.com/mac/Flux.zip'
   name 'f.lux'
   homepage 'https://justgetflux.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
See https://github.com/caskroom/homebrew-cask/pull/46246. The appcast has been out of date for a quite long time.