### PR TITLE
Update gas-mask to 0.8.6

### DIFF
--- a/Casks/gas-mask.rb
+++ b/Casks/gas-mask.rb
@@ -1,6 +1,6 @@
 cask 'gas-mask' do
-  version '0.8.5'
-  sha256 '23dba9a90432e060c144e9e35077a7dbd4b3bf1a9848807461dad9d8d8f3ae83'
+  version '0.8.6'
+  sha256 '9f75d0b11340d70832f87011c3d8ed97b9b18b3a56dec5f860d4040bb7404500'
 
   url "http://gmask.clockwise.ee/files/gas_mask_#{version}.zip"
   appcast 'http://gmask.clockwise.ee/check_update/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.