### PR TITLE
Update hbuilder to 9.0.8

### DIFF
--- a/Casks/hbuilder.rb
+++ b/Casks/hbuilder.rb
@@ -1,6 +1,6 @@
 cask 'hbuilder' do
-  version '9.0.6'
-  sha256 '7802470184fee4b7355c10bca6e39898b696926ecdfb258bc08b2fdfda80aa96'
+  version '9.0.8'
+  sha256 'fe6ee1b2fe12fa4312362278bbcbbf9d817f0644fcc60097bb465f14d36a36ef'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "http://download.dcloud.net.cn/HBuilder.#{version}.macosx_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.