### PR TITLE
Update silverback to 3.1.8,237:1516782103

### DIFF
--- a/Casks/silverback.rb
+++ b/Casks/silverback.rb
@@ -1,10 +1,10 @@
 cask 'silverback' do
-  version '2.6.6'
-  sha256 'bee6233d3cc94ccd972b6c29f6777f329a4ac862dda5e699deab525491d82cae'
+  version '3.1.8,237:1516782103'
+  sha256 'd4dd7c17a07bfcf7923e905a67eb7895febdf78d3c72ddb5980c59051e3a38f1'
 
-  # silverback.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://silverback.s3.amazonaws.com/silverback#{version.major}.zip"
-  appcast 'https://silverback.s3.amazonaws.com/release/appcast.xml'
+  # dl.devmate.com/uk.co.clearleft.SilverbackMac was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/uk.co.clearleft.SilverbackMac/#{version.after_comma.before_colon}/#{version.after_colon}/Silverback-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.devmate.com/uk.co.clearleft.SilverbackMac.xml'
   name 'Silverback'
   homepage 'https://silverbackapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.