### PR TITLE
Rename tuneskit to tuneskit-m4v-converter and update to latest

### DIFF
--- a/Casks/tuneskit-m4v-converter.rb
+++ b/Casks/tuneskit-m4v-converter.rb
@@ -1,9 +1,9 @@
-cask 'tuneskit' do
+cask 'tuneskit-m4v-converter' do
   version :latest
   sha256 :no_check
 
   url 'https://www.tuneskit.com/TunesKitforMac.dmg'
-  name 'TunesKit for Mac'
+  name 'TunesKit M4V Converter'
   homepage 'https://www.tuneskit.com/'
 
   app 'TunesKit M4V Converter.app'

--- a/Casks/tuneskit.rb
+++ b/Casks/tuneskit.rb
@@ -1,12 +1,10 @@
 cask 'tuneskit' do
-  version '3.6.5'
-  sha256 '873a74f1ff8a29fdb14b925e7512d4dea9bcb463485bbd82d223441fce5bd75e'
+  version :latest
+  sha256 :no_check
 
   url 'https://www.tuneskit.com/TunesKitforMac.dmg'
-  appcast 'https://www.tuneskit.com/app_update_files/m4vconverter/mac_update.xml',
-          checkpoint: '8a7305f1e54723f2beb227f46d60223de50c99473608df7f19d37eb6e27ecdd0'
   name 'TunesKit for Mac'
   homepage 'https://www.tuneskit.com/'
 
-  app 'TunesKit for Mac.app'
+  app 'TunesKit M4V Converter.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The `appcast` still shows that the latest version of the app is `3.5.3` – it doesn't appear to be updated.