### PR TITLE
Upgrade Discord to 0.0.251

### DIFF
--- a/Casks/discord.rb
+++ b/Casks/discord.rb
@@ -1,10 +1,10 @@
 cask 'discord' do
-  version '0.0.250'
-  sha256 '85a0a722ceba54e368bab9d231f9ac92977fa1c7319339f4ac80596c6e8a2bac'
+  version '0.0.251'
+  sha256 '98fe2d3d29b8e6ea676f8ce633122c3cc8d2541bff8fb20ffa40f014224e4a3a'
 
   url "https://cdn.discordapp.com/apps/osx/#{version}/Discord.dmg"
   appcast 'https://discordapp.com/api/stable/updates?platform=osx',
-          checkpoint: '0bca6e26a844f761d56ba49d709170a02930f24942809728452e6a8179a94c07'
+          checkpoint: '9322c83e83327a6db9ed1fe6046744ff8cb5e5a6212c1e270f1c6c46e6970983'
   name 'Discord'
   homepage 'https://discordapp.com/'
 


### PR DESCRIPTION
Updated to 0.0.251

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
