### PR TITLE
Update typinator to 7.6

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,6 +1,6 @@
 cask 'typinator' do
-  version '7.5'
-  sha256 '9d136970946511132a7af1ebbdfa1aa3310a2e1e122fc1a54a5b16f7c99cf020'
+  version '7.6'
+  sha256 '148155fc028494ee3821c97dbf4dc03e507335b56adcdf0c5d583fea87d169dc'
 
   url "http://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.