### PR TITLE
Update Scribus to 1.4.7

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,11 +1,11 @@
 cask 'scribus' do
-  version '1.4.6'
-  sha256 'db818ae3a69ca16c1b3fb873b55903062f7b81f42d7adcc64a61ee93bf95727e'
+  version '1.4.7'
+  sha256 'fc5fb1f34abd177586f3d9791801c4a166cd818f3c985960b95f1092dad8a9d4'
 
   # sourceforge.net/scribus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/scribus/rss?path=/scribus',
-          checkpoint: '977e2163a7477ca20e74f118a54acbb2df4e47567c1656cd08680bac65e9be7c'
+          checkpoint: '5e29f455f60e15acf34ae880c6c729ac10a19801c9743508cfa9c0c645b5a602'
   name 'Scribus'
   homepage 'https://www.scribus.net/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
