### PR TITLE
Update libreoffice-language-pack to 6.0.6

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,558 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '6.0.5'
+  version '6.0.6'
 
   language 'af' do
-    sha256 '0b599c28671067c3cf126aad173394890a130db96ef6ce3872e13d2c3dc32012'
+    sha256 '212593d18f985eb39031e5046e1bd29bdecd088f2026cb3129632c12fe48c86b'
     'af'
   end
 
   language 'am' do
-    sha256 '12072ef736a5d339493b20eb4a97b5f6e075968db8895d4a269db74a43d1459e'
+    sha256 '4baea0978d12e152887ac5e34eb2158a43d72442310fe0c076838026b1c9df34'
     'am'
   end
 
   language 'ar' do
-    sha256 '9bfe11d879563493729f82d96590949cc3ff66802951b07fcb8325953b5e0a07'
+    sha256 '2e46bb1571f258a94e6b3a7964fc34efaecf9eb98224099ea4191303407f0809'
     'ar'
   end
 
   language 'as' do
-    sha256 '20013156e2b04e24bf0322eaa3bc3e77ed4a02979b38c73d338f823e4d20e404'
+    sha256 '49aafea888548f1b09e23872069013d90dce5354e507ae673ad745d81640e486'
     'as'
   end
 
   language 'ast' do
-    sha256 '0662f7b1fdd213c9a6af9d50082d7b78d11f7a1837aa11a0ece45cd74002501f'
+    sha256 'e7f93e9011d5f96880c80150f0cbac495b11564d3207bf16b9153d9fb4d1da2e'
     'ast'
   end
 
   language 'be' do
-    sha256 '9cc8eb459033acef1dc9338ef72802249295d59b6d66803add8532548bbc1508'
+    sha256 '852cbc702f433b610623777a6d655c421c73d287e99175c5b78959206db9282f'
     'be'
   end
 
   language 'bg' do
-    sha256 'dce036fd1bef8a0b8a110c4479575c32ef469db89016e626310aa4a7a1c78c3e'
+    sha256 '6080c2493f97ca2e44523dbf1484e648fcdfa9e698181b1e8d587f293cbd4a80'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '0a22210438ac166669824dc6052e3e5e93889d5e356d4a7e4ac1c30b154aa226'
+    sha256 '12e653e528bb1ba7837a54ffeea216ab1c253287b2bb16cd73430d3896ac3ec9'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 'd39435c9d74cc8e59714eedac3525acf3d93c84f77430be82dd211c8465df3a9'
+    sha256 '0bfc6843d477aee541a7b4477f33af169771102e0a54fe8fba96315cba0876d7'
     'bn'
   end
 
   language 'bo' do
-    sha256 '7ac6e54cfb2dd4344dddc6d7c70f41795282b2548db53e4ab0cc526648114f5d'
+    sha256 '7a0da93d3d0808b25361e10259164a6f2d741ef90cdbf8d741f212f22c21089e'
     'bo'
   end
 
   language 'br' do
-    sha256 'e4c0069d8079a72a0452ba7a2c703e7ad583c62375b6d7eeaa5dc0dae3298edd'
+    sha256 'f8acc65e071db4920be3f7f66283ff5408730ebb44ccfa3b64803791e01105e7'
     'br'
   end
 
   language 'brx' do
-    sha256 '3d30a741fffabe54d6698bc7b70525c4708f96a14a0779aa8dd27cf98420a9e0'
+    sha256 'd2c60b416abb5903dde3ff26177dd6cea9093e55685ca76c0987a46eb7554a05'
     'brx'
   end
 
   language 'bs' do
-    sha256 '97b43d64a585aa536454f3db5652caf6dfce5d67ff55559dda6222c92675df1f'
+    sha256 '5a68631b8d5801550552b58d99188c9d50f47a7cad5caedea82eb114bf7fe3b0'
     'bs'
   end
 
   language 'ca' do
-    sha256 '7085c22210c463e3a38227d36fbe5057f9214fd3a37c63b819a99bce87609c0a'
+    sha256 'ee82aba6609110f0227d0f679a0995b2e5ce1550539c6374d8909790074a8c96'
     'ca'
   end
 
   language 'cs' do
