### PR TITLE
Update zeebe-modeler to 0.1.3

### DIFF
--- a/Casks/zeebe-modeler.rb
+++ b/Casks/zeebe-modeler.rb
@@ -1,6 +1,6 @@
 cask 'zeebe-modeler' do
-  version '0.1.1'
-  sha256 '5f9f31b04c2953cdac261f78d0807de22aaebedd663c2ccfa77205001ab960e2'
+  version '0.1.3'
+  sha256 'fe33b31b69c0304864a8e212134adb0f264fe972319cbdcd58e010b2a6493d33'
 
   # github.com/zeebe-io/zeebe-modeler was verified as official when first introduced to the cask
   url "https://github.com/zeebe-io/zeebe-modeler/releases/download/#{version}/zeebe-modeler-darwin-x64.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.