### PR TITLE
Update unity-linux-support-for-editor to 2018.1.3f1,a53ad04f7c7f

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.1.0f2,d4d99f31acba'
-  sha256 '5e674d5cfac66c537340fb7edda80f546f817a81a49272417d429b134add89eb'
+  version '2018.1.3f1,a53ad04f7c7f'
+  sha256 'c3ebf0935f22c7836b8805d1281554cc4130ed2334678ed90329e1719e09d199'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Linux Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.