### PR TITLE
Add ckb-next v0.3.0

### DIFF
--- a/Casks/ckb-next.rb
+++ b/Casks/ckb-next.rb
@@ -1,0 +1,20 @@
+cask 'ckb-next' do
+  version '0.3.0'
+  sha256 '697819054404efaaaf833c43faaa7510b523670c84e344587a5f7456e0ed1977'
+
+  url "https://github.com/ckb-next/ckb-next/releases/download/v#{version}/ckb-next_v#{version}.dmg"
+  appcast 'https://github.com/ckb-next/ckb-next/releases.atom',
+          checkpoint: '7aa55122c4e94be6ce97559daf9ce1e391c48bfe0bd99189c1782ad28ddfaa36'
+  name 'ckb-next'
+  homepage 'https://github.com/ckb-next/ckb-next'
+
+  pkg 'ckb-next.mpkg'
+
+  uninstall pkgutil:   [
+                         'org.ckb-next.ckb',
+                         'org.ckb-next.daemon',
+                       ],
+            launchctl: [
+                         'org.ckb-next.daemon',
+                       ]
+end

--- a/Casks/ckb-next.rb
+++ b/Casks/ckb-next.rb
@@ -14,7 +14,5 @@ cask 'ckb-next' do
                          'org.ckb-next.ckb',
                          'org.ckb-next.daemon',
                        ],
-            launchctl: [
-                         'org.ckb-next.daemon',
-                       ]
+            launchctl: 'org.ckb-next.daemon'
 end

--- a/Casks/ckb.rb
+++ b/Casks/ckb.rb
@@ -10,7 +10,8 @@ cask 'ckb' do
 
   pkg 'ckb.pkg'
 
-  uninstall pkgutil: 'com.ckb.ckb'
+  uninstall pkgutil:   'com.ckb.ckb',
+            launchctl: 'com.ckb.daemon'
 
   caveats do
     discontinued

--- a/Casks/ckb.rb
+++ b/Casks/ckb.rb
@@ -11,4 +11,8 @@ cask 'ckb' do
   pkg 'ckb.pkg'
 
   uninstall pkgutil: 'com.ckb.ckb'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Added ckb-next because the old ckb is no longer maintained. New repository: https://github.com/ckb-next/ckb-next

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask** (I also checked these because of the changed repository):

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].