### PR TITLE
Update navicat-for-mariadb to 12.0.27

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.26'
-  sha256 '9bc5fa194c2942616c28556f791ed5ee15f4dddb8fdfd2e135bf59964b61679c'
+  version '12.0.27'
+  sha256 '64233e3df4ce64c3cef78ac61640dcbd8d271a76a50c45b717c66e6b8ece7d73'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast "https://www.navicat.com/updater/v#{version.major_minor.no_dots}/sysProfileInfo.php?appName=Navicat%20for%20MariaDB",
-          checkpoint: '5672f5fc3ce552392468292b5de2ae655c1f6d5093ca35835310aca648ac7c01'
+          checkpoint: '850468fd6a883574f503a94af9dce9380e9956c33069bba9665cacff50ca51ea'
   name 'Navicat for MariaDB'
   homepage 'https://www.navicat.com/products/navicat-for-mariadb'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.