### PR TITLE
Update overture to 2.6.2

### DIFF
--- a/Casks/overture.rb
+++ b/Casks/overture.rb
@@ -1,11 +1,11 @@
 cask 'overture' do
-  version '2.6.0'
-  sha256 '9ecdaa3aee858459c9383c9277c82d7f2d28b1a6fba989d49c18223909f77ef6'
+  version '2.6.2'
+  sha256 'a1fba04c86c284eea65a7a92313ffa659c042339b1bab5fbb50027bcab61047a'
 
   # github.com/overturetool/overture was verified as official when first introduced to the cask
   url "https://github.com/overturetool/overture/releases/download/Release%2F#{version}/Overture-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://github.com/overturetool/overture/releases.atom',
-          checkpoint: '60e51d8d7b605de42480aba89cd6dadaa3e514fd90b27aabf8d9715cabfabd03'
+          checkpoint: '3e36e148a87639aa8ecbba654e1e1c8fb1b69337a69c5193041a654bb91168d5'
   name 'Overture Tool'
   homepage 'http://overturetool.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.