### PR TITLE
Corrects checksum of asciidocfx 1.6.1

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
   version '1.6.1'
-  sha256 '69a74c2b873b4b7669cb4c09c9d617247b20a620d2b82e8790c3da12ad4c5526'
+  sha256 '0da88f5be88f65204308baafba1a2b05872a9d506755543d9c8c8843714e163c'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
This commit corrects the checksum based on pull request #50225.
The `AsciidocFX_Mac.dmg` was in place updated after merge the pull request #50225.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
```
==> Verifying checksum for Cask asciidocfx
audit for asciidocfx: passed
```
- [x] `brew cask install {{cask_file}}` worked successfully.
```
1 file inspected, no offenses detected
```
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).