### PR TITLE
zulip: Remove mac os name from the zip file.

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -3,7 +3,7 @@ cask 'zulip' do
   sha256 '33f50ff39582a22b515c2d6c03073b6e1f98283e0f99355354c9bab25954486b'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
-  url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}-mac.zip"
+  url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}.zip"
   appcast 'https://github.com/zulip/zulip-electron/releases.atom'
   name 'Zulip'
   homepage 'https://zulipchat.com/'


### PR DESCRIPTION
The name of the zip file has been updated in the latest release which is v2.3.3.
https://github.com/zulip/zulip-electron/releases/latest

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.




[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
