### PR TITLE
Update iridient-developer to 3.2.3

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.2.2'
-  sha256 'a2c15afb957c48582cbbccbba8d579267a82ba9370064f5493cc9a6c8f8046f8'
+  version '3.2.3'
+  sha256 '480add11528a77a13af15890912f595c87b82408dd2401d345bec445f2dfcce2'
 
   url "http://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'http://www.iridientdigital.com/products/rawdeveloper_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.