### PR TITLE
Update hyperswitch to 0.2.585-dev

### DIFF
--- a/Casks/hyperswitch.rb
+++ b/Casks/hyperswitch.rb
@@ -1,6 +1,6 @@
 cask 'hyperswitch' do
-  version '0.2.584-dev'
-  sha256 '83cdc770eaf8372e76d2c0a82b2802095b5ecb5e42e2e246cd09dbc2c16a9662'
+  version '0.2.585-dev'
+  sha256 'ce29bfb40cc8fc3ebbe97c097a5dd04ee5f8d5c8194e11563d2e7b444574eba3'
 
   url "https://bahoom.com/hyperswitch/#{version}/HyperSwitch.zip"
   appcast 'https://bahoom.com/hyperswitch/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.