### PR TITLE
Update brackets to 1.13

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,6 +1,6 @@
 cask 'brackets' do
-  version '1.12'
-  sha256 '11805e056d01964c0a4226203db5e7bf55819294020c1a9194ed8e6e2fb60f7b'
+  version '1.13'
+  sha256 '34d8960d78e7301febcc6b68b85970d119b7a904cdb9a0ecfc445348de1e4bd4'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.