### PR TITLE
Update nomachine to 6.2.4_1

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '6.1.6_10'
-  sha256 '7b7b0096364ee00b7b89156242997b58ac636bf3022e7c419e4f493963b26775'
+  version '6.2.4_1'
+  sha256 'd429e6b1f68e9e76c759692e6b553a7d213fd65ae873bd46e478f9c4f15ec724'
 
   url "http://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   name 'NoMachine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.