### PR TITLE
Update devonthink to 2.10.1

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,6 +1,6 @@
 cask 'devonthink' do
-  version '2.10'
-  sha256 '43c9e2cbef1ae8e8e52d97b54be28b5ce019eaf2615db4921e9736b22c72d4c4'
+  version '2.10.1'
+  sha256 'e08348ad43b26bb0faab682c1546e8a3d0a1e40fa5f785b3daa456f48e4ae2cf'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Personal.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.