### PR TITLE
Update splashtop-business to 3.2.4.0

### DIFF
--- a/Casks/splashtop-business.rb
+++ b/Casks/splashtop-business.rb
@@ -1,11 +1,11 @@
 cask 'splashtop-business' do
-  version '3.2.2.0'
-  sha256 '94546156f5df7c337cf64fa0f5f025e0e98d132ecbcec906becf37d40a822b9d'
+  version '3.2.4.0'
+  sha256 '9f6479f313a0db992ba95412c2653e6843dc04356f9102611c61972cc5f7437a'
 
   # d17kmd0va0f0mp.cloudfront.net/macclient/STB was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STB/Splashtop_Business_Mac_INSTALLER_v#{version}.dmg"
   appcast 'https://www.splashtop.com/wp-content/themes/responsive/downloadx.php?product=stb&platform=mac-client',
-          checkpoint: '3bc26aa5aaa22dc5f027a74e515fa5e487bccb884f6a217a49f92b73a04c1651'
+          checkpoint: 'bb47a3c4c584d60148d778a25157104aa80f03357ffbc270d68fac312aafe584'
   name 'Splashtop Business'
   homepage 'https://www.splashtop.com/business'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.