### PR TITLE
Update jqbx cask

### DIFF
--- a/Casks/jqbx.rb
+++ b/Casks/jqbx.rb
@@ -6,5 +6,7 @@ cask 'jqbx' do
   name 'JQBX'
   homepage 'https://www.jqbx.fm/'
 
+  depends_on cask: 'spotify'
+
   app 'JQBX.app'
 end


### PR DESCRIPTION
Turns out JQBX requires Spotify to be installed, so I added a depends_on

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

