### PR TITLE
boostnote auto_updates true

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -9,6 +9,7 @@ cask 'boostnote' do
   name 'Boostnote'
   homepage 'https://boostnote.io/'
 
+  auto_updates true
   depends_on macos: '>= :mavericks'
 
   app 'Boostnote.app'


### PR DESCRIPTION
[boostnote](https://boostnote.io) has auto-update feature

```
$ git checkout master
$ brew cask upgrade
==> Verifying checksum for Cask boostnote
==> Starting upgrade for Cask boostnote
==> Purging files for version 0.11.4 of Cask boostnote
Error: It seems there is already an App at '/usr/local/Caskroom/boostnote/0.6.8/Boostnote.app'.
```

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256