### PR TITLE
update wkhtmltopdf to version 0.12.5

### DIFF
--- a/Casks/wkhtmltopdf.rb
+++ b/Casks/wkhtmltopdf.rb
@@ -2,7 +2,7 @@ cask 'wkhtmltopdf' do
   version '0.12.5'
   sha256 '2718c057249a133fe413b3c8cfb33b755a2e18a8e233329168f1af462cd6de5f'
 
-  url 'https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox-0.12.5-1.macos-cocoa.pkg'
+  url "https://downloads.wkhtmltopdf.org/#{version.major_minor}/#{version}/wkhtmltox-#{version}-1.macos-cocoa.pkg"
   name 'wkhtmltopdf'
   homepage 'https://wkhtmltopdf.org/'
 

--- a/Casks/wkhtmltopdf.rb
+++ b/Casks/wkhtmltopdf.rb
@@ -1,12 +1,12 @@
 cask 'wkhtmltopdf' do
-  version '0.12.4'
-  sha256 '402209589279e092c94d17c76e6fdda6be5cadb21ce12e7c093c41f82b757506'
+  version '0.12.5'
+  sha256 '2718c057249a133fe413b3c8cfb33b755a2e18a8e233329168f1af462cd6de5f'
 
-  url "http://downloads.wkhtmltopdf.org/#{version.major_minor}/#{version}/wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
+  url 'https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox-0.12.5-1.macos-cocoa.pkg'
   name 'wkhtmltopdf'
   homepage 'https://wkhtmltopdf.org/'
 
-  pkg "wkhtmltox-#{version}_osx-cocoa-x86-64.pkg"
+  pkg "wkhtmltox-#{version}-1.macos-cocoa.pkg"
 
   uninstall pkgutil: 'org.wkhtmltopdf.wkhtmltox',
             delete:  [


### PR DESCRIPTION
- [X] `brew cask audit --download wkhtmltopdf` is error-free.
```
$ brew cask audit --download wkhtmltopdf
==> Downloading https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox-0.12.5-1.macos-cocoa.pkg
Already downloaded: /Users/rmoore/Library/Caches/Homebrew/Cask/wkhtmltopdf--0.12.5.pkg
==> Verifying checksum for Cask wkhtmltopdf
audit for wkhtmltopdf: passed
```

- [X] `brew cask style --fix wkhtmltopdf` reports no offenses.
```
$ brew cask style --fix wkhtmltopdf

1 file inspected, no offenses detected
```

- [X] The commit message includes the cask’s name and version.
```
$ git log --max-count=1 --oneline --no-decorate
3562ddb627055f84 update wkhtmltopdf to version 0.12.5
```

Unfortunately this version has a `-1` appended for the package but not the version dir, future versions should be able to go back to a variant of the original versioned string.