### PR TITLE
Update flinto to 25.5

### DIFF
--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -1,6 +1,6 @@
 cask 'flinto' do
-  version '25.4'
-  sha256 '16e1384935b9df537454582667653be92bdc4ac028797787e745b3db48d086ab'
+  version '25.5'
+  sha256 '2181a70141b54614d13eb2277fd626db533dccdfa760a168586ca82e7d34f8b4'
 
   url "https://www.flinto.com/assets/Flinto-#{version}.dmg"
   name 'Flinto'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.