### PR TITLE
Update cctalk to 7.3.1,692

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -11,6 +11,6 @@ cask 'cctalk' do
   depends_on macos: '>= :yosemite'
 
   pkg "CCtalk.#{version.before_comma}-#{version.after_comma}.pkg"
-  
+
   uninstall pkgutil: 'com.hujiang.mac.cctalk'
 end

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask 'cctalk' do
-  version '1.0.2-633,2018-05-02'
-  sha256 '911d55e413237d59fb6c56ef385ea1b4844af1125f2da4fabf9d442e07931eba'
+  version '7.3.1,692'
+  sha256 'e9e372308560f3438f56769cfc0918dfa725cc192a940fb7a307eb3c4f62ab58'
 
-  # f1.ct.hjfile.cn was verified as official when first introduced to the cask
-  url "http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/in/mac/cctalk/archive/#{version.before_comma.hyphens_to_dots}/CCtalk-#{version.before_comma}-xianghu-#{version.after_comma}.dmg"
+  # n1other.hjfile.cn was verified as official when first introduced to the cask
+  url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk.#{version.before_comma}-#{version.after_comma}.pkg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -11,4 +11,6 @@ cask 'cctalk' do
   depends_on macos: '>= :yosemite'
 
   pkg "CCtalk.#{version.before_comma}-#{version.after_comma}.pkg"
+  
+  uninstall pkgutil: 'com.hujiang.mac.cctalk'
 end

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -10,5 +10,5 @@ cask 'cctalk' do
 
   depends_on macos: '>= :yosemite'
 
-  app 'CCtalk.app'
+  pkg "CCtalk.#{version.before_comma}-#{version.after_comma}.pkg"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.