### PR TITLE
Update manager to 18.5.36

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.34'
-  sha256 '5e12e5304ec9ec79f62032f27a3d9abc8c3f3f08c2982c375e36bdabb7ff73f0'
+  version '18.5.36'
+  sha256 'feaa50ef423b0f78e3dda1121a9f2baca61adeae4d1760b826d9784fb5d5c65c'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.