### PR TITLE
Update netron to 1.8.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.7.9'
-  sha256 'b9c3335ed04840f8905a71bb7379c6f6c2d5ef64d4a8f3e55f76f154361de962'
+  version '1.8.0'
+  sha256 'fdd667f89ae11dc28b406b6c1f0f89fb3ed7811fa20edeab300a09cce6bef683'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'dc2b752f37475a7a2551b7879f6d5c36cb0423c990cdc021c3c046fc92579212'
+          checkpoint: 'fd65aad341eb6f1da472cb0091546a6c33fe880893abc421c056528f7c6a4a37'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.