### PR TITLE
script.sh: uninstall instead of zap

### DIFF
--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -43,7 +43,7 @@ elif [[ ${#modified_casks[@]} -gt 0 ]]; then
     fi
     for cask in "${modified_casks[@]}"; do
       run brew cask reinstall --verbose "${cask}"
-      run brew cask zap --verbose "${cask}"
+      run brew cask uninstall --verbose "${cask}"
     done
     if [[ -f "${HOME}/Brewfile" ]]; then
       run brew bundle cleanup --force --file="${HOME}/Brewfile"


### PR DESCRIPTION
Reverts https://github.com/caskroom/homebrew-cask/pull/44407

Running `zap` makes the leftover check less useful in some cases because it [explodes](https://github.com/caskroom/homebrew-cask/issues/44993) trying to remove files it doesn't have permissions to and doesn't run the check.