### PR TITLE
Use installer package for 1password 7

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,9 +1,9 @@
 cask '1password' do
   version '7.0.3'
-  sha256 '386f4aa7057b6f207f0b7288c7d6e83390c648d4204e571f96353733833dafa8'
+  sha256 '04c66528087cc5b702dd03578711207c94fe1a4888cd8290e0a7ddf3eca0aa48'
 
   # 1password.com was verified as official when first introduced to the cask
-  url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
+  url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.pkg"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
           checkpoint: '117f165a494f5c8eacdb03249ccd7b693b21e3144a8dfe8cf7fe25063914aa56'
   name '1Password'
@@ -12,7 +12,9 @@ cask '1password' do
   auto_updates true
   depends_on macos: '>= :sierra'
 
-  app "1Password #{version.major}.app"
+  pkg "1Password-#{version}.pkg"
+
+  uninstall pkgutil: 'com.agilebits.pkg.onepassword'
 
   zap trash: [
                "~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword#{version.major}-helper",


### PR DESCRIPTION
Confirmed with an AgileBits support rep that they prefer 1Password to be
installed using their package instead of dragging the app into the Applications
folder.

Installing 1Password 7 the old way resulted in me not being able to unlock my password safe.

I've tested install and uninstall, and both work on my machine running Sierra 10.12.6.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
