### PR TITLE
Update mongodb-compass to 1.14.6

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.14.5'
-  sha256 'e88c4aee4a7dbda8e35e748aadedfafe8d6c05e88e5fec4933288101df2da6f5'
+  version '1.14.6'
+  sha256 'bfa520d75163182a04391d4917379b80df3f99f6c5282ba8d1687ad05cbde6f3'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.