### PR TITLE
Update downie to 3.3.8,1839

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.3.7,1836'
-  sha256 '0fff6b409bfb1271435fa24dc98525d3cc6f8ede906d30f83782568411f65aeb'
+  version '3.3.8,1839'
+  sha256 '72150202fc3ee2392933e07687bb337eb631560c520f1a197724b9a9f6270e85'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.