### PR TITLE
Update tortoisehg to 4.5.3

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.5.2'
-  sha256 '16696fe90096c4aa614665e204e10f03aab1d3f0bff474bde409fb5a1acf4c30'
+  version '4.5.3'
+  sha256 '5018ad81bdc02f3ffa4c1cc683c2ea6d6a7ab60bdd418e8c2629349aa4deaeed'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64-qt5.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.