### PR TITLE
Update aptanastudio to 3.7.2.201807301111

### DIFF
--- a/Casks/aptanastudio.rb
+++ b/Casks/aptanastudio.rb
@@ -1,6 +1,6 @@
 cask 'aptanastudio' do
-  version '3.7.0.201807190852'
-  sha256 '73b403c9801945e3bbe4f00da5fc6a252c419f0bf88dc88638d8861e0d53dc0d'
+  version '3.7.2.201807301111'
+  sha256 '02d0dccd808d1dd7a16ef1aab199e472726b8476cb65728f1f1ad06f6eca2363'
 
   # github.com/aptana/studio3 was verified as official when first introduced to the cask
   url "https://github.com/aptana/studio3/releases/download/#{version}/Aptana_Studio_#{version.major}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.