### PR TITLE
Update cacher to 1.5.5

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,11 +1,11 @@
 cask 'cacher' do
-  version '1.5.4'
-  sha256 'a3c5998baedfee1d6bc55ba6aff12f3c8bed718f6553162846ecea58588727c1'
+  version '1.5.5'
+  sha256 '9c7eeb05560b4b0c427d79cee91fb9631c79180348e15fd90ddc713ac9b7a6c3'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"
   appcast 'https://cacher-download.nyc3.digitaloceanspaces.com/latest-mac.json',
-          checkpoint: '14fa515781508d4e6bf50b264eb9fc3b30dfe9f7b3102169743b012e0e377c69'
+          checkpoint: 'b6aed2b14474063b8b7384c20a36d8743788b93b1f83c4e1083a73a4669b705c'
   name 'Cacher'
   homepage 'https://www.cacher.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.