### PR TITLE
Update voodoopad to 5.2.1

### DIFF
--- a/Casks/voodoopad.rb
+++ b/Casks/voodoopad.rb
@@ -4,7 +4,7 @@ cask 'voodoopad' do
 
   # voodoopad.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://voodoopad.s3.amazonaws.com/VoodooPad-#{version}.zip"
-  appcast 'https://www.voodoopad.com/download/'
+  appcast "https://www.primatelabs.com/appcast/voodoopad#{version.major}.xml"
   name 'VoodooPad'
   homepage 'https://www.voodoopad.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.