### PR TITLE
Update netron to 1.7.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.4'
-  sha256 'a8771f95650a13fac96903bfbf44336b39d06f273701b86026a9dadcf548fc9f'
+  version '1.7.5'
+  sha256 '42667678b6fc24cb7dfeef794265d21996ff035cd26b4110145950a61f2a1f3b'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '4a5f996fa4000d03d61d0bb366e9affda57f38e70e6ee26c226de4043995d4e8'
+          checkpoint: '18318977269163664fc01f496aa67acbad9bf397dc7fbc063140b29942c256dd'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.