### PR TITLE
Update itubedownloader to 6.3.7,1526476644

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,11 +1,11 @@
 cask 'itubedownloader' do
-  version '6.3.6,1525200302'
-  sha256 '065c679dfb9f9150c45a1d339710e0916c7cf7ffb36f6feb96f70a9bd5fda693'
+  version '6.3.7,1526476644'
+  sha256 '6d0458187cdcb5ea04b0345dce25620ebfd7faa41345ff656216b1223677457b'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/#{version.before_comma.no_dots}/#{version.after_comma}/iTubeDownloader-#{version.before_comma.no_dots}.zip"
   appcast 'https://updates.devmate.com/com.AlphaSoft.iTubeDownloader.xml',
-          checkpoint: '3c3100c959672e8e8bb665865f72df3e31ff890733c9fe63ec4774b7b2b0bda4'
+          checkpoint: 'ed10589cfc2c2dd7b29cd8dca515ed8371de081a29c677ead57a9cdb0f25148a'
   name 'iTubeDownloader'
   homepage 'http://alphasoftware.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.