### PR TITLE
Update jameica to 2.8.0

### DIFF
--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -1,8 +1,8 @@
 cask 'jameica' do
-  version :latest
-  sha256 :no_check
+  version '2.8.0'
+  sha256 '9aeb721ec258f363d4f63d9de156db95af18d3c4aaa1e9f08c4279d68576a375'
 
-  url 'https://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64.zip'
+  url "https://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64-#{version}.zip"
   name 'Jameica'
   homepage 'https://www.willuhn.de/products/jameica/'
   gpg "#{url}.asc", key_id: '5a8ed9cfc0db6c70'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.