### PR TITLE
Update psychopy to 1.90.3

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '1.90.2'
-  sha256 'ec17d6b554f6239a3c1dbcf45f31c5ae10d0d57b5b42025a9f0ccaa4d55c93a6'
+  version '1.90.3'
+  sha256 '7e1dfac94c39bd2a8fa5489e5e856b73add5d23a1fd381ce0c60e2478e0f6b55'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy2_PY3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.