### PR TITLE
Update 360safe to 1.2.5

### DIFF
--- a/Casks/360safe.rb
+++ b/Casks/360safe.rb
@@ -1,10 +1,10 @@
 cask '360safe' do
-  version '1.2.4'
-  sha256 '1b33ced51458e301a9dd5f00caa99c9de189da92c59b7deb75b461709cf2de95'
+  version '1.2.5'
+  sha256 '060b8c532710513eae7a8c37e8bb59008bb16d7a943798bd8519027e0e18a0fc'
 
   url "https://free.360totalsecurity.com/totalsecurity/mac/360ts_mac_#{version}.dmg"
   appcast 'https://www.360totalsecurity.com/en/version/360-total-security-mac/',
-          checkpoint: 'a28efe73d3087a82bb0506d54c2036f08cad76abd48859246588a948855f74f6'
+          checkpoint: 'ae57b711c1881529e48baf78540360db035fbf89931c164d6301fe59b300a17c'
   name '360 Total Security'
   homepage 'https://www.360totalsecurity.com/features/360-total-security-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.