### PR TITLE
Update tex-live-utility to 1.34

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -4,7 +4,7 @@ cask 'qlmarkdown' do
 
   url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"
   appcast 'https://github.com/toland/qlmarkdown/releases.atom',
-          checkpoint: '34011e782f042d65d5f64c7e7355a757d09e97466cd981cf7b67826075e37c61'
+          checkpoint: '717694274e431e47a407e8dc5f2b8971e208ad8614d967a62d4e05301d08aa1e'
   name 'QLMarkdown'
   homepage 'https://github.com/toland/qlmarkdown'
 

--- a/Casks/tex-live-utility.rb
+++ b/Casks/tex-live-utility.rb
@@ -4,7 +4,7 @@ cask 'tex-live-utility' do
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.tar.gz"
   appcast 'https://github.com/amaxwell/tlutility/releases.atom',
-          checkpoint: '295f8beecdc100b82dff5e1e00098316e7fcddad08d2fcb386033cb9b6134603'
+          checkpoint: 'dbeaeacc30bd0740237bb1dca3fb87c5502bd8422a9d1990cec438142b0809d4'
   name 'TeX Live Utility'
   homepage 'https://github.com/amaxwell/tlutility'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.