### PR TITLE
Update meta to 1.8.6

### DIFF
--- a/Casks/meta.rb
+++ b/Casks/meta.rb
@@ -1,6 +1,6 @@
 cask 'meta' do
-  version '1.8.5'
-  sha256 'f5e05fb33794daeb89fe747906667847bcd0455b7e5ed54795e9373ab2e32b9e'
+  version '1.8.6'
+  sha256 'fb7f531240f3e546f5ff5277a7f9380949875025e53d109dac266d9d48294592'
 
   url "https://www.nightbirdsevolve.com/meta/updates/bin/Meta%20#{version}.zip"
   appcast 'https://www.nightbirdsevolve.com/meta/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.