### PR TITLE
Update envkey to 1.3.6

### DIFF
--- a/Casks/envkey.rb
+++ b/Casks/envkey.rb
@@ -1,11 +1,11 @@
 cask 'envkey' do
-  version '1.3.4'
-  sha256 'c1d401f4f1a685756ab99c88b5ff0ff3fd41bd4bcf8c9db2e99db695a19e897c'
+  version '1.3.6'
+  sha256 '71180cb79fcb19bdc610dfd888d1278369ae31038cc754ddb9538aec91940fa8'
 
   # github.com/envkey/envkey-app was verified as official when first introduced to the cask
   url "https://github.com/envkey/envkey-app/releases/download/darwin-x64-prod-v#{version}/EnvKey-#{version}-mac.zip"
   appcast 'https://github.com/envkey/envkey-app/releases.atom',
-          checkpoint: '400b98d25be2c579668641894d6c07f91d3a54b6fbaa99e6ccb3e50fce71b619'
+          checkpoint: '0390a998b90d0236f66d3e0e0c517227bffa20ca1615155e4ca04853744836db'
   name 'EnvKey'
   homepage 'https://www.envkey.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.