### PR TITLE
Update golly to 3.2

### DIFF
--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -1,6 +1,6 @@
 cask 'golly' do
-  version '3.1'
-  sha256 '6084bc2464212366a03940d419f438af7df093c8b10ec84123e0fd0d912683db'
+  version '3.2'
+  sha256 '71c66136ef81d336ed0fc94a5f5a4d650e3727d99fe1f00c6036b8dc99eee8db'
 
   url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/Golly-#{version}-Mac.dmg"
   appcast 'https://sourceforge.net/projects/golly/rss?path=/golly'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.