### PR TITLE
Update patchwork to 3.10.0

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.9.0'
-  sha256 'b2af77bdc568a6b005df1de1526d6901b6b87d80685abd4109c90daa7ff9e4a3'
+  version '3.10.0'
+  sha256 '83c30a83329bfeebcdddb2a2723072b817305567e37cb754e10549eff75e9437'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.