### PR TITLE
Update signal to 1.12.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,10 +1,10 @@
 cask 'signal' do
-  version '1.11.0'
-  sha256 'c8cf36ece721c0b5757e62e201ab615dbba41ae216f14c7f917bd5a837a0c94c'
+  version '1.12.0'
+  sha256 '4da9f78e14cb2daae69f3a32f6000f780f6a57b25a40fc4f536eea6b120aa7d9'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom',
-          checkpoint: '8d5ac9f0f8906429be7d7ea6a16b25d504fb13f651d678dd53d7d58194c0af9e'
+          checkpoint: 'f94ef7c6125947a995b418109c23b4fcf23ccbc55d79184b645ad32b2bca3923'
   name 'Signal'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.