### PR TITLE
Update cctalk to 1.0.2-633,2018-05-02

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,13 +1,15 @@
 cask 'cctalk' do
-  version '1.0.1-576,2018-04-13'
-  sha256 '75fddbc3dc5b4af0eb36a3a3f1445c047b9d8b2ddbb0929a9af2a32223e1e81d'
+  version '1.0.2-633,2018-05-02'
+  sha256 '911d55e413237d59fb6c56ef385ea1b4844af1125f2da4fabf9d442e07931eba'
 
   # f1.ct.hjfile.cn was verified as official when first introduced to the cask
   url "http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/in/mac/cctalk/archive/#{version.before_comma.hyphens_to_dots}/CCtalk-#{version.before_comma}-xianghu-#{version.after_comma}.dmg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml',
-          checkpoint: 'bc478199318209caf7e3e9b2d482ad8975f6c0acec46ff3fa2cc652b34cb0050'
+          checkpoint: '0b45fde96b3b18518eb9eccfc5a40480fc44f79700f66d236cb1458b318ef447'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'CCtalk.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.