### PR TITLE
Update vagrant-manager to 2.6.0

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -4,7 +4,7 @@ cask 'qlmarkdown' do
 
   url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"
   appcast 'https://github.com/toland/qlmarkdown/releases.atom',
-          checkpoint: '34011e782f042d65d5f64c7e7355a757d09e97466cd981cf7b67826075e37c61'
+          checkpoint: '717694274e431e47a407e8dc5f2b8971e208ad8614d967a62d4e05301d08aa1e'
   name 'QLMarkdown'
   homepage 'https://github.com/toland/qlmarkdown'
 

--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -5,7 +5,7 @@ cask 'vagrant-manager' do
   # github.com/lanayotech/vagrant-manager was verified as official when first introduced to the cask
   url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
   appcast 'https://github.com/lanayotech/vagrant-manager/releases.atom',
-          checkpoint: 'bb3f4660861c88890122d0a388d847c54501de7109967d2f63484b3865a351d4'
+          checkpoint: '11cf52b7c1b5b52bd048e1107603c67962095e6713c87f6fa72df81f968b47f3'
   name 'Vagrant Manager'
   homepage 'http://vagrantmanager.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.