### PR TITLE
Update stellarium to 0.18.1

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,6 +1,6 @@
 cask 'stellarium' do
-  version '0.18.0'
-  sha256 'ef2fffc09d1b0334939ce05a8ddbd732a2e55bc5cef8258dd22bbc948f259522'
+  version '0.18.1'
+  sha256 '1737c60f4722f85bb42dda09d68a1b1e8d7b49019709a42c306984239fde7dd8'
 
   # github.com/Stellarium/stellarium was verified as official when first introduced to the cask
   url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.