### PR TITLE
Update decrediton to 1.2.1

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,10 +1,10 @@
 cask 'decrediton' do
-  version '1.2.0'
-  sha256 '87fc394e1c371001f000d8e57112afca9c076d10d4ba58f15bcd37c9ae640d4e'
+  version '1.2.1'
+  sha256 'eedeb515b02c4711e05ac685849a538a6e32911bdffe358313113068600efe44'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom',
-          checkpoint: 'aefb1740af71db6196e1443420e846d31ee492f41070d2fcb67bc22f0f4687d0'
+          checkpoint: 'e0d0cb7ce945f71012c9394883985db3a42b368781ee7c7fb341548aec7316a9'
   name 'Decrediton'
   homepage 'https://github.com/decred/decrediton'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.