### PR TITLE
Update soulver to 2.6.7-5936

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,12 +1,14 @@
 cask 'soulver' do
-  version '2.6.6-5881'
-  sha256 'a95219084fba53c99a0aec44e283d6acfad157399b004eae7cd1597b12f935ae'
+  version '2.6.7-5936'
+  sha256 '81df634e82418904b539bdc30d28e30486f3e5d1132d296c4cedc4a025f8c562'
 
   url "http://www.acqualia.com/files/sparkle/soulver_#{version}.zip"
   appcast "http://www.acqualia.com/soulver/appcast/soulver#{version.major}.xml",
-          checkpoint: 'a4e78d3e73ac5772ff213c2b2bfe700294afce50b1b745e79d7e448959d7669b'
+          checkpoint: 'a7872dca261ed69c5f485c3a0dc752f4619c9a4d41e1076a77810fbf12e01a23'
   name 'Soulver'
   homepage 'http://www.acqualia.com/soulver/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'Soulver.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.