### PR TITLE
Update unity-download-assistant to 2018.1.6f1,57cc34175ccf

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.1.5f1,732dbf75922d'
-  sha256 'e2df6802839c1d059fa481c61918eebb8f631690b4568fa2f71349a9c9493bf3'
+  version '2018.1.6f1,57cc34175ccf'
+  sha256 'f7600ac904869bc41bcaf8a797aaf8af19985a74c193ac100934eaf1a64ea66d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.