### PR TITLE
Update hipchat to 4.30.1-756

### DIFF
--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -1,11 +1,11 @@
 cask 'hipchat' do
-  version '4.30.1-754'
-  sha256 'bf4456465f04a815093cb3a343fd6a09a54a32d6fb034143df54a36942a63e03'
+  version '4.30.1-756'
+  sha256 '5b52cfefb6fcca75f4b399bc8343a14515009c78cf06e97abe16f0d5ea19d816'
 
   # amazonaws.com/downloads.hipchat.com/osx was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.hipchat.com/osx/HipChat-#{version}.zip"
   appcast 'https://www.hipchat.com/release_notes/appcast/mac',
-          checkpoint: '94dc2e3919fda990932c99ac99d01695e0c4a34db5a36174168e9f66020aae8b'
+          checkpoint: '92b892fd94b9fa90a49a5042b00f3a2beaf446d4f5b45ed5e0875d721cfae1be'
   name 'HipChat'
   homepage 'https://www.hipchat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.