### PR TITLE
Update tableplus to 1.0,112

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '1.0,111'
-  sha256 '184314222ee4567b39e476c83307b309010d864b58dd1e7350d521acb9fcfd7b'
+  version '1.0,112'
+  sha256 '5fd6ea350fb275eb8e1fa1f9cb18411c3df2eaf3785f609ef1407a5a6860804e'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.