### PR TITLE
Update manta to 1.1.4

### DIFF
--- a/Casks/manta.rb
+++ b/Casks/manta.rb
@@ -1,11 +1,11 @@
 cask 'manta' do
-  version '1.1.2'
-  sha256 'f3907c15172e7effefcc8a555c53e322d668a8c33216d9702f50a371564a4cd3'
+  version '1.1.4'
+  sha256 'f980f8d0c233e923a2352fd10521c1a04d059bc15140504bb7d2cfe235838776'
 
   # github.com/hql287/Manta was verified as official when first introduced to the cask
   url "https://github.com/hql287/Manta/releases/download/v#{version}/Manta-#{version}-mac.zip"
   appcast 'https://github.com/hql287/Manta/releases.atom',
-          checkpoint: '71e11321e83109b18ef39893a1aa7053b87f9865d756bfd8aa9eeb77c654592f'
+          checkpoint: '3f155e55dd8fb01cc72353f8c98058fbde6768e198ffe02c7bb7f650823e0044'
   name 'Manta'
   homepage 'https://manta.life/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.