### PR TITLE
Update boxcryptor to 2.24.941

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,6 +1,6 @@
 cask 'boxcryptor' do
-  version '2.23.939'
-  sha256 '1ded3194ba86e899d803d29cdb9b44a87cf3fcf308b66ddb891cc94155e164c9'
+  version '2.24.941'
+  sha256 'ba112fd2383aa983b991f853be6abb509b7a4f8f68774742d7698f3b646b841b'
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://rink.hockeyapp.net/api/2/apps/7fd6db3e51a977132e3b120c613eaea8'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.