### PR TITLE
Update go-agent to 18.7.0-7121

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,6 +1,6 @@
 cask 'go-agent' do
-  version '18.5.0-6679'
-  sha256 'ebabafdbfc3396d36d1c8c8f26650a946ee5f175f00b89c856a5e127a2db2bcd'
+  version '18.7.0-7121'
+  sha256 '4ea03c85906ea72ad260b045270c2eda243ccf2820329bdfd298b8d263a89833'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.