### PR TITLE
Update winds to 2.1.73

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '2.1.49'
-  sha256 '652d72efc757640858300551298d72239b6d532669064883e7a7216814dd557a'
+  version '2.1.73'
+  sha256 'cf2e65a880429a262718bc08830984f5b21d98dfe458ce9f56fe5085a9acd8a5'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.