### PR TITLE
Update libreoffice-language-pack to 6.0.4

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,565 +1,565 @@
 cask 'libreoffice-language-pack' do
-  version '6.0.3'
+  version '6.0.4'
 
   language 'af' do
-    sha256 '281ee7da47d629d64d4eb80d009f8c84af9b0c15142989d80c28da46183d4e57'
+    sha256 'b86bf58e69b41abe2c55c7b21dfa968ce15830f19a48e246f97a060a70fe9b62'
     'af'
   end
 
   language 'am' do
-    sha256 '748e71e3b31fbbf871bda0a9fb526748e3d577beb6dae5348a81b356fc5ec7ae'
+    sha256 '1c8bd6d9cba7e041770458a3184f4e8ff632ae87ad34884fdb5e8146871cbef3'
     'am'
   end
 
   language 'ar' do
-    sha256 '45e400ccdfcf3cde4b5dac29159bfe47fd62b45846725962d9436021b5472b6b'
+    sha256 'abf678655c34c249503c853d75c2a316299b78c8380b1c50cc8440aebedcb0f1'
     'ar'
   end
 
   language 'as' do
-    sha256 '0d5e2bd15abc6c2937e8a8acaabb61ac3c601271b26d438d33562570cb39a496'
+    sha256 'dab021c696d88031d9e1a0f5cc5c9e8cb68be50a9bc0b1f1c9a0dd816a738136'
     'as'
   end
 
   language 'ast' do
-    sha256 '60919e8bb151be4b9400ff0985cc478c74a4668aaeba75c22ddb0cf14b597f7a'
+    sha256 '0df08fe6cdc0149a8b2dda2b4ec323357c5dbeaa70a801575d1d38112ae4290f'
     'ast'
   end
 
   language 'be' do
-    sha256 'dd9b2f7327435ddabb6a3ed6bc8f3a9cf1249d71a11f0f599e872983208cccd7'
+    sha256 '076632d390565e7d26cdedad38e19b017ca868004d2252578fd54d92d55d6aba'
     'be'
   end
 
   language 'bg' do
-    sha256 '253ec4b14e728a1913fbfb9b7cc17958e6806a256a36bd97f139d38e138f3975'
+    sha256 '93e9d0a5d889792ea3b9cf845d27bc57d5c0166e3d55ffbf2f9517126e3a1437'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 'be242598023442748acc74dd9bc3f0008a81bb7d7975b41f180c1b25f447dde8'
+    sha256 '6daad9f937fbcc1f4b94b5f6426f720928b04795d00d2ae4a0cbe0dd93a7e388'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '6bb3afb518f4e2b05c577b57c6c2a4943c155cf07005bcc5df1fb175b86be4ab'
+    sha256 '2656f70a9b783924ae4a272487d49b81eeb492d477ee34889fc8819f28962997'
     'bn'
   end
 
   language 'bo' do
-    sha256 'f0ad20af74b9a61791d7949467c500507eef969c557edfdea482ad3b8ca905a4'
+    sha256 '0e74bd8a70b461bc98f541725e0e49f47b85c5c9367c0926ac319639610e8958'
     'bo'
   end
 
   language 'br' do
-    sha256 '0911bd47026bb83c892c1981c249b66a17a98af0634d14a85cd6ce0290b270cf'
+    sha256 '0f47a5897db9c7d1a7cb4742236aaffe55e6e4921741248baa5596a295000049'
     'br'
   end
 
   language 'brx' do
-    sha256 '2295dd15be95f01eeb0a7286a7ef96a5c759937e808b8ac9171e25dcca29b01c'
+    sha256 'a4f11499bb126e4a14305373693b50b760fcee747bf582598881fd7147ec63c0'
     'brx'
   end
 
   language 'bs' do
-    sha256 '2203798bdd0974bb1aa82ad18d5d8801f6da8b3d1f32ed3d8f1b01115470cbc8'
+    sha256 '5a57542a406dc2b9ff5c312510e5bc438ce79b80c2c4544164aac9f26efd6193'
     'bs'
   end
 
   language 'ca' do
