### PR TITLE
Update lyricsx to 1.3.1

### DIFF
--- a/Casks/lyricsx.rb
+++ b/Casks/lyricsx.rb
@@ -1,10 +1,10 @@
 cask 'lyricsx' do
-  version '1.3.0'
-  sha256 '6d39e5eb7e903983c58fbf986cd2ad0c782b5ceb994eabac88f00aa7f9501904'
+  version '1.3.1'
+  sha256 '1183404fde863a13825ac34139b4f3af184b5ce16fc4f775850d6fa847d452d3'
 
   url "https://github.com/ddddxxx/LyricsX/releases/download/v#{version}/LyricsX.app.zip"
   appcast 'https://github.com/ddddxxx/LyricsX/releases.atom',
-          checkpoint: '932fc65788005b8f38d8f507df73d2045ac4041f3de425f66d2b8f5def2a2845'
+          checkpoint: '0f3a22b1292e451587166c258435d063e7808aaceafcd56563b6b169dbf09da2'
   name 'LyricsX'
   homepage 'https://github.com/ddddxxx/LyricsX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.