### PR TITLE
Update sublime-text to 3.176

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text' do
-  version '3170'
-  sha256 'c61af654721bd9de6b7e82db43378f583e577d8f6cfb7c1541771c64523b30f3'
+  version '3176'
+  sha256 '68cc4a12f30511b3e9fa45e6240f18b1963407a613d8933a57dec0fddf504aaa'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/stable/appcast_osx.xml',
-          checkpoint: '6801661fd5d0fa4d25218b42d3bbbf945ec31f294d52d48642b8b0c48361e08e'
+          checkpoint: '853a79cf4d12c906924be0a0d4660b6606e18b02fa982966604c4fc0a981d529'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3'
 

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,12 +1,12 @@
 cask 'sublime-text' do
-  version '3176'
+  version '3.176'
   sha256 '68cc4a12f30511b3e9fa45e6240f18b1963407a613d8933a57dec0fddf504aaa'
 
-  url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
-  appcast 'https://www.sublimetext.com/updates/3/stable/appcast_osx.xml',
+  url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
+  appcast "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml",
           checkpoint: '853a79cf4d12c906924be0a0d4660b6606e18b02fa982966604c4fc0a981d529'
   name 'Sublime Text'
-  homepage 'https://www.sublimetext.com/3'
+  homepage "https://www.sublimetext.com/#{version.major}"
 
   auto_updates true
   conflicts_with cask: 'sublime-text-dev'
@@ -14,13 +14,13 @@ cask 'sublime-text' do
   app 'Sublime Text.app'
   binary "#{appdir}/Sublime Text.app/Contents/SharedSupport/bin/subl"
 
-  uninstall quit: 'com.sublimetext.3'
+  uninstall quit: "com.sublimetext.#{version.major}"
 
   zap trash: [
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sublimetext.3.sfl*',
-               '~/Library/Application Support/Sublime Text 3',
-               '~/Library/Caches/com.sublimetext.3',
-               '~/Library/Preferences/com.sublimetext.3.plist',
-               '~/Library/Saved Application State/com.sublimetext.3.savedState',
+               "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sublimetext.#{version.major}.sfl*",
+               "~/Library/Application Support/Sublime Text #{version.major}",
+               "~/Library/Caches/com.sublimetext.#{version.major}",
+               "~/Library/Preferences/com.sublimetext.#{version.major}.plist",
+               "~/Library/Saved Application State/com.sublimetext.#{version.major}.savedState",
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.