### PR TITLE
Update quakespasm to 0.93.1

### DIFF
--- a/Casks/quakespasm.rb
+++ b/Casks/quakespasm.rb
@@ -1,6 +1,6 @@
 cask 'quakespasm' do
-  version '0.93.0'
-  sha256 '4f071806ab0eae7a2321de760ae5ca4e041ce9bfc4dec99e17795e7a31513635'
+  version '0.93.1'
+  sha256 '7cbeba17619779717b76bb366a938d96f094c4eabd9fef008c61dd3c2e806c9a'
 
   url "https://downloads.sourceforge.net/quakespasm/Mac/QuakeSpasm-#{version}-osx.zip"
   appcast 'https://sourceforge.net/projects/quakespasm/rss?path=/Mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.