### PR TITLE
Update padlock to 2.7.1

### DIFF
--- a/Casks/padlock.rb
+++ b/Casks/padlock.rb
@@ -1,11 +1,11 @@
 cask 'padlock' do
-  version '2.6.2'
-  sha256 '95627f911298ceea84da35e6c17d12d97fcf17a1970edd062cd912ac3d59d026'
+  version '2.7.1'
+  sha256 'b3c0ae95923d11997ccf1bd9aee341f751b57ca1e374528e4ffcf727fd541c1b'
 
   # github.com/MaKleSoft/padlock was verified as official when first introduced to the cask
   url "https://github.com/MaKleSoft/padlock/releases/download/v#{version}/Padlock-#{version}.dmg"
   appcast 'https://github.com/MaKleSoft/padlock/releases.atom',
-          checkpoint: '2fd8816baa2d588f5809d17185af186008fb6d3fa38bedf2be7365ffaae0b2ff'
+          checkpoint: 'df0d5f5f53e5b43bdc8a8ac5f530ec8be4327cf6f18d8679775dc9c34a684abd'
   name 'Padlock'
   homepage 'https://padlock.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.