### PR TITLE
upgrade folx to 5.5.13723

### DIFF
--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -1,6 +1,6 @@
 cask 'folx' do
-  version '5.4.13714'
-  sha256 'd5bdeee601d647c3171806404d7f7204c5d99cdc3ac4fa3cb3ec2f29a8d1623f'
+  version '5.5.13723'
+  sha256 'b31285b8eeccf7ca7124bc21a962361f95e326ea99db147f86ce1a7b6293fc22'
 
   url "https://cdn.eltima.com/download/folx-updater/downloader_mac_#{version}.dmg"
   appcast 'https://cdn.eltima.com/download/folx-updater/folx.xml'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
  output ` - a checkpoint sha256 is required for appcast`, but cask's checkpoint has been removed.
- [*] `brew cask style --fix {{cask_file}}` reports no offenses.
- [*] The commit message includes the cask’s name and version.
