### PR TITLE
Update simple-hub to 5.0.5-1565

### DIFF
--- a/Casks/simple-hub.rb
+++ b/Casks/simple-hub.rb
@@ -1,10 +1,10 @@
 cask 'simple-hub' do
-  version '4.5.11-1304'
-  sha256 '347bf4fd0eb1327d528d6acf2d9dde319cb63f435032cb16f7fd08a6fa269322'
+  version '5.0.5-1565'
+  sha256 'df168e883cbd389d7df1ffaef1087807af038dbcbec837e0994add95f732cc54'
 
   url "https://www.simplecontrol.com/b/SimpleHub-macOS-#{version.no_dots}.zip"
   appcast 'https://www.simplecontrol.com/b/Simple-HubAppcast.xml',
-          checkpoint: '69326a906116116ea43b3292b8e438febdb3b0a1d7e93d1f29dfa62834d6adc9'
+          checkpoint: 'f030a1908ef636cf8e9caaf41c247b7f3400845829edbb6651f5d23809d0df0e'
   name 'Simple Hub'
   homepage 'https://store.simplecontrol.com/simple-sync.html/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.