### PR TITLE
Update metabase-app to 0.29.3.0

### DIFF
--- a/Casks/metabase-app.rb
+++ b/Casks/metabase-app.rb
@@ -1,11 +1,11 @@
 cask 'metabase-app' do
-  version '0.29.2.0'
-  sha256 '1117c713f0b6a098ab4f47ada255b041c00baa21166b5e3f5216e66f8a76a03e'
+  version '0.29.3.0'
+  sha256 'e85acdc700b737d35b339e2a23617b378e3ea62de4f04591b6a7ad94b3221836'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"
   appcast 'https://s3.amazonaws.com/downloads.metabase.com/appcast.xml',
-          checkpoint: '69eb39e0d50269ca61cd300256895e5bc9f5dedcdcadba213347e4e1be3733a2'
+          checkpoint: '90454776c643248aa37dac6db5b790ff453c469b51ac3b8d3aaa69d8a38bdd21'
   name 'Metabase'
   homepage 'https://www.metabase.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.