### PR TITLE
Update avocode to 2.26.2

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -4,7 +4,7 @@ cask 'avocode' do
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://avocode.com/changelog',
-          checkpoint: '780a90dce80aa33af8577a711626f07d39b743dbb202ca47a6538b7d251423ba'
+          checkpoint: 'c827b4d299e3807df1ea78d5ff1f15a320cbc8bed3d1479995116363a035db48'
   name 'Avocode'
   homepage 'https://avocode.com/'
 

--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -3,8 +3,6 @@ cask 'avocode' do
   sha256 'f532333f06ad5208c676588ec8a45b29cb06c45b4deeef05b3a6c3d09d261886'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
-  appcast 'https://avocode.com/changelog',
-          checkpoint: 'c827b4d299e3807df1ea78d5ff1f15a320cbc8bed3d1479995116363a035db48'
   name 'Avocode'
   homepage 'https://avocode.com/'
 

--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,8 +1,10 @@
 cask 'avocode' do
-  version '2.26.1'
-  sha256 'e46b1b1f31eb58c7c9ddb49bba446ab7fbeace7be88e1ac868582d7c1bae4ad0'
+  version '2.26.2'
+  sha256 'f532333f06ad5208c676588ec8a45b29cb06c45b4deeef05b3a6c3d09d261886'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
+  appcast 'https://avocode.com/changelog',
+          checkpoint: '780a90dce80aa33af8577a711626f07d39b743dbb202ca47a6538b7d251423ba'
   name 'Avocode'
   homepage 'https://avocode.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.