### PR TITLE
Update horos to 3.1.2

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -6,8 +6,8 @@ cask 'horos' do
     version '2.0.2'
     sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
   else
-    version '3.1.1'
-    sha256 'f9c50e55ec170f9d9c4b0df8450f1b66551cab7ae3a54ceedd2e273b6dca4197'
+    version '3.1.2'
+    sha256 'aad388ac771ba9fc6f7b2457a4577310f59c6a60156911357f1afe21b6fba45b'
   end
 
   url "https://horosproject.org/horos-content/Horos#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.