### PR TITLE
Re-add manpage to jtool

### DIFF
--- a/Casks/jtool.rb
+++ b/Casks/jtool.rb
@@ -7,4 +7,5 @@ cask 'jtool' do
   homepage 'http://newosxbook.com/tools/jtool.html'
 
   binary 'jtool'
+  artifact 'jtool.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/jtool.1"
 end


### PR DESCRIPTION
The manpage artifact was removed in #43766, but current version again contains the manpage, so possibly it was only missing from Jonathan's tarball for a short time, inadvertently.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

There are no versions for this so I didn't include the version in the commit message.
