### PR TITLE
Update there to 1.4.7

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,11 +1,11 @@
 cask 'there' do
-  version '1.4.0'
-  sha256 '4159df1c346a6a84b20e37052431ca54ea5ca530dd4fb0e760e341b4f6cae7b3'
+  version '1.4.7'
+  sha256 'b4bb8a372ded5ac041d6720368bba2c6628cfe6e78a69be7abde61f49b0670b5'
 
   # github.com/therepm/there-desktop was verified as official when first introduced to the cask
   url "https://github.com/therepm/there-desktop/releases/download/v#{version}/there-desktop-#{version}-mac.zip"
   appcast 'https://github.com/therepm/there-desktop/releases.atom',
-          checkpoint: '69ddda50ce43dafff2a63d86188ca70dcd8a4f4c92173c3b24f7f1e75a80a6d5'
+          checkpoint: '66d03dec0b51b3baf12cf2fbac854abe95cf269b17fab464a5058bbce5fc2dfa'
   name 'There'
   homepage 'https://there.pm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.