### PR TITLE
Update annotation-edit to 1.9.95.2

### DIFF
--- a/Casks/annotation-edit.rb
+++ b/Casks/annotation-edit.rb
@@ -1,6 +1,6 @@
 cask 'annotation-edit' do
   version '1.9.95.2'
-  sha256 '3f8892a8103a305d11891063ab19a8e34bef588e98b6e9553ee7400373d15e2a'
+  sha256 'ff43175b4f726b323b31aec669213aa72400003435518b4f1672a96bf159ef8b'
 
   url 'http://www.zeitanker.com/common/Annotation_Edit.zip'
   appcast 'http://zeitanker.com/updates.rss'

--- a/Casks/annotation-edit.rb
+++ b/Casks/annotation-edit.rb
@@ -7,5 +7,5 @@ cask 'annotation-edit' do
   name 'Annotation Edit'
   homepage 'http://www.zeitanker.com/content/tools/zeitanker_tools/zeitanker_annotation_edit/'
 
-  suite "Annotation Edit #{version.major_minor_patch}"
+  suite "Annotation Edit #{version}"
 end

--- a/Casks/annotation-edit.rb
+++ b/Casks/annotation-edit.rb
@@ -1,6 +1,6 @@
 cask 'annotation-edit' do
-  version '1.9.95'
-  sha256 '415ffcd9d4b5e6ecec1efe708a222b7ac6523ed868199059703e325f889d8a23'
+  version '1.9.95.2'
+  sha256 '3f8892a8103a305d11891063ab19a8e34bef588e98b6e9553ee7400373d15e2a'
 
   url 'http://www.zeitanker.com/common/Annotation_Edit.zip'
   appcast 'http://zeitanker.com/updates.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.