### PR TITLE
Update UnicodeChecker to 1.20.

### DIFF
--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -1,6 +1,6 @@
 cask 'unicodechecker' do
-  version '1.19'
-  sha256 '072d89e3b2b894288a7315f76c5ead3c023be24a4510cc90ee5ff7250c352e8b'
+  version '1.20'
+  sha256 '5f4c9e952b8e40e6d7dc01e1ab523f69ebadb3d5da645c71eaa2fd52d6c2671b'
 
   url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
   appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml'
@@ -9,8 +9,9 @@ cask 'unicodechecker' do
 
   app "UnicodeChecker #{version}/UnicodeChecker.app"
 
-  zap trash: [
-               '~/Library/Caches/net.earthlingsoft.UnicodeChecker',
-               '~/Library/Preferences/net.earthlingsoft.UnicodeChecker.plist',
-             ]
+  zap delete: '~/Library/Caches/net.earthlingsoft.UnicodeChecker',
+      trash:  [
+                '~/Library/Application Support/UnicodeChecker',
+                '~/Library/Preferences/net.earthlingsoft.UnicodeChecker.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
