### PR TITLE
Update beyond-compare to 4.2.6.23150

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,6 +1,6 @@
 cask 'beyond-compare' do
-  version '4.2.5.23088'
-  sha256 '523895e29db80c7c0acf6a91884d14f134d16a2f4b7af6621af3b76bfe3cbb46'
+  version '4.2.6.23150'
+  sha256 '796bebd7f327140fd8683d8c5828c2dec551d1f7d040e0ca5cce94083e75b0c9'
 
   url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "https://www.scootersoftware.com/checkupdates.php?product=bc#{version.major}&platform=osx"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.