### PR TITLE
Update onlyoffice to 5.1

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,10 +1,10 @@
 cask 'onlyoffice' do
-  version '4.8.8'
-  sha256 'bdaeac372b42920f6b6d0523d833aab3681adcd87b3d2bac589304d6111ba7b7'
+  version '5.1'
+  sha256 'c05ca69335a75d483fce6016e2bd6459876208ad7f7a1b5ff9760c778fbff301'
 
   url "http://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'http://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml',
-          checkpoint: 'ee4031cd3c52d4a2605f87ebfcba8afb3b4a8ef20f9c8a6b255702f703c2b1ee'
+          checkpoint: '26159448918b17350e242a18803a8889d4ced26969e6cd92b7c9683ab55c781b'
   name 'ONLYOFFICE'
   homepage 'https://www.onlyoffice.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.