### PR TITLE
Update rubymine to 2018.2,182.3684.86

### DIFF
--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -1,6 +1,6 @@
 cask 'rubymine' do
-  version '2018.1.4,181.5281.41'
-  sha256 'e89880cfed154e01545063f830e444f0a9ae3509b177f254a92032544cffe24a'
+  version '2018.2,182.3684.86'
+  sha256 '2057ec259e0eabbf11bca346646caad31c0b7fb1baff431e426b3ecaa7cb1dd5'
 
   url "https://download.jetbrains.com/ruby/RubyMine-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=RM&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.