### PR TITLE
Update lbry to 0.22.0

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.21.6'
-  sha256 '04e06ce837ea87ea3dba0e71ba89c69164de759dfe938014f9e885137980901d'
+  version '0.22.0'
+  sha256 'c7c7ca5c0e8e051001d8bd269867b6f4df2233453e975e2ed79076ce31a45a5c'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.