### PR TITLE
Remove appcast for 360safe

### DIFF
--- a/Casks/360safe.rb
+++ b/Casks/360safe.rb
@@ -3,8 +3,6 @@ cask '360safe' do
   sha256 '1b33ced51458e301a9dd5f00caa99c9de189da92c59b7deb75b461709cf2de95'
 
   url "https://free.360totalsecurity.com/totalsecurity/mac/360ts_mac_#{version}.dmg"
-  appcast 'https://www.360totalsecurity.com/en/version/360-total-security-mac/',
-          checkpoint: 'a28efe73d3087a82bb0506d54c2036f08cad76abd48859246588a948855f74f6'
   name '360 Total Security'
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.