### PR TITLE
Update retroarch to 1.7.2

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,10 +1,10 @@
 cask 'retroarch' do
-  version '1.7.1'
-  sha256 'c47014c9cf5f7919d6a67300c6af13e5eaa14ecdffc7cae7f68e0300413360c7'
+  version '1.7.2'
+  sha256 '82ac27cddbf0184525719aaceb04d6382f1eea47f903598ab3558f89611fac3c'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   appcast 'https://buildbot.libretro.com/stable/',
-          checkpoint: '04d5e613286fede2ec256c9e23a5eb5f968ab8aab37ed6fd82569ce337e7f471'
+          checkpoint: '00cb7e9b8b305af50d4147402b284d27c494f9eee093e17b8c5ff04dbbd8bab2'
   name 'RetroArch'
   homepage 'https://www.libretro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.