### PR TITLE
Update camtasia to 2018.0.2,141

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,6 +1,6 @@
 cask 'camtasia' do
-  version '2018.0.1,135'
-  sha256 'e0b12e8c9eb99b068c39ed5eb656a37b46feec22a338dafb6040ca91e2391424'
+  version '2018.0.2,141'
+  sha256 '2d7ead3f3cebc689c4c25552d3b7028655d504ae6c45eb99eb5523e10997a84a'
 
   # rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.