### PR TITLE
Update rocks-n-diamonds to 4.1.0.0

### DIFF
--- a/Casks/rocks-n-diamonds.rb
+++ b/Casks/rocks-n-diamonds.rb
@@ -1,10 +1,10 @@
 cask 'rocks-n-diamonds' do
-  version '4.0.1.0'
-  sha256 '340df901fafe068b6c49798920a61fad921f18bc1bc6e3e5478d0465c7f153ff'
+  version '4.1.0.0'
+  sha256 '755fa66f18ced47d1249a8c1080b683a81cbd15231bb62cd51f65b60e28e92d5'
 
   url "https://www.artsoft.org/RELEASES/macosx/rocksndiamonds/rocksndiamonds-#{version}.dmg"
   appcast 'https://www.artsoft.org/RELEASES/macosx/rocksndiamonds/',
-          checkpoint: '098b882374d98dccb75cc5e6ae0a3c1f9b3dc2cf1d58898b8128f3d86ba33f7c'
+          checkpoint: 'cc28606edcc9eca677122866a0ef3c45bb0f36f47bdcbf0397776eae9960cc0a'
   name 'Rocks\'n\'Diamonds'
   homepage 'https://www.artsoft.org/rocksndiamonds/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.