### PR TITLE
Update drivedx to 1.8.0

### DIFF
--- a/Casks/drivedx.rb
+++ b/Casks/drivedx.rb
@@ -1,6 +1,6 @@
 cask 'drivedx' do
-  version '1.7.0'
-  sha256 '2eb4030e205260445dd6dbfcd6e456d4940e746e6db394e4ce6bdae7bd88e1e5'
+  version '1.8.0'
+  sha256 '78038902cfb33ae82dc1b9ac6b9eaf164ecdf8f13d848effcdafd1dd631a4953'
 
   url "https://binaryfruit.com/download/drivedx/mac/1/bin/DriveDx.#{version}.zip"
   name 'DriveDX'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.