### PR TITLE
Update resolume-arena to 6.0.8.60887

### DIFF
--- a/Casks/resolume-arena.rb
+++ b/Casks/resolume-arena.rb
@@ -1,10 +1,10 @@
 cask 'resolume-arena' do
-  version '6.0.7'
-  sha256 'bfebbfde003956039e04193564a6b46210915a50df3b39c31c6e20f5044eb1b3'
+  version '6.0.8.60887'
+  sha256 '20308b7e5f012f9d98e22d5bdc666cb6e9e4329e8595ca05098267176995f284'
 
-  url "https://resolume.com/download/Resolume_Arena_#{version.dots_to_underscores}_Installer.dmg"
+  url "https://resolume.com/download/Resolume_Arena_#{version.major_minor_patch.dots_to_underscores}_Installer.dmg"
   appcast 'https://resolume.com/update/arena_mac.xml',
-          checkpoint: '405163af69fd9f5a822ed6ae985e07739e97ba13b54c72c7fd129602eb1a98cb'
+          checkpoint: 'a03ed64480f9b12db4702d3977eda2bffd32b10b726281aeddc287df7288c3ad'
   name 'Resolume Arena'
   homepage 'https://resolume.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.