### PR TITLE
Update freesmug-chromium to 66.0.3359.181

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '66.0.3359.170'
-  sha256 '28096c41e43e3b4245611f8b1d64b77f6ad54c17a9ab7f8f24b7ef07f6355420'
+  version '66.0.3359.181'
+  sha256 'a8db66db256dcd3ef26b032c76276926696ba6f1957b7f6a3feed714c046cd7c'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: '49dc402e5027e26c52c01ce1996f813a3e49171bb859f05e9f00fbcc48c9498d'
+          checkpoint: 'f928fb527bc7df663429218b1f43769e3e20c8903d05ea4cad760f6782a18b05'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.