### PR TITLE
Update veusz to 3.0

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,6 +1,6 @@
 cask 'veusz' do
-  version '2.2.2'
-  sha256 '3e927f3afa543dde0dd431ac1d690bd5b7f6b18bf185ce75fd7b12aecf4c6cc9'
+  version '3.0'
+  sha256 'de000c003099a4d9dec0b083f362bc7c23be1ff2d79897d7a61d7f1d42fb172c'
 
   # github.com/veusz/veusz was verified as official when first introduced to the cask
   url "https://github.com/veusz/veusz/releases/download/veusz-#{version}/veusz-#{version}-AppleOSX.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.