### PR TITLE
Update mimolive to 4.1-25475

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,10 +1,10 @@
 cask 'mimolive' do
-  version '4.0.3-24873'
-  sha256 'c5cbfb91bc3dc9554a952feed0a1596c0bd0479e2f8142dc77b8e4a46e067de5'
+  version '4.1-25475'
+  sha256 '80deae64507c7f6ee3e3ab3a907470de9bf499e4acae85671d1957068116cad4'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/mimolive',
-          checkpoint: '609b33258f108282ae38fcac40662c0fbc09eca0f0b38df2a5181b002d505fbe'
+          checkpoint: '111086d7d4590aff9dcba3892e12312d01ab596769338bd3c3a49a8590596d57'
   name 'mimoLive'
   homepage 'https://boinx.com/mimolive/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.