### PR TITLE
Update manager to 18.7.44

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.36'
-  sha256 '93d3a582861c1a4bc822469cc78fd3768f5905e37dec7fe63e8dc452101b0e28'
+  version '18.7.44'
+  sha256 '628e703ace43b3e1f4706a59b8d47787aac227093d91fbe18b8e3c57186f91e4'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.