### PR TITLE
Update navicat-for-sql-server to 12.0.27

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,10 +1,10 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.26'
-  sha256 '3ae0f46eb7166a1ccdc9efb19cd19d34001eaadba5a2dc9ed45195011f2e2df8'
+  version '12.0.27'
+  sha256 '0f12cd141c16f4b86dd81cfc9ad574816acf69fdc4753ffeaae71b3522ff56d2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast "https://www.navicat.com/updater/v#{version.major_minor.no_dots}/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server",
-          checkpoint: 'b839fde860c9b7563f625167480c9a8d0f265c73de8959c7043e5ba8aee556ba'
+          checkpoint: '65d21b4919e829d6d959a428a2d5434855d3554b58e7d8a928932ef39fb1eddb'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.