### PR TITLE
Update geoda to 1.12.1.129

### DIFF
--- a/Casks/geoda.rb
+++ b/Casks/geoda.rb
@@ -1,11 +1,11 @@
 cask 'geoda' do
-  version '1.12.1.59'
-  sha256 'f9c96644b11f3aaa5aa12f4cfbeacc51fa01a29404d427d3ae1d9355dfe6f390'
+  version '1.12.1.129'
+  sha256 '9cb343b41ba7d980cf3eda4363685457501c023f77b8f15a2c95acc8694a437b'
 
   # s3-us-west-2.amazonaws.com/geodasoftware was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/geodasoftware/GeoDa#{version}-Installer.dmg"
   appcast 'https://github.com/GeoDaCenter/geoda/releases.atom',
-          checkpoint: '1b95843042e8f0197d607653065be7f2393f231cac42579f9c1175f3c9b78ce8'
+          checkpoint: '916068e927ce2ee1d6b83840cd2f8a5a6804e65ff60ffe720d3fadbb9a7e7c1d'
   name 'GeoDa'
   homepage 'https://geodacenter.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.