### PR TITLE
Update manager to 18.5.47

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.46'
-  sha256 'af49a3036105643539860601ff0e68bcc788be3620635ceea1c9a8692997f27e'
+  version '18.5.47'
+  sha256 'd9201e4ca2ac9adfce1507290f7246a32aa672f1abd0b81c85e569871d494a01'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.