### PR TITLE
Update cutter to 1.6

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.5'
-  sha256 '5b4483f90df7c3f66ba39ca5a8e9a433529b54ad7f4f70b6e48e897022703bdd'
+  version '1.6'
+  sha256 'f3aa34644eee0d99d08c4de947b280ccd8347b5893d8f092d23614e4e34c7a42'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.