### PR TITLE
Update kite to 0.20180607.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,11 +1,11 @@
 cask 'kite' do
-  version '0.20180531.1'
-  sha256 '908433434244d73fcbf62c530cda5f07f1665034068237a3d0ceb653dd97b961'
+  version '0.20180607.0'
+  sha256 '2f469d9e42a6e25ff877bfb6c4923960d52753aad909007558f75f42b3e8bf48'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"
   appcast 'https://release.kite.com/appcast.xml',
-          checkpoint: '41178d0bd52ed0ab327adb933c8b2a93634c4de298948841b6279e1b96d3f7c3'
+          checkpoint: '1923e043a0566104e9432fb3a74b253cebc9380bc0d89223157b86006411cc04'
   name 'Kite'
   homepage 'https://kite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.