### PR TITLE
Update glyphs to 2.5.2-1146

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,10 +1,10 @@
 cask 'glyphs' do
-  version '2.5.2-1143'
-  sha256 'e59513439318c0aa541f7d797de47330e9ccf220c1b33f1ea54b351b4cf0ce7f'
+  version '2.5.2-1146'
+  sha256 '624106132847fd3f1a81e9ae0b19d515a9c415cd5919a92eaf8926d6f203120e'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml",
-          checkpoint: '67de019213d269f6fb99eaf9da04b9f6180780db1376382121bd428758348769'
+          checkpoint: '10743542cde70e57be302fdce5e7252731484d39f40e0ee4b6d73fd3699e845a'
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.