### PR TITLE
Update graphicconverter to 10.6.0,3058

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,11 +1,11 @@
 cask 'graphicconverter' do
-  version '10.5.5,2998'
-  sha256 'efb03b6487f04addf057f53228c910dd30b29dd14bb0c97bc7bcf70b85f53096'
+  version '10.6.0,3058'
+  sha256 '42a5d40921caa3831c3057d1fef90e5390552c45f5add06eb733616f45031522'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
   appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml",
-          checkpoint: '8919c6ff98af50edd7829d8795cbdb7d3bbd119ba3d3b921855f371f14f97c7f'
+          checkpoint: 'a3c5a250c2637613a6fb4548e70b5ea64cd57289eb016bb9c55a1ea775bb3190'
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.