### PR TITLE
Update amazon-chime to 4.16.6270

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,6 +1,6 @@
 cask 'amazon-chime' do
-  version '4.15.6183'
-  sha256 '412881b6d3df470b16b9d434d1d119889477ed007a7dc7b96a235b8218d09cb6'
+  version '4.16.6270'
+  sha256 'e0589c586fb715a003c21cbbfafd1477ec5c6c2dc4870d7fb18ffdccbbba5e8a'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.