### PR TITLE
Update gpodder to 3.10.3

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,6 +1,6 @@
 cask 'gpodder' do
-  version '3.10.1'
-  sha256 '895bbb49594630db42f71e687942714fbf5db651d1d4844e75d44e99df2729f2'
+  version '3.10.3'
+  sha256 'e8dadea1ec204cf537e09a303cbe5f3b0bbe59acabe949c7de451379f5e5f2a3'
 
   # github.com/gpodder/gpodder was verified as official when first introduced to the cask
   url "https://github.com/gpodder/gpodder/releases/download/#{version}/macOS-gPodder-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.