### PR TITLE
Update vnote to 1.17

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,11 +1,11 @@
 cask 'vnote' do
-  version '1.16'
-  sha256 '363ea900028761c3480b5501cdea020e429b73a21f41e0e492768d3e25571745'
+  version '1.17'
+  sha256 '74fe2a0515e29c8c96979bcfa36664e84d48c8900be726680dc9e0dd1a7dc888'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"
   appcast 'https://github.com/tamlok/vnote/releases.atom',
-          checkpoint: '5f7de97854b354a4f32d05f9b791d87502fb1c7af4f27eab27be858ca2aadf61'
+          checkpoint: '72c578ac4156edc9ebdd18abe939a9b7372f04c9641bf9785bdd3a11841fd4a4'
   name 'VNote'
   homepage 'https://tamlok.github.io/vnote/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.