### PR TITLE
Update fsnotes to 2.0.2

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.0'
-  sha256 '755ef8a36eea3f144e7b4fdb36f7c1b4e0840bc7d5d69c8baa39550a0f4a9083'
+  version '2.0.2'
+  sha256 '013ac423c6cce781fa5cbb36bad630725a95e768ec8f930b111ef751ce195f5c'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version.before_comma}/FSNotes_#{version.before_comma}#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.