### PR TITLE
Update kitty to 0.10.1

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,10 +1,10 @@
 cask 'kitty' do
-  version '0.10.0'
-  sha256 'a31cbc779a06b339942d8317e4060bf4bbbdf37a564538fc225993a627df6401'
+  version '0.10.1'
+  sha256 '630e11f748b51b27c41a8d304e590866790b93e506390b8c481ca27201ca1149'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom',
-          checkpoint: 'cd7dd7014ba0615d5c62f5a25ad320bee148cb7923fa02b037f52282e8148daa'
+          checkpoint: '927643c8990caf42826e3cf8e2b8fd8c6a58a6e4337b077b600271aa2eb97310'
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.