### PR TITLE
Update 4k-youtube-to-mp3 to 3.3.7.1819

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.3.6.1809'
-  sha256 '3166bba028cd7aa98021bbc7616881289d67760624b9c7747709e517851f7ba3'
+  version '3.3.7.1819'
+  sha256 'c4618dd5f40ab8495d7486f69df06793c6b73293109235e5885b50bc14bea620'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.