### PR TITLE
resilio-sync.rb: versioned URL & auto_updates

### DIFF
--- a/Casks/resilio-sync.rb
+++ b/Casks/resilio-sync.rb
@@ -1,10 +1,12 @@
 cask 'resilio-sync' do
-  version :latest
-  sha256 :no_check
+  version '2.5.12'
+  sha256 'f6c7a0b0e0b11399cbe5f3250b4067293d0c8a80b8a5ea3a938476e7923b0dba'
 
-  url 'https://download-cdn.resilio.com/stable/osx/Resilio-Sync.dmg'
+  url "https://download-cdn.resilio.com/#{version}/osx/Resilio-Sync.dmg"
   name 'Resilio Sync'
   homepage 'https://www.resilio.com/'
+
+  auto_updates true
 
   app 'Resilio Sync.app'
 end


### PR DESCRIPTION
Added versioned URL and `auto_updates` to the cask.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
