### PR TITLE
Update munki to 3.2.1.3499

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,11 +1,11 @@
 cask 'munki' do
-  version '3.2.0.3476'
-  sha256 '845f129dc33a0624f4ff526107294285355b597bf701e3d7888ae7a77b8106fb'
+  version '3.2.1.3499'
+  sha256 '349c8b3a74f86d397b3a6025ce490da280286c4cfc610b633ce63b5e4e4d3ad4'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: '9668f7e2a4a576c5772f78041af6266a1be6a7501e0736cfd0c2cf6561d3ff7b'
+          checkpoint: 'bb68e350b7cb6e386a5ae87a88bc9975c62fd8f44fdb6ab0fae32e0ec4c9280d'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.