### PR TITLE
Update studio-3t to 2018.3.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,10 +1,10 @@
 cask 'studio-3t' do
-  version '2018.3.0'
-  sha256 '24bec626660ce9e10d83cec78afb4927465a870a4b7e9c9a342fde1cadbb89ec'
+  version '2018.3.1'
+  sha256 '370f14b2c8d77b2b6e06a697921222893b0ad3bb7cbe6e745ce103da8fcf1b27'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt',
-          checkpoint: 'a64f3475f7e32b00689cd90faa5f21c8a5807cdcc9d0e6fb38f325925fd9188d'
+          checkpoint: '6e0e6df8f67db431469799ffd6e7eeb8d27d02c0e5962b80d1b80b2cdc3bf5ef'
   name 'Studio 3T'
   homepage 'https://studio3t.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.