### PR TITLE
Update ceceree to 1.2.3,70:1475928196

### DIFF
--- a/Casks/ceceree.rb
+++ b/Casks/ceceree.rb
@@ -1,9 +1,10 @@
 cask 'ceceree' do
-  version :latest
-  sha256 :no_check
+  version '1.2.3,70:1475928196'
+  sha256 'c27f45e91dc76ce68a7b651861f972e264bf3eecf6185e3f473132214addd73b'
 
   # dl.devmate.com/com.appiculous.Ceceree was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.appiculous.Ceceree/Ceceree.zip'
+  url "https://dl.devmate.com/com.appiculous.Ceceree/#{version.after_comma.before_colon}/#{version.after_colon}/Ceceree-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.appiculous.Ceceree.xml'
   name 'Ceceree'
   homepage 'https://ceceree.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.