### PR TITLE
Update hachidori to 2.2.4

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,11 +1,11 @@
 cask 'hachidori' do
-  version '2.2.1'
-  sha256 '51db575dd65bdcea29d554cea35bd1a6606281356e877e20d549521c5e1cbc28'
+  version '2.2.4'
+  sha256 'a9368e9ef2529d828d34c50b6997f0163f257b52c07f377b62a1e181778d62e6'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/hachidori/releases.atom',
-          checkpoint: '993b1c9eeaa17bfb35697a8b5c09e76b518b463dc312fdb5c7c10083234ecfeb'
+          checkpoint: 'e008cca070d3d01a96ed0f9a89449bf05936dd459b933547cda5e1d3e0a1ce41'
   name 'Hachidori'
   homepage 'https://hachidori.ateliershiori.moe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.