### PR TITLE
Update bbc-iplayer-downloads to 2.5.8

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -1,6 +1,6 @@
 cask 'bbc-iplayer-downloads' do
-  version '2.5.6'
-  sha256 '87656578b9ebb031ebaa658d56133f05b50a5cfcac4095d5fac8ccd50d625976'
+  version '2.5.8'
+  sha256 '8e8bd6d4aa884d29b379ef1b905a6a87276caad4f5810e51a904f4fdef97990e'
 
   # live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com/releases/darwin-x64/BBCiPlayerDownloads-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.