### PR TITLE
Update xca to 2.1.0

### DIFF
--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,9 +1,9 @@
 cask 'xca' do
-  version '2.0.1'
-  sha256 '6432f049855aadabf4c358f03f448ebc5722528c98cb50e0fa087908fcfe2763'
+  version '2.1.0'
+  sha256 'ad90848e29f199d5b9957e6f8c92bb0de38b8cc869c61ecb707b4199c68bee89'
 
   # github.com/chris2511/xca was verified as official when first introduced to the cask
-  url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}-High-Sierra.dmg"
+  url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}.dmg"
   appcast 'https://github.com/chris2511/xca/releases.atom'
   name 'XCA'
   homepage 'https://hohnstaedt.de/xca/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.