### PR TITLE
Update gifox to 010600.00

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -1,11 +1,11 @@
 cask 'gifox' do
-  version '010501.01'
-  sha256 'ed25c3a2678ebe409535356f9ebf2e1583dfc75a928fc9787ef96f09f86720b6'
+  version '010600.00'
+  sha256 '3fda02e5dd7aac3ad128ffbfcd27640175cae83dd6d9c17bc6e93533026c97ff'
 
   # s3.eu-central-1.amazonaws.com/dstlalgzor/gifox was verified as official when first introduced to the cask
   url "https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/#{version}.dmg"
   appcast 'https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/appcast.xml',
-          checkpoint: 'b91b7581bb57a40a1cde0ca06b323fe9f4d951d4144c05eb6dcaad9bdbadee00'
+          checkpoint: 'c74d6a5d6b45d32ddf878eddd040bfe8bf6c84c7944cb6f116afc1ac177afa8b'
   name 'gifox'
   homepage 'https://gifox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.