### PR TITLE
Update quip to 5.2.91

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.2.82'
-  sha256 '1e72496039ff542b53d7997584ce12dd1af083ec0972af217edec08bc378d1c1'
+  version '5.2.91'
+  sha256 '454d09b9659bc15e970af45c209c7963b49dd98db65e58ffd7f7680e15d9b87c'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.