### PR TITLE
Update jet to 2.6.0

### DIFF
--- a/Casks/jet.rb
+++ b/Casks/jet.rb
@@ -1,11 +1,11 @@
 cask 'jet' do
-  version '2.5.1'
-  sha256 '80d4112145b3e8b3414a060d46f6cacbf6bbc29983468b0e89145cb5d00cbe68'
+  version '2.6.0'
+  sha256 '35428fea9ee9eae916cf84b6327bb21228bef04effebbf01ced6d70b5fe1d435'
 
   # s3.amazonaws.com/codeship-jet-releases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/codeship-jet-releases/#{version}/jet-darwin_amd64_#{version}.tar.gz"
   appcast 'https://documentation.codeship.com/pro/jet-cli/release-notes/',
-          checkpoint: '3e0de3787f279faf7c26373af09b3f75b270e059ddfe93a75fb4490d0ae4ac7b'
+          checkpoint: 'ad4e8df437bea5785079ee027e2e3fd76020ac4627d909eb034678c77e3dd034'
   name 'Codeship Jet'
   homepage 'https://documentation.codeship.com/pro/builds-and-configuration/cli/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.