### PR TITLE
Update komodo-ide to 11.1.0-91033

### DIFF
--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -3,7 +3,7 @@ cask 'komodo-ide' do
   sha256 'b46304e7849a9c507d3e7602dd264be9961100aaf8ff3a6e7689cdeddeea1f49'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
-  appcast "http://docs.activestate.com/komodo/#{version.major}/get/relnotes/"
+  appcast 'https://www.activestate.com/komodo-ide/downloads/ide'
   name 'Komodo IDE'
   homepage 'https://www.activestate.com/komodo-ide/'
 

--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -3,6 +3,7 @@ cask 'komodo-ide' do
   sha256 'b46304e7849a9c507d3e7602dd264be9961100aaf8ff3a6e7689cdeddeea1f49'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.sub(%r{-.*}, '')}/Komodo-IDE-#{version}-macosx-x86_64.dmg"
+  appcast "http://docs.activestate.com/komodo/#{version.major}/get/relnotes/"
   name 'Komodo IDE'
   homepage 'https://www.activestate.com/komodo-ide/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.