### PR TITLE
Update lingon-x to 6.2.1

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
-  version '6.2'
-  sha256 '4bbda23e57d7be8c461e13217e586c5b3fa265243f761cf29f57c21b3c8a6a09'
+  version '6.2.1'
+  sha256 '50dd8d16fefce63b5842d16708bdc5a724f3548676ebca897ed0965c6ec1c6d2'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml",
-          checkpoint: '5d33fc35b648f9fb8d91188f5244f17e0a90d6aabfa4d65a30c99e8554ac8584'
+          checkpoint: 'a8ddd7474299bd558f5b5b4bbb8a3aeaff18e4f479044b0b65d81c9543c38953'
   name 'Lingon X'
   homepage 'https://www.peterborgapps.com/lingon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.