### PR TITLE
Update bdash to 1.3.0

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,10 +1,10 @@
 cask 'bdash' do
-  version '1.2.2'
-  sha256 '3fd4764e7454ff8861562ade2162e0a1d28ea7d80b1ba466f4a7aa6095ac84dd'
+  version '1.3.0'
+  sha256 '1a1839f87759fcd08b81b332d3d6adcd40348edfd108d26f553390e5a281f188'
 
-  url "https://github.com/bdash-app/bdash/releases/download/#{version}/Bdash-#{version}-macOS.zip"
+  url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom',
-          checkpoint: '3f5cebce3e85be302157f59b86f6dd26c595c0f60948fcbeafcd065bc5b3983c'
+          checkpoint: '6de728fe03c86ce5d485628f558e8582688accf72a5cdbbf863276e60f1b5aa5'
   name 'Bdash'
   homepage 'https://github.com/bdash-app/bdash'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.