### PR TITLE
Update fromscratch to 1.4.1

### DIFF
--- a/Casks/fromscratch.rb
+++ b/Casks/fromscratch.rb
@@ -1,6 +1,6 @@
 cask 'fromscratch' do
-  version '1.4.0'
-  sha256 '8cdfe9277c480fee3453ecfdd74cf5291be4574d3445ca46cfbad204395eecd5'
+  version '1.4.1'
+  sha256 'af8bf3220c6b89527b27d84ac5b15cdadef3b02f4bd1c55f35a84c05b661329f'
 
   # github.com/Kilian/fromscratch was verified as official when first introduced to the cask
   url "https://github.com/Kilian/fromscratch/releases/download/v#{version}/FromScratch-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

mac only release for a bugfix