### PR TITLE
Update freesmug-chromium to 67.0.3396.99

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '67.0.3396.87'
-  sha256 'ca36d90f76ee40b6c236c2e2f1aa2d988645d66deda753b406bd4eef6fa1ce20'
+  version '67.0.3396.99'
+  sha256 'e7876735a132b5a7ee2e942b526bd8b4f164f4f2dd576ec743d083d4b0a7d615'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.