### PR TITLE
Update screens to 4.5.5,21918:1528124912

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,11 +1,11 @@
 cask 'screens' do
-  version '4.5.4,21792:1526653764'
-  sha256 'ebbe9e79b9ef01203f85964e8723a03f927f418127513074be5d00fbd705e635'
+  version '4.5.5,21918:1528124912'
+  sha256 'f03aa02745085bb488ee5b0c9e6449afa6a903636407131d38fc09108bc802c1'
 
   # dl.devmate.com/com.edovia.screens4.mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.edovia.screens4.mac/#{version.after_comma.before_colon}/#{version.after_colon}/Screens#{version.major}-#{version.after_comma.before_colon}.zip"
   appcast "https://updates.devmate.com/com.edovia.screens#{version.major}.mac.xml",
-          checkpoint: 'd7f9e9f54461e1bc4469df0f70122a5080e4c4ad911f4b9eb934ad5c7126301d'
+          checkpoint: 'ce490c44838dceda1a199c6c3de1bec30f9336ea97771bac0aa1b08cf48c459f'
   name 'Screens'
   homepage 'https://edovia.com/screens-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.