-    sha256 'c1cfab3475135ddaf6bab5f9fca41e0ef4f7f8ea4e4c298c959b4ae2797ce22b'
+    sha256 '37ab4513360ce69b45c4503fb20bc6640046e92dd0c4c80286a703c1722de5b6'
     'ca'
   end
 
   language 'cs' do
-    sha256 '9a7771b125370bfe305dc430f01168c4ea949636d928c9e4ae28c8644220179b'
+    sha256 '5cc0b60cd6b01c20c33fc76c82259f74bd0ca814c067859d8bf73da339e7ffee'
     'cs'
   end
 
   language 'cy' do
-    sha256 '65adc60e6400f70c56edd2d43a078d293c8c8da402996171a57f7bfded6facec'
+    sha256 '20042779184a7d573044882cab9d817937d3765f4358211fe9dcca60c16bc425'
     'cy'
   end
 
   language 'da' do
-    sha256 '2f99c0e0e254ecbe734d5b6820a547feb0ba6bb69da128bb6d5248f52d4ab34b'
+    sha256 'df3a82c5c714049500907ec29a918bb616d20ebabe180ee9541637dd0ab71937'
     'da'
   end
 
   language 'de' do
-    sha256 'e3bcd1a21929c2ed87e0c86e68deb69772d1f7a4dfa2eac5a8db126a8739da93'
+    sha256 '22e7a72e8a76d54bec2a6f69d5b64463927a447b1370b699822541d873059d57'
     'de'
   end
 
   language 'dgo' do
-    sha256 '4df8b6c3b1a697855ef82efbf6b94d6ceacf46bc2f7e85ea5114dd9a7a47bc4b'
+    sha256 '277d49c014fa62923f23cc9c5919c6c1b3b6a5a0c7d82d5c3e1e486abd25d978'
     'dgo'
   end
 
   language 'dz' do
-    sha256 'ce851746c806caff21c54e3d3d3d462537999712c41e2e4f7f8d569bbe4a773e'
+    sha256 'c8b8b2c24cf3e50a7f7a3ec3cfd296054fb3ff2ba907352e7a1b853ea0ea560f'
     'dz'
   end
 
   language 'el' do
-    sha256 'be2da224065081beeec48fac51ea90deb55d4e3c9ff23ea7eb5fc8673c302987'
+    sha256 'bfbdee3ded88a2cf248c435055f4348ad05a4a9922bc9ee65c27ba2354a09b14'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '54e7004bcfdc319acd4a4c89a326cc437f0d1a2ae4ffc2d634a48c725f2ffebb'
+    sha256 '73f33b941eee3f9b4429a01b46e3c00f8c34af0058d281271196757eef9fe210'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 'b896a8cba38de42a78c51fce954db98ff5babb597aa5a7811ed8b64872868c58'
+    sha256 '2dd146642a6a1145f05031d533a05f0845278e7bbe26e9673fde4a2c73173c62'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '23e0d3caeb6f46f3fdb982d61a03bd5021eda27eafcd7adb03684ac1ed4f8704'
+    sha256 'd0c2a607aa4fc6d04c41e8d9c4b9b3464384f87ca225069907b11f4bae494855'
     'eo'
   end
 
   language 'es' do
-    sha256 '3da01608d1519315db309c9f2b14dbc8bc3e699ca705e1f9dad1f6a46c42f9af'
+    sha256 '56f005cd749dc8ce761b011d46ee38b1094757687eb18f0ab0fce5054f6a4db7'
     'es'
   end
 
   language 'et' do
-    sha256 'f7c222c1789623dcb6bdca07189e57b05908b9109a0e579e660095a4cb7c2c16'
+    sha256 '3ceca8723429d134ad21968bcf37747507abb69be1b8f8eee212cba21569980d'
     'et'
   end
 
   language 'eu' do
-    sha256 '091f7ec7703f9dfd5d8d8400fe7584df10bf396c448d1a5076c95751176e44a1'
+    sha256 'cca33845b179da18e90ade9aefa92f1fabd0d7c85bdf9419e43f4a688c973a27'
     'eu'
   end
 
   language 'fa' do
