### PR TITLE
Update bunq to 0.8.9

### DIFF
--- a/Casks/bunq.rb
+++ b/Casks/bunq.rb
@@ -1,11 +1,11 @@
 cask 'bunq' do
-  version '0.8.8'
-  sha256 'ead282358216174dcf4b4bc0c55f7611d2f3075a2384e894d378c5f105beaa4e'
+  version '0.8.9'
+  sha256 'aaac0bf9b15a640e8e958b26417f7332dcf4fc49696a0a9a93787797f39341db'
 
   # github.com/BunqCommunity/BunqDesktop was verified as official when first introduced to the cask
   url "https://github.com/BunqCommunity/BunqDesktop/releases/download/#{version}/BunqDesktop-#{version}.dmg"
   appcast 'https://github.com/BunqCommunity/BunqDesktop/releases.atom',
-          checkpoint: 'e0759b46386f243ab7f76668bd709dc76a628cfbb1c4af673089e2cd7bff9d95'
+          checkpoint: 'c45ad1a1b84662c96fa0ee9bd7aa6f01fca6b26ee51e89be4e91dff04619d4c2'
   name 'BunqDesktop'
   homepage 'https://bunqdesktop.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.