### PR TITLE
Update lingon-x to 6.1

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '6.0'
-  sha256 '8168b2a9ae37694dd65f3b17b978c445af4f1d916e6a4d449206a486b559d097'
+  version '6.1'
+  sha256 '4f868f48cef8dbc9a7843da754e0b33b02a5da75f5ef8f28d5ef601fc5030486'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '94b77fbea675529c2fd3d2c0cb578f0a32b2a599a2e1c0f0dcd425c12a79ce32'
+          checkpoint: '00c2ca18407dc91b927d4406ee96a8b250e0842adea70eda063864d29bb160ea'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.