### PR TITLE
Update activedock to 146,1530166632

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '145,1530000334'
-  sha256 '27b94166fa83939fbced3a4696b56040535bbf0f3d57afa05045f9f9de90d3a0'
+  version '146,1530166632'
+  sha256 'db61f72bf7ea4a0ee8cf6562942b26ee0249431a66de4e9e8fc0ec534bf87636'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.