### PR TITLE
Update frostwire to 6.6.6

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.6.5'
-  sha256 '177c927f3274666f23ae1503f9174981aaf83965b5539d48f85604f5674562b1'
+  version '6.6.6'
+  sha256 '4c35a1e9e42d10cbec0b28a686e6c59f05bd937fcec9bf05aafbbd987c8a262e'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: 'aa9a48249a252f6bfad65b9ca3725aa727cf69aae649d8b8754c81eb765a6ac0'
+          checkpoint: '792b9f013ce4fc73be733ce8475d7e6bb643183edddb2f5d571e092e0a9c3550'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.