### PR TITLE
add pdftk 2.02 cask

### DIFF
--- a/Casks/pdftk.rb
+++ b/Casks/pdftk.rb
@@ -1,0 +1,12 @@
+cask 'pdftk' do
+  version '2.02'
+  sha256 'c33cf95151e477953cd57c1ea9c99ebdc29d75f4c9af0d5f947b385995750b0c'
+
+  url 'https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg'
+  name 'PDFtk Server'
+  homepage 'https://www.pdflabs.com/tools/pdftk-server'
+
+  pkg 'pdftk_server-2.02-mac_osx-10.11-setup.pkg'
+
+  uninstall pkgutil: 'com.pdflabs.pdftkThePdfToolkit.pdftk.pkg'
+end

--- a/Casks/pdftk.rb
+++ b/Casks/pdftk.rb
@@ -8,5 +8,6 @@ cask 'pdftk' do
 
   pkg 'pdftk_server-2.02-mac_osx-10.11-setup.pkg'
 
-  uninstall pkgutil: 'com.pdflabs.pdftkThePdfToolkit.pdftk.pkg'
+  uninstall pkgutil: 'com.pdflabs.pdftkThePdfToolkit.pdftk.pkg',
+            delete: '/usr/local/bin/pdftk'
 end

--- a/Casks/pdftk.rb
+++ b/Casks/pdftk.rb
@@ -9,5 +9,5 @@ cask 'pdftk' do
   pkg 'pdftk_server-2.02-mac_osx-10.11-setup.pkg'
 
   uninstall pkgutil: 'com.pdflabs.pdftkThePdfToolkit.pdftk.pkg',
-            delete: '/usr/local/bin/pdftk'
+            delete:  '/usr/local/bin/pdftk'
 end


### PR DESCRIPTION
Hey,

there are some closed issues and PRs for pdftk, but most of them are quite old and don't have any progress on them.
There was an issue with pdftk messing up permissions in `/usr/local` (#7707). Right now, I don't see this behaviour on my machine. `brew doctor` doesn't report any issues after (un-)installing this cask.

This PR was closed by the author: #26635

What do you think?

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
