### PR TITLE
Update munki to 3.3.1.3537

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,6 +1,6 @@
 cask 'munki' do
-  version '3.3.0.3515'
-  sha256 'bda08ad4104cc892033c9a84672f6d24069c30533d0b67de113744d696a53032'
+  version '3.3.1.3537'
+  sha256 '7077cef8baafd501911117327a511aad7b1bc54cf31113e5c6b7407340d3407f'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.