### PR TITLE
Update mactracker to 7.7.4

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -1,10 +1,10 @@
 cask 'mactracker' do
-  version '7.7.3'
-  sha256 'a78c9f9a335cad8fa224d98e1c8a84e88f0959338f75d462b1c89bfe24713b1f'
+  version '7.7.4'
+  sha256 'c387757a8efc3df785ecaf6967a8394cdae319d270a06523ee3f50d67088a746'
 
   url "https://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
   appcast 'https://update.mactracker.ca/appcast-b.xml',
-          checkpoint: '9774703063a34aa2c5298b7154d8e52874abf64af9d763514b2cbf02a645e87c'
+          checkpoint: '927be17abf74afb78b9027cc164a75fea72f4aa373ca723f8490753225d1aff8'
   name 'Mactracker'
   homepage 'https://mactracker.ca/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.