-    sha256 '1c944754f56f6d85d96727e6de39ccd0979815a48f10dd584404d8b3388e953b'
+    sha256 'fef3a2b683c2c28116244f2e40a30f795e1d2abfc66e9944f520754b540c937a'
     'fa'
   end
 
   language 'fi' do
-    sha256 '02dc26f30511950ab0fd0620e1ea33b3e15a81fb2f5d06f4650b041037bbb20a'
+    sha256 'fff8035c6660bfd3f61b470eb9f2b7526628550a2532e93a1049e3b21a365541'
     'fi'
   end
 
   language 'fr' do
-    sha256 'f194f88f6906f401f21aa4cdfacebb191d2b5a36dd4fd16c22f3aee5a6d362c9'
+    sha256 '8c92f27df20d44c440bceb23650131a0d865e672684558af91be14b5bb265ed8'
     'fr'
   end
 
   language 'ga' do
-    sha256 '8759d29daa2fdfaa9bf28942af61a594f233381278968f522f2d4a878dd257c3'
+    sha256 'b1dd15b03ef8644aa1595d74328f806a0103dedf3e54f75a2d6fa4ce52e91696'
     'ga'
   end
 
   language 'gd' do
-    sha256 'a163cbe5a2eb2da06ff5dffa64d5abddab3e5db3fda35800f7ed3014bcbc0841'
+    sha256 '67f5ef2169c785a234e13f148388177ef84e78bc7afe1fd7111ab15b3a9153e0'
     'gd'
   end
 
   language 'gl' do
-    sha256 '60ae3735ac65b5841745e9a1339f67b7952b1b65ccea8e7a46d619ea5bc237a5'
+    sha256 '66aca229b1f28abd046e2e4f39a9f772c64eada86a8d006d28a7393b8f511398'
     'gl'
   end
 
   language 'gu' do
-    sha256 '8034affda9dfff0557a0d4f94e61b1ff6308cde63eb9ca32c3776e3a04313958'
+    sha256 'd806830bc24889066a3f01e84ffe3349721a5344de4ccc1a3bde9c1aa4e18858'
     'gu'
   end
 
   language 'gug' do
-    sha256 '19be5917542a4401e7982dedfdb50ddb4b74c3c97f7b49b1173002826cf25d7f'
+    sha256 'f020badfc9ce0637e99eda87411f7b03760acdecc67fbf82c4e99693f1e81326'
     'gug'
   end
 
   language 'he' do
-    sha256 'de8304ce5355778dc8aa70c30e1b43971c600e32405c955d7a0f7afde1f5113b'
+    sha256 '0238ada1ddd401e9604bb9624feda65fb1ee0d0247571a04123c1c8a7f61c876'
     'he'
   end
 
   language 'hi' do
-    sha256 '09b7d1c92080de97367b6120dc6694be57c12bde0710fcc8bf5f017cb25bf8e7'
+    sha256 '5ff99889a20cc446fa7bac990fd9e4e983e08a68509fda56e981946cfa9a5911'
     'hi'
   end
 
   language 'hr' do
-    sha256 'a23744f307f66553bcdf248ae599eeb9237b4345a72f05cdefe4bb7c8e327553'
+    sha256 '6764b05a604b82a6e6589c65ca62ff2f5414ee4d4484766d96937e0c5b8e40e7'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '489c129913c493e3435787b4be03a468400cde77d86f90fb09c3c56e00373944'
+    sha256 'd7373d2ad4e91fb3c63df0dd3eb40552753502bafbc05ff99ae573a46df59f4f'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '7f0a72898518502dc68c56dbbc0b467a743481c0dd5427ff039cb661242d4ca1'
+    sha256 '77cb4618d00b2d4682ad6d70e9298d2d28212083a4b6668d0edea3c5e56edcd2'
     'hu'
   end
 
   language 'id' do
-    sha256 'ec3c2b30a701441aa86c62bce907a4d906adc7df2c0883b1e309cd6f6f868fb5'
+    sha256 '42933d2ed6653556559d04b42b8a296adcf98e5878d85eed751d7fe33c8d31fe'
     'id'
   end
 
   language 'is' do
