### PR TITLE
Update delicious-library to 3.7.2

### DIFF
--- a/Casks/delicious-library.rb
+++ b/Casks/delicious-library.rb
@@ -1,10 +1,10 @@
 cask 'delicious-library' do
-  version '3.7.1'
-  sha256 '5b1bbee0f634ccfcb8d955e147f64be53e23b450ffa83627145dac88ee3d5e7f'
+  version '3.7.2'
+  sha256 '63aeb949ff185823d88260902dc3e246df7e5d133067fa1383f5710b40872d2c'
 
   url "https://delicious-monster.com/downloads/DeliciousLibrary#{version.major}/v#{version}/DeliciousLibrary#{version.major}.zip"
   appcast "https://www.delicious-monster.com/downloads/DeliciousLibrary#{version.major}.xml",
-          checkpoint: '92cff2a42d246d770b1a01a97d1333789e49acf823f0ad3cf45e9cd1c5114a86'
+          checkpoint: 'f36536746924a29b793fb858785f7965628fcc94b916947cc24fd13475cc3c8b'
   name 'Delicious Library'
   homepage 'https://delicious-monster.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.