### PR TITLE
Update mos to 2.3.0

### DIFF
--- a/Casks/mos.rb
+++ b/Casks/mos.rb
@@ -1,6 +1,6 @@
 cask 'mos' do
-  version '2.2.6'
-  sha256 '803b3130c722b2cf08e166f347806ab1fd427feef98f07f9edd5439845c3247e'
+  version '2.3.0'
+  sha256 '4f5dc538ec8cea0774b483cf74751ae6062b7cd13bc6e7876a67bb86439f85ef'
 
   # github.com/Caldis/Mos was verified as official when first introduced to the cask
   url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.