### PR TITLE
Update resolume-avenue to 6.0.10

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,6 +1,6 @@
 cask 'resolume-avenue' do
-  version '6.0.9'
-  sha256 '6a231157fa631fef4568d29b18248eefe0c6aaadebfe87b3fabfb992b88f1944'
+  version '6.0.10'
+  sha256 'e7108e74286796dfd78a4387a38efd75fc7ab6b38650b3490b2e6b8fed763c9d'
 
   # dd5sgwxv3xok.cloudfront.net was verified as official when first introduced to the cask
   url "https://dd5sgwxv3xok.cloudfront.net/Resolume_Avenue_#{version.dots_to_underscores}_Installer.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.