### PR TITLE
Update firefox to 60.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,125 +1,125 @@
 cask 'firefox' do
-  version '60.0.1'
+  version '60.0.2'
 
   language 'cs' do
-    sha256 '2d5af247fe9c77b6463304e2e11bc2a94c9fa29dcb041bdb4b74b9c21f31b653'
+    sha256 'd92ebcfaf3d4ee83fa751fc841d40c7dbb7608da60f16fcebe44fc90924a8691'
     'cs'
   end
 
   language 'de' do
-    sha256 '634aa70168d70e32058c6263f156af229c4965642225763a30ec91609cf81dee'
+    sha256 'c892ac02f430acc4f868820d638204f3e8dd5ac0a831536f7b5adf79ed49cec6'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'f71618820e92e7c25622c03b25b8d95d4f3195a8f1ddabba79871e1c9bc49243'
+    sha256 '5bf7a7da30df668dbc9a619130319e3aebf0807bd0035a4c956fc138e5b60e93'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '4a052833a88ce8603c719ccdcd08b8f32ae5eb3be26f61120a6f13c48eefdb49'
+    sha256 'c229cf2135a1380dfcd1439c15ebb7a36df6b3055dc2e07da584404a6414d732'
     'en-US'
   end
 
   language 'es-AR' do
-    sha256 'a00b25cd799f828a77e7dc08c96336bb42704f5b9a69caab88e2a581bf8637f5'
+    sha256 '233a35377d17cbe21d8dba583903de91e9be5de0467932dde437acf5ebc51019'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '5ad09569e19305b2e0ad040072f4c4c77b3b6ac88913609eaaeea5ca6bddc33b'
+    sha256 '9da09191ae6c64d43afac2f327eeb212eaefc82680a4b64de85a2f91a786c88d'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '12d46b1dc8cc86cb0919957d45b548787ff4bfbbfb600019bf0da016128ac259'
+    sha256 'cdda88ac2798e8ffe53a77ffd2def4ec7486640f156ac4de213b815babe5fc98'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '4f406cc3054538951486177baac32db3e1230db1429e09ba5d43c0a76d3312b5'
+    sha256 '227ded7418d544f67916504c3f5d390f3e9f17075ac4d8ef9024e832bc2fdfc6'
     'fi'
   end
 
   language 'fr' do
-    sha256 '2df259508cc3c0d708eae963a4ca7028f41c16ee5d99d44b9c9a98e784bd84c8'
+    sha256 'a25c80c64e0073b81a8c06c263418cfebc07e57c18c81051a832ed75f0e62ef5'
     'fr'
   end
 
   language 'gl' do
-    sha256 'b42601d97d3b31e3267c4d2482d20e3e2ec632d37de7fbc106dff0bf0c07bd20'
+    sha256 '394f3fff26794a6e4dd75c58b161a0b4fdc2d94958ea38d5689201245288f087'
     'gl'
   end
 
   language 'in' do
-    sha256 '6573bc66c529936f19b2a5b1280119d7b4446c6fd649c628a942fc0276040930'
+    sha256 'df642f59d0f76344de9562abd05eb672d5dbb8f8c5c9c42a2da5379305dd67d7'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '29a79ad59fcc2777a458f3ec37d1c954fe97c87f557191da53b908ed420d9676'
+    sha256 'f8a202d77162d960186c5ed9a2ee01d98d856dda583914629269a53963b1a605'
     'it'
   end
 
   language 'ja' do
-    sha256 '240c7f0c8b36eca9f60b58bb54ffd554955e6069cf41116a3882fb347f93b557'
+    sha256 'e5b176c48acdfa0158cf36ad06c41c5d8528d1c89147c9052d0d72ff416c3f7f'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 'de3908356fd99ce9d314d9df154a41598fb0270b50948732d4bb74972ec5c070'
+    sha256 '333595c5020c25e8058a74e134c915ee629e7642e954a817f8a61af49511d24b'
     'ko'
   end
 
   language 'nl' do
-    sha256 'db7bc4bba4bcfea8fe0cb2a10d9106bc87d076611b1dcc100c2c9d7c876630ed'
+    sha256 '38f849f2735cfebc9c06a30992f669e05e217b97a113b5feb84f531475daa67a'
     'nl'
   end
 
   language 'pl' do
-    sha256 '80283e1c7bad3fb9f30f92fa6e87a44ab8e77200b0524fe3d039262d4da39297'
+    sha256 '942f435dc7fee1355df8cfad3a609a5a4fd2072f146a8e71fdea5da863efe35d'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '17e6fedf953fb4dbad4927c60ef3379f93395ee6bc648a7bb2f399d2b58b9e60'
+    sha256 '02be4aa79209dd4266cd9afe0decada2c3d2b00f32ed2e16384ce0c39b904802'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'e90c0b0cb92d73010b58df89155ed49782cc7b5feaf896367e1fd41c357cf932'
+    sha256 '373719bde17a873c30f9fdfb35e0817fcb205113044e657b5bd66f2e4ff97d87'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '786ae9eff46327b04b60e74c426f99fb885bb8e50e314efde72bbff587f205ea'
+    sha256 '6211c0c8c1611d1d6138363ff91b6c96a2f973c378f03544b6d52d894c0d721f'
     'ru'
   end
 
   language 'tr' do
-    sha256 '889c5da81bd1f5132cd0fdeac6dcdecaa54108bca6a9908bef4ef25098ef8ac8'
+    sha256 '60146eb5d408faf7d78cc7808324724df548b7feab9da4a0e5c599af53e47f53'
     'tr'
   end
 
   language 'uk' do
-    sha256 '82bbc32724043b020d732b4e8474bbe5d3c51fa1f6ffba8d377da63e8a7b13bf'
+    sha256 'bf4aaa2f5fa37ad86f9500f28be8c4f7619457b576ebf08f9627095dde980eff'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '4e4e2e39b994d155604ec9b344be197a7a110eb94bbd0c2153f084b345392065'
+    sha256 '5be1b1d92fa68a11dd397f42b118d70fa5ac2ea85e5710ccae5c891f695c837c'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '3379ee85e903c54cda37ef9e08e4c0738b0aec405d688cf9c44e96ccc548bbaa'
+    sha256 'cfe814aaf256a04901ab3d2df4b721f8557e7c03bda15fdedd00ca026aaca999'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/firefox/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://aus5.mozilla.org/update/3/Firefox/#{version}/0/Darwin_x86_64-gcc3-u-i386-x86_64/en-US/release/Darwin%2015.3.0/default/default/update.xml?force=1",
-          checkpoint: '5be888d798ce9dc2e37d57ff85c37e4d7af2f840fe75caaf79ede5ed98a091fd'
+          checkpoint: '63d565da96b8b497fd9182bf01b942e664572d5867bdfc9c6b0d38e16e6bd08a'
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
