### PR TITLE
Update chronycontrol to 1.2.2

### DIFF
--- a/Casks/chronycontrol.rb
+++ b/Casks/chronycontrol.rb
@@ -1,6 +1,6 @@
 cask 'chronycontrol' do
-  version '1.2.1'
-  sha256 '35e030839de309bdd842aca40f8960b8511f70b20f5433743a54ced739c98323'
+  version '1.2.2'
+  sha256 'f00367056ecc6b8b2f03a961b8f64c562b8fc15c9f0816950fe1574d26990b7e'
 
   url "https://www.whatroute.net/software/chronycontrol-#{version}.zip"
   appcast 'https://whatroute.net/chronycontrol.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.