### PR TITLE
Update p4merge to version 2018.2-1661700

### DIFF
--- a/Casks/p4merge.rb
+++ b/Casks/p4merge.rb
@@ -1,6 +1,6 @@
 cask 'p4merge' do
-  version '2018.2-1652877'
-  sha256 '78d5beaa245ecf023939e45bccc26a6f215908e50fbb4e7155ab2581f5b01dbb'
+  version '2018.2-1661700'
+  sha256 'f45c0bf6e7f1f773b00225a4dce11a4b25d01a5c6a9aa793ba194a37c9921cb8'
 
   url "http://filehost.perforce.com/perforce/r#{version.sub(%r{\A20(\d\d\.\d+).*}, '\1')}/bin.macosx1013x86_64/P4V.dmg"
   name 'Perforce P4Merge'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
