### PR TITLE
Update plex-media-server to 1.13.0.5023-31d3c0c65

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,10 +1,10 @@
 cask 'plex-media-server' do
-  version '1.12.3.4973-215c28d86'
-  sha256 '3b33f8d8199491bfcd454efe2309ef39b5ccc337c039a7d608149c2415038e95'
+  version '1.13.0.5023-31d3c0c65'
+  sha256 'ebad5dd399fa0ecd719b4a3d81103901db757ec9be0e179817ca523a18861f18'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   appcast 'https://plex.tv/api/downloads/1.json',
-          checkpoint: '97fc5f9e6aa6491d1f04b31dda47c3c7a5a2efc0ae7026f198eae9c06eb398cd'
+          checkpoint: '546bef9f92366644323103bae38bf8499581667bea1aa1a21e6b1beae33a0cce'
   name 'Plex Media Server'
   homepage 'https://www.plex.tv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.