### PR TITLE
Update mp3tag to 2.88a

### DIFF
--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -1,6 +1,6 @@
 cask 'mp3tag' do
-  version '2.87a'
-  sha256 'ae28fc762dc645d938f72eb77982e9517cf128f9d96493f17cd74a993de6ce65'
+  version '2.88a'
+  sha256 '535e337fe5e1021e6c3490bca074102adf08ebc1432b3f77b53815e6f6cfddff'
 
   url "http://download.mp3tag.de/mp3tagv#{version.no_dots}-macOS-Wine.zip"
   name 'MP3TAG'

--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -7,4 +7,10 @@ cask 'mp3tag' do
   homepage 'http://www.mp3tag.de/en/'
 
   app "mp3tagv#{version.no_dots}-macOS-Wine/Mp3tag.app"
+
+  zap trash: [
+               '~/Library/Application Support/de.mp3tag.Mp3tag_*',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/de.mp3tag.mp3tag_*.sfl*',
+               '~/Library/Preferences/org.kronenberg.Winetricks.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.