### PR TITLE
Updated the-archive-browser.rb

### DIFF
--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -1,11 +1,22 @@
 cask 'the-archive-browser' do
-  version '1.11.1'
-  sha256 '67bd39f6951179653e25fa8d63eef5c85e4921b702b01b228091bfc7a8e98a5d'
+  version :latest
+  sha256 :no_check
 
-  # wakaba.c3.cx/releases/TheArchiveBrowser was verified as official when first introduced to the cask
-  url "https://wakaba.c3.cx/releases/TheArchiveBrowser/TheArchiveBrowser#{version}.zip"
+  # dl.devmate.com/cx.c3.thearchivebrowser was verified as official when first introduced to the cask
+  url 'https://dl.devmate.com/cx.c3.thearchivebrowser/TheArchiveBrowser.zip'
   name 'The Archive Browser'
   homepage 'https://theunarchiver.com/archive-browser'
 
+  auto_updates true
+
   app 'The Archive Browser.app'
+
+  zap trash: [
+               '~/Library/Cookies/cx.c3.thearchivebrowser.binarycookies',
+               '~/Library/Preferences/cx.c3.thearchivebrowser.plist',
+             ],
+      rmdir: [
+               '~/Library/Application Support/The Archive Browser',
+               '~/Library/Caches/cx.c3.thearchivebrowser',
+             ]
 end


### PR DESCRIPTION
Added `zap` and `auto_update`

The versioned URL-scheme does not work anymore for Version 1.11.2. This might be because of the new owner:

https://macpaw.com/blog/macpaw-bought-unarchiver

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
