### PR TITLE
Update lehreroffice to 2018.8.1

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice' do
-  version '2018.8.0'
-  sha256 '78a3b45d3e2e712b94f5e280e3d2c259582be4c6fce4241aa63597056b96c590'
+  version '2018.8.1'
+  sha256 'f317bf512cd307073fab46f05cc32416311e7072d69db9e1cb95fcb15b88cd50'
 
-  url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_osx.dmg'
+  url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop',
-          checkpoint: '4e3fc3526921b7e9827a053ccf1b87494c0d3c8281fe30857084285a94ed4653'
+          checkpoint: '24c55b7df2e4293f19168f978da2e0bba582a19bb52aba5f08521d5154e39a96'
   name 'LehrerOffice'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.