### PR TITLE
Update hsang to 1.8.7

### DIFF
--- a/Casks/hsang.rb
+++ b/Casks/hsang.rb
@@ -1,6 +1,6 @@
 cask 'hsang' do
-  version '1.8.6'
-  sha256 '74a01e493ed8df166b95e1451a69dcf5ba988830a1f176855b67accd544bf263'
+  version '1.8.7'
+  sha256 '34a77d461738327873a13410270e08b51435ddcd25a9ba842fd96d68094b93c4'
 
   # opd.gdl.netease.com/ was verified as official when first introduced to the cask
   url "http://opd.gdl.netease.com/HSAng_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.