### PR TITLE
Update gpxsee to 5.13-1

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,11 +1,11 @@
 cask 'gpxsee' do
-  version '5.12'
-  sha256 '34af58db2c9032bd7da1ad1904bdf174fdd53a87fd7698491f6e2875b6a31399'
+  version '5.13-1'
+  sha256 '68eb5a04ce29b6d0c9af2380a26cbd5fa5b44020cf4a3a9cd26643b91c869240'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/gpxsee/rss?path=/Mac%20OS%20X',
-          checkpoint: '9c0927e473a477289fe74795e366b5fcbfe0f1421c5f703537462927627c83e0'
+          checkpoint: '5fce1d62582c69b3df03c3bd8f711869e93a9e1b218b4f1c950d2d69ab664387'
   name 'GPXSee'
   homepage 'http://www.gpxsee.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.