### PR TITLE
Update superproductivity to 1.10.50

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '1.10.49'
-  sha256 '0ab59ca8e1014d597882b74924461f01f3cccc6a5c233efa6f7b4b59aba032d7'
+  version '1.10.50'
+  sha256 'bbda25588a0a42a644d401b0494650c2b452917560260b882c5a79585002816a'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.