-    sha256 'f46622ad29431e0a501334408e78b37f809a874b799053c117a1141ac348aa56'
+    sha256 '4606f8aa75fcb36864c18ddb64f4474020d415912dffedac0adf18214d687259'
     'cs'
   end
 
   language 'cy' do
-    sha256 'da438805136238c2a179f843245ce9d2e70c707b67e884d28979d7f908ad5e7a'
+    sha256 '10994e6720de7ef68a9e4c9255439f9e33c69be2034e8748c1640ce00ec28e06'
     'cy'
   end
 
   language 'da' do
-    sha256 '57ada7ae2c692c4b411d0f6eec553ac4b8580e43c2ca76ddf72dd005ae4451e8'
+    sha256 '4252ffd510dcbccc94db80bf2dacb18dd60fe494be702d569bbd13fd4e09b168'
     'da'
   end
 
   language 'de' do
-    sha256 '7e12d7108d84e2fe25098f55c88d01874973b5f5c1252b816ae208b0a4f6d951'
+    sha256 'bc22a18c10f92d2ff3b23e04a9cc90c0631fcb9b9b48792c753422ab4feb62da'
     'de'
   end
 
   language 'dgo' do
-    sha256 '8c065ea0e952af2e5158be873914ce3c90aef2cbc0aa60aa2f822dbb80c229bb'
+    sha256 '5f8230157d7b96d52bd268be47b31d4ce5e2b484ef2efdc2bda612feff37a8c6'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '7aa4f4db3b6100bf3bb30cf2fae009feb74a4e7445ad257548db22db912a37e1'
+    sha256 '43331e96fea04286f1449922ef38f068b17d283d9f8c61f05e90a520c2c63c32'
     'dz'
   end
 
   language 'el' do
-    sha256 '641d0a93d049656e15a9de1b4645a855d4407ff01b9ede0f7a5a44436e7eb6ff'
+    sha256 '778aac3eb58b3ced1b92a455aed6e4af9406cc667eb03a86bbcaa47e937cd5d8'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 'e0c6d1556fab14e28a534384ce0c673ccc1eb06b74e194963c5e2ea2831115c5'
+    sha256 '0a9d7a30c15c06f4cea83ed5ae82bf842892d3853c6e5ffa0ad1523305fe02a4'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '4f18cb5caf1149ca6083947bb8762442f45c70d6d65f97ce16fab98c4f21c23a'
+    sha256 'fa9d67125b6404bd9b5623f864cba813ac5f6f1fc0d36c44e68a8c49b3acd07f'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 'a722dcd0e935329940ad632dd8e239b116ff9542a39bda3559d9d8e090fe789e'
+    sha256 '3e46749aa75424e5e48e7aec0d83208cd294f1cc93950dcc42337887c9b8f970'
     'eo'
   end
 
   language 'es' do
-    sha256 'e480fabb84678f01b98ed48c302877f86025726278110be927b124dfe2280cc5'
+    sha256 'c847807fcd8b1adef49ec2afd52dddefc15a65d4fd2855c130fc3e66a74605fd'
     'es'
   end
 
   language 'et' do
-    sha256 '8b4b7ddd64cc6e0a18aba03b4a6abfa6c70ff4213e0c347b3d33421f7a98c143'
+    sha256 'b555fed256875681691f1dd5fca037f63779978f9e3d86cd4e8f531450072c69'
     'et'
   end
 
   language 'eu' do
-    sha256 '373cf9d5685e1c0de700ef7b48683ebcf05e118b7139603b6fd810cccd3e617e'
+    sha256 'f282b0195947c14cb7baa419be0fd9044f1e6f550b7e2e894c4edb7fe3a5f7cb'
     'eu'
   end
 
   language 'fa' do
-    sha256 '08316e1e4c3eecdc5815bfeaf72d87731a759a8722708f0c4f79eed4d2292b59'
+    sha256 '92bdd179aa8da630097c0d618c2175db1283ea0b06691bd6fbc4d1c01faf701f'
     'fa'
   end
 
   language 'fi' do
