### PR TITLE
Update rhinoceros to 5.4.1

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,15 +1,16 @@
 cask 'rhinoceros' do
-  version '5.3.2'
-  sha256 '0b3ad681897954cf26fcbe6904516ae8526a050eaed61be8e4c2e09dd5725b05'
+  version '5.4.1'
+  sha256 'a2fcda3a5143dd06b84e53c34cbd40e8dbd9c3319130bfee9b23199c770b7c32'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/#{version.major}.0/Mac/Rhinoceros_#{version}.dmg"
   appcast "https://files.mcneel.com/rhino/#{version.major}.0/mac/#{version.major}CcommercialUpdates.xml",
-          checkpoint: 'cdd83fed27818db57ff1c252c38254aa77137f7cfbb6bdec0225c010ed69452a'
+          checkpoint: 'af98714fe2491ac75ac83c87b153692ac55e31c4d4a3243be12ae509f890d0c9'
   name 'Rhinoceros'
   homepage 'https://www.rhino3d.com/'
 
   auto_updates true
+  depends_on macos: '>= :mountain_lion'
 
   app 'Rhinoceros.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.