### PR TITLE
Update TablePlus build 115.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '1.0,114'
-  sha256 '383a605159c2e4de577c933d47cfe2fa9ed91faabedab496ff9df695671c9cd0'
+  version '1.0,115'
+  sha256 'bf0f513b16098a8fc2c56525074728d369e1872913ee8857b987154804cb57c3'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.