### PR TITLE
Update yacreader to 9.5.0

### DIFF
--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -1,6 +1,6 @@
 cask 'yacreader' do
-  version '9.0.0'
-  sha256 'b9301522a6aedf3fabb3e2edc3a45597ad888e44f106e4af95946ef5b6af4573'
+  version '9.5.0'
+  sha256 'c7b3a9e8f385bdc9bdfb29e754503c64ae1f3703f4bbfcb381feb46659b28491'
 
   # bitbucket.org/luisangelsm/yacreader was verified as official when first introduced to the cask
   url "https://bitbucket.org/luisangelsm/yacreader/downloads/YACReader-#{version}-MacOSX-Intel.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.