### PR TITLE
Update electron-api-demos to 1.5.1

### DIFF
--- a/Casks/electron-api-demos.rb
+++ b/Casks/electron-api-demos.rb
@@ -1,6 +1,6 @@
 cask 'electron-api-demos' do
-  version '1.5.0'
-  sha256 '2a9f547cff863164dcfb262b11075d331f78977ff13d372ec12feb47f45e8e03'
+  version '1.5.1'
+  sha256 '1a9931992574c2bafb8078e3156ad708e364c58e8721973ed99abcca81bb2eee'
 
   url "https://github.com/electron/electron-api-demos/releases/download/v#{version}/electron-api-demos-mac.zip"
   appcast 'https://github.com/electron/electron-api-demos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.