### PR TITLE
Update lab to 0.0.74,untagged-f2f7de6625ed43865c06

### DIFF
--- a/Casks/lab.rb
+++ b/Casks/lab.rb
@@ -1,9 +1,9 @@
 cask 'lab' do
-  version '0.0.73'
-  sha256 '0c9e35fbca8b43bfe5287e772ccff8627e18112a85f93de720e51914c08f8fb6'
+  version '0.0.74,untagged-f2f7de6625ed43865c06'
+  sha256 'c8073ba00c5fcc2bf724b02d257c0684a958df3a330465bef31e3f3c2122d7de'
 
   # github.com/c8r/lab was verified as official when first introduced to the cask
-  url "https://github.com/c8r/lab/releases/download/v#{version}/Lab-#{version}-mac.zip"
+  url "https://github.com/c8r/lab/releases/download/#{version.after_comma}/Lab-#{version.before_comma}-mac.zip"
   appcast 'https://github.com/c8r/lab/releases.atom'
   name 'Lab'
   homepage 'https://compositor.io/lab/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.