### PR TITLE
Update tortoisehg to 4.6.0

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.5.3'
-  sha256 '5018ad81bdc02f3ffa4c1cc683c2ea6d6a7ab60bdd418e8c2629349aa4deaeed'
+  version '4.6.0'
+  sha256 '843c9961ec4672cde1fad7671bcab3e7f4e226485b44de4b0b8cb50c7572466b'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64-qt5.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.