### PR TITLE
Update leap to 3.8.5

### DIFF
--- a/Casks/leap.rb
+++ b/Casks/leap.rb
@@ -1,8 +1,9 @@
 cask 'leap' do
-  version :latest
-  sha256 :no_check
+  version '3.8.5'
+  sha256 '3a4c6844dfa79c113ea604de45e275c071e7696b61384471586db043e1565698'
 
   url 'https://www.ironicsoftware.com/downloads/Leap.zip'
+  appcast 'https://ironicsoftware.com/downloads/leap.xml'
   name 'Ironic Software Leap'
   homepage 'https://www.ironicsoftware.com/leap/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.