### PR TITLE
Update frostwire to 6.7.1

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -4,7 +4,7 @@ cask 'frostwire' do
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
-  appcast 'https://github.com/frostwire/frostwire//releases.atom'
+  appcast 'https://sourceforge.net/projects/frostwire/rss'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 

--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,10 +1,10 @@
 cask 'frostwire' do
-  version '6.6.7'
-  sha256 'bd892bd7fb3f077920dd09809243681fd2e5b50b48de8e0d99d77008f828a8dd'
+  version '6.7.1'
+  sha256 '62429ff4b787b2b35e1c9852b49a4cea7f0dfc29c0f035dd6e0bf6914afcdb60'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"
-  appcast "https://sourceforge.net/projects/frostwire/rss?path=/FrostWire%20#{version.major}.x"
+  appcast 'https://github.com/frostwire/frostwire//releases.atom'
   name 'FrostWire'
   homepage 'http://www.frostwire.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.