### PR TITLE
Update armory to 0.96.4

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -1,11 +1,11 @@
 cask 'armory' do
-  version '0.96.3.99'
-  sha256 '6129856a042b153185a06f0745cf5313477191cc89a8f8c3e5dc08fa0b49c8a0'
+  version '0.96.4'
+  sha256 'dd7f778d4bcbe819336286312e826e822c9ca3c405e1b2cf6f2a7e0c75526d96'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"
   appcast 'https://github.com/goatpig/BitcoinArmory/releases.atom',
-          checkpoint: '4f71fb59453d47d90216ac261bffe9c3c1760b62bacc32fe19f637711e5cf4f8'
+          checkpoint: 'f686c411e125209fb5c852cf90cb3ea901e757f950e731e2d5582151e6d428d7'
   name 'Armory'
   homepage 'https://btcarmory.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.