### PR TITLE
Update go-server to 18.5.0-6679

### DIFF
--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,11 +1,11 @@
 cask 'go-server' do
-  version '18.3.0-6540'
-  sha256 'cea20e596192cb4dd55416a76ff6d5c742916d74c4a9a5d0bc77c95098f53b53'
+  version '18.5.0-6679'
+  sha256 '746b456d5b167196a30d48766aefbf88879c8c174b740dc7d63eabb50de1cdb8'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"
   appcast 'https://github.com/gocd/gocd/releases.atom',
-          checkpoint: 'd00e4e6848947d154dde8fd401343a233eab949f9021ba9ba509a7903fd823bb'
+          checkpoint: 'c53e6d95ddaf9a7d3a51b82011f8348a7f9e81ff702b088a885f5f58291a8113'
   name 'Go Server'
   homepage 'https://www.gocd.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.