### PR TITLE
Update libreoffice-language-pack to 6.0.5

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,558 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '6.0.4'
+  version '6.0.5'
 
   language 'af' do
-    sha256 'b86bf58e69b41abe2c55c7b21dfa968ce15830f19a48e246f97a060a70fe9b62'
+    sha256 '0b599c28671067c3cf126aad173394890a130db96ef6ce3872e13d2c3dc32012'
     'af'
   end
 
   language 'am' do
-    sha256 '1c8bd6d9cba7e041770458a3184f4e8ff632ae87ad34884fdb5e8146871cbef3'
+    sha256 '12072ef736a5d339493b20eb4a97b5f6e075968db8895d4a269db74a43d1459e'
     'am'
   end
 
   language 'ar' do
-    sha256 'abf678655c34c249503c853d75c2a316299b78c8380b1c50cc8440aebedcb0f1'
+    sha256 '9bfe11d879563493729f82d96590949cc3ff66802951b07fcb8325953b5e0a07'
     'ar'
   end
 
   language 'as' do
-    sha256 'dab021c696d88031d9e1a0f5cc5c9e8cb68be50a9bc0b1f1c9a0dd816a738136'
+    sha256 '20013156e2b04e24bf0322eaa3bc3e77ed4a02979b38c73d338f823e4d20e404'
     'as'
   end
 
   language 'ast' do
-    sha256 '0df08fe6cdc0149a8b2dda2b4ec323357c5dbeaa70a801575d1d38112ae4290f'
+    sha256 '0662f7b1fdd213c9a6af9d50082d7b78d11f7a1837aa11a0ece45cd74002501f'
     'ast'
   end
 
   language 'be' do
-    sha256 '076632d390565e7d26cdedad38e19b017ca868004d2252578fd54d92d55d6aba'
+    sha256 '9cc8eb459033acef1dc9338ef72802249295d59b6d66803add8532548bbc1508'
     'be'
   end
 
   language 'bg' do
-    sha256 '93e9d0a5d889792ea3b9cf845d27bc57d5c0166e3d55ffbf2f9517126e3a1437'
+    sha256 'dce036fd1bef8a0b8a110c4479575c32ef469db89016e626310aa4a7a1c78c3e'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '6daad9f937fbcc1f4b94b5f6426f720928b04795d00d2ae4a0cbe0dd93a7e388'
+    sha256 '0a22210438ac166669824dc6052e3e5e93889d5e356d4a7e4ac1c30b154aa226'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '2656f70a9b783924ae4a272487d49b81eeb492d477ee34889fc8819f28962997'
+    sha256 'd39435c9d74cc8e59714eedac3525acf3d93c84f77430be82dd211c8465df3a9'
     'bn'
   end
 
   language 'bo' do
-    sha256 '0e74bd8a70b461bc98f541725e0e49f47b85c5c9367c0926ac319639610e8958'
+    sha256 '7ac6e54cfb2dd4344dddc6d7c70f41795282b2548db53e4ab0cc526648114f5d'
     'bo'
   end
 
   language 'br' do
-    sha256 '0f47a5897db9c7d1a7cb4742236aaffe55e6e4921741248baa5596a295000049'
+    sha256 'e4c0069d8079a72a0452ba7a2c703e7ad583c62375b6d7eeaa5dc0dae3298edd'
     'br'
   end
 
   language 'brx' do
-    sha256 'a4f11499bb126e4a14305373693b50b760fcee747bf582598881fd7147ec63c0'
+    sha256 '3d30a741fffabe54d6698bc7b70525c4708f96a14a0779aa8dd27cf98420a9e0'
     'brx'
   end
 
   language 'bs' do
-    sha256 '5a57542a406dc2b9ff5c312510e5bc438ce79b80c2c4544164aac9f26efd6193'
+    sha256 '97b43d64a585aa536454f3db5652caf6dfce5d67ff55559dda6222c92675df1f'
     'bs'
   end
 
   language 'ca' do
