### PR TITLE
Update pyfa to 2.1.1,into.the.abyss-1.1

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,10 +1,10 @@
 cask 'pyfa' do
-  version '2.0.2,yc120.3-1.8'
-  sha256 '173fa033b785c034b589d7a612b9c67d5345d775de8696a0447b31951e1c05aa'
+  version '2.1.1,into.the.abyss-1.1'
+  sha256 'debe9bc205dbecd53efb55d8084385d38923c698f8420b6287dc8e3fc1a5a2ca'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom',
-          checkpoint: '61e6f7dde48a774394ce3531d3ded5ae17420e770e1557cb5628a4be0b6d2529'
+          checkpoint: '79bf6cd1bc687d989d3b761d364a921ba4526bded1f47162fab29c85e429faef'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.