### PR TITLE
Update doomsday-engine to 2.1.0-build2769

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,6 +1,6 @@
 cask 'doomsday-engine' do
-  version '2.0.3'
-  sha256 '0a6258ed1c061b3a80f1573c7845bce39cd8c8d66ade8d3f29531b7cc658e9d5'
+  version '2.1.0-build2769'
+  sha256 'bbd6706ce7c71251b80e2284c87deff1eac4b1a233408f7823b7dbe55b14dfad'
 
   # sourceforge.net/deng was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.