### PR TITLE
Update remote-desktop-manager-free to 5.3.1.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,11 +1,11 @@
 cask 'remote-desktop-manager-free' do
-  version '5.3.0.0'
-  sha256 '5523e2c26b091735eae0f2be55b285f1fd7f25eaae9f80c303b59b99cab1ccd1'
+  version '5.3.1.0'
+  sha256 '80071a1a111fca2007d26eaab0463ba9613c7b9af4c0bab6d4d75201fd8a46fb'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"
   appcast 'http://cdn.devolutions.net/download/Mac/RemoteDesktopManagerFree.xml',
-          checkpoint: 'a4a534495e21747fe36ac40d88866e594a0ee18db1c8a3b8e915b2bf1e6d36f8'
+          checkpoint: 'c3fa9e6d76b53e67e60bf92c076d592aab673e39223b7285e0be293dd6a662e8'
   name 'Remote Desktop Manager Free'
   homepage 'https://mac.remotedesktopmanager.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.