### PR TITLE
Update freecad to 0.17-13519.1a8b868

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,11 +1,11 @@
 cask 'freecad' do
-  version '0.17-13509.0258808'
-  sha256 '96bd5548c548fd7948bf65605ac1ed6a3ac99ddce06ae363ef8f7eb6c6a3d883'
+  version '0.17-13519.1a8b868'
+  sha256 '4693eff09a7c71f7e554d72edd9a403c26cce933bf047bb77157b483b4ac4d40'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.split('-')[0]}/FreeCAD_#{version}-OSX-x86_64-Qt5.dmg"
   appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom',
-          checkpoint: '49296e9c37958188f352ffa5ec8834a6068e60e3773ef0fc495afbc8a616635c'
+          checkpoint: 'd714e50ea7f8e2fbbab2fcaee61f9398894ea236af3d835bebc2d65c7d433884'
   name 'FreeCAD'
   homepage 'https://www.freecadweb.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.