### PR TITLE
Updated cevelop to v1.10.0

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,6 +1,6 @@
 cask 'cevelop' do
-  version '1.9.1-201802220948'
-  sha256 '5273f0d409c6393f2fc1402541676972ec7e42531b927ddf0a5034180fd141c0'
+  version '1.10.0-201807191318'
+  sha256 '41063f21af93638deb2f950631d666b447f375dc144e8ce0e948e925fb19452c'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/'


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.10.0.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.