### PR TITLE
Update mountain to 1.6.5

### DIFF
--- a/Casks/mountain.rb
+++ b/Casks/mountain.rb
@@ -1,10 +1,10 @@
 cask 'mountain' do
-  version '1.6.4'
-  sha256 '7290dca93600e5c59cf797cae3f3bd874f2d9d79811969b9dad8586cf2a5c53f'
+  version '1.6.5'
+  sha256 '86140c5469683ed64e9f275240e4e5e157b4b84b39aed65157e412e287c2c9dc'
 
   url 'https://appgineers.de/mountain/files/Mountain.zip'
   appcast 'https://appgineers.de/mountain/files/mountaincast.xml',
-          checkpoint: '324c8292e7c397d2a689b0237235aca0f0b0e19f9d46d6440b76695803c45c7f'
+          checkpoint: 'bdd14156f57d031ffce89ff013e7b8811e8931bde3333f1c29695549a7376435'
   name 'Mountain'
   homepage 'https://appgineers.de/mountain/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.