### PR TITLE
Update camerabag-photo to 3.1.0

### DIFF
--- a/Casks/camerabag-photo.rb
+++ b/Casks/camerabag-photo.rb
@@ -1,9 +1,8 @@
 cask 'camerabag-photo' do
-  version '3.0.1c'
-  sha256 '5ea0312ecc6246b95f28e9848548432d328808c892cff9fd4f09aba2798fd8ea'
+  version '3.1.0'
+  sha256 '017ee2d95497ad7eb5725eda1ef47e3d01b132a1d756f6089c650949fc4a5b1f'
 
-  # downloads.nevercenter.com.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://downloads.nevercenter.com.s3.amazonaws.com/CameraBag_Photo_Mac_#{version.dots_to_underscores}.dmg"
+  url "http://nevercenter.com/camerabag/photo/download/filearchive/CameraBag_Photo_Mac_#{version.dots_to_underscores}.dmg"
   name 'CameraBag'
   homepage 'https://nevercenter.com/camerabag/photo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.