### PR TITLE
Update microsoft-teams to 1.1.00.17551

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-teams' do
-  version '1.1.00.16251'
-  sha256 '059779e1fe397ccbb69c960b896017c59215c74a02b9237d0598cd90cca60272'
+  version '1.1.00.17551'
+  sha256 '44c8ba225c46a5089cbb02815839c9d067730c1a11f93809ba6437b8507df69c'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.