### PR TITLE
Update mailspring to 1.2.2

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,8 +1,10 @@
 cask 'mailspring' do
-  version :latest
-  sha256 :no_check
+  version '1.2.2'
+  sha256 '97ac5476e26fa698a6dfb3a87b7a1f14742f6f0feef6e5be39fa350eb4cf15ea'
 
-  url 'https://updates.getmailspring.com/download?platform=darwin'
+  # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
+  url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"
+  appcast 'https://github.com/Foundry376/Mailspring/releases.atom'
   name 'Mailspring'
   homepage 'https://getmailspring.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

ref: https://github.com/Homebrew/homebrew-cask/pull/39486

This was originally versioned and then unversioned as versioned downloads weren't published and the appcast wasn't updated. The homepage now uses GitHub for downloads and has current versioned downloads.