### PR TITLE
Update plug to 2.0.18

### DIFF
--- a/Casks/plug.rb
+++ b/Casks/plug.rb
@@ -4,8 +4,8 @@ cask 'plug' do
     sha256 'd8eed07bd1f84d6f1daa7a0699617f2e21c01df2e68924945bcb4889d1251d01'
     url "https://plugformac.com/files/Plug-#{version}.dmg"
   else
-    version '2.0.17'
-    sha256 'ecde912d29f83afa386f08dd86ba39a01f96d10d2d3693bb3e2b6415449069ee'
+    version '2.0.18'
+    sha256 'bd5063d851c6a09ceb3d22c8419b8e3df80bc1aa1e3c3ada73ec97be8561ccdd'
     url "https://www.plugformac.com/updates/plug#{version.major}/Plug-latest.dmg"
     appcast "https://www.plugformac.com/updates/plug#{version.major}/sparklecast.xml"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.