### PR TITLE
Update superproductivity to 1.10.45

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '1.10.40'
-  sha256 '6a05262a9631135cbbcf4918600a8d849c5216524c25ad5e892d657884926c3c'
+  version '1.10.45'
+  sha256 '2f36d2acf2b0795b54a8e433a3aa5b1900f6eaec4c3cac06114707b352408e43'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.