### PR TITLE
Update cloudtv to 3.8.8,1526203813

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,11 +1,11 @@
 cask 'cloudtv' do
-  version '3.8.7'
-  sha256 'c3e4119c7cbd130d35b50a5daba64a34c63b49c0da728d9d1a3efc7f9ef0d51c'
+  version '3.8.8,1526203813'
+  sha256 '8fca04618c5c6c690bfa5f1e86798cb09b6522e6f2ec38ef6cfd9ffacc5bb7a5'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.nonoche.CloudTV/CloudTV.dmg?v=#{version}"
+  url "https://dl.devmate.com/com.nonoche.CloudTV/#{version.before_comma}/#{version.after_comma}/CloudTV-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.nonoche.CloudTV.xml',
-          checkpoint: '51769677f884dfe8d46dab86e81d830eabd406731288daa8fefd2a9f5253cb77'
+          checkpoint: '42cca602c9207f63a334fee9f94854f5c1e84619c9165d89495e503003c30ded'
   name 'CloudTV'
   homepage 'https://cloudtvapp.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.