### PR TITLE
note that some Casks don't show up as outdated

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -128,7 +128,7 @@ Caffeine.app (app)
 
 ## Updating/Upgrading Casks
 
-Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`.
+Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Some applications update themselves (sometime automatically), so their Casks are not included in the output of `brew cask outdated`. These can be listed with `brew outdated --greedy`; however, it is better practice to let such applications update themselves.
 
 It is generally safe to run updates from within an application.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,7 +128,7 @@ Caffeine.app (app)
 
 ## Updating/Upgrading Casks
 
-Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Many applications update themselves, so their Casks are ignored by `brew cask outdated` and `brew cask upgrade`. These can be forcibly included in these commands by adding the `--greedy` flag.
+Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Many applications update themselves, so their Casks are ignored by `brew cask outdated` and `brew cask upgrade`. This behaviour can be overridden by adding `--greedy` to the command.
 
 It is generally safe to run updates from within an application.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,7 +128,7 @@ Caffeine.app (app)
 
 ## Updating/Upgrading Casks
 
-Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Some applications update themselves (sometime automatically), so their Casks are not included in the output of `brew cask outdated`. These can be listed with `brew outdated --greedy`; however, it is better practice to let such applications update themselves.
+Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Some applications update themselves, so their Casks are not included in the output of `brew cask outdated`. These can be listed with `brew outdated --greedy`.
 
 It is generally safe to run updates from within an application.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -128,7 +128,7 @@ Caffeine.app (app)
 
 ## Updating/Upgrading Casks
 
-Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Some applications update themselves, so their Casks are not included in the output of `brew cask outdated`. These can be listed with `brew outdated --greedy`.
+Since the Homebrew-Cask repository is a Homebrew Tap, you’ll pull down the latest Casks every time you issue the regular Homebrew command `brew update`. You can check for outdated Casks with `brew cask outdated` and install the outdated Casks with `brew cask upgrade`. Many applications update themselves, so their Casks are ignored by `brew cask outdated` and `brew cask upgrade`. These can be forcibly included in these commands by adding the `--greedy` flag.
 
 It is generally safe to run updates from within an application.
 


### PR DESCRIPTION
There are a number of issues (all quickly closed) about how one Cask or another wasn't listed as being outdated. When I reported such an issue, I didn't know that the --greedy switch exists.

This is a documentation-only change, in hopes of preventing issues such as #46382, #38784, and #37294 (to choose just a few)
