### PR TITLE
Update jetbrains-toolbox to 1.9.3935

### DIFF
--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'jetbrains-toolbox' do
-  version '1.8.3868'
-  sha256 '9f4d958e6626b17f15db0b871be600e0faf3b251041a0386d8b3f290a400fef4'
+  version '1.9.3935'
+  sha256 'b08034316a2bf98fccbb4f53206c66282567a670595116d3df05b1dd1e31ef61'
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.