### PR TITLE
Update typora to 0.9.9.16.2

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,10 +1,10 @@
 cask 'typora' do
-  version '0.9.9.16.1'
-  sha256 '80601314f5b6b1844039c6ac2360e1d4205d402b4ed483be1da15aefc70e00b4'
+  version '0.9.9.16.2'
+  sha256 '38ebec7cf669c2366e0c890aebc90723e906e710e81c1e2e8a389aadb86938f8'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml',
-          checkpoint: '7c09003c7682749b0c983a3e9e47e32593d3b3eece2ea821f8c33098b246dd7f'
+          checkpoint: '747b2ecc26a0a33972bc55b269f4efddeaec21346ce03685d39da5a1c2a617c2'
   name 'Typora'
   homepage 'https://typora.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.