### PR TITLE
etrecheck: update zaps

### DIFF
--- a/Casks/etrecheck.rb
+++ b/Casks/etrecheck.rb
@@ -9,8 +9,9 @@ cask 'etrecheck' do
   app 'EtreCheck.app'
 
   zap trash: [
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.etresoft.etrecheck.sfl*',
-               '~/Library/Caches/com.etresoft.EtreCheck',
-               '~/Library/Preferences/com.etresoft.EtreCheck.plist',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.etresoft.etrecheck*.sfl*',
+               '~/Library/Caches/com.etresoft.EtreCheck*',
+               '~/Library/Preferences/com.etresoft.EtreCheck*.plist',
+               '~/Library/WebKit/com.etresoft.EtreCheck*',
              ]
 end


### PR DESCRIPTION
It appears that a lot of the files EtreCheck is leaving behind are using `EtreCheck4` in the name, despite the download being unversioned. Does asterisk expansion work midway through filenames?

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.