### PR TITLE
Update busycal to 3.3.8

### DIFF
--- a/Casks/busycal.rb
+++ b/Casks/busycal.rb
@@ -1,8 +1,9 @@
 cask 'busycal' do
-  version :latest
-  sha256 :no_check
+  version '3.3.8'
+  sha256 'c3d9ac6d70c1ab6e31691808a2be2a67939fbc5fdcca0fe44b238b13eb0e77a5'
 
   url 'https://www.busymac.com/download/BusyCal.zip'
+  appcast 'https://busymac.com/busycal/releasenotes.html'
   name 'BusyCal'
   homepage 'https://busymac.com/busycal/index.html'
 
@@ -10,17 +11,15 @@ cask 'busycal' do
 
   pkg 'BusyCal Installer.pkg'
 
-  uninstall pkgutil: 'com.busymac.busycal3.pkg',
-            quit:    [
-                       'com.busymac.busycal3',
-                       'N4RA379GBW.com.busymac.busycal3.alarm',
-                     ]
+  uninstall pkgutil: "com.busymac.busycal#{version.major}.pkg",
+            quit:    "N4RA379GBW.com.busymac.busycal#{version.major}.alarm",
+            signal:  ['TERM', "com.busymac.busycal#{version.major}"]
 
   zap trash: [
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.busymac.busycal3.sfl*',
-               '~/Library/Containers/com.busymac.busycal3',
-               '~/Library/Containers/N4RA379GBW.com.busymac.busycal3.alarm',
-               '~/Library/Group Containers/com.busymac.busycal3',
-               '~/Library/Group Containers/N4RA379GBW.com.busymac.busycal3',
+               "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.busymac.busycal#{version.major}.sfl*",
+               "~/Library/Containers/com.busymac.busycal#{version.major}",
+               "~/Library/Containers/N4RA379GBW.com.busymac.busycal#{version.major}.alarm",
+               "~/Library/Group Containers/com.busymac.busycal#{version.major}",
+               "~/Library/Group Containers/N4RA379GBW.com.busymac.busycal#{version.major}",
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.