### PR TITLE
Update cracked to 0.1.7

### DIFF
--- a/Casks/cracked.rb
+++ b/Casks/cracked.rb
@@ -1,10 +1,10 @@
 cask 'cracked' do
-  version '1.7'
+  version '0.1.7'
   sha256 'd439497ec38f685ceaeaf6093d8f2e21a0028a318d8a206953eaf6575d75a432'
 
   url "https://github.com/billorcutt/Cracked/releases/download/#{version}-Release/Cracked.dmg"
   appcast 'https://github.com/billorcutt/Cracked/releases.atom',
-          checkpoint: 'c7ab0ef3793d74d78b5e74a2c5436ad373e78a077d49e5da109815791ef59984'
+          checkpoint: 'abbf0e4c23f23884d19d180b246bf379e534811d08355d5b5c8137b986663017'
   name 'Cracked'
   homepage 'https://github.com/billorcutt/Cracked'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.