### PR TITLE
Update texstudio to 2.12.10

### DIFF
--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -1,6 +1,6 @@
 cask 'texstudio' do
-  version '2.12.8'
-  sha256 'e5826d49bc2b37092b62455a1520ca211dcf4a1deb6ec33736b266e9b62e64c2'
+  version '2.12.10'
+  sha256 '03c9cfc4ae1b296e4a46f140b642b7b84121994d6cc0b1e63fbdb51c5f2e234b'
 
   # github.com/texstudio-org/texstudio was verified as official when first introduced to the cask
   url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.