### PR TITLE
Update ieasemusic to 1.1.7

### DIFF
--- a/Casks/ieasemusic.rb
+++ b/Casks/ieasemusic.rb
@@ -1,6 +1,6 @@
 cask 'ieasemusic' do
-  version '1.1.6'
-  sha256 '4be84837e9bf11967b197690fc1626e0d74b8ee0863b7748acc15c23223263c6'
+  version '1.1.7'
+  sha256 '51a0f8126cceaf707d0492deb5724170a346cc7d721c1f29321b9f0f297b5c8e'
 
   url "https://github.com/trazyn/ieaseMusic/releases/download/v#{version}/ieaseMusic-#{version}-mac.dmg"
   appcast 'https://github.com/trazyn/ieaseMusic/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.