### PR TITLE
Update astro to 3.0.14,4121

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,6 +1,6 @@
 cask 'astro' do
-  version '3.0.13,4116'
-  sha256 '2c71d011793856be4863f8b1637deca455f90211e1a406eb35c2e2aa772198fd'
+  version '3.0.14,4121'
+  sha256 '3c97c577995a2272eb05e24631582d7c9bd68d05c0b1b09b93e59bb90d38d372'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.