### PR TITLE
Update terminus to 1.0.0-alpha.48

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.0-alpha.47'
-  sha256 '6b0aa8026206dc4979c1c658be615d1d199c23e2254ef098e547a27bf0ba9cbe'
+  version '1.0.0-alpha.48'
+  sha256 '2d8ab88ec1bf992c7899dcaf9488c368f285ee75b37a87a70c3de54fff7a1b62'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/Terminus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.