### PR TITLE
Update unity-windows-support-for-editor to 2018.1.6f1,57cc34175ccf

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.1.5f1,732dbf75922d'
-  sha256 'cdf5759109a8b5098bd3392b987a88fdb452718edab43b1f80f971569c398dad'
+  version '2018.1.6f1,57cc34175ccf'
+  sha256 '7020b00edfb90834ef0360146626ceea8ff5d3800943577c27ec143729cd6d5a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.