### PR TITLE
Update winds to 2.1.84

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '2.1.73'
-  sha256 'cf2e65a880429a262718bc08830984f5b21d98dfe458ce9f56fe5085a9acd8a5'
+  version '2.1.84'
+  sha256 '5c06e3059a2f72db1351102d8c6d7eb8ff5ccba9694c3fe485138f2803ad9494'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.