### PR TITLE
Update qutebrowser to 1.3.1

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,11 +1,11 @@
 cask 'qutebrowser' do
-  version '1.3.0'
-  sha256 '5d094e767f79835d49704bb7cf331db56998fe4b5b26e0669d7106274cc3f199'
+  version '1.3.1'
+  sha256 '459658d795751fb427e6058b10a3c5e06dec65d9fb54b4f77debba21994e0bc2'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"
   appcast 'https://github.com/qutebrowser/qutebrowser/releases.atom',
-          checkpoint: '43763a553e7ff2effec30eb8a4155d68dc4bb5e918c64da2cb84bac9b808ac07'
+          checkpoint: '600c30d9cf732801548db884e2a18878b72aa6256024de315b844a4533855eae'
   name 'qutebrowser'
   homepage 'https://www.qutebrowser.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.