### PR TITLE
Update wey to 0.2.2

### DIFF
--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,10 +1,10 @@
 cask 'wey' do
-  version '0.1.1'
-  sha256 '64375ec21d286b9be0af9a863cc53cd0159f9b27c03540fd275455998a780498'
+  version '0.2.2'
+  sha256 'd2985075766917a7d05f14d1ca402985a9122d9d01233fe20ee8f02f82d44eaa'
 
   url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom',
-          checkpoint: '6910598e1ac593f9ecf163782b88e03b36711e516847a2dddc888cffc06cd062'
+          checkpoint: '1bf496f625c4c1d4ca611cec57a15145f22d4e65c30d5533fa57cee8eff1cc35'
   name 'Wey'
   homepage 'https://github.com/yue/wey'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.