### PR TITLE
Update blast2go to 5.1.1

### DIFF
--- a/Casks/blast2go.rb
+++ b/Casks/blast2go.rb
@@ -1,8 +1,9 @@
 cask 'blast2go' do
-  version '4.1'
-  sha256 '5bb520f33900544c291f8f968d66072db613a77546aa351afac434581b4b5d95'
+  version '5.1.1'
+  sha256 'e38393288ad869bdd665ad34b40f048e92831277921f284eb70661648a1f9a8e'
 
-  url "http://download.blast2go.com/html/software/blast2go/latest/#{version.dots_to_underscores}/Blast2GO_macos_#{version.dots_to_underscores}.dmg"
+  # biobam.com/software/blast2go was verified as official when first introduced to the cask
+  url "http://resources.biobam.com/software/blast2go/nico/Blast2GO_macos_#{version.dots_to_underscores}.dmg"
   name 'Blast2GO'
   homepage 'https://www.blast2go.com/'
 

--- a/Casks/blast2go.rb
+++ b/Casks/blast2go.rb
@@ -1,6 +1,6 @@
 cask 'blast2go' do
-  version '5.1.1'
-  sha256 'e38393288ad869bdd665ad34b40f048e92831277921f284eb70661648a1f9a8e'
+  version '5.1.13'
+  sha256 'db37cac54493419690419d7d7e17e6c998c8c25e463552ff7b65b3a9e664828d'
 
   # biobam.com/software/blast2go was verified as official when first introduced to the cask
   url "http://resources.biobam.com/software/blast2go/nico/Blast2GO_macos_#{version.dots_to_underscores}.dmg"

--- a/Casks/blast2go.rb
+++ b/Casks/blast2go.rb
@@ -2,7 +2,7 @@ cask 'blast2go' do
   version '5.1.13'
   sha256 'db37cac54493419690419d7d7e17e6c998c8c25e463552ff7b65b3a9e664828d'
 
-  # biobam.com/software/blast2go was verified as official when first introduced to the cask
+  # resources.biobam.com/software/blast2go was verified as official when first introduced to the cask
   url "http://resources.biobam.com/software/blast2go/nico/Blast2GO_macos_#{version.dots_to_underscores}.dmg"
   name 'Blast2GO'
   homepage 'https://www.blast2go.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.