### PR TITLE
Update deckset to 2.0.3,2481

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -1,10 +1,10 @@
 cask 'deckset' do
-  version '2.0.1,2477'
-  sha256 '9766431a401da2e504f873263e92f5a6026c32f06d93bf5f5978567097342597'
+  version '2.0.3,2481'
+  sha256 '00693f21e8c61676ab1ae15d06efe02181cea43525d7192ca43372d8da6486df'
 
   url "https://dl.decksetapp.com/Deckset+#{version.before_comma}+(#{version.after_comma}).dmg"
   appcast 'https://dl.decksetapp.com/appcast.xml',
-          checkpoint: '153b54eda41f642e77bd9e838696a3b924c70e5e10c61706a1ad7e7c858dc4dc'
+          checkpoint: '05ffb357f546a6437d897d83ec70fef22a2d2f03cbe36297c71171acf0b450fe'
   name 'Deckset'
   homepage 'https://www.decksetapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.