### PR TITLE
Update bunq to 0.8.6

### DIFF
--- a/Casks/bunq.rb
+++ b/Casks/bunq.rb
@@ -1,11 +1,11 @@
 cask 'bunq' do
-  version '0.8.5'
-  sha256 'b0d2a326332ff999d8613af8c4d13fe0e85098fae21d1b7975cf70ff3d12d42b'
+  version '0.8.6'
+  sha256 '9bd7511f78a8a071f00e07d18c75351677724521805bcf5d6e5bb303a6c01dad'
 
   # github.com/BunqCommunity/BunqDesktop was verified as official when first introduced to the cask
   url "https://github.com/BunqCommunity/BunqDesktop/releases/download/#{version}/BunqDesktop-#{version}.dmg"
   appcast 'https://github.com/BunqCommunity/BunqDesktop/releases.atom',
-          checkpoint: '1bde93a8405cfb996054e0eecf970a36b15f94aec5af64a57845962eac38fa56'
+          checkpoint: '760a1b5a209b965821750e59b263519ecb247a601dc9e11ad7be6028a0da2883'
   name 'BunqDesktop'
   homepage 'https://bunqdesktop.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.