### PR TITLE
Update mediathekview to 13.1.0

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,6 +1,6 @@
 cask 'mediathekview' do
-  version '13.0.6'
-  sha256 'a53a62a40e94064a9d66adce7b0139f908b8d4d5bc5a8e9d590a07040694a32e'
+  version '13.1.0'
+  sha256 '6396e3279ef5306f735b0a09890e610012bbe97a946a8de7ed0ebdd6949a7b44'
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}.dmg"
   appcast 'https://mediathekview.de/changelog/index.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.