### PR TITLE
Update cloudtv to 3.9,1529671901

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,6 +1,6 @@
 cask 'cloudtv' do
-  version '3.8.9,1529018444'
-  sha256 '91516210406b840e004f38e2577049edc9fd4413ea414b04dc557000b1f4285a'
+  version '3.9,1529671901'
+  sha256 '1b0278ff2c8230be6ab20fb1cdb02001a27861abc7c62d65db6f54737c91dab7'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.nonoche.CloudTV/#{version.before_comma}/#{version.after_comma}/CloudTV-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.