### PR TITLE
Update shotcut to 18.05.03

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,11 +1,11 @@
 cask 'shotcut' do
-  version '18.03.06'
-  sha256 'ee30e49bd6ef83c9fda20b194641d45aee5ba728edc742ca2935fe5f89ceec25'
+  version '18.05.03'
+  sha256 '7a8d76551df1d18d92e9452a1d981b8165756695bfe740fc20f1d7c8f671b4b7'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom',
-          checkpoint: '30ad666d17c17c714d28555d84b9ef7f3c7250809a46542b805a1213b79ac292'
+          checkpoint: 'a826b75fad65ad8a5112f85fc92462be5c0a7edcb12495e7e84e07ed492ead2b'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.