### PR TITLE
Update lbry to 0.21.6

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.21.5'
-  sha256 '1c72b03991dd9deff4b2355a59297d302451fb39047905f8b7a84f9a0d94dfb8'
+  version '0.21.6'
+  sha256 '04e06ce837ea87ea3dba0e71ba89c69164de759dfe938014f9e885137980901d'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.