### PR TITLE
Update polymail to 1.50

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,10 +1,10 @@
 cask 'polymail' do
-  version '1.49'
-  sha256 'b5825f19af333f6447d2dec0f33ec9c1230bfb7a314b6b4252d827a2c89587f8'
+  version '1.50'
+  sha256 '33c6be12f1e49bebf547a68d0774b6342e182aa4cbbaa267179eb5d1da984a88'
 
   url "https://sparkle-updater.polymail.io/osx/builds/Polymail-v#{version.major_minor.no_dots}.zip"
   appcast 'https://sparkle-updater.polymail.io/cast.xml',
-          checkpoint: 'd9b71e57b293f0ae1480f813e63abf11b97ec74f26637e8997f91b79434b20f2'
+          checkpoint: 'd3d779182dc6ddfd58a2efeaef48c304242bb35860a10ea826a57b8a9eeb602c'
   name 'Polymail'
   homepage 'https://polymail.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.