### PR TITLE
Update eul to 0.35

### DIFF
--- a/Casks/eul.rb
+++ b/Casks/eul.rb
@@ -1,11 +1,11 @@
 cask 'eul' do
-  version '0.34'
-  sha256 '4f603d2408b18c8dd6f854bc1b3229f319fd2c7f1652b685d10ac535422a3dbe'
+  version '0.35'
+  sha256 '96cc9f370a3aaa928a7390292bf3f8df78176cda1fb50952d2e2e33c7710756d'
 
   # github.com/eul-im/eul was verified as official when first introduced to the cask
   url "https://github.com/eul-im/eul/releases/download/v#{version}/eul_mac.zip"
   appcast 'https://github.com/eul-im/eul/releases.atom',
-          checkpoint: 'a7a4458a1c7ecfa621cbf4bed1dec11a93b842a0aba67de3b170eba715eb3f3e'
+          checkpoint: 'dc2dbd45e9cb718fc71f4948e858163acb35baca030739b123a1ecea5cbb8211'
   name 'eul'
   homepage 'https://eul.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.