### PR TITLE
Update coteditor to 3.4.2

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -9,14 +9,14 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.4.1'
-    sha256 '7df0f23e3e61813b5d98d823023b74a36ec81b5b99a9a377e9489604a5bf93e8'
+    version '3.4.2'
+    sha256 'f7e2a78e36d5beed910395a9197b93c3d1fccc7c87f9a5cc9c09df062244f5b7'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask
   url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg"
   appcast 'https://github.com/coteditor/CotEditor/releases.atom',
-          checkpoint: '203a633ddbfb20833d4c21745c02f0f8e3208f418ab441c7646001c230b29321'
+          checkpoint: '820521c19ba856fe653600374cda86287be35a6391d356590bdfa6d13c073ddc'
   name 'CotEditor'
   homepage 'https://coteditor.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.