### PR TITLE
Update softorino-youtube-converter to 2.0.18,1526650339

### DIFF
--- a/Casks/softorino-youtube-converter.rb
+++ b/Casks/softorino-youtube-converter.rb
@@ -1,11 +1,12 @@
 cask 'softorino-youtube-converter' do
-  version :latest
-  sha256 :no_check
+  version '2.0.18,1526650339'
+  sha256 '0836ca98ea6a27da2201dba995e9611200c76c5342fdd515cc81d957fb2c6c2c'
 
   # devmate.com/com.softorino.syc2 was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.softorino.syc2/SYC2.dmg'
-  name 'Softorino YouTube Converter 2'
-  homepage 'https://softorino.com/youtube-converter-2/'
+  url "https://dl.devmate.com/com.softorino.syc2/#{version.before_comma}/#{version.after_comma}/SYC2-#{version.before_comma}.zip"
+  appcast "https://updates.devmate.com/com.softorino.syc#{version.major}.xml"
+  name 'Softorino YouTube Converter'
+  homepage "https://softorino.com/youtube-converter-#{version.major}/"
 
-  app 'Softorino YouTube Converter 2.app'
+  app "Softorino YouTube Converter #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.