-    sha256 '4cfd23137ba44a6a7bbc9929d8a090da2e54086f80115e0c31112fdaa79087d7'
+    sha256 '5e57f1a9374842cb124db928ee09d3e6c94684d927d228cd880555ef412864e4'
     'is'
   end
 
   language 'it' do
-    sha256 '40ec3bc9a9291eafd26d26884119e8e731f3b00650736dd3fe6e754ae565c3a1'
+    sha256 'b3cba2887ee3e3c13d438d9d8d753ded5de315ebfccbc2df1d89d8444985cc7c'
     'it'
   end
 
   language 'ja' do
-    sha256 '59a99ecdb18aa3f48ba9d6463dec0a4c8b047c99fd893b6ebeb4b617e1979b93'
+    sha256 '2c0633fcaeffeec34a0d9570f67165a3bed7c64934cbcedaff662fd0a26e5fc8'
     'ja'
   end
 
   language 'ka' do
-    sha256 '768ef34c936192ebbb5a61e7c1c87011d0ac15f56b7f6239a4f726be00cc3c4b'
+    sha256 '37add56b47ea4de8df9e6c54e093d8ea92451c027610ff7cc1d47700c5215a93'
     'ka'
   end
 
   language 'kk' do
-    sha256 '1ce707697294d0fe30b472c78ba0f9a3325bbfb279223900b1c8b8b029d316ba'
+    sha256 'a56ae2b910a4f9e1e4e1723415bba2989877a15d80dc6f72eb66f1aec2fc2483'
     'kk'
   end
 
   language 'km' do
-    sha256 '4d3cd290eed178eadaa0580d46b5cb2618f3a07f40ae043585869a3cbfdd1daa'
+    sha256 'd2a71ed123d8d23bd88e754bc8682d34e59d3053ab1f71570390c8ead397e7ea'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '0b575259f801635e1f9ba69c9226df19dd24edf56bd04f4fcc03c96046d38249'
+    sha256 'ecd89c1a83ff4f1afcc16867e2d37a1228abd231823971a1aa1a37f5ef4803a9'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'd37f332fa265a72626d13d8112fedfae2e1c2f1928265054e9945a54e395c771'
+    sha256 '640668792be9609f1386482c29eaa8501fd31254f5d5ce69639fb0e85cc14084'
     'kn'
   end
 
   language 'ko' do
-    sha256 '837a4725c8c8e7fcc497d81140086224589d6cc5a3094e1afd2cf3bce52588bc'
+    sha256 '7528af774e28450af5b72e5f28814555c6274e6bd741df817989725dcf8326fe'
     'ko'
   end
 
   language 'kok' do
-    sha256 'a2d567c8393db2e000e351baf378c49c5d35ac3a29e0847260fb5d53149dfea0'
+    sha256 'b8b924684fec1de8e90b7cf1f0ca8141e4794cee300d7f8739fc177a16ea56a3'
     'kok'
   end
 
   language 'ks' do
-    sha256 '83a749df21bace6c1f20a9448c8d836a31dc664e30b1f74c7758aa4c03394a6f'
+    sha256 'b4bd80b0730e5974ceb3c35c4aca4a004fcbfbc6686d04ac940397eea75ed64b'
     'ks'
   end
 
   language 'lb' do
-    sha256 '6ca86420d4ae449817cfc1629fc91797b81e5291644b7ac26ac5e53113255dcc'
+    sha256 '859006eab9e3505490aceb9499925c14e688451b557e804af36514c50d5ac704'
     'lb'
   end
 
   language 'lo' do
-    sha256 '779db629b372796715c2b3d3b9d67709e99b736b9acc3a7fdb524a2c8b9b75ef'
+    sha256 '076fcc0901c259106e70b85b8e5b4d50b9a8e5dbe84a7dd0773592715830b53d'
     'lo'
   end
 
   language 'lt' do
-    sha256 '40c61a9488284ed945f90706dab8dfb2fbbf2e6ec70c112a2fa54e3389641121'
+    sha256 '95d6a46ea00d6cd603c10bfb41693cd8589408b2e6368ee75db951f9048e5f5e'
     'lt'
   end
 
   language 'lv' do
