### PR TITLE
Update unity-windows-support-for-editor to 2018.1.7f1,4cb482063d12

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.1.6f1,57cc34175ccf'
-  sha256 '7020b00edfb90834ef0360146626ceea8ff5d3800943577c27ec143729cd6d5a'
+  version '2018.1.7f1,4cb482063d12'
+  sha256 '37195202d4a427a95488b14ce014da19c3f634cb204a275550ca394e3903e39b'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.