### PR TITLE
Update kactus to 0.3.6

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,11 +1,11 @@
 cask 'kactus' do
-  version '0.3.5'
-  sha256 '20b118150159fb564bee317964ff5432dc65e50271b71b2645fa95e886740d37'
+  version '0.3.6'
+  sha256 '5478ea63dab1220c93af6917e67e7e895cc25aa28f85840838a4d26f9b7f5d1d'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom',
-          checkpoint: '2228f4175e5b195b0ab95037e2b885bc916e11c498f33fb8eacbe333c05b72ae'
+          checkpoint: '3b9299c719b19312c0414de1a0039ea6176a6dee31af3a4c5b6b07f3d3f65f07'
   name 'Kactus'
   homepage 'https://kactus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.