### PR TITLE
Update omnioutliner to 5.3.2

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,6 +1,6 @@
 cask 'omnioutliner' do
-  version '5.3.1'
-  sha256 'b307f8e735486c03b6f77099da78c73a51be1f87c7e730161880a7139cb5f376'
+  version '5.3.2'
+  sha256 '26370aba11170ee9e36531031ea45bf2f672fb061f3bf9d29522f68974eab89c'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.