### PR TITLE
Update art-of-illusion to 3.0.3

### DIFF
--- a/Casks/art-of-illusion.rb
+++ b/Casks/art-of-illusion.rb
@@ -1,6 +1,6 @@
 cask 'art-of-illusion' do
   version '3.0.3'
-  sha256 'fae41002dd05973f8d2e24383722f6f864321a8ff9fe40a0d839304f80cd0526'
+  sha256 '855683968480ef24520e998d157bf94865232b3dddd7d8b2431f4dc8d6782984'
 
   # sourceforge.net/aoi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/aoi/ArtOfIllusion#{version.no_dots}-Mac.dmg"

--- a/Casks/art-of-illusion.rb
+++ b/Casks/art-of-illusion.rb
@@ -1,6 +1,6 @@
 cask 'art-of-illusion' do
   version '3.0.3'
-  sha256 '855683968480ef24520e998d157bf94865232b3dddd7d8b2431f4dc8d6782984'
+  sha256 'fae41002dd05973f8d2e24383722f6f864321a8ff9fe40a0d839304f80cd0526'
 
   # sourceforge.net/aoi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/aoi/ArtOfIllusion#{version.no_dots}-Mac.dmg"
@@ -9,5 +9,5 @@ cask 'art-of-illusion' do
   name 'Art of Illusion'
   homepage 'http://www.artofillusion.org/'
 
-  app 'Art of Illusion/Art of Illusion.app'
+  app "Art Of Illusion #{version}/Art Of Illusion #{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.