### PR TITLE
Update setapp to 1.14.2,1528985269

### DIFF
--- a/Casks/setapp.rb
+++ b/Casks/setapp.rb
@@ -1,11 +1,14 @@
 cask 'setapp' do
-  version :latest
-  sha256 :no_check
+  version '1.14.2,1528985269'
+  sha256 '9a17ef57174a5033f6cbe371eba98042f0052eb41d508ab773644d618af62fbb'
 
   # devmate.com/com.setapp.InstallSetapp was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.setapp.InstallSetapp/InstallSetapp.zip'
+  url "https://dl.devmate.com/com.setapp.InstallSetapp/#{version.before_comma}/#{version.after_comma}/InstallSetapp-#{version.before_comma}.zip"
+  appcast 'https://updates.devmate.com/com.setapp.InstallSetapp.xml'
   name 'Setapp'
   homepage 'https://setapp.com/'
+
+  auto_updates true
 
   installer manual: 'Install Setapp.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.