### PR TITLE
spek: Warn High Sierra users about incompatibility

### DIFF
--- a/Casks/spek.rb
+++ b/Casks/spek.rb
@@ -10,4 +10,8 @@ cask 'spek' do
   homepage 'http://spek.cc/'
 
   app 'Spek.app'
+
+  if MacOS.version >= :high_sierra
+    opoo 'Spek may not work for some users on High Sierra. There are forks with compatibility, but they are not currently available on Homebrew. See https://github.com/caskroom/homebrew-cask/pull/46109 for more information.'
+  end
 end


### PR DESCRIPTION
Spek doesn't work on High Sierra for some people. Cask [opted not to change to a working fork](https://github.com/caskroom/homebrew-cask/pull/46109), so this commit at least alerts people to the situation.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
