### PR TITLE
Update liteide to 33.3,5.9.5

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,11 +1,11 @@
 cask 'liteide' do
-  version '33.2'
-  sha256 'abaf9492c156048bff09fb3c6dac7657fbc6fb73389264f24b2cd03d81ad2e47'
+  version '33.3,5.9.5'
+  sha256 '0d8c86fe72f5583797932664943ad09f4af3785cbfab224a052b01735ee1007c'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
-  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macosx-qt5.zip"
+  url "https://github.com/visualfc/liteide/releases/download/x#{version.before_comma}/liteidex#{version.before_comma}.macosx-qt#{version.after_comma}.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom',
-          checkpoint: 'c19004e6cdb7414f81805b957fc88d0ad1dffc265952ffcf17455407b2d6ec43'
+          checkpoint: 'ed5ec42ee9567478e224a13ad303ab12c9232a286f44a05dbf7b02c025bec8fe'
   name 'LiteIDE'
   homepage 'http://liteide.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.