### PR TITLE
Update wechatwebdevtools to 1.02.1805150

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1804251'
-  sha256 'a96d44f717c22959ea972f7c6ffcd4aca59b85e61fd9bc713f39a384bb335168'
+  version '1.02.1805150'
+  sha256 'e78efdd44a0ee30f6d4b4222066960a9734e0f8614977c27f743868c105c9b81'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.