### PR TITLE
Update wesnoth to 1.14.2

### DIFF
--- a/Casks/wesnoth.rb
+++ b/Casks/wesnoth.rb
@@ -1,11 +1,11 @@
 cask 'wesnoth' do
-  version '1.14.1a'
-  sha256 'd76d60492546877b015b6aa185c0e500e64c39a643a1137f89bf4eedd757d89c'
+  version '1.14.2'
+  sha256 'fb1a07d2f9fd37a98a8d79f47256316d7fa0167d11871048c1774549b7c71f25'
 
   # sourceforge.net/wesnoth was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/wesnoth/rss',
-          checkpoint: 'a5501b27da01e08bad9378b822e849f205d25427499e7bcf80a2c47591c616da'
+          checkpoint: 'b1040dfa8f8f05e4847b54f444d2d08386ccddc6daf42415f1ca635d68fd000e'
   name 'The Battle for Wesnoth'
   homepage 'https://wesnoth.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.