### PR TITLE
Update mountain-duck to 2.5.0.9388

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '2.4.0.9334'
-  sha256 '3d80601676373f21b67b62f7ae7f551717d8978fa002e5cb534577394453f654'
+  version '2.5.0.9388'
+  sha256 'f42314b65bdf570793befd936fefd34c204710bab55a29b97ce78a392654bdbe'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '47b268ba832d08d8f537f45d0fcf21408f51574146126813441f79e088cdbc8d'
+          checkpoint: '83984dce45ae513461f9e2a308a8f1dab99701d99f81b2164def997336399a0c'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.