### PR TITLE
Update propresenter to 6.3.4_b16151

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,10 +1,10 @@
 cask 'propresenter' do
-  version '6.3.3_b16143'
-  sha256 'ddfad84809de7d8c84bd6f0ab54cc2f84a3da5ecec0a9aec9d30058d48289cd7'
+  version '6.3.4_b16151'
+  sha256 'e08bca4a597e3ce9b971d6a7597232b8fb8c5347b0ac0326eb321fd80be592ac'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: '0ad833585afafd37ee8de984a24a04e660c84df7da5d38e84a2f0186132d71e6'
+          checkpoint: '83d1c48633f39eeb5d36964a87531b5f696065673e4e838e673da3f23b989662'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.