### PR TITLE
Update qdesktop to 0.1.2-6

### DIFF
--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -4,8 +4,8 @@ cask 'qdesktop' do
 
   # github.com/qvacua/qdesktop was verified as official when first introduced to the cask
   url "https://github.com/qvacua/qdesktop/releases/download/v#{version}/Qdesktop-#{version.major_minor_patch}.zip"
-  appcast 'http://qvacua.com/qdesktop/appcast.xml',
-          checkpoint: '0b0de69503c4c5c113458705f0ca13e91bc87c0ca91e8a395ca25d5d80d39384'
+  appcast 'https://github.com/qvacua/qdesktop/releases.atom',
+          checkpoint: '3315189f2786ae5c1423da690d6d512af3b3f8f0b309eecf0b78e0f3c607798c'
   name 'Qdesktop'
   homepage 'http://qvacua.com/'
 

--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -1,9 +1,9 @@
 cask 'qdesktop' do
-  version '0.1.1'
-  sha256 '1eddd3513cca892fb8e53452d79d4589ef5b1e3cd885a1f52748b6df64588094'
+  version '0.1.2-6'
+  sha256 '80091362a4350baf14aa0d78eae0078ee974f68b9fa440a75569a4e591d3813a'
 
-  # bitbucket.org/qvacua/qvacua was verified as official when first introduced to the cask
-  url "https://bitbucket.org/qvacua/qvacua/downloads/Qdesktop-#{version}.zip"
+  # github.com/qvacua/qdesktop was verified as official when first introduced to the cask
+  url "https://github.com/qvacua/qdesktop/releases/download/v#{version}/Qdesktop-#{version.major_minor_patch}.zip"
   appcast 'http://qvacua.com/qdesktop/appcast.xml',
           checkpoint: '0b0de69503c4c5c113458705f0ca13e91bc87c0ca91e8a395ca25d5d80d39384'
   name 'Qdesktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.