### PR TITLE
Update devonthink to 2.10

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,11 +1,11 @@
 cask 'devonthink' do
-  version '2.9.17'
-  sha256 '063af95345f2aae7cdeb066de7e544e5d65f4ce73c3d6f5696c8600f51008596'
+  version '2.10'
+  sha256 '43c9e2cbef1ae8e8e52d97b54be28b5ce019eaf2615db4921e9736b22c72d4c4'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"
   appcast 'http://www.devon-technologies.com/fileadmin/templates/filemaker/sparkle.php?product=217255&format=xml',
-          checkpoint: 'c531e5e74b1aaa4c483dd260b7f12ea83e1a782b072023dc2aa9d2df36b08b6f'
+          checkpoint: 'def80fee3b439b2fe71185f3bc35f27aaf0e0987bbd641ba0b34c257720d96ed'
   name 'DEVONthink Personal'
   homepage 'https://www.devontechnologies.com/products/devonthink/devonthink-personal.html'
 

--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,11 +1,11 @@
 cask 'integrity' do
-  version '8.0.9'
-  sha256 'f0e0aebe2fced81bbe12c7e2319605c61f65ddf0888206867225ca574349eeb3'
+  version '8.1.01'
+  sha256 '257b6093fe05bbd20b285c487c24f1d3245c4a8a3b05ae26d908edf26efc1d69'
 
   # peacockmedia.co.uk/integrity was verified as official when first introduced to the cask
   url 'http://peacockmedia.co.uk/integrity/integrity.dmg'
   appcast 'http://peacockmedia.software/mac/integrity/version_history.html',
-          checkpoint: '64bae79fefa88e6b7e6ab5b2055c002b32077a930d2e01cf58706ef421360744'
+          checkpoint: '8f9e7706c97a53a5cda20dc62476b8d74c9d81d2c7771396a61017a2611a6bae'
   name 'Integrity'
   homepage 'http://peacockmedia.software/mac/integrity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.