### PR TITLE
Update flume to 2.8.4.1

### DIFF
--- a/Casks/flume.rb
+++ b/Casks/flume.rb
@@ -1,10 +1,10 @@
 cask 'flume' do
-  version '2.8.4'
-  sha256 '8f2bdd73981120c62d192979343dba8893a8bec2287c114baccb18c87d08d68d'
+  version '2.8.4.1'
+  sha256 '1acfbf630460e503b3fbf185fe2f16ed10ea2c545e8d4d5174babf1eb1163a4d'
 
   url "https://flumeapp.com/files/Flume-#{version}.zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/c88c56b02dcd4dd3acceb6d7a24f7122',
-          checkpoint: '404c736f25531a4dd502f5c923a9d9c02e3382ce10594b70458a8e0e3f44d800'
+          checkpoint: '95026988ac0895ce1f35861640342a8adaaf0a1db10b9e71aa23b54d3edf6671'
   name 'Flume'
   homepage 'https://flumeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.