### PR TITLE
readme, travis.yml: replace gitter with discourse, remove irc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,18 +27,3 @@ script:
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "chat.freenode.net#homebrew-cask"
-    template:
-      - "(%{repository_name}) %{build_number}: %{branch}@%{commit} %{author} -> %{message} %{build_url}"
-    use_notice: true
-    skip_join: true
-  webhooks:
-    urls:
-      - "https://webhooks.gitter.im/e/712d699360b239db14a5"
-    on_success: never
-    on_failure: always
-    on_start: never
-    on_cancel: never
-    on_error: never

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Homebrew-Cask extends [Homebrew](http://brew.sh) and brings its elegance, simpli
 
 We do this by providing a friendly Homebrew-style CLI workflow for the administration of macOS applications distributed as binaries.
 
-[![Join the chat at https://gitter.im/Homebrew/homebrew-cask](https://img.shields.io/badge/gitter-join%20chat-blue.svg)](https://gitter.im/Homebrew/homebrew-cask)
+[![Join us on https://discourse.brew.sh](https://img.shields.io/badge/Discourse-forum-blue.svg)](https://discourse.brew.sh)
 
 ## Let’s try it!
 
@@ -69,8 +69,7 @@ If your issue persists, search for it before opening a new one. If you find an o
 We’re really rather friendly! Here are the best places to talk about the project:
 
 * If none of the templates above is appropriate, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new).
-* Join us (and [caskbot](https://github.com/passcod/caskbot)) on IRC at `#homebrew-cask` on Freenode
-* Join us on [Gitter](https://gitter.im/Homebrew/homebrew-cask)
+* Join us on [discourse.brew.sh (forum)](https://discourse.brew.sh)
 
 ## License
 Code is under the [BSD 2 Clause (NetBSD) license](LICENSE)


### PR DESCRIPTION
refs: https://github.com/Homebrew/homebrew-cask/issues/49446

To do after this is merged:
- [x] run the sync script.
- [x] remove all the gitter and irc integrations from all the cask repos.
- [ ] delete the gitter room so it isn't left unmonitored.