### PR TITLE
Update soundcloud-downloader to 2.8.1.2

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,10 +1,10 @@
 cask 'soundcloud-downloader' do
-  version '2.8.1'
-  sha256 '1a111b455bf1db4ef48155d23359796be73cc98805c11a6c41e9d4c0ae54d9b4'
+  version '2.8.1.2'
+  sha256 '1d7dec3157b37a1a97eace31078aa16bcc4a40af62f792e3d12b53472486736c'
 
   url "https://black-burn.ch/app/SCD2/download/#{version}"
   appcast 'https://black-burn.ch/apps/SCD2/updates/gold.xml?hwni=1',
-          checkpoint: '3fb9eb44e0728da74ab85150abebc48e848b0ff515c0f69ecdfaf3ac4d284d2f'
+          checkpoint: '436c5f6a0fd8f81c62fea8e8bffa48d5a78d27fa2214e310107d61fbf6b5c99e'
   name 'SoundCloud Downloader'
   homepage 'https://black-burn.ch/app/SCD2'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.