### PR TITLE
Update marshallofsound-google-play-music-player to 4.6.0

### DIFF
--- a/Casks/marshallofsound-google-play-music-player.rb
+++ b/Casks/marshallofsound-google-play-music-player.rb
@@ -1,6 +1,6 @@
 cask 'marshallofsound-google-play-music-player' do
-  version '4.5.0'
-  sha256 '2d43b0c69fa38d90a26cb711bcb952cb9be525d3ace9e8a5c5d7fe5e5a27db26'
+  version '4.6.0'
+  sha256 '30b2d5bd5bf14356ae2d6e351c945208d19ea2fd5a0f6a47ffbb5102cddf83fe'
 
   # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
   url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.