### PR TITLE
Change URL and checksum for CleanMyMac 3.9.6

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -5,7 +5,7 @@ cask 'cleanmymac' do
   # devmate.com/com.macpaw.CleanMyMac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.CleanMyMac3/CleanMyMac3.dmg"
   appcast "https://updates.devmate.com/com.macpaw.CleanMyMac#{version.major}.xml",
-          checkpoint: '004841de20c5a3945fd4132ba371d9ad35c4210b1a852b3ddbdcae12bf1a3ed2'
+          checkpoint: '9a77615d0963f5eff9a207d71bcb409313946c40f00ffaf521fe4b07b6deb7ba'
   name 'CleanMyMac'
   homepage 'https://macpaw.com/cleanmymac'
 

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -1,5 +1,5 @@
 cask 'cleanmymac' do
-  version '3.9.6,1527255630'
+  version '3.9.6'
   sha256 'c23d50e5521340919a98809b487e82b3872d4606f1c5ce774c6eb4a0120ee4d2'
 
   # devmate.com/com.macpaw.CleanMyMac was verified as official when first introduced to the cask

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -3,7 +3,7 @@ cask 'cleanmymac' do
   sha256 'c23d50e5521340919a98809b487e82b3872d4606f1c5ce774c6eb4a0120ee4d2'
 
   # devmate.com/com.macpaw.CleanMyMac was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.macpaw.CleanMyMac3/CleanMyMac3.dmg"
+  url 'https://dl.devmate.com/com.macpaw.CleanMyMac3/CleanMyMac3.dmg'
   appcast "https://updates.devmate.com/com.macpaw.CleanMyMac#{version.major}.xml",
           checkpoint: '9a77615d0963f5eff9a207d71bcb409313946c40f00ffaf521fe4b07b6deb7ba'
   name 'CleanMyMac'

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -1,9 +1,9 @@
 cask 'cleanmymac' do
   version '3.9.6,1527255630'
-  sha256 '24cc5875af3ad0a1803123860e03c862ff78ea00d42b26e1f84b634a97e1fe40'
+  sha256 'c23d50e5521340919a98809b487e82b3872d4606f1c5ce774c6eb4a0120ee4d2'
 
   # devmate.com/com.macpaw.CleanMyMac was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.major}/#{version.major_minor_patch}/#{version.after_comma}/CleanMyMac3-#{version.major_minor_patch}.zip"
+  url "https://dl.devmate.com/com.macpaw.CleanMyMac3/CleanMyMac3.dmg"
   appcast "https://updates.devmate.com/com.macpaw.CleanMyMac#{version.major}.xml",
           checkpoint: '004841de20c5a3945fd4132ba371d9ad35c4210b1a852b3ddbdcae12bf1a3ed2'
   name 'CleanMyMac'


### PR DESCRIPTION
Previous URL for this cask yields 404 error. Switched to working CleanMyMac3.dmg (3.9.6) with new checksum on https://macpaw.com/cleanmymac.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.

Not able to complete as URL is broken. Also tried cask-repair.

==> Downloading external files for Cask cleanmymac
==> Downloading https://dl.devmate.com/com.macpaw.CleanMyMac3/3.9.6/1527255630/C

curl: (22) The requested URL returned error: 404 
Error: Download failed on Cask 'cleanmymac' with message: Download failed: https://dl.devmate.com/com.macpaw.CleanMyMac3/3.9.6/1527255630/CleanMyMac3-3.9.6.zip
There was an error fetching ./cleanmymac.rb. Please check your connection and try again.

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
