### PR TITLE
Update 1password to 7.0

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -40,7 +40,7 @@ cask '1password' do
 
   auto_updates true
 
-  uninstall pkgutil: '1Password*'
+  uninstall pkgutil: 'com.agilebits.pkg.onepassword'
 
   zap trash: [
                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -2,8 +2,8 @@ cask '1password' do
   version '7.0'
   sha256 '9c79de6b4ff9dadc7476cd140156087bd9ad12d66de0b7b05dbcb0a2f660d7ec'
 
-  # cache.agilebits.com/dist/1P was verified as official when first introduced to the cask
-  url "https://cache.agilebits.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
+  # 1password.com was verified as official when first introduced to the cask
+  url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
           checkpoint: '8e429ed32182657fe4b490486947246d91251853f0f39778d0976b2f8b3ba573'
   name '1Password'

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -15,7 +15,7 @@ cask '1password' do
     url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"
-  else
+  elsif MacOS.version <= :sierra
     version '6.8.9'
     sha256 'd7cc24dc354f27441929350b9e6e2e4a710d6ed0bdab06f0e9be07160fe04200'
 
@@ -23,14 +23,24 @@ cask '1password' do
     url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"
+  else
+    version '7.0'
+    sha256 '6f25d55053d5501ece2617d1d3c78f5a09eec6f14d8b404fc265389732f7ec91'
+
+    # cache.agilebits.com/dist/1P/mac4 was verified as official when first introduced to the cask
+    url "https://c.1password.com/dist/1P/mac7/1Password-#{version}.pkg"
+
+    pkg "1Password-#{version}.pkg"
   end
 
-  appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: 'eb8b60476f30a53f496a84e809b948faf81ea9f9ab442f4c923e48720e5a1f2a'
+  appcast 'https://app-updates.agilebits.com/product_history/OPM7',
+          checkpoint: '8e429ed32182657fe4b490486947246d91251853f0f39778d0976b2f8b3ba573'
   name '1Password'
   homepage 'https://1password.com/'
 
   auto_updates true
+
+  uninstall pkgutil: '1Password*'
 
   zap trash: [
                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,46 +1,18 @@
 cask '1password' do
-  if MacOS.version <= :lion
-    version '3.8.22'
-    sha256 '3afd75f1bddf791dc7dbc9a7d92ab6eb91ee891407d750cedb7b5aff5fe8bf17'
+  version '7.0'
+  sha256 '9c79de6b4ff9dadc7476cd140156087bd9ad12d66de0b7b05dbcb0a2f660d7ec'
 
-    # cache.agilebits.com/dist/1P/mac was verified as official when first introduced to the cask
-    url "https://cache.agilebits.com/dist/1P/mac/1Password-#{version}.zip"
-
-    app '1Password.app'
-  elsif MacOS.version <= :mavericks
-    version '4.4.3'
-    sha256 '6657fc9192b67dde63fa9f67b344dc3bc6b7ff3e501d3dbe0f5712a41d8ee428'
-
-    # cache.agilebits.com/dist/1P/mac4 was verified as official when first introduced to the cask
-    url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
-
-    app "1Password #{version.major}.app"
-  elsif MacOS.version <= :el_capitan
-    version '6.8.9'
-    sha256 'd7cc24dc354f27441929350b9e6e2e4a710d6ed0bdab06f0e9be07160fe04200'
-
-    # cache.agilebits.com/dist/1P/mac4 was verified as official when first introduced to the cask
-    url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
-
-    app "1Password #{version.major}.app"
-  else
-    version '7.0'
-    sha256 '6f25d55053d5501ece2617d1d3c78f5a09eec6f14d8b404fc265389732f7ec91'
-
-    # cache.agilebits.com/dist/1P/mac4 was verified as official when first introduced to the cask
-    url "https://c.1password.com/dist/1P/mac7/1Password-#{version}.pkg"
-
-    pkg "1Password-#{version}.pkg"
-
-    uninstall pkgutil: 'com.agilebits.pkg.onepassword'
-  end
-
-  appcast 'https://app-updates.agilebits.com/product_history/OPM7',
+  # cache.agilebits.com/dist/1P was verified as official when first introduced to the cask
+  url "https://cache.agilebits.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
+  appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
           checkpoint: '8e429ed32182657fe4b490486947246d91251853f0f39778d0976b2f8b3ba573'
   name '1Password'
   homepage 'https://1password.com/'
 
   auto_updates true
+  depends_on macos: '>= :sierra'
+
+  app "1Password #{version.major}.app"
 
   zap trash: [
                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -15,7 +15,7 @@ cask '1password' do
     url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
 
     app "1Password #{version.major}.app"
-  elsif MacOS.version <= :sierra
+  elsif MacOS.version <= :el_capitan
     version '6.8.9'
     sha256 'd7cc24dc354f27441929350b9e6e2e4a710d6ed0bdab06f0e9be07160fe04200'
 

--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -31,6 +31,8 @@ cask '1password' do
     url "https://c.1password.com/dist/1P/mac7/1Password-#{version}.pkg"
 
     pkg "1Password-#{version}.pkg"
+
+    uninstall pkgutil: 'com.agilebits.pkg.onepassword'
   end
 
   appcast 'https://app-updates.agilebits.com/product_history/OPM7',
@@ -39,8 +41,6 @@ cask '1password' do
   homepage 'https://1password.com/'
 
   auto_updates true
-
-  uninstall pkgutil: 'com.agilebits.pkg.onepassword'
 
   zap trash: [
                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.