### PR TITLE
Update downie to 3.3.3,1824

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,10 +1,10 @@
 cask 'downie' do
-  version '3.3.2,1819'
-  sha256 'b66aaab4f2067e87548ed58168b09f2b62072e2e506ad987ec7ac2b98f480ab7'
+  version '3.3.3,1824'
+  sha256 '55f1172da4d8a0a7caba0ce714c333a88184e4e3da3d312d948cd6c65379f597'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml",
-          checkpoint: '285fd649effee92df4c635360974de494e8f60696a36cffc33c38538a3e6624b'
+          checkpoint: '8df6d813be754d35119ea2c979ee898741f9ec976a26c4adf73fed01337cb4ef'
   name 'Downie'
   homepage 'https://software.charliemonroe.net/downie.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.