### PR TITLE
Update exifrenamer to 2.2.1

### DIFF
--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -1,10 +1,10 @@
 cask 'exifrenamer' do
-  version '2.2.0'
-  sha256 '9ab4382186943cbeaceaa2a5f22c0f6b69f095468a4aeb15537e68239820c60f'
+  version '2.2.1'
+  sha256 '559da5db5a118cfe0fc183e9aeb820badaba1f1b06b0b4e5db81eda92116cb52'
 
   url 'https://www.qdev.de/downloads/files/ExifRenamer.dmg'
   appcast 'https://www.qdev.de/versions/ExifRenamer.txt',
-          checkpoint: 'edc8e395a5182e3b231816e191b303407d511f70c1d9cb6d532927cc559c507c'
+          checkpoint: 'd01c4e9bf10ed63e0de02bdaa54ae5a279486e9125f5febcc5d8bb3fab332568'
   name 'ExifRenamer'
   homepage 'https://www.qdev.de/?location=mac/exifrenamer&forcelang=en'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.