### PR TITLE
Update santa to 0.9.28

### DIFF
--- a/Casks/santa.rb
+++ b/Casks/santa.rb
@@ -3,7 +3,7 @@ cask 'santa' do
   sha256 'd3d54d49efbb5dda26476d351a073191df4f7dcf6688e4e4663392f9a3390836'
 
   url "https://github.com/google/santa/releases/download/#{version}/santa-#{version}.dmg"
-  appcast 'https://github.com/google/santa/releases.atom'
+  appcast 'test'
   name 'Santa'
   homepage 'https://github.com/google/santa'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #49366.

Hello, this is a test.