### PR TITLE
Update backuploupe to 2.13.6

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,10 +1,10 @@
 cask 'backuploupe' do
-  version '2.13.5'
-  sha256 'c3b65d30042944f50d8cac7bf603d1f4b2141120f628ba174ae04e3e01278782'
+  version '2.13.6'
+  sha256 '91040cae88a4cc34ad65c87e215a2557c178530077c2abc1934d91ca4a6070cd'
 
   url "http://www.soma-zone.com/download/files/BackupLoupe_#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/BackupLoupe/a/appcast.xml',
-          checkpoint: 'f2a2ce4ddccd0bf45f9ca335467073a36343decbdff7c01668bbf12453bd286b'
+          checkpoint: '24ffbc5f2b848c64c3351ed1dec0776c4c02e3eed6aa747197f7c05bcff9e5ef'
   name 'BackupLoupe'
   homepage 'http://www.soma-zone.com/BackupLoupe/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.