### PR TITLE
Update lockrattler to 4.4,2018.06

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.3,2018.05'
-  sha256 'cc1df87022d74178c9cafff981ffb3c6a50508d6ebee9ded98520e288bf7be62'
+  version '4.4,2018.06'
+  sha256 '6cb50a741303b0f77fdf4efe2fed99d7874cbae3d61dcbc6cdae731b8c827e7d'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.