### PR TITLE
Update nvalt to 2.2.8-128

### DIFF
--- a/Casks/nvalt.rb
+++ b/Casks/nvalt.rb
@@ -3,7 +3,8 @@ cask 'nvalt' do
   sha256 '85420c2a8d505a580b4aa4f0ef4662f08aa4af6139fb4ed448752b6b6e8fd671'
 
   # updates.designheresy.com/nvalt was verified as official when first introduced to the cask
-  url "http://updates.designheresy.com/nvalt/nvALT#{version.no_hyphens}.dmg"
+  url "https://updates.designheresy.com/nvalt/nvALT#{version.no_hyphens}.dmg"
+  appcast 'https://updates.designheresy.com/nvalt/updates.xml'
   name 'nvALT'
   homepage 'http://brettterpstra.com/projects/nvalt/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.