### PR TITLE
Update rubitrack-pro to 5.0.2

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '4.4.8'
-  sha256 '3088c89372b296518c3441421df71e8a9028cd9ebc99254720aa5380e78862fa'
+  version '5.0.2'
+  sha256 'a4b2ce1fe96f32dfce83f708d0aadb57c6e31e3f4d151f5ae6916fa242aa1ba6'
 
-  url "https://www.rubitrack.com/files/rubiTrack-#{version}_u.dmg"
+  url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: '1702cd16a2e5eefac0b6a377c7b108ddd96345c544c3a633438aabdf0660704a'
+          checkpoint: '38da165545e9e2f5048abfd5bfad25a92ac781630da00a66eab4d22574cfd517'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.