### PR TITLE
Update vinoteka to 3.6.1

### DIFF
--- a/Casks/vinoteka.rb
+++ b/Casks/vinoteka.rb
@@ -1,6 +1,6 @@
 cask 'vinoteka' do
-  version '3.5.1'
-  sha256 '9e347baab54b5f57bf9bf8d8f687a8ee4620007572718a6e1b301018c1955428'
+  version '3.6.1'
+  sha256 '1be2a12d0714c0dc2ecccaecac8b11781354a2f00a460a2dcc09e07659b29b62'
 
   url 'http://download.vinotekasoft.com/Vinoteka.zip'
   appcast 'http://download.vinotekasoft.com/vinoteka_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.