### PR TITLE
Update jing to 2.8.1

### DIFF
--- a/Casks/jing.rb
+++ b/Casks/jing.rb
@@ -1,12 +1,14 @@
 cask 'jing' do
-  version '2.8.0'
-  sha256 '5717c1602347965dc28e53d792e252e03a5f6ee1ad59cc3ad3bb596bed910935'
+  version '2.8.1'
+  sha256 '0eac9085ab7fe35f4530bde2e5c5cb4fb574c306d3a7331a8bf9186506b2c136'
 
   url 'https://download.techsmith.com/jing/mac/jing.dmg'
   appcast 'https://download.techsmith.com/update/jing/enu/appcast.xml',
-          checkpoint: '7caf2adfd6ffe5d0330e28eb7fc939952c6862a3dc45e96b8dbda0e6898d69d8'
+          checkpoint: 'a17754d6180731fe0438d3bca4f02d97f879be2a95052d0d90d69a35182f1d2f'
   name 'Jing'
   homepage 'https://www.techsmith.com/jing.html'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'Jing.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.