### PR TITLE
Update axoloti-runtime to 1.0.12-2

### DIFF
--- a/Casks/axoloti-runtime.rb
+++ b/Casks/axoloti-runtime.rb
@@ -1,11 +1,11 @@
 cask 'axoloti-runtime' do
-  version '1.0.12-1'
-  sha256 '433c965b0814f4e01cd8d5d827ba18ea5bda6b6dd798ac8f6f6f29d0b0c9e77d'
+  version '1.0.12-2'
+  sha256 '30e887a81caf1e7ea375c0e795294f6352a3dc7291ff092a8afbf6f7f61c6736'
 
   # github.com/axoloti/axoloti was verified as official when first introduced to the cask
-  url "https://github.com/axoloti/axoloti/releases/download/#{version}/axo_runtime_mac_#{version}.dmg"
+  url "https://github.com/axoloti/axoloti/releases/download/#{version}/axo_runtime_mac_#{version.major_minor_patch}.dmg"
   appcast 'https://github.com/axoloti/axoloti/releases.atom',
-          checkpoint: '613310bd8871468b0f4446a6ef121c96131bc42434a1e1765112fefc5db3b27d'
+          checkpoint: '448924453923cd34c05f2005ea556c447d609b96ef9ecb35d2038d450f2e1cea'
   name 'Axoloti Runtime'
   homepage 'http://www.axoloti.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.