### PR TITLE
Update file-juicer to 4.66

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,6 +1,6 @@
 cask 'file-juicer' do
   version '4.66'
-  sha256 '229bca1c5523290ab35ae89a8c5a98bad601427b1fe0b1c71ebaee99bb06c218'
+  sha256 '716f38251ed389a9cf6faedd10bf5f2028a8344b6c0dba0f47d9945aac7cb540'
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   appcast 'https://echoone.com/filejuicer/download'

--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,8 +1,9 @@
 cask 'file-juicer' do
   version '4.66'
-  sha256 '716f38251ed389a9cf6faedd10bf5f2028a8344b6c0dba0f47d9945aac7cb540'
+  sha256 '229bca1c5523290ab35ae89a8c5a98bad601427b1fe0b1c71ebaee99bb06c218'
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
+  appcast 'https://echoone.com/filejuicer/download'
   name 'File Juicer'
   homepage 'https://echoone.com/filejuicer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.