### PR TITLE
Update davmail to 4.8.6-2600

### DIFF
--- a/Casks/davmail.rb
+++ b/Casks/davmail.rb
@@ -1,6 +1,6 @@
 cask 'davmail' do
-  version '4.8.5-2589'
-  sha256 '229d09a6de7ac94c125d1612fb07109a5012d862157a748e4d1a5a3872bce2e3'
+  version '4.8.6-2600'
+  sha256 '7755e8273d99c43540a205fbd1f7143420f5364c5563387eb5dbd6dccb58db05'
 
   url "https://downloads.sourceforge.net/davmail/DavMail-MacOSX-#{version}.app.zip"
   appcast 'https://sourceforge.net/projects/davmail/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.