### PR TITLE
Update darktable to 2.4.4

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask 'darktable' do
-  version '2.4.3.1'
-  sha256 '290ed5473e3125a9630a235a4a33ad9c9f3718f4a10332fe4fe7ae9f735c7fa9'
+  version '2.4.4'
+  sha256 '9324562c98a52346fa77314103a5874eb89bd576cdbc21fc19cb5d8dfaba307a'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.