### PR TITLE
Update netlogo to 6.0.3

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,10 +1,10 @@
 cask 'netlogo' do
   version '6.0.3'
-  sha256 '6d3c9da4d1bffc79689666d6319fa9ff3d2cf7e779027a1c457b3395cc12582f'
+  sha256 '5cccdfaff8af4f5556cf211f0bfe6e8c08ae7f17456932c8903125106acdf351'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml',
-          checkpoint: '1351f25e5c59bbf9f6a08cda8371fa2b7aec4f0d75c3736020cb408656833473'
+          checkpoint: 'b0ff96ad08709796d91ff19f1525f9059b3fa36a9e38e8da8c1293d980a8b5ef'
   name 'NetLogo'
   homepage 'https://ccl.northwestern.edu/netlogo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.