### PR TITLE
Update segmentant to 1.1.3

### DIFF
--- a/Casks/segmentant.rb
+++ b/Casks/segmentant.rb
@@ -1,10 +1,10 @@
 cask 'segmentant' do
-  version '1.1.1'
-  sha256 '2c621ad463b677afa58e4b9a5b265924b7923ed3cc0ea1c93c72eb0cffd1f167'
+  version '1.1.3'
+  sha256 '4f6190aa9f2c9529d5e31517459fad8745acc47cd813d974138a01b129d58717'
 
   url "http://www.laurenceanthony.net/software/segmentant/releases/SegmentAnt#{version.no_dots}/SegmentAnt.zip"
   appcast 'http://www.laurenceanthony.net/software/segmentant/releases/',
-          checkpoint: '001e89baf3649a1a88b78dedf28c465f26c5ce4e3a77e5643c09348753949342'
+          checkpoint: 'e48bd20b0ae2d040485a1daa1c79f16c51494c3c3cba1b7a6829cb0ae24460a7'
   name 'SegmentAnt'
   homepage 'http://www.laurenceanthony.net/software/segmentant/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.