### PR TITLE
Update nestopia to 1.4.2

### DIFF
--- a/Casks/nestopia.rb
+++ b/Casks/nestopia.rb
@@ -6,6 +6,8 @@ cask 'nestopia' do
   name 'Nestopia'
   homepage 'http://www.bannister.org/software/nestopia.htm'
 
+  depends_on macos: '>= :el_capitan'
+
   app "Nestopia v#{version}/Nestopia.app"
 
   zap trash: [

--- a/Casks/nestopia.rb
+++ b/Casks/nestopia.rb
@@ -1,12 +1,12 @@
 cask 'nestopia' do
-  version :latest
-  sha256 :no_check
+  version '1.4.2'
+  sha256 '59792eaac94350c497c472805c07ed1e1f422a94b4cf2746801b8af71c9ef18f'
 
   url 'http://www.bannister.org/cgi-bin/download.cgi?nestopia'
   name 'Nestopia'
   homepage 'http://www.bannister.org/software/nestopia.htm'
 
-  app 'Nestopia.app'
+  app "Nestopia v#{version}/Nestopia.app"
 
   zap trash: [
                '~/Library/Application Support/Bannister/Nestopia',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.