### PR TITLE
Update paw to 3.1.6,6

### DIFF
--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -1,10 +1,10 @@
 cask 'paw' do
-  version '3.1.5,3'
-  sha256 '7a4c658ac371539335090d7ed714b6efee566a46ea94d1ebaed06346328d4a92'
+  version '3.1.6,6'
+  sha256 '824fabdd7b658b33795131a88cbb2838f1c13ff5f6028538d08871de0aefd737'
 
   url "https://cdn-builds.paw.cloud/paw/Paw-#{version.major_minor_patch}-#{version.major}#{version.minor.rjust(3, '0')}#{version.patch.rjust(3, '0')}#{version.after_comma.rjust(3, '0')}.zip"
   appcast 'https://paw.cloud/api/v2/updates/appcast',
-          checkpoint: 'a68a175c6dea0a667403dfcf829a968fd00db3fed98e2e7ee09d3c609cea149a'
+          checkpoint: 'ae00911338c474c6662e5ed1945892d5d636134632fef49dd31364576e60bf55'
   name 'Paw'
   homepage 'https://paw.cloud/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.