### PR TITLE
Update mimolive to 4.0.2-24870

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,10 +1,10 @@
 cask 'mimolive' do
-  version '4.0.1-24864'
-  sha256 'd12ea1ec1b4d7796b0d46c06a7173b6f8a45a362fc8667626dbe8239d1a93a3f'
+  version '4.0.2-24870'
+  sha256 'fb49c0e865de6cd464b473f9d5336dd7c1758590c6e1b818cc5eb8ac4c715b26'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/mimolive',
-          checkpoint: '83df3181b727687306071420c961f616d5556b21c58d61d0f6dc61c652502505'
+          checkpoint: '903024a74400787d045155c7bcdb7089b46bcc2788eb90641bf2eaff849dc6e4'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.