### PR TITLE
Update checksum for unison 2.51.2

### DIFF
--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -13,14 +13,14 @@ cask 'unison' do
     url "https://github.com/bcpierce00/unison/releases/download/#{version}/Unison-OS-X-#{version}.zip"
   else
     version '2.51.2'
-    sha256 '52142f3aa03b7beba03aaa8c61cb1e3287058cae825845b2355081d9e925b6de'
+    sha256 '0738a6978fa29bb2af409322069cc20df293b770877942ac4b8774f06e774aa5'
 
     # github.com/bcpierce00/unison/releases/download was verified as official when first introduced to the cask
     url "https://github.com/bcpierce00/unison/releases/download/v#{version}/Unison-#{version}.OS.X.zip"
   end
 
   appcast 'https://github.com/bcpierce00/unison/releases.atom',
-          checkpoint: '98fc35df2c7db577517de4649c6886d82ba5c2034bcad1e7e46ad21b89237dce'
+          checkpoint: 'd3bc408807276d276906f10771f8332609da1f99de651937f256666db8268737'
   name 'Unison'
   homepage 'https://www.cis.upenn.edu/~bcpierce/unison/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
