### PR TITLE
Update wwdc to 6.0.1

### DIFF
--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -1,11 +1,11 @@
 cask 'wwdc' do
-  version '6.0'
-  sha256 '0d2d92915d6880a8360813a88c3f54e0b8e01a6f9d400defc73c852455aa9cc9'
+  version '6.0.1'
+  sha256 '72fe8e3cc8b7d06d0688c347e6a3405e648c132dcf12c3481557d9c3e8351368'
 
   # github.com/insidegui/WWDC was verified as official when first introduced to the cask
   url "https://github.com/insidegui/WWDC/releases/download/#{version}/WWDC_v#{version}.zip"
   appcast 'https://github.com/insidegui/WWDC/releases.atom',
-          checkpoint: '1d5b08e13209e7168d53b344ae20cdc6fe97a418e3a6405b996fc29f74fdddcd'
+          checkpoint: 'bb15dcaa4af98d85172a2c5c3aa5ca118ce160c07129e3e850a1c944db2071b1'
   name 'WWDC'
   homepage 'https://wwdc.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.