### PR TITLE
Update black-ink to 1.6.10

### DIFF
--- a/Casks/black-ink.rb
+++ b/Casks/black-ink.rb
@@ -1,6 +1,6 @@
 cask 'black-ink' do
-  version '1.6.9'
-  sha256 'e731b896c552d3585d5b22f8236029d0b765c2b8b2ed0ee24c29bb6083accbab'
+  version '1.6.10'
+  sha256 'a5845ffa7dfabb97f107fff4576c0480cd0ec39bd07cf0c4031a0ce9e76c2c1f'
 
   url "https://red-sweater.com/blackink/BlackInk#{version}.zip"
   appcast 'https://red-sweater.com/blackink/appcast1.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.