### PR TITLE
Update navicat-for-mysql to 12.0.27

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-mysql' do
-  version '12.0.26'
-  sha256 '6c45e085ad885f7a11164d5485edff37f6e2753fe6569d48bb89e1b8cee6687c'
+  version '12.0.27'
+  sha256 'd5cad433d6c765b04c895b5224b55270c6431b2992ee42457833f2e4bdd7766a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast "https://www.navicat.com/updater/v#{version.major_minor.no_dots}/sysProfileInfo.php?appName=Navicat%20for%20MySQL",
-          checkpoint: 'e184c34990da1d3a1bd080f3498c968a459f0e4b798a6047eff350372e935149'
+          checkpoint: 'a8c26c35c43fc4d5eb1a71f8e4307c8220b48a2627b302db58e114c0141fe2a3'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.