### PR TITLE
Update subgit to 3.3.3

### DIFF
--- a/Casks/subgit.rb
+++ b/Casks/subgit.rb
@@ -1,6 +1,6 @@
 cask 'subgit' do
-  version '3.3.1'
-  sha256 '813ad35367279560885f7ffe32e708bd2019a577125b5b58a325b690b21ba5c5'
+  version '3.3.3'
+  sha256 'bb16bc9a1b386511ef8b56c0b4e2934e6283375c39bf7ad99bc56d39c1c7e317'
 
   url "https://subgit.com/download/subgit-#{version}.zip"
   name 'SubGit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.