### PR TITLE
Update textadept to 10.0

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,6 +1,6 @@
 cask 'textadept' do
-  version '9.6'
-  sha256 '0e4612263654b07cc8edb978f4fd9806b37b76c085f5d39a10312c7a60b9d207'
+  version '10.0'
+  sha256 '86a08c2acde892a3e24fcd5b4bd0125d81670b1dde1b64f2ad4fb61211aa80b5'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
   appcast 'https://foicica.com/textadept/feed'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.