### PR TITLE
Update subutaicontrolcenter to 7.0.1

### DIFF
--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -1,11 +1,11 @@
 cask 'subutaicontrolcenter' do
-  version '7.0.0'
-  sha256 'c3eb5e3c0e97b3db14f8f5a609ac22ebde92335ef4568cb83c6a978e8eb82ccc'
+  version '7.0.1'
+  sha256 '45e87ab51f97158a1f64afe8e0e5dead462438b384decfd2d039b303c19abd43'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-control-center.pkg'
   appcast 'https://github.com/subutai-io/control-center/releases.atom',
-          checkpoint: '3826ac214986bc1353a310d84745a455c2cf54eb5e9a596150fb9fb73a777b9f'
+          checkpoint: 'a63fc73e1862a27ae4a278b963f8b0c40184400fb831a36acdef8ccbca2bcf3d'
   name 'Subutai Control Center'
   homepage 'https://subutai.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.