### PR TITLE
Update paintcode to 3.3.10

### DIFF
--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,11 +1,11 @@
 cask 'paintcode' do
-  version '3.3.8'
-  sha256 '070b9f220693fb195501449e68460f26114d2208b45473f51977567aec941396'
+  version '3.3.10'
+  sha256 '6c27667ba5155d154f45405df9017867a0d2cd5f9467717ec06e145d0012701e'
 
   # pixelcut.com/paintcode was verified as official when first introduced to the cask
   url "https://www.pixelcut.com/paintcode#{version.major}/paintcode.zip"
   appcast "https://www.pixelcut.com/paintcode#{version.major}/appcast.xml",
-          checkpoint: 'c69924e71b543d06f24da680ebb621deabc29db6a8ef4f29b2025500765ce8e5'
+          checkpoint: '33a1e574f49fd6541fe0f024cc6d2afa112a7311757da1a45f09cfd1795a4426'
   name 'PaintCode'
   homepage 'https://www.paintcodeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.