### PR TITLE
Revert "fix formatting in bug template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -8,7 +8,7 @@ about: Create a report to help us improve
 
 - [ ] I have retried my command with `--force` and the issue is still present.
 - [ ] I have checked the instructions for [reporting bugs](https://github.com/Homebrew/homebrew-cask#reporting-bugs).
-- [ ] None of the templates was appropriate for my issue, or I’m not sure.
+  - [ ] None of the templates was appropriate for my issue, or I’m not sure.
 - [ ] I ran `brew update-reset && brew update` and retried my command.
 - [ ] I ran `brew doctor`, fixed as many issues as possible and retried my command.
 - [ ] I understand that [if I ignore these instructions, my issue may be closed without review](https://github.com/Homebrew/homebrew-cask/blob/master/doc/faq/closing_issues_without_review.md).


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#49713

The indentation is on purpose, because it’s a subitem.