### PR TITLE
Update touchdesigner to 099.2018.22800

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,10 +1,10 @@
 cask 'touchdesigner' do
-  version '099.2017.7180'
-  sha256 'a2d0d1b50f431ba7587eeb99ebc0aa8c55b5d5d2c9b66f3c905551c62df53028'
+  version '099.2018.22800'
+  sha256 'fe08d23e976eb9490e5e5842b5487bbb807a14ce260cb7947d08e03ea9c15692'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp",
-          checkpoint: '90aacc97f46bf0ab6d0bf0cd9c28a423e3adaf7fdf27d6464648f2bd040c5c71'
+          checkpoint: '57d87cb7da7043c34f5003ce4052a87b6d439865bc1a7a2a714005bd155e29db'
   name 'Derivative TouchDesigner'
   homepage 'https://www.derivative.ca/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.