### PR TITLE
Update navicat-for-sql-server to 12.0.28

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.0.27'
-  sha256 '0f12cd141c16f4b86dd81cfc9ad574816acf69fdc4753ffeaae71b3522ff56d2'
+  version '12.0.28'
+  sha256 '610607ccbe22d6bb4f3c578ef30c9e26f097a1f6d962f7f784226b77a6845bc0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.