-    sha256 'd981a6724cf404f7339cf8457369f81050bdb2bb57b70d5d77c5eaa03a982aa1'
+    sha256 '2f4237d3aa858b10652cd3bd41f9f4fa5914430d8b748a282c222d7f67b1d39c'
     'fi'
   end
 
   language 'fr' do
-    sha256 '7e88ac8722a24305b84707a34955bdfa3554317b14c57fde3a3c18c8f79a954e'
+    sha256 '901a22bd6cb4e46ae744aa189585b4b7f9cdc778f355d70a07e16eb1b8663a75'
     'fr'
   end
 
   language 'ga' do
-    sha256 '18c36dfbc48c6ac17ec84a5afebf2ece874bfbb78e25391c1c10b1ee5d9428c4'
+    sha256 '3b3ba445d468ca52649ed3b0892948051a6c9ae3dac8dfc189eace14322e79c0'
     'ga'
   end
 
   language 'gd' do
-    sha256 '2ab0fbd0385d50f7909b34c599cd7fde772e06b802764f9129520dd4e3a7ea6c'
+    sha256 '89b881f1ba271e7d35b76d77f83b30a70bfb55cec853e524f87c010e981704c2'
     'gd'
   end
 
   language 'gl' do
-    sha256 '111e62f1b93edb1300a9e873eca5aca0349881e9a778c1bb5f7426f5c139ebb4'
+    sha256 'bfb1a611ad590721b4c3f0b31174d297dac10aa40070f029a4160d029afdd743'
     'gl'
   end
 
   language 'gu' do
-    sha256 '555118a27f7f65f6bca091b863d0eff7b32058f8ad994ae06a9935fbefa144c2'
+    sha256 '34e5a54caaa26dc982bf07eb8b71e2d48ef8655c04c03fef1df302be51bb67ea'
     'gu'
   end
 
   language 'gug' do
-    sha256 'f8598b2a99cb2d8d1d02417a4034e2366b286c22a9828ceca66c16151d4a952f'
+    sha256 'b0e58acdf802ea60250ab416c373eedd3fa024b046ebecc3ee2ae416216b974f'
     'gug'
   end
 
   language 'he' do
-    sha256 'a432a097f54b0f1ff6099d7582989b4dae01a45d53c1e85b257d2683a48c7dcf'
+    sha256 'd8c8e76d04ad2c5f90cf04daf59d26335f701766eedbe5c7ba1be9f3a5719cd6'
     'he'
   end
 
   language 'hi' do
-    sha256 'b6f16942b57aa0e986eb8ec3ce3409e15ebdeaa06d220d3d83423a898d117d91'
+    sha256 '0eebbc60a1c660fb2dfecf4560c525675cf44e969412ba381370f01c15ac423a'
     'hi'
   end
 
   language 'hr' do
-    sha256 '7b011f4616b70e17eb260308cbf14bc75c9b43e41c445033b33cfc02df8a8252'
+    sha256 '8ac6f4a198fe8e7cb3c8aa7924a8e84ef18b921d3435e8d84c973b77b1761199'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '57b05bb84521fde00266bc6cb9ff904bb85f69abaffaa44d442f21c1f509f880'
+    sha256 'e302cff006f31b0381cb28c402b707911588965ca1e0070310cbeba7ef74c0ca'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '8a83888eeb06eb50ec4dc2d3f9fbd968c2f10c496a7688ab0a42b9e505ebdacb'
+    sha256 '5301842fa1fb59b3e7e219ad341adb4a691a7cffe7f4aed82f0bb51b0dcefdd8'
     'hu'
   end
 
   language 'id' do
-    sha256 '9cb519ab8c070fd71d59869f124680d1ac05f48e2ff95a2651e48f807c9d276c'
+    sha256 '057b72db5b80d0eba8dc584860b866e458386daf680fac6072eb1bc82dbd6d9d'
     'id'
   end
 
   language 'is' do
