### PR TITLE
Update tenor to 2.0.5

### DIFF
--- a/Casks/tenor.rb
+++ b/Casks/tenor.rb
@@ -1,13 +1,15 @@
 cask 'tenor' do
-  version '2.0.4'
-  sha256 '42c666af0976b1bebdca02f0889071b9a81f5f712795de33db172ec515e0bd07'
+  version '2.0.5'
+  sha256 '017a57846ef84ca61268b33a20ec8cf16ac15fc1d520077b76bd498b58cd84fd'
 
   # media.tenor.co/mac/bin was verified as official when first introduced to the cask
   url 'https://media.tenor.co/mac/bin/GIFforMac.dmg'
   appcast 'https://media.tenor.co/mac/gif_for_mac_appcast.xml',
-          checkpoint: '3b2af09a9781777e7437c9e5a60bb674194a2cad417f8718ca43534949bc352d'
+          checkpoint: '87b4c9a9f4711c97873a90584b95bdf3810011d43a2dd953dc5cf6ac888a1b5f'
   name 'Tenor'
   homepage 'https://tenor.com/mac'
+
+  depends_on macos: '>= :el_capitan'
 
   app 'Tenor.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.