### PR TITLE
Update zotero to 5.0.51

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -3,8 +3,7 @@ cask 'zotero' do
   sha256 '65d21f6659ab65e2bcc958695ba181a0e664cd42602e6ce795c3b216b375d9b2'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
-  appcast 'https://github.com/zotero/zotero/releases.atom',
-          checkpoint: 'aaa67485370c7b4a8a44c53b6480d4851d7958f57976ee1d3d5f3a606cfdc964'
+  appcast 'https://github.com/zotero/zotero/releases.atom'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 

--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,9 +1,10 @@
 cask 'zotero' do
-  version '5.0.50'
-  sha256 'dcc87da3d7710cb0ebcd86e675a897e1f8f98c7ea2cc2cd0066e3c34b65dcebb'
+  version '5.0.51'
+  sha256 '65d21f6659ab65e2bcc958695ba181a0e664cd42602e6ce795c3b216b375d9b2'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
-  appcast 'https://github.com/zotero/zotero/releases.atom'
+  appcast 'https://github.com/zotero/zotero/releases.atom',
+          checkpoint: 'aaa67485370c7b4a8a44c53b6480d4851d7958f57976ee1d3d5f3a606cfdc964'
   name 'Zotero'
   homepage 'https://www.zotero.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.