### PR TITLE
Update chemdoodle to 9.0.1

### DIFF
--- a/Casks/chemdoodle.rb
+++ b/Casks/chemdoodle.rb
@@ -1,10 +1,12 @@
 cask 'chemdoodle' do
-  version '9.0.0'
-  sha256 'ab3c7ee5372d00cbd39440a27752ae52d0e9a02caeb750e087991be7d2811445'
+  version '9.0.1'
+  sha256 'ea2aba830bf2251094e6b3f3836a63d0619185db576d6da85c74f8d66ff62672'
 
   url "https://www.chemdoodle.com/downloads/ChemDoodle-osx-#{version}.dmg"
   name 'ChemDoodle'
   homepage 'https://www.chemdoodle.com/'
+
+  depends_on macos: '>= :yosemite'
 
   suite 'ChemDoodle'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.