### PR TITLE
Update gns3 to 2.1.8

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.7'
-  sha256 'f9ecbd29fd456f02e901cdddbb071b7313032d735975a88583949191ea4b3bcf'
+  version '2.1.8'
+  sha256 'ad71d17117e93f4806582d9dbf97bb7aee89d515e0a3b2bea37153971ae88199'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.