### PR TITLE
Update scrivener to 3.0.3,3032

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,6 +1,6 @@
 cask 'scrivener' do
-  version '3.0.2,1506'
-  sha256 '05e360e15931fbf2114d50d6b926b3c8c899257e5a514b3add8ed4f6edd313aa'
+  version '3.0.3,3032'
+  sha256 '776aa7a4ed46f6894bce4a15b4f4a53ea31044b6f2192fbd29234b3ddfd0c24a'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://scrivener.s3.amazonaws.com/mac_updates/Scrivener_1012_#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.