### PR TITLE
Update rubitrack-pro to 5.0.3

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '5.0.2'
-  sha256 'a4b2ce1fe96f32dfce83f708d0aadb57c6e31e3f4d151f5ae6916fa242aa1ba6'
+  version '5.0.3'
+  sha256 '9c0cb0360deb1fa72448eda600273f5c00083b8944958dfe69da6b80e4755089'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: '38da165545e9e2f5048abfd5bfad25a92ac781630da00a66eab4d22574cfd517'
+          checkpoint: '6dd8ac7a0a6bc34f709e017009fef77cea66fbfb4f3fc56817566b18ac83b0a5'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.