### PR TITLE
Update ubar to 4.0.5

### DIFF
--- a/Casks/ubar.rb
+++ b/Casks/ubar.rb
@@ -1,10 +1,10 @@
 cask 'ubar' do
-  version '4.0.4'
-  sha256 'a8609cde9e128cfa29aabdbd067480e93e7e2e004a3af483891918164211cb1c'
+  version '4.0.5'
+  sha256 'eccf9c393975733693808c09e318928445978ad79203e47db2ac90e32b219601'
 
   url "http://www.brawersoftware.com/downloads/ubar/ubar#{version.no_dots}.zip"
   appcast "https://brawersoftware.com/appcasts/feeds/ubar/ubar#{version.major}.xml",
-          checkpoint: '46820c6898656f017fa37f691fa7a674c52de1575f1adb88959368703ec90530'
+          checkpoint: 'dfb8a05a26c40311750a9fdf4db4a4698fa29dcb93d7108ac42362a6f0c96aa7'
   name 'uBar'
   homepage 'https://brawersoftware.com/products/ubar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.