### PR TITLE
Update patchwork to 3.10.1

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.10.0'
-  sha256 '83c30a83329bfeebcdddb2a2723072b817305567e37cb754e10549eff75e9437'
+  version '3.10.1'
+  sha256 'dbf33a2954b22cd0bc833c292741ff05ff932f6b7bf16f86f2347021137d6a47'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.