### PR TITLE
Update texturepacker to 4.8.2

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -1,6 +1,6 @@
 cask 'texturepacker' do
-  version '4.8.1'
-  sha256 'b27885af637ce4aa906fb41bf67f7e271c51153cdf3be2a662adae14881ebf00'
+  version '4.8.2'
+  sha256 'bdbe67662cae2ae2f10ab72ed5198c2996e9520b869f26f1c52b7bd42a46cbf0'
 
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/TexturePacker/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.