### PR TITLE
Update printopia to 3.0.10

### DIFF
--- a/Casks/printopia.rb
+++ b/Casks/printopia.rb
@@ -1,6 +1,6 @@
 cask 'printopia' do
-  version '3.0.9'
-  sha256 '1dc382756d3efbb9ec87e74c683ba4b79c2e39b5a0043b04300eed2cdcc7836d'
+  version '3.0.10'
+  sha256 '9acad71b496fc93f2095ceab9f0eece879710aee783541c39450d3303859aa59'
 
   url "https://www.decisivetactics.com/products/printopia/dl/Printopia_#{version}.zip"
   name 'Printopia'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.