### PR TITLE
Update signal to 1.10.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.9.0'
-  sha256 'b04f6cdfc01a2593c6e474f13d12f011f644348000fe887c249498f3854926a8'
+  version '1.10.0'
+  sha256 '07091a66a8aa7fc4780b99f87a79db1fae95fe77701c9a71a5a79d624190db6c'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom',
-          checkpoint: 'f830de874ec61590e2d613ee29ddb73c90a2adebfa70e5569bc80d16dcd98074'
+          checkpoint: 'ad54236c9e3fb0e4a1880d9c0a3b398332cdea7ec87c5cf7b87ab3260641fe71'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.