### PR TITLE
Update veusz to 2.2.2

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,11 +1,11 @@
 cask 'veusz' do
-  version '2.2.1'
-  sha256 'b1a74272bd87198843fabae8631fe97ab7fff8964012281ae7378678785ecb54'
+  version '2.2.2'
+  sha256 '3e927f3afa543dde0dd431ac1d690bd5b7f6b18bf185ce75fd7b12aecf4c6cc9'
 
   # github.com/veusz/veusz was verified as official when first introduced to the cask
   url "https://github.com/veusz/veusz/releases/download/veusz-#{version}/veusz-#{version}-AppleOSX.dmg"
   appcast 'https://github.com/veusz/veusz/releases.atom',
-          checkpoint: '31445859330d1b3697141a808cb3fbabd0a46ff5b23c89e3cf67ad6b972682ed'
+          checkpoint: 'c471b02f3bd1131a615dae8b8eb5e7735634243e5715d4335c0b373cb277d506'
   name 'Veusz'
   homepage 'https://veusz.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.