### PR TITLE
Update hands-off to 3.2.8

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '3.2.7'
-  sha256 'a9f0cf35a61316046b5320b8979aff96422a66df1e52085df97354e797014403'
+  version '3.2.8'
+  sha256 '1a45d30b5dfd05edd416414c2f6f4c845ca8ce7df6ae7c0d00e4ab047a339d22'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.