### PR TITLE
Update deezer to 0.7.3

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,8 +1,8 @@
 cask 'deezer' do
-  version '1.2.3,4312'
-  sha256 '33d355be84ef0c7777cab8c202476b61487ae6a12bf5e5aa8d852d14c05a6522'
+  version '0.7.3'
+  sha256 '0b5dc9495aa4a2cad70ce6c9019ac9c99f11f2b59d176197d53780048fd28a3a'
 
-  url "http://e-cdn-content.deezer.com/builds/mac/Deezer_#{version.after_comma}.dmg"
+  url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   name 'Deezer'
   homepage 'https://www.deezer.com/formac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.