### PR TITLE
Update unity-ios-support-for-editor to 2018.1.3f1,a53ad04f7c7f

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2018.1.0f2,d4d99f31acba'
-  sha256 'd92a030e233b6efe18569488094985a2e2082c1b6785bfef49c197eda9908095'
+  version '2018.1.3f1,a53ad04f7c7f'
+  sha256 'f10b87cc9e7d1233fbd16793621f5c34484dd5b8cfc52c0ce7a172135b33b988'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity iOS Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.