### PR TITLE
Update gemini to 2.4.4

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,11 +1,11 @@
 cask 'gemini' do
-  version '2.4.3'
-  sha256 'c3c2ef623bee5fc43c845ad5537cba4f3eb518d881db25db1e5a09ea69d5508e'
+  version '2.4.4'
+  sha256 'ac4d512d80ecf6955c35f01dac400d24d25b46d555fb8756b44d152ef4d18fda'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/Gemini#{version.major}.dmg"
   appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml",
-          checkpoint: '35ac4a226beb788c010d3ead2bfb49a8ceffdf456cca0ab497bdd0e6c35ec807'
+          checkpoint: '64dca16f289fee333164bf8a4846350268e3db8cfcb0a4d111948122927de52b'
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.