### PR TITLE
Update tableedit to 1.4.1

### DIFF
--- a/Casks/tableedit.rb
+++ b/Casks/tableedit.rb
@@ -1,6 +1,6 @@
 cask 'tableedit' do
-  version '1.4.0'
-  sha256 'd1bd009eadec6e022de6dd1bd68aa410d250956299d33bfaab50059e818d8ed3'
+  version '1.4.1'
+  sha256 'dce8e60e941a8761dcce189270f7fdb4da9710efb628f96d59240d16249b8cfe'
 
   url "https://www.corecode.io/downloads/tableedit_#{version}.zip"
   appcast 'https://www.corecode.io/tableedit/tableedit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.