### PR TITLE
Update activedock to 140,1528723167

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,11 +1,11 @@
 cask 'activedock' do
-  version '138,1528354382'
-  sha256 'd7aacff9205ddf54f52be8ce4ee5840b5c2ed62fd7cb41fa90a80b0825a7eed3'
+  version '140,1528723167'
+  sha256 '9d43460823fd7ba1e8a3c35a617148804ccd373fe5e588706a2367425555d278'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.sergey-gerasimenko.ActiveDock.xml',
-          checkpoint: '7f6d69b7204d68153b841f7965cbd4ea42f568f3f63f35469f08502ec3675cdc'
+          checkpoint: 'd0b6f1b431d7a56b3f7efc7843d0b1b52811beabffd764382c9915861b5deb6b'
   name 'ActiveDock'
   homepage 'http://www.noteifyapp.com/activedock/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.