### PR TITLE
Update manager to 18.5.87

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.65'
-  sha256 '8fd531caa4c673dfd3aab37de7ea65368da3e36454d38de03531214587362e1a'
+  version '18.5.87'
+  sha256 '489dc60319d1cf1c2297609405febe33874ebf21a4f66601d824c64373883f2e'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.