### PR TITLE
Update transmission to 2.94

### DIFF
--- a/Casks/transmission.rb
+++ b/Casks/transmission.rb
@@ -1,11 +1,11 @@
 cask 'transmission' do
-  version '2.93'
-  sha256 '61cd9b74cc542458fe2e41be6ac76d8b4201a94293bf681f8d75e12e64bd8d95'
+  version '2.94'
+  sha256 '2cae915ae0e37fc5983406ca7fbd53a054a7153d3bfd7a6cef117a8a28d8a78a'
 
   # github.com/transmission/transmission-releases was verified as official when first introduced to the cask
   url "https://github.com/transmission/transmission-releases/raw/master/Transmission-#{version}.dmg"
   appcast 'https://github.com/transmission/transmission/releases.atom',
-          checkpoint: '9cbb6259a2b36d7352456015375c5b1f30f3fc5219a92b4773972ed4e278a41e'
+          checkpoint: '81b72e634be104ae5cecf67fed8d55894190f9696a3ee2aaf72501caf32e8456'
   name 'Transmission'
   homepage 'https://transmissionbt.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.