### PR TITLE
Update comparemerge to 2.06y

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,10 +1,10 @@
 cask 'comparemerge' do
-  version '2.05y'
-  sha256 'ef20e963dd08aa3e3e2e212293eda5373f4905aa9e522997f06cbda43ef5af52'
+  version '2.06y'
+  sha256 '8dd55903e667d1999d133d62fa765ff0dfd750df73e5e55c34f542f5e54b5db2'
 
   url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss',
-          checkpoint: '589781619893788b062053663b651d711c7d666882cb8e3ee64b57c0c32a583c'
+          checkpoint: 'a32be4327b02b70ead76b4db43aa194f1717cad51e40e41a89493227e6d8fc78'
   name 'CompareMerge'
   homepage 'https://sourceforge.net/projects/comparemergenosandbox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.