### PR TITLE
Update smartsvn to 9.3.1

### DIFF
--- a/Casks/smartsvn.rb
+++ b/Casks/smartsvn.rb
@@ -1,10 +1,10 @@
 cask 'smartsvn' do
-  version '9.3.0'
-  sha256 '23d1b3b00513638330498cbac1ae0682efa6eb831210ccfa139ff25c2695433a'
+  version '9.3.1'
+  sha256 '89d4ac14ca2be9b985afffbb2ec3cbeaefae32704809e7612fa78dc75eaa4004'
 
   url "https://www.smartsvn.com/downloads/smartsvn/smartsvn-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.smartsvn.com/documents/smartsvn/changelog.txt',
-          checkpoint: '942f20a0363b7402291ef1e49e9c734e22d28557ed6767ccb3c7ce521a329432'
+          checkpoint: '2ab317ba8db35a4294dcedb9f4537a3ff1d179757ecb0f26f457cdc1398790ce'
   name 'SmartSVN'
   homepage 'http://www.smartsvn.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.