### PR TITLE
Add Synology Cloud Station Drive v4.2.6-4408

### DIFF
--- a/Casks/cloud-station-drive.rb
+++ b/Casks/cloud-station-drive.rb
@@ -15,4 +15,3 @@ cask 'cloud-station-drive' do
 
   zap trash: '~/Library/Preferences/com.synology.CloudStationUI.plist'
 end
-

--- a/Casks/cloud-station-drive.rb
+++ b/Casks/cloud-station-drive.rb
@@ -1,0 +1,18 @@
+cask 'cloud-station-drive' do
+  version '4.2.6-4408'
+  sha256 'c392cc60aefb54d4b1e67a526dcb653a6935def220ccbe4f539480718376cced'
+
+  url "https://global.download.synology.com/download/Tools/CloudStationDrive/#{version}/Mac/Installer/synology-cloud-station-drive-#{version.sub(%r{.*-}, '')}.dmg"
+  name 'Synology Cloud Station'
+  homepage 'https://www.synology.com/'
+
+  auto_updates true
+
+  pkg 'Install Cloud Station Drive.pkg'
+
+  uninstall pkgutil:   'com.synology.CloudStation',
+            launchctl: 'com.synology.Synology Cloud Station'
+
+  zap trash: '~/Library/Preferences/com.synology.CloudStationUI.plist'
+end
+


### PR DESCRIPTION
Add Synology Cloud Station Driver v4.2.6-4408 to Brew Cask Repo

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
