### PR TITLE
Update freedom to 1.6.10

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,6 +1,6 @@
 cask 'freedom' do
-  version '1.6.8'
-  sha256 'b986714064bfa0f9ff29999918665694f9a6f9a0c8404892583ca2ad07eac071'
+  version '1.6.10'
+  sha256 '773480972f6bac66664615447765e5fe4e804802449a0887b85da0610ecf8926'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.