### PR TITLE
Update yt-music to 1.0.5

### DIFF
--- a/Casks/yt-music.rb
+++ b/Casks/yt-music.rb
@@ -1,8 +1,8 @@
 cask 'yt-music' do
-  version '1.0.4'
-  sha256 'd69f7e854b5db387f04c8eee2e2479cfe71368d3c6c05b2b736645e6ba6db539'
+  version '1.0.5'
+  sha256 'c9fc48b07bb8d8dc5d260ccb396ddcb4b77130fe80342d980e6105880a94a0da'
 
-  url "https://github.com/steve228uk/YouTube-Music/releases/download/#{version}/YTMusic.zip"
+  url "https://github.com/steve228uk/YouTube-Music/releases/download/#{version}/YT.Music.zip"
   appcast 'https://github.com/steve228uk/YouTube-Music/releases.atom'
   name 'YouTube Music'
   homepage 'https://github.com/steve228uk/YouTube-Music'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.