### PR TITLE
Update bitpay to 4.3.5

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,11 +1,11 @@
 cask 'bitpay' do
-  version '4.3.2'
-  sha256 'afdcc1556ee3294e10045324907075e98bb831791f4503b6a9ee4f171c973185'
+  version '4.3.5'
+  sha256 '1ec8279677570c0c82ba7dfd6544fc66a0a2a3494680edbc7f91694275d2d7ba'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"
   appcast 'https://github.com/bitpay/copay/releases.atom',
-          checkpoint: '8fa6b12d7e49da98d6087e704b93eec3b13620daf73b621397c363fc979517e1'
+          checkpoint: 'eab3dfc008886b760f0e3c4c8f81a4e6a832db0b6fe66683eb0dfc1063a97ef9'
   name 'BitPay'
   homepage 'https://bitpay.com/'
   gpg "#{url}.sig", key_id: '9d17e656bb3b6163ae9d71725cd600a61112cfa1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.