### PR TITLE
Update routeconverter to 2.23

### DIFF
--- a/Casks/routeconverter.rb
+++ b/Casks/routeconverter.rb
@@ -1,8 +1,9 @@
 cask 'routeconverter' do
-  version :latest
-  sha256 :no_check
+  version '2.23'
+  sha256 'd1eef2e465017b9e69f1d8283b2394899eaf4cfa2b604114095c1b7f25917eca'
 
-  url 'http://static.routeconverter.com/download/RouteConverterMac.app.zip'
+  url "http://static.routeconverter.com/download/previous-releases/#{version}/RouteConverterMac.app.zip"
+  appcast 'http://static.routeconverter.com/download/previous-releases/'
   name 'RouteConverter'
   homepage 'https://www.routeconverter.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.