### PR TITLE
Update josm to 14066

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask 'josm' do
-  version '14026'
-  sha256 '6b3ced4dc485c5fecca9c51d9afc6d7ca71d98ac7493dd51532e035ff07ae37d'
+  version '14066'
+  sha256 '462f986a8d6eb487fd7bea8920f31d6eafce5db1b7441839bbe0cb34308c768e'
 
   url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
   name 'JOSM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.