### PR TITLE
Update virtualc64 to 2.3

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,7 +1,7 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '2.2'
-  sha256 '6db77b25c712e45949556bd909b03f89991a7bd693db49f1e6b4c4026fd2b4aa'
+  version '2.3'
+  sha256 '0916b38c7e0476443214c7cdf908b20c177811b572bdfbd054050829083098e3'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.