### PR TITLE
Update riot to 0.15.5

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,6 +1,6 @@
 cask 'riot' do
-  version '0.15.4'
-  sha256 '0d47cc76e2bbf8e45ced3e2138ca791ae1ae16cfc69df358b71efe1b65290059'
+  version '0.15.5'
+  sha256 '2db9105fa909a6cb6b51f4859868acd34e833a87ecd02263839c30412251ccdf'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-web/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.