### PR TITLE
Update there to 1.7.1

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,6 +1,6 @@
 cask 'there' do
-  version '1.6.2'
-  sha256 'ab6da2a6c605209622782884ca26e14bb6a76050d15b8458e41946d401eba435'
+  version '1.7.1'
+  sha256 'b1c81425612a62315e1bde0ed94c9f3178bbfe23553f84f8cf95b219d523d934'
 
   # github.com/therepm/there-desktop was verified as official when first introduced to the cask
   url "https://github.com/therepm/there-desktop/releases/download/v#{version}/there-desktop-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.