### PR TITLE
Update brave to 0.22.727

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,11 +1,11 @@
 cask 'brave' do
-  version '0.22.721'
-  sha256 '2c24d712c6ae7cd8148c07ad2b2cfa3fa4f66812854b41157b62be2792e60b36'
+  version '0.22.727'
+  sha256 '6879c7bd88bd282a1aea4442ca2467bf6982bb8d3142d11de8b7c798419115c2'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
   appcast 'https://github.com/brave/browser-laptop/releases.atom',
-          checkpoint: '9af0da7e18d41c433d9c393c3dc75c9623d7c2534ad4c9fb43f7b5002560d2ef'
+          checkpoint: '2dd0a3bf2cf300fe9d27d1d4d998e5169bd40ab914b3b0afc7b7339a7acc61bd'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.