### PR TITLE
Update manager to 18.5.40

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.39'
-  sha256 '15661ee3a56a81b851aa63e20baea2ff3c304864fb6a8e8321dde379099cd731'
+  version '18.5.40'
+  sha256 '8e7c0ba62e1584864e787267c4a3d404a66da879e4a374bc55645cae484a5f87'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.