### PR TITLE
Update fuse to 1.8.1.15610

### DIFF
--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -1,13 +1,14 @@
 cask 'fuse' do
-  version '1.1.0.13808'
-  sha256 '2ca9a5e60d2d504935a13ac6618b06df045aabc2d33ed50bec8ce5fd7768d598'
+  version '1.8.1.15610'
+  sha256 '448fd88fef4dde6b258db3304dcbf8416237fd35ee928d48c4a0bc9d40d0556a'
 
-  # fuse-dl.azureedge.net was verified as official when first introduced to the cask
-  url "https://fuse-dl.azureedge.net/releaseartifacts/fuse_osx_#{version.dots_to_underscores}.pkg"
+  url "https://www.fusetools.com/downloads/#{version}/osx"
   name 'Fuse Fusetools'
   homepage 'https://www.fusetools.com/'
 
-  pkg "fuse_osx_#{version.dots_to_underscores}.pkg"
+  depends_on macos: '>= :mavericks'
+
+  pkg "fuse_osx_#{version.dots_to_underscores}"
 
   uninstall pkgutil: 'com.fusetools.fuse'
 end

--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -7,8 +7,15 @@ cask 'fuse' do
   homepage 'https://www.fusetools.com/'
 
   depends_on macos: '>= :mavericks'
+  container type: :pkg
 
-  pkg "fuse_osx_#{version.dots_to_underscores}.pkg"
+  pkg 'fuse.pkg'
+
+  # This is a horrible hack to force the file extension.
+  # The backend code should be fixed so that this is not needed.
+  preflight do
+    system_command '/bin/mv', args: ['--', staged_path.join('osx'), staged_path.join('fuse.pkg')]
+  end
 
   uninstall pkgutil: 'com.fusetools.fuse'
 end

--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -8,7 +8,7 @@ cask 'fuse' do
 
   depends_on macos: '>= :mavericks'
 
-  pkg "fuse_osx_#{version.dots_to_underscores}"
+  pkg "fuse_osx_#{version.dots_to_underscores}.pkg"
 
   uninstall pkgutil: 'com.fusetools.fuse'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.