### PR TITLE
Update altair to 1.7.7

### DIFF
--- a/Casks/altair.rb
+++ b/Casks/altair.rb
@@ -1,6 +1,6 @@
 cask 'altair' do
-  version '1.7.6'
-  sha256 '1f675ae080720a45f2c8d9cf3f8522753d92caf73cb33944df424bf04e3fc655'
+  version '1.7.7'
+  sha256 'ac151f1dca665cf060daea6e40096f7325e1037f43a4125575003b21440cf441'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.