### PR TITLE
Update udeler to 1.6.0

### DIFF
--- a/Casks/udeler.rb
+++ b/Casks/udeler.rb
@@ -1,10 +1,10 @@
 cask 'udeler' do
-  version '1.5.4'
-  sha256 'e11759d54fd3fcef164520ed72a7406ed867aa21db6f45a0252060d8ac839d8a'
+  version '1.6.0'
+  sha256 '3ad01d8280c862bd8c9efb4ff94178128ea0001309a858766f7b442cf43f3ad4'
 
   url "https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v#{version}/Udeler-#{version}-mac.zip"
   appcast 'https://github.com/FaisalUmair/udemy-downloader-gui/releases.atom',
-          checkpoint: '4000c89a17b8dd069469a335aaaa436d9a3a3a535f872bfae349bac144413c14'
+          checkpoint: '7f1091e5bda9da195669b427878ddbb7b25d13f249e4c025225c5b38a1539439'
   name 'Udeler'
   homepage 'https://github.com/FaisalUmair/udemy-downloader-gui/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.