### PR TITLE
Update scap-workbench to 1.2.0

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,6 +1,6 @@
 cask 'scap-workbench' do
-  version '1.1.5-1'
-  sha256 'ae77bd74be0c1438fdc25ddf775b4bdf220b846946381c4cbbeb0c178fe4b1ac'
+  version '1.2.0'
+  sha256 'cf24fe103e975700532105bf32c741bfd54e4f3b9512435b2e970df607b541de'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
   url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version.sub(%r{-.+}, '')}/scap-workbench-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.