### PR TITLE
Update github to 1.2.5-02240059

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,6 +1,6 @@
 cask 'github' do
-  version '1.2.3-51b96e2d'
-  sha256 'd8918f48a95eb7887530527d4e6684c56153ff9596f301dc3bcb631484f787cf'
+  version '1.2.5-02240059'
+  sha256 '4310b64b7da790c1206fc3b17762522698e008fb9d56ec92063aebfc3470adcf'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.