### PR TITLE
Update exodus to 1.51.3

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.51.2'
-  sha256 '4f2f01ec195be57ad290a808c936a8e3c306de1394cec2e3b000c22a68108d07'
+  version '1.51.3'
+  sha256 '539656cf71583358aff23a4e3a087c010dc01d5a716cba08944a81d10d671447'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: 'd8cc216be0c83eac4b7aca57201d1ca99cee2344bd9a6f70c5fce19d81f3e835'
+          checkpoint: '72d13d2cb59682b3cbaf59f4c917d3d3f955c082cf59c8c34d808cdc1f5750f6'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.