### PR TITLE
Update exodus to 1.51.4

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,11 +1,11 @@
 cask 'exodus' do
-  version '1.51.3'
-  sha256 '539656cf71583358aff23a4e3a087c010dc01d5a716cba08944a81d10d671447'
+  version '1.51.4'
+  sha256 'bf1161eedb84a251fccaf95b8f1fc585619f66c9ef052897c325097bbc70498e'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/',
-          checkpoint: '72d13d2cb59682b3cbaf59f4c917d3d3f955c082cf59c8c34d808cdc1f5750f6'
+          checkpoint: '06a0ba74c97ee40b1953c42082ba0cacfaed470531ef042ebae706162fb9e990'
   name 'Exodus'
   homepage 'https://www.exodus.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.