### PR TITLE
Update prizmo to 3.5.2

### DIFF
--- a/Casks/prizmo.rb
+++ b/Casks/prizmo.rb
@@ -1,6 +1,6 @@
 cask 'prizmo' do
-  version '3.5.1'
-  sha256 '151e8106d013e5f3b6bd5afa2fc0271a6c77b69609ee1faced8e0fd6cc1414d3'
+  version '3.5.2'
+  sha256 '18b709b76ff07e8a4c59758fe9fc4daf5eb7133953f590ca0cbf57af7cceb939'
 
   url "https://www.creaceed.com/downloads/prizmo#{version.major}_#{version}.zip"
   appcast "https://www.creaceed.com/appcasts/prizmo#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.