### PR TITLE
Update tistoryeditor to 0.6.9

### DIFF
--- a/Casks/tistoryeditor.rb
+++ b/Casks/tistoryeditor.rb
@@ -1,11 +1,11 @@
 cask 'tistoryeditor' do
-  version '0.6.4'
-  sha256 '30d9a5254c7854e087f1d169012bfc78eab55ca1cf20c1fccf318fbe3e75abaf'
+  version '0.6.9'
+  sha256 'c52327c39467667cc463a372048c10d4470ebdfafcf8aa5ea2b78fc2606e5a97'
 
   # github.com/joostory/tistory-editor/ was verified as official when first introduced to the cask
   url "https://github.com/joostory/tistory-editor/releases/download/v#{version}/TistoryEditor-#{version}-mac.zip"
   appcast 'https://github.com/joostory/tistory-editor/releases.atom',
-          checkpoint: '530ae378fa6d4e7ccb9fc41358f962244b9455554b84162fa66b9a310e3091e6'
+          checkpoint: 'f4d423282ad1a0d75dd454afb736408e697a289ca93a5b41f4c6b42b5e5269ee'
   name 'TistoryEditor'
   homepage 'http://tistory-editor.tistory.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.