### PR TITLE
Update ieasemusic to 1.2.2

### DIFF
--- a/Casks/ieasemusic.rb
+++ b/Casks/ieasemusic.rb
@@ -1,6 +1,6 @@
 cask 'ieasemusic' do
-  version '1.2.1'
-  sha256 '84275acd423a6a8fa297b65ef9766dac29a69e9383419565be27d51b212825d9'
+  version '1.2.2'
+  sha256 'f0d1565715eba6e72cb75dfbd4338476e7fbfd83b163aca9567e36cefa26206f'
 
   url "https://github.com/trazyn/ieaseMusic/releases/download/v#{version}/ieaseMusic-#{version}-mac.dmg"
   appcast 'https://github.com/trazyn/ieaseMusic/releases.atom'


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
