### PR TITLE
Update mu-editor to 1.0.0,17

### DIFF
--- a/Casks/mu-editor.rb
+++ b/Casks/mu-editor.rb
@@ -1,6 +1,6 @@
 cask 'mu-editor' do
-  version '1.0.0,16'
-  sha256 'ae10cf856dca285bf53da5284fb77127fddf7773aa05c7c6104708af5fe054a8'
+  version '1.0.0,17'
+  sha256 '54c8a8187a92fbd50e0cd72de50b92a0aaea7986f3e192d6ce51705c6c5191fc'
 
   # github.com/mu-editor/mu was verified as official when first introduced to the cask
   url "https://github.com/mu-editor/mu/releases/download/v#{version.before_comma}.beta.#{version.after_comma}/mu-editor_beta#{version.after_comma}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.