### PR TITLE
Update 4k-stogram to 2.6.15.1600

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask '4k-stogram' do
-  version '2.6.14.1590'
-  sha256 'e19350844487d0e690647777aad22c5cf19ee3e149264275686f12fa7666bde5'
+  version '2.6.15.1600'
+  sha256 '7667f0a17a556d2177b5793adf6da4b775670bbfede334fa1f1d3c11029ebdd5'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.