### PR TITLE
Update twist to 1.0.34,4244

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,12 +1,14 @@
 cask 'twist' do
-  version '1.0.22,3279'
-  sha256 'aca89630774fa53f7cda305e525174e21307ed5455aba48e2cb9df6c32615e7a'
+  version '1.0.34,4244'
+  sha256 '4f0c34bbb92445b789711f62420cda61792462b5c5642820f3453ef35e066e20'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml',
-          checkpoint: '5aa976bc5fcce3706328408fbc81d788316845b3eb4a783c82adfd7d7ae8d227'
+          checkpoint: '6d0c58dca0c7120a9ca4e32defa152c89cc8f0dd11aa20875f53513768fdd7f6'
   name 'Twist'
   homepage 'https://twistapp.com/'
+
+  depends_on macos: '>= :el_capitan'
 
   app 'Twist.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.