### PR TITLE
Update lyrics-master to 2.4.8.3

### DIFF
--- a/Casks/lyrics-master.rb
+++ b/Casks/lyrics-master.rb
@@ -1,6 +1,6 @@
 cask 'lyrics-master' do
-  version '2.4.8.2'
-  sha256 '7ae9ab9790c3a951ae831703dfa7f5dd2ea58527a8c4996ee126c68a1eedb6cb'
+  version '2.4.8.3'
+  sha256 '094e64ca879c8566ed4c090a101da57584fc9008b80ed2e7d49d14fb693afa31'
 
   url "http://www.kenichimaehashi.com/lyricsmaster/download/LyricsMaster#{version.no_dots}.dmg"
   name 'Lyrics Master'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.