### PR TITLE
Update chatmate-for-whatsapp to 4.2.4,470:1518834547

### DIFF
--- a/Casks/chatmate-for-whatsapp.rb
+++ b/Casks/chatmate-for-whatsapp.rb
@@ -1,9 +1,10 @@
 cask 'chatmate-for-whatsapp' do
-  version :latest
-  sha256 :no_check
+  version '4.2.4,470:1518834547'
+  sha256 '0959e533dad25ad0d8fa1ba6e59e55b0e7ef6c97d8a28a59dd4fdaca9f46d4fd'
 
   # dl.devmate.com/net.coldx.mac.WhatsApp was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/net.coldx.mac.WhatsApp/ChatMateforWhatsApp.dmg'
+  url "https://dl.devmate.com/net.coldx.mac.WhatsApp/#{version.after_comma.before_colon}/#{version.after_colon}/ChatMateforWhatsApp-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/net.coldx.mac.WhatsApp.xml'
   name 'ChatMate for WhatsApp'
   homepage 'https://chatmate.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.