### PR TITLE
Update joplin to 1.0.93

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '1.0.91'
-  sha256 '123a2aeed985d48c899227b87cab0399ebcfa22963438b49796df179303d20bb'
+  version '1.0.93'
+  sha256 '9fd6db79094cd3d0c3e1b8ece679d0461d303bb1e518e14af575b5d8a47f58ac'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: 'ced0153d85b2e14fa0fa76cfe1873b05ae50327566ee8f2b7902b004f14a3284'
+          checkpoint: 'cf4cf721e0efc32a54cc0cd5a1a31813e6ac5971136a9329391913955ff9114b'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.