### PR TITLE
Update seamonkey to 2.49.3

### DIFF
--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -1,38 +1,39 @@
 cask 'seamonkey' do
-  version '2.49.2'
+  version '2.49.3'
 
   language 'de' do
-    sha256 '5d824aa5fe223ba6701243a28b94a65aa2271a685beaf181e4aa5b9626a71900'
+    sha256 '3bc0a913e420f77f5a44b1ff763ba6f1995b1f775e4a432793a08a57ddf058d1'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'f33dc841580063dcb34b06791aeb92d0530d591ff5ff6d284aa17a979a4dba5c'
+    sha256 'd22813aff2321cc17fdef594142a2c292ecb5f45b61f590c42b660b2c6c48a0e'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '2647979382e7f92f32095bdc288d0e8395860b63e3df66c3e600ecb2f4f25d73'
+    sha256 '8e39beaedc4d0f340c2d92e4f584f644cf9c18e03f3af0913ac9cc95092c9c98'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '9e582dd487afa8cc6e625ea8a817086793473a89d0a06a21050eb25576879130'
+    sha256 '620501393f2475037e4552442b61dfc3245ba31980a8be2647d76bc5edfbb571'
     'fr'
   end
 
   language 'it' do
-    sha256 'f91bf37c0ce1eafba887703dd1bcdad43a0e10fb2cd20bd9468acefe5690787a'
+    sha256 '3fb078dc08ca8756c76adde6313744d4f0ea3870b769c447070fd7f5f3796df8'
     'it'
   end
 
   language 'ru' do
-    sha256 '75f612a3d88f948a24037e279893800314f2e280cec1edcf6213858aacedbeb4'
+    sha256 '623145931366e21042fc226bd8103b06721c4bd7106197c33b0447a9521439c4'
     'ru'
   end
 
   # mozilla.org/pub/seamonkey/releases was verified as official when first introduced to the cask
   url "https://ftp.mozilla.org/pub/seamonkey/releases/#{version}/mac/#{language}/SeaMonkey%20#{version}.dmg"
+  appcast 'https://www.seamonkey-project.org/releases/'
   name 'SeaMonkey'
   homepage 'https://www.seamonkey-project.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.