### PR TITLE
Update sparkle to 1.20.0

### DIFF
--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -1,6 +1,6 @@
 cask 'sparkle' do
-  version '1.19.0'
-  sha256 '56541c5ddd0859a96ba3d2c708ca734088ccd674a2fea45cf1a1aa405bb26ad3'
+  version '1.20.0'
+  sha256 '1e345bca74e5fb74e864ec472c724780cf8c970e39870ee1f6af57e1774d1ff2'
 
   # github.com/sparkle-project/Sparkle was verified as official when first introduced to the cask
   url "https://github.com/sparkle-project/Sparkle/releases/download/#{version}/Sparkle-#{version}.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.