### PR TITLE
Update gemini to 2.4.4,1527157417

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,9 +1,9 @@
 cask 'gemini' do
-  version '2.4.4'
-  sha256 'ac4d512d80ecf6955c35f01dac400d24d25b46d555fb8756b44d152ef4d18fda'
+  version '2.4.4,1527157417'
+  sha256 'cf921b9af7fe882827efd7cbaa87ccd8814ae8543924c1b0189dbd15d43aaa2e'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/Gemini#{version.major}.dmg"
+  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.before_comma}/#{version.after_comma}/Gemini#{version.major}-#{version.before_comma}.zip"
   appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml",
           checkpoint: '64dca16f289fee333164bf8a4846350268e3db8cfcb0a4d111948122927de52b'
   name 'Gemini'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.