### PR TITLE
Update navicat-for-sql-server to 12.0.25

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.24'
-  sha256 'b8e09d96327e3106253bb6b17b7f066810b7933f586e4a3f33a5cfdb7012cc51'
+  version '12.0.25'
+  sha256 '22818e9893c0f59c0c501fd79adc994c77d658dac580602a268cc96b66d2f82d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlserver-release-note',
-          checkpoint: '00c7d2bca50b01b9e8d9e369a432bda73465be8ac57376fffb317c37b9b3c3fd'
+          checkpoint: '60d45e2790d5ad9fc6be89b5e5cd79a69267b549a3aeab8ab0803211175f512e'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.