### PR TITLE
Update suitcase-fusion to 8,19.0.5

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,10 +1,10 @@
 cask 'suitcase-fusion' do
-  version '8,19.0.2'
-  sha256 '50b716fe0dd2ceddd2d14741bcfb99ee67b1f845583a68c260a62c95f26f884f'
+  version '8,19.0.5'
+  sha256 'c949d3f4b3a81eb4e07b1024e431f21479b75bc6b1997dd737b74f0e373a5437'
 
   url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
   appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml",
-          checkpoint: 'aaab9eda125164ff1604297600e10028851be078aa622f78ded2b6e91d069ea8'
+          checkpoint: 'a0ddcb52e098bd5824c425379c5ccc486492b99de8582371425cef5b2960d9a1'
   name 'Extensis Suitcase Fusion'
   homepage 'https://www.extensis.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.