### PR TITLE
Update nisus-thesaurus to 1.1.4

### DIFF
--- a/Casks/nisus-thesaurus.rb
+++ b/Casks/nisus-thesaurus.rb
@@ -1,8 +1,8 @@
 cask 'nisus-thesaurus' do
-  version '1.1.1'
-  sha256 'ee9203ada1fa944ac4b7fc04f03ec58fd7c60ce1d73e6058321583f7dbf8ae5a'
+  version '1.1.4'
+  sha256 '463e4db2cf02766f606b86fb3e2e656a866358da4d0c8c444cb38bbebd6b9566'
 
-  url "https://nisus.com/files/free/Thesaurus-v#{version.no_dots}.zip"
+  url "https://nisus.com/files/free/NisusThesaurus-v#{version.no_dots}.zip"
   appcast 'https://nisus.com/Thesaurus/updates.php'
   name 'Nisus Thesaurus'
   homepage 'https://nisus.com/Thesaurus/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.