### PR TITLE
Update gtkwave to 3.3.89

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.87'
-  sha256 'e9e3cdfd06f76ed4de8b29d55a29f9b714a68a00501b13b4741078a506d1cc8a'
+  version '3.3.89'
+  sha256 '27d244dd428d38c3d8e5aa498f84745516238491367929e09624cc95a3ee9f1c'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: 'bea1232122ff24237497ea61cbfabc2900cc2590059eb32b66524bfbcd9515bf'
+          checkpoint: '552d25109b8786bb7c3d1216e5798b89ca740ebdf43cb48e60c51ef3a1609e66'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.