### PR TITLE
Update popo to 2.6.7

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,8 +1,8 @@
 cask 'popo' do
-  version '2.6.7'
+  version '2.6.7,5615'
   sha256 'a24c516110a1aafc329e909f4e566cb6d1674ef4724649d0ac750b6ce691cd7f'
 
-  url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
+  url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores.before_comma}.dmg"
   name 'NetEase POPO'
   homepage 'http://popo.netease.com/'
 

--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
   version '2.6.7'
-  sha256 'aa8e920118d90be77e2783ff9805c30959b6cb00aca53dc0324b980eb5481428'
+  sha256 'f1235585fa37181c3e3741928281bdeebbd02a57dd39a3aa6073343ee7917b30'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   name 'NetEase POPO'

--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
   version '2.6.7'
-  sha256 'f1235585fa37181c3e3741928281bdeebbd02a57dd39a3aa6073343ee7917b30'
+  sha256 'a24c516110a1aafc329e909f4e566cb6d1674ef4724649d0ac750b6ce691cd7f'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   name 'NetEase POPO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.