### PR TITLE
Update stereo-tool to 8.54

### DIFF
--- a/Casks/stereo-tool.rb
+++ b/Casks/stereo-tool.rb
@@ -1,10 +1,10 @@
 cask 'stereo-tool' do
-  version '8.40'
-  sha256 'eb835c3b29461d52ea9bf4721178e3817bb63f7b2bb139fbecc7d9002548b079'
+  version '8.54'
+  sha256 'e2fa88bdaa32517adb8b515ff30f6e00fbfb9b09dfce9e69665c9d5ec9f53d57'
 
   url 'http://www.stereotool.com/download/stereo_tool.zip'
-  appcast 'http://www.stereotool.com/version_history.shtml',
-          checkpoint: '65fc8b88b49fb5600e56c379be8b85ec483d8e615ac3222cb0b6819c102988b3'
+  appcast 'https://www.stereotool.com/documentation/8.50/version_history/',
+          checkpoint: '0f9934dee6dd8cb0cdad1954156d743750b5b4000f0f2a67065d9fe87a10e0a8'
   name 'Stereo Tool'
   homepage 'https://www.stereotool.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.