### PR TITLE
Update manager to 18.5.4

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.3'
-  sha256 '37e5a2bee628b95c5b3217a67d89eae95fcc8a79079da8d2a2f8550305ccede7'
+  version '18.5.4'
+  sha256 '2f60e160d9bd78a83081e1ce0926c2ac7f45b92f26b72e0855bdba5feb5a677f'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.