### PR TITLE
Update renamer to 5.2.1

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
-  version '5.2.0'
-  sha256 'ccc339c82229ff228b6a56b8f087bd21e2f2e7b8c045fa98d4fdbc8715864bb9'
+  version '5.2.1'
+  sha256 '97d00335cb973258eaa707e61c6d0df5b1351727ad1403a17918651d6b61c52b'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.