### PR TITLE
Update jamf-migrator to 2.8.2

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '2.7.2'
-  sha256 '781797e0116196b9b75bf243f98a1394a2e90da59d3ded0b81e61334bc7b34d6'
+  version '2.8.2'
+  sha256 'e5a1b13c7caf1794e218e4fd4c74d40ad4bdc4db14da65468fb42bfdbecc1035'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.