### PR TITLE
Update sonic-visualiser to 3.1,2382

### DIFF
--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -1,6 +1,6 @@
 cask 'sonic-visualiser' do
-  version '3.0.3,2249'
-  sha256 '5900b988b32c929c7f422d5d575cb221a62099b7a4bd49051233e327e3630070'
+  version '3.1,2382'
+  sha256 '9994e17ef42218fad5fcf442ce3df939599a10972fd594080ccdf9408bede8ab'
 
   # code.soundsoftware.ac.uk was verified as official when first introduced to the cask
   url "https://code.soundsoftware.ac.uk/attachments/download/#{version.after_comma}/Sonic%20Visualiser-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.