### PR TITLE
Update powder-player to 1.20

### DIFF
--- a/Casks/powder-player.rb
+++ b/Casks/powder-player.rb
@@ -1,11 +1,11 @@
 cask 'powder-player' do
-  version '1.10'
-  sha256 'd673d6ce0037198b7df888a77eb970224ea07efd6b61f6a2f708f779ce0c73bf'
+  version '1.20'
+  sha256 'd5df37eca8446b2b832ca5c7d5d480df589b4ff05df4a0e0f5a6d58f3585c105'
 
   # github.com/jaruba/PowderPlayer was verified as official when first introduced to the cask
   url "https://github.com/jaruba/PowderPlayer/releases/download/v#{version}/PowderPlayer_v#{version}.dmg"
   appcast 'https://github.com/jaruba/PowderPlayer/releases.atom',
-          checkpoint: '07ddaa5bd7ec516f4a8d99a3e6c4b1c93d9c7c93c455b3825e7f842cda7830b5'
+          checkpoint: '5b4e69b56e3e4d707caa648153b35b18ab3b33699702f5363a459ee4bd05bee3'
   name 'Powder Player'
   homepage 'http://powder.media/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.