### PR TITLE
Update telegram to 4.1-131203

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.0-130816'
-  sha256 '1c497eeeae8146434a1fbc04e7c7c82de5fd152431e3c6cb376c284563e0a75d'
+  version '4.1-131203'
+  sha256 'fb12882e737045d468f8df26072e3c586b0b1d832c70d51858cb3cacb9bb7a05'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.