### PR TITLE
Update crossover to 17.5.1

### DIFF
--- a/Casks/crossover.rb
+++ b/Casks/crossover.rb
@@ -1,6 +1,6 @@
 cask 'crossover' do
-  version '17.5.0'
-  sha256 '04a2d18d991ee6a32f6538d26019d8702dc1fe9fbafd36908601678ed701a87b'
+  version '17.5.1'
+  sha256 'c0eaf08911b3d65d40a3ce4cb27b9d2a401a71c8aacd3dcd5f9a59f144ac83b9'
 
   url "https://media.codeweavers.com/pub/crossover/cxmac/demo/crossover-#{version}.zip"
   appcast 'https://www.codeweavers.com/xml/versions/cxmac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.