### PR TITLE
Update metaz to 1.0.beta-45

### DIFF
--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -1,11 +1,11 @@
 cask 'metaz' do
-  version '1.0.beta-35'
-  sha256 '9b778eea86ac68a38bc40b88d5a74da6e6cb4a521e2ed1e8b62957309a286ffd'
+  version '1.0.beta-45'
+  sha256 'a1c2281fc135a93000e48878c45ec5ecbe9c2c7b47b7220949a3314286ffa768'
 
   # github.com/griff/metaz was verified as official when first introduced to the cask
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"
   appcast 'https://github.com/griff/metaz/releases.atom',
-          checkpoint: '64ad5ec7895d8b890eab9abef034c46083d783d1d4f40c7e41f3ed978bf49921'
+          checkpoint: '51560bb781c5d022800a848ad695a6ad5803db5b881f2cbe588afcf3a99f2e26'
   name 'MetaZ'
   homepage 'https://griff.github.io/metaz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.