### PR TITLE
Update capture-one to 11.1.1

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '11.1.0'
-  sha256 'c5de8adb934eefc3300006e0bf918cd76b5490a7d69d74d04535f6d0093ce27e'
+  version '11.1.1'
+  sha256 '671ef824b54db1e8cf146f6d6f9b2301a026c0cda180e515cc0eca588f06413a'
 
   url "http://downloads.phaseone.com/73bc2bdb-c7e0-45ec-bffc-3b2ec2adeb03/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.