### PR TITLE
Update taskpaper to 3.7.7

### DIFF
--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,8 +1,9 @@
 cask 'taskpaper' do
-  version :latest
-  sha256 :no_check
+  version '3.7.7'
+  sha256 '927026589ce92ff78146c363c86ba566b710de42bcb06c27395ddf7b2a36c4e8'
 
-  url 'https://www.taskpaper.com/assets/app/TaskPaper.dmg'
+  url "https://www.taskpaper.com/assets/app/TaskPaper-#{version}.dmg"
+  appcast 'https://www.taskpaper.com/assets/app/TaskPaper.rss'
   name 'TaskPaper'
   homepage 'https://www.taskpaper.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.