### PR TITLE
Update transmit to 5.1.3

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,10 +1,10 @@
 cask 'transmit' do
-  version '5.1.2'
-  sha256 '0f82b3442f82975c3f718072f49596babc9f930d38e9c307c0cc5118214f3a75'
+  version '5.1.3'
+  sha256 'c6e902207c584c07505dfe6772439b25a59d926b04495b68d32382226cdbc951'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}/",
-          checkpoint: '7a9bd53898acd3af38f82f9c5069b406f9d7c697a0591430cf5cc4454bf6507f'
+          checkpoint: '0172e12e2179ac7ef5dc37af9e70332b31b7f2a4463f52116bb8c5bce61374c8'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.