### PR TITLE
Update adobe-acrobat-pro to 2018

### DIFF
--- a/Casks/adobe-acrobat-pro.rb
+++ b/Casks/adobe-acrobat-pro.rb
@@ -1,8 +1,8 @@
 cask 'adobe-acrobat-pro' do
-  version '2017'
+  version '2018'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://trials3.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_#{version}_Web_WWMUI.dmg",
+  url 'http://ardownload.adobe.com/pub/adobe/acrobat/mac/AcrobatDC/1801120038/AcrobatDCUpd1801120038.dmg',
       user_agent: :fake,
       cookies:    { 'MM_TRIALS' => '1234' }
   name 'Adobe Acrobat Pro DC'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.