### PR TITLE
Update typora to 0.9.9.15.2

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.15'
-  sha256 'cedb9adc448d6602f2fd888181c69295af60c693d6b8b320c24224ab77968ab4'
+  version '0.9.9.15.2'
+  sha256 '8790593d06bd208e2d0e668e97c5b93aa0d33e373219078dbb9302edb9fcd0fa'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '60b164ffa99d5e54afaf3ff609fe82a464e9a775ba4520309a0e9b8ba4389a40'
+          checkpoint: '22b2e2b28ccfdacab46f7e0d976d28209aa922b2bb423720b2a0b1fe98c7bb8a'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.