### PR TITLE
Update tableedit to 1.4.0

### DIFF
--- a/Casks/tableedit.rb
+++ b/Casks/tableedit.rb
@@ -1,10 +1,10 @@
 cask 'tableedit' do
-  version '1.3.5'
-  sha256 '84920d15ecf3b3a6b8acba95ee45512506d272d4f806cc31242c3b6837c86ec0'
+  version '1.4.0'
+  sha256 'd1bd009eadec6e022de6dd1bd68aa410d250956299d33bfaab50059e818d8ed3'
 
   url "https://www.corecode.io/downloads/tableedit_#{version}.zip"
   appcast 'https://www.corecode.io/tableedit/tableedit.xml',
-          checkpoint: '4fdc819e857d26f8bb50a5890e94000a70df18a84b5e8f228f84d236c2268135'
+          checkpoint: '3fbae1f19febcb45b590db051352ba9d7b1c487be02f314bfe1c9eadc39e96a7'
   name 'TableEdit'
   homepage 'https://www.corecode.io/tableedit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.