### PR TITLE
Update devonthink-pro to 2.10

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,11 +1,11 @@
 cask 'devonthink-pro' do
-  version '2.9.17'
-  sha256 '3a01a261a8e5d9b452fbae7d2b22a1c1fd7b95fc0b81e28e5b00aeab79d77c14'
+  version '2.10'
+  sha256 '556157e6e7429e6e35adb3cf17cb8226e3aef6c7069ceaee4591e2b1802f55d0'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=300030707&format=xml',
-          checkpoint: '43d628815d312a19ec87ba8f9d03f668626e6b186f00f74591f2bcf573212e63'
+          checkpoint: 'b6630fd869747c404c19d94d9e2057c20eb47d4c93abe18268210542ca4ab8f3'
   name 'DEVONthink Pro'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-pro.html'
 

--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,11 +1,11 @@
 cask 'integrity' do
-  version '8.0.9'
-  sha256 'f0e0aebe2fced81bbe12c7e2319605c61f65ddf0888206867225ca574349eeb3'
+  version '8.1.01'
+  sha256 '257b6093fe05bbd20b285c487c24f1d3245c4a8a3b05ae26d908edf26efc1d69'
 
   # peacockmedia.co.uk/integrity was verified as official when first introduced to the cask
   url 'http://peacockmedia.co.uk/integrity/integrity.dmg'
   appcast 'http://peacockmedia.software/mac/integrity/version_history.html',
-          checkpoint: '64bae79fefa88e6b7e6ab5b2055c002b32077a930d2e01cf58706ef421360744'
+          checkpoint: '8f9e7706c97a53a5cda20dc62476b8d74c9d81d2c7771396a61017a2611a6bae'
   name 'Integrity'
   homepage 'http://peacockmedia.software/mac/integrity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.