### PR TITLE
Update station to 1.13.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,11 +1,11 @@
 cask 'station' do
-  version '1.12.0'
-  sha256 '07a5ab814eb74272936cb0ffa6fb4bd972587e8b002e185780a4a98b94cbecb7'
+  version '1.13.0'
+  sha256 '4e9fd57e57e53e53d40c4ac1b6d9f41b90a95885c90007fea84b0a4b43c76a5f'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"
   appcast 'https://github.com/getstation/desktop-app-releases/releases.atom',
-          checkpoint: '1c94be07b31ca049022d8f11605adb6eb0bf3309d75729927f24c56d002979d4'
+          checkpoint: 'd884f5787a260fd7530e7fa89885148d01c05ceb24fba8583027a5836c883c47'
   name 'Station'
   homepage 'https://getstation.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.