### PR TITLE
Update qlab to 4.2.5

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,6 +1,6 @@
 cask 'qlab' do
-  version '4.2.4'
-  sha256 '957773e7d502511b5c946b6e353958b092420ad914b193a224e8a7901dc51fcd'
+  version '4.2.5'
+  sha256 'a9ff60893329997c00f35c3e15c4f339e4b510304f164dc01960a0528df65f72'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.