### PR TITLE
Update kite to 0.20180703.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180628.0'
-  sha256 '2368652adc274a1f834797167f1b2e17c305e03939e57e98bd1a50544256e0d5'
+  version '0.20180703.0'
+  sha256 'b71acbb364010340fc3ef21015383b740d8d620a6eba61acc4d44b869cdf2135'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.