### PR TITLE
Update imagej to 1.52

### DIFF
--- a/Casks/imagej.rb
+++ b/Casks/imagej.rb
@@ -1,6 +1,6 @@
 cask 'imagej' do
-  version '1.50'
-  sha256 '681bb1af1cc1797e2fe5eddd5828a38128d3fc5cf9ea05a268650466e2eb6b93'
+  version '1.52'
+  sha256 '17e1ee34c2886f9abb350da271b8e3d5063dfa4547388c34e84a75d2b5c0bc56'
 
   # wsr.imagej.net/distros/osx was verified as official when first introduced to the cask
   url "https://wsr.imagej.net/distros/osx/ImageJ#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.