### PR TITLE
Update tokens to 1.6.4-69

### DIFF
--- a/Casks/tokens.rb
+++ b/Casks/tokens.rb
@@ -1,6 +1,6 @@
 cask 'tokens' do
-  version '1.6.3-68'
-  sha256 'c9135ae7c5b6fff36857f5057eca67b052900cf062cc8226484c6b5b6e0cd5e2'
+  version '1.6.4-69'
+  sha256 'c677ebe19256191ee6bbb54ed59499fbef25faa9530eaa6b2ec4c8b51b262a9a'
 
   # peerassembly.net/apps/tokens was verified as official when first introduced to the cask
   url "https://peerassembly.net/apps/tokens/#{version}/Tokens.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.