### PR TITLE
Upgrade Polymail.app to v2.0.6

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,6 +1,6 @@
 cask 'polymail' do
-  version '2.0.5'
-  sha256 '58c76163a93b762e81b2d84d34ba27bef3d5ee1d1104d7b9cc382bf67e17f59d'
+  version '2.0.6'
+  sha256 'ee5de0dcfca926bcc9c6ef44d2d23e41f7d0fbc1c989a43e5d1c81dc0dc56b17'
 
   url "https://sparkle-updater.polymail.io/macos/builds/Polymail-v#{version}.zip"
   name 'Polymail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.