### PR TITLE
Update electron to 2.0.1

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,11 +1,11 @@
 cask 'electron' do
-  version '2.0.0'
-  sha256 'a6bfdd5756af2b50ecf240d7fb5ef5b86c59bb7cd118d33bfe42ced48a90591c'
+  version '2.0.1'
+  sha256 '93037deeb1f0c4fe90913e8c4360c323badfc223d9c00d8a4e28dc9a474c60d2'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'b363d4a451ff0693c2550bf0a8239ec7a5a691625f753657662173bcee5a63bc'
+          checkpoint: '031a661733ceb4f9ee013e8eddb97dfd346e42f5c04a7af93db8089c7bc98f3a'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.