### PR TITLE
Update startupizer to 2.3.11,2060:1527510167

### DIFF
--- a/Casks/startupizer.rb
+++ b/Casks/startupizer.rb
@@ -1,11 +1,11 @@
 cask 'startupizer' do
-  version '2.3.10,2058:1506439464'
-  sha256 'c9d469c263ac1ac866ea067214e2b20e0583bb0763e1180d0e4cdc311ae52318'
+  version '2.3.11,2060:1527510167'
+  sha256 '56792a52fc91129f6f192cbbc0dbc6a7175d0699f2dab726baaf7d94f30ce150'
 
   # dl.devmate.com/com.gentlebytes.Startupizer2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.gentlebytes.Startupizer2/#{version.after_comma.before_colon}/#{version.after_colon}/Startupizer#{version.major}-#{version.after_comma.before_colon}.zip"
   appcast "https://updates.devmate.com/com.gentlebytes.Startupizer#{version.major}.xml",
-          checkpoint: '2329c9571a65c4c5283f5d5d7c8b6553ad423a8c8a1f287ca35ec81b7d82a6d9'
+          checkpoint: '769e18682d1178f8aff38043f51ef3176cf24e1f3e69e16eb19309d4eafddac3'
   name "Startupizer#{version.major}"
   homepage 'http://gentlebytes.com/startupizer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.