### PR TITLE
Update dotnet-sdk to 2.1.302

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk' do
-  version '2.1.301'
-  sha256 '9a7219bada5f4f98a778b60e05673dcdd1c661bc105d131dac39f2779020a3bf'
+  version '2.1.302'
+  sha256 '89c1a7b089d4bc12e9a70190ef5dcfc3cc82192ce7a4e6c5e3c7c2e647c55eaf'
 
-  url "https://download.microsoft.com/download/D/0/4/D04C5489-278D-4C11-9BD3-6128472A7626/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

