### PR TITLE
Update signal to 1.9.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.8.0'
-  sha256 '20bfa357f0539c6d3a2cd0f212f13934c006a9256dd194262a49534c9f374c26'
+  version '1.9.0'
+  sha256 'b04f6cdfc01a2593c6e474f13d12f011f644348000fe887c249498f3854926a8'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom',
-          checkpoint: '616f6b1b06fe73a27f3c60c067172a17ca94ec45b61c3f8ab13cf663b1c8f7d6'
+          checkpoint: 'f830de874ec61590e2d613ee29ddb73c90a2adebfa70e5569bc80d16dcd98074'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.