### PR TITLE
Update phpstorm to 2018.1.4,181.5087.24

### DIFF
--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -1,10 +1,10 @@
 cask 'phpstorm' do
-  version '2018.1.3,181.4892.97'
-  sha256 '924d856b57b6089233c5a77faf79497773851720b35347dcd71075414ce720b0'
+  version '2018.1.4,181.5087.24'
+  sha256 'f96a949dcfad46c066aaac9531f57a0bb93503374e82b43bd12320ca78f2124f'
 
   url "https://download.jetbrains.com/webide/PhpStorm-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release',
-          checkpoint: 'c9209b9bbd97d5497bbf44eaad0197336a37ba9b2c1dd961a2f967a4c12202d2'
+          checkpoint: '77644490a357a9b0ef63599680670093d06f8f621373e48ef4d897ee7017dc68'
   name 'JetBrains PhpStorm'
   homepage 'https://www.jetbrains.com/phpstorm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.