### PR TITLE
Update mightytext to 3.91.2

### DIFF
--- a/Casks/mightytext.rb
+++ b/Casks/mightytext.rb
@@ -1,6 +1,6 @@
 cask 'mightytext' do
-  version '3.90.2'
-  sha256 'c10f410492b323bd58c1ecd28cc6aa945e12e65a80042526055e7d86acc0fabe'
+  version '3.91.2'
+  sha256 '882cbe86911050bca30c293523b7156106cd05237e509e3fd171d317e933d5b5'
 
   url "https://dl-desktop.mightytext.net/MightyText-#{version}.dmg"
   name 'MightyText'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.