### PR TITLE
Update mark-text to 0.11.42

### DIFF
--- a/Casks/mark-text.rb
+++ b/Casks/mark-text.rb
@@ -1,11 +1,11 @@
 cask 'mark-text' do
-  version '0.10.21'
-  sha256 'c65b64c46ce30d522608927a827417e37687f0cee7c96570ac942bb1c2b0cd36'
+  version '0.11.42'
+  sha256 'ca91ee5a40f4898055f6f2bb26c387f26c3541fbb4cf641095a62332cdaa13e3'
 
   # github.com/marktext/marktext was verified as official when first introduced to the cask
   url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext-#{version}.dmg"
   appcast 'https://github.com/marktext/marktext/releases.atom',
-          checkpoint: '93a9a60b21bfc925c2165b8832a5559553d6cc079c177b3b55c104268aab82c6'
+          checkpoint: 'f7c7bea54c9be8ede7870a0c25602128a0aa1e9740781a50e4690eac7b43cdb6'
   name 'Mark Text'
   homepage 'https://marktext.github.io/website/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.