### PR TITLE
Update reborn to 0.5.49

### DIFF
--- a/Casks/reborn.rb
+++ b/Casks/reborn.rb
@@ -1,6 +1,6 @@
 cask 'reborn' do
-  version '0.5.48'
-  sha256 '80977d36e98582b0f6364cf9273801074adb792a09d638af652cf55f466d7c0b'
+  version '0.5.49'
+  sha256 '74441db98aa0c7bcce6a5ac94233ff8c7582bc7f4ea88571fdaf24d776a7ba82'
 
   url "https://github.com/langyanduan/Reborn/releases/download/#{version}/Reborn.zip"
   appcast 'https://github.com/langyanduan/Reborn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.