### PR TITLE
Update komodo-edit to 11.1.0-18196

### DIFF
--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -1,10 +1,12 @@
 cask 'komodo-edit' do
-  version '11.0.2-18122'
-  sha256 '4d7ca24d18df2a1e876b69369a94fde31fbcfb1e21f7318f16fa47737bdefcb5'
+  version '11.1.0-18196'
+  sha256 '6615bd11dd7fe569d171c917721e6fcff0ee83f759f49dbda3d10b16497bf00d'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"
   name 'Komodo Edit'
   homepage 'https://www.activestate.com/komodo-edit/'
+
+  appcase "http://docs.activestate.com/komodo/#{version.major}/get/relnotes/"
 
   app "Komodo Edit #{version.major}.app"
 end

--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -3,10 +3,9 @@ cask 'komodo-edit' do
   sha256 '6615bd11dd7fe569d171c917721e6fcff0ee83f759f49dbda3d10b16497bf00d'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-Edit-#{version}-macosx-x86_64.dmg"
+  appcast 'https://www.activestate.com/komodo-ide/downloads/edit'
   name 'Komodo Edit'
   homepage 'https://www.activestate.com/komodo-edit/'
-
-  appcase "http://docs.activestate.com/komodo/#{version.major}/get/relnotes/"
 
   app "Komodo Edit #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.