### PR TITLE
Update chromedriver to 2.39

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,11 +1,11 @@
 cask 'chromedriver' do
-  version '2.38'
-  sha256 '6da3e8e3604d332b73f961495cb6d01d79d995b456778a3bda87df236c138462'
+  version '2.39'
+  sha256 '8a98819f27b12db041268fa12201dcd3d4683c8cf0f5e91dc69e7c8001b0100c'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"
   appcast 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE',
-          checkpoint: '56cbe3c372f86dc281ca8b3107962d7c546a861bdf975a75c245fb46526c50ed'
+          checkpoint: 'cc2504c261f94795ae0fcb9c4eced78afe10a96f12f5dfe8c4cb21b7a9115d82'
   name 'ChromeDriver'
   homepage 'https://sites.google.com/a/chromium.org/chromedriver/home'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.