### PR TITLE
Update screaming-frog-seo-spider to 9.3

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -3,13 +3,13 @@ cask 'screaming-frog-seo-spider' do
     version '2.40'
     sha256 'f37a517cb1ddb13a0621ae2ef98eba148027b3a2b5ce56b6e6b4ca756e40329b'
   else
-    version '9.2'
-    sha256 'f7162a978b5412bc437580117f1a20a459594a3533c3e9caa5d6e1f7900a20b2'
+    version '9.3'
+    sha256 'cbc9ea9ba1140b5955d6dd20a147ed7071e46c901a9be9df3aafd1fbaf8f0875'
   end
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php',
-          checkpoint: 'ca3f7b45b66efdc6e74aee182f83352b9f21f279466b74f35424057f4711baf3'
+          checkpoint: '7fee4b2b3c3138d4a0ea6b91614931e97804ffa00222471a95d9ef28a80293bc'
   name 'Screaming Frog SEO Spider'
   homepage 'https://www.screamingfrog.co.uk/seo-spider/'
 

--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -1,17 +1,14 @@
 cask 'screaming-frog-seo-spider' do
-  if MacOS.version <= :lion
-    version '2.40'
-    sha256 'f37a517cb1ddb13a0621ae2ef98eba148027b3a2b5ce56b6e6b4ca756e40329b'
-  else
-    version '9.3'
-    sha256 'cbc9ea9ba1140b5955d6dd20a147ed7071e46c901a9be9df3aafd1fbaf8f0875'
-  end
+  version '9.3'
+  sha256 'cbc9ea9ba1140b5955d6dd20a147ed7071e46c901a9be9df3aafd1fbaf8f0875'
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php',
           checkpoint: '7fee4b2b3c3138d4a0ea6b91614931e97804ffa00222471a95d9ef28a80293bc'
   name 'Screaming Frog SEO Spider'
   homepage 'https://www.screamingfrog.co.uk/seo-spider/'
+
+  depends_on macos: '>= :mountain_lion'
 
   app 'Screaming Frog SEO Spider.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.