### PR TITLE
Update retroarch-cg to 1.7.2

### DIFF
--- a/Casks/retroarch-cg.rb
+++ b/Casks/retroarch-cg.rb
@@ -1,6 +1,6 @@
 cask 'retroarch-cg' do
-  version '1.7.1'
-  sha256 'a744620d1ef082822f339e9b083fc2a96b79855fb0c6ac2468fbbb191560e12a'
+  version '1.7.2'
+  sha256 'c4f61772a6c16187098d293ff0f9724392ae06f8f77f629d91f98432ecfdbbe3'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch_CG.dmg"
   name 'RetroArch CG'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.