### PR TITLE
Update zerotier-one to 1.2.8

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -10,6 +10,7 @@ cask 'zerotier-one' do
 
   pkg 'ZeroTier One.pkg'
 
-  uninstall pkgutil: 'com.zerotier.pkg.ZeroTierOne',
-            kext:    'com.zerotier.tap'
+  uninstall pkgutil:   'com.zerotier.pkg.ZeroTierOne',
+            launchctl: 'com.zerotier.one',
+            kext:      'com.zerotier.tap'
 end

--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -10,5 +10,6 @@ cask 'zerotier-one' do
 
   pkg 'ZeroTier One.pkg'
 
-  uninstall pkgutil: 'com.zerotier.pkg.ZeroTierOne'
+  uninstall pkgutil: 'com.zerotier.pkg.ZeroTierOne',
+            kext:    'com.zerotier.tap'
 end

--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -1,10 +1,10 @@
 cask 'zerotier-one' do
-  version '1.2.4'
-  sha256 '127216c5287d748a8e63bea0487775ea18a51b84fbcdd9461caa85da07c3991a'
+  version '1.2.8'
+  sha256 '13f39b296e04b309fbd6fb3b1a8ade3a85479ff4ea7db151ce2da1678a1eff31'
 
   url 'https://download.zerotier.com/dist/ZeroTier%20One.pkg'
   appcast 'https://github.com/zerotier/ZeroTierOne/releases.atom',
-          checkpoint: '71ba09b3edd757ba67d9283c1203b1282d3a5d48ed9d6de6f147e152de6d075c'
+          checkpoint: 'f9e5f3fdc8a07ee63b0c84c023267c5f088c99d65721e2dec0dd49a0330206e6'
   name 'ZeroTier One'
   homepage 'https://www.zerotier.com/download.shtml'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.