### PR TITLE
Update faviconographer to 1.1.2

### DIFF
--- a/Casks/faviconographer.rb
+++ b/Casks/faviconographer.rb
@@ -1,6 +1,6 @@
 cask 'faviconographer' do
-  version '1.1'
-  sha256 'bfe2345839220e0b90ffcf4ac5d5067466ba37e4347a703107a8218af19a85c7'
+  version '1.1.2'
+  sha256 'e0b099a9a6a86d24541a75704f5cbd9a991a12e3787ae7bfbc6c224dbadbba06'
 
   url "https://faviconographer.com/download/Faviconographer-#{version}.dmg"
   appcast 'https://faviconographer.com/updates/faviconographer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.