### PR TITLE
Update 1password-cli to 0.4.1

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,11 +1,11 @@
 cask '1password-cli' do
-  version '0.4'
-  sha256 '7f024e5afc9cadc2d8134cb58e469821605e72342977c38c951d5a6d2443b656'
+  version '0.4.1'
+  sha256 '1f93f2d2dc2c6c69c3b8f5636bab12f3d95da34d9e3ce3cac3ed57143b738028'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/CLI',
-          checkpoint: 'bb40e66a9ca1b9b959644d37441377aaddb91e08c279dacf90bf905de0dc10e6'
+          checkpoint: '3a3bd8fb22d11ff30803235b7f49f1522676f4d82381e6ed4e1c243d75198ce6'
   name '1Password CLI'
   homepage 'https://support.1password.com/command-line/'
   gpg 'op.sig', key_url: 'https://keybase.io/1password/pgp_keys.asc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.