### PR TITLE
Update cacher to 1.5.11

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '1.5.10'
-  sha256 '5e75b5139623dfff70b102f81241b4c9d32bd27746007009ee292d5f9a1b0d35'
+  version '1.5.11'
+  sha256 '8c6a063cb96583e57b3ff6fae62cfd2c1caea32b8c03b0290a7a71d8d45a4697'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.