### PR TITLE
Update Harvest 2.1.7 checksum

### DIFF
--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -1,6 +1,6 @@
 cask 'harvest' do
   version '2.1.7'
-  sha256 'cf07dccf7db0273cb2661bf202813f3a93a1a3d321447eebee5cf599acc9797d'
+  sha256 'a1dfc944180736cfff5de4ab1219f528ccbcd6f261df940dc68817f4fddf642b'
 
   url "https://www.getharvest.com/harvest/mac/Harvest.#{version}.zip"
   appcast 'https://www.getharvest.com/harvest/mac/appcast.xml'


### PR DESCRIPTION
It looks like the Harvest 2.1.7 checksum has changed (!).

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`brew cask audit` currently fails because of the checksum mismatch.

```console
$ brew cask audit harvest --download
==> Downloading https://www.getharvest.com/harvest/mac/Harvest.2.1.7.zip
Already downloaded: /Users/user/Library/Caches/Homebrew/Cask/harvest--2.1.7.zip
==> Verifying checksum for Cask harvest
==> Note: running "brew update" may fix sha256 checksum errors
audit for harvest: failed
 - download not possible: Checksum for Cask 'harvest' does not match.

Expected: cf07dccf7db0273cb2661bf202813f3a93a1a3d321447eebee5cf599acc9797d
Actual:   a1dfc944180736cfff5de4ab1219f528ccbcd6f261df940dc68817f4fddf642b
File:     /Users/user/Library/Caches/Homebrew/Cask/harvest--2.1.7.zip

To retry an incomplete download, remove the file above.
Error: audit failed for casks: harvest
```