### PR TITLE
Update kite to 0.20180502.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20180329.1'
-  sha256 'b03fe9355aa37502e6bdad3744d7069afc6e16c767be9d2e77052bbc948be300'
+  version '0.20180502.1'
+  sha256 '9cd5e91808754292dd78e656f9b3211fce80de5f720e444421c51c0b41ee2ba2'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: 'c47cf74ffc7cdd181a0e864b405beec4213da1c88bc62f99f199dcd569e7172c'
+          checkpoint: 'a037f68abea6ff103b52bf5ee60213d87c289a338ec8102bacd221f7469ec512'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.