### PR TITLE
Update subutaicontrolcenter to 7.1.1

### DIFF
--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -1,6 +1,6 @@
 cask 'subutaicontrolcenter' do
-  version '7.1.0'
-  sha256 '8a3846795928419bdac260e43dbb849aab746947c9aae28eec100a7b6e3d8ab6'
+  version '7.1.1'
+  sha256 '8613d1fb3237ec27ecb28d8a050aab91ccf18a381113ea5eefe9338444a336cb'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-control-center.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.