### PR TITLE
Update focused to 3.1,1817:1508267199

### DIFF
--- a/Casks/focused.rb
+++ b/Casks/focused.rb
@@ -1,9 +1,10 @@
 cask 'focused' do
-  version :latest
-  sha256 :no_check
+  version '3.1,1817:1508267199'
+  sha256 'c59d98631f8d4fcc15682b735ed0dc4e2991c52688168692c2fee5c8f55fb2c5'
 
   # devmate.com/com.71squared.focused was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.71squared.focused/Focused.zip'
+  url "https://dl.devmate.com/com.71squared.focused/#{version.after_comma.before_colon}/#{version.after_colon}/Focused-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.71squared.focused.xml'
   name 'Focused'
   homepage 'https://codebots.co.uk/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.