### PR TITLE
Update vnote to 1.19

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,6 +1,6 @@
 cask 'vnote' do
-  version '1.17'
-  sha256 '74fe2a0515e29c8c96979bcfa36664e84d48c8900be726680dc9e0dd1a7dc888'
+  version '1.19'
+  sha256 '34de409d13061f2293d68d5c901ffec582e002225afc2e50dd22fe128ca0dfc3'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.