### PR TITLE
Update shotcut to 18.07.02

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '18.06.02'
-  sha256 '950c8b9ed8ad56718ca2be31bc8dd2fd6a35b9d3eb7b95ee88661fc6e7b19fbf'
+  version '18.07.02'
+  sha256 'ce92aadcec7f0f4d0aab9dc54ed28fd3805baebf68aa21b564800dddfca89707'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-macos-x86_64-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.