### PR TITLE
Update mongodb to 3.6.4-build.1

### DIFF
--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -1,11 +1,11 @@
 cask 'mongodb' do
-  version '3.6.3-build.4'
-  sha256 'f343cd2b6e49bb143f922bfa142109baa700be66d77c2eedf3b54be8e36cf207'
+  version '3.6.4-build.1'
+  sha256 '7d07dfb2fb5b387a6fcfac6b22d9e4c1d42dd1bca570e5d2af164185aeb93078'
 
   # github.com/gcollazo/mongodbapp was verified as official when first introduced to the cask
   url "https://github.com/gcollazo/mongodbapp/releases/download/#{version}/MongoDB.zip"
   appcast 'https://github.com/gcollazo/mongodbapp/releases.atom',
-          checkpoint: 'bbb549518f509ff113e5467cbd6a8ac493b98e04a46da929bf417ecc0a1c9c6e'
+          checkpoint: '0094765cb54ed1ba45a0a457175f01830ba99d02d947ba0a8455a8433b90241f'
   name 'MongoDB'
   homepage 'https://elweb.co/mongodb-app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.