### PR TITLE
Update netron to 1.8.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.8.3'
-  sha256 '15c26347cb16f15ccb3dcd30c97f68d13716aa2bab1afb94b7d5c8538d9755e5'
+  version '1.8.4'
+  sha256 '7ada474040b47723976d9fb011f20cf6b653d06072ef5d7a9dd7507dada79769'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '04fe44a4e93fef6ca5be62a5d02530e5f7bfff00ebccec1a2b18a68f79593bf7'
+          checkpoint: '4651fa86c75e572811821b126fd890c974871df4e22be303b6f229f98ba15062'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.