### PR TITLE
Update buttercup to 1.7.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,11 +1,11 @@
 cask 'buttercup' do
-  version '1.6.2'
-  sha256 'e73748a31f8eda1fe74aeb38025f5aef314498e10049ffb48152118036f29b9a'
+  version '1.7.0'
+  sha256 '62e27b0f1ebedef627f4cedafce1eb080b75d0dde523d3385a086dbb4b20753d'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom',
-          checkpoint: 'ae5d4f2f2560672309a65359277815f140774e60bf15b6732a6b1aed70c0c84d'
+          checkpoint: '9e282da0f03eea06383fb10c0bb7f29d9bebfb550063ce61ad8b37c104e8ea21'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.