### PR TITLE
PULL_REQUEST_TEMPLATE.md: broader search for rejections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,11 @@ Additionally, if **adding a new cask**:
 - [ ] `brew cask install {{cask_file}}` worked successfully.
 - [ ] `brew cask uninstall {{cask_file}}` worked successfully.
 - [ ] Checked there are no [open pull requests] for the same cask.
-- [ ] Checked the cask was not already refused in [closed issues].
+- [ ] Checked the cask was not [already refused].
 - [ ] Checked the cask is submitted to [the correct repo].
 
 [token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
 [open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
-[closed issues]: https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
+[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
 [the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
 [version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


### PR DESCRIPTION
The previous code wasn’t catching PRs, thus making the search less useful.