### PR TITLE
Update irccloud to 0.7.2

### DIFF
--- a/Casks/irccloud.rb
+++ b/Casks/irccloud.rb
@@ -1,6 +1,6 @@
 cask 'irccloud' do
-  version '0.7.1'
-  sha256 'dce30ecc6cb2d769e51326019d2c45eec12524f11ad08f0fdbc0e42800a4e2d5'
+  version '0.7.2'
+  sha256 'd44a3e2796e8ac3ae8a346f1d78d66466ad3ca9968b312e7268ac27a057278d7'
 
   url "https://github.com/irccloud/irccloud-desktop/releases/download/v#{version}/IRCCloud-#{version}.dmg"
   appcast 'https://github.com/irccloud/irccloud-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.