### PR TITLE
Update zotero to 5.0.49

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.48'
-  sha256 '6ccede2d8276b82b1090dc23332e1b6904dcd6f25fa30b18f90daf3983b5f761'
+  version '5.0.49'
+  sha256 'a550c6419908995004a7effe66aa832fdbbea7fc5924c628423c7d5fd9fdc56c'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.