### PR TITLE
Update endicia to 2.18.2,v750

### DIFF
--- a/Casks/endicia.rb
+++ b/Casks/endicia.rb
@@ -1,8 +1,8 @@
 cask 'endicia' do
-  version '2.18.2,v750'
+  version '2.18.2,750'
   sha256 '6331785174da80eaeb68b7451d12fa883c2bd70a796ce754e155fcf26ffc1892'
 
-  url "https://download.endiciaformac.com/EndiciaForMac#{version.before_comma.no_dots}#{version.after_comma}.dmg"
+  url "https://download.endiciaformac.com/EndiciaForMac#{version.before_comma.no_dots}v#{version.after_comma}.dmg"
   appcast 'https://s3.amazonaws.com/endiciaformac/EndiciaForMacSparkle.xml',
           checkpoint: '6919823a9de15d0f7083ab56ac28c736eb0d3e7a3def53acbacc7484a3c2ad93'
   name 'Endicia for Mac'

--- a/Casks/endicia.rb
+++ b/Casks/endicia.rb
@@ -1,10 +1,10 @@
 cask 'endicia' do
-  version '2181v747'
-  sha256 '04cc596b2ddc217eba402be79580f4f62bced466d0c481e3eecccae24a2a3f38'
+  version '2.18.2,v750'
+  sha256 '6331785174da80eaeb68b7451d12fa883c2bd70a796ce754e155fcf26ffc1892'
 
-  url "https://download.endiciaformac.com/EndiciaForMac#{version.no_dots}.dmg"
+  url "https://download.endiciaformac.com/EndiciaForMac#{version.before_comma.no_dots}#{version.after_comma}.dmg"
   appcast 'https://s3.amazonaws.com/endiciaformac/EndiciaForMacSparkle.xml',
-          checkpoint: '7c1ef8af297627665d30038a42a4f133e714131d12434c47d0e89af39d3b74b0'
+          checkpoint: '6919823a9de15d0f7083ab56ac28c736eb0d3e7a3def53acbacc7484a3c2ad93'
   name 'Endicia for Mac'
   homepage 'https://endiciaformac.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.