### PR TITLE
Update trickster to 2.7

### DIFF
--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -3,15 +3,17 @@ cask 'trickster' do
     version '2.1.1'
     sha256 'cddc4a27c3c2a016f86d1688ef9708d3e8c605cfe06302470471309ccdc241db'
   else
-    version '2.6'
-    sha256 '73ddedc3e3622284f5111f9f85f0b8068355eeafe1f47c61990de1a3c0d86d91'
+    version '2.7'
+    sha256 '88938097eaafff496e1705c08e288519e93bf36fc1d10fd9f55e8cb9bc6d4453'
   end
 
   url "https://dl.apparentsoft.com/Trickster_#{version}.zip"
   appcast 'https://dl.apparentsoft.com/trickster.rss',
-          checkpoint: 'fd7806111308b4b506d92fbdbad2fb90661b0933a3e3c40896927eb7f1a693cf'
+          checkpoint: 'c355b5d2c6ec4c7ea505df1f9b93f555779567a0355e2707e099aaaba8d4e983'
   name 'Trickster'
   homepage 'https://www.apparentsoft.com/trickster/'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'Trickster.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.