### PR TITLE
Update beaker-browser to 0.8.0-prerelease.7

### DIFF
--- a/Casks/beaker-browser.rb
+++ b/Casks/beaker-browser.rb
@@ -1,6 +1,6 @@
 cask 'beaker-browser' do
-  version '0.8.0-prerelease.6'
-  sha256 '0382d8cf7d563677c444d01d5f9d9281e87ec97a714c14a1a183cffe4f85a5fb'
+  version '0.8.0-prerelease.7'
+  sha256 '7a9e81def0415f1dc085c40841a048d43dbe094c210d5b31fd2017e17ee28437'
 
   # github.com/beakerbrowser/beaker was verified as official when first introduced to the cask
   url "https://github.com/beakerbrowser/beaker/releases/download/#{version}/beaker-browser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.