### PR TITLE
Update framer to 18175,1525441270

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '18157,1524230415'
-  sha256 'f86de1a53854f275b3dbd17a3e1e427d8873b934384f1acfd0cd860fbba76729'
+  version '18175,1525441270'
+  sha256 '9243305c6c23bc9812403d7959cc6894b79acbb58f0933413795729b08160d5f'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.motif.framer/#{version.before_comma}/#{version.after_comma}/FramerStudio-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: 'e40a5144686c538a5028489b1d6582fb59a8d907711fe19c683c6ceb1e2e169b'
+          checkpoint: '6ad98327aebbf41506b4bc9c22e8d2729c05d91be4bbd350848db3073a01b077'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.