### PR TITLE
Update grandtotal to 5.1.7

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,6 +1,6 @@
 cask 'grandtotal' do
-  version '5.1.6.3'
-  sha256 '09fad1f55bfc4d4d099b1e5a40695edfe06e2ae73de1445130c692f043972e65'
+  version '5.1.7'
+  sha256 'dff6b0118d1d09979981957df17fccc3d57eca2f88b37fc5ab15630880ab970c'
 
   url "https://mediaatelier.com/GrandTotal#{version.major}/GrandTotal_#{version}.zip"
   appcast "https://mediaatelier.com/GrandTotal#{version.major}/feed.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.