### PR TITLE
Update mu to 1.0.0,16:beta

### DIFF
--- a/Casks/mu-editor.rb
+++ b/Casks/mu-editor.rb
@@ -1,4 +1,4 @@
-cask 'mu' do
+cask 'mu-editor' do
   version '1.0.0,16'
   sha256 'ae10cf856dca285bf53da5284fb77127fddf7773aa05c7c6104708af5fe054a8'
 

--- a/Casks/mu.rb
+++ b/Casks/mu.rb
@@ -8,5 +8,5 @@ cask 'mu' do
   name 'Mu'
   homepage 'https://codewith.mu/'
 
-  app 'Mu.app'
+  app 'mu-editor.app'
 end

--- a/Casks/mu.rb
+++ b/Casks/mu.rb
@@ -1,9 +1,9 @@
 cask 'mu' do
-  version '1.0.0,16:beta'
+  version '1.0.0,16'
   sha256 'ae10cf856dca285bf53da5284fb77127fddf7773aa05c7c6104708af5fe054a8'
 
   # github.com/mu-editor/mu was verified as official when first introduced to the cask
-  url "https://github.com/mu-editor/mu/releases/download/v#{version.before_comma}.#{version.after_colon}.#{version.after_comma.before_colon}/mu-editor_#{version.after_colon}#{version.after_comma.before_colon}_osx.dmg"
+  url "https://github.com/mu-editor/mu/releases/download/v#{version.before_comma}.beta.#{version.after_comma}/mu-editor_beta#{version.after_comma}_osx.dmg"
   appcast 'https://github.com/mu-editor/mu/releases.atom'
   name 'Mu'
   homepage 'https://codewith.mu/'

--- a/Casks/mu.rb
+++ b/Casks/mu.rb
@@ -1,9 +1,9 @@
 cask 'mu' do
-  version '0.9.13'
-  sha256 '58301468059907b10c1f8176df1240231371541836688355b44e1716b10bae84'
+  version '1.0.0,16:beta'
+  sha256 'ae10cf856dca285bf53da5284fb77127fddf7773aa05c7c6104708af5fe054a8'
 
   # github.com/mu-editor/mu was verified as official when first introduced to the cask
-  url "https://github.com/mu-editor/mu/releases/download/v#{version}/mu-#{version}.osx.zip"
+  url "https://github.com/mu-editor/mu/releases/download/v#{version.before_comma}.#{version.after_colon}.#{version.after_comma.before_colon}/mu-editor_#{version.after_colon}#{version.after_comma.before_colon}_osx.dmg"
   appcast 'https://github.com/mu-editor/mu/releases.atom'
   name 'Mu'
   homepage 'https://codewith.mu/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.