### PR TITLE
Update arkclient to 1.6.0

### DIFF
--- a/Casks/arkclient.rb
+++ b/Casks/arkclient.rb
@@ -1,6 +1,6 @@
 cask 'arkclient' do
-  version '1.5.1'
-  sha256 'a33256df845f440763b3738168ba10951c16683fec37330a94ebb2637b612273'
+  version '1.6.0'
+  sha256 '588b92d889d0b23b28ece6b165ed49d592985e62d33a133390090eb75561997b'
 
   # github.com/ArkEcosystem/ark-desktop was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/ark-desktop/releases/download/#{version}/ArkClient-MacOS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.