### PR TITLE
Update extraterm to 0.35.1

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,11 +1,11 @@
 cask 'extraterm' do
-  version '0.34.0'
-  sha256 '9023c9fcafc32d07dc3a279e6c78ece48a76aa558fd74f4437448ef723f1df7f'
+  version '0.35.1'
+  sha256 '01723ea7592af345fe722a8e9fddb96a057c6480889bedfc6bfaa609a3865735'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"
   appcast 'https://github.com/sedwards2009/extraterm/releases.atom',
-          checkpoint: '3937ef875fc9a6fc9481b93019788eda2cf1693ecf778c399e6bcd9e2ee4dade'
+          checkpoint: 'ce2542f3b1532ddfb0f31de94c555b3feaa15f4741a6372d0817ff7a28280442'
   name 'extraterm'
   homepage 'http://extraterm.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.