### PR TITLE
Update zotero to 5.0.52

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.51'
-  sha256 '65d21f6659ab65e2bcc958695ba181a0e664cd42602e6ce795c3b216b375d9b2'
+  version '5.0.52'
+  sha256 '2a6c824e6696fd465bc3cb172bdc0c5694bf57449e8ab5b035cd83207f56afa0'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.