### PR TITLE
Update envkey to 1.3.8

### DIFF
--- a/Casks/envkey.rb
+++ b/Casks/envkey.rb
@@ -1,6 +1,6 @@
 cask 'envkey' do
-  version '1.3.7'
-  sha256 'f17ef4978f9421affedfada4e79541367a85adbb4fc54feba1980b8fd7c375df'
+  version '1.3.8'
+  sha256 'fc07d2000cadddcd4e3412baa6440255f481849928555ebae94ffc28ffcba69e'
 
   # github.com/envkey/envkey-app was verified as official when first introduced to the cask
   url "https://github.com/envkey/envkey-app/releases/download/darwin-x64-prod-v#{version}/EnvKey-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.