### PR TITLE
Add webex-teams

### DIFF
--- a/Casks/webex-teams.rb
+++ b/Casks/webex-teams.rb
@@ -1,0 +1,22 @@
+cask 'webex-teams' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://www.webex.com/downloads/WebexTeams.dmg'
+  name 'Webex Teams'
+  homepage 'https://www.webex.com/'
+
+  depends_on macos: '>= :mavericks'
+
+  app 'Webex Teams.app'
+
+  uninstall signal: [
+                      ['TERM', 'Cisco-Systems.Spark'],
+                    ]
+
+  zap trash: [
+               '~/Library/Preferences/Cisco-Systems.Spark.plist',
+               '~/Library/Caches/Cisco-Systems.Spark',
+               '~/Library/Logs/SparkMacDesktop',
+             ]
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Unsure if its better to rename the old **cisco-spark** cask or have both available for a while until the old cask is eventually phased out?

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version. 
  - No versioning in installer / downloads page, similar to how the old cask for Cisco-Spark worked.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
