### PR TITLE
Update autofirma to 1.6

### DIFF
--- a/Casks/autofirma.rb
+++ b/Casks/autofirma.rb
@@ -1,13 +1,13 @@
 cask 'autofirma' do
-  version '1.5'
-  sha256 'c39ad866df3e655a3bff390ae98a768af1c26d51bffef2fd92a507335d1c98c4'
+  version '1.6.2'
+  sha256 'dc97bebc453a9f79589ae8f1e8eae46596c659fc8f5d4d11c0f85c0b307246d4'
 
   # estaticos.redsara.es/comunes/autofirma was verified as official when first introduced to the cask
   url 'https://estaticos.redsara.es/comunes/autofirma/currentversion/AutoFirma_Mac.zip'
   name 'AutoFirma'
   homepage 'https://administracionelectronica.gob.es/ctt/clienteafirma'
 
-  pkg "AutoFirma_#{version.dots_to_underscores}_signed.pkg"
+  pkg "AutoFirma_#{version.dots_to_underscores}.pkg"
 
   # remove 'Autofirma ROOT' and '127.0.0.1' certificates from keychain (these were installed by pkg)
   uninstall_postflight do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.