### PR TITLE
Update jetbrains-toolbox to 1.8.3868

### DIFF
--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -1,10 +1,10 @@
 cask 'jetbrains-toolbox' do
-  version '1.8.3678'
-  sha256 '739bade6ff02f2ed97295ebe61ea65dfc07a63ff23c317342fd98a28e967fc96'
+  version '1.8.3868'
+  sha256 '9f4d958e6626b17f15db0b871be600e0faf3b251041a0386d8b3f290a400fef4'
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release',
-          checkpoint: 'db94980024e2da02d22514929cc31d64ebee3298bf05ba9a0c61ec4bceb689c9'
+          checkpoint: '38d8c1807a35f07c472af0235578363e071da5b4e7fc51270f93abf7dff9f706'
   name 'JetBrains Toolbox'
   homepage 'https://www.jetbrains.com/toolbox/app/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.