### PR TITLE
Update endurance to 1.1r18

### DIFF
--- a/Casks/endurance.rb
+++ b/Casks/endurance.rb
@@ -3,8 +3,13 @@ cask 'endurance' do
   sha256 'a20ceb5629de4b8785ebb6b4e0e86ca0be36de591c2dc6ed39f73e9cdd0c9884'
 
   url "https://enduranceapp.com/downloads/Endurance#{version}.zip"
+  appcast 'https://enduranceapp.com/appcast',
+          checkpoint: '6b642532ab8d28d5fe7d5282fd8086ab47c2111f017893fcc9ea7f6b1e47a182'
   name 'Endurance'
   homepage 'https://enduranceapp.com/'
 
   app 'Endurance.app'
+
+  uninstall delete:    '/Library/PrivilegedHelperTools/com.MagnetismStudios.endurance.helper',
+            launchctl: '/Library/LaunchDaemons/com.MagnetismStudios.endurance.helper.plist'
 end

--- a/Casks/endurance.rb
+++ b/Casks/endurance.rb
@@ -11,5 +11,5 @@ cask 'endurance' do
   app 'Endurance.app'
 
   uninstall delete:    '/Library/PrivilegedHelperTools/com.MagnetismStudios.endurance.helper',
-            launchctl: '/Library/LaunchDaemons/com.MagnetismStudios.endurance.helper.plist'
+            launchctl: 'com.MagnetismStudios.endurance.helper'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.