### PR TITLE
Update capto to 1.2.9,1519212504

### DIFF
--- a/Casks/capto.rb
+++ b/Casks/capto.rb
@@ -1,9 +1,10 @@
 cask 'capto' do
-  version :latest
-  sha256 :no_check
+  version '1.2.9,1519212504'
+  sha256 '18594a1f435560cafd40d3b1db3416f0f504becd83cad4db97f716885af2ea27'
 
-  # dl.devmate.com/com.globaldelight.Capto/Capto.dmg was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.globaldelight.Capto/Capto.dmg'
+  # dl.devmate.com/com.globaldelight.Capto was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/com.globaldelight.Capto/#{version.before_comma}/#{version.after_comma}/Capto-#{version.before_comma}.dmg"
+  appcast 'https://updates.devmate.com/com.globaldelight.Capto.xml'
   name 'Capto'
   homepage 'http://www.globaldelight.com/capto/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.