### PR TITLE
Update winds to 2.1.47

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '2.1.44'
-  sha256 'e0ea243ac97b672ac732e8be3f0ac617ad094156cea21cd1c2e03e17394b6c23'
+  version '2.1.47'
+  sha256 '65efab23915e3ef10d664648addc03fff3dfcd9cb9d2c32a5711e256e907f71d'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.