### PR TITLE
Update serviio to 1.9.2

### DIFF
--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -1,6 +1,6 @@
 cask 'serviio' do
-  version '1.9'
-  sha256 '18577b1e9bb23d46b232264a5fde13ae24650133a0f8e1d630ccf5ddc5834905'
+  version '1.9.2'
+  sha256 'de9a2918ae15b7bdd3042a5007a621bd111dcc552e6b580b74d7c1293fad26ed'
 
   url "http://download.serviio.org/releases/serviio-#{version}-osx.tar.gz"
   name 'Serviio'

--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -8,12 +8,13 @@ cask 'serviio' do
 
   pkg "Serviio-#{version}.pkg"
 
-  uninstall pkgutil: [
-                       'org.serviio.pkg.autostart',
-                       'org.serviio.pkg.JRE',
-                       'org.serviio.pkg.ServiioConsole',
-                       'org.serviio.pkg.Serviio',
-                     ]
+  uninstall pkgutil:   [
+                         'org.serviio.pkg.autostart',
+                         'org.serviio.pkg.JRE',
+                         'org.serviio.pkg.ServiioConsole',
+                         'org.serviio.pkg.Serviio',
+                       ],
+            launchctl: 'org.serviio.server'
 
   zap trash: [
                '/Library/Application Support/Serviio',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.