### PR TITLE
Update kite to 0.20180713.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180711.1'
-  sha256 'c62f3f63b7b56c658a98196b921064dc3a5b5bcba415d4aeb046f28be40e338f'
+  version '0.20180713.0'
+  sha256 '3092f90041d2dad0d4b96696563cacd18a53fbd7ff2d2a8a641f5c6b55e69d16'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.