### PR TITLE
Update resolume-avenue to 6.0.9

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -10,5 +10,8 @@ cask 'resolume-avenue' do
 
   pkg 'Resolume Avenue Installer.pkg'
 
-  uninstall pkgutil: 'com.resolume.pkg.Resolume*'
+  uninstall pkgutil: [
+    'com.resolume.pkg.ResolumeDXV',
+    'com.resolume.pkg.ResolumeQuickLook'
+    ]
 end

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -11,7 +11,7 @@ cask 'resolume-avenue' do
   pkg 'Resolume Avenue Installer.pkg'
 
   uninstall pkgutil: [
-    'com.resolume.pkg.ResolumeDXV',
-    'com.resolume.pkg.ResolumeQuickLook'
-    ]
+                       'com.resolume.pkg.ResolumeDXV',
+                       'com.resolume.pkg.ResolumeQuickLook',
+                     ]
 end

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,8 +1,9 @@
 cask 'resolume-avenue' do
-  version '6.0.8.60677'
-  sha256 'f6f45145d66966ad29ac1e0d0a8e1ae28f73cb94b6005cca47724e99ede284de'
+  version '6.0.9'
+  sha256 '6a231157fa631fef4568d29b18248eefe0c6aaadebfe87b3fabfb992b88f1944'
 
-  url "https://resolume.com/download/Resolume_Avenue_#{version.major_minor_patch.dots_to_underscores}_Installer.dmg"
+  # dd5sgwxv3xok.cloudfront.net was verified as official when first introduced to the cask
+  url "https://dd5sgwxv3xok.cloudfront.net/Resolume_Avenue_#{version.dots_to_underscores}_Installer.dmg"
   appcast 'https://resolume.com/update/avenue_mac.xml'
   name 'Resolume Avenue'
   homepage 'https://resolume.com/'

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -10,5 +10,5 @@ cask 'resolume-avenue' do
 
   pkg 'Resolume Avenue Installer.pkg'
 
-  uninstall pkgutil: 'com.resolume.pkg.ResolumeAvenue*'
+  uninstall pkgutil: 'com.resolume.pkg.Resolume*'
 end

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -11,6 +11,7 @@ cask 'resolume-avenue' do
   pkg 'Resolume Avenue Installer.pkg'
 
   uninstall pkgutil: [
+                       "com.resolume.pkg.ResolumeAvenue#{version.major}",
                        'com.resolume.pkg.ResolumeDXV',
                        'com.resolume.pkg.ResolumeQuickLook',
                      ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.