### PR TITLE
Update winds to 2.1.90

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '2.1.88'
-  sha256 '68d5680bd2191f4c74a7cc4163bf13d9b1386f8711e2a1909c8a058b71639f12'
+  version '2.1.90'
+  sha256 'ff4877c575bdd82e4003c58f6c01f924c54b0d74b735c7439619be8538a6cd43'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.