### PR TITLE
Update boostnote to 0.11.7

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,6 +1,6 @@
 cask 'boostnote' do
-  version '0.11.6'
-  sha256 '62c94b6a0bb5235247b38ae4ff16e895d3121ddbcc236009bdb1f440fe88efdc'
+  version '0.11.7'
+  sha256 'e5e3b5386fad420a94f3a8bb5adf476c466102fc4ae7b90099a98b4879a3c1b2'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.