### PR TITLE
Update mal-updater to 2.4.4

### DIFF
--- a/Casks/mal-updater.rb
+++ b/Casks/mal-updater.rb
@@ -1,11 +1,11 @@
 cask 'mal-updater' do
-  version '2.4.3'
-  sha256 '682540991b701896a4c664d930690e99f8acc0d4527369a9620332d2ba586df7'
+  version '2.4.4'
+  sha256 'efe4b238a0dee5d9baf74af330e6dabd758ce858c4e1ca33d476ac3c1c56af8b'
 
   # github.com/Atelier-Shiori/malupdaterosx-cocoa was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases/download/#{version}/malupdaterosx-#{version}.dmg"
   appcast 'https://github.com/Atelier-Shiori/malupdaterosx-cocoa/releases.atom',
-          checkpoint: '4e4d5e15393454b3944ebeb27b971e1f79f8d227e423f38c7312dbfe05afff34'
+          checkpoint: 'f0e79ff5bc4c29b1e2bdfb5d50f4edc5f09123f7bd67fd9c758a4e22a8226985'
   name 'MAL Updater OS X'
   homepage 'https://malupdaterosx.ateliershiori.moe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.