### PR TITLE
Update prusa-slic3r to 1.40.0,201806121009

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,6 +1,6 @@
 cask 'prusa-slic3r' do
-  version '1.39.2,201805041531'
-  sha256 '57431549e6ac7251579c67a2e2826a8ad7dd62678b4b5ce39976390be3056392'
+  version '1.40.0,201806121009'
+  sha256 '1c5dbebddd24c2600e855028f39f29a74215e03201133a81a43b6c9bdd313f50'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3rPE-#{version.before_comma}.full-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.