### PR TITLE
Update astro to 3.0.12,4006

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,11 +1,11 @@
 cask 'astro' do
-  version '3.0.11,3974'
-  sha256 'b2570d171b59b8cd507167266e00d7997cc343ee1488bc308ccd660277d3ccff'
+  version '3.0.12,4006'
+  sha256 'acb5973fc65b6c2f2b827fc81537369ba1280e301d83b6c13ac9e2dd9eb7a6d0'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"
   appcast 'https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/pexappcast.xml',
-          checkpoint: '1ae9b72e931648fb2b6bb3184ccf84f32a252f21e01f7f4d9993af43c047ba60'
+          checkpoint: 'da45cb31f01fcbcc5abed7af9e35b1a593fff26ab57179b1288a85a0af8ce4a7'
   name 'Astro'
   homepage 'https://www.helloastro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.