### PR TITLE
Update suitcase-fusion to 8,19.1.0

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,6 +1,6 @@
 cask 'suitcase-fusion' do
-  version '8,19.0.5'
-  sha256 'c949d3f4b3a81eb4e07b1024e431f21479b75bc6b1997dd737b74f0e373a5437'
+  version '8,19.1.0'
+  sha256 '780b33cd57cdb8cb49f68b0387cd7c1e45a7b05b8c91519045b801b9c7172db7'
 
   url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
   appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.