### PR TITLE
Update jaksta to 2.2.3

### DIFF
--- a/Casks/jaksta-media-recorder.rb
+++ b/Casks/jaksta-media-recorder.rb
@@ -18,5 +18,5 @@ cask 'jaksta-media-recorder' do
     system_command '/bin/mv', args: ['--', staged_path.join(version.to_s), staged_path.join('JMR.pkg')]
   end
 
-  uninstall pkgutil: 'com.shedwork.Jaksta'
+  uninstall pkgutil: 'com.shedworx.Jaksta'
 end

--- a/Casks/jaksta-media-recorder.rb
+++ b/Casks/jaksta-media-recorder.rb
@@ -18,5 +18,6 @@ cask 'jaksta-media-recorder' do
     system_command '/bin/mv', args: ['--', staged_path.join(version.to_s), staged_path.join('JMR.pkg')]
   end
 
-  uninstall pkgutil: 'com.shedworx.Jaksta'
+  uninstall pkgutil:   'com.shedworx.Jaksta',
+            launchctl: 'com.ProxyConfigDaemon'
 end

--- a/Casks/jaksta-media-recorder.rb
+++ b/Casks/jaksta-media-recorder.rb
@@ -1,4 +1,4 @@
-cask 'jaksta' do
+cask 'jaksta-media-recorder' do
   version '2.2.3'
   sha256 '92cb1eeff5360e0d2ac890556f92c1f0ada74c32209eea5e4eaa27ca3204cc7c'
 
@@ -8,7 +8,13 @@ cask 'jaksta' do
   name 'Jaksta'
   homepage 'https://www.jaksta.com/products'
 
-  pkg "JMR-#{version}.pkg"
+  pkg 'JMR.pkg'
+
+  # This is a horrible hack to force the file extension.
+  # The backend code should be fixed so that this is not needed.
+  preflight do
+    system_command '/bin/mv', args: ['--', staged_path.join(version.to_s), staged_path.join('JMR.pkg')]
+  end
 
   uninstall pkgutil: 'com.shedwork.Jaksta'
 end

--- a/Casks/jaksta-media-recorder.rb
+++ b/Casks/jaksta-media-recorder.rb
@@ -8,6 +8,8 @@ cask 'jaksta-media-recorder' do
   name 'Jaksta'
   homepage 'https://www.jaksta.com/products'
 
+  container type: :naked
+
   pkg 'JMR.pkg'
 
   # This is a horrible hack to force the file extension.

--- a/Casks/jaksta.rb
+++ b/Casks/jaksta.rb
@@ -3,8 +3,8 @@ cask 'jaksta' do
   sha256 '92cb1eeff5360e0d2ac890556f92c1f0ada74c32209eea5e4eaa27ca3204cc7c'
 
   url "https://www.jaksta.com/services/download/mac/jaksta-media-recorder/#{version}"
-  appcast 'https://www.jaksta.com/Services/VersionDirector/jmr-mac?v=2.2.0',
-          checkpoint: '40e7d49f541432521eff2f08a733d88034114b56ec3980f32914b9f40c8099d5'
+  appcast 'https://www.jaksta.com/Services/VersionDirector/jmr-mac',
+          checkpoint: '44dd59d7ec02995687685d56ed99e0607f197b1a3eb03724c61b74daec209c62'
   name 'Jaksta'
   homepage 'https://www.jaksta.com/products'
 

--- a/Casks/jaksta.rb
+++ b/Casks/jaksta.rb
@@ -1,12 +1,14 @@
 cask 'jaksta' do
-  version '1.3.3'
-  sha256 '8f54cdba4ab42aec0430cdc15f9fd62370391bd2c42e0b734d6d5adea0355f69'
+  version '2.2.3'
+  sha256 '92cb1eeff5360e0d2ac890556f92c1f0ada74c32209eea5e4eaa27ca3204cc7c'
 
-  url "http://downloads.jaksta.com/release/mac/Jaksta-#{version}.dmg"
-  appcast 'http://downloads.jaksta.com/release/mac/sparkle/JakstaforMac.xml',
-          checkpoint: '164a2b0a2fa866c475947fe2ae1e4a1020f11ca6ab03d5525bc54fc41d274be1'
+  url "https://www.jaksta.com/services/download/mac/jaksta-media-recorder/#{version}"
+  appcast 'https://www.jaksta.com/Services/VersionDirector/jmr-mac?v=2.2.0',
+          checkpoint: '40e7d49f541432521eff2f08a733d88034114b56ec3980f32914b9f40c8099d5'
   name 'Jaksta'
   homepage 'https://www.jaksta.com/products'
 
-  app 'Jaksta.app'
+  pkg "JMR-#{version}.pkg"
+
+  uninstall pkgutil: 'com.shedwork.Jaksta'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.