### PR TITLE
Update twist to 1.0.36,4448

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.0.36,4343'
-  sha256 'a6d60e2b05ca17a8c8d50c4bc213a0afb685147c85bb3edb73695bdab2aff528'
+  version '1.0.36,4448'
+  sha256 'c574ca9fb2c8e5db1b9f2bab4f96f9a2d277de9a2c4e4a936e308148347cb04c'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.