### PR TITLE
Update brave to 0.23.73

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,6 +1,6 @@
 cask 'brave' do
-  version '0.23.39'
-  sha256 'c5e3d182e8e901c8539aef3be937ddb6d7245f4ffa759140781d95bdedcbe7d1'
+  version '0.23.73'
+  sha256 '202f9815b0185ee36137eb9be4d49c835cb734db1e3e32d547be1d9e34f83186'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.