### PR TITLE
Update godot-mono to 3.0.5

### DIFF
--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -1,6 +1,6 @@
 cask 'godot-mono' do
-  version '3.0.4'
-  sha256 '1354d4c80fe15ad8bef5ed342e3920c74f30b51113ca8e54cecd6e12dc42b13c'
+  version '3.0.5'
+  sha256 '22c2b83713e856bd34f490f5684be790a0a68eb0a0bb120c03f9a8826bf443b1'
 
   # downloads.tuxfamily.org/godotengine was verified as official when first introduced to the cask
   url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_osx.fat.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.