### PR TITLE
Update swimat to 1.5.1

### DIFF
--- a/Casks/swimat.rb
+++ b/Casks/swimat.rb
@@ -1,10 +1,10 @@
 cask 'swimat' do
-  version '1.5.0'
-  sha256 '8a88598c20841e52af2f8160d1dde9c1173f65e878e4c918c32c7f67b0077d71'
+  version '1.5.1'
+  sha256 '775159b22d29a867545a8611199ee4665dd2957f3a6695c8dc77db5e8b3d283b'
 
   url "https://github.com/Jintin/Swimat/releases/download/v#{version}/Swimat.zip"
   appcast 'https://github.com/Jintin/Swimat/releases.atom',
-          checkpoint: '8e888809ec82489edd6f00f0b0cc7d506e801d65373d8a278993832bd1a9a025'
+          checkpoint: 'e84277f725f9ed150c436f5373ec5bdebf9ed9625d67e9dd943ef6a6bc5c3b20'
   name 'Swimat'
   homepage 'https://github.com/Jintin/Swimat'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.