### PR TITLE
Update terminus to 1.0.0-alpha.46

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,11 +1,11 @@
 cask 'terminus' do
-  version '1.0.0-alpha.23'
-  sha256 '896733b77bcc28998d4b99fe61ba941ccc0d27dcf391a4c808c22c524f60e844'
+  version '1.0.0-alpha.46'
+  sha256 '291de808b0b0be8cd1a298f24cdaacdeaccc44baa9557eecd4f448f1bf6f38a1'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/Terminus-#{version}.dmg"
   appcast 'https://github.com/Eugeny/terminus/releases.atom',
-          checkpoint: 'c6c29983c33ebd13a25dd9bf086709360d448738c8df33ed9b26dfa4faa6e1dd'
+          checkpoint: 'db1cebef8752310d86b9aae4df98d3f027d2d961ae69f4f9bd94847286c94ec7'
   name 'Terminus'
   homepage 'https://eugeny.github.io/terminus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.