### PR TITLE
Add DarkRadiant latest

### DIFF
--- a/Casks/darkradiant.rb
+++ b/Casks/darkradiant.rb
@@ -1,0 +1,15 @@
+cask 'darkradiant' do
+  version '2.5.0'
+  sha256 'a401373b265b66a94abb1c4c77cb7f0f3e11ee11c533658449acccd0bcab47dd'
+
+  # github.com/codereader/DarkRadiant was verified as official when first introduced to the cask
+  url "https://github.com/codereader/DarkRadiant/releases/download/#{version}/DarkRadiant.#{version}.app.zip"
+  appcast 'https://github.com/codereader/DarkRadiant/releases.atom',
+          checkpoint: '6ccd946515845e0432d3dd5b932f12ef6229b5ae43d51af81829250bf966f3a2'
+  name 'DarkRadiant'
+  homepage 'http://www.darkradiant.net/index.html'
+
+  app 'DarkRadiant 2.5.0.app'
+
+  zap delete: ['~/Library/Saved\ Application\ State/com.brokenglass.DarkRadiant.savedState']
+end


### PR DESCRIPTION
This adds the latest version (2.5.0) of DarkRadiant, “an open-source Level Editor for Doom 3 and The Dark Mod.”

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
