### PR TITLE
Update tableau-public to 2018.1.2

### DIFF
--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,6 +1,6 @@
 cask 'tableau-public' do
-  version '10.5.3'
-  sha256 '11fa3adb0dc01ef01e8d56fc7c82358b914594ff4f83ac6f0e3af50367f7e852'
+  version '2018.1.3'
+  sha256 '225301ec83764a2cbcb951c5048884f1ef4a7c3c3a24bdfb812555ea91b28dbc'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   name 'Tableau Public'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.