### PR TITLE
Update firefox 60.0.2: add binary link

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -129,6 +129,7 @@ cask 'firefox' do
                        ]
 
   app 'Firefox.app'
+  binary "#{appdir}/Firefox.app/Contents/MacOS/firefox"
 
   zap trash: [
                '/Library/Logs/DiagnosticReports/firefox_*',


### PR DESCRIPTION
Link the firefox binary to allow command-line use of Firefox.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.