### PR TITLE
Make Mendeley-Desktop 1.17.13+ powersave-friendly

### DIFF
--- a/Casks/mendeley.rb
+++ b/Casks/mendeley.rb
@@ -7,4 +7,9 @@ cask 'mendeley' do
   homepage 'https://www.mendeley.com/'
 
   app 'Mendeley Desktop.app'
+
+  preflight do
+    # FIX: add Application variable to prevent Mendeley from requiring discrete graphics card
+    system_command '/usr/libexec/PlistBuddy', args: ['-c', 'Add :NSSupportsAutomaticGraphicsSwitching bool true', "#{staged_path}/Mendeley Desktop.app/Contents/Info.plist"]
+  end
 end


### PR DESCRIPTION
This post-install rule patches Mendeley Desktop.app's Info.plist, adding
the NSSupportsAutomaticGraphicsSwitching flag which enables significant
power savings on MacBook Pros with a dedicated graphics card.
Currently, since this flag is missing Mendeley Desktop.app forces MacOS
to switch to discrete graphics which drains the battery much more than
necessary. However, the app doesn't really need the discrete card to
function, as I have extensively tested on a late 2012 Macbook Pro Retina
for over a year.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.