### PR TITLE
Update lidarr to 0.3.0.430

### DIFF
--- a/Casks/lidarr.rb
+++ b/Casks/lidarr.rb
@@ -1,11 +1,11 @@
 cask 'lidarr' do
-  version '0.2.0.371'
-  sha256 'bf75e65df3c03f62905b8c6bbfee0eb3b7d38d3f22183c6a3690825190abd84c'
+  version '0.3.0.430'
+  sha256 'e7990d43cb1b2efec926b178a277fb4d954e1a50bdbec5dcbd16f32466d99905'
 
   # github.com/lidarr/Lidarr was verified as official when first introduced to the cask
   url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.develop.#{version}.osx-app.zip"
   appcast 'https://github.com/lidarr/Lidarr/releases.atom',
-          checkpoint: '264cd631035ca81145519da0bd44d79732f7a241361540c083499fbb7c0e40ee'
+          checkpoint: '33a70363b276f35d4500cfc1287fbfd02ae8b75efa94c0fd8779e40be34aadf3'
   name 'Lidarr'
   homepage 'http://lidarr.audio/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.