### PR TITLE
Update astro to 3.0.10,3955

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '3.0.9,3859'
-  sha256 'c596f7b47fe1e70fb3a5e96bc594485439977b69835fd21064a02079523e63e8'
+  version '3.0.10,3955'
+  sha256 'ec962ad645e4b2890a83d96ebdfa7d0df760601ef48ebb5484aeb0af592766d0'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: '8991e80cab2afb5f75c5475193bbda069796a9af8f9571ccf7629756ea50bdb4'
+          checkpoint: 'd42b560b6a2022a6cfe59cbec02d469b4e3fb4cfb4034a8c3260c74c71b32800'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.