### PR TITLE
Update reflector-teacher to 3.1.1

### DIFF
--- a/Casks/reflector-teacher.rb
+++ b/Casks/reflector-teacher.rb
@@ -1,6 +1,6 @@
 cask 'reflector-teacher' do
-  version '3.0.2'
-  sha256 '1d9d2db04d6b5d4c2a4150718693792a813560d0af20d5afa8a067617f70558f'
+  version '3.1.1'
+  sha256 '5db3c9144d2d7f9b8487fda12d6c9d81ad6e87c516baadc33eb28d598d051b9d'
 
   url "https://download.airsquirrels.com/ReflectorTeacher/Mac/ReflectorTeacher-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/ReflectorTeacher/Mac/ReflectorTeacher.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.