### PR TITLE
Update operadriver to 2.37

### DIFF
--- a/Casks/operadriver.rb
+++ b/Casks/operadriver.rb
@@ -1,6 +1,6 @@
 cask 'operadriver' do
-  version '2.36'
-  sha256 'ab15214da6f5ab754e0121c08fef4a5a01539c162061f887f822caa684c8b7d1'
+  version '2.37'
+  sha256 'd7220fef597a6e7da28c594a82fe0edab8449d6992ef28a20cd1fa4173d02fd3'
 
   url "https://github.com/operasoftware/operachromiumdriver/releases/download/v.#{version}/operadriver_mac64.zip"
   appcast 'https://github.com/operasoftware/operachromiumdriver/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.