### PR TITLE
Update scythebill to 14.0.1

### DIFF
--- a/Casks/scythebill.rb
+++ b/Casks/scythebill.rb
@@ -1,6 +1,6 @@
 cask 'scythebill' do
-  version '14.0.0'
-  sha256 '61cc8f2f7a6a47c6d689a82710efe9533a1afb309b5d2a7847544fc56f2a2825'
+  version '14.0.1'
+  sha256 '4d497d461634b24a37343a51b97a0cfeacbc825e8394df553acc5ee0aa129c02'
 
   # storage.googleapis.com/scythebill-releases was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/scythebill-releases/Scythebill-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.