### PR TITLE
Update picat to 2.4

### DIFF
--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,10 +1,10 @@
 cask 'picat' do
   version '2.4'
-  sha256 '6b5da2bcf5a7d62576018c0968e406677cf4c8f207c4db2ed6939701a5f13e06'
+  sha256 '6b9233145122984873511416bc69bea952ee74ba274e1fe1d0ec946c453f8f9f'
 
   url "http://picat-lang.org/download/picat#{version.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt',
-          checkpoint: 'ca2fcc9224520e6222e1e3b50bcf1eb7a80f5bca3a2900486fcb86fd2e7eb9ed'
+          checkpoint: '24bf287a0490eeb31628d8d6ead3749faacb515c1d260d59cdf87e12afa23c9d'
   name 'Picat'
   homepage 'http://www.picat-lang.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.