### PR TITLE
Update postbox to 6.0.8,1_2a08007f8e141ca2b84e20ac7f7ce60203b04054

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.0.7.1,1_24b4067b69a0cc5736cd4653e16524b0076c5f0e'
-  sha256 'a1d767a8351bbaf5dcb4cb011e5d72b4eb23ef3ec30f60d2f7dea8bd4b7d811b'
+  version '6.0.8,1_2a08007f8e141ca2b84e20ac7f7ce60203b04054'
+  sha256 'ddd3ae10cf65bbcd2d6e9441e1e95294a05762569695a44633bd2a7489e67d52'
 
   # amazonaws.com/download.getpostbox.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/download.getpostbox.com/installers/#{version.before_comma}/#{version.after_comma}/postbox-#{version.before_comma}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.