### PR TITLE
Update bitpay to 4.4.0

### DIFF
--- a/Casks/bitpay.rb
+++ b/Casks/bitpay.rb
@@ -1,6 +1,6 @@
 cask 'bitpay' do
-  version '4.3.6'
-  sha256 'fb7fde80b70d172c4b6d58ef22581fe997cc1a8f54e95c87228910c2ce10f35f'
+  version '4.4.0'
+  sha256 'cebd89e2381e7cfb7fbbd2a4367ba74dba6b5fef4690f6334293d2dd5bd8a051'
 
   # github.com/bitpay/copay was verified as official when first introduced to the cask
   url "https://github.com/bitpay/copay/releases/download/v#{version}/BitPay.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.