### PR TITLE
Update trezor-bridge to 2.0.14

### DIFF
--- a/Casks/trezor-bridge.rb
+++ b/Casks/trezor-bridge.rb
@@ -1,10 +1,10 @@
 cask 'trezor-bridge' do
-  version '2.0.13'
-  sha256 'db580a7b3846e152a210351ef6ea487002a7d9398a41fa406d65a6c40352f230'
+  version '2.0.14'
+  sha256 '01cdc05500c1d465300c73235d6cc65ad3eacb733144f10cc64768ba4e7c0ccf'
 
   url "https://wallet.trezor.io/data/bridge/#{version}/trezor-bridge-#{version}.pkg"
   appcast 'https://wallet.trezor.io/data/bridge/latest.txt',
-          checkpoint: 'b43889a851b767c2082dc89467e96b56b6d41eb4cc8a14621884fe16f7c1297c'
+          checkpoint: '06727ff5fc1efe87efc71bed58294573cc94effaf6f31ef22fc3819da0518e6b'
   name 'TREZOR Bridge'
   homepage 'https://wallet.trezor.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.