### PR TITLE
Update cacher to 1.5.9

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '1.5.8'
-  sha256 '311efc3873900c1954591b2ab01dd3f03bc6b749a7931e49833e0c48765dc3a2'
+  version '1.5.9'
+  sha256 '072b93a87343b58fee1d06f192172c676c602a2733b0565a800ec6c6ab1d81a1'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.