### PR TITLE
Update graphql-playground to 1.5.6

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.5.2'
-  sha256 '7307364cfd8221fe7e7b91f146447bbbbbbe079f8a357c8aedd351dbee23cbfd'
+  version '1.5.6'
+  sha256 'ab1b2a2407d64ef409b1f6d18f90cf021faff60c0086c42414ca2a73aeb715df'
 
   url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}-mac.zip"
   appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: '37aed50da2a0bedc710ec03a4a4dbedc4586b7cbad6dc74fdad6cd41bbfe2c9d'
+          checkpoint: 'a54ee411d9ddd05e021debae5831abbb990ada744c049925dfc2eae25aabb974'
   name 'GraphQL Playground'
   homepage 'https://github.com/graphcool/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.