### PR TITLE
Update preferencecleaner to 1.7.2

### DIFF
--- a/Casks/preferencecleaner.rb
+++ b/Casks/preferencecleaner.rb
@@ -3,6 +3,7 @@ cask 'preferencecleaner' do
   sha256 '1407b17fd46e784fba7aa45cf5469047ae30e49dc99c749b3315c8bab0bd398d'
 
   url "https://www.echomist.co.uk/software/downloads/PreferenceCleaner_#{version}.dmg"
+  appcast 'https://www.echomist.co.uk/software/PreferenceCleaner.php'
   name 'PreferenceCleaner'
   homepage 'https://www.echomist.co.uk/software/PreferenceCleaner.php'
 

--- a/Casks/preferencecleaner.rb
+++ b/Casks/preferencecleaner.rb
@@ -1,8 +1,8 @@
 cask 'preferencecleaner' do
-  version :latest
-  sha256 :no_check
+  version '1.7.2'
+  sha256 '1407b17fd46e784fba7aa45cf5469047ae30e49dc99c749b3315c8bab0bd398d'
 
-  url 'http://www.echomist.co.uk/software/downloads/PreferenceCleaner.dmg'
+  url "https://www.echomist.co.uk/software/downloads/PreferenceCleaner_#{version}.dmg"
   name 'PreferenceCleaner'
   homepage 'https://www.echomist.co.uk/software/PreferenceCleaner.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.