### PR TITLE
Cask for tn3270-x v3.4.0 from Brown University

### DIFF
--- a/Casks/tn3270-x.rb
+++ b/Casks/tn3270-x.rb
@@ -2,9 +2,9 @@ cask 'tn3270-x' do
   version '3.4.0'
   sha256 'a2e405dba632f6e2a72d0f6d3ed4ac622750fdf1ad67d3c63e2dd964914297ee'
 
-  url 'https://www.brown.edu/cis/tn3270/tn3270_X_3.4.0.dmg'
+  url "https://www.brown.edu/cis/tn3270/tn3270_X_#{version}.dmg"
   name 'tn3270 for the Macintosh'
-  homepage 'https://www.brown.edu/cis/tn3270/index.html#latest'
+  homepage 'https://www.brown.edu/cis/tn3270/index.html'
 
   app 'tn3270 X.app'
 end

--- a/Casks/tn3270-x.rb
+++ b/Casks/tn3270-x.rb
@@ -1,0 +1,10 @@
+cask 'tn3270-x' do
+  version '3.4.0'
+  sha256 'a2e405dba632f6e2a72d0f6d3ed4ac622750fdf1ad67d3c63e2dd964914297ee'
+
+  url 'https://www.brown.edu/cis/tn3270/tn3270_X_3.4.0.dmg'
+  name 'tn3270 for the Macintosh'
+  homepage 'https://www.brown.edu/cis/tn3270/index.html#latest'
+
+  app 'tn3270 X.app'
+end


### PR DESCRIPTION
tn3270-x is free TN3270 terminal emulator for IBM z/OS Mainframe access.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ X] `brew cask audit --download {{cask_file}}` is error-free.
- [ X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [X ] Named the cask according to the [token reference].
- [ X] `brew cask install {{cask_file}}` worked successfully.
- [ X] `brew cask uninstall {{cask_file}}` worked successfully.
- [ X] Checked there are no [open pull requests] for the same cask.
- [ X] Checked the cask was not already refused in [closed issues].
- [ X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
