### PR TITLE
Update botframework-emulator to 3.5.36

### DIFF
--- a/Casks/botframework-emulator.rb
+++ b/Casks/botframework-emulator.rb
@@ -1,10 +1,10 @@
 cask 'botframework-emulator' do
-  version '3.5.35'
-  sha256 '860bfbcacfc6f5998b33b71ca6114b5c560c6404b7234343cec216b8298a459c'
+  version '3.5.36'
+  sha256 'fa49f77581feb854ea4911faabadc8b0759aacbd1fa5e897f976f36a0da1bc35'
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom',
-          checkpoint: 'd7feb36c4d036ba29d339d2a2940b80c3d01b414d71185f97d7eebee09a4cfbc'
+          checkpoint: '40f13a8b6c71f3f985bd8bed3637549f2c77ef3e7e08f89f462e8508041b7abf'
   name 'Microsoft Bot Framework Emulator'
   homepage 'https://github.com/Microsoft/BotFramework-Emulator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.