### PR TITLE
Update ganache to 1.2.1

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,6 +1,6 @@
 cask 'ganache' do
-  version '1.2.0'
-  sha256 '068bf7aa9e7b76f95e966630f8de30f8e41ab4d82b45e9392c29ab9747ecf4b2'
+  version '1.2.1'
+  sha256 'cb03072aeea228ebd945dda30836cd4d38cb951cf94a72064255c6e075f36c58'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.