### PR TITLE
Update imazing-mini to 2.5.4,8449:1520350258

### DIFF
--- a/Casks/imazing-mini.rb
+++ b/Casks/imazing-mini.rb
@@ -1,9 +1,10 @@
 cask 'imazing-mini' do
-  version '2'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '2.5.4,8449:1520350258'
+  sha256 '2412379613cb564953e0b134c47e6a041298174d5922d774ec050ead01e5e367'
 
-  # dl.devmate.com was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.DigiDNA.iMazing#{version}Mac.Mini/iMazingMini#{version}forMac.dmg"
+  # dl.devmate.com/com.DigiDNA.iMazing2Mac.Mini was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac.Mini/#{version.after_comma.before_colon}/#{version.after_colon}/iMazingMini2forMac-#{version.after_comma.before_colon}.dmg"
+  appcast "https://updates.devmate.com/com.DigiDNA.iMazing#{version.major}Mac.Mini.xml"
   name 'iMazing Mini'
   homepage 'https://imazing.com/mini'
 
@@ -13,16 +14,16 @@ cask 'imazing-mini' do
   app 'iMazing Mini.app'
 
   uninstall login_item: 'iMazing Mini',
-            quit:       "com.DigiDNA.iMazing#{version}Mac.Mini"
+            quit:       "com.DigiDNA.iMazing#{version.major}Mac.Mini"
 
   zap trash: [
                '~/Library/Application Support/iMazing',
                '~/Library/Application Support/iMazing Mini',
                '~/Library/Application Support/MobileSync/Backup/iMazing.Versions',
-               "~/Library/Caches/com.DigiDNA.iMazing#{version}Mac.Mini",
-               "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.DigiDNA.iMazing#{version}Mac.Mini",
+               "~/Library/Caches/com.DigiDNA.iMazing#{version.major}Mac.Mini",
+               "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.DigiDNA.iMazing#{version.major}Mac.Mini",
                '~/Library/Caches/iMazing',
-               "~/Library/Preferences/com.DigiDNA.iMazing#{version}Mac.Mini.plist",
+               "~/Library/Preferences/com.DigiDNA.iMazing#{version.major}Mac.Mini.plist",
                '/Users/Shared/iMazing Mini',
              ]
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.