### PR TITLE
Update blockstack to 0.29.2

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.29.1'
-  sha256 'ac92cd6b94fb4a6f119155bce5972b7a70117236394226eabc25816441d1879c'
+  version '0.29.2'
+  sha256 '603bf7a7533d9643ede11b62c05133ffb7b12c91d9ae3508919f3212ab12c18d'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.