### PR TITLE
Update workflowy to 1.0.15

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,11 +1,11 @@
 cask 'workflowy' do
-  version '1.0.12'
-  sha256 '1174ef8ca59abaedef5fe2247b9339c38a10ad1dac8102b983d10deb3ee687e1'
+  version '1.0.15'
+  sha256 '3e19668719d305a41ae1a22568439954a9f8f002e7c5c6e4f3fcb39a07e7b413'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"
   appcast 'https://github.com/workflowy/desktop/releases.atom',
-          checkpoint: '045ffb0d3ce9bff488943ecff1eba5595ee6bd75af018b19482ea366c9824739'
+          checkpoint: '8c82cdf29ab8b6a1f06ceb51927dbeec2bda75fe2e217fcdddb2d6e5139ff8b6'
   name 'WorkFlowy'
   homepage 'https://workflowy.com/downloads/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.