### PR TITLE
Update apple-juice to 1.3.0

### DIFF
--- a/Casks/apple-juice.rb
+++ b/Casks/apple-juice.rb
@@ -1,10 +1,10 @@
 cask 'apple-juice' do
-  version '1.2.3.1'
-  sha256 'a30c9d271bcda8d48c670dbf7e98c2a2c955152c413caea0868889d56b15e258'
+  version '1.3.0'
+  sha256 'b77a9deefe429ce875c8b628e3fb41b4fb6dbe4408401dd9ec3b9a845b51bc45'
 
   url "https://github.com/raphaelhanneken/apple-juice/releases/download/#{version}/Apple.Juice.dmg"
   appcast 'https://github.com/raphaelhanneken/apple-juice/releases.atom',
-          checkpoint: '8eab87ff2f3bc47e3259d7b0f5f2da4bc8ae6c25fd71edd49212544ed01baba9'
+          checkpoint: '54ca7b9e5b7ddeba0af9430ef15c2518d074010c6ec2c2be9179b241ca226fa0'
   name 'Apple Juice'
   homepage 'https://github.com/raphaelhanneken/apple-juice'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.