### PR TITLE
Update washedoutco-katana to 1.4.1

### DIFF
--- a/Casks/washedoutco-katana.rb
+++ b/Casks/washedoutco-katana.rb
@@ -1,10 +1,10 @@
 cask 'washedoutco-katana' do
-  version '1.1.1'
-  sha256 'bb618628bd335c60dab87bc82c4e5d72df8e80e0baf5510c861962afda915fbc'
+  version '1.4.1'
+  sha256 '47712925c772150326e798f809e5037a9426f0629eb0a7d0bb71fea79f3f68d1'
 
   url "https://github.com/washedoutco/katana/releases/download/v#{version}/katana-#{version}-mac.zip"
   appcast 'https://github.com/washedoutco/katana/releases.atom',
-          checkpoint: '39ca93772f2b3236537672f582296ce6eeafc652807ec475a11728d370ced13c'
+          checkpoint: 'de1fa71a1413cd31f37f55182523b86534cade409d51807756ec9a83dd07d2d1'
   name 'Katana'
   homepage 'https://github.com/washedoutco/katana/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.