### PR TITLE
Update monal to 2.1.1b1

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,10 +1,10 @@
 cask 'monal' do
-  version '2.1b6'
-  sha256 'bf05fd97f35855a3d20d5cde2364228800b72239bcf9f54c069935db742c9491'
+  version '2.1.1b1'
+  sha256 'da4d448959b98a7c2e0fd66962633f5d42f0a0a4459b4b018ee4fa6d891b1dc2'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',
-          checkpoint: '347da5a589d4ca6886fe66dd93cb004294160b5402311d1e831acfb13d5431b0'
+          checkpoint: 'e1f00250cd7c25b510e66be29ae3b6e1156eff8b89c0b06dcdf3a199153475ac'
   name 'Monal'
   homepage 'https://monal.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.