### PR TITLE
Update jing to 2.8.0

### DIFF
--- a/Casks/jing.rb
+++ b/Casks/jing.rb
@@ -1,10 +1,10 @@
 cask 'jing' do
-  version '2.7.0'
-  sha256 '99fefbe732cb7afcc6956be58929f401a36ce9f406951e7ff0d127b7b958264a'
+  version '2.8.0'
+  sha256 '5717c1602347965dc28e53d792e252e03a5f6ee1ad59cc3ad3bb596bed910935'
 
   url 'https://download.techsmith.com/jing/mac/jing.dmg'
   appcast 'https://download.techsmith.com/update/jing/enu/appcast.xml',
-          checkpoint: '25aea2af9dcfde0834ef353d2c970b98344c42cf189d019b9d86e2001179f79f'
+          checkpoint: '7caf2adfd6ffe5d0330e28eb7fc939952c6862a3dc45e96b8dbda0e6898d69d8'
   name 'Jing'
   homepage 'https://www.techsmith.com/jing.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.