### PR TITLE
Update hab to 0.56.0-20180530234342

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,11 +1,11 @@
 cask 'hab' do
-  version '0.55.0-20180321215236'
-  sha256 'fdc87f2e82b8ef0b82f5b9fb56b56b24a45277e92f48e0ef58fdd6270513c53a'
+  version '0.56.0-20180530234342'
+  sha256 'e75755f806d870592adba82e61eecdd8478c3c37c66c67d4901da94feb9dad0e'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"
   appcast 'https://github.com/habitat-sh/habitat/releases.atom',
-          checkpoint: '295b1b731b162737af164e49efc4adad2b90175ba749527de38a69dbacf09804'
+          checkpoint: '5d1db46cb2ddffafaa84dfce064d494d61417c844f2ffd49f52dcde519514bc8'
   name 'Habitat'
   homepage 'https://www.habitat.sh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.