### PR TITLE
Update gpg-suite to 2018.3

### DIFF
--- a/Casks/gpg-suite.rb
+++ b/Casks/gpg-suite.rb
@@ -1,6 +1,6 @@
 cask 'gpg-suite' do
-  version '2018.2'
-  sha256 'cc772725dae73c5bc1f98b8fa264068db2e9584094590db88074cf77f7f7407b'
+  version '2018.3'
+  sha256 '00a6d0c69dd050acd2df4a34bf8502d4e0de3af9b4f7523a0003af14b60006be'
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast 'https://gpgtools.org/releases/gka/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.