### PR TITLE
Update wesnoth to 1.14.1a

### DIFF
--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -1,13 +1,15 @@
 cask 'wesnoth' do
-  version '1.12.6'
-  sha256 'c94fe7880b1ed0f52e31ad570d3f082412ffbeb9d7ddadf0c64d501dfc1f0589'
+  version '1.14.1a'
+  sha256 'd76d60492546877b015b6aa185c0e500e64c39a643a1137f89bf4eedd757d89c'
 
   # sourceforge.net/wesnoth was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/wesnoth/rss',
-          checkpoint: '6ab872944613cebe3c54f7922e42f01e3122841a526699ccea41373f258c2ea0'
+          checkpoint: 'a5501b27da01e08bad9378b822e849f205d25427499e7bcf80a2c47591c616da'
   name 'The Battle for Wesnoth'
   homepage 'https://wesnoth.org/'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'Wesnoth.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.