### PR TITLE
Update unity-webgl-support-for-editor to 2018.1.4f1,1a308f4ebef1

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.1.3f1,a53ad04f7c7f'
-  sha256 '4f4d3f191d2de341322c1e2a99a0bb6cff4d5da9e388b8fe55b2bdf7d4d21931'
+  version '2018.1.4f1,1a308f4ebef1'
+  sha256 '8f80fbeb6d9ffdb0ffc735f8101b40e3a6582e77b78dd36b804485ada07d3a41'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity WebGL Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.