### PR TITLE
Update displaycal to 3.5.3.0

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,11 +1,11 @@
 cask 'displaycal' do
-  version '3.5.2.0'
-  sha256 '290c0b589e82742a33fc09e8ddd493d991b1ec000da70e750f98090b78512311'
+  version '3.5.3.0'
+  sha256 '1828b5dea240570bd759484917c2c52e5b96ca87c841669859b18a4cb7caa7db'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/dispcalgui/rss?path=/release',
-          checkpoint: '752489c2eb5cf12e1d326c6f0bad2fd27686f2d0eacfdb1b752277ac360699c6'
+          checkpoint: '92e1b9b6d5a749357d9e050e5fe7cc0ac3c5a17f0b23295a2a08493802ef8775'
   name 'DisplayCAL'
   homepage 'https://displaycal.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.