### PR TITLE
Update prezi-classic to 6.12.1

### DIFF
--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -1,10 +1,10 @@
 cask 'prezi-classic' do
-  version '6.10.0'
-  sha256 '494c8d6cd63222b17de6ba0e90d6a5c29d13aa40479226b4b8ac0a5cda49a495'
+  version '6.12.1'
+  sha256 '03e014d0944f51ecb91f93c45d07d8fb1a0d5ed226d6d3b68b6d12d4bfbc9f53'
 
   url "https://desktopassets.prezi.com/mac/pd6/releases/Prezi_Classic_#{version}.dmg"
   name 'Prezi Classic'
-  homepage 'https://prezi.com/'
+  homepage 'https://prezi.com/desktop'
 
   app 'Prezi Classic.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.