### PR TITLE
Update manager to 18.5.22

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.21'
-  sha256 '0be82612b7f63653e73d9a64077a112c93bf8cecf5f9989434b828a9c976f3b5'
+  version '18.5.22'
+  sha256 'aca296b244cb87dfc455a4c5bdfa0afd732972afcaf94852ef8619c0c4a9fd8b'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.