### PR TITLE
Update deckset to 2.0.4,2486

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -1,12 +1,14 @@
 cask 'deckset' do
-  version '2.0.3,2481'
-  sha256 '00693f21e8c61676ab1ae15d06efe02181cea43525d7192ca43372d8da6486df'
+  version '2.0.4,2486'
+  sha256 'deaa799561714d9bfd5ee900baa0f88222fbf06ffc8564c3bfe40dc1dcc3d128'
 
   url "https://dl.decksetapp.com/Deckset+#{version.before_comma}+(#{version.after_comma}).dmg"
   appcast 'https://dl.decksetapp.com/appcast.xml',
-          checkpoint: '05ffb357f546a6437d897d83ec70fef22a2d2f03cbe36297c71171acf0b450fe'
+          checkpoint: '1af92d4c723c44dab50746655008451664d275e5d1eba40dcbd9aa622301c7ad'
   name 'Deckset'
   homepage 'https://www.decksetapp.com/'
+
+  depends_on macos: '>= :el_capitan'
 
   app 'Deckset.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.