### PR TITLE
Update namechanger to 3.3.2-6

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -1,12 +1,14 @@
 cask 'namechanger' do
-  version '3.3.1'
-  sha256 'd00f9d9eaaa9d228f686dc313e9c5f8978d2d35fc9e598d759e8a2c9ca993198'
+  version '3.3.2-6'
+  sha256 'cd44006b4f223a5adb862d9143349261df5bb41dd5bff2ad5998f219dfa57b06'
 
   url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.dots_to_underscores}.zip"
   appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml',
-          checkpoint: '3caded5e8f5c07e6ec260322176151019a091a429d46af9ea3230ab00b6d13cd'
+          checkpoint: '73031631d37b9173d54dc75900f9791429ef7c4ccf83a83ce278467d757779a3'
   name 'NameChanger'
   homepage 'https://mrrsoftware.com/namechanger/'
+
+  depends_on macos: '>= :lion'
 
   app 'NameChanger.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.