### PR TITLE
Update cantata to 2.3.2

### DIFF
--- a/Casks/cantata.rb
+++ b/Casks/cantata.rb
@@ -1,6 +1,6 @@
 cask 'cantata' do
-  version '2.3.0'
-  sha256 'a67830578a3faf7df01e4a32021fd1af788d442ab61cde54ec8b50a28addcafd'
+  version '2.3.2'
+  sha256 'c9eb8a1102d0a68cafc93f22df73445b8f69706f3322285f9a2f623a28df0176'
 
   url "https://github.com/CDrummond/cantata/releases/download/v#{version}/Cantata-#{version}.dmg"
   appcast 'https://github.com/CDrummond/cantata/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.