### PR TITLE
Update ckb to 0.3.0 and update to the new repository

### DIFF
--- a/Casks/ckb.rb
+++ b/Casks/ckb.rb
@@ -1,14 +1,20 @@
 cask 'ckb' do
-  version '0.2.6'
-  sha256 '724f7ee9a0e363304bc2b0b82713582bf366a07f2e4c4639389bb6f7efb7ebbf'
+  version '0.3.0'
+  sha256 '697819054404efaaaf833c43faaa7510b523670c84e344587a5f7456e0ed1977'
 
-  url "https://github.com/ccMSC/ckb/releases/download/v#{version}/ckb.pkg"
-  appcast 'https://github.com/ccMSC/ckb/releases.atom',
-          checkpoint: '7c4d9d7c8e23e91beb865efdf41512c8ed77b820fe28d11630dc67ab5fc710b9'
-  name 'ckb'
-  homepage 'https://github.com/ccMSC/ckb'
+  url "https://github.com/ckb-next/ckb-next/releases/download/v#{version}/ckb-next_v#{version}.dmg"
+  appcast 'https://github.com/ckb-next/ckb-next/releases.atom',
+          checkpoint: '7aa55122c4e94be6ce97559daf9ce1e391c48bfe0bd99189c1782ad28ddfaa36'
+  name 'ckb-next'
+  homepage 'https://github.com/ckb-next/ckb-next'
 
-  pkg 'ckb.pkg'
+  pkg 'ckb-next.mpkg'
 
-  uninstall pkgutil: 'com.ckb.ckb'
+  uninstall pkgutil:   [
+                         'org.ckb-next.ckb',
+                         'org.ckb-next.daemon',
+                       ],
+            launchctl: [
+                         'org.ckb-next.daemon',
+                       ]
 end


### PR DESCRIPTION
ckb is moved to its new repository: https://github.com/ckb-next/ckb-next so I changed and updated it to the new version.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask** (I also checked these because of the changed repository):

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].