-    sha256 '37ab4513360ce69b45c4503fb20bc6640046e92dd0c4c80286a703c1722de5b6'
+    sha256 '7085c22210c463e3a38227d36fbe5057f9214fd3a37c63b819a99bce87609c0a'
     'ca'
   end
 
   language 'cs' do
-    sha256 '5cc0b60cd6b01c20c33fc76c82259f74bd0ca814c067859d8bf73da339e7ffee'
+    sha256 'f46622ad29431e0a501334408e78b37f809a874b799053c117a1141ac348aa56'
     'cs'
   end
 
   language 'cy' do
-    sha256 '20042779184a7d573044882cab9d817937d3765f4358211fe9dcca60c16bc425'
+    sha256 'da438805136238c2a179f843245ce9d2e70c707b67e884d28979d7f908ad5e7a'
     'cy'
   end
 
   language 'da' do
-    sha256 'df3a82c5c714049500907ec29a918bb616d20ebabe180ee9541637dd0ab71937'
+    sha256 '57ada7ae2c692c4b411d0f6eec553ac4b8580e43c2ca76ddf72dd005ae4451e8'
     'da'
   end
 
   language 'de' do
-    sha256 '22e7a72e8a76d54bec2a6f69d5b64463927a447b1370b699822541d873059d57'
+    sha256 '7e12d7108d84e2fe25098f55c88d01874973b5f5c1252b816ae208b0a4f6d951'
     'de'
   end
 
   language 'dgo' do
-    sha256 '277d49c014fa62923f23cc9c5919c6c1b3b6a5a0c7d82d5c3e1e486abd25d978'
+    sha256 '8c065ea0e952af2e5158be873914ce3c90aef2cbc0aa60aa2f822dbb80c229bb'
     'dgo'
   end
 
   language 'dz' do
-    sha256 'c8b8b2c24cf3e50a7f7a3ec3cfd296054fb3ff2ba907352e7a1b853ea0ea560f'
+    sha256 '7aa4f4db3b6100bf3bb30cf2fae009feb74a4e7445ad257548db22db912a37e1'
     'dz'
   end
 
   language 'el' do
-    sha256 'bfbdee3ded88a2cf248c435055f4348ad05a4a9922bc9ee65c27ba2354a09b14'
+    sha256 '641d0a93d049656e15a9de1b4645a855d4407ff01b9ede0f7a5a44436e7eb6ff'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '73f33b941eee3f9b4429a01b46e3c00f8c34af0058d281271196757eef9fe210'
+    sha256 'e0c6d1556fab14e28a534384ce0c673ccc1eb06b74e194963c5e2ea2831115c5'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '2dd146642a6a1145f05031d533a05f0845278e7bbe26e9673fde4a2c73173c62'
+    sha256 '4f18cb5caf1149ca6083947bb8762442f45c70d6d65f97ce16fab98c4f21c23a'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 'd0c2a607aa4fc6d04c41e8d9c4b9b3464384f87ca225069907b11f4bae494855'
+    sha256 'a722dcd0e935329940ad632dd8e239b116ff9542a39bda3559d9d8e090fe789e'
     'eo'
   end
 
   language 'es' do
-    sha256 '56f005cd749dc8ce761b011d46ee38b1094757687eb18f0ab0fce5054f6a4db7'
+    sha256 'e480fabb84678f01b98ed48c302877f86025726278110be927b124dfe2280cc5'
     'es'
   end
 
   language 'et' do
-    sha256 '3ceca8723429d134ad21968bcf37747507abb69be1b8f8eee212cba21569980d'
+    sha256 '8b4b7ddd64cc6e0a18aba03b4a6abfa6c70ff4213e0c347b3d33421f7a98c143'
     'et'
   end
 
   language 'eu' do
-    sha256 'cca33845b179da18e90ade9aefa92f1fabd0d7c85bdf9419e43f4a688c973a27'
+    sha256 '373cf9d5685e1c0de700ef7b48683ebcf05e118b7139603b6fd810cccd3e617e'
     'eu'
   end
 
   language 'fa' do
-    sha256 'fef3a2b683c2c28116244f2e40a30f795e1d2abfc66e9944f520754b540c937a'
+    sha256 '08316e1e4c3eecdc5815bfeaf72d87731a759a8722708f0c4f79eed4d2292b59'
     'fa'
   end
 
   language 'fi' do
