### PR TITLE
Add Lidarr.app v0.2.0.371

### DIFF
--- a/Casks/lidarr.rb
+++ b/Casks/lidarr.rb
@@ -1,0 +1,13 @@
+cask 'lidarr' do
+  version '0.2.0.371'
+  sha256 'bf75e65df3c03f62905b8c6bbfee0eb3b7d38d3f22183c6a3690825190abd84c'
+
+  # github.com/lidarr/Lidarr was verified as official when first introduced to the cask
+  url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.develop.#{version}.osx-app.zip"
+  appcast 'https://github.com/lidarr/Lidarr/releases.atom',
+          checkpoint: '264cd631035ca81145519da0bd44d79732f7a241361540c083499fbb7c0e40ee'
+  name 'Lidarr'
+  homepage 'http://lidarr.audio/'
+
+  app 'Lidarr.app'
+end


### PR DESCRIPTION
Add Lidarr.app v0.2.0.371 to homebrew cask

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].
