### PR TITLE
Update grandtotal to 5.1.6.3

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,10 +1,10 @@
 cask 'grandtotal' do
-  version '5.1.6'
-  sha256 '876884c0ea61177feda2333cdd0506b537b3309ed62e9f452ecfe93c952f8a7b'
+  version '5.1.6.3'
+  sha256 '09fad1f55bfc4d4d099b1e5a40695edfe06e2ae73de1445130c692f043972e65'
 
   url "https://mediaatelier.com/GrandTotal#{version.major}/GrandTotal_#{version}.zip"
   appcast "https://mediaatelier.com/GrandTotal#{version.major}/feed.php",
-          checkpoint: '0b2fa9f3239db87404ea1e2b821f3213e232a3cc1e2ec5b8ea6089a1070b601c'
+          checkpoint: '7e17f94fe005f13a80c66202fd05cc72abf65eb55ced50339b4069f98e2298c1'
   name 'GrandTotal'
   homepage "https://www.mediaatelier.com/GrandTotal#{version.major}/"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.