### PR TITLE
Update projectlibre to 1.8.0

### DIFF
--- a/Casks/projectlibre.rb
+++ b/Casks/projectlibre.rb
@@ -1,11 +1,11 @@
 cask 'projectlibre' do
   version '1.8.0'
-  sha256 'c25bed132701c929afeb649ff208c5a75620e20f02f63eb7b10dae207635fe28'
+  sha256 '0132bcf33b7e792ed0693888982b1163e5397c7820329188f0f916b2e0246ec7'
 
   # sourceforge.net/projectlibre was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/projectlibre/ProjectLibre/#{version.major_minor}/ProjectLibre-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/projectlibre/rss?path=/ProjectLibre',
-          checkpoint: '81de9423473f85272160e65781f4221e2c4e9cde9e9dfa8423744e93690a15b0'
+          checkpoint: '313162741ceef8c0b601acecd3dbb30484f765029cae1e7800408a1dd95a95b1'
   name 'ProjectLibre'
   homepage 'https://www.projectlibre.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.