### PR TITLE
Update mos to 2.2.2

### DIFF
--- a/Casks/mos.rb
+++ b/Casks/mos.rb
@@ -1,11 +1,11 @@
 cask 'mos' do
-  version '2.2.0'
-  sha256 'fc8f5359f9d6e826741ef59c975a8ffe9be1cadda22933e6d0f40929e2413da3'
+  version '2.2.2'
+  sha256 '93fec3925fb2761ecd5ac92cb5fe1eba8fbaf68e8a50717c3aa2b2df4a0cc601'
 
   # github.com/Caldis/Mos was verified as official when first introduced to the cask
   url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.dmg"
   appcast 'https://github.com/Caldis/Mos/releases.atom',
-          checkpoint: '3ddaddac825c26ac3cb4dd57826770e524a498bd4d7d364627fac510baa20459'
+          checkpoint: '716e6e213751273884cf83927cece4c42350c61eae968bfedb03938777e8512f'
   name 'Mos'
   homepage 'https://mos.caldis.me/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.