### PR TITLE
Update smooze to 1.6.2

### DIFF
--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -1,10 +1,10 @@
 cask 'smooze' do
-  version '1.5.8'
-  sha256 '5cdb9f16beb86333ae287343e82a7d5ece945514e5dd903674acf22e43e433df'
+  version '1.6.2'
+  sha256 'fda24f73f81bf4dd533cfbf570764cda60c59155a57cb9a9421af20ce5bba784'
 
   url 'https://smooze.co/updates/Smooze.dmg'
   appcast 'https://smooze.co/updates/update.xml',
-          checkpoint: 'e42762310b3e0b0b42d01801812a35ea89a3a46c814cac87538e90e60ff84be0'
+          checkpoint: 'ead6f0be9bff04875ed0e654852b2a805de4b95504ff2a074c6a4ad64d58331d'
   name 'Smooze'
   homepage 'https://smooze.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.