### PR TITLE
Update fredm-fuse to 1.5.3

### DIFF
--- a/Casks/fredm-fuse.rb
+++ b/Casks/fredm-fuse.rb
@@ -1,10 +1,10 @@
 cask 'fredm-fuse' do
-  version '1.5.2'
-  sha256 '0dbaa072cdf12000a664d74bec332a041185a5800c84f9dbb2a3fd3f7de933c6'
+  version '1.5.3'
+  sha256 '4f06f5856971530c43e484d57bd8342e6e6a3dfbf6366d6af13ffc5fd5299e2d'
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip"
   appcast 'https://sourceforge.net/projects/fuse-for-macosx/rss?path=/fuse-for-macosx',
-          checkpoint: 'f5a5ddd256fea03e4e90953343995c328a42c9b3abe91cacf3a1e7bdd70490c7'
+          checkpoint: 'a442e3efd5091f6632bcd1b4865fa143f360f792fd96a91a13f03ab12f85fc21'
   name 'Fuse for Mac OS X'
   homepage 'http://fuse-for-macosx.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.