### PR TITLE
Update printrun to 1.6.0,18Nov2017

### DIFF
--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,10 +1,9 @@
 cask 'printrun' do
-  version '18Nov2017'
+  version '1.6.0,18Nov2017'
   sha256 '426229043a2a33a6768dcca12135f0751c007595af078665eb854cf87e4e2999'
 
-  # koti.kapsi.fi/~kliment/printrun was verified as official when first introduced to the cask
-  url "http://koti.kapsi.fi/~kliment/printrun/Printrun-Mac-#{version}.zip"
-  appcast 'http://koti.kapsi.fi/~kliment/printrun/'
+  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version.before_comma}/Printrun-Mac-#{version.after_comma}.zip"
+  appcast 'https://github.com/kliment/Printrun/releases.atom'
   name 'Printrun'
   homepage 'https://github.com/kliment/Printrun'
 

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -7,5 +7,5 @@ cask 'printrun' do
   name 'Printrun'
   homepage 'https://github.com/kliment/Printrun'
 
-  app "Printrun-Mac-#{version}.app"
+  app "Printrun-Mac-#{version.after_comma}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.