### PR TITLE
Update outline-manager to 1.0.7

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,11 +1,11 @@
 cask 'outline-manager' do
-  version '1.0.5'
-  sha256 '4d5298ff1db0a012058e200891e8c0825b808b7d5a670199751c4d6cfce2aef3'
+  version '1.0.7'
+  sha256 '476d3a5993b391b0275179348d8aea42fe5ece018f46373e227d1d82fc360579'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"
   appcast 'https://github.com/Jigsaw-Code/outline-server/releases.atom',
-          checkpoint: '9ff5eeb367e86a7c8f5c0c4fd4e725f843fe30475cb3bd0815da5202757ec180'
+          checkpoint: 'a0b7f418fea518581cab1c8de9f221d2a233dc3939a0706d8a0b265ae7ad0093'
   name 'Outline Manager'
   homepage 'https://www.getoutline.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.