### PR TITLE
Update aptible to 0.16.0

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,6 +1,6 @@
 cask 'aptible' do
-  version '0.15.2+20171208094126,168'
-  sha256 'cb977f7719192dbc489596c4ac99185cb742e4cd2ed12dead8a8c57b8547b7d5'
+  version '0.16.0+20180515093244,174'
+  sha256 'cb25fcd5f73907da032df1c6128affe5a29e8e86791bd05d49077ad8b8ec5a1d'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma}/pkg/aptible-toolbelt-#{version.before_comma.sub('+', '%2B')}-mac-os-x.10.11.6-1.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.