### PR TITLE
Update asciidocfx to 1.6.1

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
-  version '1.6.0'
-  sha256 'da3e1f7e141ba6caf41caeafc4caad5611dac40a173546c1f3e9b41924288970'
+  version '1.6.1'
+  sha256 '69a74c2b873b4b7669cb4c09c9d617247b20a620d2b82e8790c3da12ad4c5526'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.