### PR TITLE
Update tower to 3.0.0-152,40287324

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,9 +1,9 @@
 cask 'tower' do
-  version '2.6.6-359,b84d867f'
-  sha256 '3283e5b750336e5c14273b51376481bebc44bd03c5c028df52a5d0091ddf946a'
+  version '3.0.0-152,40287324'
+  sha256 '0a484d1f69976bddb8fcc3c5de418bf790738df349f4c68e04823b93bbe83e5f'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.major}-#{version.before_comma}.zip"
+  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.before_comma}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable"
   name 'Tower'
   homepage 'https://www.git-tower.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.