### PR TITLE
Update quip to 5.3.17

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.3.7'
-  sha256 'afe59d815546124c9f9b3096320d38bfc187a9f16dcd731dde385a42e3a9190e'
+  version '5.3.17'
+  sha256 '30929bc641d0acd6236146d7fb9a64f22de2d46bb4c6debf357ef8a561106fa8'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.