### PR TITLE
Update praat to 6.0.40

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,11 +1,11 @@
 cask 'praat' do
-  version '6.0.38'
-  sha256 'dc69203cddecf1c4dde441d2fd78e83b35b96b498fb7bc9d02a3a644299053ae'
+  version '6.0.40'
+  sha256 '117531be1476545d5f70a032dedb09a748117fd9a6aa0d0c3da984a6c17d6b4f'
 
   # github.com/praat/praat/releases was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom',
-          checkpoint: '885c266f67baf05fff6d811f3470bf254b76b666758549823c4945abfd151377'
+          checkpoint: 'c65fb16eb92e1aab257a9096fd1f2a919223a16c5d850aec8ce69daff0431e68'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.