### PR TITLE
Update pocket-casts to 0.9.9

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,6 +1,6 @@
 cask 'pocket-casts' do
-  version '0.9.8'
-  sha256 'af64a8f2d7cf9cf669c338ffb48f7430c332db09cdfa16a891055ad671fdb8fe'
+  version '0.9.9'
+  sha256 '5febb76c5ad67167c5fc73b461806e763c34ae1219368f54cf1e25519b07132b'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
   appcast 'https://static2.pocketcasts.com/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.