### PR TITLE
Update tortoisehg to 4.6.1

### DIFF
--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -1,6 +1,6 @@
 cask 'tortoisehg' do
-  version '4.6.0'
-  sha256 '843c9961ec4672cde1fad7671bcab3e7f4e226485b44de4b0b8cb50c7572466b'
+  version '4.6.1'
+  sha256 '7ab54a6268284a9e54bac55552a644e5872610741caab8be8b8a0a3234e9bf65'
 
   # bitbucket.org/tortoisehg/files/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/tortoisehg/files/downloads/TortoiseHg-#{version}-mac-x64-qt5.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.