### PR TITLE
Update fuse to 1.9.0

### DIFF
--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -6,18 +6,11 @@ cask 'fuse' do
   url "https://github.com/fuse-open/fuse-studio/releases/download/#{version}/fuse_osx_#{version.dots_to_underscores}.pkg"
   appcast 'https://github.com/fuse-open/fuse-studio/releases.atom'
   name 'Fuse Fusetools'
-  homepage 'https://www.fusetools.com/'
+  homepage 'https://fuse-open.github.io/'
 
   depends_on macos: '>= :mavericks'
-  container type: :pkg
 
   pkg "fuse_osx_#{version.dots_to_underscores}.pkg"
-
-  # This is a horrible hack to force the file extension.
-  # The backend code should be fixed so that this is not needed.
-  preflight do
-    system_command '/bin/mv', args: ['--', staged_path.join('osx'), staged_path.join('fuse.pkg')]
-  end
 
   uninstall pkgutil: 'com.fusetools.fuse'
 end

--- a/Casks/fuse.rb
+++ b/Casks/fuse.rb
@@ -1,15 +1,17 @@
 cask 'fuse' do
-  version '1.8.1.15610'
-  sha256 '448fd88fef4dde6b258db3304dcbf8416237fd35ee928d48c4a0bc9d40d0556a'
+  version '1.9.0'
+  sha256 '31e737086d546176f436a2792baca604487f529008a21c424610baec25146a20'
 
-  url "https://www.fusetools.com/downloads/#{version}/osx"
+  # github.com/fuse-open/fuse-studio was verified as official when first introduced to the cask
+  url "https://github.com/fuse-open/fuse-studio/releases/download/#{version}/fuse_osx_#{version.dots_to_underscores}.pkg"
+  appcast 'https://github.com/fuse-open/fuse-studio/releases.atom'
   name 'Fuse Fusetools'
   homepage 'https://www.fusetools.com/'
 
   depends_on macos: '>= :mavericks'
   container type: :pkg
 
-  pkg 'fuse.pkg'
+  pkg "fuse_osx_#{version.dots_to_underscores}.pkg"
 
   # This is a horrible hack to force the file extension.
   # The backend code should be fixed so that this is not needed.


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.