### PR TITLE
Update byteball to 2.3.0

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,6 +1,6 @@
 cask 'byteball' do
-  version '2.2.0'
-  sha256 '436f81611ace2722016228c2f3313e89567231d2ae9d4b0fbb2b2c80030090da'
+  version '2.3.0'
+  sha256 '155ca1db521d3fc506c8869d633028f8bd10d860f54a00cefe9ef676f07c23ad'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.