### PR TITLE
Update ring to 1.80

### DIFF
--- a/Casks/ring.rb
+++ b/Casks/ring.rb
@@ -1,11 +1,11 @@
 cask 'ring' do
-  version '1.79'
-  sha256 'f4f2e0138999d0977baf3d3bc4b7f363d2c8f78a7ea45ccd9eda238ec14f6021'
+  version '1.80'
+  sha256 'a5fef06526eae64aba299ab827d78658ab543799df9218e404b470be588fa5d7'
 
   # ring-mac-app-assets.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ring-mac-app-assets.s3.amazonaws.com/production/Ring_#{version}.zip"
   appcast 'https://ring-mac-app-assets.s3.amazonaws.com/production/ring-appcast.xml',
-          checkpoint: '999c288bbdd06aeffa48457f915cdd6f62062ffc27ed6649e7cded08eded53f3'
+          checkpoint: 'a4ede0df00e6630ca6ab247e50c2f1970b93b0678f331043a4627d202497b897'
   name 'Ring'
   homepage 'https://ring.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.