### PR TITLE
Update picat to 2.4

### DIFF
--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,10 +1,10 @@
 cask 'picat' do
-  version '2.2'
-  sha256 'fa8336776da18d7669ce59e5a4836c7c3bfeed9d509d4a7a50f0e72862e8ed62'
+  version '2.4'
+  sha256 '6b5da2bcf5a7d62576018c0968e406677cf4c8f207c4db2ed6939701a5f13e06'
 
   url "http://picat-lang.org/download/picat#{version.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt',
-          checkpoint: '83b1ef8773629f7608539b747f3dfc6317278e83d69988e83d06d258883c5009'
+          checkpoint: 'ca2fcc9224520e6222e1e3b50bcf1eb7a80f5bca3a2900486fcb86fd2e7eb9ed'
   name 'Picat'
   homepage 'http://www.picat-lang.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.