### PR TITLE
Update crunch to 2.0.1

### DIFF
--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -1,10 +1,10 @@
 cask 'crunch' do
-  version '2.0.0'
-  sha256 'fcb91a281d3c6f9c5374c0171766325bd279be31124b645bd048a7ffe809db3b'
+  version '2.0.1'
+  sha256 '23d37e03f63f6463013004c28f25bf0c4f693afab4727a4b613835f66eb845ad'
 
   url "https://github.com/chrissimpkins/Crunch/releases/download/v#{version}/Crunch-Installer.dmg"
   appcast 'https://github.com/chrissimpkins/Crunch/releases.atom',
-          checkpoint: '26cb8485dc928836aef770e322c32de02949bcecdba44667d856f67044b8595a'
+          checkpoint: 'a434af117352df832883eb65ec9ef8dbce9145b1672c8f28b49af49ce59596e8'
   name 'Crunch'
   homepage 'https://github.com/chrissimpkins/Crunch'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.