### PR TITLE
Update monal to 2.1b6

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,12 +1,14 @@
 cask 'monal' do
-  version '2.1b3'
-  sha256 '8185f47eda658b15a1d397b9a556ed6cdee92145950e11655fbaee89c4991bc1'
+  version '2.1b6'
+  sha256 'bf05fd97f35855a3d20d5cde2364228800b72239bcf9f54c069935db742c9491'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',
-          checkpoint: '87d3f3fe8a27382f90b9b6f8b914a1297b259cf80f089bcf42d2a0d41b02d90e'
+          checkpoint: '347da5a589d4ca6886fe66dd93cb004294160b5402311d1e831acfb13d5431b0'
   name 'Monal'
   homepage 'https://monal.im/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'Monal.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.