### PR TITLE
Update cloudtv to 3.9.5,1532273409

### DIFF
--- a/Casks/cloudtv.rb
+++ b/Casks/cloudtv.rb
@@ -1,6 +1,6 @@
 cask 'cloudtv' do
-  version '3.9.4,1532083364'
-  sha256 '4f70120468c5a6f78f9e595e7c210d7109258c0b021926531b59835a09deeb4f'
+  version '3.9.5,1532273409'
+  sha256 '2d580f6e06872b905b7d8abfedf7aaf8ee6873d057f63d1e905e35ff78f16463'
 
   # dl.devmate.com/com.nonoche.CloudTV was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.nonoche.CloudTV/#{version.before_comma}/#{version.after_comma}/CloudTV-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.