### PR TITLE
Update pokertracker to 4.15.3

### DIFF
--- a/Casks/pokertracker.rb
+++ b/Casks/pokertracker.rb
@@ -1,6 +1,6 @@
 cask 'pokertracker' do
-  version '4.14.25'
-  sha256 'd788ff1bc28a83b9c22ff4b2c10e92849aab4c0fc1e1171043030101a5dc6897'
+  version '4.15.3'
+  sha256 '9751eb70dfc0747692c4565c4604dc79c335e69fa558507b8d15f15f5d2f4dbd'
 
   # s3-us1.ptrackupdate.com was verified as official when first introduced to the cask
   url "http://s3-us1.ptrackupdate.com/releases/PT-Install-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.