### PR TITLE
Update winds to 2.1.44

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '2.1.37'
-  sha256 '486fb118de1f4b2703b914cfffda7fa8c5ecce8ee262e3e3dcbe4a558b24d97c'
+  version '2.1.44'
+  sha256 'e0ea243ac97b672ac732e8be3f0ac617ad094156cea21cd1c2e03e17394b6c23'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.