### PR TITLE
Update mtmr to 0.16

### DIFF
--- a/Casks/mtmr.rb
+++ b/Casks/mtmr.rb
@@ -1,10 +1,10 @@
 cask 'mtmr' do
-  version '0.14'
-  sha256 '558a2a68f6c258120efd9ab34f3b9c70e4f869ed59d32c49b2bfd57b06537503'
+  version '0.16'
+  sha256 '523545c994b81527041b5a611cc2a0ba339d6b94753e12850f85790189338f77'
 
-  url "https://github.com/Toxblh/MTMR/releases/download/v#{version}/MTMR-#{version}.dmg"
+  url "https://github.com/Toxblh/MTMR/releases/download/v#{version}/MTMR.#{version}.dmg"
   appcast 'https://github.com/Toxblh/MTMR/releases.atom',
-          checkpoint: '56a4be29f5be421c9f5d9098b2a536faa78f3dd5c2785c0c983331f521408a10'
+          checkpoint: '12de116f2cb92d3ddb52ac3ace8c681548e16fd39ad41f4b9f6c5d15f2f8b8d1'
   name 'My TouchBar. My rules'
   homepage 'https://github.com/Toxblh/MTMR'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.