### PR TITLE
Update wireshark casks: remove postflight

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -29,17 +29,6 @@ cask 'wireshark-chmodbpf' do
                  },
                ]
 
-  postflight do
-    system_command '/usr/sbin/dseditgroup',
-                   args: [
-                           '-o', 'edit',
-                           '-a', Etc.getpwuid(Process.euid).name,
-                           '-t', 'user',
-                           '--', 'access_bpf'
-                         ],
-                   sudo: true
-  end
-
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
   end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -12,17 +12,6 @@ cask 'wireshark' do
 
   pkg "Wireshark #{version} Intel 64.pkg"
 
-  postflight do
-    system_command '/usr/sbin/dseditgroup',
-                   args: [
-                           '-o', 'edit',
-                           '-a', Etc.getpwuid(Process.euid).name,
-                           '-t', 'user',
-                           '--', 'access_bpf'
-                         ],
-                   sudo: true
-  end
-
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
   end


### PR DESCRIPTION
Can be merged after the next brew tag.

https://github.com/Homebrew/brew/pull/4265 makes the postflight unnecessary. 