### PR TITLE
Update openshot-video-editor to 2.4.2

### DIFF
--- a/Casks/openshot-video-editor.rb
+++ b/Casks/openshot-video-editor.rb
@@ -1,6 +1,6 @@
 cask 'openshot-video-editor' do
-  version '2.4.1'
-  sha256 'b33ce8081f42b7e31681d925220709444e409be1b43293a6baa56fbd7b8da91b'
+  version '2.4.2'
+  sha256 'be8d67b2f5b07bdd23a4cd7877f961cef42c8b1d08b39a7f7c25fa5b1ceaf398'
 
   # github.com/OpenShot/openshot-qt was verified as official when first introduced to the cask
   url "https://github.com/OpenShot/openshot-qt/releases/download/v#{version}/OpenShot-v#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.