### PR TITLE
Update trim-enabler to 4.1.2,1507416957

### DIFF
--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -1,9 +1,10 @@
 cask 'trim-enabler' do
-  version '4'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '4.1.2,1507416957'
+  sha256 '227fbbe724bcfdac4fb8c60f3fb271efd0092ba07d27adcb1c894cd02ec21cb0'
 
-  # dl.devmate.com/org.cindori.TrimEnabler was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/org.cindori.TrimEnabler#{version}/TrimEnabler.zip"
+  # dl.devmate.com/org.cindori.TrimEnabler4 was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/org.cindori.TrimEnabler4/#{version.minor_patch.no_dots}/#{version.after_comma}/TrimEnabler-#{version.minor_patch.no_dots}.zip"
+  appcast "https://updates.devmate.com/org.cindori.TrimEnabler#{version.major}.xml"
   name 'Trim Enabler'
   homepage 'https://cindori.org/trimenabler/'
 
@@ -15,15 +16,15 @@ cask 'trim-enabler' do
             launchctl: 'org.cindori.TEHelper'
 
   zap trash: [
-               "~/Library/Application Support/CrashReporter/Trim Enabler_#{version}.plist",
-               "~/Library/Application Support/org.cindori.TrimEnabler#{version}",
+               "~/Library/Application Support/CrashReporter/Trim Enabler_#{version.major}.plist",
+               "~/Library/Application Support/org.cindori.TrimEnabler#{version.major}",
                '~/Library/Application Support/Trim Enabler',
-               "~/Library/Caches/org.cindori.TrimEnabler#{version}",
-               "~/Library/Caches/com.plausiblelabs.crashreporter.data/org.cindori.TrimEnabler#{version}",
-               "~/Library/Cookies/org.cindori.TrimEnabler#{version}.binarycookies",
-               "~/Library/Logs/DiagnosticReports/Trim Enabler_#{version}.crash",
+               "~/Library/Caches/org.cindori.TrimEnabler#{version.major}",
+               "~/Library/Caches/com.plausiblelabs.crashreporter.data/org.cindori.TrimEnabler#{version.major}",
+               "~/Library/Cookies/org.cindori.TrimEnabler#{version.major}.binarycookies",
+               "~/Library/Logs/DiagnosticReports/Trim Enabler_#{version.major}.crash",
                '~/Library/Preferences/org.cindori.TrimEnabler.plist',
-               "~/Library/Preferences/org.cindori.TrimEnabler#{version}.plist",
-               "~/Library/Saved Application State/org.cindori.TrimEnabler#{version}.savedState",
+               "~/Library/Preferences/org.cindori.TrimEnabler#{version.major}.plist",
+               "~/Library/Saved Application State/org.cindori.TrimEnabler#{version.major}.savedState",
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Blocked on https://github.com/Homebrew/brew/pull/4346