### PR TITLE
Update noteplan to 1.6.26,50

### DIFF
--- a/Casks/noteplan.rb
+++ b/Casks/noteplan.rb
@@ -1,13 +1,13 @@
 cask 'noteplan' do
-  version '1.6.25'
-  sha256 '5bc778be8f4620aac021606a0ad1db94af2b1241c6fb34fc1bcb93a1ac915aa5'
+  version '1.6.26,50'
+  sha256 'aafcda3ed2ccf4083c1f48f420679c9abcd11898d4c0dcd21499650eca234f21'
 
   # rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380/?format=zip'
+  url "https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380',
-          checkpoint: 'f9255ceadec4ed03ce4be87460aaddc45cd90ccd16ccfccdac1fbd511af8cfa1'
+          checkpoint: '3f8af4de8d34d6252e45ff4cf76a7b603bb43c07067ec4cebc67c039b1e63d2a'
   name 'NotePlan'
-  homepage 'http://noteplan.co/'
+  homepage 'https://noteplan.co/'
 
   app 'NotePlan.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.