### PR TITLE
Update omniplan to 3.9.3

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,6 +1,6 @@
 cask 'omniplan' do
-  version '3.9.2'
-  sha256 'a96ac0fcb37f1c48f2160ad0c7658535573a089a84786d6d3a489636736c4498'
+  version '3.9.3'
+  sha256 'da90a0377117aea9b4e81d386cae9203f3ce486abe3c08cd49c7a22149296a5c'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
   name 'OmniPlan'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.