### PR TITLE
Update eclipse-ide to 4.7.3a,oxygen:3a

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.7.3,oxygen:3'
-  sha256 '8dc8c366f2f1eab94c6eb9adaff8506363debd84a953f932e1c28e5652e32853'
+  version '4.7.3a,oxygen:3a'
+  sha256 'de8dfa56b0e1047078e539831b3c958dab12d4ca870f8249293650840aa863ab'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.