### PR TITLE
Update jupyter-notebook-viewer to 0.1.2

### DIFF
--- a/Casks/jupyter-notebook-viewer.rb
+++ b/Casks/jupyter-notebook-viewer.rb
@@ -1,10 +1,10 @@
 cask 'jupyter-notebook-viewer' do
-  version '0.1.1'
-  sha256 '4157b2d79185027d9c67c3c4d6e1b0cd4da8d3c0587bda296125d945f278a863'
+  version '0.1.2'
+  sha256 'd8d38a77f59613dc94c68f48f95729685ecba0efdccfc8bfb3d2488bfd3a3164'
 
   url "https://github.com/tuxu/nbviewer-app/releases/download/#{version}/nbviewer-app.zip"
   appcast 'https://github.com/tuxu/nbviewer-app/releases.atom',
-          checkpoint: '91dd5229cdb8130c9c101554af84b040555fc8600d774b2729b363ed76e5a7c3'
+          checkpoint: '15f5d75a1047f7c338495ec8b0ce3c8cee77b13ae13c88f02aca9db6d9fce1eb'
   name 'Jupyter Notebook Viewer'
   homepage 'https://github.com/tuxu/nbviewer-app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.