### PR TITLE
Update bestres to 1.0.0,1426778671

### DIFF
--- a/Casks/bestres.rb
+++ b/Casks/bestres.rb
@@ -1,9 +1,10 @@
 cask 'bestres' do
-  version :latest
-  sha256 :no_check
+  version '1.0.0,1426778671'
+  sha256 '1b706a3550edbc1411bdc4665490cce3b22cef68a6abae82af0fbd46370ce697'
 
   # devmate.com/com.icyberon.BestRes was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.icyberon.BestRes/BestRes.zip'
+  url "https://dl.devmate.com/com.icyberon.BestRes/#{version.before_comma.no_dots}/#{version.after_comma}/BestRes-#{version.before_comma.no_dots}.zip"
+  appcast 'https://updates.devmate.com/com.icyberon.BestRes.xml'
   name 'BestRes'
   homepage 'https://bestres.wojtek.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.