### PR TITLE
Adds the auto_updates stanza to tower.

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -8,6 +8,8 @@ cask 'tower' do
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 
+  auto_updates true
+
   app 'Tower.app'
   binary "#{appdir}/Tower.app/Contents/MacOS/gittower"
 


### PR DESCRIPTION
This adds the `auto_updates true` stanza to tower since tower can update itself from the menu bar.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name but **no version** since it don't change the version.