### PR TITLE
Update blue-jeans to 2.5.1.33

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -12,5 +12,5 @@ cask 'blue-jeans' do
                       ['TERM', 'com.bluejeansnet.Blue'],
                       ['TERM', 'com.bluejeansnet.BlueMenulet'],
                     ],
-            delete: '~/Applications/Blue Jeans.app'
+            delete: '/Applications/Blue Jeans.app'
 end

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -6,7 +6,7 @@ cask 'blue-jeans' do
   name 'Blue Jeans videoconferencing'
   homepage 'https://www.bluejeans.com/'
 
-  installer manual: 'BlueJeanInstaller.app'
+  installer manual: 'BlueJeansInstaller.app'
 
   uninstall signal: [
                       ['TERM', 'com.bluejeans.nw.app'],

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,12 +1,12 @@
 cask 'blue-jeans' do
-  version '1.6.8'
-  sha256 '9f76c386659697c11752b8e0c04d40c4a07c08733a6c928bbff11210303789db'
+  version '2.5.1.33'
+  sha256 '20914226694e4a0734d85f8de9a42bc81e7166af933016de66e0a82dd5383e89'
 
-  url "https://swdl.bluejeans.com/desktop/mac/launchers/BlueJeansLauncher_live_#{version.no_dots}.dmg"
+  url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   name 'Blue Jeans videoconferencing'
   homepage 'https://www.bluejeans.com/'
 
-  installer manual: 'Blue Jeans Launcher.app'
+  installer manual: 'BlueJeanInstaller.app'
 
   uninstall signal: [
                       ['TERM', 'com.bluejeans.nw.app'],

--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -9,8 +9,8 @@ cask 'blue-jeans' do
   installer manual: 'BlueJeansInstaller.app'
 
   uninstall signal: [
-                      ['TERM', 'com.bluejeans.nw.app'],
-                      ['TERM', 'com.bluejeans.nw.helper'],
+                      ['TERM', 'com.bluejeansnet.Blue'],
+                      ['TERM', 'com.bluejeansnet.BlueMenulet'],
                     ],
             delete: '~/Applications/Blue Jeans.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.