### PR TITLE
Update securityspy to 4.2.4

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,10 +1,10 @@
 cask 'securityspy' do
-  version '4.2.3'
-  sha256 '007fe48dd93b19f48f876917bfea30dad5cdb1b33e688d8f68b583a4cf884ea2'
+  version '4.2.4'
+  sha256 '9a21f957622a79b8145079383ee8283151a249a57bce89d2da37d4ed137f6a61'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html',
-          checkpoint: 'f40adb3fce8973d1abd4732ff08bf2aa9f534ece58be26c37f1c38fce1bff4f1'
+          checkpoint: '1d4929d379e0bae248512f8c90556374fb5a93e37bd558a4762afe60cde3f246'
   name 'SecuritySpy'
   homepage 'https://www.bensoftware.com/securityspy/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.