### PR TITLE
Update torguard to 0.3.84

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,11 +1,11 @@
 cask 'torguard' do
-  version '0.3.83'
-  sha256 'c7ce58c1e55cb3748e5c8951abc3cccfad148c2bb83445ff9c616b01c6742ea3'
+  version '0.3.84'
+  sha256 '1c9ed9dccd0e07b3688f999cc37fbc491029d66a4948738923105d80eb2a3336'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"
   appcast 'https://updates.torguard.biz/Software/MacOSX/checksums.sha256',
-          checkpoint: 'a134e08fc113a961b5ea2b5ec2af3636c1625611a6c380f22b63ee500810c04f'
+          checkpoint: '2b8428e5cac6da7aa44a1ae9c5b532e2f38a0e5742652518f3ab1a696e30f13b'
   name 'TorGuard'
   homepage 'https://torguard.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.