### PR TITLE
Update reduce to 1.4,6:1517401022

### DIFF
--- a/Casks/reduce.rb
+++ b/Casks/reduce.rb
@@ -1,9 +1,10 @@
 cask 'reduce' do
-  version :latest
-  sha256 :no_check
+  version '1.4,6:1517401022'
+  sha256 '3d77d0bad97a24e7832c95aa3cbf0f2b3c476ec0746c01e4d812a74e5860faf5'
 
   # dl.devmate.com/com.flawless.utils.Reduce was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.flawless.utils.Reduce/ReduceApp.zip'
+  url "https://dl.devmate.com/com.flawless.utils.Reduce/#{version.after_comma.before_colon}/#{version.after_colon}/ReduceApp-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.flawless.utils.Reduce.xml'
   name 'Reduce'
   homepage 'https://flawlessapp.io/reduce'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.