### PR TITLE
Update qtox to 1.15.0

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,11 +1,11 @@
 cask 'qtox' do
   version '1.15.0'
-  sha256 '566397a5dd01ee4a0f21cac91e2ff8ea98739db87dca560ec16145b3e62b19b7'
+  sha256 '75a07a73dbc3eab13c853e9754e9c4c5dd8b17234ff8b215efb352736f99330b'
 
   # github.com/qTox/qTox was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"
   appcast 'https://github.com/qTox/qTox/releases.atom',
-          checkpoint: '9d0f8fe34feba26506f5da3917dbb2f8ef750bd4137626f87858c61cac33776e'
+          checkpoint: '41a7c64bb401642f7062f7df2e3e675ad1fce6ef1e9c932872aa4d94f8dedb0a'
   name 'qTox'
   homepage 'https://qtox.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.