### PR TITLE
Update dictionaries to 1.2.6,241:1525016854

### DIFF
--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -1,9 +1,10 @@
 cask 'dictionaries' do
-  version :latest
-  sha256 :no_check
+  version '1.2.6,241:1525016854'
+  sha256 'a9a1beb18231ac83af757da86f49383569911700f25ca353498775640a126ef5'
 
-  # dl.devmate.com was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/io.dictionaries.Dictionaries/Dictionaries.zip'
+  # dl.devmate.com/io.dictionaries.Dictionaries was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/io.dictionaries.Dictionaries/#{version.after_comma.before_colon}/#{version.after_colon}/Dictionaries-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/io.dictionaries.Dictionaries.xml'
   name 'Dictionaries'
   homepage 'https://dictionaries.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.