### PR TITLE
Update evernote to 7.1.1_456663

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -9,13 +9,13 @@ cask 'evernote' do
     version '6.12.3_455520'
     sha256 'fdda9701f1d8ff56a5e8bcadcf5b04dba66ad7e08511700de4675d20fda2bc71'
   else
-    version '7.1_456448'
-    sha256 '37004ff921d5c925f53586bc599837d5fbf015465c6f3b27fff308e39ec66ebd'
+    version '7.1.1_456663'
+    sha256 'fcd8351206d7879cc70dcc117eb50b81437cb29a1930c502d400a80bcb5834af'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
   appcast 'https://update.evernote.com/public/ENMacSMD/EvernoteMacUpdate.xml',
-          checkpoint: 'c8bb88ef8eaea0307aabf169ece947dc46bf683d94fe384e34d9fffee3908241'
+          checkpoint: '0cc060fe4e852627631cced3367150b1c9015edc88453b04576e851043f8267f'
   name 'Evernote'
   homepage 'https://evernote.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.