### PR TITLE
Update qtox to 1.16.1

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,6 +1,6 @@
 cask 'qtox' do
-  version '1.16.0'
-  sha256 '88e21ecf403d024e5bbcc9fad4db0ad4fd6f1794abf706b744bff4a039f43793'
+  version '1.16.1'
+  sha256 '0b797d3cf42b72c5789efd2e9d9d1b9e4fe5e6743cb8480fb7731ac83471bf45'
 
   # github.com/qTox/qTox was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.