### PR TITLE
Update netron to 1.9.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '1.9.0'
-  sha256 '2000e473a48820bb9c8929a5f6bc058b66dd163e012f6baed38bad6020c1aeb7'
+  version '1.9.1'
+  sha256 '4d4a01231aea7977471b3c34fab527705fc05067eb6f8b027b0c435d97cc52a6'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.