### PR TITLE
Update studio-3t to 2018.3.2

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
   version '2018.3.2'
-  sha256 '9854e2ec74687a131fe7392dd9a4c0c4256d5ea5ffb4dc2370965dd211f08957'
+  sha256 '9ea3a66fc952260eec335526ddb5f692064b919de4335446341cd64358c0d014'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.