### PR TITLE
Update aquamacs to 3.4

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,6 +1,6 @@
 cask 'aquamacs' do
-  version '3.3'
-  sha256 '7356ee7df44ce23a0946c247039dd25b490eeec01b80f1254e1baf4669d25d59'
+  version '3.4'
+  sha256 '9c4ec15ac7f440a3aa6ea4346543f4550f8e48962a103b49ee1d6f240d16686e'
 
   # github.com/davidswelt/aquamacs-emacs was verified as official when first introduced to the cask
   url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}/Aquamacs-Emacs-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.