### PR TITLE
Update etcher to 1.4.4

### DIFF
--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,11 +1,11 @@
 cask 'etcher' do
-  version '1.4.3'
-  sha256 'a13792e06f82ad8b1ed0dcf25d2f8cfaf335628512a4483dbf34a5dc602eeadf'
+  version '1.4.4'
+  sha256 'b09f9352d69741ffbef9d99afbfd3db0230e2e9fe93f37723fe5028005df7a5e'
 
   # github.com/resin-io/etcher/releases/download was verified as official when first introduced to the cask
   url "https://github.com/resin-io/etcher/releases/download/v#{version}/Etcher-#{version}.dmg"
   appcast 'https://github.com/resin-io/etcher/releases.atom',
-          checkpoint: '4e63969ab9821eccd300d41697ce7c6445456a482dcbda07fd60183a5833f1ba'
+          checkpoint: 'ad732fe09130bbb97d0e083bd8e081e8d8e63ac910bbfbbfda94a0031497728c'
   name 'Etcher'
   homepage 'https://etcher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.