### PR TITLE
Update milanote to 1.0.31

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.0.30'
-  sha256 'e2e8170d2e01dc4b7f97871e617514e7824f9db87901d111e8ceda981f804e60'
+  version '1.0.31'
+  sha256 'e2894937e4f0c8ea5e895b150b81783973eb8894f0b0b54b0cff5b75964e3bf1'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.