### PR TITLE
Update standard-notes to 2.3.2

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
-  version '2.3.1'
-  sha256 'e1a54e2aea235d984986098acf4d78d9e5809e7e0d06c2d35e225f3c66439409'
+  version '2.3.2'
+  sha256 'cd35b4351900e3cb31716f837aa64e3d67eedf8b995eec328c70d868b9af1271'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.