### PR TITLE
Update manager to 18.5.39

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.38'
-  sha256 '7c6e43c1557c261ca0d026e092c40e2e318e0c78482666b298975c37bc47a652'
+  version '18.5.39'
+  sha256 '15661ee3a56a81b851aa63e20baea2ff3c304864fb6a8e8321dde379099cd731'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.