### PR TITLE
Update bonjeff to 1.0.4

### DIFF
--- a/Casks/bonjeff.rb
+++ b/Casks/bonjeff.rb
@@ -1,10 +1,10 @@
 cask 'bonjeff' do
-  version '1.0.3'
-  sha256 'f083ca2e5f46e1a3a012863e7e6012087e700ef7b7e8cd3354f123a649522984'
+  version '1.0.4'
+  sha256 '77ed99dc1f2ffd49374454ab13b1079c8bdda9b214330d5af90a1e5a1f3e77e3'
 
   url "https://github.com/lapcat/Bonjeff/releases/download/v#{version}/Bonjeff.#{version}.zip"
   appcast 'https://github.com/lapcat/Bonjeff/releases.atom',
-          checkpoint: '1b6822f478c8e50b0f2e69ed0514647e8e91aa10e9e0d78f338e427bb5396e8e'
+          checkpoint: '658e6a48b4b7c3e7b8a4ce37c8ed5578429188fc3504cde0a200d61888ed6223'
   name 'Bonjeff'
   homepage 'https://github.com/lapcat/Bonjeff'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.