### PR TITLE
Update noteplan to 1.6.27,51

### DIFF
--- a/Casks/noteplan.rb
+++ b/Casks/noteplan.rb
@@ -1,6 +1,6 @@
 cask 'noteplan' do
-  version '1.6.26,50'
-  sha256 'aafcda3ed2ccf4083c1f48f420679c9abcd11898d4c0dcd21499650eca234f21'
+  version '1.6.27,51'
+  sha256 '34cae69c6290e33f88fa76ba3ebfab9ba2823a6c22d975f560cf78d700520210'
 
   # rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.