-    sha256 'e25ded23f0eec942096a2bcf97acd432f810637eec50007a8cffb18ea99f324d'
+    sha256 '315242f8d735ac033df4fa1970b1b4f3e31208ed68d56d01bbe503e980a3257b'
     'is'
   end
 
   language 'it' do
-    sha256 'a5575c12d39fb4cca6ff3490572491c10e9a2fc6bf2cbdf750f410702f39051c'
+    sha256 '06fed11e5497e25a27c13bbcc74f39db1e7226454d1517ec08d4bb531c38c611'
     'it'
   end
 
   language 'ja' do
-    sha256 '1689138a3149b1c97f3da282901bb8d6826e87d68e173dc19bc7636cb0b35dc8'
+    sha256 '1ea366e19635570ecb6427e8723f0e7e475b337f8cfca976648e5720c59dc3c7'
     'ja'
   end
 
   language 'ka' do
-    sha256 '2d61bf00a0ef0107bd22f672faf21f500d3ef2cd567eba3b9676fd77d4e6b86b'
+    sha256 'f1bae7ba43376be23a76c248f2305473d14c3a42b917a338b9a027b410c46bfd'
     'ka'
   end
 
   language 'kk' do
-    sha256 '1466f26240fa87878a99748e8a134cbc0af7e99bc169bcb21d705bbb170746a8'
+    sha256 '557ed3b358ce9176123bd8407da809df37de97d5492dc48dfa2fe9f203583208'
     'kk'
   end
 
   language 'km' do
-    sha256 '47880961ddd8eee44cf97d20f5c1f1f12f8d92883ad66d9705f545d7d798faa4'
+    sha256 '12e31e755d6f6824003c28aad763beb935594b2594e12737aa3f4fce466c0bd2'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 'e68541599d22c109793f90c119ef6e48b72f535d63699613b5280dd7667aaffc'
+    sha256 '7573b76363115ccdcb681ab4a1ea6263281e2225ff7644e98f723bd5b0fe51a7'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'bbec7e7c327287ce04f565a8a4dbe129d9d76cb7a3aeb4b6c08f100421b3dc4e'
+    sha256 '880c3008b16c4371951bc57e88646d57b0a3af3ffdfbdf7624ecd546e67d5a85'
     'kn'
   end
 
   language 'ko' do
-    sha256 '0a825c0316b57d4c86d01dbea27c863a8caf58cef884db4616e62b4226989437'
+    sha256 'b71ad6e5dedd447c8160135bb19012f0d3822292e022c2492412da55c45ebbf6'
     'ko'
   end
 
   language 'kok' do
-    sha256 '0fefb908d68dab4d08598b8dfb6b866e89cfaa2902724ec4efc6c2bf7123ee8f'
+    sha256 'e74265b551966a50cdfd2422dce4dbe112204d34ba70f5897ebddb78af28ab10'
     'kok'
   end
 
   language 'ks' do
-    sha256 'cb611778b6fb51cb2c83c6afcf80660a6acd8289c3d5f5761ecd4e17ab4087cf'
+    sha256 '1f5cf286a930160e1a1ef74e5ff3a2462b6b59811cfe8491e8ec63050bf244e7'
     'ks'
   end
 
   language 'lb' do
-    sha256 'f49b1555d9a7ad538ddfd4fd68fce0f7ef941e2c7fb34ce671414d3a5c7add5d'
+    sha256 'dca6d140f3455ea69c5c7ecf05a777f841486e9545342ac0bc1eebb609543623'
     'lb'
   end
 
   language 'lo' do
-    sha256 'fa75f5161e3f9b78a0c35eab65fe917defa98f2abe0c0dc111ccb9f8bf094b56'
+    sha256 '246738610242f02c9b30970e397c7aee5ff5fc8925e47ed984ae38d6ba73a75b'
     'lo'
   end
 
   language 'lt' do
-    sha256 '845d43acef6bfb73bd0857a373c9e6dbf2bffd3476245ec599724d7f6829766d'
+    sha256 'a1badc0cc7325cc7159c0a8317b7f0ccdfec140fd5bda8984d763c052d027087'
     'lt'
   end
 
   language 'lv' do
