### PR TITLE
Update aptanastudio to 3.7.0.201807190852

### DIFF
--- a/Casks/aptanastudio.rb
+++ b/Casks/aptanastudio.rb
@@ -8,5 +8,5 @@ cask 'aptanastudio' do
   name 'Aptana Studio'
   homepage 'http://www.aptana.com/'
 
-  app "Aptana Studio #{version.major}/AptanaStudio#{version.major}.app"
+  app 'AptanaStudio.app'
 end

--- a/Casks/aptanastudio.rb
+++ b/Casks/aptanastudio.rb
@@ -3,7 +3,7 @@ cask 'aptanastudio' do
   sha256 '73b403c9801945e3bbe4f00da5fc6a252c419f0bf88dc88638d8861e0d53dc0d'
 
   # github.com/aptana/studio3 was verified as official when first introduced to the cask
-  url "https://github.com/aptana/studio3/releases/download/#{version}/Aptana_Studio_3.dmg"
+  url "https://github.com/aptana/studio3/releases/download/#{version}/Aptana_Studio_#{version.major}.dmg"
   appcast "https://github.com/aptana/studio#{version.major}/releases.atom"
   name 'Aptana Studio'
   homepage 'http://www.aptana.com/'

--- a/Casks/aptanastudio.rb
+++ b/Casks/aptanastudio.rb
@@ -1,9 +1,9 @@
 cask 'aptanastudio' do
-  version '3.6.1'
-  sha256 '0d7ea3079822b26105e74d27d8a64bb138f5ab57705f6451a67432190c0697d8'
+  version '3.7.0.201807190852'
+  sha256 '73b403c9801945e3bbe4f00da5fc6a252c419f0bf88dc88638d8861e0d53dc0d'
 
   # github.com/aptana/studio3 was verified as official when first introduced to the cask
-  url "https://github.com/aptana/studio3/releases/download/v#{version}/Aptana_Studio_#{version}_Setup.dmg"
+  url "https://github.com/aptana/studio3/releases/download/#{version}/Aptana_Studio_3.dmg"
   appcast "https://github.com/aptana/studio#{version.major}/releases.atom"
   name 'Aptana Studio'
   homepage 'http://www.aptana.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.