### PR TITLE
Update hstracker to 1.4.3 (untagged-6b350eea272b791b4fb5)

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.4.2'
-  sha256 '88e941f01b6154cdb859995b84bc82dbe72a1e2fb1752dba6c6ad40bc8b56fac'
+  version 'untagged-6b350eea272b791b4fb5'
+  sha256 '5a98f99756b8d70c44778445281bda605fb1e0b95020109d523aabf49094cfcb'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.