### PR TITLE
Update jclasslib-bytecode-viewer to 5.3

### DIFF
--- a/Casks/jclasslib-bytecode-viewer.rb
+++ b/Casks/jclasslib-bytecode-viewer.rb
@@ -1,6 +1,6 @@
 cask 'jclasslib-bytecode-viewer' do
-  version '5.2.1'
-  sha256 '471bd9d5d9b68a0fbfda08f1c16005aa842bfe7ee52b2b0431fa25df125c3491'
+  version '5.3'
+  sha256 'f0117f256a34106732bca3d449dcbcb488dc0300e2569ef2171bef6ce026e8b5'
 
   url "https://github.com/ingokegel/jclasslib/releases/download/#{version}/jclasslib_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/ingokegel/jclasslib/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.