### PR TITLE
Update subsurface to 4.8.0

### DIFF
--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,6 +1,6 @@
 cask 'subsurface' do
   version '4.8.0'
-  sha256 'b3b62120bb3c90e378d3b574ca8274b8ad474352c6b32d68fdf28699e2478d5a'
+  sha256 '51fe5c49eb726f5eda780cc3e845574648c3521b350a56d9d6574d035cabf3fc'
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   name 'Subsurface'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.