### PR TITLE
Update virtualc64 to 2.1

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,7 +1,7 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '2.0'
-  sha256 '69172a35efcdda0bdd05bc04b74db4d3a77ad3ca2c6aa18aed545d41a775a03c'
+  version '2.1'
+  sha256 '2de41a6b2cb240da80193ed5ff7fafd47729f061f2987d7a9e0daa43627fa832'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.