### PR TITLE
Update sparkle to 1.19.0

### DIFF
--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -1,11 +1,11 @@
 cask 'sparkle' do
-  version '1.18.1'
-  sha256 '7a7a486d2c5adb75bdd78775946da2b37b82b93cb3eea96049f7b1d8569f11cc'
+  version '1.19.0'
+  sha256 '56541c5ddd0859a96ba3d2c708ca734088ccd674a2fea45cf1a1aa405bb26ad3'
 
   # github.com/sparkle-project/Sparkle was verified as official when first introduced to the cask
   url "https://github.com/sparkle-project/Sparkle/releases/download/#{version}/Sparkle-#{version}.tar.bz2"
   appcast 'https://github.com/sparkle-project/Sparkle/releases.atom',
-          checkpoint: '64a09869d80b7e7355696e243a05692ea77414a97e12f71ff4e6535acd224a47'
+          checkpoint: 'e30d9ea91f318ff1e1522bb26beaee4a4ed4fc18a1df311a311452642df8dea4'
   name 'Sparkle'
   homepage 'https://sparkle-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.