### PR TITLE
Update netron to 1.8.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,10 +1,10 @@
 cask 'netron' do
-  version '1.8.5'
-  sha256 '3aa5713395be2e53940fbd31c260293f4a6a2b762c51bb228b54e7c84bf120f4'
+  version '1.8.6'
+  sha256 '2f76b9eb8f5bcbba7f558d184a0a35377bb623a207f6cc2469f40d9906a359fe'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom',
-          checkpoint: '457895f2ec86b07fa61d4bb0ac082c0e2663850e434628ac17308f3d8289b973'
+          checkpoint: '441703f881996321eebf9236b7b18e70214259ea790ff1aa625d9694edd85b0a'
   name 'Netron'
   homepage 'https://github.com/lutzroeder/Netron'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.