### PR TITLE
Update comparemerge to 2.07y

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,6 +1,6 @@
 cask 'comparemerge' do
-  version '2.06y'
-  sha256 '8dd55903e667d1999d133d62fa765ff0dfd750df73e5e55c34f542f5e54b5db2'
+  version '2.07y'
+  sha256 'a585787cb58c1c37a0b8c58bd3882cfa3750689bd01dbefcb86ace3a334acd47'
 
   url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.