### PR TITLE
Update netron to 1.7.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.8'
-  sha256 '756ff13d0afeb782b1b1c97b052dba2939beaf76f4720e681e1ef1db407299e8'
+  version '1.7.9'
+  sha256 'b9c3335ed04840f8905a71bb7379c6f6c2d5ef64d4a8f3e55f76f154361de962'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '3bcf5302a896a6412a8514dd6149db53777f29b7e455baad17455920a9deae4b'
+          checkpoint: 'dc2b752f37475a7a2551b7879f6d5c36cb0423c990cdc021c3c046fc92579212'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.