### PR TITLE
Update apple-events to 1.1

### DIFF
--- a/Casks/apple-events.rb
+++ b/Casks/apple-events.rb
@@ -1,10 +1,10 @@
 cask 'apple-events' do
-  version '1.0'
-  sha256 'd2daa6a298d9037b2d073b3857dd4d7d55152d93d3074417d191f94f7ca4f4db'
+  version '1.1'
+  sha256 '70b2b360cba05e72e49ceb9ee0410514fe14cca0fe65b7c8ae5a13aa991f3d15'
 
   url "https://github.com/insidegui/AppleEvents/releases/download/#{version}/AppleEvents_v#{version}.zip"
   appcast 'https://github.com/insidegui/AppleEvents/releases.atom',
-          checkpoint: '093a310cac1abdb64ee3e152747c5b571474f937398af8caaca01fcc8f022db9'
+          checkpoint: '502db9ed45596ef5c6f26baa3606b27e794418d02891f02be6493468b47372e5'
   name 'Apple Events'
   homepage 'https://github.com/insidegui/AppleEvents'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.