### PR TITLE
Update 4k-youtube-to-mp3 to 3.3.8.1834

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.3.7.1819'
-  sha256 'c4618dd5f40ab8495d7486f69df06793c6b73293109235e5885b50bc14bea620'
+  version '3.3.8.1834'
+  sha256 'a3dcfd5835adf7d107af1e6347220c5d89ff2c14c281b3202627d5897fa75851'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.