### PR TITLE
Update yojimbo to 4.1.2

### DIFF
--- a/Casks/yojimbo.rb
+++ b/Casks/yojimbo.rb
@@ -1,6 +1,6 @@
 cask 'yojimbo' do
-  version '4.1.1'
-  sha256 '401b36cb12910a61d53b86fef571dcd8794f3970808098e1f0849e7d8a47f8e0'
+  version '4.1.2'
+  sha256 '33e087692c7fee4cb01c0014f6d5cca674060a1303f59f2294d9e9a43f220819'
 
   # amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/Yojimbo_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.