### PR TITLE
Update graphql-playground to 1.5.9

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,12 +1,12 @@
 cask 'graphql-playground' do
-  version '1.5.8'
-  sha256 'fc98d3e0e44adceb935cc4b02041cb71601f926310abeff64d3171aabe0305b5'
+  version '1.5.9'
+  sha256 '84908c21d9b0c0723718a344718cf2c4297bb6c1026def4e50ee4ca5a1576a2d'
 
-  url "https://github.com/graphcool/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
-  appcast 'https://github.com/graphcool/graphql-playground/releases.atom',
-          checkpoint: '8b6f1145d3ff0aecad8adfc867424514d14c39194f96882ce2ab9a027f3a3143'
+  url "https://github.com/prismagraphql/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
+  appcast 'https://github.com/prismagraphql/graphql-playground/releases.atom',
+          checkpoint: 'a49e533c53e8785990bf903a9fe7a34799867b4cde87747e4e5626cda2118580'
   name 'GraphQL Playground'
-  homepage 'https://github.com/graphcool/graphql-playground'
+  homepage 'https://github.com/prismagraphql/graphql-playground'
 
   app 'GraphQL Playground.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.