### PR TITLE
Update vuescan to 9.6.11

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.6.10'
-  sha256 'f84b4ac943d15c8401c4b7830b847c2fa9803036b4eb90cad3311cf1f8d7cd72'
+  version '9.6.11'
+  sha256 '6a3024b480b24ef9ec65a0dc4f693801307c1a51e050edc7170dc1eda3b2c119'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.