### PR TITLE
Update superproductivity to 1.10.38

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,11 +1,11 @@
 cask 'superproductivity' do
-  version '1.10.36'
-  sha256 '6e318abd3875b6f1de393ee4ff169759bfbd80b40723cdb66aafec21e404cf14'
+  version '1.10.38'
+  sha256 '9cf85138a3ae67016148b5d38fa92233e349172b84b02efbf94785fd3a72b974'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"
   appcast 'https://github.com/johannesjo/super-productivity/releases.atom',
-          checkpoint: '5124f145cea976d53b745d45751e2d1b0ebb4ab0f5e0aa1ede54191cf0e8a71e'
+          checkpoint: '43aca981bfe92069b043a26a05ea1c8f7d64eb0bf070fbde1fdbf87db7a30716'
   name 'Super Productivity'
   homepage 'https://super-productivity.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.