### PR TITLE
Update outline-manager to 1.1.1

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,11 +1,11 @@
 cask 'outline-manager' do
-  version '1.0.7'
-  sha256 '476d3a5993b391b0275179348d8aea42fe5ece018f46373e227d1d82fc360579'
+  version '1.1.1'
+  sha256 'bb43a5d80f96f0ec28c48c8d648bb579e9c33ddaa7abf5986a13932ea51c476b'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"
   appcast 'https://github.com/Jigsaw-Code/outline-server/releases.atom',
-          checkpoint: 'a0b7f418fea518581cab1c8de9f221d2a233dc3939a0706d8a0b265ae7ad0093'
+          checkpoint: '9855dda731018f9e60a8fb1b6e0b55f059d3ea593d12b7ceafe64b155cb6835d'
   name 'Outline Manager'
   homepage 'https://www.getoutline.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.