### PR TITLE
Update atom to 1.28.0

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,6 +1,6 @@
 cask 'atom' do
-  version '1.27.2'
-  sha256 '048528e6915910bd3723dbaad26601308ba8dc6161388aaeecdd884013af0d07'
+  version '1.28.0'
+  sha256 'dbfc5529364b7cf7f10d89f30613ad49ba13d9d3c1caf32493da2c72209ae96e'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.