### PR TITLE
Update lehreroffice to 2018.9.1

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2018.9.0'
-  sha256 '6c060ba42c8bb481ae26824c9ed2820d6236d2c29a338cdfe4dcd76b42a29b75'
+  version '2018.9.1'
+  sha256 'c436bdc73ab15c1c7b6c5ead19f61d0aa5cc89ef22a4bfde07db1518c77fa3ba'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.