### PR TITLE
Update studio-3t to 2018.3.2

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2018.3.1'
-  sha256 '370f14b2c8d77b2b6e06a697921222893b0ad3bb7cbe6e745ce103da8fcf1b27'
+  version '2018.3.2'
+  sha256 '9854e2ec74687a131fe7392dd9a4c0c4256d5ea5ffb4dc2370965dd211f08957'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.