### PR TITLE
Update bee to 3.0.21,5403

### DIFF
--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -1,11 +1,11 @@
 cask 'bee' do
-  version '3.0.18,5379'
-  sha256 'ad2f950642399619a9b9b40f0b136e1a7b1ad6ba5a2635e1d5bc673943e47de9'
+  version '3.0.21,5403'
+  sha256 'ebe55846bc8d587be4b6a918351de9e04c0e4256af9da88b18b7b1ae664cb64f'
 
   # bee-app.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://bee-app.s3.amazonaws.com/public/Bee-#{version.after_comma}-#{version.before_comma}.zip"
   appcast 'https://s3.amazonaws.com/www.neat.io/bee/appcast.xml',
-          checkpoint: 'dc617cf42480fa8e4be9b43e3d3c89f1d6783002318be4c254569bc7a8205053'
+          checkpoint: '28d29701761a783c419b20c886ef8b446fa77c103db06dd8199dd90772478fb1'
   name 'Bee'
   homepage 'http://www.neat.io/bee/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.