### PR TITLE
Add AirUnlock 0.4 (OSX/Android BT unlock pair)

### DIFF
--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -2,7 +2,7 @@ cask 'airunlock' do
   version '0.4'
   sha256 '85f4aee6bc67f6b7c0d01ab36e50a117690574c0e31b210aa3f80931269bf170'
 
-  # airunlock.qtlin.tw was verified as official when first introduced to the cask
+  # github.com/pinetum/AirUnlock-for-Mac was verified as official when first introduced to the cask
   url "https://github.com/pinetum/AirUnlock-for-Mac/releases/download/#{version}/AirUnlock_mac_#{version}.zip"
   appcast 'https://github.com/pinetum/AirUnlock-for-Mac/releases.atom',
           checkpoint: '9726ba88fbaae1966769444d7dc4f845602b2c4e0fdcb723ae9ef792db696bdb'

--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -7,7 +7,7 @@ cask 'airunlock' do
   appcast 'https://github.com/pinetum/AirUnlock-for-Mac/releases.atom',
           checkpoint: '9726ba88fbaae1966769444d7dc4f845602b2c4e0fdcb723ae9ef792db696bdb'
   name 'AirUnlock'
-  homepage 'http://airunlock.qtlin.tw/'
+  homepage 'https://airunlock.qtlin.tw/'
 
   app 'AirUnlock.app'
 end

--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -1,0 +1,19 @@
+cask 'airunlock' do
+  version '0.4'
+  sha256 '85f4aee6bc67f6b7c0d01ab36e50a117690574c0e31b210aa3f80931269bf170'
+
+  # homepage and URL verified at time of pull request
+  url "https://github.com/pinetum/AirUnlock-for-Mac/releases/download/#{version}/AirUnlock_mac_#{version}.zip"
+  appcast 'https://github.com/pinetum/AirUnlock-for-Mac/releases.atom',
+          checkpoint: '9726ba88fbaae1966769444d7dc4f845602b2c4e0fdcb723ae9ef792db696bdb'
+  name 'AirUnlock'
+  homepage 'http://airunlock.qtlin.tw/'
+
+  app 'AirUnlock.app'
+
+  caveats <<~EOS
+    To run this app you need AirUnlock for Android:
+    https://github.com/pinetum/AirUnlock-for-Android
+    https://f-droid.org/packages/tw.qtlin.mac.airunlocker/
+  EOS
+end

--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -2,7 +2,7 @@ cask 'airunlock' do
   version '0.4'
   sha256 '85f4aee6bc67f6b7c0d01ab36e50a117690574c0e31b210aa3f80931269bf170'
 
-  # homepage and URL verified at time of pull request
+  # airunlock.qtlin.tw was verified as official when first introduced to the cask
   url "https://github.com/pinetum/AirUnlock-for-Mac/releases/download/#{version}/AirUnlock_mac_#{version}.zip"
   appcast 'https://github.com/pinetum/AirUnlock-for-Mac/releases.atom',
           checkpoint: '9726ba88fbaae1966769444d7dc4f845602b2c4e0fdcb723ae9ef792db696bdb'

--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -10,10 +10,4 @@ cask 'airunlock' do
   homepage 'http://airunlock.qtlin.tw/'
 
   app 'AirUnlock.app'
-
-  caveats <<~EOS
-    To run this app you need AirUnlock for Android:
-    https://github.com/pinetum/AirUnlock-for-Android
-    https://f-droid.org/packages/tw.qtlin.mac.airunlocker/
-  EOS
 end


### PR DESCRIPTION
Add AirUnlock cask, which creates a status bar icon that listens for BT LE hashes from an Android client to unlock the Mac using the biometrics on the Android phone:
AirUnlock for Android:
    https://github.com/pinetum/AirUnlock-for-Android
    https://f-droid.org/packages/tw.qtlin.mac.airunlocker/

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].
