### PR TITLE
Update minishift to 1.17.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.16.1'
-  sha256 'c8783645a6d9d1648c05db0b66c90edb6deceeab6a46bb739f4a238293d2df93'
+  version '1.17.0'
+  sha256 'fb2c5d2ce2c59e81a2ac33a13e6ec527c482f9ad3776d2aad644a679949fcc20'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: '3ba890792787f72e85146543e593e305eac74492ef803010ca1e22e594ee5087'
+          checkpoint: 'c8f4d71d08655894d1b712f251d3dbb0063e8d78236bbd9502b6cd96c2570f89'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.