### PR TITLE
Update perforce to 2018.1

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,5 +1,5 @@
 cask 'perforce' do
-  version '17.2'
+  version '18.1'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://cdist2.perforce.com/perforce/r#{version}/bin.darwin90x86_64/helix-versioning-engine.tgz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

