### PR TITLE
Update filepane to 1.10.4,1529228948

### DIFF
--- a/Casks/filepane.rb
+++ b/Casks/filepane.rb
@@ -1,9 +1,10 @@
 cask 'filepane' do
-  version :latest
-  sha256 :no_check
+  version '1.10.4,1529228948'
+  sha256 'cbf9c13a110cf209ea0aa77ee030f00770bd3b9ee9347dfe0b5ef1dbefb3ef4e'
 
   # dl.devmate.com/com.mymixapps.FilePane was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.mymixapps.FilePane/FilePane.dmg'
+  url "https://dl.devmate.com/com.mymixapps.FilePane/#{version.before_comma}/#{version.after_comma}/FilePane-#{version.before_comma}.dmg"
+  appcast 'https://updates.devmate.com/com.mymixapps.FilePane.xml'
   name 'FilePane'
   homepage 'https://mymixapps.com/filepane'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.