### PR TITLE
Update 'vnote' to 1.15, fix url

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,9 +1,9 @@
 cask 'vnote' do
-  version '1.14'
-  sha256 'f6a576fcb14990ded7c58fdba9d8f97a8e26c2b47602270af2efb4ba0b6f25d8'
+  version '1.15'
+  sha256 'eb64ee54426fb5525c077e4538f74aac20fc2108a39937aeee700835dfc95825'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
-  url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote_X64_#{version}.dmg"
+  url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"
   appcast 'https://github.com/tamlok/vnote/releases.atom',
           checkpoint: '5b65722928f42af4f8c1fb06a3258a60e9e266d89993dcdc5e21bb566d26923d'
   name 'VNote'

--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -5,7 +5,7 @@ cask 'vnote' do
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"
   appcast 'https://github.com/tamlok/vnote/releases.atom',
-          checkpoint: '5b65722928f42af4f8c1fb06a3258a60e9e266d89993dcdc5e21bb566d26923d'
+          checkpoint: '79b2d2df441140b7b190c96e29121385b995f9663e537de5d84bd161fd03652f'
   name 'VNote'
   homepage 'https://tamlok.github.io/vnote/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
