### PR TITLE
Update virtualc64 to 2.0

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,7 +1,7 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.11'
-  sha256 '87b3a7a7db77bdc12ad8a850b241e0b635638c30524f30a9a883f6def1ef4ca5'
+  version '2.0'
+  sha256 '69172a35efcdda0bdd05bc04b74db4d3a77ad3ca2c6aa18aed545d41a775a03c'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.