-    sha256 'de6156262422dcfa8e035bbbad49053fdba8753b21f3b5b2972c108949efbbe5'
+    sha256 '06bd681e28cdd284898290e48987e92e33ac0ee5df60f4f1f6f0674329fe7aee'
     'lv'
   end
 
   language 'mai' do
-    sha256 '0f02c0739d10d85c6969c56a654ab206d9c50ae5d3cc0eab5fbb7c870205a859'
+    sha256 'c7818f970314e281ea64fee928cc04c891bf46a6f5931aedb6f28ffb349fe82c'
     'mai'
   end
 
   language 'mk' do
-    sha256 '06ad4c4c26818c2d15f8ea808f7b5eda8652cfd7e81bde110f6ecc0ebb5d6d58'
+    sha256 'c4d7df0d6d173394dc4e8a13aa1d366ee81e06f2b96d678c928abb0a9c4d16c0'
     'mk'
   end
 
   language 'ml' do
-    sha256 'fd02a0b464cdb9f59009ead177b33eeb473610317b40a0f604ed8ecb4ae8e498'
+    sha256 'f343f21f201b80f2318542969c512463d612beb6b71cd5817778358599297ba6'
     'ml'
   end
 
   language 'mn' do
-    sha256 '55dde047c4d04c31711e10e98dee2760fc71c0364eb46def93a69682e32406ac'
+    sha256 '9e6917c89e87534320481f0fb2c38ed3c507ccc374b28f3add43adc428a5c6e5'
     'mn'
   end
 
   language 'mni' do
-    sha256 'e472627f946a63c1da215a0eedf28cdc35761aadc2791df8eb4ff3958308576f'
+    sha256 '2fe99acf686fb5e20b6ae9d2b08cee0ef50a1ba73eee3e5f8dd8759ba1ab0fbd'
     'mni'
   end
 
   language 'mr' do
-    sha256 'bcceec81d1f8c9942b52c22a09dc60b99cce1caac8c770cb616cf67900bb73dc'
+    sha256 'f1952954624a52da59561e6b0f450fcf492c405e877552162893e24e4a3b7caf'
     'mr'
   end
 
   language 'my' do
-    sha256 '782797ea898ddc97e3b7cb463cef30bcbbfffb912654ec62b4ea8cdb18bb7993'
+    sha256 '2be99f4e6ac4532a54ceceb089d1228e6bd54afd5d935352a65c2b707ea9317a'
     'my'
   end
 
   language 'nb' do
-    sha256 'a7ecd8561b8dcfada4252dace87a0634ad0dc2d1247ccc1aa87e888dd8317416'
+    sha256 '6802729dfa0b5f103518371ca404d72f56ac8be6a3f619c87618fd9981e0efb8'
     'nb'
   end
 
   language 'ne' do
-    sha256 '5c9bd83a3458fc44ef74fcf259aba92f6dc6128240c7c80e83e891eab9904219'
+    sha256 '4df5fb91ff0ec42f147426d4fc860f070f984b27bb4ed9212f940a2ad0ccf487'
     'ne'
   end
 
   language 'nl' do
-    sha256 'e580c90bc7582628e28b54a93173802aff741c7d989b8370764942d7b41546e8'
+    sha256 'c09aab57ff7549eab4f863bbd97b16933fcc00855520d41c669d98d5dc497f44'
     'nl'
   end
 
   language 'nn' do
-    sha256 '76501d7c244995e5871cd8ba7a66d7cedc53bfebe7c28d3ecba4bc61e31db561'
+    sha256 'f53bf4e11e1ddd5836843a866f45c0efde9029734429ca9ae02300de436cf88f'
     'nn'
   end
 
   language 'nr' do
-    sha256 '2df1b76c452704f5f4c0d96b50720a65c06d06a533b0b72eeef908d07a0dab84'
+    sha256 'ba0383acb40d23fc22f0d74ffc3e801f2e32babeb9642779a04852986b758b2d'
     'nr'
   end
 
   language 'nso' do
