### PR TITLE
Update unity-linux-support-for-editor to 2018.1.0f2,d4d99f31acba

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2017.4.1f1,9231f953d9d3'
-  sha256 '2497328952944e9f6aab796e96e549046d272641f7bc026c5c6348669ca5f6d4'
+  version '2018.1.0f2,d4d99f31acba'
+  sha256 '5e674d5cfac66c537340fb7edda80f546f817a81a49272417d429b134add89eb'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Linux Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.