### PR TITLE
Update qt-creator to 4.6.1

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.6.0'
-  sha256 '3a39f078bcdc2bcc563df284c26ba236b889750eec8fa36b3996d8682be7f24a'
+  version '4.6.1'
+  sha256 '50d9d084e84f963bf4dc191047b9498bf17878f65d2f01946921097b8b631e37'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.