### PR TITLE
Update cacher to 1.5.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.5.1'
-  sha256 '309ab4d973634f4d670155c49802a0b0fab60ecb117d19d5e7859c6b4b1d5df0'
+  version '1.5.3'
+  sha256 'f054ac3c5b3f1a7f4f1b5438359ae059aa5689237b54e23aa8bbf08fb248ddcc'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: 'cbb66c36d64bfe45e3dfe287f7654fc1aab266c21dc8a588826e9ca1cf05e49a'
+          checkpoint: '5955b7c7c3ef407cae23172db56f0e37d9ff5ee650bd3dd923626799788212ee'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.