### PR TITLE
Update wechatwebdevtools to 1.02.1807120

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1806120'
-  sha256 '8833fb2e3c6c35b249b27453bcadeec9b6147dd8d269d2a23b05a9b8d47cb6ae'
+  version '1.02.1807120'
+  sha256 'ada2634be9262cf7cfbee57e5ab12a03d48dcdcda6f458cf0318455364824950'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.