### PR TITLE
Update get-backup-pro to 3.4.5

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,11 +1,11 @@
 cask 'get-backup-pro' do
-  version '3.4.4'
-  sha256 'b3014bfdf32204a4b112a5769ffe3acf614f06feccbeb41574d0881fbdb51860'
+  version '3.4.5'
+  sha256 '784ffe7c34e32ff65046059788deac6b190651b47c570265e4074a2b132d2fae'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"
   appcast "https://www.belightsoft.com/download/updates/appcast_getbackup_pro#{version.major}.xml",
-          checkpoint: '405ecdcaa9c05435bf80207982e48395d5f7a845d3acd476a8bd5ace404e8cb2'
+          checkpoint: '507d215b61bcd6493e08d33bbaa8a6385a0db59b1312d10b38c23d89696eaeb6'
   name "Get Backup Pro #{version.major}"
   homepage 'https://www.belightsoft.com/products/getbackup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.