### PR TITLE
Update manager to 18.7.74

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.73'
-  sha256 'be5c96ecc919ca1006fdf7462399262f758f7252c92d4fd0bb8c9d71d24442a9'
+  version '18.7.74'
+  sha256 '624fa90c7cc4c75fdd1c2c128f27981b186a55aabf080b539510386abe5f0173'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.