### PR TITLE
Update lockrattler to 4.6,2018.07

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.5,2018.06'
-  sha256 'c0eb2b1a32c9fce2794a6a4e80dadd0c51fa32c41d38a1e0d5b48e61e2a29ed0'
+  version '4.6,2018.07'
+  sha256 '1d4a477e615b621fdee8ca8fbaa11428fe3a83ce26a06c68a38e455d6d8e08f6'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.