### PR TITLE
dynamodb-local (latest) as a service

### DIFF
--- a/Casks/dynamodb-local.rb
+++ b/Casks/dynamodb-local.rb
@@ -19,6 +19,51 @@ cask 'dynamodb-local' do
     EOS
   end
 
+  launchd_plist = "#{staged_path}/dynamodb-local.plist"
+
+  postflight do
+    IO.write launchd_plist, <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>caskroom.dynamodb-local</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{HOMEBREW_PREFIX}/bin/dynamodb-local</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+        <key>StandardErrorPath</key>
+        <string>#{HOMEBREW_PREFIX}/var/log/dynamodb-local-error.log</string>
+        <key>StandardOutPath</key>
+        <string>#{HOMEBREW_PREFIX}/var/log/dynamodb-local.log</string>
+        <key>HardResourceLimits</key>
+        <dict>
+          <key>NumberOfFiles</key>
+          <integer>4096</integer>
+        </dict>
+        <key>SoftResourceLimits</key>
+        <dict>
+          <key>NumberOfFiles</key>
+          <integer>4096</integer>
+        </dict>
+      </dict>
+      </plist>
+      EOS
+
+    system_command '/bin/launchctl',
+                   args: ['unload', '-F', launchd_plist]
+
+    system_command '/bin/launchctl',
+                   args: ['load', '-F', launchd_plist]
+  end
+
   caveats do
     depends_on_java('6+')
   end


### PR DESCRIPTION
Installs dynamodb-local as a launchd service.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
