### PR TITLE
Update google-chrome to 66.0.3359.181

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -3,8 +3,8 @@ cask 'google-chrome' do
   sha256 '6fc4139ad458f177ac2939ef51c84a26d5e8ed7c96a4f16acbac935f48fe83f1'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
-  appcast 'https://omahaproxy.appspot.com/history?os=mac;channhttpsel=stable',
-          checkpoint: '06de2ca4220d265171221613df48c47df29270f42c6a5e452941c306457c6a89'
+  appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable',
+          checkpoint: '281d6e76d63cad8a7b869ba143cdae444b72b62080013f3c00c0d0fd4be5c1de'
   name 'Google Chrome'
   homepage 'https://www.google.com/chrome/'
 

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,10 +1,10 @@
 cask 'google-chrome' do
-  version '66.0.3359.170'
-  sha256 '452fc92528885b818c2a63c2b6c1b32e650cb9f0d8bd1d1e0e1e9379dbf71fc8'
+  version '66.0.3359.181'
+  sha256 '6fc4139ad458f177ac2939ef51c84a26d5e8ed7c96a4f16acbac935f48fe83f1'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
-  appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable',
-          checkpoint: 'a6324af64d98cbdcf106f5c6ea158f9469493c71509a8534777e358282c56664'
+  appcast 'https://omahaproxy.appspot.com/history?os=mac;channhttpsel=stable',
+          checkpoint: '06de2ca4220d265171221613df48c47df29270f42c6a5e452941c306457c6a89'
   name 'Google Chrome'
   homepage 'https://www.google.com/chrome/'
 


### PR DESCRIPTION
Hi all, I would like to update the cask to the latest version of Google Chrome

https://chromereleases.googleblog.com

Cheers, Fokko

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
