### PR TITLE
musescore 2.3.1: add shim for command line usage

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -10,4 +10,15 @@ cask 'musescore' do
   depends_on macos: '>= :lion'
 
   app "MuseScore #{version.major}.app"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/musescore.wrapper.sh"
+  binary shimscript, target: 'musescore'
+  binary shimscript, target: 'mscore'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/MuseScore #{version.major}.app/Contents/MacOS/mscore' "$@"
+    EOS
+  end
 end

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -11,8 +11,7 @@ cask 'musescore' do
 
   app "MuseScore #{version.major}.app"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/musescore.wrapper.sh"
-  binary shimscript, target: 'musescore'
+  shimscript = "#{staged_path}/mscore.wrapper.sh"
   binary shimscript, target: 'mscore'
 
   preflight do


### PR DESCRIPTION
MuseScore looks for the Qt library in a location relative to the executable. If we symlink to the executable then MuseScore will look in a location relative to the symlink and Qt won't be found. The shim solves this by running MuseScore inside the .app bundle.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
