### PR TITLE
Update android-sdk to 4333796

### DIFF
--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -1,6 +1,6 @@
 cask 'android-sdk' do
-  version '3859397'
-  sha256 '4a81754a760fce88cba74d69c364b05b31c53d57b26f9f82355c61d5fe4b9df9'
+  version '4333796'
+  sha256 'ecb29358bc0f13d7c2fa0f9290135a5b608e38434aad9bf7067d0252c160853e'
 
   # dl.google.com/android/repository was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/sdk-tools-darwin-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.