### PR TITLE
Update vnote to 1.16

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,11 +1,11 @@
 cask 'vnote' do
-  version '1.15'
-  sha256 'eb64ee54426fb5525c077e4538f74aac20fc2108a39937aeee700835dfc95825'
+  version '1.16'
+  sha256 '363ea900028761c3480b5501cdea020e429b73a21f41e0e492768d3e25571745'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"
   appcast 'https://github.com/tamlok/vnote/releases.atom',
-          checkpoint: '79b2d2df441140b7b190c96e29121385b995f9663e537de5d84bd161fd03652f'
+          checkpoint: '5f7de97854b354a4f32d05f9b791d87502fb1c7af4f27eab27be858ca2aadf61'
   name 'VNote'
   homepage 'https://tamlok.github.io/vnote/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.