### PR TITLE
Update goland to 2018.1.5,181.5281.38

### DIFF
--- a/Casks/goland.rb
+++ b/Casks/goland.rb
@@ -1,6 +1,6 @@
 cask 'goland' do
-  version '2018.1.4,181.5087.39'
-  sha256 'e5108e26597afde721a62c1203bcb024163a88fbbb09a56d70053585d5735ac9'
+  version '2018.1.5,181.5281.38'
+  sha256 '7e75e755a2fbaf9b439af4ab867179bc0299283d4adb9a0ff3eb7ca0337e8043'
 
   url "https://download.jetbrains.com/go/goland-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=GO&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.