### PR TITLE
Update studio-3t to 2018.4.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2018.4.0'
-  sha256 '4daa456dfee0abd994e226011271d2f2dc56527ea97549dff43e75ce3c32c8a6'
+  version '2018.4.1'
+  sha256 '5d2b7815d74d1ed9c4bd4b14cffefa155c299f606c91ee702305f2d56224d919'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.