### PR TITLE
Update pdfpenpro to 1010.4,1526435892

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '1001.3,1523931775'
-  sha256 '607725db0eda0bcde0de17742f194e4536a79df453cd575c9d836dcfb5bab238'
+  version '1010.4,1526435892'
+  sha256 '3504060f91393b91ee9a2a03339bd7b222d64bce9ab6e70c1bb715c8ebfb8242'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '3d911edf1a23e36fc4942814e8adaba2dd3c94c64d342eb97ebe8429b3d95a9e'
+          checkpoint: '06b6ff91eb643bd93dc5a3c53314db7922f3a30a1b041cd4421f99747847fa62'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.