-    sha256 'fff8035c6660bfd3f61b470eb9f2b7526628550a2532e93a1049e3b21a365541'
+    sha256 'd981a6724cf404f7339cf8457369f81050bdb2bb57b70d5d77c5eaa03a982aa1'
     'fi'
   end
 
   language 'fr' do
-    sha256 '8c92f27df20d44c440bceb23650131a0d865e672684558af91be14b5bb265ed8'
+    sha256 '7e88ac8722a24305b84707a34955bdfa3554317b14c57fde3a3c18c8f79a954e'
     'fr'
   end
 
   language 'ga' do
-    sha256 'b1dd15b03ef8644aa1595d74328f806a0103dedf3e54f75a2d6fa4ce52e91696'
+    sha256 '18c36dfbc48c6ac17ec84a5afebf2ece874bfbb78e25391c1c10b1ee5d9428c4'
     'ga'
   end
 
   language 'gd' do
-    sha256 '67f5ef2169c785a234e13f148388177ef84e78bc7afe1fd7111ab15b3a9153e0'
+    sha256 '2ab0fbd0385d50f7909b34c599cd7fde772e06b802764f9129520dd4e3a7ea6c'
     'gd'
   end
 
   language 'gl' do
-    sha256 '66aca229b1f28abd046e2e4f39a9f772c64eada86a8d006d28a7393b8f511398'
+    sha256 '111e62f1b93edb1300a9e873eca5aca0349881e9a778c1bb5f7426f5c139ebb4'
     'gl'
   end
 
   language 'gu' do
-    sha256 'd806830bc24889066a3f01e84ffe3349721a5344de4ccc1a3bde9c1aa4e18858'
+    sha256 '555118a27f7f65f6bca091b863d0eff7b32058f8ad994ae06a9935fbefa144c2'
     'gu'
   end
 
   language 'gug' do
-    sha256 'f020badfc9ce0637e99eda87411f7b03760acdecc67fbf82c4e99693f1e81326'
+    sha256 'f8598b2a99cb2d8d1d02417a4034e2366b286c22a9828ceca66c16151d4a952f'
     'gug'
   end
 
   language 'he' do
-    sha256 '0238ada1ddd401e9604bb9624feda65fb1ee0d0247571a04123c1c8a7f61c876'
+    sha256 'a432a097f54b0f1ff6099d7582989b4dae01a45d53c1e85b257d2683a48c7dcf'
     'he'
   end
 
   language 'hi' do
-    sha256 '5ff99889a20cc446fa7bac990fd9e4e983e08a68509fda56e981946cfa9a5911'
+    sha256 'b6f16942b57aa0e986eb8ec3ce3409e15ebdeaa06d220d3d83423a898d117d91'
     'hi'
   end
 
   language 'hr' do
-    sha256 '6764b05a604b82a6e6589c65ca62ff2f5414ee4d4484766d96937e0c5b8e40e7'
+    sha256 '7b011f4616b70e17eb260308cbf14bc75c9b43e41c445033b33cfc02df8a8252'
     'hr'
   end
 
   language 'hsb' do
-    sha256 'd7373d2ad4e91fb3c63df0dd3eb40552753502bafbc05ff99ae573a46df59f4f'
+    sha256 '57b05bb84521fde00266bc6cb9ff904bb85f69abaffaa44d442f21c1f509f880'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '77cb4618d00b2d4682ad6d70e9298d2d28212083a4b6668d0edea3c5e56edcd2'
+    sha256 '8a83888eeb06eb50ec4dc2d3f9fbd968c2f10c496a7688ab0a42b9e505ebdacb'
     'hu'
   end
 
   language 'id' do
-    sha256 '42933d2ed6653556559d04b42b8a296adcf98e5878d85eed751d7fe33c8d31fe'
+    sha256 '9cb519ab8c070fd71d59869f124680d1ac05f48e2ff95a2651e48f807c9d276c'
     'id'
   end
 
   language 'is' do
