### PR TITLE
Update twist to 1.0.37,4652

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.0.37,4651'
-  sha256 '433fe4857b31186f7f415e625db9c4309cf2a7c913a5d5a457789a4dc0a3a016'
+  version '1.0.37,4652'
+  sha256 '0b1f27287dd2f57fb88722f2f684fdc0592acd5eadae18fd5f869034d97e2496'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.