### PR TITLE
Update whoozle-android-file-transfer to 3.4

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -10,5 +10,5 @@ cask 'whoozle-android-file-transfer' do
 
   conflicts_with cask: 'android-file-transfer'
 
-  app 'Android File Transfer.app'
+  app 'Android File Transfer for Linux.app'
 end

--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -1,9 +1,9 @@
 cask 'whoozle-android-file-transfer' do
-  version '3.2,62d1c79'
-  sha256 '84469fd3adba4046a9137093c3e0731e60ae2220381502b452d767cd4de4e676'
+  version '3.4'
+  sha256 'b32fd4958760f5f184721e61a589ea9d49d22778e8370bbf53f4a66dcb35cbef'
 
   # github.com/whoozle/android-file-transfer-linux was verified as official when first introduced to the cask
-  url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version.before_comma}/AFTOSX-#{version.before_comma}-#{version.after_comma}.dmg"
+  url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version}/AndroidFileTransferForLinux.dmg"
   appcast 'https://github.com/whoozle/android-file-transfer-linux/releases.atom'
   name 'Android File Transfer'
   homepage 'https://whoozle.github.io/android-file-transfer-linux/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.