### PR TITLE
Update imazing to 2.6.1,9057:1528923520

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,9 +1,10 @@
 cask 'imazing' do
-  version '2'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '2.6.1,9057:1528923520'
+  sha256 '3d2b71244b5eab58511d96e37b02b93e1457ba51940ada6713633f9cd6a2545b'
 
   # dl.devmate.com was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.DigiDNA.iMazing#{version}Mac/iMazing#{version}forMac.dmg"
+  url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"
+  appcast "https://updates.devmate.com/com.DigiDNA.iMazing#{version.major}Mac.xml"
   name 'iMazing'
   homepage 'https://imazing.com/'
 
@@ -22,12 +23,12 @@ cask 'imazing' do
                '~/Library/Application Support/iMazing',
                '~/Library/Application Support/iMazing Mini',
                '~/Library/Application Support/MobileSync/Backup/iMazing.Versions',
-               "~/Library/Caches/com.DigiDNA.iMazing#{version}Mac",
-               "~/Library/Caches/com.DigiDNA.iMazing#{version}Mac.Mini",
-               "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.DigiDNA.iMazing#{version}Mac.Mini",
+               "~/Library/Caches/com.DigiDNA.iMazing#{version.major}Mac",
+               "~/Library/Caches/com.DigiDNA.iMazing#{version.major}Mac.Mini",
+               "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.DigiDNA.iMazing#{version.major}Mac.Mini",
                '~/Library/Caches/iMazing',
-               "~/Library/Preferences/com.DigiDNA.iMazing#{version}Mac.plist",
-               "~/Library/Preferences/com.DigiDNA.iMazing#{version}Mac.Mini.plist",
+               "~/Library/Preferences/com.DigiDNA.iMazing#{version.major}Mac.plist",
+               "~/Library/Preferences/com.DigiDNA.iMazing#{version.major}Mac.Mini.plist",
                '/Users/Shared/iMazing Mini',
                '/Users/Shared/iMazing',
              ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.