### PR TITLE
Update lockrattler to 4.7.1,2018.07

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.6,2018.07'
-  sha256 '1d4a477e615b621fdee8ca8fbaa11428fe3a83ce26a06c68a38e455d6d8e08f6'
+  version '4.7.1,2018.07'
+  sha256 'b9a32b5faca3a525243bfa2c924c8cadca9168034592903c83c2c353b21b3ea8'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.