### PR TITLE
Update zulip to 2.3.3

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,6 +1,6 @@
 cask 'zulip' do
-  version '2.3.2'
-  sha256 'a5f7b8dc1dfc5e9ba63aa2ebcd7b1d36db0117f80c09de3175675fb8504e47b2'
+  version '2.3.3'
+  sha256 '33f50ff39582a22b515c2d6c03073b6e1f98283e0f99355354c9bab25954486b'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.