### PR TITLE
Update command-tab-plus to 1.61,274:1528725384

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,9 +1,10 @@
 cask 'command-tab-plus' do
-  version :latest
-  sha256 :no_check
+  version '1.61,274:1528725384'
+  sha256 'c10b32ff868cd9b53f3f2f134cbac0d0545cd00ec1ce8c066a27646cf8ea838d'
 
-  # dl.devmate.com was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/Command-Tab.zip'
+  # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.sergey-gerasimenko.Command-Tab.xml'
   name 'Command-Tab Plus'
   homepage 'http://commandtab.noteifyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.