### PR TITLE
Update gitkraken to 3.6.2

### DIFF
--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -1,10 +1,10 @@
 cask 'gitkraken' do
-  version '3.6.1'
-  sha256 '3e0c79696613f6ae0e9263c8bed4cecde1090b99bc4b3f9a49c4b1d35a0580c0'
+  version '3.6.2'
+  sha256 'ed946ab5d7d2cc5fe6a7605cbb2b27e0ba8ff5c26b2958326f890180b5964a37'
 
   url "https://release.gitkraken.com/darwin/v#{version}.zip"
-  appcast 'https://release.gitkraken.com/darwin/RELEASES',
-          checkpoint: '835db29e31b4faccfae13ef675f8eeb5b274a8a6a1a07a1166bcdb1024d242d8'
+  appcast 'https://support.gitkraken.com/release-notes/current',
+          checkpoint: '322f0c5f3566f8c9e066e4770ea454350afbc16a7c68b814a6133712d2927151'
   name 'GitKraken'
   homepage 'https://www.gitkraken.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.