### PR TITLE
Update projectlibre to 1.8.0

### DIFF
--- a/Casks/projectlibre.rb
+++ b/Casks/projectlibre.rb
@@ -1,11 +1,11 @@
 cask 'projectlibre' do
-  version '1.7'
-  sha256 'ca165c27bea9f160cd069e464c3b8a1a3d3bc6f79876d221fb4a88165e0941e7'
+  version '1.8.0'
+  sha256 'c25bed132701c929afeb649ff208c5a75620e20f02f63eb7b10dae207635fe28'
 
   # sourceforge.net/projectlibre was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/projectlibre/ProjectLibre/#{version}/projectlibre-#{version}.dmg"
+  url "https://downloads.sourceforge.net/projectlibre/ProjectLibre/#{version.major_minor}/ProjectLibre-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/projectlibre/rss?path=/ProjectLibre',
-          checkpoint: '0097cef0c2be756e33fa9c0c73557f1cfe62121e824c08b8cb8ee6c56bc72b08'
+          checkpoint: '81de9423473f85272160e65781f4221e2c4e9cde9e9dfa8423744e93690a15b0'
   name 'ProjectLibre'
   homepage 'https://www.projectlibre.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.