### PR TITLE
Update speechify to 2.1.2

### DIFF
--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -1,10 +1,10 @@
 cask 'speechify' do
-  version '2.0.16'
-  sha256 'a3ae4b96657f43f713cbd8e8b9a1fc0f58d7536c813b9bdd616a353fbf29f35a'
+  version '2.1.2'
+  sha256 '164b9ab83933eece21b61c92d2f1192f5d89de114f7ccd99bd68f4b2d8a12f80'
 
   url 'https://getspeechify.com/Speechify.zip'
   appcast 'https://getspeechify.com/appcast.xml',
-          checkpoint: '3dcf421537183898f39f38d57e4e87ff0d73771f27649d9739c43de3c4f53520'
+          checkpoint: 'b0f850709f393d884679ca52c546590b666683b293db2f9469b1fa058d344c70'
   name 'Speechify'
   homepage 'https://getspeechify.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.