### PR TITLE
Update retroshare to 0.6.4,20180303.9d6e642

### DIFF
--- a/Casks/retroshare.rb
+++ b/Casks/retroshare.rb
@@ -1,11 +1,11 @@
 cask 'retroshare' do
-  version '0.6.3,20170821-cebcc4b4'
-  sha256 'ea908eb98f3af69486b4b950635dff9774c004488bdb950db27f8bac92bdf45a'
+  version '0.6.4,20180303.9d6e642'
+  sha256 'b91b93afd2e002c3001598e57ab62a9f2e0ada047ca041d891a447da1d20d388'
 
   # github.com/RetroShare/RetroShare was verified as official when first introduced to the cask
-  url "https://github.com/RetroShare/RetroShare/releases/download/v#{version.before_comma}/Retroshare-#{version.before_comma}-OSX-#{version.after_comma}.dmg"
+  url "https://github.com/RetroShare/RetroShare/releases/download/v#{version.before_comma}/retroshare-#{version.before_comma}_#{version.after_comma}-Mac-OSX.dmg"
   appcast 'https://github.com/RetroShare/RetroShare/releases.atom',
-          checkpoint: '336c2f3110552dfc7a2b18807ea2273cbfa837e2b4df1a26e295e055fc44b152'
+          checkpoint: '36f88c9f7ec1d98701813f0fee060b5eb13f4a02c4dda2d797d188292f69d84a'
   name 'RetroShare'
   homepage 'http://retroshare.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.