### PR TITLE
Update vidcutter to 6.0.0

### DIFF
--- a/Casks/vidcutter.rb
+++ b/Casks/vidcutter.rb
@@ -1,6 +1,6 @@
 cask 'vidcutter' do
-  version '5.5.0'
-  sha256 '66ec76e878ccf70a7ebadda94f4b599426201cc3b30b52c42d84c4a7142e6f1b'
+  version '6.0.0'
+  sha256 '33e18085470fc241373fb4f1b9cb8d2caebba2f3a1a4f5bb57da339d94d198e6'
 
   # github.com/ozmartian/vidcutter was verified as official when first introduced to the cask
   url "https://github.com/ozmartian/vidcutter/releases/download/#{version}/VidCutter-#{version}-macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.