### PR TITLE
Update kite to 0.20180524.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20180511.0'
-  sha256 '273715f2e3c3db694abe210349c5ee0f090933fb31acf1eeb81f7e07f83f21b3'
+  version '0.20180524.0'
+  sha256 '3473b6172316f919e1a4fe1d890265e55263bbe41235e2ab47cc84615c906740'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '6f91ebf0583dcdb9bba55ed29fadf54c9e6a49ed4bd372023ed4bd1c1fe200aa'
+          checkpoint: 'c32c3bd01407fe64f3ae30f9236f1688151aa25c02ad5a08857347fa8fdc1bfd'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.