### PR TITLE
Update navicat-for-mysql to 12.0.25

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.24'
-  sha256 'd756542ba0bbe548ed3811b4f50115b33ad919dba58051b45d62f090425bd9bf'
+  version '12.0.25'
+  sha256 '17ef4876f0502ec7240fc92d6e2840b09e361bf62e38403aea1f0bae3b5caf03'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: 'd226beefb69d8f66801530be0a696417ee048c897d73c7a5d7d7d93ecffb4fa9'
+          checkpoint: 'bba74d286fb13068152254fa411060fb9420e48770decfd4c175ba8f449e11ca'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.