### PR TITLE
Update trenchbroom to 2.0.5

### DIFF
--- a/Casks/trenchbroom.rb
+++ b/Casks/trenchbroom.rb
@@ -1,6 +1,6 @@
 cask 'trenchbroom' do
-  version '2.0.3'
-  sha256 '338a0ed80b86650b0aa3e787ac40d8e5fb77e60062f63a398b6b0d74744bd1c4'
+  version '2.0.5'
+  sha256 '8a566ed7bc0295a5f4199ee12d612165235063c5c2badf5ae0f013470924fa6d'
 
   # github.com/kduske/TrenchBroom was verified as official when first introduced to the cask
   url "https://github.com/kduske/TrenchBroom/releases/download/v#{version}/TrenchBroom-MacOSX-v#{version}-Release.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.