### PR TITLE
Update burp-suite to 1.7.36

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,6 +1,6 @@
 cask 'burp-suite' do
-  version '1.7.35'
-  sha256 '1fcc57822bc463acd8e72117cdf7b80abcae8075184c6a78af544bc92231a491'
+  version '1.7.36'
+  sha256 '51561f308d268410201154efecd60c30c3142ad532458197534abc0af006598a'
 
   url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=macosx"
   appcast 'https://portswigger.net/burp/releasesarchive/community'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.