### PR TITLE
Update journey to 2.6.12

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,6 +1,6 @@
 cask 'journey' do
-  version '2.6.11'
-  sha256 'b34ea2a6f7d00ab6c5eaa91f98a434da8dcac615837d86f905edca865d17828c'
+  version '2.6.12'
+  sha256 '98b4c3cc0523307702640d39bd0523346b88a41a0cc4db3378dc8f3591aff4ec'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
   url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-x64-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.