### PR TITLE
Update smooze to 1.6.4

### DIFF
--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -1,10 +1,10 @@
 cask 'smooze' do
-  version '1.6.3'
-  sha256 '19c88372fefec2114985f40a8312b298c5ab8a77848507b1d872ec9dd396c97e'
+  version '1.6.4'
+  sha256 '7e4669f21f102c3e6575a6925d062c1ed76cd6b143ac66eaf47521a2a082e40c'
 
   url 'https://smooze.co/updates/Smooze.dmg'
   appcast 'https://smooze.co/updates/update.xml',
-          checkpoint: '9ab132054fab93d34e7d54981f098b28aba10e33dcc374c08f61f2921372652d'
+          checkpoint: 'e3b03973279535b4a4db5514143a71886d7d87087f7b0f409ae0e52ef8941e40'
   name 'Smooze'
   homepage 'https://smooze.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.