### PR TITLE
Update navicat-for-mariadb to 12.0.25

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.24'
-  sha256 '466d8ab7903f0045edcedabe911231b3b0025a101908212a946308de1459926d'
+  version '12.0.25'
+  sha256 '82ab0db7e9c68e7502a13bcf29f31f44e99fc341bba70e76339645722592cb31'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note',
-          checkpoint: 'f7a31c3526925ac0a0be0481d6a0d90ffd833a5ececf983f7d708ecf0c7e5065'
+          checkpoint: 'ca7665434d68b2e89637f84316faa5ab151c872bc17c477987a606e43a7c884b'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.