### PR TITLE
Update unity-standard-assets to 2017.4.1f1,9231f953d9d3

### DIFF
--- a/Casks/unity-standard-assets.rb
+++ b/Casks/unity-standard-assets.rb
@@ -1,6 +1,6 @@
 cask 'unity-standard-assets' do
-  version '2017.3.1f1,fc1d3344e6ea'
-  sha256 '6caa54b4d194f1763cdea47f6eea1afb60bacf7209f7d6e55be41c943d245123'
+  version '2017.4.1f1,9231f953d9d3'
+  sha256 '33e1da805d3b3653f9d96f57661981e50e2d0b1334402d0402975ce3ae97add0'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacStandardAssetsInstaller/StandardAssets-#{version.before_comma}.pkg"
   name 'Unity Standard Assets'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.