-    sha256 '51c7ad0dc1fbdedbefb5bb3f591bcc686048cae3d13aa1dd4cf2c002bc1bd528'
+    sha256 'f960d8f908f72670ba376b89fa9ce77418a06353748109ddcb8485d0a13a55d4'
     'lv'
   end
 
   language 'mai' do
-    sha256 'da509b4b56c29e098b11625de20cd13c6f05bb898e2d0610130fddc5eed8c886'
+    sha256 '2d3feb9a708a7cea8e2ab32ba7cf8743a136ba79fa5ebc9ad39a11636835fb90'
     'mai'
   end
 
   language 'mk' do
-    sha256 'ff6cbc3dc0961e3d61fcc54ecd30d67b79ab59f95be3903176c05ddbd5fbe493'
+    sha256 '6e3e380da604d620441bee7dbb6d1fcabb0e3a4e35d4057115b8d19f24bf94ba'
     'mk'
   end
 
   language 'ml' do
-    sha256 '07526287c101ce38565b16a545ecd2082bc5ea8fed7215a820d84928f42ee490'
+    sha256 '62b76652603ea93785641c772de1a4f7f0c3cef63cdb151d59062ef7459ed98c'
     'ml'
   end
 
   language 'mn' do
-    sha256 'f9701cec08fd527f223c64feeac25c6e28603c328c9f905ecdf2635ce007022d'
+    sha256 '4d3130b3ef9124be89f0e63225994a1db1891334fb51b23022a17bbbd8495217'
     'mn'
   end
 
   language 'mni' do
-    sha256 '7a62c2c4ab6b372ee673ec1c0dc786ce3b604daf5a705a9a050882888c7ba4b2'
+    sha256 'd2a7744987d6abca190834a99250815168f6231743306894c70b3c0e5638f85a'
     'mni'
   end
 
   language 'mr' do
-    sha256 'c1ec9b6ae5ea9e22b87f4188637b058142a6f02c70444baea748aa8f7e8e60a0'
+    sha256 '53f23f128e0b80df2fe177c3649f26a2116e1795375474acd7e85232eedd6d9e'
     'mr'
   end
 
   language 'my' do
-    sha256 '2909a428e86f8a1b6a3997804f1feca1932c2d992d75448726bd7bdb392d8d82'
+    sha256 'c46d9ecb1e3d448a27f2bcdf6b7eb4828c01f45c2de1ea59df4087d46292e7fe'
     'my'
   end
 
   language 'nb' do
-    sha256 '43f8e734077c2454834bc6d589b5de1c47bccf05236752b00fa4808a4cc75fa0'
+    sha256 '917243d75607fd0d20988ffd37f86e6c9cd71cf377b467a0167d64c7e01c610d'
     'nb'
   end
 
   language 'ne' do
-    sha256 '0c6436b887e6097142631eeefccd6276ec2ca3befd93f01ea521ac173067ccfb'
+    sha256 '354a6cbdb8e77f83b2a3ed64cfe550fc3d2b664a60ce75f8bbd2eab3738cfec3'
     'ne'
   end
 
   language 'nl' do
-    sha256 '829a3954215eb446a01dba567dd90bd41637b949cb58695f64a2ccc300d72cc8'
+    sha256 '6da280884f1a7bc5db713c7d3f7bc89b83f9a69b2d3ce36669bffcb73664ad15'
     'nl'
   end
 
   language 'nn' do
-    sha256 '7ded7847e5dffed07dfc77cc3b5932e9bbdc59c9ab35ff22e69e62023a7278fd'
+    sha256 'cb02d75ccbc8bdcc2bb9e5fe73c20c717a9426a365467e7a4b422255fa8c20bb'
     'nn'
   end
 
   language 'nr' do
-    sha256 '92181eabe724a81fed27cc6e2bb4c9ae9f0ff80dbd220253cd283c9e10488cb9'
+    sha256 'd829b7942e0aae25465866dde97e4d794af86237f8c6baab2af18c7d4acd0407'
     'nr'
   end
 
   language 'nso' do
-    sha256 'ab7456f837b6aaaaefd25484ea1f231f98727cae44de984d18de3a02124ae38c'
+    sha256 '3f3bcb77ad259eae1aabeb22faa8ff7a9b31288ddac4302faa2b2ec5d98fa2bf'
     'nso'
   end
 
   language 'oc' do
