### PR TITLE
Update activedock to 141,1529309013

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '140,1528723167'
-  sha256 '9d43460823fd7ba1e8a3c35a617148804ccd373fe5e588706a2367425555d278'
+  version '141,1529309013'
+  sha256 '9e0e6174a5a7fa7529396abe538e43910b1657b32697da7527e6380ff53f8a18'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.