### PR TITLE
Update framer to 18184,1526378841

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,11 +1,11 @@
 cask 'framer' do
-  version '18175,1525441270'
-  sha256 '9243305c6c23bc9812403d7959cc6894b79acbb58f0933413795729b08160d5f'
+  version '18184,1526378841'
+  sha256 'bd9ea7dd6eb7be752b8cb6a7c514b639991bd8344fc132a3b876e656325fafa7'
 
   # devmate.com/com.motif.framer was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.motif.framer/#{version.before_comma}/#{version.after_comma}/FramerStudio-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.motif.framer.xml',
-          checkpoint: '6ad98327aebbf41506b4bc9c22e8d2729c05d91be4bbd350848db3073a01b077'
+          checkpoint: '898a621173c2e4bd2f309db086b5e02144234512617eca0aa84b8e607cbc3735'
   name 'Framer'
   homepage 'https://framer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.