### PR TITLE
Update hopper-disassembler to 4.3.21

### DIFF
--- a/Casks/hopper-disassembler.rb
+++ b/Casks/hopper-disassembler.rb
@@ -1,11 +1,11 @@
 cask 'hopper-disassembler' do
-  version '4.3.20'
-  sha256 '0efdb10e68f7548606e13d4724971d609c19381827e3259c8e734cebf980b4f0'
+  version '4.3.21'
+  sha256 'a66d98d69b1b3e0782f3756991718b35783e745a5bb1f5a00b7ad30fc16e315e'
 
   # d2ap6ypl1xbe4k.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-#{version}-demo.dmg"
   appcast "https://www.hopperapp.com/HopperWeb/appcast_v#{version.major}.php",
-          checkpoint: 'a1a4cbcdba9fa03978e6fd65d37eca591f94794380e13a0727920ec074a660d5'
+          checkpoint: '5319c087c4ca56dd971645a0e22d38b19577619a606a1fbe1c718c068627110a'
   name 'Hopper Disassembler'
   homepage 'https://www.hopperapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.