### PR TITLE
Update exodus to 1.55.2

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '1.55.1'
-  sha256 '44bcbe822bb63a45d450d0e064ebdaee6b460dc7f864847fab8d31ad19a3f922'
+  version '1.55.2'
+  sha256 '09fbf06debd2e9f426fb82d0979879085733e91c0c94d41dcc14b9f7fc872aaf'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.