### PR TITLE
Update opentoonz to 1.2.1

### DIFF
--- a/Casks/opentoonz.rb
+++ b/Casks/opentoonz.rb
@@ -1,6 +1,6 @@
 cask 'opentoonz' do
-  version '1.2.0'
-  sha256 '21d91a82284ffabc6d37362bcdd32f3c87fe362fc76d29661166b86925c048e4'
+  version '1.2.1'
+  sha256 'af738c53f4d31d0f524348ac93d82ef8f80508a4908ad2fac98b7d3e473032b5'
 
   # github.com/opentoonz/opentoonz was verified as official when first introduced to the cask
   url "https://github.com/opentoonz/opentoonz/releases/download/v#{version}/OpenToonz.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.