### PR TITLE
Update yandex-disk 3.0 checksum

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
   version '3.0'
-  sha256 'd5f9c1b43faeb99e30e203c612d678cbe6d2f08d187c74e7cf1c6e7efac5c53c'
+  sha256 'dac1f0e1710bc06b59a872148c940fbd15f8e34e4e5e22009caba5d67163f888'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.no_dots}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

VirusTotal (container is not signed): https://www.virustotal.com/#/file/dac1f0e1710bc06b59a872148c940fbd15f8e34e4e5e22009caba5d67163f888/details