### PR TITLE
Update qt-creator to 4.7.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.6.2'
-  sha256 'dcc1c9956add13d06423ad09a1fe68b4a21a7bb72db21da1d76283a791606246'
+  version '4.7.0'
+  sha256 '3fdcb30220b39cb9b7c22721435b044559dfdb273675a632abd9ffba1f2501b7'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.