### PR TITLE
Update navicat-for-mariadb to 12.0.26

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.25'
-  sha256 '82ab0db7e9c68e7502a13bcf29f31f44e99fc341bba70e76339645722592cb31'
+  version '12.0.26'
+  sha256 '9bc5fa194c2942616c28556f791ed5ee15f4dddb8fdfd2e135bf59964b61679c'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note',
-          checkpoint: 'ca7665434d68b2e89637f84316faa5ab151c872bc17c477987a606e43a7c884b'
+          checkpoint: '1a308bf0359af74fe4bd7259112684e06814e7100ab5338a53e68259144f7e66'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.