### PR TITLE
Update milanote to 1.0.38

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.0.37'
-  sha256 'b7486de2740ac6813d210cb69be6939ceb30be610cfc94db6c429f903fdc7a4d'
+  version '1.0.38'
+  sha256 '261666a27ed51d309925531323c227a3877e043f7c5da0278bedc91314c4b0fb'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.