### PR TITLE
Update airtame to 3.2.0

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '3.1.1'
-  sha256 '4947ae4186d62d1c0587e536ddecf078de187c518edf7f744e1b418939847de5'
+  version '3.2.0'
+  sha256 '7cf669b7ea5974818891428b7ef37f03879840ffa42ae559db7302a6bd6c1b45'
 
   url "https://downloads-cdn.airtame.com/application/ga/osx_x64/releases/airtame-application-#{version}.dmg"
   name 'Airtame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.