### PR TITLE
Update igetter to 2.9.6

### DIFF
--- a/Casks/igetter.rb
+++ b/Casks/igetter.rb
@@ -1,6 +1,6 @@
 cask 'igetter' do
-  version '2.9.5'
-  sha256 '6e07dd6ba828b99a009bae254fe632897b492e489ae02da788728ec4b443ba2e'
+  version '2.9.6'
+  sha256 '31acb5393debc5fbb26a8d7a8ff1acf64144422ec127393dbc1a7329d9669a14'
 
   url "https://www.igetter.net/search/downloads/iGetter#{version}.dmg"
   name 'iGetter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.