-    sha256 '5e57f1a9374842cb124db928ee09d3e6c94684d927d228cd880555ef412864e4'
+    sha256 'e25ded23f0eec942096a2bcf97acd432f810637eec50007a8cffb18ea99f324d'
     'is'
   end
 
   language 'it' do
-    sha256 'b3cba2887ee3e3c13d438d9d8d753ded5de315ebfccbc2df1d89d8444985cc7c'
+    sha256 'a5575c12d39fb4cca6ff3490572491c10e9a2fc6bf2cbdf750f410702f39051c'
     'it'
   end
 
   language 'ja' do
-    sha256 '2c0633fcaeffeec34a0d9570f67165a3bed7c64934cbcedaff662fd0a26e5fc8'
+    sha256 '1689138a3149b1c97f3da282901bb8d6826e87d68e173dc19bc7636cb0b35dc8'
     'ja'
   end
 
   language 'ka' do
-    sha256 '37add56b47ea4de8df9e6c54e093d8ea92451c027610ff7cc1d47700c5215a93'
+    sha256 '2d61bf00a0ef0107bd22f672faf21f500d3ef2cd567eba3b9676fd77d4e6b86b'
     'ka'
   end
 
   language 'kk' do
-    sha256 'a56ae2b910a4f9e1e4e1723415bba2989877a15d80dc6f72eb66f1aec2fc2483'
+    sha256 '1466f26240fa87878a99748e8a134cbc0af7e99bc169bcb21d705bbb170746a8'
     'kk'
   end
 
   language 'km' do
-    sha256 'd2a71ed123d8d23bd88e754bc8682d34e59d3053ab1f71570390c8ead397e7ea'
+    sha256 '47880961ddd8eee44cf97d20f5c1f1f12f8d92883ad66d9705f545d7d798faa4'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 'ecd89c1a83ff4f1afcc16867e2d37a1228abd231823971a1aa1a37f5ef4803a9'
+    sha256 'e68541599d22c109793f90c119ef6e48b72f535d63699613b5280dd7667aaffc'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 '640668792be9609f1386482c29eaa8501fd31254f5d5ce69639fb0e85cc14084'
+    sha256 'bbec7e7c327287ce04f565a8a4dbe129d9d76cb7a3aeb4b6c08f100421b3dc4e'
     'kn'
   end
 
   language 'ko' do
-    sha256 '7528af774e28450af5b72e5f28814555c6274e6bd741df817989725dcf8326fe'
+    sha256 '0a825c0316b57d4c86d01dbea27c863a8caf58cef884db4616e62b4226989437'
     'ko'
   end
 
   language 'kok' do
-    sha256 'b8b924684fec1de8e90b7cf1f0ca8141e4794cee300d7f8739fc177a16ea56a3'
+    sha256 '0fefb908d68dab4d08598b8dfb6b866e89cfaa2902724ec4efc6c2bf7123ee8f'
     'kok'
   end
 
   language 'ks' do
-    sha256 'b4bd80b0730e5974ceb3c35c4aca4a004fcbfbc6686d04ac940397eea75ed64b'
+    sha256 'cb611778b6fb51cb2c83c6afcf80660a6acd8289c3d5f5761ecd4e17ab4087cf'
     'ks'
   end
 
   language 'lb' do
-    sha256 '859006eab9e3505490aceb9499925c14e688451b557e804af36514c50d5ac704'
+    sha256 'f49b1555d9a7ad538ddfd4fd68fce0f7ef941e2c7fb34ce671414d3a5c7add5d'
     'lb'
   end
 
   language 'lo' do
-    sha256 '076fcc0901c259106e70b85b8e5b4d50b9a8e5dbe84a7dd0773592715830b53d'
+    sha256 'fa75f5161e3f9b78a0c35eab65fe917defa98f2abe0c0dc111ccb9f8bf094b56'
     'lo'
   end
 
   language 'lt' do
-    sha256 '95d6a46ea00d6cd603c10bfb41693cd8589408b2e6368ee75db951f9048e5f5e'
+    sha256 '845d43acef6bfb73bd0857a373c9e6dbf2bffd3476245ec599724d7f6829766d'
     'lt'
   end
 
   language 'lv' do
