### PR TITLE
Update wwdc to 6.0.4

### DIFF
--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -1,6 +1,6 @@
 cask 'wwdc' do
-  version '6.0.3'
-  sha256 'b2615bba5d64a6c556973e73d7994ed11cb9f5f873848f10aca9d5fe21bed04c'
+  version '6.0.4'
+  sha256 '195bc704ae7f7d30fb3f3420e143e527ae93bb4d69c6da594c7dc81394a2a160'
 
   # github.com/insidegui/WWDC was verified as official when first introduced to the cask
   url "https://github.com/insidegui/WWDC/releases/download/#{version}/WWDC_v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.