### PR TITLE
Update bitcoin-xt to 0.11.0,J

### DIFF
--- a/Casks/bitcoin-xt.rb
+++ b/Casks/bitcoin-xt.rb
@@ -1,9 +1,9 @@
 cask 'bitcoin-xt' do
-  version '0.11E'
-  sha256 '1a1dcfcaef0d3cf87b8994eca25aa53789650220c783488e10eb74eac287d40a'
+  version '0.11.0,J'
+  sha256 '838534841d6cd2fe72961508805086b48543ba5c1fb01519d0025add33e94a4c'
 
   # github.com/bitcoinxt/bitcoinxt was verified as official when first introduced to the cask
-  url "https://github.com/bitcoinxt/bitcoinxt/releases/download/v#{version}/BitcoinXT-#{version}.dmg",
+  url "https://github.com/bitcoinxt/bitcoinxt/releases/download/v#{version.major_minor}#{version.after_comma}/bitcoin-xt-#{version.before_comma}-#{version.after_comma}-osx-unsigned.dmg",
       cookies: {
                  'i_follow_redirects' => 'yes',
                }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.