### PR TITLE
Update wechat to 2.3.16

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,6 +1,6 @@
 cask 'wechat' do
-  version '2.3.15'
-  sha256 '46a8ae707addfb6544266244a6d140b07f06ede63815b4ed646e6a36ac3f4200'
+  version '2.3.16'
+  sha256 '9d5c533d349bd034f8ab80e51b254192f51baa6fcd75225e04b2a2d9c9da8bf3'
 
   url "https://dldir1.qq.com/weixin/mac/Wechat_#{version}.dmg"
   name 'WeChat for Mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.