### PR TITLE
Update dash-dash to 0.12.3.2

### DIFF
--- a/Casks/dash-dash.rb
+++ b/Casks/dash-dash.rb
@@ -1,6 +1,6 @@
 cask 'dash-dash' do
-  version '0.12.3.1'
-  sha256 '4b10f9d69d0307ea203434c9367231b14a8b7f709db9f83410e7e438a1c132d0'
+  version '0.12.3.2'
+  sha256 '3de18efe376e60a77d80e3daf3e7e2eb43a145e75c8da69368a1d018ba683de5'
 
   # github.com/dashpay/dash was verified as official when first introduced to the cask
   url "https://github.com/dashpay/dash/releases/download/v#{version}/dashcore-#{version}-osx-unsigned.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.