### PR TITLE
Update rambox to 0.5.17

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,11 +1,11 @@
 cask 'rambox' do
-  version '0.5.16'
-  sha256 'bf5da49c53579137e9904d10460313041d0c9698cac564e40033bcf08dc3cb0e'
+  version '0.5.17'
+  sha256 '530ce10f337261e77be3c954dae7fd3cdda4299a55585876ca7e4ac54a315e97'
 
   # github.com/saenzramiro/rambox was verified as official when first introduced to the cask
   url "https://github.com/saenzramiro/rambox/releases/download/#{version}/Rambox-#{version}-mac.zip"
   appcast 'https://github.com/saenzramiro/rambox/releases.atom',
-          checkpoint: 'd5852eacbf3084a759b0d4675af8fc2da11164d914155eb69df10561539ae477'
+          checkpoint: '4b7470886606078c2febf7cb84d936e3d7890af5af4d0fd146f7dee35151313d'
   name 'Rambox'
   homepage 'http://rambox.pro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.