### PR TITLE
Update tankix to andromeda3-18059

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version 'hydra2-17830'
-  sha256 '68497e19e23a8fd792bde79483d1fbbfb022615c3e51181bc87a4eb1daa62d3b'
+  version 'andromeda3-18059'
+  sha256 '6afb78dac2227db038c1e1bc153c70bce80027c9ac081e332631e5805b655845'
 
   url "http://static.tankix.com/app/StandaloneOSXIntel64/#{version}/TankiX.dmg"
   name 'Tanki X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.