### PR TITLE
Update omnioutliner to 5.3.1

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,10 +1,10 @@
 cask 'omnioutliner' do
-  version '5.3'
-  sha256 '14109560270bdc8bf7dec9f511896e67549864799b4851d85ee6b587ed56ab39'
+  version '5.3.1'
+  sha256 'b307f8e735486c03b6f77099da78c73a51be1f87c7e730161880a7139cb5f376'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}",
-          checkpoint: '31f197afde53bbfd9107cb329facd026fefacb23af55a0a8232974936e8139c3'
+          checkpoint: 'c7f3d91a1a4e5640d2ed5e4ec26a15f4cecbefc4095a0514aa744df09dea21c9'
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.