### PR TITLE
Update tusk to 0.11.0

### DIFF
--- a/Casks/tusk.rb
+++ b/Casks/tusk.rb
@@ -1,11 +1,11 @@
 cask 'tusk' do
-  version '0.9.3'
-  sha256 '4058dd88b99591e460de57847258b7d3c9d2b0dd122f587fc39ecbba9fb11f6c'
+  version '0.11.0'
+  sha256 '1970b34f42ec1ba59bb6e5cef6015e6184fc650f49fad242f30b3d5b973e2b39'
 
   # github.com/klauscfhq/tusk was verified as official when first introduced to the cask
   url "https://github.com/klauscfhq/tusk/releases/download/v#{version}/tusk-macos-#{version}.dmg"
   appcast 'https://github.com/klauscfhq/tusk/releases.atom',
-          checkpoint: 'c64e58762e41b63626a1d7d8da0d0fa462895a6f2fa3fdea7afee8e2c3fe0e83'
+          checkpoint: '59ae315fe80a7ef969c7f96628455b179ed3883c104a5d9a15d30330f4c259ea'
   name 'Tusk'
   homepage 'https://klauscfhq.github.io/tusk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.