### PR TITLE
Update haskell-for-mac to 1.6.0,1473.1526101439

### DIFF
--- a/Casks/haskell-for-mac.rb
+++ b/Casks/haskell-for-mac.rb
@@ -1,11 +1,11 @@
 cask 'haskell-for-mac' do
-  version '1.5.1,1358.1503125985'
-  sha256 '1b95fe3037a518ed560272863b0354f93ffc6b1224ebf1e20b62e0b615e114d0'
+  version '1.6.0,1473.1526101439'
+  sha256 'f54aff2658de791ba299b84fecb6934cca75eb2af4d2bb29124c91d1c591a493'
 
   # dl.devmate.com/com.haskellformac.Haskell.basic was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.haskellformac.Haskell.basic/#{version.after_comma.dots_to_slashes}/Haskell%E2%80%94FunctionalProgrammingLab-#{version.after_comma.major}.zip"
   appcast 'https://updates.devmate.com/com.haskellformac.Haskell.basic.xml',
-          checkpoint: '76bb48d60bd694259114d616bd0b20312804209891cec3efedebf24e03b7293a'
+          checkpoint: '0ea33731abd1d8f6f02363c59f00e62d70fe19d281fe72a0b0db71c680c952bd'
   name 'Haskell for Mac'
   homepage 'http://haskellformac.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.