### PR TITLE
audio hijack checksum mismatch - update release binary with display error

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -1,6 +1,6 @@
 cask 'audio-hijack' do
   version '3.5'
-  sha256 'f86bafe732a04714272cdbec8247fba6220f4c9911d24d3bae9c7a80eea29dca'
+  sha256 '392114c74b5f23370158303f2caea186eb11d8ee80fad840b4edf90a5e752e2c'
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   appcast "https://www.rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.audiohijack#{version.major}"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/49065

Release binary was apparently swapped to fix some kind of display error.

>"We swapped out the initial release of Audio Hijack 3.5 due to an unexpected display issue, which we were able to identify within just a few hours. The proper build reports `58dcf33f61` in the About window, and the download on our server is safe." - Chris Barajas


```
	Certificate “Developer ID Application: Rogue Amoeba Software, LLC (7266XEXAPM)”: ￼
		Will expire on May 23, 2022.
		SHA1 fingerprint: “627508F25BD4848112CBA0376E735B89C13C6954”.
		Team ID or Organizational Unit: “7266XEXAPM”.
			This matches the Team ID contained in the signature.
```

Archive of relevant file in case the binary changes again: https://d.pr/X4u3kw `<- Link EXPIRES 2018-07-05`

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Audio Hijack `3.5`

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
