### PR TITLE
Update kid3 to 3.6.1

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,11 +1,11 @@
 cask 'kid3' do
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  version '3.6.0'
-  sha256 '64b0b6af0e146f1a80f6f56063410b7c43183747916bfc475758057aaf61032d'
+  version '3.6.1'
+  sha256 '07844015af79674461e9cf46eef5991aac02cbeecd9dee9b88c33200b4a508e2'
 
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin.dmg"
   appcast 'https://sourceforge.net/projects/kid3/rss',
-          checkpoint: 'dbf9ad50da002d6bcdd029f014093f68d8a378e6ac62a25629e7b2505665f23a'
+          checkpoint: '9f70ca398a4588a6175ef15aa998627b2bd3b61931cd72c44345495d2aaa2b81'
   name 'Kid3'
   homepage 'http://kid3.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.