### PR TITLE
Update ableton-live-suite to 10.0.2

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite' do
-  version '10.0.1'
-  sha256 '73f8b7d9c2e058639466cbb765e6e1610f97f542745e2c69567d7bf55a407e11'
+  version '10.0.2'
+  sha256 '94df1bcc1c5cc69a739aa1bf0eaac1651a528d37dbe3c62314d6937456ba6fb4'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   name 'Ableton Live Suite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.