### PR TITLE
Update kamakiri to 1.0.9,32

### DIFF
--- a/Casks/kamakiri.rb
+++ b/Casks/kamakiri.rb
@@ -1,8 +1,8 @@
 cask 'kamakiri' do
-  version '1.0.9-32'
+  version '1.0.9,32'
   sha256 '5634ce3166f0f613490bae043a3ac4376c18f35a6066829f90ebc23b7ec44f4f'
 
-  url "https://mochidev.com/appresources/downloads/Kamakiri%20#{version.sub(%r{-.*$}, '')}%20(#{version.sub(%r{^.*-}, '')}).zip"
+  url "https://mochidev.com/appresources/downloads/Kamakiri%20#{version.before_comma}%20(#{version.after_comma}).zip"
   appcast 'https://mochidev.com/appresources/updates/kamakiridd.xml',
           checkpoint: '5ac217895c1f06fb9b30b67b46630b8e26b4d3a7cbf9102cd38c12b521d94197'
   name 'Kamakiri'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.