### PR TITLE
Update ableton-live-intro to 10.0.2

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-intro' do
-  version '10.0.1'
-  sha256 '2fe0c5b1ca1892398e3155def1704f25c0054e12c668699a879089acdd991f5e'
+  version '10.0.2'
+  sha256 '9c5067caac96a0826b500333fca6498f72617fe6cdeaf7336d45ba3ede734a51'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
   name 'Ableton Live Intro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #.