### PR TITLE
Update wordmark to 3.0.1-beta.3

### DIFF
--- a/Casks/wordmark.rb
+++ b/Casks/wordmark.rb
@@ -1,11 +1,11 @@
 cask 'wordmark' do
-  version '3.0.1-beta.2'
-  sha256 '99222b222c94276049181da3dabef1aa96f4c292dd3bd4dfef55494dae21bc88'
+  version '3.0.1-beta.3'
+  sha256 '455d2920bc1b2138deccdbd09a9c47a83a4f021428b8cdead8a0b27ed8b5e9e6'
 
   # github.com/wordmark/wordmark was verified as official when first introduced to the cask
   url "https://github.com/wordmark/wordmark/releases/download/v#{version}/wordmark-#{version}-mac.zip"
   appcast 'https://github.com/wordmark/wordmark/releases.atom',
-          checkpoint: '93bfa185cc98f6eb99753d81322cf53a035c8aeb44adbcadc894329f7286f84c'
+          checkpoint: '78779c9c8a97899acfb17bfdb905ab8387669a6871932c9961942b5fe613a063'
   name "WordMark #{version.major}"
   homepage 'https://wordmarkapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.