### PR TITLE
Update lehreroffice to 2018.8.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice' do
-  version '2018.7.0'
-  sha256 'd75b9fa3f40edc46d318863ea39ccff03dd0144cf6d51314faa4c92185a8f70e'
+  version '2018.8.0'
+  sha256 '78a3b45d3e2e712b94f5e280e3d2c259582be4c6fce4241aa63597056b96c590'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_osx.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop',
-          checkpoint: '257e5606f1d1c59e1122a05a25f26360210c5b690fd823da6ea039b16871962f'
+          checkpoint: '4e3fc3526921b7e9827a053ccf1b87494c0d3c8281fe30857084285a94ed4653'
   name 'LehrerOffice'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.