### PR TITLE
Update postbox to 6.0.6,1_791ca5d8da0583340c515aff3f1501c0061559af

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.0.5,1_a8751702fe9e017c2d4ed3fd23c6b6aa9b230c49'
-  sha256 'cd3ef95c5778c87fd4da63d20a26fa524a1164d82644dbe873ba56b44a07cc70'
+  version '6.0.6,1_791ca5d8da0583340c515aff3f1501c0061559af'
+  sha256 'eafe4359fbb5e0311556911343fb8dea8e12f1254ce2a765f5faa8449fdc9671'
 
   # amazonaws.com/download.getpostbox.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/download.getpostbox.com/installers/#{version.before_comma}/#{version.after_comma}/postbox-#{version.before_comma}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.