### PR TITLE
Update pyfa to 2.0.0,yc120.3-1.8

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '1.36.0,yc120.3-1.8'
-  sha256 '68566ce1132f3901300f938dce5eda9b5e3a0bdc16a11e820f038c6d06f39554'
+  version '2.0.0,yc120.3-1.8'
+  sha256 '36d1540580f4893a4b49aa8ccd7709f16ebf8dbc3f8dad365f1161bcf8d961b9'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '903134392159db4b7b0922a6b9e9d40318c6ae4d4566365f78ac196e54acdef6'
+          checkpoint: '13c72e4e6295e6f345a0d402ac474726564dcd260837a7bc6545b2a0e3cbf4f7'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.