### PR TITLE
Update brave to 0.22.714

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.22.669'
-  sha256 '514872f8aedaec22ec18ad6c2be8db2a28e91dee3797148dbf6e719c5199b632'
+  version '0.22.714'
+  sha256 '0d7b9896dfc1f44df9c28976cee8ee1989f5e57f674c2eef8910274bbb689299'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: 'c201404f138f9d64000a52a4e7d62a1361de08a2cbca2c3647d9b3648f66b848'
+          checkpoint: '7306c0a98156ac8f5c5b69f5304532fabccb1327cd3c3e7e098cd4403ee90cd8'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.