### PR TITLE
Update dupin to 2.13.1

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,8 +3,8 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.13.0'
-    sha256 'c00c6258aab33c193b7300681295166d6fdb7759cbd2f40c5aa266756b63a991'
+    version '2.13.1'
+    sha256 '56d6c70355beaf1fe06c483dbe457d125782e185af7047cbcb28145535f58784'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.