### PR TITLE
Update gingko to 2.0.11

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,11 +1,11 @@
 cask 'gingko' do
-  version '2.0.10'
-  sha256 '8669d7a46e4b682915d60953cdf8b963e96a8d4cf631b58a5972fdde4281f8f8'
+  version '2.0.11'
+  sha256 '12ee22d22bfed6a6372cdb9ece5fc0b0aee61e12000e12567cb16e7e1ac6761f'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/gingko-client-#{version}-mac.zip"
   appcast 'https://github.com/gingko/client/releases.atom',
-          checkpoint: 'f2da6d0929c3b1af26de928ebb4e0258df797954f07e533f27affc9ec192639a'
+          checkpoint: '5a67c3b56f03182c28a6e7fe25db766a30b8cf76dc14a1d8dd71a23fc13b7ce3'
   name 'Gingko'
   homepage 'https://gingko.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.