### PR TITLE
Update tower to 3.1.0-157,5d201a39

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,6 +1,6 @@
 cask 'tower' do
-  version '3.0.2-154,eea196a9'
-  sha256 '2a4c6e14ac727d58e618482b6224d99d8dce4d9c45fab0531a0c3463a5ff3333'
+  version '3.1.0-157,5d201a39'
+  sha256 '118810f0ad232a4f58ab43c79cfa91c9f978346d5940a31fa6306b81d3ed8c1a'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.