### PR TITLE
Update postman to 6.1.4

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,6 +1,6 @@
 cask 'postman' do
-  version '6.1.3'
-  sha256 'cbd845ab6191f72c67f400d9140d63d4b59eeb2179545eb889dcb919980f61e5'
+  version '6.1.4'
+  sha256 '07d368966f3d90007a3f4684440618c68084da02fa25ca56f997b21a7601297a'
 
   # dl.pstmn.io/download/version/ was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.