### PR TITLE
Update chromedriver to 2.41

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,6 +1,6 @@
 cask 'chromedriver' do
-  version '2.40'
-  sha256 '3a5e47d7530923268e6ade36eb4647b6a327fc48c7a54e72d7ea67791a0cae29'
+  version '2.41'
+  sha256 'fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.