### PR TITLE
Add Memory Tracker by Timely latest

### DIFF
--- a/Casks/memory-tracker-by-timely.rb
+++ b/Casks/memory-tracker-by-timely.rb
@@ -1,9 +1,10 @@
 cask 'memory-tracker-by-timely' do
-  version :latest
-  sha256 :no_check
+  version '1.1.1'
+  sha256 '9b0793d338d2c47ea99f5e5bd497511610c2cd483215a16d149ba88745a4e881'
 
   # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'
+  appcast 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/sparkle.xml'
   name 'Memory Tracker by Timely'
   homepage 'https://timelyapp.com/'
 

--- a/Casks/memory-tracker-by-timely.rb
+++ b/Casks/memory-tracker-by-timely.rb
@@ -1,0 +1,13 @@
+cask 'memory-tracker-by-timely' do
+  version :latest
+  sha256 :no_check
+
+  # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'
+  name 'Memory Tracker by Timely'
+  homepage 'https://timelyapp.com/'
+
+  auto_updates true
+
+  app 'Memory Tracker by Timely.app'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

------

This is the companion tracker app for [Timely](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/timely.rb) that act as an activity recorder for the Electron/web app. I choose `memory-tracker-for-timely` to be consistent with [local-by-flywheel](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-by-flywheel.rb) which uses the same naming pattern. The download URL doesn't have versions and neither do the URL in [appcast](https://timelytimetracking.s3.amazonaws.com/mac_tracker/sparkle.xml) so I'm using `version :latest` as the app version and `auto_updates` set to true.

Thanks!