### PR TITLE
Update pd-l2ork to 2.5.1

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,11 +1,11 @@
 cask 'pd-l2ork' do
-  version '2.5.0'
-  sha256 '84986de234df55facdfc84afbd746eb101e7bbd3f7e0d4b2d4c5b3592c91b444'
+  version '2.5.1'
+  sha256 '170899bfa1650818f7dbda5d2bbee20a238aa89de39669518d94ac1770be3dad'
 
   # github.com/agraef/purr-data was verified as official when first introduced to the cask
-  url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-x86_64.zip"
+  url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-x86_64-dmg.zip"
   appcast 'https://github.com/agraef/purr-data/releases.atom',
-          checkpoint: '1c2c9ece7b00a5f95bc3c745b9c1b15128c2f98a263a951b4f5990d5025d1d5f'
+          checkpoint: '7b281c15cbe54d8e878ce501537d79a232657cd726d8ecc7c417258912a920e2'
   name 'Pd-l2ork'
   name 'Purr Data'
   homepage 'https://agraef.github.io/purr-data/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.