### PR TITLE
Update qownnotes to 18.05.7,b3605-162547

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,11 +1,11 @@
 cask 'qownnotes' do
-  version '18.05.2,b3579-160121'
-  sha256 '0f7026ac81d9f835ed9799e8e44c69cdcd85d11d97cfdae7ffec847e7cbe2d9b'
+  version '18.05.7,b3605-162547'
+  sha256 '714cba3282ad0782cafc8f2f1349c1fe1ff91c44fcf8cc9ae43900ab662b007f'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"
   appcast 'https://github.com/pbek/QOwnNotes/releases.atom',
-          checkpoint: '8e3f080d4761475bf9f1a577caf04c37fb03e6780a450be920cdc4f0875c9ac9'
+          checkpoint: '74a44c488a8df011b4e10352db7a10d7ad0e8ab7cf1f22ed17e4133d7a2e4a78'
   name 'QOwnNotes'
   homepage 'https://www.qownnotes.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.