### PR TITLE
Update virtualc64 to 1.10

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,11 +1,11 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.8.1'
-  sha256 '9dcb926044862b8e69a9eda28a37240d65a52074fee5ea10beda94c0e3f29bac'
+  version '1.10'
+  sha256 'f8f19a1afa7b0fb842b691a99ea100cdda2eb97c974743c495e5a320c8fdde82'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml',
-          checkpoint: '73df4f00fec8cbef15bde0d10456765df4e875848595ae538770a81b6a467923'
+          checkpoint: 'c8a60207d8c226d944baa1ce381ca4a754f37a1e4117cf2b11b858bfa046fa25'
   name 'Virtual C64'
   homepage 'http://www.dirkwhoffmann.de/virtualc64/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.