### PR TITLE
Update pdfpenpro to 1011.9,1528860502

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1010.4,1526435892'
-  sha256 '3504060f91393b91ee9a2a03339bd7b222d64bce9ab6e70c1bb715c8ebfb8242'
+  version '1011.9,1528860502'
+  sha256 'dc26d235162dbf30f0b919987c12318b88a58fac9e0a22551d64163bc10bb873'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.