### PR TITLE
Update get-iplayer-automator to 1.13.10.b20180621001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,6 +1,6 @@
 cask 'get-iplayer-automator' do
-  version '1.13.9.b20180615001'
-  sha256 '6835b6157395971a0c6476c87f96701f7f4a0ef0a163b0a2c6163e1eec1d9adf'
+  version '1.13.10.b20180621001'
+  sha256 'ef38c4d833779f93246128e04762f7aa8bcf10f70e96fd353b5de3f2acd788aa'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.