### PR TITLE
Update nscope to 0.8.1

### DIFF
--- a/Casks/nscope.rb
+++ b/Casks/nscope.rb
@@ -1,6 +1,6 @@
 cask 'nscope' do
-  version '0.7'
-  sha256 '34d8c3cc3858a1f007f82687482a3421685b809452b8c84af8e75ea65d680c11'
+  version '0.8.1'
+  sha256 'fdc6bf8ad67e20eb20f5fb4757a80014675388421e5d8e7afa200fe5aa7cc415'
 
   url "http://www.nscope.org/v#{version.no_dots}/mac/nScope.dmg"
   name 'nScope'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.