### PR TITLE
Update unity-ios-support-for-editor to 2018.1.5f1,732dbf75922d

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2018.1.4f1,1a308f4ebef1'
-  sha256 '19637cb9d6c3e205c085d7e90a67ce8e62c1637a0186f4ef26c30a1d902762c4'
+  version '2018.1.5f1,732dbf75922d'
+  sha256 'caf2b63ffd46ea742506a107b9e07560677f5e572be7f4869fd54dabecbcf510'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/update'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.