-    sha256 '324f45f059baf2ad5cd10a6c73ef07a9e70edb1fda6cc005e1eb812958090513'
+    sha256 '1e6748156eef1ce3eb91f444533bab8d0754f4e322f65bf4043ef3b41ba7fd3e'
     'nso'
   end
 
   language 'oc' do
-    sha256 '188944163c543819de1b03165f993ffc5a3b298c958cb7f2033ba680dd3d81e8'
+    sha256 '472bf1c6979c4742c0ab18bf3e884f8929d9600e37b97a03241932e258c2c444'
     'oc'
   end
 
   language 'om' do
-    sha256 '94b6fa51ae516fe898b44d43fac1fcd8364e4ca148d9658a23c2a5a6d145b3bc'
+    sha256 '6d32382f2d2d718d45585f59ee3891b04004cd827809d073dab8a5e400312fca'
     'om'
   end
 
   language 'or' do
-    sha256 '51877affc55c3ea6f915b2ca0ad9003aec2d29d721b8b1920ce0ee39364e01b4'
+    sha256 '6cac1541f74e7c17e3611f801d55211504f96c1788866e6294b1f2fea60d63d7'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 'c298cd299f00d90b6b97ce416b4585316cbf379434d772ff416236d56434b013'
+    sha256 'f4968718e1b59d175609408fcce4cb5b2cb371acb83f8c9d4cb8445c31f7cb32'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 'bd0606b21fb2ca549faa0d85a6c26c750c57bd0dd5cc98f395d3d0938d99fa09'
+    sha256 '31280bc2615150ae1f3062f6fe1cbdca877e94f4b6cb0476b356bf2111b26b26'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '521c445dbee8a6e63d3c4a8f085aca94727787219d84e32e9b99ad6a24d49d6a'
+    sha256 '0d931e313ef3a63de3a1731fc1510febb690a121bd6b1332a9e923bd9fc4ac43'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '8df0c7d230052a62cdc349c867106265fa8915dd8f19dc1eb3e3bc6871b2950c'
+    sha256 'ec75570dc489667cc5d004ad486e627566fd44e94d9fdc441513bedd6204a533'
     'pt'
   end
 
   language 'ro' do
-    sha256 'b17abf0596ebd47146daddde60d33dd8e7a97a3919459114f3c29f874d7713aa'
+    sha256 'fa0378fa1539ceb83e109e47d1e2d8b55fd0656bcc97fe769bd347ab0bb1fefd'
     'ro'
   end
 
   language 'ru' do
-    sha256 'e20276d66727646fa86eb5d542c1bd8540d914590f093c08b0bb34b0cb504366'
+    sha256 '9db3a93384e7b0cab3d33ee63f05f4fed03becd37f99db6c326a59baa3157d39'
     'ru'
   end
 
   language 'rw' do
-    sha256 '39145c0651bbf5a2906771323ec383a0205902262aa1e74f20d156ef05d64c43'
+    sha256 'e79d3e3e9485570d92f13f7dace3e69384d474863c55d1043cd4fcf04dd64199'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '298199c67e40062d030e9ee81be60108e961a4fbecc71c3e841fe5a40c55ab9a'
+    sha256 'a5092fa0e9206d8b15c78d8dcc1f5175b5e9ee015a46146868710c7783a2fe00'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '8b1e2a4f12f028754faa87717812e0ab844f53a282a032719c04bbfe8a15e4e0'
+    sha256 'd1c6e5d6863772b8b486be0923dcfe6dfa20b312a8fbfdeadabcccb241d8e9e4'
     'sat'
   end
 
   language 'sd' do
-    sha256 '3aee52567b20728fa300f5bff217f73e5f9ff1f43e65cd549adc7eba8947b9f6'
+    sha256 '9e966ce2719e5b8916245c9a95de17101a21039e341d1fd19fdb3ef25180d338'
     'sd'
   end
 
   language 'si' do
-    sha256 'bc8584d5d5aedc5405a358059d57baef507ee783ba107ce68d5111494bfe11b7'
+    sha256 '78fdf4100e413f2bbb3d4f28ea37f4c2565ddef7d8b06c26c7133cedfa0f0fe6'
     'si'
   end
 
   language 'sid' do
