### PR TITLE
Update screens to 4.5.6,21936:1529438870

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,6 +1,6 @@
 cask 'screens' do
-  version '4.5.5,21918:1528124912'
-  sha256 'f03aa02745085bb488ee5b0c9e6449afa6a903636407131d38fc09108bc802c1'
+  version '4.5.6,21936:1529438870'
+  sha256 '9b1dbfe78cedcd850e03f9aa18956bf0010f673d028ad8e1c68050956492be5a'
 
   # dl.devmate.com/com.edovia.screens4.mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.edovia.screens4.mac/#{version.after_comma.before_colon}/#{version.after_colon}/Screens#{version.major}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.