### PR TITLE
Update isyncr to 5.14.0

### DIFF
--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -1,14 +1,18 @@
 cask 'isyncr' do
-  version '5.14.0'
-  sha256 '68e65554b12083c35b0180c6535cefcc7897c0aa4902848dcf706459ecfab3ad'
+  if MacOS.version <= :lion
+    version '5.0.8'
+    sha256 '1b1c0e6054b890fa7dd903cc680fd2543bc6b40b34cde2d23f4c2e355dcffb87'
+  elsif MacOS.version <= :sierra
+    version '5.6.5'
+    sha256 '8cd6b1c96a902d8810e52aab6a980424370237617bfd3ff574367ff1ce8d4f4e'
+  else
+    version '5.14.0'
+    sha256 '68e65554b12083c35b0180c6535cefcc7897c0aa4902848dcf706459ecfab3ad'
+  end
 
   url "http://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"
-  appcast 'http://www.jrtstudio.com/files/SlashiSyncr25.js',
-          checkpoint: '65385df99037be7b37ea118f503a51036b2af6c11a3c6230ff5b4f3576dee4ab'
   name 'iSyncr Desktop'
   homepage 'http://www.jrtstudio.com/iSyncr-iTunes-for-Android'
-
-  depends_on macos: '>= :mountain_lion'
 
   pkg "iSyncr Desktop #{version}.pkg"
 

--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -1,8 +1,5 @@
 cask 'isyncr' do
-  if MacOS.version <= :lion
-    version '5.0.8'
-    sha256 '1b1c0e6054b890fa7dd903cc680fd2543bc6b40b34cde2d23f4c2e355dcffb87'
-  elsif MacOS.version <= :sierra
+  if MacOS.version <= :sierra
     version '5.6.5'
     sha256 '8cd6b1c96a902d8810e52aab6a980424370237617bfd3ff574367ff1ce8d4f4e'
   else
@@ -13,6 +10,8 @@ cask 'isyncr' do
   url "http://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"
   name 'iSyncr Desktop'
   homepage 'http://www.jrtstudio.com/iSyncr-iTunes-for-Android'
+
+  depends_on macos: '>= :mountain_lion'
 
   pkg "iSyncr Desktop #{version}.pkg"
 

--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -1,6 +1,6 @@
 cask 'isyncr' do
-  version '5.6.3'
-  sha256 'e4de8de36b1e191aa511846549cac5f36727e44b0ad2607efa07a249fde55d91'
+  version '5.14.0'
+  sha256 '68e65554b12083c35b0180c6535cefcc7897c0aa4902848dcf706459ecfab3ad'
 
   url "http://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"
   appcast 'http://www.jrtstudio.com/files/SlashiSyncr25.js',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.