### PR TITLE
Update pdfsam-basic to 3.3.6

### DIFF
--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -1,6 +1,6 @@
 cask 'pdfsam-basic' do
-  version '3.3.5'
-  sha256 'a053c1c1815d66110b7da8e598099896841dd36cb3672a5e79f3843fdc872688'
+  version '3.3.6'
+  sha256 '886ff12f2d81dadc3ca538f779797ea1dfc104618470c12dcd02415f03d03bce'
 
   # github.com/torakiki/pdfsam was verified as official when first introduced to the cask
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}/PDFsam-#{version}.dmg"

--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -8,5 +8,5 @@ cask 'pdfsam-basic' do
   name 'PDFsam Basic'
   homepage 'http://www.pdfsam.org/'
 
-  app 'PDFsam.app'
+  app 'PDFsam Basic.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.