### PR TITLE
subutaip2p.rb: force extension comment consistency

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -13,7 +13,8 @@ cask 'subutaip2p' do
 
   pkg 'subutai-p2p.pkg'
 
-  # This is a hack to force the file extension.
+  # This is a horrible hack to force the file extension.
+  # The backend code should be fixed so that this is not needed.
   preflight do
     system_command '/bin/mv', args: ['--', staged_path.join('get'), staged_path.join('subutai-p2p.pkg')]
   end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.