### PR TITLE
Update appcode to 2018.1.5,181.5451.8

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -1,6 +1,6 @@
 cask 'appcode' do
-  version '2018.1.4,181.5087.34'
-  sha256 '2842e1c2fa560ec3e5f8f924fcaaeb9316a7e7a675577571e68504f341626f0c'
+  version '2018.1.5,181.5451.8'
+  sha256 '00c053b50fa00c176c3c690435a7aee6a8108ad634762eef191408f0422df02b'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=AC&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.