### PR TITLE
Update standard-notes to 2.1.33

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,11 +1,11 @@
 cask 'standard-notes' do
-  version '2.1.32'
-  sha256 'df086e19e613390ce7d2ba0e677206a19e9dfea626859b370ebd45f16e6af4d3'
+  version '2.1.33'
+  sha256 '8b59781c5b246d994d7c54070da1ffb30c78574cd957586141bc6477211d9b65'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"
   appcast 'https://github.com/standardnotes/desktop/releases.atom',
-          checkpoint: 'f6fd1c97b8e06603e11ed825fe09ad9fe59cb20c29996472c482ce6ce049277d'
+          checkpoint: 'e52079d7f6ebb4429e49f57f279d1cc76e68a57e4071ea992142960292cfaa0f'
   name 'Standard Notes'
   homepage 'https://standardnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.