### PR TITLE
Update there to 1.5.3

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,11 +1,11 @@
 cask 'there' do
-  version '1.4.7'
-  sha256 'b4bb8a372ded5ac041d6720368bba2c6628cfe6e78a69be7abde61f49b0670b5'
+  version '1.5.3'
+  sha256 'f9a28f0bded3f8a9fc6a20fdc502a7b6679d7c1ea93627def2666618ccc54609'
 
   # github.com/therepm/there-desktop was verified as official when first introduced to the cask
   url "https://github.com/therepm/there-desktop/releases/download/v#{version}/there-desktop-#{version}-mac.zip"
   appcast 'https://github.com/therepm/there-desktop/releases.atom',
-          checkpoint: '66d03dec0b51b3baf12cf2fbac854abe95cf269b17fab464a5058bbce5fc2dfa'
+          checkpoint: 'c4ac3ce39a1869c85a1002bbcd21e69f36bbef8fcdb30fe333dd02e0c3d744e4'
   name 'There'
   homepage 'https://there.pm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.