### PR TITLE
Update captin to 1.0.14,87:1532235836

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.13,86:1532095863'
-  sha256 '0d502c2bbc46dc0f3a5e45e25f68acbb303bd55139fdfed06e404212c5dd5a76'
+  version '1.0.14,87:1532235836'
+  sha256 '43466e6d5f7d37f63d6ff2547b3a19fc822ecb98953123032195d68a2661b093'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.