### PR TITLE
Update prizmo to 3.5.0.1

### DIFF
--- a/Casks/prizmo.rb
+++ b/Casks/prizmo.rb
@@ -1,10 +1,10 @@
 cask 'prizmo' do
-  version '3.5'
-  sha256 '146703a2fa149ca7e79e3bec083b7dbdaeedd510dc86751308e3e18345c10d16'
+  version '3.5.0.1'
+  sha256 '7e22f923312bd1dc862e5b9c8fa89f68f47d23f0e027a2b81e4aac871dbca6d5'
 
   url "https://www.creaceed.com/downloads/prizmo#{version.major}_#{version}.zip"
   appcast "https://www.creaceed.com/appcasts/prizmo#{version.major}.xml",
-          checkpoint: '62556f7ad6a75443c608c17f1e8adf29513335f3c62c251824b4d4c1cc5b7770'
+          checkpoint: '3f4dcf20f374e5fd3d9155c51b4fb5ad373c1e98cb2fb8dfc9c45758045fcb57'
   name 'Prizmo'
   homepage 'https://creaceed.com/prizmo'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.