### PR TITLE
Update qlstephen to 1.4.4

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -4,7 +4,7 @@ cask 'qlmarkdown' do
 
   url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"
   appcast 'https://github.com/toland/qlmarkdown/releases.atom',
-          checkpoint: '34011e782f042d65d5f64c7e7355a757d09e97466cd981cf7b67826075e37c61'
+          checkpoint: '717694274e431e47a407e8dc5f2b8971e208ad8614d967a62d4e05301d08aa1e'
   name 'QLMarkdown'
   homepage 'https://github.com/toland/qlmarkdown'
 

--- a/Casks/qlstephen.rb
+++ b/Casks/qlstephen.rb
@@ -5,7 +5,7 @@ cask 'qlstephen' do
   # github.com/whomwah/qlstephen was verified as official when first introduced to the cask
   url "https://github.com/whomwah/qlstephen/releases/download/#{version}/QLStephen.qlgenerator.#{version}.zip"
   appcast 'https://github.com/whomwah/qlstephen/releases.atom',
-          checkpoint: '3f5376b9e01281eeb64251fc47b115d774641ec44a623430f132e2718dc1a422'
+          checkpoint: 'b2acb482282824efb102b8fcea3c91010e5fba31a01e01a86157866609ba888f'
   name 'QLStephen'
   homepage 'https://whomwah.github.io/qlstephen/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.