### PR TITLE
Update rsyncosx to 5.3.1

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,10 +1,10 @@
 cask 'rsyncosx' do
-  version '5.2.1'
-  sha256 '1d7926ea5e5d1ac7c7fb1c5975dad35943206efcdb8dd98ba913901f9adf0082'
+  version '5.3.1'
+  sha256 '3944712f0ad2dafe4ad9293c9670fe4cc533b0df54ec58a349ef23a09a43a5b7'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom',
-          checkpoint: 'f22a306df4ecf7756ab0bbb7e03bcfd9a09c1176691d47ef51de607b033e132a'
+          checkpoint: 'b6a126ea4285896c362b9054573db3c010d416c07f1c0485ad0fd75e772b73fb'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.