### PR TITLE
Update postbox to 6.0.15

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.0.13'
-  sha256 '498abe58976b03e547d57427cdf65b43028aaf191ee6ed66d42363118ab0f5cb'
+  version '6.0.15'
+  sha256 '965d7cbf528cce563b105f0a8abedda42d85b57d25385e6ec77e225e55ef3722'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.