### PR TITLE
Update radarr to 0.2.0.1067

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,11 +1,11 @@
 cask 'radarr' do
-  version '0.2.0.995'
-  sha256 '28119d8e5e32e8039278c094a22d33a30c98c48239dc79643532d5b0b7e444ef'
+  version '0.2.0.1067'
+  sha256 'bb0885cb03ad8b15811f1ff60439fafe45b699e51d47b6bc4c072242b18d2c78'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"
   appcast 'https://github.com/Radarr/Radarr/releases.atom',
-          checkpoint: '1220385ac520d66ebab3c7c83f7d42fc892df41ca4a901df437f223ba1ed9583'
+          checkpoint: '6964bd1370f3a535eb72088205d16531e97b0c299c58767cc2a6e7314fd60828'
   name 'Radarr'
   homepage 'https://radarr.video/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.