### PR TITLE
Update manager to 18.5.2

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,9 +1,9 @@
 cask 'manager' do
-  version :latest
-  sha256 :no_check
+  version '18.5.2'
+  sha256 '7d1e8ec09d80413f0429a9fc64c5bfa9873e071648b78d42fda5cb77b14f4326'
 
-  # mngr.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://mngr.s3.amazonaws.com/Manager.dmg'
+  # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"
   name 'Manager'
   homepage 'https://www.manager.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.