### PR TITLE
Update microsoft-teams to 1.1.00.11551

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-teams' do
-  version '1.1.00.8752'
-  sha256 '537e0030d0e93c91daf449d6913bdbf2b833f07e9375ea3fe0ddbd153643020d'
+  version '1.1.00.11551'
+  sha256 '971b4cf18b4f8d8578d0e762b489ccf0a8f999174c0e2d4d2df11ee7516a0980'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx',
-          checkpoint: 'd048d6663c4deb572a128f551acec1826637eda1277b0e63720a15e7542d2b88'
+          checkpoint: '9114c66e9c6d65128177ed94a416ab951048559864ed67c916e853a54ab2c5a5'
   name 'Microsoft Teams'
   homepage 'https://teams.microsoft.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.