### PR TITLE
Update keka to 1.0.16

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,11 +1,11 @@
 cask 'keka' do
-  version '1.0.15'
-  sha256 '39a0041497bc95ec0a1b9031c16fce792d38894b15d8fdddbfa304f138b7bc9d'
+  version '1.0.16'
+  sha256 'ab5d815e322d70ed8a8f8c834d0a5c8ed9ff7eab89ba5fd8678430fef7ed1578'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: '2b4d4376b7350bd85eb747b563466619c756f17e3adaba0bef1be8475377a0ed'
+          checkpoint: '88acf990495c8ffcfadba91a865c641c0fb799f453a129b4a8dc672020b13332'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.