### PR TITLE
Update lbry to 0.21.4

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,11 +1,11 @@
 cask 'lbry' do
-  version '0.21.3'
-  sha256 '3008d0755491d96b07d7d7626e9033114f22aaf33f6ed8b4349396a2db79676f'
+  version '0.21.4'
+  sha256 '7592d6d064dbac5f92d15bb1c0f948be8aaa75891b6e84dfc7079173c613b51d'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"
   appcast 'https://github.com/lbryio/lbry-app/releases.atom',
-          checkpoint: 'd3aef5bd098ec5054f21c483b5f2b946ebe0a599cd3d4f51fac4e138489071e2'
+          checkpoint: '75367adee9e80b56ef798938ed19c543ba4777b7a443ede3107eae7ef69e8f3b'
   name 'LBRY'
   homepage 'https://lbry.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.