### PR TITLE
Update screenflick to 2.7.34

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,6 +1,6 @@
 cask 'screenflick' do
-  version '2.7.32'
-  sha256 '287e80e0242c25d66c1dbb126a7f5d20265c71b03bffd3a45fd2e59ceed5ed46'
+  version '2.7.34'
+  sha256 'e0991bdbf8c7a20ca01217f1f576adcb71dc15986b747226ccb8f67a8a8453f4'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.