### PR TITLE
Update qtox to 1.16.3

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,6 +1,6 @@
 cask 'qtox' do
-  version '1.16.2'
-  sha256 '9c511a969877a06e5373e5dae1013dcc80062d73851a8aa94c2576e67a6acd84'
+  version '1.16.3'
+  sha256 'c11fb1063b4985a42d19f07ee8704b30b287a2a88a37752c102bf8a91a81f209'
 
   # github.com/qTox/qTox was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.