### PR TITLE
Update remote-desktop-manager to 5.3.2.0

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,11 +1,11 @@
 cask 'remote-desktop-manager' do
-  version '5.3.1.0'
-  sha256 '96109b73335a9a74b8d4739c70f91939f10e5dfd99bb60fe8441f184aab72626'
+  version '5.3.2.0'
+  sha256 '305618f5ff0753bb556e15dc2e7fab6b9c08cc0d8f92232c8bb44e793a363a8f'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"
   appcast 'http://cdn.devolutions.net/download/Mac/RemoteDesktopManager.xml',
-          checkpoint: 'f9e07721a520a93b2467e89454c912cb23c974d3ff27b10ab28d5c90b50b0b8d'
+          checkpoint: '6c898406d8c28b0371bb4c553993c91b8d1ec76a9e5ed232eda9f5ef32b628a0'
   name 'Remote Desktop Manager'
   homepage 'https://mac.remotedesktopmanager.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.