### PR TITLE
Update microblog to 1.3.1

### DIFF
--- a/Casks/microblog.rb
+++ b/Casks/microblog.rb
@@ -1,11 +1,11 @@
 cask 'microblog' do
-  version '1.1.4'
-  sha256 '621f4c15374605760862aab74669ee102a8381aab3a24550266bb5a0ab523343'
+  version '1.3.1'
+  sha256 '75fbf1a8aa9856c4f6e927460fbc6cd7832aa839ba055c0dbefde149a79ad76a'
 
   # s3.amazonaws.com/micro.blog was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/micro.blog/mac/Micro.blog_#{version}.zip"
   appcast 'https://s3.amazonaws.com/micro.blog/mac/appcast.xml',
-          checkpoint: 'f0458b12614000a968cc511816fe93760c33a894cc7e42851e193ec31343345c'
+          checkpoint: '6d9b59e5aeb334a95299f1226ca0c1b4730e18ebcd960fbf95762d6ea4b07251'
   name 'Micro.blog'
   homepage 'http://help.micro.blog/2017/mac-version/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.