### PR TITLE
Update exfalso to 4.1.0

### DIFF
--- a/Casks/exfalso.rb
+++ b/Casks/exfalso.rb
@@ -1,6 +1,6 @@
 cask 'exfalso' do
-  version '4.0.2'
-  sha256 'aea8192a089affc58f955400029a936b579bc1ee06bddc5b6f839cfb696ce9e9'
+  version '4.1.0'
+  sha256 '53a065100c904ad82462cccabbe1e8f1dad5f66132b6e59820b7dc36dbbbdc3a'
 
   # github.com/quodlibet/quodlibet was verified as official when first introduced to the cask
   url "https://github.com/quodlibet/quodlibet/releases/download/release-#{version}/ExFalso-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download exfalso` is error-free.
- [x] `brew cask style --fix exfalso` reports no offenses.
- [x] The commit message includes the cask’s name and version.