### PR TITLE
Update lingon-x to 6.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '6.1'
-  sha256 '4f868f48cef8dbc9a7843da754e0b33b02a5da75f5ef8f28d5ef601fc5030486'
+  version '6.2'
+  sha256 '4bbda23e57d7be8c461e13217e586c5b3fa265243f761cf29f57c21b3c8a6a09'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '00c2ca18407dc91b927d4406ee96a8b250e0842adea70eda063864d29bb160ea'
+          checkpoint: '5d33fc35b648f9fb8d91188f5244f17e0a90d6aabfa4d65a30c99e8554ac8584'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.