### PR TITLE
Update kite to 0.20180613.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180612.0'
-  sha256 '21d0b5f3dc4d9c546906d6839bbf9b3c08da26580829ab10845437aac0752461'
+  version '0.20180613.0'
+  sha256 '26c121c209d70717e6a698ed55ad9afcff9ec1ebde6db299d0429ea2aa800ecf'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.