### PR TITLE
Update cacher to 1.4.5

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.4.4'
-  sha256 '17a64e9d4b8b5774c4c449c0dc73cfd08e7f6993385e86ba99b46a2762bb1cc9'
+  version '1.4.5'
+  sha256 '14d9708990da57505686ea6896ae380de06bf5bca6dfb886293d08bc4920a25c'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'fb0df71ff68e4462a9ec4872b116f9cc2c3b58fe419bde3f61ba40b0cce0925f'
+          checkpoint: '7b775be005aca960a0120c84870f422022065bebd4f05e2900957e46f0bdb9ba'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.