### PR TITLE
Update deep-dreamer to 1.0,251:1513327272

### DIFF
--- a/Casks/deep-dreamer.rb
+++ b/Casks/deep-dreamer.rb
@@ -1,9 +1,10 @@
 cask 'deep-dreamer' do
-  version :latest
-  sha256 :no_check
+  version '1.0,251:1513327272'
+  sha256 '4328e358c16ca381c3b1a40ada81addf57b439ba5dc1ce2e4503d3c11a44f8c2'
 
   # devmate.com/com.realmacsoftware.deepdreamer was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.realmacsoftware.deepdreamer/DeepDreamer.zip'
+  url "https://dl.devmate.com/com.realmacsoftware.deepdreamer/#{version.after_comma.before_colon}/#{version.after_colon}/DeepDreamer-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.realmacsoftware.deepdreamer.xml'
   name 'Deep Dreamer'
   homepage 'https://www.realmacsoftware.com/deepdreamer'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.