### PR TITLE
Update manager to 18.5.3

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.2'
-  sha256 '7d1e8ec09d80413f0429a9fc64c5bfa9873e071648b78d42fda5cb77b14f4326'
+  version '18.5.3'
+  sha256 '37e5a2bee628b95c5b3217a67d89eae95fcc8a79079da8d2a2f8550305ccede7'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.