### PR TITLE
Update unity-android-support-for-editor to 2018.1.4f1,1a308f4ebef1

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2018.1.3f1,a53ad04f7c7f'
-  sha256 'ea5dba30ae12a4d571d449d55c4d37a9539273840d212ce18eb189cd33525e49'
+  version '2018.1.4f1,1a308f4ebef1'
+  sha256 '4e21ddccca6bff448a94bc1ccb9000735ffcf840ae98a8115cae738412c3eb74'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Android Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.