### PR TITLE
Update cacher to 1.5.4

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.5.3'
-  sha256 'f054ac3c5b3f1a7f4f1b5438359ae059aa5689237b54e23aa8bbf08fb248ddcc'
+  version '1.5.4'
+  sha256 'a3c5998baedfee1d6bc55ba6aff12f3c8bed718f6553162846ecea58588727c1'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '5955b7c7c3ef407cae23172db56f0e37d9ff5ee650bd3dd923626799788212ee'
+          checkpoint: '14fa515781508d4e6bf50b264eb9fc3b30dfe9f7b3102169743b012e0e377c69'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.