### PR TITLE
Update frostwire to 6.6.5

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.6.4'
-  sha256 'afcbb87b0f9aae14a95e0ce020bf60f8dd4c5ac8d3a73690350717629b4ddb9e'
+  version '6.6.5'
+  sha256 '177c927f3274666f23ae1503f9174981aaf83965b5539d48f85604f5674562b1'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: 'e4bcd06a3a615aa792595bd76ce1f50813f4389316df20cbf84687518b0a670f'
+          checkpoint: 'aa9a48249a252f6bfad65b9ca3725aa727cf69aae649d8b8754c81eb765a6ac0'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.