### PR TITLE
Update iboostup to 5.9.91

### DIFF
--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -1,10 +1,10 @@
 cask 'iboostup' do
-  version '5.9.81'
-  sha256 '6eb7a40dbe54b60064403980cfda3e33b89f35be3570978d4a51a312f82b2080'
+  version '5.9.91'
+  sha256 '44d7c589f2cfd715ad00a3797d72878903aa2b87c5d5a9a86f79df2f412379ae'
 
   url 'https://www.iboostup.com/iboostup.dmg'
   appcast 'https://www.iboostup.com/updates',
-          checkpoint: '169038ac2747ec13607379452b11fa2e8b090e6928275f997dc512fca51b4044'
+          checkpoint: '428df2d5123c995b6dea94baed9a71eefcdd689fcaa3da2973bda5d424de5a93'
   name 'iBoostUp'
   homepage 'https://www.iboostup.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.