### PR TITLE
Update 4k-stogram to 2.6.12.1567

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,10 +1,10 @@
 cask '4k-stogram' do
-  version '2.6.11.1557'
-  sha256 '8035c50a7d9dfa7cb3824206d9dd7f849162ed93e3c2d89da08f4e1cd5c81d9b'
+  version '2.6.12.1567'
+  sha256 'b20e3f476294600ce69e0dae19a2111f9e20b6ca7a58edaadee1db14eaa0c4c5'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '6976352a19a6acbaf5953cb3db8d18a88d5258e9d05fd2a0d5018be457741204'
+          checkpoint: '65c84cd2c25eea4ad18a46183c8ad14040be6766248d99f8b4e2b856a7013d59'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.