### PR TITLE
Update riot to 0.15.4

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,10 +1,10 @@
 cask 'riot' do
-  version '0.15.3'
-  sha256 '0a34681593f0a2e62cae73ecfca3ba7e6aedaed0cf88c4f12998cf250b19a873'
+  version '0.15.4'
+  sha256 '0d47cc76e2bbf8e45ced3e2138ca791ae1ae16cfc69df358b71efe1b65290059'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-web/releases.atom',
-          checkpoint: '09abacf513b6b8cb1a4bd41f82ff1f8809e38608666d0818d399dbc750bbaa69'
+          checkpoint: '0e261ddce20b5f07ee9bf355d61493cb245c30fac2e5cdcdfcfed00a43f39e74'
   name 'Riot'
   homepage 'https://about.riot.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.