### PR TITLE
Update rhinoceros to 5.4.2

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceros' do
-  version '5.4.1'
-  sha256 'a2fcda3a5143dd06b84e53c34cbd40e8dbd9c3319130bfee9b23199c770b7c32'
+  version '5.4.2'
+  sha256 '25f47d059f5b83e290ecbcc2375d62478f93de5fb53b23525afa7a00d2fcded6'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/#{version.major}.0/Mac/Rhinoceros_#{version}.dmg"
   appcast "https://files.mcneel.com/rhino/#{version.major}.0/mac/#{version.major}CcommercialUpdates.xml",
-          checkpoint: 'af98714fe2491ac75ac83c87b153692ac55e31c4d4a3243be12ae509f890d0c9'
+          checkpoint: '08ffc8e4773d87bada8e5ef9b18601d4df014389cfe60afc4fa6fb834f9a9962'
   name 'Rhinoceros'
   homepage 'https://www.rhino3d.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.