### PR TITLE
Update the-unarchiver to 4.0.0,120:1528909123

### DIFF
--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -1,6 +1,6 @@
 cask 'the-unarchiver' do
-  version '3.11.6,119:1527191272'
-  sha256 '78becd148d5f3cd9a1570751786f364399062b43f576e5a78d9aec3b9450b942'
+  version '4.0.0,120:1528909123'
+  sha256 'fc59d9dcd40d65642083991b93b44ded782518f9395e248ee246b360b23ee740'
 
   # devmate.com/com.macpaw.site.theunarchiver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.theunarchiver/#{version.after_comma.before_colon}/#{version.after_colon}/TheUnarchiver-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.