### PR TITLE
Update carbon-copy-cloner to 5.1.5389

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.1.5387'
-  sha256 '4d7b5bf43d9b17fb21ca3ae492e51f6930db2a9ebc0160a4e6198e53983fb6e6'
+  version '5.1.5389'
+  sha256 '4efdb5936e1832954e0e5166b86047c8e642b80937afdf620b432713f8b05c2e'
 
   # bombich.scdn1.secure.raxcdn.com/software/files was verified as official when first introduced to the cask
   url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.