### PR TITLE
Update bookmacster to 2.8.3

### DIFF
--- a/Casks/bookmacster.rb
+++ b/Casks/bookmacster.rb
@@ -1,12 +1,14 @@
 cask 'bookmacster' do
-  version :latest
-  sha256 :no_check
+  version '2.8.3'
+  sha256 '7c54b0326b055ec0f435cee7795527ac2f48684d2855a9d5e304b6dbd961f5c9'
 
   url 'https://sheepsystems.com/bookmacster/BookMacster.zip'
+  appcast 'https://sheepsystems.com/bookmacster/appcast.xml'
   name 'BookMacster'
   homepage 'https://sheepsystems.com/products/bookmacster.html'
 
   auto_updates true
+  depends_on macos: '>= :yosemite'
 
   app 'BookMacster.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.