### PR TITLE
Update vectoraster to 7.2.5

### DIFF
--- a/Casks/vectoraster.rb
+++ b/Casks/vectoraster.rb
@@ -1,10 +1,10 @@
 cask 'vectoraster' do
-  version '7.2.4'
-  sha256 'c0106135c408d80236e6901899e6e9e4a3b808dfcf747f248af2861d9e7cd207'
+  version '7.2.5'
+  sha256 '1c685fa7d507c447f37c6d72e0da2bb2d956c8424d8aa2a0e2eed1dab975348b'
 
   url "https://www.lostminds.com/downloads/vectoraster#{version.major}.dmg"
   appcast "https://www.lostminds.com/vectoraster#{version.major}/version_history.php",
-          checkpoint: 'd6a4c659d08fed92c43d59b189321b12b7b66b7ca11cff8c4599f66af2d53020'
+          checkpoint: '001dbe0570906ae686dd46679e5c4b84649de1540a340046bfa05850ad35acfb'
   name 'Vectoraster'
   homepage "https://www.lostminds.com/vectoraster#{version.major}/"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.