### PR TITLE
Update wallpaper-wizard to 1.5.1,1455290016

### DIFF
--- a/Casks/wallpaper-wizard.rb
+++ b/Casks/wallpaper-wizard.rb
@@ -1,9 +1,10 @@
 cask 'wallpaper-wizard' do
-  version :latest
-  sha256 :no_check
+  version '1.5.1,1455290016'
+  sha256 '5f6d190cff7af60050357d993ee34b9544fe15672b535769766ab783cbd09f99'
 
   # dl.devmate.com/com.wallwiz was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.wallwiz/WallpaperWizard.dmg'
+  url "https://dl.devmate.com/com.wallwiz/#{version.before_comma}/#{version.after_comma}/WallpaperWizard-#{version.before_comma}.dmg"
+  appcast 'https://updates.devmate.com/com.wallwiz.xml'
   name 'Wallpaper Wizard'
   homepage 'https://wallwiz.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.