### PR TITLE
Update securityspy to 4.2.6

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,6 +1,6 @@
 cask 'securityspy' do
-  version '4.2.5'
-  sha256 '476e628ce9348c8f55fe6d0dec83ad03607850f6146dc815be15bcf96093db3e'
+  version '4.2.6'
+  sha256 '97b79af1a78bcf00f828806494c40c4dc782e524888b2ff9dd379f324088bf97'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.