### PR TITLE
Update fsnotes to 2.0.4

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.0.3'
-  sha256 '8c298fa7e5ec8acfe4cbc3935d1eac565ef48529321f46cf47becf97ea29df91'
+  version '2.0.4'
+  sha256 '9a30527129f2bf4de5b189730e6eb093d8cf4a7c322b1a711217a4d53283e91a'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version.before_comma}/FSNotes_#{version.before_comma}#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.