### PR TITLE
Update namechanger to 3.3.3-7

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -1,6 +1,6 @@
 cask 'namechanger' do
-  version '3.3.2-6'
-  sha256 'cd44006b4f223a5adb862d9143349261df5bb41dd5bff2ad5998f219dfa57b06'
+  version '3.3.3-7'
+  sha256 'f0c0b43a67b74c9ce63ecac72749a16f362a34598ae46efda4ef6f4dcaf997a4'
 
   url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.dots_to_underscores}.zip"
   appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.