### PR TITLE
Update manager to 18.5.62

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.61'
-  sha256 '9adb1a389ace723cad34aa5ea7cfe2dc3305eed17673916385f33726ce677af5'
+  version '18.5.62'
+  sha256 '62f7c1ef3928c7397c81e8ad3d4ed359c531315367eecd6de8b209711a510a35'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.