### PR TITLE
Update fastonosql to 1.17.5

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,10 +1,10 @@
 cask 'fastonosql' do
-  version '1.17.4'
-  sha256 '249e60716acf94c00d2049a14da411e5985ca2cfe7f3ed42462c45edee422684'
+  version '1.17.5'
+  sha256 '193943743e1779355ddf05cf4a06024c80e66b9fa25cde05999ce4a13777907a'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom',
-          checkpoint: '41f72610c3d64b529b092c1f587fbe2ef4eb79fdfbb1d03a72ff0ebc0663f621'
+          checkpoint: '86024caa72f71b24d4f45aa96a1ab8513715e6c6ed30e54222b02c9e7a5b353f'
   name 'FastoNoSQL'
   homepage 'https://www.fastonosql.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.