### PR TITLE
Update kactus to 0.3.12

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,9 +1,9 @@
 cask 'kactus' do
-  version '0.3.10'
-  sha256 'bd92ad9e1997a3ff5c66a149321ba0a37cadbc8ee18054d3213c9f81fca17896'
+  version '0.3.12'
+  sha256 'da53c899364c28fa1363c0fd5f5e3d2803c3507301cd12a8b8068ecfa630c8bf'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
-  url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
+  url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom'
   name 'Kactus'
   homepage 'https://kactus.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.