### PR TITLE
Update hbuilder to 9.0.4

### DIFF
--- a/Casks/hbuilder.rb
+++ b/Casks/hbuilder.rb
@@ -1,6 +1,6 @@
 cask 'hbuilder' do
-  version '9.0.2'
-  sha256 '44dd208cd27b228c7ce12afa28e749be70d0087c389431cf8638c372ecaff6d5'
+  version '9.0.4'
+  sha256 '8214f26360dc2ad9dd24a371c8e29391cd80ab51d0418491ebc76c4af9bbb898'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "http://download.dcloud.net.cn/HBuilder.#{version}.macosx_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.