### PR TITLE
Update appcast checkpoint for ProPresenter 6.3.4 cask

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -4,7 +4,7 @@ cask 'propresenter' do
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php",
-          checkpoint: '83d1c48633f39eeb5d36964a87531b5f696065673e4e838e673da3f23b989662'
+          checkpoint: '7bab7adac4b19ec59b080528250ac430dd347734d0167559f3ec094f9c44e66b'
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
