### PR TITLE
add reboot caveat to programmer-dvorak

### DIFF
--- a/Casks/programmer-dvorak.rb
+++ b/Casks/programmer-dvorak.rb
@@ -26,4 +26,8 @@ cask 'programmer-dvorak' do
                        '/System/Library/Caches/com.apple.IntlDataCache.le*',
                        '/private/var/folders/*/*/-Caches-/com.apple.IntlDataCache.le*',
                      ]
+
+  caveats do
+    reboot
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

This is just the addition of a reboot caveat for programmer-dvorak.

From https://www.kaufmann.no/roland/dvorak/macosx.html:

> and then you must reboot the system to have the new cache built upon startup.

When I installed the cask, the layout wasn't available until I rebooted.