### PR TITLE
Update beamdog-client to 2.1.8

### DIFF
--- a/Casks/beamdog-client.rb
+++ b/Casks/beamdog-client.rb
@@ -1,6 +1,6 @@
 cask 'beamdog-client' do
-  version '2.1.3'
-  sha256 'bdf72248c9b0a90bee5a6fe76b0c44824e2ddceecfad93ef069f41de5b0e544f'
+  version '2.1.8'
+  sha256 'b5e23a1f505f839865ff7b2c05cfccd8e9b981cff49bb84899fbe2773734a067'
 
   url "http://client.beamdog.com/download/#{version}/osx_64/Beamdog%20Client-#{version}.dmg"
   name 'Beamdog Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.