### PR TITLE
Update vivaldi to 1.15.1147.47

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '1.15.1147.42'
-  sha256 '1d3822090f39f5633bb9832630fb261f94cf466d93fcfcd6dcc8d5811047bb9e'
+  version '1.15.1147.47'
+  sha256 'c9d0109591b9a84fb15c05f4275d1713703297021266a6e0ab86b962723c7498'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.