### PR TITLE
Update waterfox to 56.2.1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.2.0'
-  sha256 '400ce6fb163e3f5edb9067eb0b3c3a80d54c1d718b713ae3247734aacc61f5be'
+  version '56.2.1'
+  sha256 'ebc5b52c40456706a82dfc7479f4755c0e33ecef8c4a938d96a911c503f50bfe'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.