### PR TITLE
Update navicat-for-oracle to 12.0.27

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-oracle' do
-  version '12.0.26'
-  sha256 'ef78fe563d4fc46e36f3aff801707accb4386f41a4a467974c10bd0c4e83e916'
+  version '12.0.27'
+  sha256 '42f555c081e8f008a835ba0b6a493c8ac980832dfdce40acf36e94aef3e21f62'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast "https://www.navicat.com/updater/v#{version.major_minor.no_dots}/sysProfileInfo.php?appName=Navicat%20for%20Oracle",
-          checkpoint: '207d327121aa651fc9d3d5adcca51a708ae56a94f89bb08eea45458d30263eeb'
+          checkpoint: 'b15f8ab43ee4de517988256d7c19620d881c90d53aaecb989813dd7187e3716b'
   name 'Navicat for Oracle'
   homepage 'https://www.navicat.com/products/navicat-for-oracle'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.