### PR TITLE
Update provisionql to 1.4.1

### DIFF
--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -1,6 +1,6 @@
 cask 'provisionql' do
-  version '1.4.0'
-  sha256 'c2d4b48f3e6f191fc9daafad67941caadf60b4023085849d2bce3d5fbb0b5193'
+  version '1.4.1'
+  sha256 'faebd520c79b0d8a598745a8d0a1ad7042d6b3d65cc4c49b29c0cc6b3c162e8d'
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
   appcast 'https://github.com/ealeksandrov/ProvisionQL/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.