### PR TITLE
Update manager to 18.5.90

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.5.89'
-  sha256 'fd092b789bd0835920c6c3640204b506af4e7fa85ef59ca243b06c26e921a67f'
+  version '18.5.90'
+  sha256 'cc9e5927bed9a8c835343161d239b0f411f655bab607aa9a97b88d4341e9cdf6'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.