### PR TITLE
Update bbc-iplayer-downloads to 2.5.6

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -1,9 +1,9 @@
 cask 'bbc-iplayer-downloads' do
-  version '1.14.2'
-  sha256 'feb02a935380805598b211a94c28466f0e064bfc938767ddc084a37a8c4719ee'
+  version '2.5.6'
+  sha256 '87656578b9ebb031ebaa658d56133f05b50a5cfcac4095d5fac8ccd50d625976'
 
-  # bbci.co.uk was verified as official when first introduced to the cask
-  url "https://a.files.bbci.co.uk/iplayer/downloads/BBC-iPlayer-Downloads-#{version}.dmg"
+  # live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com/releases/darwin-x64/BBCiPlayerDownloads-#{version}.dmg"
   name 'BBC iPlayer Downloads'
   homepage 'https://www.bbc.co.uk/iplayer/install'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.