### PR TITLE
probot: lock closed issues/pull requests

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,13 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 90
+# Comment to post before locking. Set to `false` to disable
+lockComment: false
+# Issues or pull requests with these labels will not be locked
+# exemptLabels:
+#   - no-locking
+# Limit to only `issues` or `pulls`
+# only: issues
+# Add a label when locking. Set to `false` to disable
+lockLabel: false


### PR DESCRIPTION
https://probot.github.io/apps/lock/
https://github.com/dessant/lock-threads

> only 30 issues and pull requests will be locked per hour. If your repository has more than that, it will just take a few hours or days to lock them all.

@vitorgalvao I don't have permissions to enable this for Caskroom but I've sent a "request", which seems to be a new GitHub feature.