### PR TITLE
Update pretzel to 0.0.19

### DIFF
--- a/Casks/pretzel.rb
+++ b/Casks/pretzel.rb
@@ -1,6 +1,6 @@
 cask 'pretzel' do
-  version '0.0.18'
-  sha256 'fe5d9bc77531b56f0b7a072fde26ba5788a4a5ab85c41c2f5242d306067f18d1'
+  version '0.0.19'
+  sha256 'c3d91a4db3b3fe8fd64db9ed037e568b324dc6276efdd7f3b586272222f027a9'
 
   url "https://download.pretzel.rocks/Pretzel-#{version}-mac.zip"
   appcast 'https://download.pretzel.rocks/latest-mac.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.