### PR TITLE
Update mos to 2.2.6

### DIFF
--- a/Casks/mos.rb
+++ b/Casks/mos.rb
@@ -1,11 +1,11 @@
 cask 'mos' do
-  version '2.2.2'
-  sha256 '93fec3925fb2761ecd5ac92cb5fe1eba8fbaf68e8a50717c3aa2b2df4a0cc601'
+  version '2.2.6'
+  sha256 '803b3130c722b2cf08e166f347806ab1fd427feef98f07f9edd5439845c3247e'
 
   # github.com/Caldis/Mos was verified as official when first introduced to the cask
   url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.dmg"
   appcast 'https://github.com/Caldis/Mos/releases.atom',
-          checkpoint: '716e6e213751273884cf83927cece4c42350c61eae968bfedb03938777e8512f'
+          checkpoint: '0c31918a80ad04abda612c4222dd5f865abcfd5975de13d45e5b0d0fda7c835d'
   name 'Mos'
   homepage 'https://mos.caldis.me/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.