### PR TITLE
Update r-app to 3.5.0

### DIFF
--- a/Casks/r-app.rb
+++ b/Casks/r-app.rb
@@ -1,10 +1,10 @@
 cask 'r-app' do
-  version '3.4.4'
-  sha256 'afa75787f21601efc82947ce094681f67ff69a4fc668bc2b8331a1c69cceef3c'
+  version '3.5.0'
+  sha256 '7e56ea676e0bdfff5f88ed7db2201afd0feb7debc07ed803b0da96f3867cc16d'
 
   url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   appcast 'https://www.r-project.org/',
-          checkpoint: 'b206f01fb8821dd7a9b368310e345bace49176974c5d025657cd0c481bab9393'
+          checkpoint: '27ab5ed070c8f6e1a01b989134bed0b2ed3d093e148a20fdac4e64ee2f22ff62'
   name 'R'
   homepage 'https://www.r-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.