### PR TITLE
PULL_REQUEST_TEMPLATE.md: confirm version is stable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ After making all changes to the cask:
 - [ ] `brew cask audit --download {{cask_file}}` is error-free.
 - [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
 - [ ] The commit message includes the cask’s name and version.
+- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
 
 Additionally, if **adding a new cask**:
 


### PR DESCRIPTION
There have been too many non-stable versions slipping through to non-versions repos.

I’m not sure this checkbox will be effective at all, especially for `cask-repair` submissions (will leave unchecked). Maybe `cask-repair` will need to be modified to make that question as well (and giving a flag for override).

Naturally, in [Homebrew/homebrew-cask-versions](https://github.com/Homebrew/homebrew-cask-versions) it would be left unchecked.