### PR TITLE
Update buttercup to 1.9.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,9 +1,9 @@
 cask 'buttercup' do
-  version '1.8.0'
-  sha256 '237cd2c2108ae624809fc18bd80a31e15beb2eca2d23a0919e8ce2b3677e368d'
+  version '1.9.0'
+  sha256 '50fda16bed80e93d35673bbd22f7f2a9602d1615e8f5435f48ae6a06866e7f56'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
-  url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/buttercup-desktop-#{version}-mac.zip"
+  url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"
   appcast 'https://github.com/buttercup/buttercup-desktop/releases.atom'
   name 'Buttercup'
   homepage 'https://buttercup.pw/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.