### PR TITLE
Update bdash to 1.5.0

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.4.0'
-  sha256 '257bc19e68a16a8f3aea0a40aadbdffab7aaf6e285ceb6bc6895f9f96122c2e7'
+  version '1.5.0'
+  sha256 '7adaa59e2af974cca90041f69c4d8dc6631eb47d4646bd89adccf0660b41b08d'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.