### PR TITLE
Update qownnotes to 18.07.2,b3679-095757

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.07.1,b3670-183652'
-  sha256 'a27726ce67866e20a709353dd3cf7465d8ef3874a073916ca2b0d236a3522c5d'
+  version '18.07.2,b3679-095757'
+  sha256 '07e23aecf0ffee9cbf37454a9878ad219864b1fec761a4ed0566c66add36e6eb'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.