### PR TITLE
Update plex-media-server to 1.13.2.5142-3ba6662e9

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,10 +1,10 @@
 cask 'plex-media-server' do
-  version '1.13.0.5023-31d3c0c65'
-  sha256 'ebad5dd399fa0ecd719b4a3d81103901db757ec9be0e179817ca523a18861f18'
+  version '1.13.2.5142-3ba6662e9'
+  sha256 'b5ad03f2fa2242b027fad59b5fc0d5de10f2c5af55a612c5031c6f67806ae08c'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   appcast 'https://plex.tv/api/downloads/1.json',
-          checkpoint: '546bef9f92366644323103bae38bf8499581667bea1aa1a21e6b1beae33a0cce'
+          checkpoint: '957931fc05464588fa76d6b3de7bb7156b83d33554e1a91876243897a65424f3'
   name 'Plex Media Server'
   homepage 'https://www.plex.tv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.