### PR TITLE
Update navicat-for-mariadb to 12.1.3

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.0.28'
-  sha256 '601292a90722f830f7b27ed5978308f5bcb510e8d9cee27fd79f41de29be40cd'
+  version '12.1.3'
+  sha256 '0a38d2759072de55283e6af74cbd697990cca0da3fd4d4232ef1cad7b2cee8c2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.