### PR TITLE
libreoffice-language-pack v6.0.4: use quotes in caveats paths

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -574,6 +574,6 @@ cask 'libreoffice-language-pack' do
   end
 
   caveats <<~EOS
-    #{token} assumes LibreOffice is installed in #{appdir}. If it is not, you’ll need to run #{staged_path}/LibreOffice Language Pack.app manually.
+    #{token} assumes LibreOffice is installed in '#{appdir}'. If it is not, you’ll need to run '#{staged_path}/LibreOffice Language Pack.app' manually.
   EOS
 end


### PR DESCRIPTION
Summary: app name contains spaces, so it's hard to copy paste it to run via `open` command in terminal, so I added single quotes to it.

After making all changes to the cask:
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
N/A
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
