### PR TITLE
Adding spectacleapp cask for current 1.2 version

### DIFF
--- a/Casks/spectacleapp.rb
+++ b/Casks/spectacleapp.rb
@@ -1,0 +1,11 @@
+cask 'spectacleapp' do
+  version '1.2'
+  sha256 '766d5bf3b404ec567110a25de1d221290bc829302283b28ed0fbe73b9557f30c'
+
+  # s3.amazonaws.com/spectacle/downloads/Spectacle+1.2.zip was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/spectacle/downloads/Spectacle+1.2.zip'
+  name 'spectacleapp'
+  homepage 'https://www.spectacleapp.com/'
+
+  app 'Spectacle.app'
+end


### PR DESCRIPTION
This is a cask for the current 1.2 version of the Spectacle App.
Spectacle App an application for managing windows with fancy keybindings.  

Naming of the cask: The developer calls themselves
Spectacleapp and has domain name [Spectacleapp.com](https://www.spectacleapp.com) & twitter handle 
of [@spectacleapp](https://twitter.com/spectacleapp) but refers to the application as just Spectacle which conflicts 
with an existing Cask.  I picked cask name to align with domain name
and developer name.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo] 

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
