### PR TITLE
Update get-iplayer-automator to 1.13.4.b20180501001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.13.3.b20180411001'
-  sha256 'f65c322486c4b00386151ef49560a2f8aec0cc8ea0860d761fc32bebd6ace1be'
+  version '1.13.4.b20180501001'
+  sha256 '1942885851bc761602c77d662756f64a50cbbedbaccd2392e701a565a0751770'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          checkpoint: '411c4d2d4a717c7f7bf55aef10b53d8a904822a076d53d87b30e96c9c1ef4623'
+          checkpoint: '9e639332bc8162dfef0d4ecbe2b339b40ed87c98ece45811da6a8df95a67e39e'
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.