### PR TITLE
Add google-chrome binary shim for Google Chrome

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -16,6 +16,16 @@ cask 'google-chrome' do
   depends_on macos: '>= :mavericks'
 
   app 'Google Chrome.app'
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/google-chrome.wrapper.sh"
+  binary shimscript, target: 'google-chrome'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/bash
+      exec  "#{appdir}/Google Chrome.app/Contents/MacOS/Google Chrome" "$@"
+    EOS
+  end
 
   uninstall launchctl: [
                          'com.google.keystone.agent',


### PR DESCRIPTION
Puts `google-chrome` in the path.

Refs: https://github.com/caskroom/homebrew-cask/issues/18809

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
