### PR TITLE
Update qsync-client to 3.2.3.0130

### DIFF
--- a/Casks/qsync-client.rb
+++ b/Casks/qsync-client.rb
@@ -1,6 +1,6 @@
 cask 'qsync-client' do
-  version '3.2.2.1121'
-  sha256 '75e81092805c38ef61609f038b66c323e58e41254e9f5c268e8e2378a3b95861'
+  version '3.2.3.0130'
+  sha256 'fb4693289ff02217fdd92366e4160825948711500588547fb116cef0f714b191'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQsyncClientMac-#{version}.dmg"
   appcast 'http://update.qnap.com/SoftwareRelease.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.