### PR TITLE
Bring back dymo-label, dymo-stamps

### DIFF
--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -1,0 +1,28 @@
+cask 'dymo-label' do
+  version '8.6.2'
+  sha256 'efda7c1428974261c77b765d94751502eaf58521f179c8bc169362f9fddaee6e'
+
+  url "http://download.dymo.com/dymo/Software/Mac/DLS#{version.major}Setup.#{version}.dmg"
+  name 'Dymo Label'
+  homepage 'https://www.dymo.com/en-US/online-support'
+
+  pkg "DYMO Label v.#{version.major}.pkg"
+
+  uninstall launchctl: 'com.dymo.pnpd',
+            pkgutil:   [
+                         'com.dymo.cups',
+                         'com.dymo.dls.addressbook.addin',
+                         'com.dymo.dls.application',
+                         'com.dymo.dls.appsupport',
+                         'com.dymo.dls.documents',
+                         'com.dymo.dls.frameworks',
+                         'com.dymo.dls.npapi.addin',
+                         'com.dymo.dls.office.addins',
+                         'com.dymo.dls.safari.addin',
+                       ]
+
+  zap delete: [
+                '~/Library/Preferences/com.dymo.dls.plist',
+                '~/Library/Caches/com.dymo.dls',
+              ]
+end

--- a/Casks/dymo-label.rb
+++ b/Casks/dymo-label.rb
@@ -1,6 +1,6 @@
 cask 'dymo-label' do
-  version '8.6.2'
-  sha256 'efda7c1428974261c77b765d94751502eaf58521f179c8bc169362f9fddaee6e'
+  version '8.7.2'
+  sha256 'cd626b5107b36f935103d68543c1d4fffc37cea26bf3f9996856fda14b08386f'
 
   url "http://download.dymo.com/dymo/Software/Mac/DLS#{version.major}Setup.#{version}.dmg"
   name 'Dymo Label'
@@ -8,21 +8,17 @@ cask 'dymo-label' do
 
   pkg "DYMO Label v.#{version.major}.pkg"
 
-  uninstall launchctl: 'com.dymo.pnpd',
+  uninstall launchctl: [
+                         'com.dymo.dls.webservice',
+                         'com.dymo.pnpd',
+                       ],
             pkgutil:   [
                          'com.dymo.cups',
-                         'com.dymo.dls.addressbook.addin',
-                         'com.dymo.dls.application',
-                         'com.dymo.dls.appsupport',
-                         'com.dymo.dls.documents',
-                         'com.dymo.dls.frameworks',
-                         'com.dymo.dls.npapi.addin',
-                         'com.dymo.dls.office.addins',
-                         'com.dymo.dls.safari.addin',
+                         'com.dymo.dls.*',
                        ]
 
-  zap delete: [
-                '~/Library/Preferences/com.dymo.dls.plist',
-                '~/Library/Caches/com.dymo.dls',
-              ]
+  zap trash: [
+               '~/Library/Preferences/com.dymo.dls.plist',
+               '~/Library/Caches/com.dymo.dls',
+             ]
 end

--- a/Casks/dymo-stamps.rb
+++ b/Casks/dymo-stamps.rb
@@ -1,0 +1,13 @@
+cask 'dymo-stamps' do
+  version :latest
+  sha256 :no_check
+
+  # endicia.com/dymostamps was verified as official when first introduced to the cask
+  url 'http://download.endicia.com/dymostamps/dymostamps.dmg'
+  name 'Dymo Stamps'
+  homepage 'https://www.dymo.com/en-US/online-support'
+
+  depends_on cask: 'dymo-label'
+
+  app 'DYMO Stamps.app'
+end

--- a/Casks/dymo-stamps.rb
+++ b/Casks/dymo-stamps.rb
@@ -2,10 +2,9 @@ cask 'dymo-stamps' do
   version :latest
   sha256 :no_check
 
-  # endicia.com/dymostamps was verified as official when first introduced to the cask
   url 'http://download.endicia.com/dymostamps/dymostamps.dmg'
   name 'Dymo Stamps'
-  homepage 'https://www.dymo.com/en-US/online-support'
+  homepage 'http://mac.endicia.com/stamps/'
 
   depends_on cask: 'dymo-label'
 

--- a/Casks/dymo-stamps.rb
+++ b/Casks/dymo-stamps.rb
@@ -1,8 +1,9 @@
 cask 'dymo-stamps' do
-  version :latest
-  sha256 :no_check
+  version '2.18.3v752'
+  sha256 'c124cc9afa96df68c0c880e7bf20cda844be439df17d8ecbea81a44e56403c28'
 
-  url 'http://download.endicia.com/dymostamps/dymostamps.dmg'
+  url "https://download.endiciaformac.com/EndiciaForMac#{version.no_dots}.dmg"
+  appcast 'https://s3.amazonaws.com/endiciaformac/EndiciaForMacSparkle.xml'
   name 'Dymo Stamps'
   homepage 'http://mac.endicia.com/stamps/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

___

Both casks got [deleted](https://github.com/Homebrew/homebrew-cask/pull/36884) in 2017 due to `dymo-label`’s installation failing; cf. #36883. Given that the issue has been fixed in https://github.com/Homebrew/brew/pull/4265, **this PR re-adds both casks.**

Also, this PR:

- fixes the homepage for `dymo-stamps`, attributing the product to [Endicia, its actual vendor](https://www.endicia.com/landing-pages/dymo-software/dymostamps);

- updates `dymo-label` to the current version, 8.7.2; and

- in `dymo-label`, adds a missing entry `com.dymo.dls.webservice` to the launchctl uninstall list.
