### PR TITLE
Update unity-windows-support-for-editor to 2018.1.5f1,732dbf75922d

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.1.4f1,1a308f4ebef1'
-  sha256 'ba8f386ff5ed95210ad03b9c505514d5881c2def45f89ae0e1085c3eab9b521c'
+  version '2018.1.5f1,732dbf75922d'
+  sha256 'cdf5759109a8b5098bd3392b987a88fdb452718edab43b1f80f971569c398dad'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/update'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.