### PR TITLE
Update appium to 1.6.1

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,11 +1,11 @@
 cask 'appium' do
-  version '1.5.0'
-  sha256 '221187839a0218fbb3c6f254d3a0d070a5189d2fc7b9b3719fb74bdb2cc4d4bb'
+  version '1.6.1'
+  sha256 'bdd19869aba715fe32b279b320224cc5940748072b3c1d781a3d3eeea39f5d15'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
   url "https://github.com/appium/appium-desktop/releases/download/v#{version}/appium-desktop-#{version}-mac.zip"
   appcast 'https://github.com/appium/appium-desktop/releases.atom',
-          checkpoint: 'a20a5a20aeb11ce6010d65d3a5b4bd51710f67a4a3538bcc5a06812fce8a5176'
+          checkpoint: '72505bd3b348b47a2f06d8c09f81a31f84ce5278e1a64e7c37e884d9ebe2850f'
   name 'Appium Desktop'
   homepage 'https://appium.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.