### PR TITLE
Update formular-designer to 2018.2.0

### DIFF
--- a/Casks/formular-designer.rb
+++ b/Casks/formular-designer.rb
@@ -1,10 +1,10 @@
 cask 'formular-designer' do
-  version '2018.1.0'
-  sha256 'f40f0c8b5e1259ad8cd575102ec36393e3c296534ffb477c50f32398d115b307'
+  version '2018.2.0'
+  sha256 '86f6f70b5df6535e81c17deb2dc16166ce5f7a92be79be28c3b73d74b5187474'
 
   url 'https://www.lehreroffice.ch/lo/dateien/designer/lo_designer_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Designer',
-          checkpoint: '6fe4f5161c743ebd123751643531c2d1b4e78f578dc1b5bed3ca094501c44cde'
+          checkpoint: '96aab4a8f7d62edade54ceb5a82d24e4710dab28af25be8b1ef4cbe68d1d6d58'
   name 'Formular-Designer'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.