### PR TITLE
Update netlogo to 6.0.4

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,6 +1,6 @@
 cask 'netlogo' do
-  version '6.0.3'
-  sha256 '5cccdfaff8af4f5556cf211f0bfe6e8c08ae7f17456932c8903125106acdf351'
+  version '6.0.4'
+  sha256 '07657a6c464bf27762f866c952e2acea31e801c26798c66282efacfbe7271841'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.