### PR TITLE
Update camunda-modeler to 1.16.2

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '1.16.1'
-  sha256 '069e791b9ecc709cdb6de59ec627d264d689f244989393ab32a9c1a08cdf829e'
+  version '1.16.2'
+  sha256 '498bb3ce8707d5c7d7f68ba3bafa7f2bca7498c2670770ec5841601324a82513'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-darwin-x64.tar.gz"
   appcast 'https://camunda.com/download/modeler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.