### PR TITLE
Update renamer to 5.2.0

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,9 +1,10 @@
 cask 'renamer' do
-  version '5'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '5.2.0'
+  sha256 'ccc339c82229ff228b6a56b8f087bd21e2f2e7b8c045fa98d4fdbc8715864bb9'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
-  url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer.zip"
+  url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer-#{version}.zip"
+  appcast "https://api.incrediblebee.com/appcasts/renamer-#{version.major}.xml"
   name 'Renamer'
   homepage 'http://renamer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.