### PR TITLE
Update typora to 0.9.9.16

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,14 +1,15 @@
 cask 'typora' do
-  version '0.9.9.15.3'
-  sha256 '63abc28fe0ff5563b5d0841288515501c415587ed14fcc1998ba7e08ebf92f85'
+  version '0.9.9.16'
+  sha256 '0a22e88ea35937fd2d8077d83feb93644b0e135593959116a6534fba45794a2f'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: 'fc50aa57db2a814508e166bfdb18063d3413e99091ec96cdcce027f03ae2e30a'
+          checkpoint: '66adf209412ad0e9155515cadf4f37a3359bb793211c1075f143105549397099'
   name 'Typora'
   homepage 'https://typora.io/'
 
   auto_updates true
+  depends_on macos: '>= :mavericks'
 
   app 'Typora.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.