### PR TITLE
Update qz-tray to 2.0.6-1

### DIFF
--- a/Casks/qz-tray.rb
+++ b/Casks/qz-tray.rb
@@ -1,11 +1,11 @@
 cask 'qz-tray' do
-  version '2.0.5'
-  sha256 '14ed68d40d02cffec1ec3f3abf5e61a1470e6ed1a71920fd069966bbcb4e5dfb'
+  version '2.0.6-1'
+  sha256 'a7698a477826385ad895084ebd84c757832b80f04cbdfe21449e91f62fd1568f'
 
   # github.com/qzind/tray was verified as official when first introduced to the cask
-  url "https://github.com/qzind/tray/releases/download/v#{version}/qz-tray-#{version}.pkg"
+  url "https://github.com/qzind/tray/releases/download/v#{version.major_minor_patch}/qz-tray-#{version}.pkg"
   appcast 'https://github.com/qzind/tray/releases.atom',
-          checkpoint: '1565896f75cde4c86d62ff318e65ba4437290d3980914470cfe5b31dd0236d38'
+          checkpoint: '07ddf9328642c9bb9ca21922b83935e9313bd8086e46373f9b7a7ea334f775c8'
   name 'QZ Tray'
   homepage 'https://qz.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.