### PR TITLE
Update mailbutler to 2.1-9264

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,11 +1,11 @@
 cask 'mailbutler' do
-  version '2.0.4-9086'
-  sha256 'b6d6ece72ceb49638e9bd36cc370b2b22ad5dfd50d27de25a70bcf094f3a1648'
+  version '2.1-9264'
+  sha256 '82b013f367d2eacc7ad18df4833c89a365e7a74d581ecacfaa8d1bc0168fdebf'
 
   # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-data.s3.amazonaws.com/downloads/Mailbutler_#{version}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php",
-          checkpoint: 'a5c5085d09e66f9ee23f6ea56f27248b7b063a2acf82175f9702972ec377e411'
+          checkpoint: '3b1161aea019107a2991d8c4912769daf473700d3405a55c0495f2d4fd011a4a'
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.