### PR TITLE
Update freesmug-chromium to 67.0.3396.87

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
   version '67.0.3396.87'
-  sha256 '7e28db21d2562bca9dad9b341b0488df312f8bc812576c870f9212ee9fcd9bcb'
+  sha256 'ca36d90f76ee40b6c236c2e2f1aa2d988645d66deda753b406bd4eef6fa1ce20'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.