### PR TITLE
Update wey to 0.2.3

### DIFF
--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,10 +1,10 @@
 cask 'wey' do
-  version '0.2.2'
-  sha256 'd2985075766917a7d05f14d1ca402985a9122d9d01233fe20ee8f02f82d44eaa'
+  version '0.2.3'
+  sha256 'e3c14444fee3e04ef0f8a0808aa1cb3607f62dfba0f8aaa0edcf8b80fdd021cd'
 
   url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom',
-          checkpoint: '1bf496f625c4c1d4ca611cec57a15145f22d4e65c30d5533fa57cee8eff1cc35'
+          checkpoint: 'bab5a35194352575519d4b99ffabab5c0fa1148ab25aefce3bb4e404fe148ab4'
   name 'Wey'
   homepage 'https://github.com/yue/wey'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.