### PR TITLE
Update livereload to 2.3.84

### DIFF
--- a/Casks/livereload.rb
+++ b/Casks/livereload.rb
@@ -1,6 +1,6 @@
 cask 'livereload' do
-  version '2.3.74'
-  sha256 '7a192cda9c15efdeea00ca53153be0c649e3d413719f8291e4f1684c0132506b'
+  version '2.3.84'
+  sha256 '1c915d4956177cfa5981896cb060fd00743f3d74157ad4e189901d0123fd8c7f'
 
   url "http://download.livereload.com/LiveReload-#{version}.zip"
   appcast 'https://s3.amazonaws.com/download.livereload.com/LiveReload-Mac-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.