### PR TITLE
Update noti to 0.3.2

### DIFF
--- a/Casks/noti.rb
+++ b/Casks/noti.rb
@@ -1,6 +1,6 @@
 cask 'noti' do
-  version '0.3.1'
-  sha256 '7ce31dfc0a177bc21591d18b7f3b96f72f7105c132641e7d3a296ec02eaf23db'
+  version '0.3.2'
+  sha256 '3ad018a37b2a16f019aac3680fd83ae6e5580a5548210179d305cdbf330eedad'
 
   # github.com/jariz/Noti was verified as official when first introduced to the cask
   url "https://github.com/jariz/Noti/releases/download/#{version}/Noti.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.