### PR TITLE
Update visit to 2.13.1

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,11 +1,11 @@
 cask 'visit' do
-  version '2.13.0'
-  sha256 'e04668ee5bdfcb352e238eca579543ec548c995d4a9e1ce0d4b5be2877bfb045'
+  version '2.13.1'
+  sha256 '8956f047277c1e30f7d33233fae14f5fca12f261150480100a6db27bb445eb3e'
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
   url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}-10.11.dmg"
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables',
-          checkpoint: 'af9ad999de6149081917bc2f37a2ab0de3527b442d5e8cee8372e20735a02f18'
+          checkpoint: '8a3443e23de3dfddee12ed1187566e651cd5a642d66b30dec849705b713722a4'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.