### PR TITLE
Update protopie to 3.8.2

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,10 +1,10 @@
 cask 'protopie' do
-  version '3.8.1'
-  sha256 'a4ef58120343e50ab5aff1d1e4ea1a98a1e125b14b5e39396c12df637345f1ab'
+  version '3.8.2'
+  sha256 'e64912d472d590702dae58f65603a18348e25b25c39982ced9e9b6bbab180395'
 
   url "http://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/',
-          checkpoint: '9782b15224eedf0a3d721e5569cdbcbd327befb4e788a7982e32be8771517228'
+          checkpoint: '31d00ff6ab7ccbf6257591d0a4a9627bba15114b5af05187dca6e877cdddd12d'
   name 'ProtoPie'
   homepage 'https://www.protopie.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.