### PR TITLE
Update navicat-for-postgresql to 12.0.25

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.24'
-  sha256 '849636d08384d9625d9d811a3cca80f5f92ad3d242188d45dee9b64ee9e2baf0'
+  version '12.0.25'
+  sha256 'a4da0e772a0b02a04a6fde50b639f2f4827dc4f84a866650d9c87447d517b2d5'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-postgresql-release-note',
-          checkpoint: '4d74131ba30bfde7255e864bf12ad112fedc2233e3962c8c3ace242b4e482024'
+          checkpoint: '8313f25992aa93b408080a32e79332f26dd1f597a1d832a2b51a227d1d8fdb4a'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.