### PR TITLE
Update komodo-ide to 11.1.0-91033

### DIFF
--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -1,6 +1,6 @@
 cask 'komodo-ide' do
-  version '11.0.2-90813'
-  sha256 '62f8423ba92f94205aec1a2f34f6330ace7f4156d41f6d046b189c9ebe93a64c'
+  version '11.1.0-91033'
+  sha256 'b46304e7849a9c507d3e7602dd264be9961100aaf8ff3a6e7689cdeddeea1f49'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
   name 'Komodo IDE'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.