### PR TITLE
Update ckan-app to 1.25.1

### DIFF
--- a/Casks/ckan-app.rb
+++ b/Casks/ckan-app.rb
@@ -1,10 +1,10 @@
 cask 'ckan-app' do
-  version '1.25.0'
-  sha256 '59931b28c91d456d400091a78c29cb8ac99ad9a8cf7019c2a1275f61133fe8df'
+  version '1.25.1'
+  sha256 'e7c3e36f66aca11decc0a3e9f0102152f097a13a98ec8d952a97f148ec5e368f'
 
   url "https://github.com/KSP-CKAN/CKAN/releases/download/v#{version}/CKAN.dmg"
   appcast 'https://github.com/KSP-CKAN/CKAN/releases.atom',
-          checkpoint: '7332163f6416402a6756bf0a08c57a3f948c3b6b94af20db5ec44fccc1c4e888'
+          checkpoint: '742a881c3fab694ff3f77dc714dcb6c0acea811da6a4ced0ac2a2348187dde3e'
   name 'Comprehensive Kerbal Archive Network client'
   homepage 'https://github.com/KSP-CKAN/CKAN'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.