### PR TITLE
Update munki to 3.3.0.3515

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -13,7 +13,7 @@ cask 'munki' do
 
   uninstall pkgutil:   'com.googlecode.munki.*',
             launchctl: [
-                        'com.googlecode.munki.app_usage_monitor',
-                        'com.googlecode.munki.appusaged',
+                         'com.googlecode.munki.app_usage_monitor',
+                         'com.googlecode.munki.appusaged',
                        ]
 end

--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -12,5 +12,8 @@ cask 'munki' do
   pkg "munkitools-#{version}.pkg"
 
   uninstall pkgutil:   'com.googlecode.munki.*',
-            launchctl: 'com.googlecode.munki.app_usage_monitor'
+            launchctl: [
+                        'com.googlecode.munki.app_usage_monitor',
+                        'com.googlecode.munki.appusaged',
+                       ]
 end

--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,11 +1,11 @@
 cask 'munki' do
-  version '3.2.1.3499'
-  sha256 '349c8b3a74f86d397b3a6025ce490da280286c4cfc610b633ce63b5e4e4d3ad4'
+  version '3.3.0.3515'
+  sha256 'bda08ad4104cc892033c9a84672f6d24069c30533d0b67de113744d696a53032'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"
   appcast 'https://github.com/munki/munki/releases.atom',
-          checkpoint: 'bb68e350b7cb6e386a5ae87a88bc9975c62fd8f44fdb6ab0fae32e0ec4c9280d'
+          checkpoint: 'fcdf4a4a7172c5a0108006afa462524d2510bf985506b1eba081dfefba621ee1'
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.