### PR TITLE
Update paste to 2.3.9,23

### DIFF
--- a/Casks/paste.rb
+++ b/Casks/paste.rb
@@ -1,10 +1,12 @@
 cask 'paste' do
-  version :latest
-  sha256 :no_check
+  version '2.3.9,23'
+  sha256 '419d857c5d34bf1fc6840fb27eb9cd270900cb08a5af9c8ae38291d03fee1c3b'
 
-  url 'http://pasteapp.me/download'
+  # rink.hockeyapp.net/api/2/apps/f44b38c5d9824344acdb920513bbbf8f was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/f44b38c5d9824344acdb920513bbbf8f/app_versions/#{version.after_comma}?format=zip"
+  appcast 'https://rink.hockeyapp.net/api/2/apps/f44b38c5d9824344acdb920513bbbf8f'
   name 'Paste'
-  homepage 'http://pasteapp.me/'
+  homepage 'https://pasteapp.me/'
 
   app 'Paste.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #49220