### PR TITLE
Update hab to 0.55.0-20180321215236

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.54.0-20180221020527'
-  sha256 '3eb8f6e1f8145bad9edf1ceceafd7a97a10d1cab78e6c7ebec6b05e2b5e36fe7'
+  version '0.55.0-20180321215236'
+  sha256 'fdc87f2e82b8ef0b82f5b9fb56b56b24a45277e92f48e0ef58fdd6270513c53a'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: 'dc64e5193123de97efd533e8af931faccd4a74f50068074e03a455d629032fdb'
+          checkpoint: '295b1b731b162737af164e49efc4adad2b90175ba749527de38a69dbacf09804'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.