-    sha256 'b9e031617cd2dcb05abbd8ef72dbe3a7041747b9394a1c15f47798984da56fa6'
+    sha256 '749cae2d2c867a8b1d5b9319337923607918e194f9109a6e23975a2300f89624'
     'sid'
   end
 
   language 'sk' do
-    sha256 'aaf38d6a055241a9d705e659fb3149ef9b8fa03ae743fdc7a3f6a56dd3207b7e'
+    sha256 '10dd950ea65a1a41de4858e28d146bbe2271911994cce1e4a8a85684e892c18f'
     'sk'
   end
 
   language 'sl' do
-    sha256 'c947414b06774d91747c7819ff3d4a1eca914ccca19bebbb88df98617a1c0f52'
+    sha256 '77deeac7103429493a045987fea06b908ab0be78a2ff428ea00d58d3cc18e372'
     'sl'
   end
 
   language 'sq' do
-    sha256 'b2d9514e1f318fdcfe3291c310eef3211d06eeaf1db18e132e7f79d17a7c740c'
+    sha256 '6936a299a691c78857e789ad1e237f42c34486b20b6a167e44f992cfb42e721c'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '7b50a2b53a96f32d5d2a455320b05e810664644df7bd7e3d42c66f109686c6b4'
+    sha256 '6af2f60c938e777b2cfdf040f381db920703b7ec3feb7a2dec0f5a0411ea7c8a'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'b0d54ace7da225642d5b542633a45e287a3115c3e93c0373a9ba301c542ab04c'
+    sha256 '014d288e97f3b974d359a9c81dc74a231fa20fa51c5b5350fca8e6a4bb48e5d2'
     'sr'
   end
 
   language 'ss' do
-    sha256 'c00fb038263391499778c66e51b4450d7ccb87ddd87a24b334ca2f94b6340efa'
+    sha256 '8a1fc20016d0fbf6d6e09b6eb956952b7243cd66efd7846268fd703c7346a023'
     'ss'
   end
 
   language 'st' do
-    sha256 'e2196c886e8cf84f3c8c9c99699f1df0b6cd59e3ae3f2936fdfc611e631dc4f9'
+    sha256 '1cfb9c53b35a8eec46fee7feec0648b814f8853c0222fdaa87961dee2dfc5811'
     'st'
   end
 
   language 'sv' do
-    sha256 '9caaa5e0bca7dafc7eb6ddd136e480992eb175314b37746f1b0618b2bd853eb4'
+    sha256 'febef2de20ca65cfb80e9af263acbfe99821dacd16903bfeedcd56740b59d1a3'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 '1cc75703b09494ee5d68a893f37fff4e563e84b1a926860d3d4212a1019223cb'
+    sha256 '7bf90cdb63d3c942ffe8f8d4fdb3f6b085d8ddc0758002137adacd9202aff5e1'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '58036de9e16743dfd23f900deeb1737e96cbb1a7fe843b9dbc373f28abba133b'
+    sha256 '52de81b65e8a6ca6583898391e8dad153850daabf2deaa0fa5cd9226b6eb4c40'
     'ta'
   end
 
   language 'te' do
-    sha256 '833d00e707b7b797de9535be164b255acd1462efb817e31d14df71ae29db9974'
+    sha256 'f885ca590e1129d093e8f9f42d38f32e1311a068335eecb729b02610bef7070c'
     'te'
   end
 
   language 'tg' do
-    sha256 '9a19b1ee7c934e1aa345e034bec29ce8a67734d645768c372f4f89ed61f97ed1'
+    sha256 '8deeb984dbbdabb5a11f8c15af092cc480b084759e42aa45361d6150b479b173'
     'tg'
   end
 
   language 'th' do
-    sha256 'c97e463c3f57aeba48c11866fd6d89d10ce851a09c5db36c9a19547a0890fd02'
+    sha256 '60890c44cd91cd2da16a788da7dc249252712442476a11d5b51a857639323739'
     'th'
   end
 
   language 'tn' do
