### PR TITLE
Update unity-windows-support-for-editor to 2018.1.0f2,d4d99f31acba

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,14 +1,14 @@
 cask 'unity-windows-support-for-editor' do
-  version '2017.4.1f1,9231f953d9d3'
-  sha256 'a10027e471187eda4e51b097f8531702edbd77ba1620d683fef5b544fd2ec786'
+  version '2018.1.0f2,d4d99f31acba'
+  sha256 '31a96532a48bb69f34f36bff452ba8fcceb1c7d2b08555a0c2e2310967ad6815'
 
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
-  name 'Unity Windows Build Support'
+  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
+  name 'Unity Windows (Mono) Build Support'
   homepage 'https://unity3d.com/unity/'
 
   depends_on cask: 'unity'
 
-  pkg "UnitySetup-Windows-Support-for-Editor-#{version.before_comma}.pkg"
+  pkg "UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
 
   uninstall pkgutil: 'com.unity3d.WindowsStandaloneSupport'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.