### PR TITLE
Update tv-browser to 4.0.1

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -1,11 +1,11 @@
 cask 'tv-browser' do
-  version '4'
-  sha256 '814899388669d5d0501dc35e4cf6d47a3c5393c5a1a02bcaecce49ab02692ddb'
+  version '4.0.1'
+  sha256 '0f881a81da4a10ee29622e1667df07b9445559746a900a1ac24000f6da9f1e0a'
 
   # sourceforge.net/tvbrowser was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/tvbrowser/tvbrowser_#{version}_macjava.dmg"
   appcast 'https://sourceforge.net/projects/tvbrowser/rss',
-          checkpoint: 'a802a00e4357b4e6f392434073843a9b12308f299420d2ddefd72c07d702f1d3'
+          checkpoint: '9ea7b46492ef993bef0f498ef62fcb8255c10ab0220fff228ca2d04e8017720e'
   name 'TV-Browser'
   homepage 'http://www.tvbrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.