### PR TITLE
Update r-app to 3.5.1

### DIFF
--- a/Casks/r-app.rb
+++ b/Casks/r-app.rb
@@ -1,6 +1,6 @@
 cask 'r-app' do
-  version '3.5.0'
-  sha256 '7e56ea676e0bdfff5f88ed7db2201afd0feb7debc07ed803b0da96f3867cc16d'
+  version '3.5.1'
+  sha256 '5f781220ff2f9374a4db114435fa2d22cfebc353ed8d5246a1f1e162eab75a01'
 
   url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   appcast 'https://www.r-project.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.