### PR TITLE
Add docker-credential-gcloud binary to google-cloud-sdk

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -14,6 +14,7 @@ cask 'google-cloud-sdk' do
   binary 'google-cloud-sdk/bin/gcloud'
   binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', target: 'git-credential-gcloud'
   binary 'google-cloud-sdk/bin/gsutil'
+  binary 'google-cloud-sdk/bin/docker-credential-gcloud'
 
   uninstall delete: "#{staged_path}/#{token}" # Not actually necessary, since it would be deleted anyway. It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
 

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -11,10 +11,10 @@ cask 'google-cloud-sdk' do
                       args:       ['--usage-reporting', 'false', '--bash-completion', 'false', '--path-update', 'false', '--rc-path', 'false', '--quiet'],
                     }
   binary 'google-cloud-sdk/bin/bq'
+  binary 'google-cloud-sdk/bin/docker-credential-gcloud'
   binary 'google-cloud-sdk/bin/gcloud'
   binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', target: 'git-credential-gcloud'
   binary 'google-cloud-sdk/bin/gsutil'
-  binary 'google-cloud-sdk/bin/docker-credential-gcloud'
 
   uninstall delete: "#{staged_path}/#{token}" # Not actually necessary, since it would be deleted anyway. It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
 


### PR DESCRIPTION
Using Google Cloud Platform's Container Registry (GCR) to store docker images requires giving Docker access to GCR. There are a couple of authentication methods: https://cloud.google.com/container-registry/docs/advanced-authentication#using_the_standalone_docker_credential_helper

One way is to use `gcloud docker ` instead of `docker`. However, this method is now deprecated for Docker client versions above 18.03.

The recommended way authentication now is to configure docker to use a standalone docker credential helper, `docker-credential-gcloud`, a binary that ships with new versions of google-cloud-sdk. To do so, you use the following command:

```
$ gcloud auth configure-docker 
WARNING: `docker-credential-gcloud` not in system PATH.
gcloud's Docker credential helper can be configured but it will not work until this is corrected.
Docker configuration file updated.
```

This gcloud auth command uses the `docker-credential-gcloud` command to configure docker. It works fine if you install google-cloud-sdk the normal way, but doesn't work if you install it via brew cask. The reason is that even though cask actually installs the binary to `/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin`, it doesn't symlink it to `usr/local/bin`, as documented here: https://stackoverflow.com/questions/49780218/docker-credential-gcloud-not-in-system-path. This fixes that.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
