### PR TITLE
Update emacs to 26.1-2

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,10 +1,10 @@
 cask 'emacs' do
-  version '26.1'
-  sha256 'c8ca0838901ae9d3f889e76141f971425169cc047281e60b8f6b70ad185c7bd2'
+  version '26.1-2'
+  sha256 '2ea8d0b0055d5d0ba604771dbb2f9731dd5c815776eec6a9bca3c44d7ab40d99'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/release',
-          checkpoint: '59d728a9a6a7e7223191eec747680fbb249eba98510cd08314e2e5b36aaa8b5b'
+          checkpoint: '7665006fab5be71be22a48a82f0402825e42c6fd7168272492447782fae08b1d'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.