### PR TITLE
Update airtool to 1.6.1

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -10,15 +10,17 @@ cask 'airtool' do
 
   pkg "airtool_#{version}.pkg"
 
+  uninstall_preflight do
+    set_ownership '/Library/Application Support/Airtool'
+  end
+
   uninstall pkgutil:    [
                           'com.adriangranados.airtool.airtool-bpf.*',
                           'com.adriangranados.airtool.Airtool.pkg',
                         ],
             launchctl:  'com.adriangranados.airtool.airtool-bpf.pkg',
-            login_item: 'Airtool'
+            login_item: 'Airtool',
+            delete:     '/Library/Application Support/Airtool'
 
-  zap trash: [
-               '/Library/Application Support/Airtool',
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.adriangranados.airtool.sfl*',
-             ]
+  zap trash: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.adriangranados.airtool.sfl*'
 end

--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -18,7 +18,7 @@ cask 'airtool' do
                           'com.adriangranados.airtool.airtool-bpf.*',
                           'com.adriangranados.airtool.Airtool.pkg',
                         ],
-            launchctl:  'com.adriangranados.airtool.airtool-bpf.pkg',
+            launchctl:  'com.adriangranados.airtool.airtool-bpf',
             login_item: 'Airtool',
             delete:     '/Library/Application Support/Airtool'
 

--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,11 +1,10 @@
 cask 'airtool' do
-  version '1.6'
-  sha256 'ba7db87984d2f18f2d46cdbb0b75fdfdda920d3f43dfa3cf18aff1866bac0701'
+  version '1.6.1'
+  sha256 '68fa07f9c3d452a34f505f454640e3920f919236b6017dda0a16d5f486f41b2d'
 
-  # amazonaws.com/apps.adriangranados.com was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/apps.adriangranados.com/airtool_#{version}.pkg"
-  appcast 'https://www.adriangranados.com/appcasts/airtoolcast.xml',
-          checkpoint: 'e2801e382b08cc44b507979619bfef3c1bb019d803a269148564e8366426d583'
+  url "https://www.adriangranados.com/downloads/airtool_#{version}.pkg"
+  appcast 'https://updates.devmate.com/com.adriangranados.Airtool.xml',
+          checkpoint: 'f958fc2ca7c337d9991fe150deeb1a22d6e2030eb0d0a3c7946b9070adf2f38e'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.