### PR TITLE
Update freesmug-chromium to 67.0.3396.79

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,11 +1,11 @@
 cask 'freesmug-chromium' do
-  version '67.0.3396.62'
-  sha256 '6f4809b415cc02991c5c98d250d88fd57c0bbb47730f3da87731cf19af610ab9'
+  version '67.0.3396.79'
+  sha256 '2f1be940167ef34f3a0d33a17e84d897a1a13101754a45840bc47553af8cc492'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium',
-          checkpoint: 'd585d2eff3b37f5696907d0931971299171a60dc5b46787878265ae6f88cbf40'
+          checkpoint: '27caeac244c23f3778fde1ec7e24238f4a328583b19af7292c9d8086cf19b0a7'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.