### PR TITLE
Update waltr to 2.6.8,1527095138

### DIFF
--- a/Casks/waltr.rb
+++ b/Casks/waltr.rb
@@ -1,9 +1,10 @@
 cask 'waltr' do
-  version :latest
-  sha256 :no_check
+  version '2.6.8,1527095138'
+  sha256 '75f74aaa6ef155cd47d21a609b845562a90fd45291f6aef6e60bb39d77224832'
 
   # dl.devmate.com/com.softorino.waltr2 was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.softorino.waltr2/Waltr2.zip'
+  url "https://dl.devmate.com/com.softorino.waltr2/#{version.before_comma}/#{version.after_comma}/Waltr#{version.major}-#{version.before_comma}.zip"
+  appcast "http://updates.devmate.com/com.softorino.waltr#{version.major}.xml"
   name 'WALTR 2'
   homepage 'https://softorino.com/w2/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.