### PR TITLE
Update electron to 2.0.5

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '2.0.4'
-  sha256 'd18b4b975fa84d8e50fe2c868d6ab3de636c5bd9a3988898723023b3ecb8bea5'
+  version '2.0.5'
+  sha256 'cb58c05cb79e802a5ff4aa8bb8c3190ef072241e3a9e53f1afc56ae16f80e463'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.