### PR TITLE
Update signal to 1.11.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.10.1'
-  sha256 '0944e9e29b71c5a7a722fc626d2fc7ed03d0fc6f1d8281960a47b9fccdb6a7f6'
+  version '1.11.0'
+  sha256 'c8cf36ece721c0b5757e62e201ab615dbba41ae216f14c7f917bd5a837a0c94c'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom',
-          checkpoint: '25a8a902518c44a13ddb9eaab2d60644fa034b72df7cac41f9f0e8bf60097e66'
+          checkpoint: '8d5ac9f0f8906429be7d7ea6a16b25d504fb13f651d678dd53d7d58194c0af9e'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.