### PR TITLE
Update reborn to 0.5.48

### DIFF
--- a/Casks/reborn.rb
+++ b/Casks/reborn.rb
@@ -1,6 +1,6 @@
 cask 'reborn' do
-  version '0.5.47'
-  sha256 'a44413eb7197dae4a3c336ddbb35d4168821e1445264ca47873d5fb4160a0c30'
+  version '0.5.48'
+  sha256 '80977d36e98582b0f6364cf9273801074adb792a09d638af652cf55f466d7c0b'
 
   url "https://github.com/langyanduan/Reborn/releases/download/#{version}/Reborn.zip"
   appcast 'https://github.com/langyanduan/Reborn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.