### PR TITLE
Update yt-music to 1.0.6

### DIFF
--- a/Casks/yt-music.rb
+++ b/Casks/yt-music.rb
@@ -1,6 +1,6 @@
 cask 'yt-music' do
-  version '1.0.5'
-  sha256 'c9fc48b07bb8d8dc5d260ccb396ddcb4b77130fe80342d980e6105880a94a0da'
+  version '1.0.6'
+  sha256 'a49bbdd1a6da40a55de3a356f9f9dc8a8a537bcc4908379ee6b856f1e57bc43b'
 
   url "https://github.com/steve228uk/YouTube-Music/releases/download/#{version}/YT.Music.zip"
   appcast 'https://github.com/steve228uk/YouTube-Music/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.