### PR TITLE
Update abyss-web-server to 2.11.8

### DIFF
--- a/Casks/abyss-web-server.rb
+++ b/Casks/abyss-web-server.rb
@@ -1,8 +1,10 @@
 cask 'abyss-web-server' do
-  version 'x1'
+  version '2.11.8'
   sha256 '1df93374340a939c9bdb34e39eef06a317c7c1240d119784f5f75773f3e9da4c'
 
-  url "https://aprelium.com/data/abws#{version}.dmg"
+  url 'https://aprelium.com/data/abwsx1.dmg'
+  appcast 'https://aprelium.com/abyssws/download.php',
+          checkpoint: 'ab483c7138e9bebe00cb87d3f2e14e6bcc27f71c055afef1ce938c9939cfc9f0'
   name 'Abyss Web Server'
   homepage 'https://aprelium.com/abyssws/'
 

--- a/Casks/abyss-web-server.rb
+++ b/Casks/abyss-web-server.rb
@@ -9,4 +9,8 @@ cask 'abyss-web-server' do
   homepage 'https://aprelium.com/abyssws/'
 
   app 'Abyss Web Server/Abyss Web Server.app'
+
+  preflight do
+    set_permissions "#{staged_path}/Abyss Web Server/Abyss Web Server.app", '0755'
+  end
 end

--- a/Casks/abyss-web-server.rb
+++ b/Casks/abyss-web-server.rb
@@ -1,6 +1,6 @@
 cask 'abyss-web-server' do
   version 'x1'
-  sha256 '2130e3da4d97c71d2c932261f51ed31cbb3bcadfc600db5eb6b7f646ccf31707'
+  sha256 '1df93374340a939c9bdb34e39eef06a317c7c1240d119784f5f75773f3e9da4c'
 
   url "https://aprelium.com/data/abws#{version}.dmg"
   name 'Abyss Web Server'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.