### PR TITLE
Update alfred to 3.6.1_910

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -3,6 +3,8 @@ cask 'alfred' do
   sha256 'fdefdb35047e193e1d06f5a441f4aabd4b45b24fd43c63d223d8508ad11a131e'
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.dmg"
+  appcast 'https://www.alfredapp.com/app/update/general.xml',
+          checkpoint: 'dd1cdfd7338d25e0ab3fb50e15ebf63e60080be406f1e4c455f99254927a84c9'
   name 'Alfred'
   homepage 'https://www.alfredapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.