### PR TITLE
Update sqleditor to 3.3.11

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,6 +1,6 @@
 cask 'sqleditor' do
-  version '3.3.9'
-  sha256 'a004e7cdfcae821aae03f9b07405a03e9f91bf3404aefcbf2735db4ec6487e6f'
+  version '3.3.11'
+  sha256 '468d9bf4df2d6372ea6fc128392f3bdc529502ed87a2f2df6eb63cf933490951'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.