### PR TITLE
Update graphql-playground to 1.6.0

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,10 +1,10 @@
 cask 'graphql-playground' do
-  version '1.5.9'
-  sha256 '84908c21d9b0c0723718a344718cf2c4297bb6c1026def4e50ee4ca5a1576a2d'
+  version '1.6.0'
+  sha256 '121e7015fc076b4029d3ecc37e4ff65afb32f689f3f6cfd4ed8f4d86b084ec39'
 
   url "https://github.com/prismagraphql/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prismagraphql/graphql-playground/releases.atom',
-          checkpoint: 'a49e533c53e8785990bf903a9fe7a34799867b4cde87747e4e5626cda2118580'
+          checkpoint: '96df374cbf19b00a1b2e8b25a89034e3f161f23b341f0e71fd75b080a1bbfb85'
   name 'GraphQL Playground'
   homepage 'https://github.com/prismagraphql/graphql-playground'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.