### PR TITLE
Update electron-cash to 3.3

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '3.2'
-  sha256 '7da9595a7d56ec9e59e15f809ebb522f1b72e47ab26fbc6435324c1b17d4dbd3'
+  version '3.3'
+  sha256 '561a64d72530c8a48b168cd66604db280a3cccb96623da70d7d7759b840a3cfc'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/fyookball/electrum/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.