### PR TITLE
Update splitshow to 0.9.10-alpha

### DIFF
--- a/Casks/splitshow.rb
+++ b/Casks/splitshow.rb
@@ -1,10 +1,10 @@
 cask 'splitshow' do
-  version '0.9.9-alpha'
-  sha256 '751ddad47f75834ebd998e9de6bc5640b741f0a2ee4f892188f2ac0ae3c26d15'
+  version '0.9.10-alpha'
+  sha256 '2bd1a68dda450e1052a54499731f710d119728f85f34187436cdffb5707dccd4'
 
-  url "https://github.com/mpflanzer/splitshow/releases/download/v#{version}/SplitShow.app.zip"
+  url "https://github.com/mpflanzer/splitshow/releases/download/v.#{version}/SplitShow.app.zip"
   appcast 'https://github.com/mpflanzer/splitshow/releases.atom',
-          checkpoint: '37df53bd109adabe4c948e5eeeb22ac805617354a54e092c034f458706897981'
+          checkpoint: 'a61d4692d09d0d17f5bcbeb7f71a54f4ad662b356c5b23fa01339ffb939da570'
   name 'SplitShow'
   homepage 'https://github.com/mpflanzer/splitshow'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.