### PR TITLE
Update zulip to 2.3.2

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,11 +1,11 @@
 cask 'zulip' do
-  version '2.3.1'
-  sha256 '549e6e06d90895964e6ab32dd0bcadc527adcd5503d614f999538e9245e8b6da'
+  version '2.3.2'
+  sha256 'a5f7b8dc1dfc5e9ba63aa2ebcd7b1d36db0117f80c09de3175675fb8504e47b2'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}-mac.zip"
   appcast 'https://github.com/zulip/zulip-electron/releases.atom',
-          checkpoint: '745f7ad0874504a13c8a80daf4446ed7ae0fb675c3ce0b7074ace8f01234e759'
+          checkpoint: '32af0a26c48c045d806a5f6ae950bd78e0ed85147d16fbee5c7fdaa240800b48'
   name 'Zulip'
   homepage 'https://zulipchat.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.