### PR TITLE
Update electron to 1.6.18

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '2.0.0'
-  sha256 'a6bfdd5756af2b50ecf240d7fb5ef5b86c59bb7cd118d33bfe42ced48a90591c'
+  version '1.6.18'
+  sha256 '93427b8e1a27b25e6532a64ff7706df7d13070cc887769ca74b7161651f6cb98'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'b363d4a451ff0693c2550bf0a8239ec7a5a691625f753657662173bcee5a63bc'
+          checkpoint: '501f6f166cec2d253749d210f3de828839484f62842bd6592997125dd54e000e'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.