### PR TITLE
Update kode54-cog to 0.08,7d6af357

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,1a084b43'
-  sha256 '9c52cb8d79fe74991a58e814b46a8bcdc40067d304d617a837ae56ee1c6bb5cb'
+  version '0.08,7d6af357'
+  sha256 '7bdf4cd2dccaf91c3dfb8dde7625679a341c578e8af571018079901b137af880'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.