### PR TITLE
Update station to 1.11.2

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.10.0'
-  sha256 '6dbe04c36bee999b1e83ad73c4e14cd6cf3c211530ca88cb7d371f5a6ce87f96'
+  version '1.11.2'
+  sha256 '5c0bf5e0689547cd3c89110ac4e5efa10b6a698ccd52306955127a758dc64ec0'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}-mac.zip"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: 'c97e850cab50f6942a9fa6ff82cf68fe7c7d8c207969595e052c015de3e20e61'
+          checkpoint: '0a8bf61f63c114486573a212b384f9a9c9a22eb6e903c15bc5ae1038c06c122c'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.