### PR TITLE
Update emacs to 26.1

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,10 +1,10 @@
 cask 'emacs' do
-  version '25.3'
-  sha256 'b2bfc1e90a2e3a9e138fdd42ec1796bf38eeaf06021905f9ffbaf8b397ca64ac'
+  version '26.1'
+  sha256 'c8ca0838901ae9d3f889e76141f971425169cc047281e60b8f6b70ad185c7bd2'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/release',
-          checkpoint: 'dd284d2f08cac506fc34711eff27ac68268dbe0d2deab602d23c602222f88249'
+          checkpoint: '59d728a9a6a7e7223191eec747680fbb249eba98510cd08314e2e5b36aaa8b5b'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.