### PR TITLE
Update remembear to 1.0.5

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.0.4'
-  sha256 '187ac13ec7f05f7fc57244be76a4b95e81eda990f2ac23240e475a1abf480e8d'
+  version '1.0.5'
+  sha256 '5f69738acff0c843df47ad9a8472ca4c17c68c5e215598c61ba52990b142fc25'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.