### PR TITLE
Update fromscratch to 1.4.0

### DIFF
--- a/Casks/fromscratch.rb
+++ b/Casks/fromscratch.rb
@@ -1,9 +1,9 @@
 cask 'fromscratch' do
-  version '1.3.0'
-  sha256 'a3621940ae0eaafe7fdcabe038a027ffa6c609f8764e74edbfa91d24e419e960'
+  version '1.4.0'
+  sha256 '8cdfe9277c480fee3453ecfdd74cf5291be4574d3445ca46cfbad204395eecd5'
 
   # github.com/Kilian/fromscratch was verified as official when first introduced to the cask
-  url "https://github.com/Kilian/fromscratch/releases/download/v#{version}/FromScratch-darwin-x64-#{version}.zip"
+  url "https://github.com/Kilian/fromscratch/releases/download/v#{version}/FromScratch-#{version}.dmg"
   appcast 'https://github.com/Kilian/fromscratch/releases.atom'
   name 'FromScratch'
   homepage 'https://fromscratch.rocks/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.