### PR TITLE
Update ncar-ncl to 6.5.0

### DIFF
--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -1,12 +1,12 @@
 cask 'ncar-ncl' do
-  version '6.4.0'
+  version '6.5.0'
 
-  if MacOS.version == :el_capitan
+  if MacOS.version == :sierra
     sha256 '2e1a2957dacd14835716f0f7309117a35e1f6255fa8569d0dc3038c42df9cbfd'
-    url "https://www.earthsystemgrid.org/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.11_64bit_gnu610.tar.gz"
+    url "https://www.earthsystemgrid.org/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.12_64bit_gnu710.tar.gz"
   else
-    sha256 '3db9396a6b33eff1a5d31b8e4d41eeac17f459a2740b614131fbbe943bc76a3c'
-    url "https://www.earthsystemgrid.org/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.12_64bit_gnu530.tar.gz"
+    sha256 '18d95acc8a9904c930d61b24348d13603c53a28e7c50c86f28b4354f823dc3df'
+    url "https://www.earthsystemgrid.org/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.13_64bit_gnu730.tar.gz"
   end
 
   appcast 'https://www.ncl.ucar.edu/current_release.shtml'
@@ -16,7 +16,7 @@ cask 'ncar-ncl' do
 
   depends_on x11: true
   depends_on formula: 'gcc'
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   artifact 'include', target: "#{HOMEBREW_PREFIX}/ncl-#{version}/include"
   artifact 'bin', target: "#{HOMEBREW_PREFIX}/ncl-#{version}/bin"

--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -2,7 +2,7 @@ cask 'ncar-ncl' do
   version '6.5.0'
 
   if MacOS.version == :sierra
-    sha256 '2e1a2957dacd14835716f0f7309117a35e1f6255fa8569d0dc3038c42df9cbfd'
+    sha256 'b107934b17085c39053467aa3faa07f00b4e18a89271a0b15eec6768d6ab06fb'
     url "https://www.earthsystemgrid.org/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.12_64bit_gnu710.tar.gz"
   else
     sha256 '18d95acc8a9904c930d61b24348d13603c53a28e7c50c86f28b4354f823dc3df'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.