### PR TITLE
Update unity-download-assistant to 2018.1.7f1,4cb482063d12

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.1.6f1,57cc34175ccf'
-  sha256 'f7600ac904869bc41bcaf8a797aaf8af19985a74c193ac100934eaf1a64ea66d'
+  version '2018.1.7f1,4cb482063d12'
+  sha256 '5a2d6f5b6886de27a9ce5feaf5e7cd69433691bd5fb95b2d31e6faaf640fad90'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.