### PR TITLE
Update unity-webgl-support-for-editor to 2018.1.7f1,4cb482063d12

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.1.6f1,57cc34175ccf'
-  sha256 'c74f03b47072b69e19567ae6d919a1f981051795c48c2b67209834f016f72708'
+  version '2018.1.7f1,4cb482063d12'
+  sha256 'a797bd232dfd8da7b8ec48f96f2691aa2fa167300b4c6cd5a2cf15c697d49c16'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.