### PR TITLE
Update boinc to 7.10.3

### DIFF
--- a/Casks/boinc.rb
+++ b/Casks/boinc.rb
@@ -1,6 +1,6 @@
 cask 'boinc' do
-  version '7.10.2'
-  sha256 '6e4768e094dac585996f5ae0cd715cc7a292d9db55191f2932999a54818417b0'
+  version '7.10.3'
+  sha256 '9da911bdcff87e088b8a9de3cb0862b8a53074df75a597936c11654b787493c1'
 
   url "https://boinc.berkeley.edu/dl/boinc_#{version}_macOSX_x86_64.zip"
   name 'Berkeley Open Infrastructure for Network Computing'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.