### PR TITLE
Update camtasia to 2018.0.1,135

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -8,5 +8,7 @@ cask 'camtasia' do
   name 'Camtasia'
   homepage 'https://www.techsmith.com/camtasia.html'
 
+  auto_updates true
+
   app "Camtasia #{version.major}.app"
 end

--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,8 +1,10 @@
 cask 'camtasia' do
-  version '3.1.5'
-  sha256 'e0e0b1e879f10cb164b09aaa8eb97b22d9947751cb09f775a5187cbdcc5d2a0e'
+  version '2018.0.1,135'
+  sha256 'e0b12e8c9eb99b068c39ed5eb656a37b46feec22a338dafb6040ca91e2391424'
 
-  url "https://download.techsmith.com/camtasiamac/enu/#{version.no_dots}/camtasia.dmg"
+  # rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09/ was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09/app_versions/#{version.after_comma}?format=zip"
+  appcast 'https://rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09'
   name 'Camtasia'
   homepage 'https://www.techsmith.com/camtasia.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.