### PR TITLE
Update stella to 5.1.1

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,11 +1,11 @@
 cask 'stella' do
-  version '5.0.2'
-  sha256 'f09be7c5419276da275488a734fc5b27c3d37ac1bc0fe77445ec568f42f7fa26'
+  version '5.1.1'
+  sha256 'cc6e292968afc82f6b9f237f09bbd51eae6040a50cbbf1c225af897fce773b18'
 
   # github.com/stella-emu/stella/releases/download was verified as official when first introduced to the cask
   url "https://github.com/stella-emu/stella/releases/download/#{version}/Stella-#{version}-macosx.dmg"
   appcast 'https://github.com/stella-emu/stella/releases.atom',
-          checkpoint: '6bedf88b8daec318a44ecd520a27095db806df6d9b1b92494778883eb4be7713'
+          checkpoint: '5de1792c023ab9f485dbf42c5e3240065d123e77f985c2c92e99459875761f0b'
   name 'Stella'
   homepage 'https://stella-emu.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.