### PR TITLE
Update netron to 1.7.7

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.6'
-  sha256 '99aaf906b3b4ab807d0d16e7e7c5b10885fa56b0e816a2bb48bc847ebcac04ed'
+  version '1.7.7'
+  sha256 '98bcd89f4b3a6e6bfa3997516b74152c15afe93d799bdae1e6de12e8ee7622d1'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'ca394bad81f1460f9c4adabb953de46f80b4b3425cc107a576a0ddfb62a23615'
+          checkpoint: '1d8e10dc3429c133d186755f6e9fcd15385417ba962d2fddd795761552baf4dc'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.