### PR TITLE
Update glyphs to 2.5.2-1143

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.5.1-1141'
-  sha256 'f360ce97d12425f6e0686be2db46c8ccd78bae99256f0d381f22477692067d70'
+  version '2.5.2-1143'
+  sha256 'e59513439318c0aa541f7d797de47330e9ccf220c1b33f1ea54b351b4cf0ce7f'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: '83be043e56e2b3ac682f7574031a2b3143d7bff7a87fa84392792276f26589e5'
+          checkpoint: '67de019213d269f6fb99eaf9da04b9f6180780db1376382121bd428758348769'
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.