### PR TITLE
Update jubler to 6.0.2

### DIFF
--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -1,6 +1,6 @@
 cask 'jubler' do
-  version '6.0'
-  sha256 'ed330203ce9a16ee5fa8708fa89b66907e62475f089f463adc6fb51db2f6a4a0'
+  version '6.0.2'
+  sha256 'd0d01cf027c745a2aaf3f88c1e00f003e1dacae8108564ebe8f158dfa8c2630c'
 
   # sourceforge.net/jubler was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jubler/Jubler-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.