### PR TITLE
android-platform-tools: remove sqlite3 symlink

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -13,5 +13,4 @@ cask 'android-platform-tools' do
   binary "#{staged_path}/platform-tools/fastboot"
   binary "#{staged_path}/platform-tools/hprof-conv"
   binary "#{staged_path}/platform-tools/mke2fs"
-  binary "#{staged_path}/platform-tools/sqlite3"
 end


### PR DESCRIPTION
Moved from issue https://github.com/Homebrew/homebrew-cask/issues/49640

After months of dealing with a sqlite3 without readline that I assumed was the default macOS binary, I finally ran `which sqlite3` on it and discovered it was linked from a Cask. Sometime before this I tried to link a sqlite3 from regular Homebrew and got the following warning:

> Warning: Refusing to link macOS-provided software: sqlite

Fast forward to when I found out the sqlite3 binary was from a Cask, I put 2+2 together and began to think maybe android-platform tools, the Cask in question shouldn't link sqlite3.

I also noticed a similar issue (#31797) in which a pull request that contained an updated Cask formula didn't link the sqlite3 binary, so I figured I should try and do the same for android-platform-tools.

Hopefully I'm doing this correctly and not breaking any rules 😬