### PR TITLE
Update camunda-modeler to 1.16.0

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.15.1'
-  sha256 '300d79e7a3d7a8a34839c82c604892637423d97a33aff9fbeffca13564c59cbb'
+  version '1.16.0'
+  sha256 'e5a8a9ac8088426664ca515f21dec4f49f1cff5ccb9bd11497d77ca3fa69131c'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   name 'Camunda Modeler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.