### PR TITLE
Update focuswriter to 1.6.13

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,6 +1,6 @@
 cask 'focuswriter' do
-  version '1.6.12'
-  sha256 'b7d920241a522d1781ee77c2560f71e70924d47a12c711a6342d6fd61d9a865f'
+  version '1.6.13'
+  sha256 '6312242d980029b86fa022197c00d5d044d244784454316337901013a700885c'
 
   url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   name 'FocusWriter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.