### PR TITLE
Update Dash to 4.3.2

### DIFF
--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -1,6 +1,6 @@
 cask 'dash' do
-  version '4.3.1'
-  sha256 '89edf68914d46f04846312a4dedeedf036528db39ccfb3ebd1465395b78c8b29'
+  version '4.3.2'
+  sha256 'fcd9f71c45fa53b77a57134d342ed186b7d65ca88f434361c560ea964f04ecbd'
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
   appcast "https://kapeli.com/Dash#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
