### PR TITLE
Update mpv to 0.29.0

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -8,6 +8,8 @@ cask 'mpv' do
   name 'mpv'
   homepage 'https://mpv.io/'
 
+  depends_on macos: '>= :yosemite'
+
   app 'mpv.app'
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"
 

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -1,6 +1,6 @@
 cask 'mpv' do
   version '0.29.0'
-  sha256 '41f79cc33758888ed75d2163cb1c209d79e6fa7d558b6e8fef3dfe05b4a6fc29'
+  sha256 'eeddff95ba8ece89c539485bbe94b942c43588500e32c60b2a2b9da1ae8a5f84'
 
   # laboratory.stolendata.net/~djinn/mpv_osx was verified as official when first introduced to the cask
   url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv-#{version}.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://laboratory.stolendata.net/~djinn/mpv_osx/

<img width="1044" alt="screen shot 2018-07-27 at 08 42 05" src="https://user-images.githubusercontent.com/6127163/43295669-02351e38-9179-11e8-9c14-1c8324fdf4fa.png">