### PR TITLE
Update xca to 2.0.1

### DIFF
--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,11 +1,11 @@
 cask 'xca' do
-  version '2.0.0'
-  sha256 '2fa713dc2d4edc55fdde7714d32f953939b6a43597a20601c08614e5270f3d8d'
+  version '2.0.1'
+  sha256 '6432f049855aadabf4c358f03f448ebc5722528c98cb50e0fa087908fcfe2763'
 
   # github.com/chris2511/xca was verified as official when first introduced to the cask
-  url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}.dmg"
+  url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}-High-Sierra.dmg"
   appcast 'https://github.com/chris2511/xca/releases.atom',
-          checkpoint: '3789bafcf36898387b6a2db98ad3e3fca0dfa213e76f0df8152e6e0182304f2f'
+          checkpoint: 'f4f6ba6c8f80cd69aeb7e17aeb11799ff0f18e79ccbd1165085dc5e0306b59b5'
   name 'XCA'
   homepage 'https://hohnstaedt.de/xca/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.