### PR TITLE
Update netron to 1.7.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.5'
-  sha256 '42667678b6fc24cb7dfeef794265d21996ff035cd26b4110145950a61f2a1f3b'
+  version '1.7.6'
+  sha256 '99aaf906b3b4ab807d0d16e7e7c5b10885fa56b0e816a2bb48bc847ebcac04ed'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '18318977269163664fc01f496aa67acbad9bf397dc7fbc063140b29942c256dd'
+          checkpoint: 'ca394bad81f1460f9c4adabb953de46f80b4b3425cc107a576a0ddfb62a23615'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.