### PR TITLE
Update IDA free 7.0 SHA

### DIFF
--- a/Casks/idafree.rb
+++ b/Casks/idafree.rb
@@ -1,6 +1,6 @@
 cask 'idafree' do
   version '7.0'
-  sha256 'aaf962bf02134f147cba56fe6b2c146549f5b270512e1406a4004f417e2799ac'
+  sha256 '7cbcfbcbff4154e358428987e8511196cc84a1562de4406ba13c6df5d2230bcb'
 
   url "https://out7.hex-rays.com/files/idafree#{version.no_dots}_mac.tgz"
   name 'IDA Free'

--- a/Casks/idafree.rb
+++ b/Casks/idafree.rb
@@ -7,7 +7,7 @@ cask 'idafree' do
   homepage 'https://www.hex-rays.com/index.shtml'
 
   installer script: {
-                      executable: "idafree#{version.no_dots}_mac.app/Contents/MacOS/installbuilder.sh",
+                      executable: "idafree-#{version}-osx-installer.app/Contents/MacOS/installbuilder.sh",
                       args:       ['--mode', 'unattended'],
                     }
 


### PR DESCRIPTION
The sha provided is actually the SHA-1 and not SHA256 thus the checksum check fails. I've updated it to use the SHA256

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Verification: https://www.virustotal.com/#/file/7cbcfbcbff4154e358428987e8511196cc84a1562de4406ba13c6df5d2230bcb/detection