### PR TITLE
Update qz-tray to 2.0.7

### DIFF
--- a/Casks/qz-tray.rb
+++ b/Casks/qz-tray.rb
@@ -1,6 +1,6 @@
 cask 'qz-tray' do
-  version '2.0.6-1'
-  sha256 'a7698a477826385ad895084ebd84c757832b80f04cbdfe21449e91f62fd1568f'
+  version '2.0.7'
+  sha256 '0664bc19a004f40cdb2cf414a4eaad0cdfb7111b9691dde16a6ecc9ea6046e1a'
 
   # github.com/qzind/tray was verified as official when first introduced to the cask
   url "https://github.com/qzind/tray/releases/download/v#{version.major_minor_patch}/qz-tray-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.