### PR TITLE
Update freesmug-chromium to 67.0.3396.87

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '67.0.3396.79'
-  sha256 '2f1be940167ef34f3a0d33a17e84d897a1a13101754a45840bc47553af8cc492'
+  version '67.0.3396.87'
+  sha256 '7e28db21d2562bca9dad9b341b0488df312f8bc812576c870f9212ee9fcd9bcb'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.