### PR TITLE
Update bee to 3.1,5423

### DIFF
--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -1,11 +1,11 @@
 cask 'bee' do
-  version '3.0.21,5403'
-  sha256 'ebe55846bc8d587be4b6a918351de9e04c0e4256af9da88b18b7b1ae664cb64f'
+  version '3.1,5423'
+  sha256 '4df98ace793d92f37773e55ef64843e32d0160dce57ba6615d822f5acb173c2e'
 
   # bee-app.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://bee-app.s3.amazonaws.com/public/Bee-#{version.after_comma}-#{version.before_comma}.zip"
   appcast 'https://s3.amazonaws.com/www.neat.io/bee/appcast.xml',
-          checkpoint: '28d29701761a783c419b20c886ef8b446fa77c103db06dd8199dd90772478fb1'
+          checkpoint: '4368144ce7ddc32bb3be47a0a510d1fe6ab99f95b2e22ce3b8de57e94e4058c2'
   name 'Bee'
   homepage 'http://www.neat.io/bee/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.