### PR TITLE
Update torbrowser to 7.5.4

### DIFF
--- a/Casks/torbrowser.rb
+++ b/Casks/torbrowser.rb
@@ -1,89 +1,89 @@
 cask 'torbrowser' do
-  version '7.5.3'
+  version '7.5.4'
 
   language 'ar' do
-    sha256 'd774f12c24391b9974366a0bfb7858cda10f2432021a7e8503886654b6fd937c'
+    sha256 '062cf091cb34a0bd6c8d95e82b38f3ca8dd3980127d4a73ce12915878f10be59'
     'ar'
   end
 
   language 'de' do
-    sha256 '03fb7decf5f9c0730b036554ce5ca7ff235281c837523fe7c5d71b7909a8eafb'
+    sha256 'b94de2cb5af970b7bae3c61efc81a392eaea92a3a824fe46f52e956ac91af6c7'
     'de'
   end
 
   language 'en', default: true do
-    sha256 '384614270449014bedf003c44b8daed0539bd9c8b646b6ac9d40cb0943a60629'
+    sha256 '298cd494d144ae6ec30922e0b1800ecb5f7bff75ea654b9b32b38bec52d927a9'
     'en-US'
   end
 
   language 'es' do
-    sha256 '0442d761d80ada30c657fc7e47bb5e6f1e27ac135cfbf58c16ac873afdf2f82e'
+    sha256 '4409e646893cbfc9f05d5a0c85a912c32ae87c6abc8e0b2b9dec09e50b35db68'
     'es-ES'
   end
 
   language 'fa' do
-    sha256 'acd17970d885ac4d3dc8f688ad6bc9c805df7e4ed10501d8740fcab8f6076771'
+    sha256 'aa1569f2f090f0cae2608e8e0e72a16852ae09fd0f66679d348041820ebe3ce1'
     'fa'
   end
 
   language 'fr' do
-    sha256 '377ebb074d34f626ea5dfd790d901fc94e645f9f1c9fedbc0d9062f6f4b042f7'
+    sha256 'e0d94bdd9c302f8af920462330d457aed9f4554b788227b6f37e011f91bcf6cc'
     'fr'
   end
 
   language 'it' do
-    sha256 '7233047673f31638ce00c88f24cc10801243132e3e7f753e80a7b0feb1c84c82'
+    sha256 'f28aa6b07d6e1ced13ac356b3930645a20e4324b8b435b6d9b1ef43e14893a69'
     'it'
   end
 
   language 'ja' do
-    sha256 '95f74de2d22f6613a29b7b38fcb4709f333ea817ff82abcafa48a8843d88f72e'
+    sha256 '5ea6b09ad0aa5f5241ae4e3e209e15fc3445fd96f56e8cb61f107105123d7425'
     'ja'
   end
 
   language 'ko' do
-    sha256 '5b45203ca1eea5913dab6f9bbc183552175b0ab11ed439123f6b42036d88a8fe'
+    sha256 'd0285a3ee7704736e7cec33982b62dfeb7bc8cc196e91bb2b21172a220444939'
     'ko'
   end
 
   language 'nl' do
-    sha256 '79e66d3c64d055a4132d550c76aaff11e4b2e63f809dc880e669a12d814b230c'
+    sha256 '157f9f665d355a36491ce6134273fc24565f1eaf771e47bb6fa4f2b82928d2a7'
     'nl'
   end
 
   language 'pl' do
-    sha256 'fe52de1d85bda66d84842b0c57ecc33c451af0b7785d279dfdb86f830e55fc0c'
+    sha256 '21e856c5327b66248ea25a8977bc247ed1d4b6fc660c2194aae755eb1468ea86'
     'pl'
   end
 
   language 'pt' do
-    sha256 'ff714c4fe6ae409ebe0e4d6a154c4a956c18c3d16deb45d83fb0d09ffd0aac84'
+    sha256 'f58009d34eb152329b84f0828d77f4e5a93e6fd73263bf83a2898a522b2482fc'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 'be9962ddb9059f41e1c66a44e084de58ff29edd8763e2239377c4d1d59809c6a'
+    sha256 '9beeeba0de384e372d74a91ba55214555f03f0930f70d29825c1c94c3516ff3d'
     'ru'
   end
 
   language 'tr' do
-    sha256 '21a2c3b493f8014cd30871e979848205e3ba7f4ef811c13881eed25b0e4d9544'
+    sha256 '03abb9b979d6d08f7cf3df6e3a767aaeb35103c9330bcd482b12d4e9f5124b76'
     'tr'
   end
 
   language 'vi' do
-    sha256 'ecc879d06ef6aa32ecd250c44c90499ce7ee28a0c95dc4010ee3697a267e8b31'
+    sha256 '505702858977c336f50b4f3da7dddc54362bb2a6e0cc9f2abfa075f445c0d0d4'
     'vi'
   end
 
   language 'zh' do
-    sha256 '6c6b45ce7dc0e01312cb4f23c910580c10202c874e254aba75aa12d2ebc63bb6'
+    sha256 'b6d2b3bb5c95247e17919a7ee2e5030e8f526a88266b05aa9b90d4d9b1c2311c'
     'zh-CN'
   end
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_#{language}.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: '9c83aed70d09743acaa211929cb3eb57921a1aaf46ca858bbae876404c2b8cb2'
+          checkpoint: '821b5e99ab6c6d95bc1a226bcb63fe153787ff864c19f6b8a807259f5a5941c4'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
