### PR TITLE
Update mirrordisplays to 1.2

### DIFF
--- a/Casks/mirrordisplays.rb
+++ b/Casks/mirrordisplays.rb
@@ -1,11 +1,11 @@
 cask 'mirrordisplays' do
-  version '1.1'
-  sha256 'd1e39663d426cc7bdd23c0abd03b1a99d2ea4003e62c6824768547f087880089'
+  version '1.2'
+  sha256 '68b6b9a0bd79945d0e1239f308520a6cfd582fdde4dd061195de888b41643dd5'
 
   # github.com/fcanas/mirror-displays was verified as official when first introduced to the cask
   url "https://github.com/fcanas/mirror-displays/releases/download/v#{version}/MirrorDisplays.zip"
   appcast 'https://github.com/fcanas/mirror-displays/releases.atom',
-          checkpoint: '95b3f775e677d90f09f0c2b2a7b192ffddc73cf05cd45f79ae2c41807ee2cdd0'
+          checkpoint: '7c3f6b927fbf70891a0f805db308e60e0f85ad5ee7e312bd153176688c804d56'
   name 'Mirror Displays'
   homepage 'https://fabiancanas.com/open-source/mirror-displays'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.