### PR TITLE
Update electron to 1.8.6

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '1.8.5'
-  sha256 'ffcfe332568f255f72d96470d24bdd99f2b274a68866dac8bd09045f73cce538'
+  version '1.8.6'
+  sha256 '5c5f59aa38d33198a6de2669cafc93f3ed9e1f9b28c38387cbade29dd80ae8d5'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '04bbbb59bf2a80dd068b7259ac0df61924cdfb6fa65197070d3b9894a452fbbe'
+          checkpoint: '4af38022353a43d3f7df690ba5b2236f7586fe07d535bc033370f0ad4f35fde5'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.