### PR TITLE
Update tap to 1.5.16,72:1521529036

### DIFF
--- a/Casks/tap.rb
+++ b/Casks/tap.rb
@@ -1,19 +1,14 @@
 cask 'tap' do
-  version :latest
-  sha256 :no_check
+  version '1.5.16,72:1521529036'
+  sha256 '6d04bf5f6ae1da65be616a9142d885267ed2d60f13eed92d1c6a23e3aee41515'
 
-  if MacOS.version <= :mavericks
-    # dl.devmate.com/com.pabix.tap-mountain was verified as official when first introduced to the cask
-    url 'https://dl.devmate.com/com.pabix.tap-mountain/Tap-mountain.dmg'
-  else
-    # dl.devmate.com/com.pabix.tap was verified as official when first introduced to the cask
-    url 'https://dl.devmate.com/com.pabix.tap/Tap.dmg'
-  end
-
+  # dl.devmate.com/com.pabix.tap was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/com.pabix.tap/#{version.after_comma.before_colon}/#{version.after_colon}/Tap-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/com.pabix.tap.xml'
   name 'Tap'
   homepage 'http://tap.thepabix.com/'
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :yosemite'
 
   app 'Tap.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.