### PR TITLE
Add Esperanto language for Firefox cask (61.0.1)

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -21,6 +21,11 @@ cask 'firefox' do
     'en-US'
   end
 
+  language 'eo' do
+    sha256 'cf6be4d799cf6a066c59c7c226fc96816ccac454c3adeaec8d9f7eb1c41fb19c'
+    'eo'
+  end
+
   language 'es-AR' do
     sha256 'e6d2f2ffeb3e8b3ad00501febeb9b8862748f58b5312defd78e87161a0271ff2'
     'es-AR'


### PR DESCRIPTION
Mozilla offers an Esperanto-language version of Firefox.

Mozilla ofertas Esperantan linvgan version de Firefox.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).