### PR TITLE
Update Cutter to 1.4 (definitive)

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,11 +1,11 @@
 cask 'cutter' do
   version '1.4'
-  sha256 'd052e519403a14e6cee7182c71ac7f73a788b4bd262972c719cf4c21934d06e0'
+  sha256 '78cefb1b0f28f76d749694ba3e953c8a64b0505c7788aa89569bb6039711d200'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}.dmg"
   appcast 'https://github.com/radareorg/cutter/releases.atom',
-          checkpoint: '72f24c97bab229c12258e7ec4d4d01d3f185045bca282df30832feb02261e315'
+          checkpoint: '9a701c98fea005734f0c3b28edf585bb9ce09eae138531c1aeb13e61ab42e1c5'
   name 'Cutter'
   homepage 'https://radare.org/cutter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

(the build is failing because sha256 changed while version didn't)