### PR TITLE
Update toggl to 7.4.155

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.129'
-  sha256 '1eb1f0dc3baed9e293040f9e77946c055376339802f967beb1266f8e8bfe22c2'
+  version '7.4.155'
+  sha256 'db8fe1b569aa294857d75d98e2bf78451230ba8d491ed403be9409427d4a1fda'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.