### PR TITLE
Update buttercup to 1.7.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.7.0'
-  sha256 '62e27b0f1ebedef627f4cedafce1eb080b75d0dde523d3385a086dbb4b20753d'
+  version '1.7.1'
+  sha256 'e9ae179b2afaabd2d4fce4d2bbf87c8557e58f855735cba006a31c78fdeb5ef5'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.