### PR TITLE
Update macports to 2.5.0

### DIFF
--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -2,27 +2,27 @@ cask 'macports' do
   version '2.5.0'
 
   if MacOS.version <= :mountain_lion
-    sha256 'ba75e4a1151a5e06b8e271b26296c4418a2285bd27090c83867aeddd3a62c508'
+    sha256 '9212c3803e2d53a765e31fcd231d43a7bc7191f824c00a195f5e9be213449cae'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.8-MountainLion.pkg"
     pkg "MacPorts-#{version}-10.8-MountainLion.pkg"
   elsif MacOS.version <= :mavericks
-    sha256 '7bb4e9285eee6fc5c75d5f0532e4dc091c9d921a2fba62784e275410bb4b9894'
+    sha256 'c3fb4a53d38ff6bcb03b84cb979d80a21a84092fa969bee473866e3e42d88b76'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.9-Mavericks.pkg"
     pkg "MacPorts-#{version}-10.9-Mavericks.pkg"
   elsif MacOS.version <= :yosemite
-    sha256 '44871c8d1e6ed05fab15dcb85912c836259c7af13ab9c3729eb4da0476a22ed4'
+    sha256 '763b14cd5c7a3daa743739d874df1258dc580ee7f2c34fed4c3c46ee25a28244'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.10-Yosemite.pkg"
     pkg "MacPorts-#{version}-10.10-Yosemite.pkg"
   elsif MacOS.version <= :el_capitan
-    sha256 'dc5b697deb9a17c6d9f2a8e955322665cebdde26bb4f4548ded29bd2f13042a7'
+    sha256 'b51bd1984641b43ec3b44c8236a7e2b84ab562e5a167417aab541060b6f4bc54'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.11-ElCapitan.pkg"
     pkg "MacPorts-#{version}-10.11-ElCapitan.pkg"
   elsif MacOS.version <= :sierra
-    sha256 '3a8fee56254c650fbf56c5b131a10e4fc8b86d4e5de4a1b5bb5a5a64d27cf461'
+    sha256 'c66ae68ebd3a37e4a1055a7e90332777a72b28c24bc5d3d0524b088a467393d6'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.12-Sierra.pkg"
     pkg "MacPorts-#{version}-10.12-Sierra.pkg"

--- a/Casks/macports.rb
+++ b/Casks/macports.rb
@@ -1,5 +1,5 @@
 cask 'macports' do
-  version '2.4.4'
+  version '2.5.0'
 
   if MacOS.version <= :mountain_lion
     sha256 'ba75e4a1151a5e06b8e271b26296c4418a2285bd27090c83867aeddd3a62c508'
@@ -27,14 +27,14 @@ cask 'macports' do
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.12-Sierra.pkg"
     pkg "MacPorts-#{version}-10.12-Sierra.pkg"
   else
-    sha256 'ce7eca9b5fed5e794fcb44cf7363b894f9f6189bdd0f921ec713515ea3eeb656'
+    sha256 '5024942ebe6dbef01a624b12b9ad25701eaa60e934f59285551c363413f2f7cf'
     # github.com/macports/macports-base was verified as official when first introduced to the cask
     url "https://github.com/macports/macports-base/releases/download/v#{version}/MacPorts-#{version}-10.13-HighSierra.pkg"
     pkg "MacPorts-#{version}-10.13-HighSierra.pkg"
   end
 
   appcast 'https://github.com/macports/macports-base/releases.atom',
-          checkpoint: '745646b5744d5d5d159a2d6a276fab7338b60ca1827416ff5c2e49a8538129c4'
+          checkpoint: 'cf85055221762657350fd4d580efc31d7e1f71e60fa103b5ead055e38e917a37'
   name 'MacPorts'
   homepage 'https://www.macports.org/'
   gpg "#{url}.asc", key_id: '01ff673fb4aae6cd'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.