### PR TITLE
Update navicat-for-mysql to 12.0.28

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.0.27'
-  sha256 'd5cad433d6c765b04c895b5224b55270c6431b2992ee42457833f2e4bdd7766a'
+  version '12.0.28'
+  sha256 '392f436f8061926a61b914a9fb66b2737e47c1d25e98c9f2302c594ce75b5247'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.