### PR TITLE
Update there to 1.6.2

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,11 +1,11 @@
 cask 'there' do
-  version '1.6.1'
-  sha256 '50a0a7982d9228c700b26c3a30c587458f4512b6e87bd79f7556d9bac5c968b7'
+  version '1.6.2'
+  sha256 'ab6da2a6c605209622782884ca26e14bb6a76050d15b8458e41946d401eba435'
 
   # github.com/therepm/there-desktop was verified as official when first introduced to the cask
   url "https://github.com/therepm/there-desktop/releases/download/v#{version}/there-desktop-#{version}-mac.zip"
   appcast 'https://github.com/therepm/there-desktop/releases.atom',
-          checkpoint: '89240f6f3142b4af31d470502ed24c0fbff3cfa859270522b087fe5a6757b69c'
+          checkpoint: 'b427f9247a690f688aa0aa07b4ec7a335c7759fdb4e32abcee54d539612b2031'
   name 'There'
   homepage 'https://there.pm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.