### PR TITLE
Update yu-writer to beta-0.5.2

### DIFF
--- a/Casks/yu-writer.rb
+++ b/Casks/yu-writer.rb
@@ -1,6 +1,6 @@
 cask 'yu-writer' do
-  version 'beta-0.5.0'
-  sha256 '9781500ddebb7fad193dedb91907bf25a682712f2fab96892728bc73f6af5db5'
+  version 'beta-0.5.2'
+  sha256 '2b459338c2f9ece00ddcab4f9d67306bbcfdd527f9ba8e3624e9c1e14d8a816d'
 
   # github.com/ivarptr/yu-writer.site was verified as official when first introduced to the cask
   url "https://github.com/ivarptr/yu-writer.site/releases/download/#{version.hyphens_to_dots}/yu-writer-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.