-    sha256 'f960d8f908f72670ba376b89fa9ce77418a06353748109ddcb8485d0a13a55d4'
+    sha256 'de6156262422dcfa8e035bbbad49053fdba8753b21f3b5b2972c108949efbbe5'
     'lv'
   end
 
   language 'mai' do
-    sha256 '2d3feb9a708a7cea8e2ab32ba7cf8743a136ba79fa5ebc9ad39a11636835fb90'
+    sha256 '0f02c0739d10d85c6969c56a654ab206d9c50ae5d3cc0eab5fbb7c870205a859'
     'mai'
   end
 
   language 'mk' do
-    sha256 '6e3e380da604d620441bee7dbb6d1fcabb0e3a4e35d4057115b8d19f24bf94ba'
+    sha256 '06ad4c4c26818c2d15f8ea808f7b5eda8652cfd7e81bde110f6ecc0ebb5d6d58'
     'mk'
   end
 
   language 'ml' do
-    sha256 '62b76652603ea93785641c772de1a4f7f0c3cef63cdb151d59062ef7459ed98c'
+    sha256 'fd02a0b464cdb9f59009ead177b33eeb473610317b40a0f604ed8ecb4ae8e498'
     'ml'
   end
 
   language 'mn' do
-    sha256 '4d3130b3ef9124be89f0e63225994a1db1891334fb51b23022a17bbbd8495217'
+    sha256 '55dde047c4d04c31711e10e98dee2760fc71c0364eb46def93a69682e32406ac'
     'mn'
   end
 
   language 'mni' do
-    sha256 'd2a7744987d6abca190834a99250815168f6231743306894c70b3c0e5638f85a'
+    sha256 'e472627f946a63c1da215a0eedf28cdc35761aadc2791df8eb4ff3958308576f'
     'mni'
   end
 
   language 'mr' do
-    sha256 '53f23f128e0b80df2fe177c3649f26a2116e1795375474acd7e85232eedd6d9e'
+    sha256 'bcceec81d1f8c9942b52c22a09dc60b99cce1caac8c770cb616cf67900bb73dc'
     'mr'
   end
 
   language 'my' do
-    sha256 'c46d9ecb1e3d448a27f2bcdf6b7eb4828c01f45c2de1ea59df4087d46292e7fe'
+    sha256 '782797ea898ddc97e3b7cb463cef30bcbbfffb912654ec62b4ea8cdb18bb7993'
     'my'
   end
 
   language 'nb' do
-    sha256 '917243d75607fd0d20988ffd37f86e6c9cd71cf377b467a0167d64c7e01c610d'
+    sha256 'a7ecd8561b8dcfada4252dace87a0634ad0dc2d1247ccc1aa87e888dd8317416'
     'nb'
   end
 
   language 'ne' do
-    sha256 '354a6cbdb8e77f83b2a3ed64cfe550fc3d2b664a60ce75f8bbd2eab3738cfec3'
+    sha256 '5c9bd83a3458fc44ef74fcf259aba92f6dc6128240c7c80e83e891eab9904219'
     'ne'
   end
 
   language 'nl' do
-    sha256 '6da280884f1a7bc5db713c7d3f7bc89b83f9a69b2d3ce36669bffcb73664ad15'
+    sha256 'e580c90bc7582628e28b54a93173802aff741c7d989b8370764942d7b41546e8'
     'nl'
   end
 
   language 'nn' do
-    sha256 'cb02d75ccbc8bdcc2bb9e5fe73c20c717a9426a365467e7a4b422255fa8c20bb'
+    sha256 '76501d7c244995e5871cd8ba7a66d7cedc53bfebe7c28d3ecba4bc61e31db561'
     'nn'
   end
 
   language 'nr' do
-    sha256 'd829b7942e0aae25465866dde97e4d794af86237f8c6baab2af18c7d4acd0407'
+    sha256 '2df1b76c452704f5f4c0d96b50720a65c06d06a533b0b72eeef908d07a0dab84'
     'nr'
   end
 
   language 'nso' do
