### PR TITLE
Update outline-manager to 1.1.3

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.1.2'
-  sha256 '189ee98a849d756e04c91d668e8ef13e544c7aee644acae745ec48d6d3dcd8a2'
+  version '1.1.3'
+  sha256 '46e919cf6eb841120b53e76d2c8d8948f758ddfb1a6e00e755b93bdbdbb84e32'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.