### PR TITLE
Update trailrunner to 3.8.3205,199

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,6 +1,6 @@
 cask 'trailrunner' do
-  version '3.8.3200,197'
-  sha256 'ded001616141e6e781cb23ff602996c63483b20dfc29ce0dfde2f766dc2f98f7'
+  version '3.8.3205,199'
+  sha256 'ff8043d446cff1bda94ae3fc4ab268d4e5f5701198e03ecdaf1531ddd4ee5b48'
 
   # rink.hockeyapp.net was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.