### PR TITLE
Update kitty to 0.11.0

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,6 +1,6 @@
 cask 'kitty' do
-  version '0.10.1'
-  sha256 '630e11f748b51b27c41a8d304e590866790b93e506390b8c481ca27201ca1149'
+  version '0.11.0'
+  sha256 '0e0745b208bb5ce6eb69f50ccc1637c6450dcba266a7d2a1865e78686df028fe'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.