### PR TITLE
Update torguard to 3.85.0

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,11 +1,11 @@
 cask 'torguard' do
-  version '0.3.84'
-  sha256 '1c9ed9dccd0e07b3688f999cc37fbc491029d66a4948738923105d80eb2a3336'
+  version '3.85.0'
+  sha256 'e3200827a3d001e5f75334ec63cd24b616382d4104ed8dbfbc3572cd9bc71c05'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"
   appcast 'https://updates.torguard.biz/Software/MacOSX/checksums.sha256',
-          checkpoint: '2b8428e5cac6da7aa44a1ae9c5b532e2f38a0e5742652518f3ab1a696e30f13b'
+          checkpoint: '2bb225e8c50dc7a8cb1b807458aef56210aada881bb3465c839ab657593b014b'
   name 'TorGuard'
   homepage 'https://torguard.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.