### PR TITLE
Update airdroid to 3.6.3.1

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
-  version '3.6.3.0'
-  sha256 '3d23d7e711243322ed545badd60e6e1ca40d0ca97cb435fb281c60cbf7ec56c9'
+  version '3.6.3.1'
+  sha256 '3010932cd20aed546dfe9b324e7a56f4980f10c53de45fa4841b89aafb716c2b'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.