### PR TITLE
Update photo-supreme-postgresql to 4.1.0

### DIFF
--- a/Casks/photo-supreme-postgresql.rb
+++ b/Casks/photo-supreme-postgresql.rb
@@ -8,7 +8,7 @@ cask 'photo-supreme-postgresql' do
 
   depends_on formula: 'postgresql'
 
-  pkg "PhotoSupremePostgreSQL_V#{version}.pkg"
+  pkg "PhotoSupremePostgreSQL_V#{version.major}.pkg"
 
   uninstall pkgutil: 'com.idimager.idimagersu'
 end

--- a/Casks/photo-supreme-postgresql.rb
+++ b/Casks/photo-supreme-postgresql.rb
@@ -1,8 +1,8 @@
 cask 'photo-supreme-postgresql' do
-  version '4'
-  sha256 '5adb6a010e48398cbdf84a11acc8581ef2ce757cefa236b201f7cf97c2a8e7c3'
+  version '4.1.0'
+  sha256 '0439f51291f4ae9778f2b41b46dbfd229515bb36d4cce66cbdc7ae8b0224336f'
 
-  url "http://trial.idimager.com/PhotoSupremePostgreSQL_V#{version}.pkg"
+  url "http://trial.idimager.com/PhotoSupremePostgreSQL_V#{version.major}.pkg"
   name 'Photo Supreme with PostreSQL'
   homepage 'http://www.idimager.com/WP/?page_id=20'
 

--- a/Casks/photo-supreme-postgresql.rb
+++ b/Casks/photo-supreme-postgresql.rb
@@ -1,14 +1,14 @@
 cask 'photo-supreme-postgresql' do
-  version '4.1.0'
-  sha256 '0439f51291f4ae9778f2b41b46dbfd229515bb36d4cce66cbdc7ae8b0224336f'
+  version '4'
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://trial.idimager.com/PhotoSupremePostgreSQL_V#{version.major}.pkg"
+  url "http://trial.idimager.com/PhotoSupremePostgreSQL_V#{version}.pkg"
   name 'Photo Supreme with PostreSQL'
   homepage 'http://www.idimager.com/WP/?page_id=20'
 
   depends_on formula: 'postgresql'
 
-  pkg "PhotoSupremePostgreSQL_V#{version.major}.pkg"
+  pkg "PhotoSupremePostgreSQL_V#{version}.pkg"
 
   uninstall pkgutil: 'com.idimager.idimagersu'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.