### PR TITLE
Update rapidweaver to 7.5.5,18814.1513161980

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,11 +1,11 @@
 cask 'rapidweaver' do
-  version '7.5.4,18811.1511975403'
-  sha256 'b25ae4b3fd9e51270c1c9f1a348174ba53c447903975f96a96c0c82711dce6a1'
+  version '7.5.5,18814.1513161980'
+  sha256 '0da43f39cc2d16bda314cf8e57faddb7660068b315281c21b99a836323b29fd0'
 
   # devmate.com/com.realmacsoftware.rapidweaver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.realmacsoftware.rapidweaver/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver-#{version.after_comma.major}.zip"
   appcast 'https://updates.devmate.com/com.realmacsoftware.rapidweaver.xml',
-          checkpoint: '83fc8fff13ae051c2ce7c6b78fc2792c085602c1c695e95da88dd356464a4385'
+          checkpoint: 'b079c3ecc4cc455a84dcd3f49edb575d18b3556165c558f4e5b8d42f15ffa709'
   name 'RapidWeaver'
   homepage 'https://www.realmacsoftware.com/rapidweaver/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.