### PR TITLE
Update texpad to 1.8.4,392,0ea1407

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -5,8 +5,8 @@ cask 'texpad' do
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.dots_to_underscores}.zip"
   else
-    version '1.8.3,384,d8388e3'
-    sha256 '43420e5fe5d9e90e8bbe5eb9a7e281cb3449b2b969e983c8869e495bcbf92c7b'
+    version '1.8.4,392,0ea1407'
+    sha256 '88c0c140e136099656a21a3534078edf00ba7970c5a6f6c29b8718a4eff1438f'
 
     url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"
     appcast 'https://www.texpad.com/static-collected/upgrades/texpadappcast.xml',

--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,23 +1,16 @@
 cask 'texpad' do
-  if MacOS.version <= :mountain_lion
-    version '1.6.14'
-    sha256 '18fcbe93e77e5b5bc848172546962fcde397a26fd543efcc1054004369192f7e'
+  version '1.8.4,392,0ea1407'
+  sha256 '88c0c140e136099656a21a3534078edf00ba7970c5a6f6c29b8718a4eff1438f'
 
-    url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.dots_to_underscores}.zip"
-  else
-    version '1.8.4,392,0ea1407'
-    sha256 '88c0c140e136099656a21a3534078edf00ba7970c5a6f6c29b8718a4eff1438f'
-
-    url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"
-    appcast 'https://www.texpad.com/static-collected/upgrades/texpadappcast.xml',
-            checkpoint: '70324384fc8fdcd1d93ecb153a5308210768eafdebbf82b09ab24fe5e4e8223e'
-  end
-
+  # download.texpadapp.com was verified as official when first introduced to the cask
+  url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"
+  appcast 'https://www.texpad.com/static-collected/upgrades/texpadappcast.xml',
+          checkpoint: '70324384fc8fdcd1d93ecb153a5308210768eafdebbf82b09ab24fe5e4e8223e'
   name 'Texpad'
   homepage 'https://www.texpad.com/osx'
 
   auto_updates true
-  depends_on macos: '>= :lion'
+  depends_on macos: '>= :el_capitan'
 
   app 'Texpad.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.