### PR TITLE
Update kerio-connect to 9.2.7.12444

### DIFF
--- a/Casks/kerio-connect.rb
+++ b/Casks/kerio-connect.rb
@@ -1,6 +1,6 @@
 cask 'kerio-connect' do
-  version '9.2.5.9921'
-  sha256 '01b1c9da268cdccbbba560e22e2d615e37e4ca4818ac57dc84c598949b6f9a6a'
+  version '9.2.7.12444'
+  sha256 '5b9aa3926081952cdf74a223509989fa67e7fb5c7f2629b8c6baa7bcb581fddf'
 
   # kerio-dc-releases.kerio.com was verified as official when first introduced to the cask
   url "http://kerio-dc-releases.kerio.com/kerio-connect-client-update-darwin64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.