### PR TITLE
Update godot-mono to 3.0.3

### DIFF
--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -1,9 +1,9 @@
 cask 'godot-mono' do
-  version '3.0.2'
-  sha256 '6451722d8154b878acd516f8e12fe53f5cf05fd12bc31c0017c3408fc9f5bba7'
+  version '3.0.3'
+  sha256 '84554bc4d0a6a427c7d289df3b73bbe18d03f974632a2d7e847746af74ff2524'
 
   # downloads.tuxfamily.org/godotengine was verified as official when first introduced to the cask
-  url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_osx64.zip"
+  url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_osx.fat.zip"
   appcast 'https://github.com/godotengine/godot/releases.atom'
   name 'Godot Engine'
   homepage 'https://godotengine.org/'

--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -10,5 +10,5 @@ cask 'godot-mono' do
 
   depends_on formula: 'mono'
 
-  app "Godot_mono.app"
+  app 'Godot_mono.app'
 end

--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -10,5 +10,5 @@ cask 'godot-mono' do
 
   depends_on formula: 'mono'
 
-  app "Godot_v#{version}-stable_mono_osx64.app"
+  app "Godot_mono.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.