### PR TITLE
Update there to 1.6.1

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,11 +1,11 @@
 cask 'there' do
-  version '1.5.3'
-  sha256 'f9a28f0bded3f8a9fc6a20fdc502a7b6679d7c1ea93627def2666618ccc54609'
+  version '1.6.1'
+  sha256 '50a0a7982d9228c700b26c3a30c587458f4512b6e87bd79f7556d9bac5c968b7'
 
   # github.com/therepm/there-desktop was verified as official when first introduced to the cask
   url "https://github.com/therepm/there-desktop/releases/download/v#{version}/there-desktop-#{version}-mac.zip"
   appcast 'https://github.com/therepm/there-desktop/releases.atom',
-          checkpoint: 'c4ac3ce39a1869c85a1002bbcd21e69f36bbef8fcdb30fe333dd02e0c3d744e4'
+          checkpoint: '89240f6f3142b4af31d470502ed24c0fbff3cfa859270522b087fe5a6757b69c'
   name 'There'
   homepage 'https://there.pm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.