### PR TITLE
Update jamf-migrator to 2.7.2

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,10 +1,10 @@
 cask 'jamf-migrator' do
-  version '2.7.1'
-  sha256 '86529ef9d9d0dcc659c1b5e5a7a35f0ee4ef4454537ff590168521ab5210d599'
+  version '2.7.2'
+  sha256 '781797e0116196b9b75bf243f98a1394a2e90da59d3ded0b81e61334bc7b34d6'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom',
-          checkpoint: 'a55817d73874f77e2a5056ab402054a6f288a939bb9c3874f0f0d8f8be7c2f64'
+          checkpoint: '6682226fd23867f9524bc67841ffce9eb0ad848d3bfa6fcfb4ea2013e4902857'
   name 'JamfMigrator'
   homepage 'https://github.com/jamfprofessionalservices/JamfMigrator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.