### PR TITLE
Update shotcut to 18.08.01

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '18.07.02'
-  sha256 'ce92aadcec7f0f4d0aab9dc54ed28fd3805baebf68aa21b564800dddfca89707'
+  version '18.08.01'
+  sha256 'c4ec893bff456d4227f912a4133f38a5eaf3485c756c8e4ed17956f4442307aa'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-macos-x86_64-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.