### PR TITLE
Update tribler to 7.0.2

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,11 +1,11 @@
 cask 'tribler' do
-  version '7.0.1'
-  sha256 '320e2d587cc9f4eb357f9e662e5a31fbadec55ea3f36f2868b32b785d2bb30a9'
+  version '7.0.2'
+  sha256 '72dd70c5b3d761141ae1a2f8745ab839b85aed4b9e4c66d65041a5334ffca741'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
   appcast 'https://github.com/Tribler/tribler/releases.atom',
-          checkpoint: '4852b66079146e43ba608a52718694670a60e3862df10ef2cec129097b65ca4d'
+          checkpoint: '8c44570a3bd0f56ba23e47046163b49d3a507bb75b8c10609df1e2ead269acdd'
   name 'Tribler'
   homepage 'https://www.tribler.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.