### PR TITLE
Update superproductivity to 1.10.36

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,11 +1,11 @@
 cask 'superproductivity' do
-  version '1.10.14'
-  sha256 'fa0631f72bd1e3d8884661b5c824298315270609368bb9341ed146be8f61a6e1'
+  version '1.10.36'
+  sha256 '6e318abd3875b6f1de393ee4ff169759bfbd80b40723cdb66aafec21e404cf14'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"
   appcast 'https://github.com/johannesjo/super-productivity/releases.atom',
-          checkpoint: 'a12a674e331deed8e2cd3b271a282b89b645be0e2e9da66069a479ef4c3fe99c'
+          checkpoint: '5124f145cea976d53b745d45751e2d1b0ebb4ab0f5e0aa1ede54191cf0e8a71e'
   name 'Super Productivity'
   homepage 'https://super-productivity.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.