### PR TITLE
Update sticker to 1.0.3,8:1503613557

### DIFF
--- a/Casks/sticker.rb
+++ b/Casks/sticker.rb
@@ -1,9 +1,10 @@
 cask 'sticker' do
-  version :latest
-  sha256 :no_check
+  version '1.0.3,8:1503613557'
+  sha256 '8e638c6c305fc2060145c2e2780948182bb73ee057da4f970e91975a7cba2256'
 
   # dl.devmate.com/com.chompstomp.Sticker was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.chompstomp.Sticker/Sticker.zip'
+  url "https://dl.devmate.com/com.chompstomp.Sticker/#{version.after_comma.before_colon}/#{version.after_colon}/Sticker-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.chompstomp.Sticker.xml'
   name 'Sticker Window manager'
   homepage 'http://www.chompstomp.com/sticker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.