### PR TITLE
Update cracked to 0.1.10

### DIFF
--- a/Casks/cracked.rb
+++ b/Casks/cracked.rb
@@ -1,8 +1,8 @@
 cask 'cracked' do
-  version '0.1.7'
-  sha256 'd439497ec38f685ceaeaf6093d8f2e21a0028a318d8a206953eaf6575d75a432'
+  version '0.1.10'
+  sha256 '5992a057a2805b2023c5ee9fbe22abf64e919694398c7083512f3cd1c16a32c4'
 
-  url "https://github.com/billorcutt/Cracked/releases/download/#{version}-Release/Cracked.dmg"
+  url "https://github.com/billorcutt/Cracked/releases/download/#{version}/Cracked.dmg"
   appcast 'https://github.com/billorcutt/Cracked/releases.atom'
   name 'Cracked'
   homepage 'https://github.com/billorcutt/Cracked'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.