### PR TITLE
Update qtpass to 1.2.2

### DIFF
--- a/Casks/qtpass.rb
+++ b/Casks/qtpass.rb
@@ -1,11 +1,11 @@
 cask 'qtpass' do
-  version '1.2.1'
-  sha256 '9da6c00fcc57087c00079a89f225a48b008b0fba1f9f50c0ea67261d3f7de58b'
+  version '1.2.2'
+  sha256 '1fa21f618a4bd28cef7e97bc2a470f537a366319e9523d13048535d78ec1d65f'
 
   # github.com/IJHack/qtpass was verified as official when first introduced to the cask
   url "https://github.com/IJHack/qtpass/releases/download/v#{version}/qtpass-#{version}.dmg"
   appcast 'https://github.com/IJHack/qtpass/releases.atom',
-          checkpoint: '4469441746cad35ff53aa44c10d7b60bcab34d487ee8c054c64a469a0f7e28bd'
+          checkpoint: '99b7eb2c0f2ac3022681b61cf48affce42c54fb64f9e656e257d6e7770025bec'
   name 'QtPass'
   homepage 'https://qtpass.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.