### PR TITLE
Update gtkwave to 3.3.92

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,6 +1,6 @@
 cask 'gtkwave' do
-  version '3.3.91'
-  sha256 '1a36d50d3c6bafd708bea4a6af721cf961d22ebddaf37c3924fbf620a0642da7'
+  version '3.3.92'
+  sha256 '78989e3be530d97a3404fccb0bb243ad602962e3b59753b9fa19cbb8a7325d54'
 
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
   appcast 'https://sourceforge.net/projects/gtkwave/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.