### PR TITLE
Update vfuse to 2.0.5

### DIFF
--- a/Casks/vfuse.rb
+++ b/Casks/vfuse.rb
@@ -1,10 +1,10 @@
 cask 'vfuse' do
-  version '2.0.4'
-  sha256 'f2c444a72cac7f99cbc3a63cbe422e4e94cb5047d4a71b1e2af9460e184b7408'
+  version '2.0.5'
+  sha256 'fff3b4f960b7ec0f131a12ba53a1b556e20741aea53eb3b85d04539f836a0648'
 
   url "https://github.com/chilcote/vfuse/releases/download/#{version}/vfuse-#{version}.pkg"
   appcast 'https://github.com/chilcote/vfuse/releases.atom',
-          checkpoint: 'fc1feecdc30efa24cd70e34e85e3f9213fd26e04acc026116a96502439198366'
+          checkpoint: '108f22f1587093b89db239aa4e0b878136b04600ad6f950927ac2cc3a2465524'
   name 'vfuse'
   homepage 'https://github.com/chilcote/vfuse'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.