### PR TITLE
Update padlock to 2.7.2

### DIFF
--- a/Casks/padlock.rb
+++ b/Casks/padlock.rb
@@ -1,10 +1,10 @@
 cask 'padlock' do
-  version '2.7.1'
-  sha256 'b3c0ae95923d11997ccf1bd9aee341f751b57ca1e374528e4ffcf727fd541c1b'
+  version '2.7.2'
+  sha256 'cb25ba911a07476d4914a9f9c20b252cbd141ddeff2bf0c677ead33cdb2a84d8'
 
-  # github.com/MaKleSoft/padlock was verified as official when first introduced to the cask
-  url "https://github.com/MaKleSoft/padlock/releases/download/v#{version}/Padlock-#{version}.dmg"
-  appcast 'https://github.com/MaKleSoft/padlock/releases.atom'
+  # github.com/padlock/padlock was verified as official when first introduced to the cask
+  url "https://github.com/padlock/padlock/releases/download/v#{version}/Padlock-#{version}.dmg"
+  appcast 'https://github.com/padlock/padlock/releases.atom'
   name 'Padlock'
   homepage 'https://padlock.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.