### PR TITLE
Upgrade Postbox.app to v6.0.12 and fixed download url

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,9 +1,9 @@
 cask 'postbox' do
-  version '6.0.10,1_9d44288fe2fa5ec561b1ffc601c179224ff7ae7a'
-  sha256 'fed5e71c083d09fa2f43e2a0a9140929ca8c1fb776895ad385f1d73820a343e6'
+  version '6.0.12'
+  sha256 '54d29e6ccb69ee20a020166b6d430a74ef1a32f1c44327d56e08aab444255b7b'
 
-  # amazonaws.com/download.getpostbox.com was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/download.getpostbox.com/installers/#{version.before_comma}/#{version.after_comma}/postbox-#{version.before_comma}-mac64.dmg"
+  # https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg was verified as official when first introduced to the cask
+  url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"
   name 'Postbox'
   homepage 'https://www.postbox-inc.com/'
 


### PR DESCRIPTION
Upgrade Postbox.app to v6.0.12 and fixed download url

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
