### PR TITLE
Update atext to 2.24

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,6 +1,6 @@
 cask 'atext' do
-  version '2.23'
-  sha256 'b2ffbb94fcfea5668bd55d137f8607c6cfee77a11c0eae5d0fd21bc091de74b3'
+  version '2.24'
+  sha256 '3be1ea68e1c860de1ce97a5c1881b92d9f981392fb1d0567c843ce53cf8a0d5b'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.