### PR TITLE
Update flightgear to 2018.2.2

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask 'flightgear' do
-  version '2018.2.1'
-  sha256 'e2e82e0c2ae157f1dcab0667c2e2878826756c2b723c3039ece7823807244886'
+  version '2018.2.2'
+  sha256 '9028e0ac60d145f5ca5fce5afe7ef86f9eecae60cead34d21d2fbbeaa3030fe2'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.