### PR TITLE
Update jet to 2.5.1

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,6 +1,6 @@
 cask 'jet' do
-  version '2.4.1'
-  sha256 '173c3653fbf57ccb16d73840455b48298d4218b75136732b168b885895f2894f'
+  version '2.5.1'
+  sha256 '80d4112145b3e8b3414a060d46f6cacbf6bbc29983468b0e89145cb5d00cbe68'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.