### PR TITLE
Update scrutiny to 8.1.2

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.1.1'
-  sha256 '21e728f7bb7f540cd6768587180c90b8c34f8cec4d857cc8de4971b2c33c44e5'
+  version '8.1.2'
+  sha256 '4a58a89d8f0a231dc3c721068f636d41039cd0e2b319ce34c128b5e785fe7b54'
 
   url 'http://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'http://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.