### PR TITLE
Update fork to 1.0.67.5

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -4,7 +4,7 @@ cask 'fork' do
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',
-          checkpoint: '84ec63c7dbaa75d07f2d0fd8d98fb750b9005883d70432e4485a8f74f7e7c609'
+          checkpoint: '2a4def5f0763cd4a51f1496e65bc1e511663b843c91823f495c4ca6bb54ec971'
   name 'Fork'
   homepage 'https://git-fork.com/'
 

--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,6 +1,6 @@
 cask 'fork' do
-  version '1.0.67.4'
-  sha256 '4f10bb1543ec7a4fe71270358ce89373296b1463779a955e965d2f9395edd816'
+  version '1.0.67.5'
+  sha256 'f02fc78fe635dbd2a8f2e93e6053d58907d6b4a9a25be30f67f0eb3cc2cbb653'
 
   url 'https://git-fork.com/update/files/Fork.dmg'
   appcast 'https://git-fork.com/update/feed.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The appcast still shows `1.0.67.2`, but downloading and inspecting the app shows `1.0.67.5`. Feel free to remove the appcast if this is becoming too much of a problem.