### PR TITLE
D16 vsts

### DIFF
--- a/Casks/d16-frontier.rb
+++ b/Casks/d16-frontier.rb
@@ -1,0 +1,12 @@
+cask 'd16-frontier' do
+  version '1.0.0'
+  sha256 '7ed4762003b3a40b3306523404a1665a41bd7ba0016e6ed66073967cbfabdfd4'
+
+  url "http://d16.pl/pub/install/Frontier%20-%20#{version}.dmg"
+  name 'D16 Frontier'
+  homepage 'http://d16.pl/frontier'
+
+  pkg "Frontier-#{version}.pkg"
+
+  uninstall pkgutil: 'com.d16group.pkg.frontier'
+end

--- a/Casks/d16-sigmund.rb
+++ b/Casks/d16-sigmund.rb
@@ -1,0 +1,12 @@
+cask 'd16-sigmund' do
+  version '1.1.2'
+  sha256 '6f87a82c4f3e57c1121c697a7d95b1bc3c3311b7612929e520ab6a725fed45b7'
+
+  url "http://d16.pl/pub/install/Sigmund%20-%20#{version}.dmg"
+  name 'D16 Sigmund'
+  homepage 'http://d16.pl/sigmund'
+
+  pkg "Sigmund-#{version}.pkg"
+
+  uninstall pkgutil: 'com.d16group.pkg.sigmund'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

--
Note, these are two separate VSTs from one company. I know that it's possible that we don't usually want to include the manufacturer's name in the cask, but I think given the quantity of possible instruments (http://d16.pl/products), it may be worth considering relaxing this idea for VSTs. An alternative might be to split audio plug ins out to another repo.