-    sha256 '3f3bcb77ad259eae1aabeb22faa8ff7a9b31288ddac4302faa2b2ec5d98fa2bf'
+    sha256 '324f45f059baf2ad5cd10a6c73ef07a9e70edb1fda6cc005e1eb812958090513'
     'nso'
   end
 
   language 'oc' do
-    sha256 '2244a7ed8c4bc68a709667eb307b27dff69bdbbe1211aca6bdf7b965a7307fc7'
+    sha256 '188944163c543819de1b03165f993ffc5a3b298c958cb7f2033ba680dd3d81e8'
     'oc'
   end
 
   language 'om' do
-    sha256 'c2a79fb6d7d419793c36e326fd5b51dbe6f5970ada15fb6cefff60f7af37e784'
+    sha256 '94b6fa51ae516fe898b44d43fac1fcd8364e4ca148d9658a23c2a5a6d145b3bc'
     'om'
   end
 
   language 'or' do
-    sha256 '080778f088a3a6b34270c4ccada68e62e78070f3a80dcbb1b9f8be97652ce795'
+    sha256 '51877affc55c3ea6f915b2ca0ad9003aec2d29d721b8b1920ce0ee39364e01b4'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 'cf8ca017d5b1b65dbfb76c4eb60de2480093a6833be122ab3dfbc6d2012fedc3'
+    sha256 'c298cd299f00d90b6b97ce416b4585316cbf379434d772ff416236d56434b013'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 'dcbaccb98f8dd416aea17377ca3ea02f247ab2d76c42bdeb958879c165b4b252'
+    sha256 'bd0606b21fb2ca549faa0d85a6c26c750c57bd0dd5cc98f395d3d0938d99fa09'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'd0d6b2df717f3ddc5a52c28f0d3619fb7d9a73d029501094ef9611518b6bbc66'
+    sha256 '521c445dbee8a6e63d3c4a8f085aca94727787219d84e32e9b99ad6a24d49d6a'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'dbd33eb3ca1408145cb3ff02d8eab40d1aee81371482cae662cf70d4d53240aa'
+    sha256 '8df0c7d230052a62cdc349c867106265fa8915dd8f19dc1eb3e3bc6871b2950c'
     'pt'
   end
 
   language 'ro' do
-    sha256 'e4c1695558a6c0a764265d09fdba432a810448af7cd84e358a3c8b06fd1160a3'
+    sha256 'b17abf0596ebd47146daddde60d33dd8e7a97a3919459114f3c29f874d7713aa'
     'ro'
   end
 
   language 'ru' do
-    sha256 '55d73d714302bbf165e6ee6848643d159212a92d1fc0fe0786d32c989faa8168'
+    sha256 'e20276d66727646fa86eb5d542c1bd8540d914590f093c08b0bb34b0cb504366'
     'ru'
   end
 
   language 'rw' do
-    sha256 'ff27e8eeee1a2efe69a4eb9311515277e3c7f3d224301d2244661dc41b63981e'
+    sha256 '39145c0651bbf5a2906771323ec383a0205902262aa1e74f20d156ef05d64c43'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '277e2154f90191c46c3a2d7f94bedc6e0b386861f90ba3d059d4d606828beff2'
+    sha256 '298199c67e40062d030e9ee81be60108e961a4fbecc71c3e841fe5a40c55ab9a'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '4dcee65f6f5930b1dd515d7d121eadd415112d2e27576778c29664c32e8262e6'
+    sha256 '8b1e2a4f12f028754faa87717812e0ab844f53a282a032719c04bbfe8a15e4e0'
     'sat'
   end
 
   language 'sd' do
-    sha256 'bf869a27f96b22fc2faba6102059c9578b3ab330aa7250d191cb5fd4b70edb95'
+    sha256 '3aee52567b20728fa300f5bff217f73e5f9ff1f43e65cd549adc7eba8947b9f6'
     'sd'
   end
 
   language 'si' do
-    sha256 '9d66da47a2a5f2951349aa02fbe86f4b531e8943aeee315944c8f24bd68b734c'
+    sha256 'bc8584d5d5aedc5405a358059d57baef507ee783ba107ce68d5111494bfe11b7'
     'si'
   end
 
   language 'sid' do
