### PR TITLE
Update prusa-slic3r to 1.39.2,201805041531

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,11 +1,11 @@
 cask 'prusa-slic3r' do
-  version '1.39.1,201803010854'
-  sha256 '745a156f366c06e0863383d2e661e970443905a10370bbbcb44ad9167332f1b0'
+  version '1.39.2,201805041531'
+  sha256 '57431549e6ac7251579c67a2e2826a8ad7dd62678b4b5ce39976390be3056392'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
-  url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3r-#{version.before_comma}-prusa3d-full-#{version.after_comma}.dmg"
+  url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3rPE-#{version.before_comma}.full-#{version.after_comma}.dmg"
   appcast 'https://github.com/prusa3d/Slic3r/releases.atom',
-          checkpoint: '7043d27fe21072d2e88e3580f51e068c60ddc649d878e30ef4406c651ee83d37'
+          checkpoint: 'b688d5b3b3fed485629c6c754f0a591e5ae6f2f45f1576396e5e98baa72e5146'
   name 'Slic3r - Prusa Edition'
   homepage 'https://www.prusa3d.com/slic3r-prusa-edition/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.