### PR TITLE
fix sha256 value

### DIFF
--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -1,6 +1,6 @@
 cask 'rar' do
   version '5.4.0'
-  sha256 '09a14f40718c68fc1c24b30acb55d0f2f90f3e13b372c48b6ef1e789d748b754'
+  sha256 '381ca05ca2701cf72148da49d36a4dda4e8e29cd0c3879f697b2861326277d5d'
 
   url "http://www.rarlab.com/rar/rarosx-#{version}.tar.gz"
   name 'RAR Archiver'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


The checksum for the cask "rar" version 5.6.0 is not correct and raises error,
link to the file is  https://www.rarlab.com/rar/rarosx-5.6.0.tar.gz
current sha256 is 381eb0c0645bfbd603e7e20a6a8cb34e484c6eeca161a1b3017cf93415448fde
correct sha256 is 381ca05ca2701cf72148da49d36a4dda4e8e29cd0c3879f697b2861326277d5d

This pull request only fixes the sha256.

First pull request to this project, be kind :)