### PR TITLE
Update gretl to 2018a

### DIFF
--- a/Casks/gretl.rb
+++ b/Casks/gretl.rb
@@ -1,10 +1,10 @@
 cask 'gretl' do
-  version '2017d'
-  sha256 'ee2c881924bd339a55ae912a7df6abc76abbbd8d0bf2dc50c0803c8113662329'
+  version '2018a'
+  sha256 '43336535c6d9f940b146a1197ffdc72f894755183ab2364d7950e562818c3e08'
 
   url "https://downloads.sourceforge.net/gretl/gretl-#{version}-quartz.pkg"
   appcast 'https://sourceforge.net/projects/gretl/rss?path=/gretl',
-          checkpoint: 'b26795fac004d7e7049cb8c650fa8a3ff85e3d5b7ff6a8190bb033493c995ec4'
+          checkpoint: '8b46ad14178f4fda65d449290905b83b5fa3b44fccf80650fe7e475ec6578852'
   name 'gretl'
   homepage 'http://gretl.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.