### PR TITLE
Update minikube to 0.28.1

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,6 +1,6 @@
 cask 'minikube' do
-  version '0.28.0'
-  sha256 'bfde769dc3e1bf050a079927fdcd646723ae73d13dda3505eea6a80acc27cb57'
+  version '0.28.1'
+  sha256 '7d9b67c4c716184d6a854fb91b08b99094356a44b51e315659b254fbd74022cc'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.