### PR TITLE
Update servetome to 4.0.0165

### DIFF
--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -1,6 +1,6 @@
 cask 'servetome' do
-  version '4.0.0156'
-  sha256 '4540c0ef25008cb7aa810d192d7246b8b10675ac3df9d311ed9951127dc06b8e'
+  version '4.0.0165'
+  sha256 '65bfacbb58d86c95bd05ebdfd81c37242593144046d4c66cdf70b1b97d032251'
 
   url "http://downloads.zqueue.com/ServeToMe-v#{version}.dmg"
   appcast 'https://www.zqueue.com/servetome/changehistory.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.