### PR TITLE
Update kollaborate-transfer to 1.5.2.0

### DIFF
--- a/Casks/kollaborate-transfer.rb
+++ b/Casks/kollaborate-transfer.rb
@@ -1,6 +1,6 @@
 cask 'kollaborate-transfer' do
-  version '1.5.0.0'
-  sha256 '35a05feafa7d8499b1462a0a28970fcd1e8b265f037be0f23aaaa57c9a2ced4c'
+  version '1.5.2.0'
+  sha256 'b5dab39e60846ec5f7926806120ad4f84ec42cbef0d0b57ac4eef2279d91a3ab'
 
   # digitalrebellion.com was verified as official when first introduced to the cask
   url "http://www.digitalrebellion.com/download/kollabtransfer?version=#{version.no_dots}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.