### PR TITLE
Update zulip to 2.0.0

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,11 +1,11 @@
 cask 'zulip' do
-  version '1.9.0'
-  sha256 '330d4351088ef929832f48d720fc5de02cb71557545ccc2a2c00ba6b32394446'
+  version '2.0.0'
+  sha256 '6d91a4971cfe5f0af227edf6ab002f81cedc66270b9e50f6b1daa7655326b8c1'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}-mac.zip"
   appcast 'https://github.com/zulip/zulip-electron/releases.atom',
-          checkpoint: '32db585876169f8b441bd1cb58e233ace0946d257e64605cad3415ad5d548c68'
+          checkpoint: 'fccf46be6d76f1ebd01328d8839e2dbf3a4e87ebe7fb015cdcd1a0d3d6e56d57'
   name 'Zulip'
   homepage 'https://zulipchat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.