### PR TITLE
Update soundcloud-downloader to 2.8.2

### DIFF
--- a/Casks/soundcloud-downloader.rb
+++ b/Casks/soundcloud-downloader.rb
@@ -1,6 +1,6 @@
 cask 'soundcloud-downloader' do
-  version '2.8.1.2'
-  sha256 '1d7dec3157b37a1a97eace31078aa16bcc4a40af62f792e3d12b53472486736c'
+  version '2.8.2'
+  sha256 'b83cded033e9fd2211171cd2bd40dfefb3e328944f81a34ec49c2a487f296b16'
 
   url "https://black-burn.ch/app/SCD2/download/#{version}"
   appcast 'https://black-burn.ch/apps/SCD2/updates/gold.xml?hwni=1',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.