### PR TITLE
Update sqleditor to 3.3.7

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -3,8 +3,8 @@ cask 'sqleditor' do
   sha256 '82a5b35d0e0f9ddd3d8df302c01cb24633c0404fdb924984a6c7f8ef965de2e9'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
-  appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml',
-          checkpoint: '34db2e166e7c91e9f6fca5fa787bcdb7065d124253871d62bd5ce9480c90af73'
+  appcast "https://www.malcolmhardie.com/sqleditor/appcast/sq#{version.major}release.xml",
+          checkpoint: 'ce37975658c7539f6c64e517a10e44ea1a9f9a125d1782f555353b40e24493bb'
   name 'SQLEditor'
   homepage 'https://www.malcolmhardie.com/sqleditor/'
 

--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,6 +1,6 @@
 cask 'sqleditor' do
-  version '3.3.5'
-  sha256 'b70a48b8e1a5175195e82e5fc9c1001e88b2feb4f34ccb6fe2e847078d0d2ef7'
+  version '3.3.7'
+  sha256 '82a5b35d0e0f9ddd3d8df302c01cb24633c0404fdb924984a6c7f8ef965de2e9'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.