### PR TITLE
Update ganttproject to 2.8.8,r2308

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,11 +1,11 @@
 cask 'ganttproject' do
-  version '2.8.7,r2262'
-  sha256 'a622a81ad6ff47e17da7935ee9b63a3c1b9cb605332887b8dbf2e8c7f36556be'
+  version '2.8.8,r2308'
+  sha256 '6f6b026207abb3bd5ec1602e1fd762edb77aafcf390a50fd673c5b54862ab02b'
 
   # github.com/bardsoftware/ganttproject/releases/download was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/bardsoftware/ganttproject/releases.atom',
-          checkpoint: '3538464ada05bf578f7f4e8adfb7dfcb5a20fdb3c1791d34dd219d40f5c7f000'
+          checkpoint: 'd2915538665b4b10aa5aaa49de208b05e46dea8b81fff5f7dc436945537b9b62'
   name 'GanttProject'
   homepage 'https://www.ganttproject.biz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.