### PR TITLE
Update freac to 1.1-alpha-20180306a

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,11 +1,11 @@
 cask 'freac' do
-  version '1.1-alpha-20171119'
-  sha256 '265d6a9304c947b866d36191e9820810a02f4696a66f68828603c86d434ce86e'
+  version '1.1-alpha-20180306a'
+  sha256 'ba48db45a292da52065b598b7ba506eb96672b606e4efe764bc95d362e9c4ad1'
 
   # sourceforge.net/bonkenc was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/bonkenc/rss',
-          checkpoint: '1af0978fed96f9747bcf6adccd9eeaae474d16544bf49c26b37ce74e502cb162'
+          checkpoint: '25db413c755d23ab096e7b01300a158cd25b06422d50dd93b38c1ac579b6113a'
   name 'fre:ac'
   homepage 'https://www.freac.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.