### PR TITLE
Update checksum for BZFlag 2.4.14

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -1,6 +1,6 @@
 cask 'bzflag' do
   version '2.4.14'
-  sha256 '9b2a5d8c23889c7f65d288fa22a2b841318d023667f322523cb0fd3bfae13f77'
+  sha256 '1a4a7c498e276ad3762fe0c8d6bed5e5664bb6548b09081af25da0e308fb4c4b'
 
   url "https://download.bzflag.org/bzflag/macos/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

---

Our initial binary for 2.4.14 had a bug, so we had to [recompile and post a new version](https://forums.bzflag.org/viewtopic.php?f=62&p=175719&sid=83c813e86e3ab75a3e7f6c7310c3f79f#p175719). I've just updated the checksum to the new value.