-    sha256 'ba5591837ebb2c21e9fcec48a45525aa5cc605ddac60fba4f5047f11687e8fbe'
+    sha256 '308ae0494e451f8bc6c6dea709c0b66b391efe00604ca759f6fb18f6e75b1779'
     'tn'
   end
 
   language 'tr' do
-    sha256 '6d4fe6f3cab9cfb84e51414f0ac89ce28222fd2205d00bb1f7398e9bab6d46a5'
+    sha256 '3b549d335ec2264b72170cca5df139c1e3091fb428638e5471ff71301fd65caa'
     'tr'
   end
 
   language 'ts' do
-    sha256 '5550e57f2dc9f4b316b18920ac178eab4c307f3fd684da02fbd7868583c23f33'
+    sha256 'ebbdaf047257122c7302db825903572e36d094a286ecc5c5ed7630fc7c0e2b22'
     'ts'
   end
 
   language 'tt' do
-    sha256 'ee70b1b06cc92d0ab075799bd0817e74ac0bf9bac4ffa4449bcfab7a527b871e'
+    sha256 'b7be0b62877809e6543a2473aae73a3d2e24696dd13d374d3a948cfb38d24266'
     'tt'
   end
 
   language 'ug' do
-    sha256 '22cb9ca23c598560075327a8087effe7ad2a599e305b296fe04c5b64d2f034d8'
+    sha256 '2dbec2e140832fda6d3914dd8614727d43ac8b0d047b8a2397df6067ebd57ebe'
     'ug'
   end
 
   language 'uk' do
-    sha256 'e54b54dcad5453ed620d58fe02dd354cd920d6523cba514dbd021dbf969a69df'
+    sha256 '88322b5a48f7154a6a82b36f1cd62fc40c646d682dbd2ca00912f707f0fc6e5f'
     'uk'
   end
 
   language 'uz' do
-    sha256 '17e37e7b2c992dc362baef1733fe557de26217fff44b2313b319308884afe855'
+    sha256 'fce9292e72d17336de572e4ac859b866dd4d5d1dfc7233e286d9d5815b42d560'
     'uz'
   end
 
   language 've' do
-    sha256 '781c25e91b3cb49b08f1f146d48fcf4e8114ba639e2e148e5214278e41132905'
+    sha256 'c6104c5dd95bbec893369ed82d839349bdc066cf6dcfbe1cc8fdaf2022348d63'
     've'
   end
 
   language 'vec' do
-    sha256 '52993159dd21d8bc31c4635f1eea8e6336964d32f29e253e3b75bc37dd8f38e7'
+    sha256 '24c4d2cef4fcded5d8b95db386d94e4b5bae194e0a8c097a86c8e4ce5384e5ad'
     'vec'
   end
 
   language 'vi' do
-    sha256 'c8f3183379daa95b3ef0ea45d5de198f45bc6b036895771ca89416be147c82f0'
+    sha256 '15a1447e8472c97f0cd0432baffcf2661ce3371e35b5e10bc27070c0f700ead5'
     'vi'
   end
 
   language 'xh' do
-    sha256 'deba01b2efdacf689e2d8a9c5bb0d713da80e7664e859f71cde8f9b303466b68'
+    sha256 '4c6b33a2e0f331e73045b6e24ddbcc7f1a57567a11aee66627fc065090bbb729'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 '48cab674d19434479a883a0872f8cedd74dd6cbffc2bb9bf7209f99cdf7ee6b3'
+    sha256 'a4edf71d8d20b063ea95c656b7499720849c8086af1620f44e9c7100e706c25b'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 'd7a5a8ae427d48a461270e7a70502855a204680e6454d20a217dce9a87f13a69'
+    sha256 'e46eae1ca22704082c6f11f908612b4cd4557155b69b83fd682554aef5cc13e6'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '8ea789b249c3c925cab988d0a8e5c2c8b307d8bf1c1534777261c4dff727c7b2'
+    sha256 'dab069e77fa1225faa2dcf29b2f4fa9a564d673608e404bbb5d0fb4965acb1b0'
     'zu'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).