### PR TITLE
Update rubitrack-pro to 5.0.6

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,10 +1,10 @@
 cask 'rubitrack-pro' do
-  version '5.0.5'
-  sha256 'd19427d94dad47752055ebad0f8fb58b5adfffb86714d8d6bc7c7f71e7683579'
+  version '5.0.6'
+  sha256 '650f7353345cea38b3bbcc9b85717a8a9ff22c2c052f2f33b249839471af975e'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml",
-          checkpoint: '157abf2625259b1f03ab18346c022cc9d3f5c22bae94cc8679aca7323876b123'
+          checkpoint: '10a7320664c57c30ae826a4ff5f512c3dc0d46e5b7cbca464e6f9e98b40137e6'
   name 'rubiTrack'
   homepage 'https://www.rubitrack.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.