### PR TITLE
Update postgres to 2.1.4

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,11 +1,11 @@
 cask 'postgres' do
-  version '2.1.3'
-  sha256 '1498a39a4383b8cc59cc9318e535e6e5be8128350b85ff45dab353f7c50915b6'
+  version '2.1.4'
+  sha256 'f035d6df7dbc99988c8f418888657b0f7a09c3654f7a692ca47c42e9ffb047bc'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom',
-          checkpoint: 'c051d1096e47ad817205a65247b28ab71e382b8391b051a26771d107847ba67b'
+          checkpoint: 'f713d7de4a5ea404e869daefe965f564b37f059bbcb80ec91cd68a58fc527d0b'
   name 'Postgres'
   homepage 'https://postgresapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.