### PR TITLE
Update spriteilluminator to 1.5.0

### DIFF
--- a/Casks/spriteilluminator.rb
+++ b/Casks/spriteilluminator.rb
@@ -1,10 +1,10 @@
 cask 'spriteilluminator' do
-  version '1.4.1'
-  sha256 'f170610a2871fbc2c256e54052e679e6f7d23c61c403a2be5a294594bed3a253'
+  version '1.5.0'
+  sha256 '59f623fc31a7ab4412434d126929c4fecd7f85432562e019476c1cbe8a4c8e2f'
 
   url "https://www.codeandweb.com/download/spriteilluminator/#{version}/SpriteIlluminator-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/SpriteIlluminator/appcast-mac-release.xml',
-          checkpoint: 'e08d170722a688cecb7d4b0b22c93c88c0290dd7e8d1a898323604b5e1587d5a'
+          checkpoint: 'e4da8e06aba076ad008fcc65b920c56a8bd2b2a12e3257e0a056664069cfeb0a'
   name 'SpriteIlluminator'
   homepage 'https://www.codeandweb.com/spriteilluminator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.