### PR TITLE
Update scrutiny to 8.0.13

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,10 +1,10 @@
 cask 'scrutiny' do
-  version '8.0.11'
-  sha256 '488c93ed03dcb7f7de106842f54a46ec30b5c8cc0c9af3793257b952a09af804'
+  version '8.0.13'
+  sha256 '8ec9e24b19b493943406b91915e6890865f018161a493add19188bb6225fa195'
 
   url 'http://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'http://peacockmedia.software/mac/scrutiny/version_history.html',
-          checkpoint: 'b4425f6cc43774c7eed527d9123c2a78c77cc1c1aab2611624a07738fffad2a8'
+          checkpoint: '89b8994b30a145c5856ea27c0e59bf7f2f29e8c946a8bffaf558e3f3612d60d6'
   name 'Scrutiny'
   homepage 'http://peacockmedia.software/mac/scrutiny/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.