### PR TITLE
Update pdf-expert to 2.4.2,511

### DIFF
--- a/Casks/pdf-expert.rb
+++ b/Casks/pdf-expert.rb
@@ -1,11 +1,11 @@
 cask 'pdf-expert' do
-  version '2.4,511'
+  version '2.4.2,511'
   sha256 '22026d0de90b25b1bf04d06e51bfd95e6a1b5388cd839a69a8144aac17a5f2de'
 
   # readdle-test-binaries.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://readdle-test-binaries.s3.amazonaws.com/versions/#{version.after_comma}/PDFExpert.dmg"
   appcast 'https://readdle-test-binaries.s3.amazonaws.com/release/appcast.xml',
-          checkpoint: '04f046b8f417005d3fe57468fd5ab4a1e8a574d13753e355cba710cc26ddafc2'
+          checkpoint: '4376404cf45c6b5a80fb6c256cc45903ece6c0c8911d0bea56dc3f569f302b12'
   name 'PDF Expert'
   homepage 'https://pdfexpert.com/'
 

--- a/Casks/pdf-expert.rb
+++ b/Casks/pdf-expert.rb
@@ -1,6 +1,6 @@
 cask 'pdf-expert' do
-  version '2.4.2,511'
-  sha256 '22026d0de90b25b1bf04d06e51bfd95e6a1b5388cd839a69a8144aac17a5f2de'
+  version '2.4.2,528'
+  sha256 '1c20a34a028a94b2c6d20a086d6062a6426a976a7626e4253efc3f506363d4a0'
 
   # readdle-test-binaries.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://readdle-test-binaries.s3.amazonaws.com/versions/#{version.after_comma}/PDFExpert.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.