### PR TITLE
Update metasploit to 4.16.57+20180619104411.git.4.6219ce0

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,6 +1,6 @@
 cask 'metasploit' do
-  version '4.16.57+20180618104254.git.4.6219ce0'
-  sha256 'afcd55c568841d59b26ab3bb54e9c47e751e5d38b434cfe5dfa6ec4136c8f453'
+  version '4.16.57+20180619104411.git.4.6219ce0'
+  sha256 '85ae5f91177a3caee4b1af87bc5d5d4559e0eacad21611b7451c0fdf0b55e056'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.