### PR TITLE
Update devrantron to 1.5.3

### DIFF
--- a/Casks/devrantron.rb
+++ b/Casks/devrantron.rb
@@ -1,11 +1,11 @@
 cask 'devrantron' do
-  version '1.5.2'
-  sha256 '5fb8b5076fcc41de40df126f75d685f16d42d2e14b41eb57e4acad25f198a3e7'
+  version '1.5.3'
+  sha256 '2528807393fb3acc6fd3410512dd8194e61056f98d175976a26275be0374315f'
 
   # github.com/tahnik/devRantron was verified as official when first introduced to the cask
   url "https://github.com/tahnik/devRantron/releases/download/v#{version}/devrantron-#{version}.dmg"
   appcast 'https://github.com/tahnik/devRantron/releases.atom',
-          checkpoint: 'b4c2e4a0616d5f116eebb0b93e1fbd637ca95e9a26fea5fe5c0bae1902a9540e'
+          checkpoint: 'c4b9d53d6136e555d7a373cd45d49bb69510ed6ec65800e7e31d2e0847c0ea2a'
   name 'devRantron'
   homepage 'https://devrantron.firebaseapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.