### PR TITLE
Update avidemux to 2.7.1

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,11 +1,11 @@
 cask 'avidemux' do
-  version '2.7.0'
-  sha256 '52257cef2bf5b0a844188af920184f82c3f7cc68ccf13e902a6f8adc8fcad849'
+  version '2.7.1'
+  sha256 'e45507e8f4fd501061136956527f0a9492c18254547d5dec3c38dce91aea2db6'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Sierra_64Bits_Qt5.dmg"
+  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_HighSierra_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux',
-          checkpoint: '4547fdff94b92356f2597f8983c7616df1efac7209f72bb962427b888bc2185c'
+          checkpoint: 'fefa1e1da6b3e6fc1e11852c92f68024f1fa0f70b34565e1841ef58b45b134bf'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.