### PR TITLE
Update subutaicontrolcenter to 7.0.2

### DIFF
--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -1,11 +1,11 @@
 cask 'subutaicontrolcenter' do
-  version '7.0.1'
-  sha256 '45e87ab51f97158a1f64afe8e0e5dead462438b384decfd2d039b303c19abd43'
+  version '7.0.2'
+  sha256 '38ce25989209ce475a91b3c6f1d52c5442d58845755814d02fcb7a4c544c1907'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-control-center.pkg'
   appcast 'https://github.com/subutai-io/control-center/releases.atom',
-          checkpoint: 'a63fc73e1862a27ae4a278b963f8b0c40184400fb831a36acdef8ccbca2bcf3d'
+          checkpoint: '986178fb005d81b2858f70ddbfc3aff2346aa6f570deb08661004c3bf5fa4c2d'
   name 'Subutai Control Center'
   homepage 'https://subutai.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.