### PR TITLE
Update qownnotes to 18.06.6,b3652-080019

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.06.5,b3647-205200'
-  sha256 '3176a7dec5f743e3167fb2bd6bc9523aa9534994630f7d46c87060c85b3c6cc4'
+  version '18.06.6,b3652-080019'
+  sha256 '66f56b287eabff8531c3bcc93a6bbc1d12167ea9cedbd12ac6b2dc1e1a03e400'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.