### PR TITLE
Update activedock to 142,1529489412

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '141,1529309013'
-  sha256 '9e0e6174a5a7fa7529396abe538e43910b1657b32697da7527e6380ff53f8a18'
+  version '142,1529489412'
+  sha256 '1c918b0e1a63080eb69054cba62b70acaab7d87c26ab62478212c48e82f7be76'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.