### PR TITLE
Update vuo-editor to 1.2.7

### DIFF
--- a/Casks/vuo-editor.rb
+++ b/Casks/vuo-editor.rb
@@ -1,10 +1,10 @@
 cask 'vuo-editor' do
-  version '1.2.6'
-  sha256 '6a114d3e266a57d8ce82014784bdb3ead1ca1d2c02d564ade74a805f62a45aca'
+  version '1.2.7'
+  sha256 '7210b425fded394733c7b00e4cd5ba6128bd41e21b5ba83108473d771d1443ca'
 
   url "https://vuo.org/sites/default/files/vuo-#{version}-editor.zip"
   appcast 'https://vuo.org/releases.rss',
-          checkpoint: '086d28c17c3adb3f46d2e71ff73bf030e0462a16c3056887c382d3885af05376'
+          checkpoint: '5af5f75a78c8413f6336811d0f2628f3c1af1569140970c19af0df88c3d9da71'
   name 'Vuo'
   homepage 'https://vuo.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.