### PR TITLE
Update udeler to 1.5.4

### DIFF
--- a/Casks/udeler.rb
+++ b/Casks/udeler.rb
@@ -1,10 +1,10 @@
 cask 'udeler' do
-  version '1.5.0'
-  sha256 'b63abdb2cd5567b87b57915e14251acd25ba62a5167667d8c6b2c8f501767127'
+  version '1.5.4'
+  sha256 'e11759d54fd3fcef164520ed72a7406ed867aa21db6f45a0252060d8ac839d8a'
 
   url "https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v#{version}/Udeler-#{version}-mac.zip"
   appcast 'https://github.com/FaisalUmair/udemy-downloader-gui/releases.atom',
-          checkpoint: '422e1bc8d9db8084063d011186555a65e132fd2c80aa905d2e9dda134ef63622'
+          checkpoint: '4000c89a17b8dd069469a335aaaa436d9a3a3a535f872bfae349bac144413c14'
   name 'Udeler'
   homepage 'https://github.com/FaisalUmair/udemy-downloader-gui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.