### PR TITLE
Update filezilla to 3.35.1

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,8 +1,8 @@
 cask 'filezilla' do
-  version '3.35.0'
-  sha256 '4a7f291b0c1f69595cf01105821a4055a75420dbde80baff1f3dc0f4534689f5'
+  version '3.35.1'
+  sha256 '150eb5040bd0dac8d0540c678350dac9ab4dbe30d0e659d24bf77f3ce18f96a9'
 
-  url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
+  url "https://dl3.cdn.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'

--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -2,7 +2,7 @@ cask 'filezilla' do
   version '3.35.1'
   sha256 '150eb5040bd0dac8d0540c678350dac9ab4dbe30d0e659d24bf77f3ce18f96a9'
 
-  url "https://dl3.cdn.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
+  url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client'
   name 'FileZilla'
   homepage 'https://filezilla-project.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.