### PR TITLE
Update skype to 8.21.0.7

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.20.0.9'
-  sha256 '841f1c1e0afe474f2399752b18761dc41cc93af95dd4f895990e5fe51704eb53'
+  version '8.21.0.7'
+  sha256 '94064d3d30b9e693e0a36314cff98e7979385c109722f9ef9ce05106dd023c97'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.