### PR TITLE
Update manager to 18.7.77

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.76'
-  sha256 '690a143fe7396d1499f383f53864670395736db1ce178eea47219427cbcde816'
+  version '18.7.77'
+  sha256 'a6ad7cd4a7f0bdbd382458b670a2c95b175bcd4c73fa4da92657487f2cdf50f5'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.