### PR TITLE
Update dcp-o-matic-encode-server to 2.12.8

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.12.6'
-  sha256 '1395c27621219665756420438542369d7dd5257ee7a5114ed05bb50939a84fd2'
+  version '2.12.8'
+  sha256 '52568aac3b9d8988e8aa08da9b9c955b64bc4bc2daaeb8ba8a64063c2f52e765'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.