### PR TITLE
Update vuescan to 9.6.10

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.6.09'
-  sha256 'f49f6c308707da207b89499ce6caf8648779aa2c249eafef6af85effc1228b9f'
+  version '9.6.10'
+  sha256 '15835048b4af7ba309fb4c432424ed8c821f7f23c3ae02e5b75b57bf328e3c33'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.