### PR TITLE
Update reborn to 0.5.41

### DIFF
--- a/Casks/reborn.rb
+++ b/Casks/reborn.rb
@@ -1,6 +1,6 @@
 cask 'reborn' do
-  version '0.5.3'
-  sha256 'f86fa79fef9ba686e802690b6fa935779fb73e683d5e462553be608b177b6b1c'
+  version '0.5.41'
+  sha256 '6fd5045b9e8f8dceeb443f0df81ce8e0b01455191538e297e3c04644552c5681'
 
   url "https://github.com/langyanduan/Reborn/releases/download/#{version}/Reborn.zip"
   appcast 'https://github.com/langyanduan/Reborn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.