### PR TITLE
Update lando to 3.0.0-beta.45

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,11 +1,11 @@
 cask 'lando' do
-  version '3.0.0-beta.44'
-  sha256 '9b940771d7a14019f2849276046abe1e1b38c8a7d1925777f6b601187e59d730'
+  version '3.0.0-beta.45'
+  sha256 'd381cfff62784b7452091385913646042d6ba681cd34b5715a7a376f68fde830'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"
   appcast 'https://github.com/lando/lando/releases.atom',
-          checkpoint: '9a040d81aa758d72fef1be62623ab279af42ce47eac9c3ed3c01d35c289f0119'
+          checkpoint: '900d124f3087e13820ea7be19a1a8bf1d789bf5bf39900c479d315a46b49f8e6'
   name 'Lando'
   homepage 'https://docs.devwithlando.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.