### PR TITLE
Update bitshares to 2.0.180526

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,11 +1,11 @@
 cask 'bitshares' do
-  version '2.0.180512'
-  sha256 'f51ca73b0d519d07529f5037c2a3f1e51eeb9dc7f885c3ffcd5d1b7185209d4b'
+  version '2.0.180526'
+  sha256 'bc8f7d9a5d21c2c032f30f065eab4fa58a870ae95c1d38dcc2245bb06c2b6a51'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom',
-          checkpoint: '28f91c92290d19b2fa100957fc99f6f5c3ad1a0f51e3ae77cfafa3f446451e27'
+          checkpoint: '20827331fc4a19cdb7457c605567f8308eb636c1f71e86fd1da334e3274ae4c8'
   name 'BitShares'
   homepage 'https://bitshares.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.