### PR TITLE
Update texpad to 1.8.5,404,f8f30e5

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,6 +1,6 @@
 cask 'texpad' do
-  version '1.8.4,392,0ea1407'
-  sha256 '88c0c140e136099656a21a3534078edf00ba7970c5a6f6c29b8718a4eff1438f'
+  version '1.8.5,404,f8f30e5'
+  sha256 '676a1b071142c022cdfda57668c811f7747b36ded442548073fe6dda1b9ca934'
 
   # download.texpadapp.com was verified as official when first introduced to the cask
   url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.before_comma.dots_to_underscores}__#{version.after_comma.before_comma}__#{version.after_comma.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.