### PR TITLE
Update lehreroffice to 2018.7.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice' do
-  version '2018.6.0'
-  sha256 '18bfbb32f0a719857aa53d43e936edc96fde4835824b67fd416fe6a9846d10d3'
+  version '2018.7.0'
+  sha256 'd75b9fa3f40edc46d318863ea39ccff03dd0144cf6d51314faa4c92185a8f70e'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop',
-          checkpoint: '46f4af140891dbba91890b2a69bedd15adb7dd6e4b08bf7617924434796f9cac'
+          checkpoint: '257e5606f1d1c59e1122a05a25f26360210c5b690fd823da6ea039b16871962f'
   name 'LehrerOffice'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.