### PR TITLE
update dotnet-sdk to 2.1.300

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk' do
-  version '2.1.200'
-  sha256 '88f58c451b3bc4317b96064429434111d78bb7fc453a511418a0c86276c87c28'
+  version '2.1.300'
+  sha256 '764b6331d9d95ba2440491e25545e42558edfffcb93787b0b3d8d328a1d06113'
 
-  url "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.microsoft.com/download/8/8/5/88544F33-836A-49A5-8B67-451C24709A8F/dotnet-sdk-#{version}-osx-x64.pkg"
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'
 


### PR DESCRIPTION
According to https://github.com/dotnet/core/blob/master/release-notes/releases.json

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.