### PR TITLE
Update qownnotes to 18.06.2,b3632-171813

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.05.7,b3605-162547'
-  sha256 '714cba3282ad0782cafc8f2f1349c1fe1ff91c44fcf8cc9ae43900ab662b007f'
+  version '18.06.2,b3632-171813'
+  sha256 'd31dd41a29ae21abf148d8c86206523ab874dda73a3f5b2065427940fab9ddba'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.