### PR TITLE
Update sookasa to 3.20.9

### DIFF
--- a/Casks/sookasa.rb
+++ b/Casks/sookasa.rb
@@ -7,6 +7,8 @@ cask 'sookasa' do
   name 'Sookasa'
   homepage 'https://www.sookasa.com/'
 
+  depends_on cask: 'osxfuse'
+
   pkg "Sookasa_#{version}.pkg"
 
   uninstall quit:    'com.sookasa.Sookasa',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Reported in https://github.com/Homebrew/homebrew-cask/issues/49095, confirmed in a VM.