### PR TITLE
Update visual-studio-code to 1.23.0,7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code' do
-  version '1.22.2,3aeede733d9a3098f7b4bdc1f66b63b0f48c1ef9'
-  sha256 '92e51c4be9e945a295d719ed2e5e570daf98a4fd1c7be3192ca4f6ffe28f7020'
+  version '1.23.0,7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45'
+  sha256 '868b28b19afdb090a397ee2229da1d87082b5e715764d525400d97a6f57f6f88'
 
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/stable/VERSION',
-          checkpoint: 'e1fa33e0e058dcde10e6559b19bd75503054bd3aafad8e77b3cca44e7f3483a8'
+          checkpoint: '5e76fa46be9175bf3c77e0b12a3d912d566004fff21d97ea1b87fabe8c164c51'
   name 'Microsoft Visual Studio Code'
   name 'VS Code'
   homepage 'https://code.visualstudio.com/'

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -5,7 +5,7 @@ cask 'visual-studio-code' do
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/stable/VERSION',
-          checkpoint: '5e76fa46be9175bf3c77e0b12a3d912d566004fff21d97ea1b87fabe8c164c51'
+          checkpoint: 'f52d96a5ab4d9b86cf3efbdf221450f0ca0eb61e4f64de655be446c0cba58aec'
   name 'Microsoft Visual Studio Code'
   name 'VS Code'
   homepage 'https://code.visualstudio.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.