### PR TITLE
Update remembear to 1.0.4

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.0.3'
-  sha256 'c493186f97dc05cce366d6515b775c5c70f3fee997c0b901b39523f1b6a61afa'
+  version '1.0.4'
+  sha256 '187ac13ec7f05f7fc57244be76a4b95e81eda990f2ac23240e475a1abf480e8d'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.