### PR TITLE
Update ganttproject to 2.8.7,r2262

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,11 +1,11 @@
 cask 'ganttproject' do
-  version '2.8.6,r2233'
-  sha256 'ec7f11f057329ebeb9545103b7821871d2737caed4dcfdf248adc4b3f0f35946'
+  version '2.8.7,r2262'
+  sha256 'a622a81ad6ff47e17da7935ee9b63a3c1b9cb605332887b8dbf2e8c7f36556be'
 
   # github.com/bardsoftware/ganttproject/releases/download was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/bardsoftware/ganttproject/releases.atom',
-          checkpoint: '4d1a804b315baa3a7e690aa4933fe7462d551659b5bc0f23bfc2ba6657d0101c'
+          checkpoint: '3538464ada05bf578f7f4e8adfb7dfcb5a20fdb3c1791d34dd219d40f5c7f000'
   name 'GanttProject'
   homepage 'https://www.ganttproject.biz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.