### PR TITLE
Update kitty to 0.10.0

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,10 +1,10 @@
 cask 'kitty' do
-  version '0.9.1'
-  sha256 '9e388c43dac0fae0f5c29e444361c93d56fce91826090e93972c6ca769566240'
+  version '0.10.0'
+  sha256 'a31cbc779a06b339942d8317e4060bf4bbbdf37a564538fc225993a627df6401'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom',
-          checkpoint: '6cf29446233f1ab6f606babe9bfcc73e182e4215be7134cbc0675227d679988f'
+          checkpoint: 'cd7dd7014ba0615d5c62f5a25ad320bee148cb7923fa02b037f52282e8148daa'
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.