### PR TITLE
Update savoir-faire-linux-ring to 201806130940

### DIFF
--- a/Casks/savoir-faire-linux-ring.rb
+++ b/Casks/savoir-faire-linux-ring.rb
@@ -1,6 +1,6 @@
 cask 'savoir-faire-linux-ring' do
-  version '201806121825'
-  sha256 'b66236b3bbe9d1153d9be957578705833f67be98afba04a05149d01776dd3e6d'
+  version '201806130940'
+  sha256 '786f0bc5dbfc68630d759923656bc891874188dde5409e295ffa701aee3598d6'
 
   url "https://dl.ring.cx/mac_osx/ring-#{version}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.