### PR TITLE
Update telegram to 4.2-133353

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.2-133195'
-  sha256 '363c122b80332fb879cd74df325635da8bda24afcab4fd816374f7e75885262c'
+  version '4.2-133353'
+  sha256 '1dafbe8532a5a11edfd9c346c59d246835bd42c6c79f5d1488cb6abe02899627'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.