### PR TITLE
Update shotcut to 18.06.02

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,9 +1,9 @@
 cask 'shotcut' do
-  version '18.05.08'
-  sha256 '066b768d5986e7d1ee7c6ead0aa28d27e6a6ba5b774f4528c3a7ba5aa4ca32ae'
+  version '18.06.02'
+  sha256 '950c8b9ed8ad56718ca2be31bc8dd2fd6a35b9d3eb7b95ee88661fc6e7b19fbf'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
-  url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-osx-x86_64-#{version.no_dots}.dmg"
+  url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-macos-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.