### PR TITLE
Update freefilesync to 10.2

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '10.1'
-  sha256 'a722349ee7768078b8a908aa742c4a0b4ade89766d1f89381c9f21be2a75287d'
+  version '10.2'
+  sha256 'e64ec6a1c9c5355affadc2842adf0a7dda164476317f21baa3506aa8507b4315'
 
   url "http://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.