### PR TITLE
Update smartgit to 18.1.4

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '18.1.3'
-  sha256 'c80a8197349b4a47705a3f570f2c5bb10c3069ce760b1c248917fb9ed48e0380'
+  version '18.1.4'
+  sha256 '4537105929752cd91c0db3e1d4dd832b9dd8a9faa811fac021989c80b2232e0d'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.