### PR TITLE
Update mountain-duck to 2.5.1.9399

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,10 +1,10 @@
 cask 'mountain-duck' do
-  version '2.5.0.9388'
-  sha256 'f42314b65bdf570793befd936fefd34c204710bab55a29b97ce78a392654bdbe'
+  version '2.5.1.9399'
+  sha256 '3b755983f5ec2c5c4c8e34217cd2b4064cb0b43d054b7c008f199e288b3c51db'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss',
-          checkpoint: '83984dce45ae513461f9e2a308a8f1dab99701d99f81b2164def997336399a0c'
+          checkpoint: '30d3f02def54676dfb53e4c7f55f0bdbf670717bcda9697dcf18b2cb0e7f5339'
   name 'Mountain Duck'
   homepage 'https://mountainduck.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.