### PR TITLE
Update unity-download-assistant to 2018.1.3f1,a53ad04f7c7f

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.1.2f1,a46d718d282d'
-  sha256 'd6c5c2ed427798be81d5086f68d4463afa5fc6bf84c6a283a63bbc41e9409590'
+  version '2018.1.3f1,a53ad04f7c7f'
+  sha256 '93b03f493d8c388808f76e4b40c928520329c55c3177ed1e8fcbb77cd0ee0a67'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   name 'Unity'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.