### PR TITLE
docs: remove appcast checkpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ cask-repair --help
 cask-repair <outdated_cask>
 ```
 
-If there is a more complicated change, or there is a case where `cask-repair` fails (for example, where a Cask uses a [`url do` block](https://github.com/Homebrew/homebrew-cask/blob/60531a2812005dd5f17dc92f3ce7419af3c5d019/Casks/audacity.rb#L5#L15) or the [`language` stanza](https://github.com/Homebrew/homebrew-cask/blob/306b8fbd9502036f1ca742f70c569d8677b62403/Casks/firefox.rb#L4L74)), you can also follow the steps in [Adding a Cask](doc/development/adding_a_cask.md) to do the same thing manually. Remember to update the `version` and `shasum` values, as well as the appcast [`checkpoint`](doc/cask_language_reference/stanzas/appcast.md), if there is one.
+If there is a more complicated change, or there is a case where `cask-repair` fails (for example, where a Cask uses a [`url do` block](https://github.com/Homebrew/homebrew-cask/blob/60531a2812005dd5f17dc92f3ce7419af3c5d019/Casks/audacity.rb#L5#L15) or the [`language` stanza](https://github.com/Homebrew/homebrew-cask/blob/306b8fbd9502036f1ca742f70c569d8677b62403/Casks/firefox.rb#L4L74)), you can also follow the steps in [Adding a Cask](doc/development/adding_a_cask.md) to do the same thing manually. Remember to update the `version` and `shasum` values.
 
 
 ## Getting Set Up To Contribute

--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -122,8 +122,7 @@ sha256
 language
 
 url
-appcast,
-  checkpoint: # shown here as it is required with `appcast`
+appcast
 name
 homepage
 gpg, key_id: # on same line, since first part is typically small

--- a/doc/cask_language_reference/stanzas/appcast.md
+++ b/doc/cask_language_reference/stanzas/appcast.md
@@ -2,12 +2,6 @@
 
 The value of the `appcast` stanza is a string, holding the URL for an appcast which provides information on future updates.
 
-## Required Appcast Parameters
-
-| key           | value       |
-| ------------- | ----------- |
-| `checkpoint:` | a string holding a custom checksum of the most recent appcast which matches the current Cask versioning. Use `brew cask _appcast_checkpoint --calculate "{{appcast_url}}"` to calculate it.
-
 Example: [`atom.rb`](https://github.com/Homebrew/homebrew-cask/blob/4d5a2dd2376f42c726148cfccaefe839f21e42ab/Casks/atom.rb#L7L8)
 
 There are a few different ways the `appcast` can be determined:
@@ -24,4 +18,4 @@ There are a few different ways the `appcast` can be determined:
 
 * An appcast can be any URL hosted by the app’s developer that changes every time a new release is out (e.g. a changelog HTML page). (Example: [`shortcat.rb`](https://github.com/Homebrew/homebrew-cask/blob/60531a2812005dd5f17dc92f3ce7419af3c5d019/Casks/shortcat.rb#L6L7))
 
-The [`find_appcast`](https://github.com/Homebrew/homebrew-cask/blob/master/developer/bin/find_appcast) script can automatically identify some of these. You can run it with `"$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/find_sparkle_appcast" '{{/path/to/software.app'}}` to find the `appcast` and `checkpoint` automatically.
+The [`find_appcast`](https://github.com/Homebrew/homebrew-cask/blob/master/developer/bin/find_appcast) script can automatically identify some of these. You can run it with `"$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/find_appcast" '{{/path/to/software.app'}}` to find the `appcast` automatically.

--- a/doc/cask_language_reference/stanzas/appcast.md
+++ b/doc/cask_language_reference/stanzas/appcast.md
@@ -2,20 +2,20 @@
 
 The value of the `appcast` stanza is a string, holding the URL for an appcast which provides information on future updates.
 
-Example: [`atom.rb`](https://github.com/Homebrew/homebrew-cask/blob/4d5a2dd2376f42c726148cfccaefe839f21e42ab/Casks/atom.rb#L7L8)
+Example: [`atom.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/atom.rb#L7)
 
 There are a few different ways the `appcast` can be determined:
 
