### PR TITLE
Update sciebo to qt5.6.2-2.4.2.2144

### DIFF
--- a/Casks/sciebo.rb
+++ b/Casks/sciebo.rb
@@ -1,6 +1,6 @@
 cask 'sciebo' do
-  version '2.4.1.2038'
-  sha256 '7de4af04d0187ad2ed849e06d608e16576c85a10be31f9ce08c24865a9688ccc'
+  version 'qt5.6.2-2.4.2.2144'
+  sha256 'b0928d80192b87a069df13db04a4b6ae83d460cbbf2574a926d868098a212eb6'
 
   url "https://www.sciebo.de/install/sciebo-#{version}.pkg"
   name 'sciebo'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.