### PR TITLE
Update protonmail-bridge to 1.0.4

### DIFF
--- a/Casks/protonmail-bridge.rb
+++ b/Casks/protonmail-bridge.rb
@@ -1,6 +1,6 @@
 cask 'protonmail-bridge' do
-  version :latest
-  sha256 :no_check
+  version '1.0.4'
+  sha256 'b91dd59732c1cbc708ce9040f3268656fbb7bb5c81f7bd5c2ced25926a9c1861'
 
   url 'https://protonmail.com/download/Bridge-Installer.dmg'
   name 'ProtonMail Bridge'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.