### PR TITLE
Update mac2imgur to b226

### DIFF
--- a/Casks/mac2imgur.rb
+++ b/Casks/mac2imgur.rb
@@ -3,8 +3,8 @@ cask 'mac2imgur' do
   sha256 '8faeb435fcb866267fa67d4b93d5fc9fb82bcfb2e959c7fcc6f59ab15fb05ccb'
 
   url "https://github.com/mileswd/mac2imgur/releases/download/#{version}/mac2imgur.zip"
-  appcast 'https://raw.githubusercontent.com/mileswd/mac2imgur/master/Resources/appcast.xml',
-          checkpoint: 'da366727457f59fc675cf7f486ec5f1dde7b3c5c80b0caa4f327af6b069daa3d'
+  appcast 'https://github.com/mileswd/mac2imgur/releases.atom',
+          checkpoint: '5078de9b5f76f2d5c9ad91d4b793fbaca67bd908253eb3576add883d674db837'
   name 'mac2imgur'
   homepage 'https://github.com/mileswd/mac2imgur'
 

--- a/Casks/mac2imgur.rb
+++ b/Casks/mac2imgur.rb
@@ -1,10 +1,10 @@
 cask 'mac2imgur' do
-  version 'b223'
-  sha256 'b2e4dce409b2855a351beedd0151da08c7f90567cba8dd1f4f21ce02beb4f345'
+  version 'b226'
+  sha256 '8faeb435fcb866267fa67d4b93d5fc9fb82bcfb2e959c7fcc6f59ab15fb05ccb'
 
   url "https://github.com/mileswd/mac2imgur/releases/download/#{version}/mac2imgur.zip"
-  appcast 'https://mileswd.com/mac2imgur/update',
-          checkpoint: '57c7f3e153fb500c6db3534651d4fb93c291b399c4c7578cc427b4278715963c'
+  appcast 'https://raw.githubusercontent.com/mileswd/mac2imgur/master/Resources/appcast.xml',
+          checkpoint: 'da366727457f59fc675cf7f486ec5f1dde7b3c5c80b0caa4f327af6b069daa3d'
   name 'mac2imgur'
   homepage 'https://github.com/mileswd/mac2imgur'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.