### PR TITLE
Update fastonosql to 1.17.7

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.17.6'
-  sha256 '83c5cb7c8903b0be609d330beba921da9131d5b1c6714fdd90ced33dd854eef3'
+  version '1.17.7'
+  sha256 '8ef78a764b9beaae94e46c4248afae59716edf0b9f3594994b5eb646bdd26c64'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.