### PR TITLE
Update receipts to 1.8.0-192

### DIFF
--- a/Casks/receipts.rb
+++ b/Casks/receipts.rb
@@ -1,12 +1,14 @@
 cask 'receipts' do
-  version '1.7.4-183'
-  sha256 '016430d49a5b1df2b416a913020178fba3ba2844f63d841954e9e2f4bd413bb2'
+  version '1.8.0-192'
+  sha256 '32dea2c25bee86ba0dd18f39869a749e6c220c9a6d726fe01a97f297c4f8d8da'
 
   url "https://www.receipts-app.com/update/download/Receipts-#{version}.zip"
   appcast 'https://www.receipts-app.com/updater.php',
-          checkpoint: 'c6354604204e765de37ac78b65f79bd90b26038f255f075f92849e3a4250d992'
+          checkpoint: 'b0b5e80feec0f22f7e4296b88bf6e7d8b7e215a71be1ba235c48239cb3daf420'
   name 'Receipts'
   homepage 'https://www.receipts-app.com/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'Receipts.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.