### PR TITLE
Update hab to 0.57.0-20180614230204

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,6 +1,6 @@
 cask 'hab' do
-  version '0.56.0-20180530234342'
-  sha256 'e75755f806d870592adba82e61eecdd8478c3c37c66c67d4901da94feb9dad0e'
+  version '0.57.0-20180614230204'
+  sha256 '4174b443765f927144b0db03e64d195afc72f02a7f4c228c94c93e5f52e10c72'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.