### PR TITLE
Update short-menu to 3.0.4,589:1511958035

### DIFF
--- a/Casks/short-menu.rb
+++ b/Casks/short-menu.rb
@@ -1,9 +1,10 @@
 cask 'short-menu' do
-  version :latest
-  sha256 :no_check
+  version '3.0.4,589:1511958035'
+  sha256 '0c33a300fc3de7cba9db22630014a5bf5f05adc0c974edf16a33f6694627f4b7'
 
   # dl.devmate.com/com.floschliep.Short-Menu was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.floschliep.Short-Menu/ShortMenu.zip'
+  url "https://dl.devmate.com/com.floschliep.Short-Menu/#{version.after_comma.before_colon}/#{version.after_colon}/ShortMenu-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.floschliep.Short-Menu.xml'
   name 'Short Menu'
   homepage 'https://appiculous.com/short-menu-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.