### PR TITLE
Update glyphs to 2.5.2-1149

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.5.2-1146'
-  sha256 '624106132847fd3f1a81e9ae0b19d515a9c415cd5919a92eaf8926d6f203120e'
+  version '2.5.2-1149'
+  sha256 '624b1bdf0062a6e59491cc5ffdfd146fd49450c94cd4eee021e3300ec48e6f1f'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.