### PR TITLE
Update studio-3t to 2018.3.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '2018.2.5'
-  sha256 '3e84381adef8e207a18a740a87fb8ec26e22dd1ffc97ac83b7d7d6575feb9594'
+  version '2018.3.0'
+  sha256 '24bec626660ce9e10d83cec78afb4927465a870a4b7e9c9a342fde1cadbb89ec'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: 'a7674667e1071c8636d70555d8b27e83bf0b48956b796b78bbb307a847df698f'
+          checkpoint: 'a64f3475f7e32b00689cd90faa5f21c8a5807cdcc9d0e6fb38f325925fd9188d'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.