### PR TITLE
Update lehreroffice-zusatz to 2018.9.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,10 +1,10 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.8.1'
-  sha256 'a1fca5bccee47bab7c8baee0af10e96968f54a65916415879242775b31d3c3e0'
+  version '2018.9.0'
+  sha256 '491aa84f1f124683561d2c1be792edac74fb5d4ee280c5b8ca0707b4edf963fb'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz',
-          checkpoint: '24c55b7df2e4293f19168f978da2e0bba582a19bb52aba5f08521d5154e39a96'
+          checkpoint: '9a8b0874eed6a469ca27a0dff9a096bea9d9ce2a045eefc001ea01b63fdb2523'
   name 'LehrerOffice Zusatz'
   homepage 'https://www.lehreroffice.ch/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.