-    sha256 '57c3ea7fd1f38b4ede0a1e38e68d0e3baa60e2692c0cf676e5187331c5ce1ca2'
+    sha256 '2244a7ed8c4bc68a709667eb307b27dff69bdbbe1211aca6bdf7b965a7307fc7'
     'oc'
   end
 
   language 'om' do
-    sha256 'b08900d527c62f8764ef1e3a2935f282ae20b598f6d07c8ef164c1ea00f29c8d'
+    sha256 'c2a79fb6d7d419793c36e326fd5b51dbe6f5970ada15fb6cefff60f7af37e784'
     'om'
   end
 
   language 'or' do
-    sha256 '79325fcfbd236b5f5f721f5a798ed783d63eb7ee40d8ac18eb5a151d01fd5438'
+    sha256 '080778f088a3a6b34270c4ccada68e62e78070f3a80dcbb1b9f8be97652ce795'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 'c1650fa19f7bb964a0c3120ce9d6faba36d8fb2a760aa7cf5ddfa01cab326e2c'
+    sha256 'cf8ca017d5b1b65dbfb76c4eb60de2480093a6833be122ab3dfbc6d2012fedc3'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '1f60defaca9e053b02951ddd610087c9212f85a0475c3654d05d4723d0df07f1'
+    sha256 'dcbaccb98f8dd416aea17377ca3ea02f247ab2d76c42bdeb958879c165b4b252'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '438df4f0fd13d7666cd658f4f1556f0d750f346e816e2e61ef7592a66978da84'
+    sha256 'd0d6b2df717f3ddc5a52c28f0d3619fb7d9a73d029501094ef9611518b6bbc66'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '96d488d1f062cfebed87233344f975e3d0d901c7373a0009e0b728ca2dbe2e3d'
+    sha256 'dbd33eb3ca1408145cb3ff02d8eab40d1aee81371482cae662cf70d4d53240aa'
     'pt'
   end
 
   language 'ro' do
-    sha256 '0f7b96c1eca7bd45f1de6c367b08e040d08ca0662a224f660b396aabe1d99cf6'
+    sha256 'e4c1695558a6c0a764265d09fdba432a810448af7cd84e358a3c8b06fd1160a3'
     'ro'
   end
 
   language 'ru' do
-    sha256 '4bb9d92dc18008478fe8e02545805eb6a60b6126ccaee5aa050517ec2cadb44d'
+    sha256 '55d73d714302bbf165e6ee6848643d159212a92d1fc0fe0786d32c989faa8168'
     'ru'
   end
 
   language 'rw' do
-    sha256 '10839995b7d0c317436f012d5978faa4d01e260a0b60e23a85e4430a739c0488'
+    sha256 'ff27e8eeee1a2efe69a4eb9311515277e3c7f3d224301d2244661dc41b63981e'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '71f55084ebf87b3ce4d2acbcfc15b30f4912e094972c568626899cb80deab738'
+    sha256 '277e2154f90191c46c3a2d7f94bedc6e0b386861f90ba3d059d4d606828beff2'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '55197a9b825e617d5d39bb87ca5a51f3cf4b49f279fda1e09c5976337f878c4b'
+    sha256 '4dcee65f6f5930b1dd515d7d121eadd415112d2e27576778c29664c32e8262e6'
     'sat'
   end
 
   language 'sd' do
-    sha256 'af12baea8f41ec352b72886ddbb633fdff0fb551c55eded865374fcd0a7d5084'
+    sha256 'bf869a27f96b22fc2faba6102059c9578b3ab330aa7250d191cb5fd4b70edb95'
     'sd'
   end
 
   language 'si' do
-    sha256 'be17986eecda7e0d74f3432e07eef87d3535ebb31b18318c563295cd93dbffd5'
+    sha256 '9d66da47a2a5f2951349aa02fbe86f4b531e8943aeee315944c8f24bd68b734c'
     'si'
   end
 
   language 'sid' do
