### PR TITLE
Update mp3tag to 2.89a

### DIFF
--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -1,6 +1,6 @@
 cask 'mp3tag' do
-  version '2.88a'
-  sha256 '535e337fe5e1021e6c3490bca074102adf08ebc1432b3f77b53815e6f6cfddff'
+  version '2.89a'
+  sha256 '5f2551c900dfd16020b0b4fd7d346187b9dc5112fbb58e33f470b6876222d32f'
 
   url "http://download.mp3tag.de/mp3tagv#{version.no_dots}-macOS-Wine.zip"
   name 'MP3TAG'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.