### PR TITLE
Update darktable to 2.4.3.1

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,11 +1,11 @@
 cask 'darktable' do
-  version '2.4.2'
-  sha256 '2b0b456f6efbc05550e729a388c55e195eecc827b0b691cd42d997b026f0867c'
+  version '2.4.3.1'
+  sha256 '290ed5473e3125a9630a235a4a33ad9c9f3718f4a10332fe4fe7ae9f735c7fa9'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
-  url "https://github.com/darktable-org/darktable/releases/download/release-#{version.before_comma}/darktable-#{version.before_comma}.dmg"
+  url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg"
   appcast 'https://github.com/darktable-org/darktable/releases.atom',
-          checkpoint: '69ab2ed06877928ab72c5b942d8a0b806460e34f828875c220455153dd637fdf'
+          checkpoint: '4fed1be79dc4acfe4f34a4ca8e3a8433b83e06627a0df831ba6b38c75fbacd8b'
   name 'darktable'
   homepage 'https://www.darktable.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
