### PR TITLE
Update deepstream to 3.1.3

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,6 +1,6 @@
 cask 'deepstream' do
-  version '4.0.0-rc.4'
-  sha256 'f170b2839f87b0b072068cdf7c70a100f272ee0e1f987ec61d25aaeab6078307'
+  version '3.1.3'
+  sha256 'c690d1374028bb7fbb3d000bac64176e0cc93a50b15909d186e77ab0a154f055'
 
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.