### PR TITLE
Update gtkwave to 3.3.91

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,10 +1,10 @@
 cask 'gtkwave' do
-  version '3.3.90'
-  sha256 'ef93f018ebac8a09e584ad332f81cac6b9186379086fd31176e25d0f632f263b'
+  version '3.3.91'
+  sha256 '1a36d50d3c6bafd708bea4a6af721cf961d22ebddaf37c3924fbf620a0642da7'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss',
-          checkpoint: '0281ba2d546c1becd31b339a1c4ad51f9bd738c49cbe2be158176c2d68405b56'
+          checkpoint: 'f2d615550875cdb18355a70e9811b08709ddabe6ad5a1cbbaa6602d133a95859'
   name 'GTKWave'
   homepage 'http://gtkwave.sourceforge.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.