### PR TITLE
Update netron to 1.8.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.8.0'
-  sha256 'fdd667f89ae11dc28b406b6c1f0f89fb3ed7811fa20edeab300a09cce6bef683'
+  version '1.8.3'
+  sha256 '15c26347cb16f15ccb3dcd30c97f68d13716aa2bab1afb94b7d5c8538d9755e5'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: 'fd65aad341eb6f1da472cb0091546a6c33fe880893abc421c056528f7c6a4a37'
+          checkpoint: '04fe44a4e93fef6ca5be62a5d02530e5f7bfff00ebccec1a2b18a68f79593bf7'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.