### PR TITLE
Update ExifRenamer to 2.2.3

### DIFF
--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -1,10 +1,10 @@
 cask 'exifrenamer' do
-  version '2.2.2'
-  sha256 '7df7055250984820e5f91f0ec3718658f4570258af72766a2c487457a6a7f04f'
+  version '2.2.3'
+  sha256 'de1e0b0f068c540bace010b33023aabccf4191f62e203337a06c962da8f9f763'
 
   url 'https://www.qdev.de/downloads/files/ExifRenamer.dmg'
   appcast 'https://www.qdev.de/versions/ExifRenamer.txt',
-          checkpoint: '36f4d4845f52a9b18d480b77b7e473ce0af9a412a1be5fd8c2e7a1ec5d125307'
+          checkpoint: '9da98effe8a85d98c511e6bb2dd6c3037b49ae41add248e2e543198e1457a157'
   name 'ExifRenamer'
   homepage 'https://www.qdev.de/?location=mac/exifrenamer&forcelang=en'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
