### PR TITLE
Update lbry to 0.23.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.23.0'
-  sha256 '7cf9094e0511dc07d74a4a59321150aba3af6fc4c2c5e8dcfcd174012e46a879'
+  version '0.23.1'
+  sha256 '868f72972cc9e951372f34c75d1a3cadd0766faf33f87a34c562aac0f6712061'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.