### PR TITLE
Update securityspy to 4.2.5

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,10 +1,10 @@
 cask 'securityspy' do
-  version '4.2.4'
-  sha256 '9a21f957622a79b8145079383ee8283151a249a57bce89d2da37d4ed137f6a61'
+  version '4.2.5'
+  sha256 '476e628ce9348c8f55fe6d0dec83ad03607850f6146dc815be15bcf96093db3e'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html',
-          checkpoint: '1d4929d379e0bae248512f8c90556374fb5a93e37bd558a4762afe60cde3f246'
+          checkpoint: '75ac1c4adf2e9cda71cc18fe8dc2c103c9e48b218e4762eb8e4c84a6516276c0'
   name 'SecuritySpy'
   homepage 'https://www.bensoftware.com/securityspy/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.