### PR TITLE
Update mongodb-compass-readonly to 1.14.6

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.14.5'
-  sha256 '123f1b77849fec7e710dcda03088d7bf6202be889a99307e7365d20fd3212f12'
+  version '1.14.6'
+  sha256 '9e6007a2bd3d642566cf8a1c50e938ed21b234f67f5296ad43ef037535941e44'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass Readonly'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.