### PR TITLE
Update netron to 1.8.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '1.8.8'
-  sha256 '0c813d8739af9206728a1c680bb7e04cf02a49dd3707b9e06545d104574f5d06'
+  version '1.8.9'
+  sha256 '2f3eac1d425fdc67163a626224b4176c3a35808c0d821d4294b07af0e767a613'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.