### PR TITLE
Update savoir-faire-linux-ring to 201805111841

### DIFF
--- a/Casks/savoir-faire-linux-ring.rb
+++ b/Casks/savoir-faire-linux-ring.rb
@@ -1,10 +1,10 @@
 cask 'savoir-faire-linux-ring' do
-  version '201802231805'
-  sha256 '0dd8605a408552faab7aa4f2cc29ee076ebac9bf95101b657d1842039ca0e6eb'
+  version '201805111841'
+  sha256 'e31d841ca37867757fbeca8a3ad94c697e81789d3a996f4537208ba9257ab581'
 
   url "https://dl.ring.cx/mac_osx/ring-#{version}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',
-          checkpoint: '7803aa2cc88bf9357de9c9cc28d359baf3c93ba7a40787c7ceba6f44d81d612d'
+          checkpoint: '04d0c5303f3b1ad6225e21b5981de1b18442dcf1d51864e55cc9203103a3f1a7'
   name 'Savoir-faire LINUX Ring'
   name 'Ring'
   homepage 'https://ring.cx/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.