### PR TITLE
Update scythebill to 14.0.0

### DIFF
--- a/Casks/scythebill.rb
+++ b/Casks/scythebill.rb
@@ -1,6 +1,6 @@
 cask 'scythebill' do
-  version '13.9.4'
-  sha256 '70ab53b1ac6c5d25fcab6e1f42882439155966d9c1a07c584b6143096a287528'
+  version '14.0.0'
+  sha256 '61cc8f2f7a6a47c6d689a82710efe9533a1afb309b5d2a7847544fc56f2a2825'
 
   # storage.googleapis.com/scythebill-releases was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/scythebill-releases/Scythebill-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.