### PR TITLE
Update opensc to 0.18.0

### DIFF
--- a/Casks/opensc.rb
+++ b/Casks/opensc.rb
@@ -1,10 +1,10 @@
 cask 'opensc' do
-  version '0.17.0'
-  sha256 'b35a56cafa4403fcb941422e4975c843018965282571d05a660485a21fde1bbe'
+  version '0.18.0'
+  sha256 'adb8f79a983ef6c4262e7601373e0502c474951582cc014c7ed48eba71e99be3'
 
   url "https://github.com/OpenSC/OpenSC/releases/download/#{version}/OpenSC-#{version}.dmg"
   appcast 'https://github.com/OpenSC/OpenSC/releases.atom',
-          checkpoint: '064e2a4870fa8f8989661fc602f396220906cea5c4d4e1383f92108a757bdeef'
+          checkpoint: '3f362b16ec5b1dae1789c3a9a495aed0ce0d8ab7845bfe8e63c8ec8fe2acb402'
   name 'OpenSC'
   homepage 'https://github.com/OpenSC/OpenSC/wiki'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.