### PR TITLE
Update dbeaver-enterprise to 5.1.0

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,6 +1,6 @@
 cask 'dbeaver-enterprise' do
-  version '5.1.1'
-  sha256 '7f42b824972087f6465fb1cfaf9796753acfdbd2dfd4b85494567febab3aeb74'
+  version '5.1.0'
+  sha256 'e1113ada15d326d3a68bf28c2a7c6dacdb6e2cdf52ed369ce5b5bbd9b5f4066b'
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
   appcast 'https://dbeaver.com/product/version.xml'


### PR DESCRIPTION
Ref: https://github.com/Homebrew/homebrew-cask/pull/48730

Homepage and appcast are at `5.1.0`.

Checksum is still the same. https://github.com/Homebrew/homebrew-cask/commit/c19867d7e57637cd3f3c3d293502566ce9c019ce