### PR TITLE
Update shifty to 0.5.2

### DIFF
--- a/Casks/shifty.rb
+++ b/Casks/shifty.rb
@@ -1,6 +1,6 @@
 cask 'shifty' do
-  version '0.5.1'
-  sha256 'c43afb9b6836d907649d5346ff0a22279bd754ddc115616b4e96e71983624d95'
+  version '0.5.2'
+  sha256 '30a7d16d602d8756c4662b50ce4595f687ceb0a41abbabacab711e3a4b1b335d'
 
   # github.com/thompsonate/Shifty was verified as official when first introduced to the cask
   url "https://github.com/thompsonate/Shifty/releases/download/#{version}/Shifty-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.