### PR TITLE
Update antconc to 3.5.7

### DIFF
--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -1,10 +1,10 @@
 cask 'antconc' do
-  version '3.5.6'
-  sha256 '7cf816ea30257c3663cbb0932bd598dc0378c42c1dd370cee59cfda0489a18e7'
+  version '3.5.7'
+  sha256 '660fb0df5376544c41bb3d7c4b4c22cd11d2d20d09e1c895cc342713089890be'
 
   url "http://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   appcast 'http://www.laurenceanthony.net/software/antconc/releases/',
-          checkpoint: '35a1e7bf4acabbec68ceb0e0d2170fe79aa9032c3313dbc9fa8f384a88887301'
+          checkpoint: '9fbd6dab4bdc22540c9d29b8d542c5f04079914111d99f0ee11352bb2351ab0f'
   name 'AntConc'
   homepage 'http://www.laurenceanthony.net/software/antconc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.