### PR TITLE
Update nocturn to 1.6.3

### DIFF
--- a/Casks/nocturn.rb
+++ b/Casks/nocturn.rb
@@ -1,6 +1,6 @@
 cask 'nocturn' do
-  version '1.6.2'
-  sha256 '76bf310719ab2da6ee3356d548a3e2405403ab4dfbb8ec7721a277fbff6401d8'
+  version '1.6.3'
+  sha256 'bfe4d9d3fcf8efe2a6814cacb47f14a177e30d58e02b21244387196eadc7c61f'
 
   url "https://github.com/k0kubun/Nocturn/releases/download/v#{version}/Nocturn-darwin-x64.zip"
   appcast 'https://github.com/k0kubun/Nocturn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.