### PR TITLE
Update formular-designer to 2018.2.1

### DIFF
--- a/Casks/formular-designer.rb
+++ b/Casks/formular-designer.rb
@@ -1,10 +1,10 @@
 cask 'formular-designer' do
-  version '2018.2.0'
-  sha256 '86f6f70b5df6535e81c17deb2dc16166ce5f7a92be79be28c3b73d74b5187474'
+  version '2018.2.1'
+  sha256 'f7f42ba37690551b0c1132671d7730817fabfd8f2c5199b62c77efe46cf923df'
 
-  url 'https://www.lehreroffice.ch/lo/dateien/designer/lo_designer_osx.dmg'
+  url 'https://www.lehreroffice.ch/lo/dateien/designer/lo_designer_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Designer',
-          checkpoint: '96aab4a8f7d62edade54ceb5a82d24e4710dab28af25be8b1ef4cbe68d1d6d58'
+          checkpoint: '448978f227fba2a1f8b2682b73e925ba6b90f816b271e6eb4030897b24d76a12'
   name 'Formular-Designer'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.