### PR TITLE
Update imazing to 2.6.4,9261:1533229973

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.6.4,9260:1533224898'
-  sha256 'aacb5f15bb401d9883fe4fdfdc24f9a741f9541fd39da17828f60b80cbffa095'
+  version '2.6.4,9261:1533229973'
+  sha256 'c30635936ba7eaf4af762a29e3c9190066085f527c15c6f0031a52663edc2cff'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.