### PR TITLE
Update fldigi to 4.0.17

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.0.16'
-  sha256 '2105929d385a192f1e0168be1a6697234cf5998ce8902297ca8d1786b4b801e2'
+  version '4.0.17_macos'
+  sha256 '1508c2c8357739417a4917321f871bf388850af009dddb7f9fc08481d9136e41'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -8,5 +8,5 @@ cask 'fldigi' do
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 
   app "fldigi-#{version}.app"
-  app 'flarq-4.3.6.app'
+  app 'flarq-4.3.7.app'
 end

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,8 +1,8 @@
 cask 'fldigi' do
-  version '4.0.17_macos'
+  version '4.0.17'
   sha256 '1508c2c8357739417a4917321f871bf388850af009dddb7f9fc08481d9136e41'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_macos.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,12 +1,12 @@
 cask 'fldigi' do
-  version '4.0.17'
+  version '4.0.17,4.3.7'
   sha256 '1508c2c8357739417a4917321f871bf388850af009dddb7f9fc08481d9136e41'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_macos.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_macos.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 
-  app "fldigi-#{version}.app"
-  app 'flarq-4.3.7.app'
+  app "fldigi-#{versionbefore_comma}.app"
+  app "flarq-#{version.after_comma}.app"
 end

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -7,6 +7,6 @@ cask 'fldigi' do
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'
 
-  app "fldigi-#{versionbefore_comma}.app"
+  app "fldigi-#{version.before_comma}.app"
   app "flarq-#{version.after_comma}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.