### PR TITLE
Update clover-configurator to 5.1.5.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.1.4.0,CCG'
-  sha256 '4c353c6a94aed7acd59fbf21517f7130a5655d7b2936ff6468aa13cc9fe5c476'
+  version '5.1.5.0,CCG'
+  sha256 'e449f8c56a5c78e230a23222d2cf2bcccf1c8998c34c68e341ba022aefc96f77'
 
   url "http://mackie100projects.altervista.org/apps/cloverconf/#{version.after_comma}/builds-data/#{version.after_comma}.zip"
   appcast 'http://mackie100projects.altervista.org/apps/cloverconf/10.10/update.xml'

--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,11 +1,11 @@
 cask 'clover-configurator' do
-  version '5.1.5.0,CCG'
+  version '5.1.5.0'
   sha256 'e449f8c56a5c78e230a23222d2cf2bcccf1c8998c34c68e341ba022aefc96f77'
 
-  url "http://mackie100projects.altervista.org/apps/cloverconf/#{version.after_comma}/builds-data/#{version.after_comma}.zip"
-  appcast 'http://mackie100projects.altervista.org/apps/cloverconf/10.10/update.xml'
+  url 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/builds-data/CCG.zip'
+  appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'
   name 'Clover Configurator'
-  homepage 'http://mackie100projects.altervista.org/'
+  homepage 'https://mackie100projects.altervista.org/'
 
   app 'Clover Configurator.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.