### PR TITLE
Update canary to 2.07,419

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,6 +1,6 @@
 cask 'canary' do
-  version '2.06,418'
-  sha256 'dae114de1e02c3cb980acb2af2deed5793a9d5a0e5e3f9231d4b390c657eecc4'
+  version '2.07,419'
+  sha256 'd646ba76c93a1a1f9ebce4e21aaa6e0c071bb2411f3060766e85f104bf9959d2'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.