### PR TITLE
Update rsyncosx to 5.3.7

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,6 +1,6 @@
 cask 'rsyncosx' do
-  version '5.3.5'
-  sha256 '972849d47e86401e03bd9fcd8a10aad3648b1c39557e431adfe94187914cf41c'
+  version '5.3.7'
+  sha256 'f69e4b11f40165c41836a24ef726478adc65a70f9d31af87c70a472aee5553ce'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.