### PR TITLE
Update decrediton to 1.2.0

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,10 +1,10 @@
 cask 'decrediton' do
-  version '1.1.3'
-  sha256 '1c1a8d6ae9d5f0e80401e2a442ab593149375fe9fb2834c0fdc4f17a7f5d8ce6'
+  version '1.2.0'
+  sha256 '87fc394e1c371001f000d8e57112afca9c076d10d4ba58f15bcd37c9ae640d4e'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom',
-          checkpoint: 'e4373be60826a72d3087966c6764f415104859323cdb07a1026b919411178885'
+          checkpoint: 'aefb1740af71db6196e1443420e846d31ee492f41070d2fcb67bc22f0f4687d0'
   name 'Decrediton'
   homepage 'https://github.com/decred/decrediton'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.