### PR TITLE
Update splashtop-business to 3.2.2.0

### DIFF
--- a/Casks/splashtop-business.rb
+++ b/Casks/splashtop-business.rb
@@ -1,11 +1,11 @@
 cask 'splashtop-business' do
-  version '3.2.0.0'
-  sha256 '09151ece4e3b7139a52ebc43a276b50604a2e7546901d226837dfc32484d2249'
+  version '3.2.2.0'
+  sha256 '94546156f5df7c337cf64fa0f5f025e0e98d132ecbcec906becf37d40a822b9d'
 
   # d17kmd0va0f0mp.cloudfront.net/macclient/STB was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STB/Splashtop_Business_Mac_INSTALLER_v#{version}.dmg"
   appcast 'https://www.splashtop.com/wp-content/themes/responsive/downloadx.php?product=stb&platform=mac-client',
-          checkpoint: 'c12dd30429b1eab2dbc72a6f50ced0342abfbea505db90c327df552b7a9349ce'
+          checkpoint: '3bc26aa5aaa22dc5f027a74e515fa5e487bccb884f6a217a49f92b73a04c1651'
   name 'Splashtop Business'
   homepage 'https://www.splashtop.com/business'
 

--- a/Casks/splashtop-business.rb
+++ b/Casks/splashtop-business.rb
@@ -11,5 +11,8 @@ cask 'splashtop-business' do
 
   pkg 'Splashtop Business.pkg'
 
-  uninstall pkgutil: 'com.splashtop.stb.*'
+  uninstall pkgutil: [
+                       'com.splashtop.stb.*',
+                       'com.splashtop.splashtopBusiness.*',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.