### PR TITLE
Update activedock to 149,1531825149

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '146,1530166632'
-  sha256 'db61f72bf7ea4a0ee8cf6562942b26ee0249431a66de4e9e8fc0ec534bf87636'
+  version '149,1531825149'
+  sha256 '25ed25d4a097d527b218374a011a0be81a16c48eb89c218fae98fbe7138d85d2'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.