### PR TITLE
Update cycling74-max to 7.3.5_180307

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -4,6 +4,8 @@ cask 'cycling74-max' do
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"
+  appcast 'https://auth.cycling74.com/maxversion',
+          checkpoint: 'f47a96e6d18fe6ca21a145057aa69077ba13a1fe0d3cabeb4064826fe83efddb'
   name 'Cycling ‘74 Max'
   name 'Ableton Max for Live'
   homepage 'https://cycling74.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.