### PR TITLE
Update pdf-expert to 2.4,511

### DIFF
--- a/Casks/pdf-expert.rb
+++ b/Casks/pdf-expert.rb
@@ -1,4 +1,4 @@
-cask 'pdfexpert' do
+cask 'pdf-expert' do
   version '2.4,511'
   sha256 '22026d0de90b25b1bf04d06e51bfd95e6a1b5388cd839a69a8144aac17a5f2de'
 

--- a/Casks/pdfexpert.rb
+++ b/Casks/pdfexpert.rb
@@ -1,11 +1,15 @@
 cask 'pdfexpert' do
-  version :latest
-  sha256 :no_check
+  version '2.4,511'
+  sha256 '22026d0de90b25b1bf04d06e51bfd95e6a1b5388cd839a69a8144aac17a5f2de'
 
   # readdle-test-binaries.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://readdle-test-binaries.s3.amazonaws.com/release/PDFExpert.dmg'
+  url "https://readdle-test-binaries.s3.amazonaws.com/versions/#{version.after_comma}/PDFExpert.dmg"
+  appcast 'https://readdle-test-binaries.s3.amazonaws.com/release/appcast.xml',
+          checkpoint: '04f046b8f417005d3fe57468fd5ab4a1e8a574d13753e355cba710cc26ddafc2'
   name 'PDF Expert'
   homepage 'https://pdfexpert.com/'
+
+  auto_updates true
 
   app 'PDF Expert.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.