### PR TITLE
Update twist to 1.0.37,4648

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.0.36,4451'
-  sha256 '04f86f2f03f2b674a14af213727858459440cd7c76c32aec42b4e82448cda16b'
+  version '1.0.37,4648'
+  sha256 'b3130e1ca213d30e162bcec29bb75817928bcb395484d550eb50dcf561926090'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.