### PR TITLE
Update unity-standard-assets to 2018.1.4f1,1a308f4ebef1

### DIFF
--- a/Casks/unity-standard-assets.rb
+++ b/Casks/unity-standard-assets.rb
@@ -1,6 +1,6 @@
 cask 'unity-standard-assets' do
-  version '2018.1.3f1,a53ad04f7c7f'
-  sha256 'b9e8869f45c9f4528d311d9a0eadd4d35afd9c0a565b7efd988738f8f6c4ffbb'
+  version '2018.1.4f1,1a308f4ebef1'
+  sha256 '4fd6bae28f6bdc0463c965316c18283accabc75f862016e56c04b19eeecba2c1'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacStandardAssetsInstaller/StandardAssets-#{version.before_comma}.pkg"
   name 'Unity Standard Assets'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.