### PR TITLE
Update gdisk to 1.0.4

### DIFF
--- a/Casks/gdisk.rb
+++ b/Casks/gdisk.rb
@@ -1,6 +1,6 @@
 cask 'gdisk' do
-  version '1.0.3'
-  sha256 '11a738629d4e40d5830c122ab063f9f07ffab80f0df9294e78f6e85f5f30930c'
+  version '1.0.4'
+  sha256 '67fa54f927439f969f08a093e9c2f85485b1f7015ea399632f5891b1694c9372'
 
   url "https://downloads.sourceforge.net/gptfdisk/gdisk-#{version}.pkg"
   appcast 'https://sourceforge.net/projects/gptfdisk/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.