### PR TITLE
Update freesmug-chromium to 66.0.3359.139

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '66.0.3359.117'
-  sha256 '85e4320708bebdc26c5597c48d54d46f07005d89c873aa36eed7dd1f94e24785'
+  version '66.0.3359.139'
+  sha256 'b500a59c6f14075c2900f0bb12cf41268cead077dff97dd6d353dee4457218fa'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: 'e109d61870ff005524d5e2d191fea23a8ee2cb48caf50a9715b894a727341721'
+          checkpoint: 'e6adefc3e280428e0457998a26a55a570ba6e5b87f3aba67dc19fa10c779acb0'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.