### PR TITLE
Update metasploit to 4.16.45+20180425104329.git.3.60152e9

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,10 +1,10 @@
 cask 'metasploit' do
-  version '4.16.45+20180422104338.git.3.60152e9'
-  sha256 '9c2550b4a5e81de32e3638ad87c12c952db53b808ef42a4df4864daf22b1096c'
+  version '4.16.45+20180425104329.git.3.60152e9'
+  sha256 'ba84e2e8e349878c60c8d3a324c09387a5d5745838248e72c0c145e6d1105268'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST',
-          checkpoint: '7f5b2379c03254ffcc599abf3fd2bfd8b68bfce40fcb341ef59fee795459ddc3'
+          checkpoint: '582dcccd4bb12f246b0914c8db89de8ff3426b38f0aeee3a54bcebc9d0fceb3b'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
   gpg "#{url}.asc", key_id: '2007B954'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.