### PR TITLE
Update diskmaker-x to 7.0.1

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,8 +1,8 @@
 cask 'diskmaker-x' do
-  version '7'
-  sha256 'd0c80961ca06dca436c0c784e8779defe56a0675d032f054064215a1b193a184'
+  version '7.0.1'
+  sha256 'c9b12c63d9742b2eb0136d352725b364a2af98f26e7efd310520a44a3d367471'
 
-  url "https://diskmakerx.com/downloads/DiskMaker_X_#{version}.dmg"
+  url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.