### PR TITLE
Update and rename subutai-control-center to subutaicontrolcenter 7.0.0

### DIFF
--- a/Casks/subutai-control-center.rb
+++ b/Casks/subutai-control-center.rb
@@ -19,5 +19,5 @@ cask 'subutai-control-center' do
   end
 
   uninstall pkgutil: 'com.Subutai.Control.Center',
-            trash:   '/Applications/SubutaiControlCenter.app'
+            delete:  '/Applications/SubutaiControlCenter.app'
 end

--- a/Casks/subutai-control-center.rb
+++ b/Casks/subutai-control-center.rb
@@ -1,11 +1,11 @@
 cask 'subutai-control-center' do
-  version '6.10.0'
-  sha256 '6d11367d7ae44124aea364c35e00217118c29f58b5288a2b567d1aee884dd755'
+  version '7.0.0'
+  sha256 'c3eb5e3c0e97b3db14f8f5a609ac22ebde92335ef4568cb83c6a978e8eb82ccc'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-control-center.pkg'
   appcast 'https://github.com/subutai-io/control-center/releases.atom',
-          checkpoint: 'e9212afc4368bd27fc509dd59b030a194316180793f3f4123b46f6e7eaa3a194'
+          checkpoint: '3826ac214986bc1353a310d84745a455c2cf54eb5e9a596150fb9fb73a777b9f'
   name 'Subutai Tray'
   homepage 'https://subutai.io/'
 
@@ -18,5 +18,6 @@ cask 'subutai-control-center' do
     system_command '/bin/mv', args: ['--', staged_path.join('get'), staged_path.join('subutai-control-center.pkg')]
   end
 
-  uninstall pkgutil: 'com.Subutai.Control.Center'
+  uninstall pkgutil: 'com.Subutai.Control.Center',
+            trash:   '/Applications/SubutaiControlCenter.app'
 end

--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -1,4 +1,4 @@
-cask 'subutai-control-center' do
+cask 'subutaicontrolcenter' do
   version '7.0.0'
   sha256 'c3eb5e3c0e97b3db14f8f5a609ac22ebde92335ef4568cb83c6a978e8eb82ccc'
 
@@ -6,7 +6,7 @@ cask 'subutai-control-center' do
   url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-control-center.pkg'
   appcast 'https://github.com/subutai-io/control-center/releases.atom',
           checkpoint: '3826ac214986bc1353a310d84745a455c2cf54eb5e9a596150fb9fb73a777b9f'
-  name 'Subutai Tray'
+  name 'Subutai Control Center'
   homepage 'https://subutai.io/'
 
   auto_updates true


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.