-    sha256 '9bd6b823fc4b7e38c32644289c7cd53978aa72b2545ee69ca86a8196ce22aa0a'
+    sha256 'b9e031617cd2dcb05abbd8ef72dbe3a7041747b9394a1c15f47798984da56fa6'
     'sid'
   end
 
   language 'sk' do
-    sha256 'c41d8f8a76bcb7d338e5f22b16d102167c4a9214040c035fabc140454e0d9a00'
+    sha256 'aaf38d6a055241a9d705e659fb3149ef9b8fa03ae743fdc7a3f6a56dd3207b7e'
     'sk'
   end
 
   language 'sl' do
-    sha256 '3b1983990cc1fe669d30d9d35358e455bb581542c94f7c63d20f01cf7359b3d3'
+    sha256 'c947414b06774d91747c7819ff3d4a1eca914ccca19bebbb88df98617a1c0f52'
     'sl'
   end
 
   language 'sq' do
-    sha256 'f8736657695fa5af1470985345fbf4136fafde24ef84019ca2459946950708a3'
+    sha256 'b2d9514e1f318fdcfe3291c310eef3211d06eeaf1db18e132e7f79d17a7c740c'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '0f09a2558822a80270b31f487e95deef2f50ae4726124ce853f19be19eb9db1e'
+    sha256 '7b50a2b53a96f32d5d2a455320b05e810664644df7bd7e3d42c66f109686c6b4'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'b6326487ac9cd988da6d4bca2c0a7a3824fc246752e30eabdc8194fbca96228b'
+    sha256 'b0d54ace7da225642d5b542633a45e287a3115c3e93c0373a9ba301c542ab04c'
     'sr'
   end
 
   language 'ss' do
-    sha256 '0ff13efb5ff17b8e30628ef897615bdfc548c991a19335b5a9a1c5efc614c08f'
+    sha256 'c00fb038263391499778c66e51b4450d7ccb87ddd87a24b334ca2f94b6340efa'
     'ss'
   end
 
   language 'st' do
-    sha256 'e36d28e5b025dc6a62af49220652f31f9239b1fda64e0cc9ca691bbecb272fb2'
+    sha256 'e2196c886e8cf84f3c8c9c99699f1df0b6cd59e3ae3f2936fdfc611e631dc4f9'
     'st'
   end
 
   language 'sv' do
-    sha256 '5944dfb2b34b03e9e1825f70abeb8f732ab352c958795717789358223d5b5784'
+    sha256 '9caaa5e0bca7dafc7eb6ddd136e480992eb175314b37746f1b0618b2bd853eb4'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 '0ebb3c8c87fd4fba34787f2ec03c8588b76c9d482ec0dd8663edc37340529b1c'
+    sha256 '1cc75703b09494ee5d68a893f37fff4e563e84b1a926860d3d4212a1019223cb'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '4be3da6e4903803737818699d17391fe101dc597c1b93c1751d1a7f6449c8c22'
+    sha256 '58036de9e16743dfd23f900deeb1737e96cbb1a7fe843b9dbc373f28abba133b'
     'ta'
   end
 
   language 'te' do
-    sha256 '83f7685eadde121bfd72ea2333262719c725db5949352f05f3d41ede01ea9b29'
+    sha256 '833d00e707b7b797de9535be164b255acd1462efb817e31d14df71ae29db9974'
     'te'
   end
 
   language 'tg' do
-    sha256 '31b11badf1458c975c2b80a46c508379db1e9aa7dce664e4372557c9dcee18af'
+    sha256 '9a19b1ee7c934e1aa345e034bec29ce8a67734d645768c372f4f89ed61f97ed1'
     'tg'
   end
 
   language 'th' do
-    sha256 '710bfd266fe5e0cbcb77cbbe2473bec67ecb1f17621c84d536ab1a5e64dcefad'
+    sha256 'c97e463c3f57aeba48c11866fd6d89d10ce851a09c5db36c9a19547a0890fd02'
     'th'
   end
 
   language 'tn' do