-    sha256 'b4e6ed4e25c7224ae56972583815d68ac1952b72c548d9109c45ba6ceb8671cc'
+    sha256 '9bd6b823fc4b7e38c32644289c7cd53978aa72b2545ee69ca86a8196ce22aa0a'
     'sid'
   end
 
   language 'sk' do
-    sha256 '6d5657a99a8b0dc847f86eb6cc96353c2b6c88a309e4a6b8628fe7e7da8a43b3'
+    sha256 'c41d8f8a76bcb7d338e5f22b16d102167c4a9214040c035fabc140454e0d9a00'
     'sk'
   end
 
   language 'sl' do
-    sha256 'e239dafaf00f8a3a7d02a0a05a5aca69c670eaa22c04f891527d597fcb443eca'
+    sha256 '3b1983990cc1fe669d30d9d35358e455bb581542c94f7c63d20f01cf7359b3d3'
     'sl'
   end
 
   language 'sq' do
-    sha256 '99f2cdf41281964d817144c6d7e5ee46d9f7ae4494fbfe0d1e5fb5564f53be29'
+    sha256 'f8736657695fa5af1470985345fbf4136fafde24ef84019ca2459946950708a3'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 'e3609481a4afba0b8aa850232aeadaa1fd4b015c7c2d5e3a3dd794bb7b2e7b06'
+    sha256 '0f09a2558822a80270b31f487e95deef2f50ae4726124ce853f19be19eb9db1e'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'fec969748ad52c766d730a5689279d23ac50e4368277caf0998172b9d22bac20'
+    sha256 'b6326487ac9cd988da6d4bca2c0a7a3824fc246752e30eabdc8194fbca96228b'
     'sr'
   end
 
   language 'ss' do
-    sha256 '3f360505631e118f3c3bc803c76cbdf542a77895cd55c2318ec0022686ae14fa'
+    sha256 '0ff13efb5ff17b8e30628ef897615bdfc548c991a19335b5a9a1c5efc614c08f'
     'ss'
   end
 
   language 'st' do
-    sha256 'c255b1dbd8105b6a2eae96718e398725570368778dc42623ec035a65279080ff'
+    sha256 'e36d28e5b025dc6a62af49220652f31f9239b1fda64e0cc9ca691bbecb272fb2'
     'st'
   end
 
   language 'sv' do
-    sha256 '7f63a3ed6da8ba89854434f072be89388d40ff30b1df30ce3a0d4755fe53d90f'
+    sha256 '5944dfb2b34b03e9e1825f70abeb8f732ab352c958795717789358223d5b5784'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'eb09b98a4f15123e9b5899fb7a105d80f8f2f5ce878694c473666c38537c3f99'
+    sha256 '0ebb3c8c87fd4fba34787f2ec03c8588b76c9d482ec0dd8663edc37340529b1c'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '0add829d9f7b069e41960161ae6f4eff3f103a88bb70eac3db159cbef9fc5cf2'
+    sha256 '4be3da6e4903803737818699d17391fe101dc597c1b93c1751d1a7f6449c8c22'
     'ta'
   end
 
   language 'te' do
-    sha256 'cc5f7eaf0a0f28616e18ac14e338cdac1fbc3c55301307044ec58002411148fe'
+    sha256 '83f7685eadde121bfd72ea2333262719c725db5949352f05f3d41ede01ea9b29'
     'te'
   end
 
   language 'tg' do
-    sha256 '64991430703034ac25fc467e5285c035c961e1dcb0e338dfb20bb626c638c2e1'
+    sha256 '31b11badf1458c975c2b80a46c508379db1e9aa7dce664e4372557c9dcee18af'
     'tg'
   end
 
   language 'th' do
-    sha256 '595a185687a10483e4381fd37e2f3109f3a048db01be42c6e7328a91f51e47be'
+    sha256 '710bfd266fe5e0cbcb77cbbe2473bec67ecb1f17621c84d536ab1a5e64dcefad'
     'th'
   end
 
   language 'tn' do
-    sha256 'c9da40bc2ea19e94706a4343663bb06b4648a4e7c58a5c7a44b6951704ef6ac7'
+    sha256 'b2dc1af756918d3a999e5e2f447650510d8712218e975e84b6b297b993717dbc'
     'tn'
   end
 
   language 'tr' do
