### PR TITLE
Update lbry to 0.21.5

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,11 +1,11 @@
 cask 'lbry' do
-  version '0.21.4'
-  sha256 '7592d6d064dbac5f92d15bb1c0f948be8aaa75891b6e84dfc7079173c613b51d'
+  version '0.21.5'
+  sha256 '1c72b03991dd9deff4b2355a59297d302451fb39047905f8b7a84f9a0d94dfb8'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"
   appcast 'https://github.com/lbryio/lbry-app/releases.atom',
-          checkpoint: '75367adee9e80b56ef798938ed19c543ba4777b7a443ede3107eae7ef69e8f3b'
+          checkpoint: '71cdfb6985b94b2558790e7a8dd16a9384b8d069b38a70e91d17413b00f07c27'
   name 'LBRY'
   homepage 'https://lbry.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.