### PR TITLE
Update adobe-air to 30.0

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,5 +1,5 @@
 cask 'adobe-air' do
-  version '29.0'
+  version '30.0'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://airdownload.adobe.com/air/mac/download/#{version}/AdobeAIR.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.