### PR TITLE
Update freesmug-chromium to 68.0.3440.75

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '67.0.3396.99'
-  sha256 'e7876735a132b5a7ee2e942b526bd8b4f164f4f2dd576ec743d083d4b0a7d615'
+  version '68.0.3440.75'
+  sha256 '228b32a009710f1fb904406bcbace5d2963cdc67988d2d77d05bbdace498034e'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.