### PR TITLE
Update hab to 0.59.0-20180712162348

### DIFF
--- a/Casks/hab.rb
+++ b/Casks/hab.rb
@@ -1,6 +1,6 @@
 cask 'hab' do
-  version '0.58.0-20180629144721'
-  sha256 '43e22076bd77aa683982716e394027b04c16964b307d600bddc676e13476d9f6'
+  version '0.59.0-20180712162348'
+  sha256 '541982ac05dbf250018573b8a7efe7e3b9801b84cb8a2f09fee4198aa94c1ab4'
 
   # habitat.bintray.com was verified as official when first introduced to the cask
   url "https://habitat.bintray.com/stable/darwin/x86_64/hab-#{version}-x86_64-darwin.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.