### PR TITLE
Update softu2f: remove postflight

### DIFF
--- a/Casks/softu2f.rb
+++ b/Casks/softu2f.rb
@@ -11,19 +11,6 @@ cask 'softu2f' do
 
   pkg 'SoftU2F.pkg'
 
-  postflight do
-    launchd_plist = "#{ENV['HOME']}/Library/LaunchAgents/com.github.SoftU2F.plist"
-
-    system_command '/bin/launchctl',
-                   args: ['unload', launchd_plist],
-                   sudo: true
-
-    set_ownership launchd_plist
-
-    system_command '/bin/launchctl',
-                   args: ['load', launchd_plist]
-  end
-
   uninstall launchctl: 'com.github.SoftU2F',
             kext:      'com.github.SoftU2FDriver',
             pkgutil:   'com.GitHub.SoftU2F'


### PR DESCRIPTION
Can be merged after the next brew tag.

https://github.com/Homebrew/brew/pull/4265 makes the postflight unnecessary.

Install will fail regardless because it has a kext.