### PR TITLE
Update tripmode to 2.1.4-742

### DIFF
--- a/Casks/tripmode.rb
+++ b/Casks/tripmode.rb
@@ -1,8 +1,8 @@
 cask 'tripmode' do
-  version '2.1.1-595'
-  sha256 '533d6696b17e1571c080f57f5ae80f00370be22ff61e2e35657eb1a19c0201b1'
+  version '2.1.4-742'
+  sha256 '425e8b268472b800687067e7637fabbfa6450b52ad66720bca6025891cfcbc1b'
 
-  url "https://www.tripmode.ch/app/TripMode-#{version}-app-Release.dmg"
+  url "https://www.tripmode.ch/app/TripMode-#{version}-app.dmg"
   appcast 'https://www.tripmode.ch/app/appcast.xml'
   name 'TripMode'
   homepage 'https://www.tripmode.ch/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.