### PR TITLE
Update plex-media-player to 2.14.1.880-301a4b6c

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.13.0.877-6e1ea2cb'
-  sha256 '73dbc3289761e9c2144a3985769db097a672b4a5dee8052515c22486f53c6203'
+  version '2.14.1.880-301a4b6c'
+  sha256 '50bca3314b97530dde4bf6175e63aa50b107e5635863a5b618fb385d9491a4a8'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.