### PR TITLE
Update rsyncosx to 5.3.9

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,6 +1,6 @@
 cask 'rsyncosx' do
-  version '5.3.7'
-  sha256 'f69e4b11f40165c41836a24ef726478adc65a70f9d31af87c70a472aee5553ce'
+  version '5.3.9'
+  sha256 'cd2ae39f59038b813baeebfac7aa91f2fb3ac8259d3a0fd712643725101e70bc'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.