### PR TITLE
Update kite to 0.20180719.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180718.0'
-  sha256 '26e8065d93d6bdcb2e33d27581ec754a846a582a79dfe08a75af084f180fe3e1'
+  version '0.20180719.0'
+  sha256 '58ee20eb93d13e3f4770f5b785827655a72c400bb9c6b2e91414f7b2027f8e13'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.