### PR TITLE
Update virtualc64 to 1.11

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,11 +1,11 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.10'
-  sha256 'f8f19a1afa7b0fb842b691a99ea100cdda2eb97c974743c495e5a320c8fdde82'
+  version '1.11'
+  sha256 '87b3a7a7db77bdc12ad8a850b241e0b635638c30524f30a9a883f6def1ef4ca5'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml',
-          checkpoint: 'c8a60207d8c226d944baa1ce381ca4a754f37a1e4117cf2b11b858bfa046fa25'
+          checkpoint: 'dc50b95259fad5d7e9e9b9fa92f73a75cc812ac12407da7ef2bf37dc9eb1acf7'
   name 'Virtual C64'
   homepage 'http://www.dirkwhoffmann.de/virtualc64/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.