### PR TITLE
Update grandtotal to 5.1.6

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,14 +1,14 @@
 cask 'grandtotal' do
-  version '5.1.5'
-  sha256 'aeda8d79516e5fd6bdfb29b50e606ff05bf638cae404f142c207f57bb4420eef'
+  version '5.1.6'
+  sha256 '876884c0ea61177feda2333cdd0506b537b3309ed62e9f452ecfe93c952f8a7b'
 
   url "https://mediaatelier.com/GrandTotal#{version.major}/GrandTotal_#{version}.zip"
   appcast "https://mediaatelier.com/GrandTotal#{version.major}/feed.php",
-          checkpoint: '6960c34c6da5c8d319ed744a3f16c11db989a2503fb24dc679573b33a88361af'
+          checkpoint: '0b2fa9f3239db87404ea1e2b821f3213e232a3cc1e2ec5b8ea6089a1070b601c'
   name 'GrandTotal'
   homepage "https://www.mediaatelier.com/GrandTotal#{version.major}/"
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :mavericks'
 
   app 'GrandTotal.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.