### PR TITLE
Update splashtop-streamer to 3.2.2.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,11 +1,11 @@
 cask 'splashtop-streamer' do
-  version '3.1.4.1'
-  sha256 'fde44e9c706bcaa80b982829cc3e6c4bb9808f2ce0a0f4450d6b87bdca166107'
+  version '3.2.2.0'
+  sha256 'd52ec43249097917610b1b73360017264243e35a33cf25886ef9f98850eda0e4'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_v#{version}.dmg"
+  url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"
   appcast 'https://www.splashtop.com/wp-content/themes/responsive/downloadx.php?platform=mac',
-          checkpoint: 'bc0c6f61b57c30fcbf977dd55b7afd7ef6df737a161845bcc218075523591f31'
+          checkpoint: '854099d5dea13379cd2e386c94fc5c1b5326af3e4b81c769c5a667cd9282b6b6'
   name 'Splashtop Streamer'
   homepage 'https://www.splashtop.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.