### PR TITLE
Update instead to 3.2.1

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,11 +1,11 @@
 cask 'instead' do
-  version '3.2.0'
-  sha256 '1b3ef401dc3c4a2bcece09b74ad759bbc043b5f0ebc8f18ef29dc17e7b4f0593'
+  version '3.2.1'
+  sha256 '34ca0aac226f4c2f87cb0db4217e09c8deed2a29c6d7d67871bef1087796caa7'
 
   # github.com/instead-hub/instead was verified as official when first introduced to the cask
   url "https://github.com/instead-hub/instead/releases/download/#{version}/Instead-#{version}.dmg"
   appcast 'https://github.com/instead-hub/instead/releases.atom',
-          checkpoint: '22bfb0a6ec9f5105740b4a377e772a373ff101b1e1a6198806cd7c1a3ffb4fbc'
+          checkpoint: '06653147040958627385de015edd4f9c18d94e9c9c88b1ee2f449845cd92f32a'
   name 'INSTEAD'
   homepage 'https://instead.syscall.ru/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.