### PR TITLE
Update prezi-classic to 6.13.1

### DIFF
--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -1,6 +1,6 @@
 cask 'prezi-classic' do
-  version '6.12.1'
-  sha256 '03e014d0944f51ecb91f93c45d07d8fb1a0d5ed226d6d3b68b6d12d4bfbc9f53'
+  version '6.13.1'
+  sha256 '9870c55a6e7f9d6163bb45e8a4eadb39192319219638941b08a9eb10841750fb'
 
   url "https://desktopassets.prezi.com/mac/pd6/releases/Prezi_Classic_#{version}.dmg"
   name 'Prezi Classic'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.