### PR TITLE
Update docker-toolbox to 18.06.0-ce

### DIFF
--- a/Casks/docker-toolbox.rb
+++ b/Casks/docker-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'docker-toolbox' do
-  version '18.03.0-ce'
-  sha256 '16ea4d6d8125dfd9dc78492beb3cef6239b87cf568715df8d9efffd63c6a3cfe'
+  version '18.06.0-ce'
+  sha256 '04ee8f6beb2114e20447f912cde4d5e9a827b51cb1cf2ef9968839e4debf48d3'
 
   # github.com/docker/toolbox was verified as official when first introduced to the cask
   url "https://github.com/docker/toolbox/releases/download/v#{version}/DockerToolbox-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.