### PR TITLE
Update transmit to 5.1.5

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,6 +1,6 @@
 cask 'transmit' do
-  version '5.1.4'
-  sha256 '15a89e738891554b853d24726d4d11f0b734f32a2423b8e3119446c3349114b2'
+  version '5.1.5'
+  sha256 'b73c25bfe2290ad50dacf684a58a38081d3c6861921cce1626f4a464a065cc84'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.