### PR TITLE
Update graphql-playground to 1.6.1

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,6 +1,6 @@
 cask 'graphql-playground' do
-  version '1.6.0'
-  sha256 '121e7015fc076b4029d3ecc37e4ff65afb32f689f3f6cfd4ed8f4d86b084ec39'
+  version '1.6.1'
+  sha256 '8a78902c05b76426d1a72b07fbf229921e25c9f3d34133004f2af76a80e062c3'
 
   url "https://github.com/prismagraphql/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prismagraphql/graphql-playground/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.