### PR TITLE
Update metasploit to 4.17.0+20180710104435

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,6 +1,6 @@
 cask 'metasploit' do
-  version '4.17.0+20180709104409'
-  sha256 '6cf63efd2cd51c58f5bb444ed2c52c0d0ec6a782a32a1b7c8e24773c2e844e6f'
+  version '4.17.0+20180710104435'
+  sha256 '4230c8dce517d14429bc12584e1e3ddefb833f3bbb56af64962db63ae42f4c4c'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.