### PR TITLE
Update bitshares to 2.0.180512

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.180402'
-  sha256 'ac1efff629fbdd97e07396c81d111276072e4d5301441d977b2b798985f40627'
+  version '2.0.180512'
+  sha256 'f51ca73b0d519d07529f5037c2a3f1e51eeb9dc7f885c3ffcd5d1b7185209d4b'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: 'af65e8b84c6d90debf210c2ba6f7627430b71065548acb8211ace92c4e2c8900'
+          checkpoint: '28f91c92290d19b2fa100957fc99f6f5c3ad1a0f51e3ae77cfafa3f446451e27'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.