### PR TITLE
Update nylas-mail-lives to 2.2.3

### DIFF
--- a/Casks/nylas-mail-lives.rb
+++ b/Casks/nylas-mail-lives.rb
@@ -1,10 +1,10 @@
 cask 'nylas-mail-lives' do
-  version '2.2.2'
-  sha256 '4403231644c2cbca7d07c2763ff1a8116687ef499bd2e1ba544f1826f8cecfe2'
+  version '2.2.3'
+  sha256 '01bfc2625b4de06da1164e0cb78661a6a7d0aca9d235984c3fd249a70632f0a9'
 
-  url "https://github.com/nylas-mail-lives/nylas-mail/releases/download/#{version}/nylas-mail-#{version}.dmg"
+  url "https://github.com/nylas-mail-lives/nylas-mail/releases/download/#{version}/NylasMail.dmg"
   appcast 'https://github.com/nylas-mail-lives/nylas-mail/releases.atom',
-          checkpoint: 'facf678c3480dd77ac1f31de0e99b82d1a6b695fa001be7b44b919551740c091'
+          checkpoint: 'fd60b726eba11f5dd20c7a1d382d5ebf41bfc098c854e631e935d6b70e1e9d32'
   name 'Nylas Mail Lives'
   homepage 'https://github.com/nylas-mail-lives/nylas-mail'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.