### PR TITLE
Update inspec to 2.1.83-1

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,11 +1,11 @@
 cask 'inspec' do
-  version '2.1.72-1'
-  sha256 '97dd92798ca94784c5d41f5e63c1c070671e89f2a3b6b132eb79f2ab053c0dd2'
+  version '2.1.83-1'
+  sha256 'bb15f8f838ffdc1ade98df2aaabedbbaeed9fd1cd43869fe247fce745ca92999'
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version.major_minor_patch}/mac_os_x/10.13/inspec-#{version}.dmg"
   appcast 'https://github.com/chef/inspec/releases.atom',
-          checkpoint: 'f665c96273c4c253032444f7eb6accb122958f3f1f72afd429de0f73facb2004'
+          checkpoint: '0b3806898e36415f87d04c4709d54162b497663d7da8c3150d42ef109709a099'
   name 'InSpec by Chef'
   homepage 'https://www.inspec.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.