### PR TITLE
Update navicat-for-sql-server to 12.0.26

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.25'
-  sha256 '22818e9893c0f59c0c501fd79adc994c77d658dac580602a268cc96b66d2f82d'
+  version '12.0.26'
+  sha256 '3ae0f46eb7166a1ccdc9efb19cd19d34001eaadba5a2dc9ed45195011f2e2df8'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-sqlserver-release-note',
-          checkpoint: '60d45e2790d5ad9fc6be89b5e5cd79a69267b549a3aeab8ab0803211175f512e'
+          checkpoint: '51dcd53f1fe91cda03e6281f912b6832a6b80652f32e24232d5b9730ad0e2ebb'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.