### PR TITLE
Update astro to 3.0.15,4135

### DIFF
--- a/Casks/astro.rb
+++ b/Casks/astro.rb
@@ -1,6 +1,6 @@
 cask 'astro' do
-  version '3.0.14,4121'
-  sha256 '3c97c577995a2272eb05e24631582d7c9bd68d05c0b1b09b93e59bb90d38d372'
+  version '3.0.15,4135'
+  sha256 '2a7ae8f9f88df720ee17f097c81f07a8cdb3f345e1783f36b5e5af7d7c146018'
 
   # pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://pexlabs-updates-xvuif5mcicazzducz2j2xy3lki.s3-us-west-2.amazonaws.com/Astro-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.