### PR TITLE
Update manager to 18.5.46

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,9 +1,10 @@
 cask 'manager' do
-  version '18.5.45'
-  sha256 'acafaed2ec57406e53e3fec564d6c14e3298aba800cc137adb10b90a60430a68'
+  version '18.5.46'
+  sha256 'af49a3036105643539860601ff0e68bcc788be3620635ceea1c9a8692997f27e'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"
+  appcast 'https://www.manager.io/desktop/download/'
   name 'Manager'
   homepage 'https://www.manager.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.