### PR TITLE
Update tla-plus-toolbox to 1.5.7

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'tla-plus-toolbox' do
-  version '1.5.6'
-  sha256 'bd8419ceffd82a848ff28cad34c825720a677c58b9eae443d9e529727abbf4cf'
+  version '1.5.7'
+  sha256 '0e732bf865ba6fc6f95c5ef8ee5c2bb9d85455b149d4cd4f36ed3dca4da7a4d5'
 
   # github.com/tlaplus/tlaplus/releases/download was verified as official when first introduced to the cask
   url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.