### PR TITLE
Update porting-kit to 2.9.495

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,6 +1,6 @@
 cask 'porting-kit' do
-  version '2.9.484'
-  sha256 '22e63c95e9789bda7dca3dbaa3c949df16791b5650e9354dd84d491bec72380f'
+  version '2.9.495'
+  sha256 '04388919a3352e7b44e2d5cf09b97d8526e418cc1f7358118d9d0253d600c4d1'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.