### PR TITLE
File cityofzion-neon dmg file name

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -2,7 +2,7 @@ cask 'cityofzion-neon' do
   version '0.2.4'
   sha256 '7b39fab2f6182dfe8b399b228f7d84b0e231629bd893eb45a029056539d7904b'
 
-  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.dmg"
+  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom',
           checkpoint: 'a31dcb81982612298e16fe223e3f71711bff4c493b001241aec3bc9d1be73073'
   name 'Neon Wallet'


### PR DESCRIPTION
Not sure when this started but the release dmg file contains "Mac" in the name. The file without "Mac" in the name is not available.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.