### PR TITLE
Update retro-virtual-machine to 1.1.7

### DIFF
--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -1,6 +1,6 @@
 cask 'retro-virtual-machine' do
-  version '1.1.6'
-  sha256 '4025387610cdc8bca78b5ac3513001fe2ef7ab14d6019472b14653e89bb58afa'
+  version '1.1.7'
+  sha256 'a31930bcc63d9dd69e43b84376a11d8d86064b15fc0e47a0acb29c86b964e09f'
 
   url "http://static1.retrovirtualmachine.org/release/Retro%20Virtual%20Machine%20v#{version}.dmg"
   appcast 'http://www.retrovirtualmachine.org/en/changelog'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.