### PR TITLE
Update manager to 18.5.45

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.42'
-  sha256 '9cba3f5cf39c4f0a5ff9ecc4b42f6c46fdc414520f2220663cc13f9c13a15f2e'
+  version '18.5.45'
+  sha256 'acafaed2ec57406e53e3fec564d6c14e3298aba800cc137adb10b90a60430a68'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.