### PR TITLE
Update frostwire to 6.6.7

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,11 +1,11 @@
 cask 'frostwire' do
-  version '6.6.6'
-  sha256 '4c35a1e9e42d10cbec0b28a686e6c59f05bd937fcec9bf05aafbbd987c8a262e'
+  version '6.6.7'
+  sha256 'bd892bd7fb3f077920dd09809243681fd2e5b50b48de8e0d99d77008f828a8dd'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
   appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x",
-          checkpoint: '792b9f013ce4fc73be733ce8475d7e6bb643183edddb2f5d571e092e0a9c3550'
+          checkpoint: 'e00a70a06676e361616d76917bc32ff0d376d20a7b4a7502b38c9236c7082751'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.