### PR TITLE
Fix next browser sha

### DIFF
--- a/Casks/next.rb
+++ b/Casks/next.rb
@@ -4,7 +4,7 @@ cask 'next' do
 
   url "https://github.com/nEXT-Browser/nEXT/releases/download/#{version}/nEXT.dmg"
   appcast 'https://github.com/nEXT-Browser/nEXT/releases.atom',
-          checkpoint: 'f5dec83b8e73c75011c335ec2e57be3a9b4c60f52246650657f68a89247db1e4'
+          checkpoint: '87d4619eaf4bb026c226f87fb2a57dbf601a64f21698dfbcc8ff43cb49b4516d'
   name 'nEXT-Browser'
   homepage 'https://github.com/nEXT-Browser/nEXT'
 

--- a/Casks/next.rb
+++ b/Casks/next.rb
@@ -1,6 +1,6 @@
 cask 'next' do
   version '0.07'
-  sha256 '88f92765fe9963b0800de73775cf9bf5fd8d793674f9da1755676e832d523d2a'
+  sha256 '6b253f26f5866a883d499c269b3dab69ad5f554c7424946d5983eb1a4cc194e2'
 
   url "https://github.com/nEXT-Browser/nEXT/releases/download/#{version}/nEXT.dmg"
   appcast 'https://github.com/nEXT-Browser/nEXT/releases.atom',


### PR DESCRIPTION
This PR fixes the invalid sha256 on [next](https://github.com/caskroom/homebrew-cask/blob/master/Casks/next.rb) cask package.

there isn't any new version, I simply re-calculate the sha256 for the dmg.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256