- * If the app is distributed via GitHub releases, the `appcast` will be of the form `https://github.com/{{user}}/{{project_name}}/releases.atom`. (Example: [`electron.rb`](https://github.com/Homebrew/homebrew-cask/blob/14f8510e4466f1409feb0de4a309c21f5395aefe/Casks/electron.rb#L7L8))
+ * If the app is distributed via GitHub releases, the `appcast` will be of the form `https://github.com/{{user}}/{{project_name}}/releases.atom`. (Example: [`electron.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/electron.rb#L7))
 
- * The popular update framework [Sparkle](https://sparkle-project.org/) generally uses the `SUFeedURL` property in `Contents/Info.plist` inside `.app` bundles. (Example: [`glyphs.rb`](https://github.com/Homebrew/homebrew-cask/blob/e7cb7464e58b01b641da64f6016761411fbaef12/Casks/glyphs.rb#L6L7))
+ * The popular update framework [Sparkle](https://sparkle-project.org/) generally uses the `SUFeedURL` property in `Contents/Info.plist` inside `.app` bundles. (Example: [`glyphs.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/glyphs.rb#L6))
 
-* HockeyApp URLs are of the form `https://rink.hockeyapp.net/api/2/apps/{{hexadecimal_string}}{{something_else}}`. For the `appcast`, remove `{{something_else}}` (ending up with `https://rink.hockeyapp.net/api/2/apps/{{hexadecimal_string}}`. (Example: [`iconjar.rb`](https://github.com/Homebrew/homebrew-cask/blob/190c98214e699be43f00ab91780d9184a96c7525/Casks/iconjar.rb#L7L8))
+* HockeyApp URLs are of the form `https://rink.hockeyapp.net/api/2/apps/{{hexadecimal_string}}{{something_else}}`. For the `appcast`, remove `{{something_else}}` (ending up with `https://rink.hockeyapp.net/api/2/apps/{{hexadecimal_string}}`. (Example: [`canary.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/canary.rb#L7))
 
-* DevMate appcasts resemble `https://updates.devmate.com/{{app_bundle_id}}.xml`. (Example: [vox.rb](https://github.com/Homebrew/homebrew-cask/blob/e705f44d58ca093d478f8bb07b6d3aa83ba2fce4/Casks/vox.rb#L7L8))
+* DevMate appcasts resemble `https://updates.devmate.com/{{app_bundle_id}}.xml`. (Example: [screens.rb](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/screens.rb#L7))
 
-* Sourceforge projects follow the form `https://sourceforge.net/projects/{{project_name}}/rss`. A more specific page can be used as needed, pointing to a specific directory structure: `https://sourceforge.net/projects/{{project_name}}/rss?path=/{{path_here}}`. (Example: [`seashore.rb`](https://github.com/Homebrew/homebrew-cask/blob/60531a2812005dd5f17dc92f3ce7419af3c5d019/Casks/seashore.rb#L6L7))
+* Sourceforge projects follow the form `https://sourceforge.net/projects/{{project_name}}/rss`. A more specific page can be used as needed, pointing to a specific directory structure: `https://sourceforge.net/projects/{{project_name}}/rss?path=/{{path_here}}`. (Example: [`seashore.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/seashore.rb#L6))
 
-* An appcast can be any URL hosted by the app’s developer that changes every time a new release is out (e.g. a changelog HTML page). (Example: [`shortcat.rb`](https://github.com/Homebrew/homebrew-cask/blob/60531a2812005dd5f17dc92f3ce7419af3c5d019/Casks/shortcat.rb#L6L7))
+* An appcast can be any URL hosted by the app’s developer that changes every time a new release is out (e.g. a changelog HTML page). (Example: [`razorsql.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/razorsql.rb#L6))
 
 The [`find_appcast`](https://github.com/Homebrew/homebrew-cask/blob/master/developer/bin/find_appcast) script can automatically identify some of these. You can run it with `"$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/find_appcast" '{{/path/to/software.app'}}` to find the `appcast` automatically.

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -15,8 +15,7 @@ cask 'shuttle' do
 
   # github.com/fitztrev/shuttle was verified as official when first introduced to the cask
   url "https://github.com/fitztrev/shuttle/releases/download/v#{version}/Shuttle.zip"
-  appcast 'https://github.com/fitztrev/shuttle/releases.atom',
-          checkpoint: 'c3dea2ed479b3ebba7c56ace6040901795f6dc6be92f9ffc30cc808d31723f17'
+  appcast 'https://github.com/fitztrev/shuttle/releases.atom'
   name 'Shuttle'
   homepage 'https://fitztrev.github.io/shuttle/'
 
@@ -49,8 +48,7 @@ cask 'airdisplay' do
   sha256 'db84a66fe3522929a0afa58a4fe0189977baded89df0035ead1ccd334f7b8126'
 
   url "https://www.avatron.com/updates/software/airdisplay/ad#{version.no_dots}.zip"
-  appcast 'https://avatron.com/updates/software/airdisplay/appcast.xml',
-          checkpoint: '938bdb9fbee793dce92818366cb2c19ba84c5b0cd6853fd893897d4a40689bc2'
+  appcast 'https://avatron.com/updates/software/airdisplay/appcast.xml'
   name 'Air Display'
   homepage 'https://avatron.com/apps/air-display/'
 


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/48051 

https://github.com/Homebrew/brew/pull/4310

~~`appcast.md` needs to be updated with new examples which we can't do until the checkpoints have been removed from the casks.~~