### PR TITLE
Update lingon-x to 6.3.1

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,6 +1,6 @@
 cask 'lingon-x' do
-  version '6.3'
-  sha256 '354a8fa7270d3ff314cb90363e6aa55d2b8de6c765af1099b875f89297d73f73'
+  version '6.3.1'
+  sha256 'c9b873a28fc84f2a98ad470a30ebd8a4d4d24ece8f1afca73d7cb7b48ddfb471'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.