### PR TITLE
Update visual-studio-code to 1.23.1,d0182c3417d225529c6d5ad24b7572815d0de9ac

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code' do
-  version '1.23.0,7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45'
-  sha256 '868b28b19afdb090a397ee2229da1d87082b5e715764d525400d97a6f57f6f88'
+  version '1.23.1,d0182c3417d225529c6d5ad24b7572815d0de9ac'
+  sha256 'ace64ab0b56284b270b4ff7e6f5b83837317f371a91ad8a50b98eb53e366220f'
 
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/stable/VERSION',
-          checkpoint: 'f52d96a5ab4d9b86cf3efbdf221450f0ca0eb61e4f64de655be446c0cba58aec'
+          checkpoint: '003f0c2a6243cfed8dd90b82a414ec5596d853a59d3c76997b4c7c491c2692e2'
   name 'Microsoft Visual Studio Code'
   name 'VS Code'
   homepage 'https://code.visualstudio.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.