### PR TITLE
Update bisq to 0.7.0

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,11 +1,11 @@
 cask 'bisq' do
-  version '0.6.7'
-  sha256 '8c7ad8f9887e67623cc2bea791f453ffe321be6c5ce3079fc89cf413bd43fa62'
+  version '0.7.0'
+  sha256 '9b8e3d99e8f8dc1ecfb7a2ecfb3f267ed95676b171d63f112843dbdf2808c1d6'
 
   # github.com/bisq-network/bisq-desktop was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq-desktop/releases/download/v#{version}/Bisq-#{version}.dmg"
   appcast 'https://github.com/bisq-network/bisq-desktop/releases.atom',
-          checkpoint: '0cdbd7e724ca3c88060485491b5aa007217629f9f5adcb1be754f2632347cbd5'
+          checkpoint: '9d487afe87269474fc2273253c9d721b8bbe7ac6697ad4596c32da02f1a39f75'
   name 'Bisq'
   homepage 'https://bisq.io/'
   gpg "#{url}.asc", key_id: '1dc3c8c4316a698ac494039cf5b84436f379a1c6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.