-    sha256 'a2fcad710f42cb5062c0305bf281b86b6139954c5c447b9fdb6bbc8c4acdfb41'
+    sha256 '36e04c897ad7631814804115638f8b5ec37ce7063431dc296baea48f8c973047'
     'tr'
   end
 
   language 'ts' do
-    sha256 '1a4dd2a2c5a1f10f3dd171b0773047112420a6997d393369bff04dc2ea199a40'
+    sha256 'ba7601be048dd59fc077f938e5db9261855bacdcf979bb64122bd77ddf7e01d8'
     'ts'
   end
 
   language 'tt' do
-    sha256 'ac7edf899cc4ed19d5b68043eec570940a2dc1a3280f7ac4bd54852b3448fa41'
+    sha256 'f7d295ee0c31d251d0b95f6452dd071da67f4015470920d02cb8ef27b0c2c309'
     'tt'
   end
 
   language 'ug' do
-    sha256 '53b64ea0a6189e1012809e732d549aa4b85018f470a01239a8fdf8f59104d724'
+    sha256 'd6458c2806e0f74ded89d73a73469bda31a25b8e17e284425c45f71746a20346'
     'ug'
   end
 
   language 'uk' do
-    sha256 '5e89e9202c3eaea7609bb0f6a1240cc8a40066738fb2929f6fe2e1113a9359e8'
+    sha256 'a74a988affe136cd36f0fef929a4c57b9ec1a77820deff0f8dbcfe10e312d5b5'
     'uk'
   end
 
   language 'uz' do
-    sha256 '8fcb62c90d5a17b36ce75af6344c5cec790a5a6a40d4907f048c7d662079c85f'
+    sha256 '3f156aeae899142fbb538754de33a9bf3534f15caa689213e5506ac4a8df2b56'
     'uz'
   end
 
   language 've' do
-    sha256 'dd9123acdea01bd05956170c8a0a68697ce40f1ce06d29198bc598f98421f763'
+    sha256 'c23e3f223f1c7576ee67816d65c73ebeb64a108054414ce9118aabbe4cc1921f'
     've'
   end
 
   language 'vec' do
-    sha256 '0f85bf12b84253a2345707ea2e1fb07b43837932da850f19d573e4688354efe3'
+    sha256 'a4088d87b87a8b0419171715299770b2def2abf9f8c5542ec3ba9678cedd3921'
     'vec'
   end
 
   language 'vi' do
-    sha256 '30befa17d8f76667d41f259ac8d594ce076bc2bdbba32770e9d13f6ceed55ed8'
+    sha256 'cf45af0d0e5c932e9177843d74987a8d18e7432f24b48bf424c1a8dba17d77bb'
     'vi'
   end
 
   language 'xh' do
-    sha256 '66859c54638f9af854efe574dda998c4587d19b88be5278069f40ff7d8e3008c'
+    sha256 'c2961263f84918c900687feaf44d0d8e7084de2a4ef52b687fa53d29c4b3cfc7'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'df881c039507b11c4fc6e63430091aaf215ec5b0ada8f30b9a8d347b3c8fe4f0'
+    sha256 '53b5c9cac7f51bd5a6a2fd01ba25ac4218e4ec18b221af6ebd36140eeac7ec03'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 'd93c58af404518101a59e6774cdcc09081fe34c52a2725584c4b454374c0517e'
+    sha256 '7fc54ff7b1c132065f3e3ceed523d41cb6b4e5d7fc90ef7603604e84f1fbbc63'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '2f567903cb6d08c2edf6870498f2aef58b92ec19a9e369c40e273084605ffd0d'
+    sha256 '9d51bce802933567fd4d9c0b53448efa0881fde3c08673c405843b0640b5e875'
     'zu'
   end
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "http://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64_langpack_#{language}.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/stable/',
-          checkpoint: '0810423ee662c57a69ca39a40ee9c1c1ce8f2d1584451ac14e6428edae048a80'
+          checkpoint: '2e57ea39a1c69476b9f26f1db9709c8705030fcf40f57891bc635b8821fa2e7f'
   name 'LibreOffice Language Pack'
   homepage 'https://www.libreoffice.org/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
