### PR TITLE
 script.sh: gnupg

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -30,14 +30,20 @@ for file in "${modified_ruby_files[@]}"; do
   [[ "${file}" == 'Casks/'* ]] && modified_casks+=("${file}") || casks_wrong_dir+=("${file}")
 done
 
+run export HOMEBREW_NO_AUTO_UPDATE=1
+
 if [[ ${#casks_wrong_dir[@]} -gt 0 ]]; then
   odie "Casks added outside Casks directory: ${casks_wrong_dir[*]}"
 elif [[ ${#modified_casks[@]} -gt 0 ]]; then
+  for cask in "${modified_casks[@]}"; do
+    if brew cask _stanza gpg "${cask}" > /dev/null; then
+      run brew outdated gnupg || run brew upgrade gnupg
+    fi
+  done
   run brew cask _audit_modified_casks "${TRAVIS_COMMIT_RANGE}"
   run brew cask style "${modified_casks[@]}"
   if [[ ${#modified_casks[@]} -le 3 ]]; then
     if /usr/bin/grep "depends_on cask:" "${modified_casks[@]}" > /dev/null; then
-      export HOMEBREW_NO_AUTO_UPDATE=1
       run brew tap homebrew/bundle
       run brew bundle dump --file="${HOME}/Brewfile"
     fi
@@ -60,7 +66,7 @@ sleep 5 # Rerunning the checks too soon can result in false positives
 for check in "${checks[@]}"; do
   "${check}" > "${HOME}/cask-checks/after/${check}"
 
-  if ! /usr/bin/diff "${HOME}/cask-checks/before/${check}" "${HOME}/cask-checks/after/${check}" > /dev/null; then 
+  if ! /usr/bin/diff "${HOME}/cask-checks/before/${check}" "${HOME}/cask-checks/after/${check}" > /dev/null; then
     ohai "Leftover: ${check}"
     /usr/bin/diff "${HOME}/cask-checks/before/${check}" "${HOME}/cask-checks/after/${check}" | /usr/bin/grep '>'
   fi


### PR DESCRIPTION
https://github.com/Homebrew/brew/pull/4120

The travis pre-installed `gnupg` is relatively recent but is missing several required dependancies (no idea if they would impact the functionality we need), seems easier just to upgrade it to the current version and install the missing deps which would also mirror the setup that most users have.
```
>>> brew info gnupg
gnupg: stable 2.2.6 (bottled)
GNU Pretty Good Privacy (PGP) package
https://gnupg.org/
/usr/local/Cellar/gnupg/2.2.1 (132 files, 10.3MB)
  Poured from bottle on 2017-09-19 at 20:01:30
/usr/local/Cellar/gnupg/2.2.3 (133 files, 10.3MB) *
  Poured from bottle on 2017-12-06 at 04:46:19
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/gnupg.rb
==> Dependencies
Build: pkg-config ✔
Required: npth ✔, gnutls ✘, libgpg-error ✘, libgcrypt ✘, libksba ✔, libassuan ✘, pinentry ✘, gettext ✔, adns ✔
```