### PR TITLE
Update gnucash to 3.1-3

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,11 +1,11 @@
 cask 'gnucash' do
-  version '3.1-2'
-  sha256 '71d06ea408302defacf08dcc8343ade86eeb2298b8b33e75a6e240754c2faf71'
+  version '3.1-3'
+  sha256 '777e532a80c8061c352bf518e6948155af5e408b148df381a1e6cd85b13d66e9'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}/Gnucash-Intel-#{version}.dmg"
   appcast 'https://github.com/Gnucash/gnucash/releases.atom',
-          checkpoint: '9c0f6151bee77f165cff37a5298b3a5f6a6e8ad1c22cc9e95f36722657b702aa'
+          checkpoint: '4cd5db8d9c61b9bba13c1bfe4f04258ba7ef84ee6d23481d075b169bb2b2b070'
   name 'GnuCash'
   homepage 'https://www.gnucash.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.