### PR TITLE
Update manager to 18.7.33

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.23'
-  sha256 'dc56d743c6cab760a7c0ed4a0577115fe02191fa195696e2ba7b7657bf086c83'
+  version '18.7.33'
+  sha256 '71c2521f781df31d3995f3468bdf1a3437dfd4c65a830b00ac2a3418dfecd965'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.