### PR TITLE
Update keybase to 2.1.0-20180620025801,fc760bdb84

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,6 +1,6 @@
 cask 'keybase' do
-  version '2.0.0-20180604163023,f899a761a7'
-  sha256 'fcce88c7e04753354086b7e9db797ade14af4291b18716bf5e04e1772c55c456'
+  version '2.1.0-20180620025801,fc760bdb84'
+  sha256 '2478791c7c24a741e3a5e5e6f9793510a3574c3d468c50e7c30756815cc3b571'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.