### PR TITLE
Update unity-windows-support-for-editor to 2018.1.4f1,1a308f4ebef1

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.1.3f1,a53ad04f7c7f'
-  sha256 'ffec80667f1d760dd9c222f4b384af8048a77d2de55d24602286c9078b3b35b2'
+  version '2018.1.4f1,1a308f4ebef1'
+  sha256 'ba8f386ff5ed95210ad03b9c505514d5881c2def45f89ae0e1085c3eab9b521c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   name 'Unity Windows (Mono) Build Support'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.