### PR TITLE
Update imaging-edge to 1.2.0_1805a,9FloiwulRZ

### DIFF
--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,6 +1,6 @@
 cask 'imaging-edge' do
-  version '1.0.1_1712a,boACM00MOv'
-  sha256 '24312f445c59b2a569913f12231911d9dd6c486fa394044d31518f07da328fe0'
+  version '1.2.0_1805a,9FloiwulRZ'
+  sha256 '79f063cd1b51f9f54541075f296945e7eb894878e7a59276247bb91691cb76cc'
 
   # ids.update.sony.net/IDC/ was verified as official when first introduced to the cask
   url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.