### PR TITLE
Update managenameext to 1.6.5

### DIFF
--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -1,6 +1,6 @@
 cask 'managenameext' do
-  version '1.6.4'
-  sha256 'c037419321ee4dd16dbbbfef42220789683336eaefcce1fb72f7ca9ce3f7df3e'
+  version '1.6.5'
+  sha256 '6b127ff94ff3b16b8eda7d9b44c791105f98c86bcda6298f15bc0cc6553773b4'
 
   url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
   appcast 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.