### PR TITLE
Update qownnotes to 18.07.4,b3694-160104

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.07.3,b3688-182349'
-  sha256 '099cc0873ed033f1e8081e2785cebac40faf9f201f8a699b79ba139588d3795e'
+  version '18.07.4,b3694-160104'
+  sha256 'dcf7da745aec3fcdb7db76fac36ff0ab5c56bbfee83fe23a069f70d1a9e4d4b6'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.