### PR TITLE
Update 4k-stogram to 2.6.13.1580

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -4,7 +4,7 @@ cask '4k-stogram' do
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: 'f2777a0a97a28e24e763132e040dea6e2359c2cbb805eab952a3f383383eeff6'
+          checkpoint: 'bc602309e88e5f0311dbad6bb4feaa37187e97aa2db120383b4e765347959bf8'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 

--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,10 +1,10 @@
 cask '4k-stogram' do
-  version '2.6.12.1567'
-  sha256 'b20e3f476294600ce69e0dae19a2111f9e20b6ca7a58edaadee1db14eaa0c4c5'
+  version '2.6.13.1580'
+  sha256 'be96f15216a129a575f25254d8b46e759417a3fd8d790ee2943d9fccea661c0b'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download',
-          checkpoint: '65c84cd2c25eea4ad18a46183c8ad14040be6766248d99f8b4e2b856a7013d59'
+          checkpoint: 'f2777a0a97a28e24e763132e040dea6e2359c2cbb805eab952a3f383383eeff6'
   name '4K Stogram'
   homepage 'https://www.4kdownload.com/products/product-stogram'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.