### PR TITLE
Update liteide to 34,5.9.5

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,9 +1,9 @@
 cask 'liteide' do
-  version '33.4,5.9.5'
-  sha256 '9e01622e3bc8f982cb79ff999ebbbaa9377a2cbab5830a95cda8b319706e6723'
+  version '34,5.9.5'
+  sha256 '97e9be26238a8b6bf7816008cb0419124d5ee0b35cec73787286e023a5ad178e'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
-  url "https://github.com/visualfc/liteide/releases/download/x#{version.before_comma}/liteidex#{version.before_comma}.macosx-qt#{version.after_comma}.zip"
+  url "https://github.com/visualfc/liteide/releases/download/x#{version.before_comma}/liteidex#{version.before_comma}.macos-qt#{version.after_comma}.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom'
   name 'LiteIDE'
   homepage 'http://liteide.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.