### PR TITLE
Update microsoft-teams to 1.1.00.14353

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-teams' do
-  version '1.1.00.11551'
-  sha256 '5239931c11303c89c10646600b01a847581f6e5d21974c847e29d04475cbcd93'
+  version '1.1.00.14353'
+  sha256 'edbd96e266a14d52e810cbb2b41e41789394d3e5ee1bbdc1e848948efcb835e7'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.