### PR TITLE
Update navicat-for-postgresql to 12.0.27

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.26'
-  sha256 'a86c818d32692ca322025e9a24cfef5ddd2cf5c7e971f8c141f7d1309b186687'
+  version '12.0.27'
+  sha256 '3b0d5ddf1b3b79aeb58305457ea75b8ca159d6f8b683f469896cd28cacb896e1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast "https://www.navicat.com/updater/v#{version.major_minor.no_dots}/sysProfileInfo.php?appName=Navicat%20for%20PostgreSQL",
-          checkpoint: 'd7f00d4f071ba8c1e132db5754f82b0f10d815d35d1c465b6f7bacb1c4ea2f8d'
+          checkpoint: '7fa1010737cc6b8e4553aecc358c034afa41e95f7b2d7b1a7bf52d3aa16a0ba0'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.