### PR TITLE
Update mimolive to 4.0.3-24873

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,10 +1,10 @@
 cask 'mimolive' do
-  version '4.0.2-24870'
-  sha256 'fb49c0e865de6cd464b473f9d5336dd7c1758590c6e1b818cc5eb8ac4c715b26'
+  version '4.0.3-24873'
+  sha256 'c5cbfb91bc3dc9554a952feed0a1596c0bd0479e2f8142dc77b8e4a46e067de5'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/mimolive',
-          checkpoint: '903024a74400787d045155c7bcdb7089b46bcc2788eb90641bf2eaff849dc6e4'
+          checkpoint: '609b33258f108282ae38fcac40662c0fbc09eca0f0b38df2a5181b002d505fbe'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.