### PR TITLE
Update mactex-no-gui to 20180417

### DIFF
--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -1,11 +1,11 @@
 cask 'mactex-no-gui' do
-  version '20170524'
-  sha256 '0caf76027c9e0534a0b636f2b880ace4a0463105a7ad5774ccacede761be8c2d'
+  version '20180417'
+  sha256 'e6ee8f69ca6e5ca5d20a31afc3dff3b4e5aa7a0b1b89ace9864ac22b10c34b98'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
-  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
+  url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   appcast 'https://www.tug.org/mactex/downloading.html',
-          checkpoint: '2dd3e7c71fe586512a5241f2b26c24f93af3510d2bda2f56da1a404098b894ee'
+          checkpoint: 'd39276f0d9d85bed9f501efb30c15d4e9ec18681aa00b98ba0ab649c3a1ff331'
   name 'MacTeX'
   homepage 'https://www.tug.org/mactex/'
 
@@ -38,9 +38,9 @@ cask 'mactex-no-gui' do
                  },
                ]
 
-  uninstall pkgutil: 'org.tug.mactex.texlive2017',
+  uninstall pkgutil: 'org.tug.mactex.texlive2018',
             delete:  [
-                       '/usr/local/texlive/2017',
+                       '/usr/local/texlive/2018',
                        '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
                        '/Library/TeX',
                        '/etc/paths.d/TeX',
@@ -49,7 +49,7 @@ cask 'mactex-no-gui' do
 
   zap trash: [
                '/usr/local/texlive/texmf-local',
-               '~/Library/texlive/2017',
+               '~/Library/texlive/2018',
              ],
       rmdir: [
                '/usr/local/texlive',

--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -3,7 +3,7 @@ cask 'mactex-no-gui' do
   sha256 'e6ee8f69ca6e5ca5d20a31afc3dff3b4e5aa7a0b1b89ace9864ac22b10c34b98'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
-  url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
+  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg"
   appcast 'https://www.tug.org/mactex/downloading.html',
           checkpoint: 'd39276f0d9d85bed9f501efb30c15d4e9ec18681aa00b98ba0ab649c3a1ff331'
   name 'MacTeX'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.