### PR TITLE
Update listen1 to 1.8.0

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,10 +1,10 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '1.6.0'
-  sha256 '036281f54d0d9bb53ee48a265f60c97e57d3dc51b30ca28d2bc05d91c7b9d756'
+  version '1.8.0'
+  sha256 '85f2044ecca3999331e8b96e1b317574dbd13c83c33aab6a9f48e2ec22d6a985'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
-  url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg.zip"
+  url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"
   appcast 'https://github.com/listen1/listen1_desktop/releases.atom'
   name 'Listen 1'
   homepage 'https://listen1.github.io/listen1/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.