### PR TITLE
Update cocoapods-app to 1.5.2

### DIFF
--- a/Casks/cocoapods-app.rb
+++ b/Casks/cocoapods-app.rb
@@ -1,11 +1,11 @@
 cask 'cocoapods-app' do
-  version '1.4.0'
-  sha256 '46e1e9b8e2e1ce70b53baac4ec151b5b047a39f6322faf4fc2bd37d35f805d8c'
+  version '1.5.2'
+  sha256 '03aa37afb129d6ae515d3b9ee7a81c30ba91050131e2dfbb3683bdd2f05ac67a'
 
   # github.com/CocoaPods/CocoaPods was verified as official when first introduced to the cask
   url "https://github.com/CocoaPods/CocoaPods-app/releases/download/#{version}/CocoaPods.app-#{version}.tar.bz2"
   appcast 'https://app.cocoapods.org/sparkle',
-          checkpoint: '6206c5a93fbaa1502ed6dd0ba6bebe6785cc9a5eadc6f3eb08ea51cd295c36b8'
+          checkpoint: 'ca6d25f4b987885e0bd17e91c33e52852a084b445340dbafe8cc9694c7e373c8'
   name 'CocoaPods.app'
   homepage 'https://cocoapods.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.