### PR TITLE
Update isubtitle to 3.1.1

### DIFF
--- a/Casks/isubtitle.rb
+++ b/Casks/isubtitle.rb
@@ -1,10 +1,10 @@
 cask 'isubtitle' do
-  version '3.1'
-  sha256 '043c492b3baf53ccde1016272c2a065eb404c305c28e51caf9f0cee55f382ea8'
+  version '3.1.1'
+  sha256 '05acbe95fd72f449147ba0d1e298b9feba041a9adc9319d00938daf1c890e700'
 
   url "http://www.bitfield.se/isubtitle#{version.major}/download/iSubtitle_#{version}.zip"
   appcast "http://www.bitfield.se/isubtitle#{version.major}/changelog.xml",
-          checkpoint: '3f62caa56691c22d13c56b137cea646dcb7dac2131f5a27ea8ff0b1a32354357'
+          checkpoint: '2e497388a372c0a10cfc187264dcb8aee4a86d9888e40eea9257fb79d521204c'
   name 'iSubtitle'
   homepage 'https://www.bitfield.se/isubtitle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.