### PR TITLE
Update cloudtv to 3.8.9,1529018444

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,6 +1,6 @@
 cask 'cloudtv' do
-  version '3.8.8,1526203813'
-  sha256 '8fca04618c5c6c690bfa5f1e86798cb09b6522e6f2ec38ef6cfd9ffacc5bb7a5'
+  version '3.8.9,1529018444'
+  sha256 '91516210406b840e004f38e2577049edc9fd4413ea414b04dc557000b1f4285a'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.nonoche.CloudTV/#{version.before_comma}/#{version.after_comma}/CloudTV-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.