### PR TITLE
Update beaker-browser to 0.8.0-prerelease.5

### DIFF
--- a/Casks/beaker-browser.rb
+++ b/Casks/beaker-browser.rb
@@ -1,11 +1,11 @@
 cask 'beaker-browser' do
-  version '0.7.11'
-  sha256 '78f988186e3668aa1e6e4459f3e5f3c045ef9fd291e0a790f9c595eb73874ee9'
+  version '0.8.0-prerelease.5'
+  sha256 '5712914c3c6ea0a824e66c8ae1c180cb69b179086e5b80f2f66c8d9601621bab'
 
   # github.com/beakerbrowser/beaker was verified as official when first introduced to the cask
   url "https://github.com/beakerbrowser/beaker/releases/download/#{version}/beaker-browser-#{version}.dmg"
   appcast 'https://github.com/beakerbrowser/beaker/releases.atom',
-          checkpoint: '81c94a620c59bd5ea85e1d562381d7f709d55edd33356947024015c7033d98a3'
+          checkpoint: 'fa46ebab5e79c4fde9698bc69eb32753a90ee33a64916da7cb9f8ab17d740697'
   name 'Beaker Browser'
   homepage 'https://beakerbrowser.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.