### PR TITLE
Update insteadman to 3.1.2

### DIFF
--- a/Casks/insteadman.rb
+++ b/Casks/insteadman.rb
@@ -1,6 +1,6 @@
 cask 'insteadman' do
-  version '3.1.1'
-  sha256 '6be571c6ddb16c6f034c66cce7e8699c2e79133ff3a012d3edbd14b6910f8938'
+  version '3.1.2'
+  sha256 '9307ac274c8550420116cc15eea1d7923ea0c7e1d8ac5cff098aaf528edc6894'
 
   # github.com/jhekasoft/insteadman3 was verified as official when first introduced to the cask
   url "https://github.com/jhekasoft/insteadman3/releases/download/v#{version}/InsteadMan-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.