### PR TITLE
Update rhodes-kite to 1.9.4

### DIFF
--- a/Casks/rhodes-kite.rb
+++ b/Casks/rhodes-kite.rb
@@ -1,6 +1,6 @@
 cask 'rhodes-kite' do
-  version '1.9.3'
-  sha256 '2e38a2053feb13804da43ecea299211ebd194ac7afdae1bc8567aef6a6402cde'
+  version '1.9.4'
+  sha256 'e88912172dd9e501775c480bb93c773bb48e942044bccd9a57be38a96124295b'
 
   url "https://kiteapp.co/downloads/Kite-#{version}.zip"
   appcast 'https://api.kiteapp.co/kite_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.