### PR TITLE
Update craftmanager to 1.0.63

### DIFF
--- a/Casks/craftmanager.rb
+++ b/Casks/craftmanager.rb
@@ -1,10 +1,10 @@
 cask 'craftmanager' do
-  version '1.0.62'
-  sha256 'baa7ac585bb6e1394396b0525547ba8993aa0be17728ac23d3e39b3458f5465b'
+  version '1.0.63'
+  sha256 '7c42ad52c7d1023b4be9f0f7ddb2962d61edc43c432fba9a62a1af403d3d3d22'
 
   url 'https://craft-assets.invisionapp.com/CraftManager/production/CraftManager.zip'
   appcast 'https://craft-assets.invisionapp.com/CraftManager/production/appcast.xml',
-          checkpoint: 'd3d2d070069ff097aa8ec44eeedffb87f93f20ed0e7c66a0a287887cfedecda7'
+          checkpoint: 'f084e8a95eb062fefa1853914570963066aaf645fbcb68ab4c0482e6add7e573'
   name 'CraftManager'
   homepage 'https://www.invisionapp.com/craft'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.