### PR TITLE
Update zotero to 5.0.47

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,10 +1,10 @@
 cask 'zotero' do
-  version '5.0.45'
-  sha256 'eb9df6f01b68ff9363f057960e8c1804e60e9c946633ec3d91924dfa2d1a1c58'
+  version '5.0.47'
+  sha256 'bb1685bf298b095f2cd1db9d2e9a16aaed242b2cb26e1ad4a10f38c90ba53c25'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: '92ae47cbfc519792b89c24aff896bec69fa568372154f5f54a380d46581d904a'
+          checkpoint: 'e94fb9ab4e1cdb0d214c77fac0ee8895cd9805bd0ecfba981e4c58bda660c98f'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.