### PR TITLE
Update manager to 18.5.9

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.8'
-  sha256 'cc1f9c251a19c9a716e036aaa7ad92f64ebe053930dfb3147bd16647b9a02637'
+  version '18.5.9'
+  sha256 '24831d62c89871578f71d58a03523e550621eccb8d41a66675649fd25c1f478e'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.