### PR TITLE
Update trailrunner to 3.8.3200,197

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,11 +1,11 @@
 cask 'trailrunner' do
-  version '3.8.3192,196'
-  sha256 '2ff889e9b1c45c58f078580a6d216226f26554788904140cc7bae469abb0dc65'
+  version '3.8.3200,197'
+  sha256 'ded001616141e6e781cb23ff602996c63483b20dfc29ce0dfde2f766dc2f98f7'
 
   # rink.hockeyapp.net was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610',
-          checkpoint: '89ae0a5efaafc1a3f1e33d749b84a23a96ac23966cd4933c3f90e11f57835c2b'
+          checkpoint: 'be5fd9426fe7418a35164e31c78d7a275f56797bbe8767936507e54dff69cbac'
   name 'TrailRunner'
   homepage 'http://www.trailrunnerx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.