### PR TITLE
Add Flutter SDK v0.3.1

### DIFF
--- a/Casks/flutter-sdk.rb
+++ b/Casks/flutter-sdk.rb
@@ -1,0 +1,11 @@
+cask 'flutter-sdk' do
+  version '0.3.1'
+  sha256 'a88356eb37c37e89f92698ed06eaf02d6364c50f6accea6fe793b9d04c9e0c98'
+
+  # storage.googleapis.com/flutter_infra/releases/beta/macos was verified as official when first introduced to the cask
+  url "https://storage.googleapis.com/flutter_infra/releases/beta/macos/flutter_macos_v#{version}-beta.zip"
+  name 'Flutter SDK'
+  homepage 'https://flutter.io/'
+
+  binary 'flutter/bin/flutter'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

Flutter SDK is only available as beta.  
There is no stable version, so I sent PR to this repository.

https://flutter.io/setup-macos/

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
