### PR TITLE
Update remembear to 1.0.2

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,11 +1,11 @@
 cask 'remembear' do
-  version '1.0.1'
-  sha256 '50085d0f1c03dc760863991360ef70b591f858d50d744aa7463624073ea80694'
+  version '1.0.2'
+  sha256 '8291ca68a05870cb7d4ac48937ad2da5e9469b39b0088d96e9a31479c846af2d'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"
   appcast 'https://s3.amazonaws.com/remembear/app/release/downloads/macOS/appcast.xml',
-          checkpoint: '051a54637054a24e1dc5475f88d224dd08b12bec90a45d84462f8235b6bd3842'
+          checkpoint: '10e72b0e82b2200ff34d82baafe4b6c043319ef25c854d9efb47ee3ba4e97fd9'
   name 'RememBear'
   homepage 'https://www.remembear.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.