### PR TITLE
Update keybase to 1.0.47-20180508010858,c06519b740

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,10 +1,10 @@
 cask 'keybase' do
-  version '1.0.47-20180410052738,f705a9510f'
-  sha256 '1f919cc2ef8d52d9e54a0e0b31383e42c6142994304271e3ac8a20d0a3c18802'
+  version '1.0.47-20180508010858,c06519b740'
+  sha256 'd58d857a72d5710c68b42fb7432d11e46edb6e393fc66d0e5961b4ba4be26bb4'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json',
-          checkpoint: '75b6d0ab6dfe8c1b1eaabe49cdee004320e2f9fd4579993c9795faae8f8c71e3'
+          checkpoint: 'a2ca0b317f0217e88d8aae454fda13f51bd842b37f515639ae568de9ce459c08'
   name 'Keybase'
   homepage 'https://keybase.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.