### PR TITLE
Update freedom to 1.6.8

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,10 +1,10 @@
 cask 'freedom' do
   version '1.6.8'
-  sha256 '1fbd20e6ca8772a67205ad3f2e200d7d14496479546f371b4db11fcbcb3d2213'
+  sha256 'b986714064bfa0f9ff29999918665694f9a6f9a0c8404892583ca2ad07eac071'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml',
-          checkpoint: '41865c55071391babb11444e9aec7a8d822787cee693bf56cac3fc9d4d4bf72c'
+          checkpoint: '756394462b1e948a8a3510b5c4300f95056d4936ff23e023c2cfbb4390aee80e'
   name 'Freedom'
   homepage 'https://freedom.to/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.