### PR TITLE
Update appium to 1.6.2

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,6 +1,6 @@
 cask 'appium' do
-  version '1.6.1'
-  sha256 'bdd19869aba715fe32b279b320224cc5940748072b3c1d781a3d3eeea39f5d15'
+  version '1.6.2'
+  sha256 'a95306aaac264e68e880b269eda777fe9c1e0526b4d8b9409272faf1df051bf6'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
   url "https://github.com/appium/appium-desktop/releases/download/v#{version}/appium-desktop-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.