### PR TITLE
Update cacher to 1.5.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.5.0'
-  sha256 '534fea7c14b7d5cc78cb14c4f4d07809de4fedc180a40d792f3113093ef2e075'
+  version '1.5.1'
+  sha256 '309ab4d973634f4d670155c49802a0b0fab60ecb117d19d5e7859c6b4b1d5df0'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '944ada3a6043b772d26e9b44518b6c301f903494a7edd316e8632b8d3c3e09ed'
+          checkpoint: 'cbb66c36d64bfe45e3dfe287f7654fc1aab266c21dc8a588826e9ca1cf05e49a'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.