### PR TITLE
Update coqide to 8.8.0

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,11 +1,11 @@
 cask 'coqide' do
-  version '8.7.2'
-  sha256 'ad3e7239c3bd157bc8a14d3b5fa7c8bf34e2c9c5db83703330591610e845d35f'
+  version '8.8.0'
+  sha256 '285353fff1c98231577e0a2aa77054df80821d7193d0378751b9c1b9facfc36e'
 
   # github.com/coq/coq was verified as official when first introduced to the cask
   url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version}-installer-macos.dmg"
   appcast 'https://github.com/coq/coq/releases.atom',
-          checkpoint: '96ab2db426f4a4e9c5bb0f35cb45b8d4ad03fafdf4f2e52af7e3547d2c242579'
+          checkpoint: '8e8e9bfa7ec60c48490d8c0eaccd29683f075f8324623d338584eaf00ef33b1d'
   name 'Coq'
   homepage 'https://coq.inria.fr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.