### PR TITLE
Update the-archive-browser to 1.11.2,1504018288

### DIFF
--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -1,9 +1,10 @@
 cask 'the-archive-browser' do
-  version :latest
-  sha256 :no_check
+  version '1.11.2,1504018288'
+  sha256 'a9cffc4d7a4e9869c9b7542dff7b9614c487623fce6404ce779b0c4b654eb72b'
 
   # dl.devmate.com/cx.c3.thearchivebrowser was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/cx.c3.thearchivebrowser/TheArchiveBrowser.zip'
+  url "https://dl.devmate.com/cx.c3.thearchivebrowser/#{version.major_minor.no_dots}/#{version.after_comma}/TheArchiveBrowser-#{version.major_minor.no_dots}.zip"
+  appcast 'https://updates.devmate.com/cx.c3.thearchivebrowser.xml'
   name 'The Archive Browser'
   homepage 'https://theunarchiver.com/archive-browser'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.