### PR TITLE
Update deckset to 2.0.5,2488

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -1,10 +1,10 @@
 cask 'deckset' do
-  version '2.0.4,2486'
-  sha256 'deaa799561714d9bfd5ee900baa0f88222fbf06ffc8564c3bfe40dc1dcc3d128'
+  version '2.0.5,2488'
+  sha256 '52438a91eea2844a2acb27ac2c7f5bed3e8f6059495eee656da99329f4290e6c'
 
   url "https://dl.decksetapp.com/Deckset+#{version.before_comma}+(#{version.after_comma}).dmg"
   appcast 'https://dl.decksetapp.com/appcast.xml',
-          checkpoint: '1af92d4c723c44dab50746655008451664d275e5d1eba40dcbd9aa622301c7ad'
+          checkpoint: '9d707349d48682282b98ba464e86969fe917482ca0b177062e220c6ec0513c68'
   name 'Deckset'
   homepage 'https://www.decksetapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.