### PR TITLE
Update ocrkit to 18.4.19,cf4278314ef8e4b996e1b798d8eb92cf

### DIFF
--- a/Casks/ocrkit.rb
+++ b/Casks/ocrkit.rb
@@ -1,6 +1,6 @@
 cask 'ocrkit' do
   version '18.7.15'
-  sha256 'b8054ebca6e1417eac12255bb47f3320422f736dc6a8ceb70f3198386f9869ea'
+  sha256 'f6cdae2d312279218e86ebfe4aff9e67bf21f130534f9ed29e249021bc148af7'
 
   # dl.exactcode.de was verified as official when first introduced to the cask
   url "http://dl.exactcode.de/sync/#{version.major}/OCRKit-#{version}.tar.gz"

--- a/Casks/ocrkit.rb
+++ b/Casks/ocrkit.rb
@@ -1,9 +1,10 @@
 cask 'ocrkit' do
-  version '18.4.19,cf4278314ef8e4b996e1b798d8eb92cf'
+  version '18.7.15'
   sha256 'b8054ebca6e1417eac12255bb47f3320422f736dc6a8ceb70f3198386f9869ea'
 
-  # exactcode.de was verified as official when first introduced to the cask
-  url "https://dl.exactcode.de/tmp/#{version.after_comma}/OCRKit-#{version.before_comma}.dmg"
+  # dl.exactcode.de was verified as official when first introduced to the cask
+  url "http://dl.exactcode.de/sync/#{version.major}/OCRKit-#{version}.tar.gz"
+  appcast 'https://synchronicity.exactcode.de/OCRKit/seed-Darwin.xml'
   name 'OCRKit'
   homepage 'https://ocrkit.com/'
 

--- a/Casks/ocrkit.rb
+++ b/Casks/ocrkit.rb
@@ -1,6 +1,6 @@
 cask 'ocrkit' do
-  version '15.11.24,62c3a0fc70ed4e5c64527ba781d634bc'
-  sha256 '39502f49af57eea167232cdb7cc71b9f2c102aea611dd11777ba95166368bb7a'
+  version '18.4.19,cf4278314ef8e4b996e1b798d8eb92cf'
+  sha256 'b8054ebca6e1417eac12255bb47f3320422f736dc6a8ceb70f3198386f9869ea'
 
   # exactcode.de was verified as official when first introduced to the cask
   url "https://dl.exactcode.de/tmp/#{version.after_comma}/OCRKit-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.