### PR TITLE
Update fredm-fuse to 1.5.2

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,10 +1,10 @@
 cask 'fredm-fuse' do
-  version '1.4.1'
-  sha256 '3c638d34fa8f015332bf71e4ed4d67aa29e4bdf3191556aaf2df8de05cbfd3bd'
+  version '1.5.2'
+  sha256 '0dbaa072cdf12000a664d74bec332a041185a5800c84f9dbb2a3fd3f7de933c6'
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: '7316e29750413452be8e76ec1f35f7a3fbaa4e720fb5de6070e9c90933ba38ff'
+          checkpoint: 'f5a5ddd256fea03e4e90953343995c328a42c9b3abe91cacf3a1e7bdd70490c7'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.