### PR TITLE
Update eclipse-platform to 4.8,201806110500

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.7.3a,201803300640'
-  sha256 'c7ca985ffaf604508371945d46f4af5de86aceea722034100ec1280202111f8d'
+  version '4.8,201806110500'
+  sha256 '2d5a377c64b64dc3661b90e66c51141467ed7c7ee6235bab91ae1a569da0b422'
 
   url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.