### PR TITLE
Update TablePlus build to 104.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,11 +1,11 @@
 cask 'tableplus' do
-  version '1.0,103'
-  sha256 'ef418adc98a52ed2051722138cac36a28280cf0c9c10bfe8f37dcc72918370c8'
+  version '1.0,104'
+  sha256 'd68bc1f1b94a31c20cc87b0b5bcbeb8f2a58f9088dc189787cb285c711d03a07'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"
   appcast 'https://tableplus.io/osx/version.xml',
-          checkpoint: '9eacca9df95d634238f4d69f97ce02ce95e89df53289d0ad78bae1a709aa78e1'
+          checkpoint: '060599417f49a18d5d34fb659a935870c7405c6c968b7e595b005664c3b6919b'
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.