### PR TITLE
Update story-writer to 5.6.0

### DIFF
--- a/Casks/story-writer.rb
+++ b/Casks/story-writer.rb
@@ -1,11 +1,11 @@
 cask 'story-writer' do
-  version '5.1.0'
-  sha256 'fe600419483a44bcc8bb444b5ad343ae8e088c7da03f2b64f5974d83cacc202b'
+  version '5.6.0'
+  sha256 '4c35bb5d3c4e0efbdc1b21724b343e18b58ca841ecb29ade1b445d473f560d48'
 
   # github.com/suziwen/markdownxiaoshujiang was verified as official when first introduced to the cask
   url "https://github.com/suziwen/markdownxiaoshujiang/releases/download/v#{version}/Story-writer-osx64.zip"
   appcast 'https://github.com/suziwen/markdownxiaoshujiang/releases.atom',
-          checkpoint: 'a673662f2a37af76a8d4a1de2be76d2c6e5b67532d7b1aaa767d98958f6f8532'
+          checkpoint: '0e42ac1435c0d1b3f82532dfd3e3c448b2a0bb31474088109c56be0205b2cb13'
   name 'Story Writer'
   homepage 'http://soft.xiaoshujiang.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.