### PR TITLE
Update telegram to 4.2-133195

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.2-133154'
-  sha256 'bcaae670397f817dc47ac54f1eb062d40bb7bd4d1d58e0601bd852a01e95ffd1'
+  version '4.2-133195'
+  sha256 '363c122b80332fb879cd74df325635da8bda24afcab4fd816374f7e75885262c'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.