### PR TITLE
Update super-otr to 1.0,2017.09

### DIFF
--- a/Casks/super-otr.rb
+++ b/Casks/super-otr.rb
@@ -1,10 +1,11 @@
 cask 'super-otr' do
-  version '0.9.6.0b79'
-  sha256 '610d74c43d2fa38527b66fa677c6eff07543f8a853950160954e59cb251b066b'
+  version '1.0,2017.09'
+  sha256 'e7f3650fd6cd0670b55b0e2b00638414ef57f123f4401a8d1b1e450d8082ea98'
 
-  url "http://apfel-a.macbay.de/wordpress/wp-content/plugins/download-monitor/download.php?id=Super-OTR-#{version}.zip"
+  url "http://apfel-a.macbay.de/wordpress/wp-content/downloads/#{version.after_comma.dots_to_slashes}/Super_OTR_#{version.before_comma}_neu.zip",
+      user_agent: :fake
   appcast 'http://apfel-a.macbay.de/software/superotr/appcast-superotr.xml',
-          checkpoint: 'e6b1c672d73b888eb2a8533258b7c8b9dcb093d92c55ac5adc84838edb2b33ab'
+          checkpoint: '80fd936889d18af4abecb6156ccc19d43d1d6d3a684ca52337dc12ee093d7344'
   name 'Super OTR'
   homepage 'http://apfel-a.macbay.de/super-otr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.