### PR TITLE
Update framer to 18157,1524230415

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,13 +1,15 @@
 cask 'framer' do
-  version '17919,1519228836'
-  sha256 '2619c398b7107c6ba4db467a84b3df6685237a309ede26b3f5352fc166819b6c'
+  version '18157,1524230415'
+  sha256 'f86de1a53854f275b3dbd17a3e1e427d8873b934384f1acfd0cd860fbba76729'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.motif.framer/#{version.before_comma}/#{version.after_comma}/FramerStudio-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '617837e1f58f1ba25599c723fc83aa0381e433b7dc22cd7070b9916241126a6b'
+          checkpoint: 'e40a5144686c538a5028489b1d6582fb59a8d907711fe19c683c6ceb1e2e169b'
   name 'Framer'
   homepage 'https://framer.com/'
+
+  depends_on macos: '>= :sierra'
 
   app 'Framer.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.