### PR TITLE
Update sparkleshare to 3.28

### DIFF
--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -1,6 +1,6 @@
 cask 'sparkleshare' do
-  version '2.0.1'
-  sha256 'e8c393e380cd26bcf9dd28f02c74d5532b69a98723de8b85bfdf9c13972f826c'
+  version '3.28'
+  sha256 'd0e561706b65d379ae947f77a2fc443395b69462d1dd968ac334155c73a38381'
 
   # github.com/hbons/SparkleShare was verified as official when first introduced to the cask
   url "https://github.com/hbons/SparkleShare/releases/download/#{version}/sparkleshare-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.