### PR TITLE
Update imazing to 2.6.3,9098:1531155340

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.6.3,9098:1530031841'
-  sha256 '97b0832bf730e00a165ea5933c95c6f52e8ccd3380a9fd601844832888932eec'
+  version '2.6.3,9098:1531155340'
+  sha256 'dc7fcb83cf9bec5c9e4d605009713b731bf1b2cc9b0ae5418dc785fc91c84cce'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.