### PR TITLE
Upgrade unetbootin to 661

### DIFF
--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -1,11 +1,11 @@
 cask 'unetbootin' do
-  version '657'
-  sha256 '50f181ddaeb487f4b29e7a1778d8597009f3cf3a60f15c3c8140108719947351'
+  version '661'
+  sha256 'b028a512515d6d8019c53536ec55e824cc1a0d89eb1fae9609d0e9d4385ff4b5'
 
   # github.com/unetbootin/unetbootin was verified as official when first introduced to the cask
   url "https://github.com/unetbootin/unetbootin/releases/download/#{version}/unetbootin-mac-#{version}.dmg"
   appcast 'https://github.com/unetbootin/unetbootin/releases.atom',
-          checkpoint: '491fea992c89ffa7974c4916380a64506369a3edf140f7d1fbee3d9720b4a3e0'
+          checkpoint: 'd5ad9f2962f180e80c4e3459479a0d521a87169b7c4e402a4bc81076dd4ab676'
   name 'UNetbootin'
   homepage 'https://unetbootin.github.io/'
 


### PR DESCRIPTION
Updated to 661

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.