### PR TITLE
Update utox to 0.17.0

### DIFF
--- a/Casks/utox.rb
+++ b/Casks/utox.rb
@@ -1,11 +1,11 @@
 cask 'utox' do
-  version '0.16.1'
-  sha256 '722ef3e8d1145b7746db6544ccb50a85558da93e0d39a588223a4489479fd85d'
+  version '0.17.0'
+  sha256 '4ca786a57fdd8f50f210f7ff58c1e7bfd5b9d0575af3d24a7536c1817c8d0232'
 
   # github.com/uTox/uTox was verified as official when first introduced to the cask
-  url "https://github.com/uTox/uTox/releases/download/v#{version}/uTox-#{version}.dmg"
+  url "https://github.com/uTox/uTox/releases/download/v#{version}/uTox.#{version}.dmg"
   appcast 'https://github.com/uTox/uTox/releases.atom',
-          checkpoint: '762ca9b3d6015647546bcee5ca8859ff3b4f4f281373149511229b860413d651'
+          checkpoint: '5518c883226073b31f1dbfad28658d0ebd22cf86c690de35d9fbe84928bbd92b'
   name 'uTox'
   homepage 'https://www.tox.chat/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.