### PR TITLE
Update openvisualtraceroute to 1.7.1

### DIFF
--- a/Casks/openvisualtraceroute.rb
+++ b/Casks/openvisualtraceroute.rb
@@ -1,6 +1,6 @@
 cask 'openvisualtraceroute' do
-  version '1.7.0'
-  sha256 '29e76aff13e15cd6123238ce6673e7de74ce98ca0f0940d100423aac7e0bce42'
+  version '1.7.1'
+  sha256 'bf57e3f85e1d9174f6e934174aa113b7fe8286a060e3d1d4ea357b76e4089f8f'
 
   # downloads.sourceforge.net/openvisualtrace was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/openvisualtrace/#{version}/OpenVisualTraceRoute#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.