### PR TITLE
Update twist to 1.0.36,4343

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,10 +1,10 @@
 cask 'twist' do
-  version '1.0.36,4338'
-  sha256 '394104d95ee2a1fd93774215854774c0e8250efebf1521b3b8439b0e5ac1ba0d'
+  version '1.0.36,4343'
+  sha256 'a6d60e2b05ca17a8c8d50c4bc213a0afb685147c85bb3edb73695bdab2aff528'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml',
-          checkpoint: 'bf0b4e9d8387634cefce208d0744e977543470a6e4ae0aec3b73e30649ebff59'
+          checkpoint: 'ae22d6d5d9d4b1dc2018ecb31401cc08329946a43473fbbab5936c7d87f10bce'
   name 'Twist'
   homepage 'https://twistapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.