### PR TITLE
Update winds to 2.1.37

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '2.1.0'
-  sha256 '8d25e427d258183be058aaada8baacec6e97ae73862eb485394596db9464aa6b'
+  version '2.1.37'
+  sha256 '486fb118de1f4b2703b914cfffda7fa8c5ecce8ee262e3e3dcbe4a558b24d97c'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.