### PR TITLE
Update activedock to 138,1528354382

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,11 +1,11 @@
 cask 'activedock' do
-  version '129,1527073906'
-  sha256 'fb65006e8530d11a2a0250ca3d4c44d07a28820f12dda6ba9129f419681fed43'
+  version '138,1528354382'
+  sha256 'd7aacff9205ddf54f52be8ce4ee5840b5c2ed62fd7cb41fa90a80b0825a7eed3'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.sergey-gerasimenko.ActiveDock.xml',
-          checkpoint: 'fcbe96ab0ebc6aa1ea795ef174d7f807b4ea0e7841646323e4f9e5fabf01a483'
+          checkpoint: '7f6d69b7204d68153b841f7965cbd4ea42f568f3f63f35469f08502ec3675cdc'
   name 'ActiveDock'
   homepage 'http://www.noteifyapp.com/activedock/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.