### PR TITLE
Update hype to 3.6.6

### DIFF
--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -1,10 +1,10 @@
 cask 'hype' do
-  version '3.6.3'
-  sha256 '5bff8dd6b3286086027709ffd47f990a36160ba881ab6228cc25ddb32dcdbc49'
+  version '3.6.6'
+  sha256 'aaee53e8232769b986eb6545babff96b433a27bcbcaa301077dae24bc3a6e7b3'
 
   url 'https://tumult.com/hype/download/Hype.zip'
   appcast 'https://tumult.com/hype/appcast_hype2.xml',
-          checkpoint: '47284199a6594d0703a56b7e257efaec6a8d39b73028ba0106c6a6ab0de94cfe'
+          checkpoint: '107554dd13a44b6e9cb34d58a868669c616e787e41e1cd218f22046cb35dac16'
   name 'Tumult Hype'
   homepage 'https://tumult.com/hype/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.