### PR TITLE
Update vimediamanager to 0.7.17

### DIFF
--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -1,10 +1,10 @@
 cask 'vimediamanager' do
-  version '0,7a15:c'
-  sha256 '020ad0384093cc7846234f38e6e4016743368e1f83a462b0771e9471c2cae7ab'
+  version '0.7.17'
+  sha256 'd4948aa0c70cfd860c491b13016bb4a3355d3a40bf04189580046a791009011f'
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version.after_comma.before_colon}/vimediamanager_v#{version.before_comma}.#{version.after_comma.before_colon}#{version.after_colon}.dmg"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version.minor}a#{version.patch}/ViMediaManager_v#{version}c.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom',
-          checkpoint: '238a92a1893bda5b37298493fc872f0055ffcfaf7815619b8d547ff838ab1510'
+          checkpoint: 'b6a846e7367ccdf40e7cec2683c08bc1d12c6095d42ac98288ecca9490de4cfb'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.