### PR TITLE
Update cacher to 1.5.0

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.4.5'
-  sha256 '14d9708990da57505686ea6896ae380de06bf5bca6dfb886293d08bc4920a25c'
+  version '1.5.0'
+  sha256 '534fea7c14b7d5cc78cb14c4f4d07809de4fedc180a40d792f3113093ef2e075'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '7b775be005aca960a0120c84870f422022065bebd4f05e2900957e46f0bdb9ba'
+          checkpoint: '944ada3a6043b772d26e9b44518b6c301f903494a7edd316e8632b8d3c3e09ed'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.