### PR TITLE
Update falcon-sql-client to 2.8.0

### DIFF
--- a/Casks/falcon-sql-client.rb
+++ b/Casks/falcon-sql-client.rb
@@ -8,8 +8,6 @@ cask 'falcon-sql-client' do
   name 'Falcon SQL Client'
   homepage 'https://plot.ly/free-sql-client-download'
 
-  container nested: "release/mac-falcon-v#{version}.dmg"
-
   app 'Falcon SQL Client.app'
 
   zap trash: [

--- a/Casks/falcon-sql-client.rb
+++ b/Casks/falcon-sql-client.rb
@@ -8,7 +8,7 @@ cask 'falcon-sql-client' do
   name 'Falcon SQL Client'
   homepage 'https://plot.ly/free-sql-client-download'
 
-  container nested: "release/Falcon SQL Client-#{version}.dmg"
+  container nested: "release/mac-falcon-v#{version}.dmg"
 
   app 'Falcon SQL Client.app'
 

--- a/Casks/falcon-sql-client.rb
+++ b/Casks/falcon-sql-client.rb
@@ -1,6 +1,6 @@
 cask 'falcon-sql-client' do
-  version '2.7.0'
-  sha256 'bb27deb67b94934d8cba4de49dd5d03874bc61ae804ebf68b5ef78d0b174fe6b'
+  version '2.8.0'
+  sha256 'e17dd62f73417c8134cc0cef6ebacdcd01846ffcd8f85068aec8204619251926'
 
   # github.com/plotly/falcon-sql-client was verified as official when first introduced to the cask
   url "https://github.com/plotly/falcon-sql-client/releases/download/v#{version}/mac-falcon-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.