### PR TITLE
Update stella to 5.1.2

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,11 +1,11 @@
 cask 'stella' do
-  version '5.1.1'
-  sha256 'cc6e292968afc82f6b9f237f09bbd51eae6040a50cbbf1c225af897fce773b18'
+  version '5.1.2'
+  sha256 '33d891136230a9e99d620dd725b85dbb6d985c0c433bf68a0611605434eb75aa'
 
   # github.com/stella-emu/stella/releases/download was verified as official when first introduced to the cask
   url "https://github.com/stella-emu/stella/releases/download/#{version}/Stella-#{version}-macosx.dmg"
   appcast 'https://github.com/stella-emu/stella/releases.atom',
-          checkpoint: '5de1792c023ab9f485dbf42c5e3240065d123e77f985c2c92e99459875761f0b'
+          checkpoint: '7ef53c4c02c4abbd71e2e5b986c90c4a155606bfccd61824b68f0721a46e9cd4'
   name 'Stella'
   homepage 'https://stella-emu.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.