### PR TITLE
Update pyfa to 2.0.2,yc120.3-1.8

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '2.0.0,yc120.3-1.8'
-  sha256 '36d1540580f4893a4b49aa8ccd7709f16ebf8dbc3f8dad365f1161bcf8d961b9'
+  version '2.0.2,yc120.3-1.8'
+  sha256 '173fa033b785c034b589d7a612b9c67d5345d775de8696a0447b31951e1c05aa'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '13c72e4e6295e6f345a0d402ac474726564dcd260837a7bc6545b2a0e3cbf4f7'
+          checkpoint: '61e6f7dde48a774394ce3531d3ded5ae17420e770e1557cb5628a4be0b6d2529'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.