### PR TITLE
Update camunda-modeler to 1.15.0

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.14.0'
-  sha256 '46d9ada1672eb3314afc6a286f0cf9b993b3cf0d0c9c713138a074fb4b0f93d8'
+  version '1.15.0'
+  sha256 'a8584337402b7ec6ece0c170d5810bc51fc49fcfcaf8ae79cc43f40b95c0bd8f'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.