### PR TITLE
Update omnioutliner to 5.3

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -4,9 +4,11 @@ cask 'omnioutliner' do
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}",
-          checkpoint: 'e90144e5478e8bf259933e9ded9db14a26d0332cb8925c4a2f9fd7770ae1cb1e'
+          checkpoint: '31f197afde53bbfd9107cb329facd026fefacb23af55a0a8232974936e8139c3'
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
+
+  depends_on macos: '>= :sierra'
 
   app 'OmniOutliner.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.