### PR TITLE
Update extraterm to 0.34.0

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,11 +1,11 @@
 cask 'extraterm' do
-  version '0.33.1'
-  sha256 '18b28f7ad83a3c256e0fa30784aacd620f81cd86e5c1311d476d2e5f8665a04d'
+  version '0.34.0'
+  sha256 '9023c9fcafc32d07dc3a279e6c78ece48a76aa558fd74f4437448ef723f1df7f'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"
   appcast 'https://github.com/sedwards2009/extraterm/releases.atom',
-          checkpoint: 'bc8ca0b688a4e846692af6efc278a11feaadce805b2b8e2a1d6fa6d3e3c5ea9b'
+          checkpoint: '3937ef875fc9a6fc9481b93019788eda2cf1693ecf778c399e6bcd9e2ee4dade'
   name 'extraterm'
   homepage 'http://extraterm.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.