### PR TITLE
Update joplin to 1.0.97

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,11 @@
 cask 'joplin' do
-  version '1.0.96'
-  sha256 '643373e4b98456143691460233532f2ac6962421e63562d080fe754061747c22'
+  version '1.0.97'
+  sha256 '27e089c9d51ca21ce9f6a18e207e4c4e24d8be9f197957a530da6a3b9fa32175'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast 'https://github.com/laurent22/joplin/releases.atom',
-          checkpoint: '384ff9e31e2007b304bbe19a424035b7deec11cf37e27f0a329a80a960851ff9'
+          checkpoint: 'c0d83abaa85e879bab57cf4918bebbe21cd6315ed6f68c68e42f1c2259f5f0d0'
   name 'Joplin'
   homepage 'http://joplin.cozic.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.