### PR TITLE
Update typinator to 7.5

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,11 +1,11 @@
 cask 'typinator' do
-  version '7.4'
-  sha256 '1309f6758aea7d52c760cd7fcf0101795be295600c02870de533f7c0d61660d4'
+  version '7.5'
+  sha256 '9d136970946511132a7af1ebbdfa1aa3310a2e1e122fc1a54a5b16f7c99cf020'
 
   url "http://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake
   appcast 'http://www.ergonis.com/products/typinator/history.html',
-          checkpoint: '9ee68c5c8d1e1ac1bd386e67c878caf615bf9a33376e535867efa46056eb8f45'
+          checkpoint: 'd0b882aa259304909c9b1488b513717a355faad296ac2e4f5514067b4a8a7696'
   name 'Typinator'
   homepage 'http://www.ergonis.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.