### PR TITLE
Update googleappengine to 1.9.70

### DIFF
--- a/Casks/googleappengine.rb
+++ b/Casks/googleappengine.rb
@@ -1,11 +1,11 @@
 cask 'googleappengine' do
-  version '1.9.69'
-  sha256 '11113c69fffd3fb8301df437c6bb4eb0f55339540675828c3b83dba485ad5c92'
+  version '1.9.70'
+  sha256 '39490082740a4f571523051282296b5bb74d1d3773c14533fb12a037c9f434c1'
 
   # storage.googleapis.com/appengine-sdks was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/appengine-sdks/featured/GoogleAppEngineLauncher-#{version}.dmg"
   appcast 'https://storage.googleapis.com/appengine-sdks',
-          checkpoint: 'e7bccfe2f5f40681cfc3cfcaefb40fabddb87327cda4789c6964453ffbd74599'
+          checkpoint: '454a640b5b63498c88c73bd77471d66ea12e6832522fbc0b3ee583119abfb823'
   name 'Google App Engine'
   homepage 'https://cloud.google.com/appengine/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.