### PR TITLE
Update brewservicesmenubar to 3.0.0

### DIFF
--- a/Casks/brewservicesmenubar.rb
+++ b/Casks/brewservicesmenubar.rb
@@ -1,10 +1,10 @@
 cask 'brewservicesmenubar' do
-  version '2.1.0'
-  sha256 '59cc2a2cdb2dc3762071e2b67d8aa787af52f500141f3af4f481403c02999ddb'
+  version '3.0.0'
+  sha256 '13c8401bc212b65d38a4aa96daf7f98f76e27758ac29fc80fb25e21c989b194d'
 
   url "https://github.com/andrewn/brew-services-menubar/releases/download/v#{version}/BrewServicesMenubar.zip"
   appcast 'https://github.com/andrewn/brew-services-menubar/releases.atom',
-          checkpoint: 'bb694b2453628becf0888b949205e020db1ad9381e5412904d0ad85383f5917c'
+          checkpoint: '6a4109caef2580e80804ba86825d5812d1886e1ba87e9f9310fc6b184172d757'
   name 'Brew Services Menubar'
   homepage 'https://github.com/andrewn/brew-services-menubar'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.