-    sha256 'b2dc1af756918d3a999e5e2f447650510d8712218e975e84b6b297b993717dbc'
+    sha256 'ba5591837ebb2c21e9fcec48a45525aa5cc605ddac60fba4f5047f11687e8fbe'
     'tn'
   end
 
   language 'tr' do
-    sha256 '36e04c897ad7631814804115638f8b5ec37ce7063431dc296baea48f8c973047'
+    sha256 '6d4fe6f3cab9cfb84e51414f0ac89ce28222fd2205d00bb1f7398e9bab6d46a5'
     'tr'
   end
 
   language 'ts' do
-    sha256 'ba7601be048dd59fc077f938e5db9261855bacdcf979bb64122bd77ddf7e01d8'
+    sha256 '5550e57f2dc9f4b316b18920ac178eab4c307f3fd684da02fbd7868583c23f33'
     'ts'
   end
 
   language 'tt' do
-    sha256 'f7d295ee0c31d251d0b95f6452dd071da67f4015470920d02cb8ef27b0c2c309'
+    sha256 'ee70b1b06cc92d0ab075799bd0817e74ac0bf9bac4ffa4449bcfab7a527b871e'
     'tt'
   end
 
   language 'ug' do
-    sha256 'd6458c2806e0f74ded89d73a73469bda31a25b8e17e284425c45f71746a20346'
+    sha256 '22cb9ca23c598560075327a8087effe7ad2a599e305b296fe04c5b64d2f034d8'
     'ug'
   end
 
   language 'uk' do
-    sha256 'a74a988affe136cd36f0fef929a4c57b9ec1a77820deff0f8dbcfe10e312d5b5'
+    sha256 'e54b54dcad5453ed620d58fe02dd354cd920d6523cba514dbd021dbf969a69df'
     'uk'
   end
 
   language 'uz' do
-    sha256 '3f156aeae899142fbb538754de33a9bf3534f15caa689213e5506ac4a8df2b56'
+    sha256 '17e37e7b2c992dc362baef1733fe557de26217fff44b2313b319308884afe855'
     'uz'
   end
 
   language 've' do
-    sha256 'c23e3f223f1c7576ee67816d65c73ebeb64a108054414ce9118aabbe4cc1921f'
+    sha256 '781c25e91b3cb49b08f1f146d48fcf4e8114ba639e2e148e5214278e41132905'
     've'
   end
 
   language 'vec' do
-    sha256 'a4088d87b87a8b0419171715299770b2def2abf9f8c5542ec3ba9678cedd3921'
+    sha256 '52993159dd21d8bc31c4635f1eea8e6336964d32f29e253e3b75bc37dd8f38e7'
     'vec'
   end
 
   language 'vi' do
-    sha256 'cf45af0d0e5c932e9177843d74987a8d18e7432f24b48bf424c1a8dba17d77bb'
+    sha256 'c8f3183379daa95b3ef0ea45d5de198f45bc6b036895771ca89416be147c82f0'
     'vi'
   end
 
   language 'xh' do
-    sha256 'c2961263f84918c900687feaf44d0d8e7084de2a4ef52b687fa53d29c4b3cfc7'
+    sha256 'deba01b2efdacf689e2d8a9c5bb0d713da80e7664e859f71cde8f9b303466b68'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 '53b5c9cac7f51bd5a6a2fd01ba25ac4218e4ec18b221af6ebd36140eeac7ec03'
+    sha256 '48cab674d19434479a883a0872f8cedd74dd6cbffc2bb9bf7209f99cdf7ee6b3'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '7fc54ff7b1c132065f3e3ceed523d41cb6b4e5d7fc90ef7603604e84f1fbbc63'
+    sha256 'd7a5a8ae427d48a461270e7a70502855a204680e6454d20a217dce9a87f13a69'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '9d51bce802933567fd4d9c0b53448efa0881fde3c08673c405843b0640b5e875'
+    sha256 '8ea789b249c3c925cab988d0a8e5c2c8b307d8bf1c1534777261c4dff727c7b2'
     'zu'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
