### PR TITLE
Update wechatwebdevtools to 1.10.1807230,1807300

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1807120'
-  sha256 'ada2634be9262cf7cfbee57e5ab12a03d48dcdcda6f458cf0318455364824950'
+  version '1.10.1807230,1807300'
+  sha256 'd66703a8ab24c5f9f1bcb2ed63e0baf365a7aa96ff03400d9815c4d942bbea32'
 
-  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
+  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.after_comma}/wechat_devtools_#{version.before_comma}.dmg"
   name 'wechat web devtools'
   name '微信web开发者工具'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This is a new download link for the current version, but is not sure if the change is temporary or permanent.