### PR TITLE
Update minishift to 1.18.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,10 +1,10 @@
 cask 'minishift' do
-  version '1.17.0'
-  sha256 'fb2c5d2ce2c59e81a2ac33a13e6ec527c482f9ad3776d2aad644a679949fcc20'
+  version '1.18.0'
+  sha256 '7d8104c3244b0477ee4873670be9264fd89659b2af1c127540a97943856a96a5'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: 'c8f4d71d08655894d1b712f251d3dbb0063e8d78236bbd9502b6cd96c2570f89'
+          checkpoint: '68bca4da23ce69a66239f60f773a30dcbb78ed88728cdcb7c480394e15112998'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.