### PR TITLE
Update rhodes-kite to 1.9.3

### DIFF
--- a/Casks/rhodes-kite.rb
+++ b/Casks/rhodes-kite.rb
@@ -1,6 +1,6 @@
 cask 'rhodes-kite' do
-  version '1.9.2'
-  sha256 '498259975bff1035111b789c1ad45e6ce210f834dbecb0d959027ee4ee185f4a'
+  version '1.9.3'
+  sha256 '2e38a2053feb13804da43ecea299211ebd194ac7afdae1bc8567aef6a6402cde'
 
   url "https://kiteapp.co/downloads/Kite-#{version}.zip"
   appcast 'https://api.kiteapp.co/kite_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.