### PR TITLE
Update navicat-for-postgresql to 12.1.3

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '12.0.28'
-  sha256 'ff07dd4f3bccadccdbc3ffc82fdc58b6c0b7b2e155ea120181af472a14ff2bcc'
+  version '12.1.3'
+  sha256 'b3a01032dd78842fde3a2c116429dfbf7ce2a0e773a26ecc0e72a43e7b0f4179'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.