### PR TITLE
Update endurance to 1.1r25

### DIFF
--- a/Casks/endurance.rb
+++ b/Casks/endurance.rb
@@ -1,6 +1,6 @@
 cask 'endurance' do
-  version '1.1r18'
-  sha256 'a20ceb5629de4b8785ebb6b4e0e86ca0be36de591c2dc6ed39f73e9cdd0c9884'
+  version '1.1r25'
+  sha256 '06a116b70b3ae78879152bfcd6168a4e83b5b2e79782abff630ee38ec45076a9'
 
   url "https://enduranceapp.com/downloads/Endurance#{version}.zip"
   appcast 'https://enduranceapp.com/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.