### PR TITLE
Update unity-android-support-for-editor to 2018.1.5f1,732dbf75922d

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2018.1.4f1,1a308f4ebef1'
-  sha256 '4e21ddccca6bff448a94bc1ccb9000735ffcf840ae98a8115cae738412c3eb74'
+  version '2018.1.5f1,732dbf75922d'
+  sha256 'efb54f05d6f6590806783de8d60cfc6e96d1af0a37454e4e8e45f4bffc673e55'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/update'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.