### PR TITLE
Update stretchly to 0.17.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,11 +1,11 @@
 cask 'stretchly' do
-  version '0.16.0'
-  sha256 'b87e7cc798effc8ac5ca948679f1de693556893c6b44e6c42d99ea4a3d12eaf3'
+  version '0.17.0'
+  sha256 '3da764b3abc61f9cb7ae042f0bc85da17c99dd8ccadca216cd43652347187dfa'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"
   appcast 'https://github.com/hovancik/stretchly/releases.atom',
-          checkpoint: '1835820d39bcdb08dc371830f798d2169db3bde1341fdebabbf85a2ef7f74d30'
+          checkpoint: 'b51d9a3af616f01e3f655e39fdd94b923ca79cb4a81d778c5c86f49c189f1092'
   name 'stretchly'
   homepage 'https://hovancik.net/stretchly/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.