### PR TITLE
Update the-ur-quan-masters to 0.7.0-2

### DIFF
--- a/Casks/the-ur-quan-masters.rb
+++ b/Casks/the-ur-quan-masters.rb
@@ -1,10 +1,10 @@
 cask 'the-ur-quan-masters' do
-  version '0.7.0-1'
-  sha256 '19c313478efee8d7c51d8916b64fba4711e46b93b0c4596119dfc67d61ffa7dd'
+  version '0.7.0-2'
+  sha256 '90898874bab6f22b4ce57fbb1ce5d98e914b8480cb4f50422dde0a93672d214d'
 
   url "https://downloads.sourceforge.net/sc2/uqm-#{version}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/sc2/rss',
-          checkpoint: '3e25028c41088bc692420d9b64a8e11c0b32cba57beeb4a5fadfebbb10b63415'
+          checkpoint: 'e2b623bbe82f64c3d35679210901a52eadd4a1f5e44b6d6823800e98175d7587'
   name 'The Ur-Quan Masters'
   homepage 'http://sc2.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.