### PR TITLE
Update pyfa to 2.3.0,yc120.7-1.2

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.1.1,into.the.abyss-1.1'
-  sha256 'debe9bc205dbecd53efb55d8084385d38923c698f8420b6287dc8e3fc1a5a2ca'
+  version '2.3.0,yc120.7-1.2'
+  sha256 '76a27baac54f3d77381a5c659f8ac9f42b32f363f8aaf45e331c965740b0c8b5'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.