### PR TITLE
Update porting-kit to 2.9.443

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,6 +1,6 @@
 cask 'porting-kit' do
-  version '2.9.434'
-  sha256 '2bff7be0aea8c4025cd11b56699108d2dccb196c050a5c5fe4f7c2c30bc6c873'
+  version '2.9.443'
+  sha256 'dcb7cf541dc67bb6d28c4cd794046f4e9b4bb4be1fdebe1a4838b5b02581faeb'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.