### PR TITLE
Update unity-webgl-support-for-editor to 2018.2.1f1,1a9968d9f99c

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.2.0f2,787658998520'
-  sha256 'a72e8e2420920b2f02a291b1eca42dca438f8821885ce8a6d2e7a1fa002f3f7f'
+  version '2018.2.1f1,1a9968d9f99c'
+  sha256 '9285d16e0cc6415141226716387af2e9be23727c7572fe0bf85ca7527899083c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.