### PR TITLE
Update journey to 2.6.11

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,6 +1,6 @@
 cask 'journey' do
-  version '2.6.9'
-  sha256 '60bbdec894e63a82ec3a15f683cad444142f08d938096dfc073e1002fa6f953e'
+  version '2.6.11'
+  sha256 'b34ea2a6f7d00ab6c5eaa91f98a434da8dcac615837d86f905edca865d17828c'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
   url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-x64-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.