### PR TITLE
Update inspec to 2.1.59-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '2.1.21-1'
-  sha256 'cc2945be4df5dee867e293a6a6753383189780aa4f464f29422898843a1f3497'
+  version '2.1.59-1'
+  sha256 '6fce3fb0e8d5c142f160f4aba234220ab118404f20ade0c634bc0bcfebb04e4c'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.13/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'f17c168734bc29a6a7e92fc83bb9014df84dadbefb59442eb872c673e4811ea6'
+          checkpoint: 'c38f49b4429a80bed55a3e942eb60b4d142f8809ae3584fbefde2f4a01c8344c'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.