### PR TITLE
Update natron to 2.3.13

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,6 +1,6 @@
 cask 'natron' do
-  version '2.3.12'
-  sha256 '8de9937134119c365ec592a5ed813b969dd1170d75b2d02b78f73c8290e1346e'
+  version '2.3.13'
+  sha256 '117aa5df7843a25e48941cd904236d510c679740b17c1eca98e94cccf7925e4c'
 
   url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
       referer: 'https://natron.fr/download/?os=Mac'

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -2,7 +2,7 @@ cask 'natron' do
   version '2.3.13'
   sha256 '117aa5df7843a25e48941cd904236d510c679740b17c1eca98e94cccf7925e4c'
 
-    # https://ayera.dl.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
+  # https://ayera.dl.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
   url "https://ayera.dl.sourceforge.net/project/natron/OSX/Universal/releases/Natron-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/natron/files/OSX/Universal/releases/'
   name 'Natron'

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -3,7 +3,7 @@ cask 'natron' do
   sha256 '117aa5df7843a25e48941cd904236d510c679740b17c1eca98e94cccf7925e4c'
 
   # https://downloads.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/project/natron/OSX/Universal/releases/Natron-#{version}.dmg"
+  url "https://downloads.sourceforge.net/natron/Natron-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/natron/files/OSX/Universal/releases/'
   name 'Natron'
   homepage 'https://natron.fr/'

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -2,9 +2,9 @@ cask 'natron' do
   version '2.3.13'
   sha256 '117aa5df7843a25e48941cd904236d510c679740b17c1eca98e94cccf7925e4c'
 
-  url "https://downloads.natron.fr/Mac/releases/Natron-#{version}.dmg",
-      referer: 'https://natron.fr/download/?os=Mac'
-  appcast 'https://github.com/NatronGithub/Natron/releases.atom'
+    # https://ayera.dl.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
+  url "https://ayera.dl.sourceforge.net/project/natron/OSX/Universal/releases/Natron-#{version}.dmg"
+  appcast 'https://sourceforge.net/projects/natron/files/OSX/Universal/releases/'
   name 'Natron'
   homepage 'https://natron.fr/'
 

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -2,8 +2,8 @@ cask 'natron' do
   version '2.3.13'
   sha256 '117aa5df7843a25e48941cd904236d510c679740b17c1eca98e94cccf7925e4c'
 
-  # https://ayera.dl.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
-  url "https://ayera.dl.sourceforge.net/project/natron/OSX/Universal/releases/Natron-#{version}.dmg"
+  # https://downloads.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/project/natron/OSX/Universal/releases/Natron-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/natron/files/OSX/Universal/releases/'
   name 'Natron'
   homepage 'https://natron.fr/'

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -2,7 +2,7 @@ cask 'natron' do
   version '2.3.13'
   sha256 '117aa5df7843a25e48941cd904236d510c679740b17c1eca98e94cccf7925e4c'
 
-  # https://downloads.sourceforge.net/project/natron/ was verified as official when first introduced to the cask
+  # downloads.sourceforge.net/natron was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/natron/Natron-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/natron/files/OSX/Universal/releases/'
   name 'Natron'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.