### PR TITLE
Update zulip to 2.3.1

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,11 +1,11 @@
 cask 'zulip' do
-  version '2.0.0'
-  sha256 '6d91a4971cfe5f0af227edf6ab002f81cedc66270b9e50f6b1daa7655326b8c1'
+  version '2.3.1'
+  sha256 '549e6e06d90895964e6ab32dd0bcadc527adcd5503d614f999538e9245e8b6da'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}-mac.zip"
   appcast 'https://github.com/zulip/zulip-electron/releases.atom',
-          checkpoint: 'fccf46be6d76f1ebd01328d8839e2dbf3a4e87ebe7fb015cdcd1a0d3d6e56d57'
+          checkpoint: '745f7ad0874504a13c8a80daf4446ed7ae0fb675c3ce0b7074ace8f01234e759'
   name 'Zulip'
   homepage 'https://zulipchat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.