### PR TITLE
Update navicat-for-mysql to 12.0.26

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.25'
-  sha256 '17ef4876f0502ec7240fc92d6e2840b09e361bf62e38403aea1f0bae3b5caf03'
+  version '12.0.26'
+  sha256 '6c45e085ad885f7a11164d5485edff37f6e2753fe6569d48bb89e1b8cee6687c'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note',
-          checkpoint: 'bba74d286fb13068152254fa411060fb9420e48770decfd4c175ba8f449e11ca'
+          checkpoint: 'fd8f3b5d7c2cfe604bbfcf352f0254e64af22ed83e011f143d5e9d12876d300f'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.