### PR TITLE
Update zerotier-one to 1.2.12

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -1,6 +1,6 @@
 cask 'zerotier-one' do
-  version '1.2.8'
-  sha256 '13f39b296e04b309fbd6fb3b1a8ade3a85479ff4ea7db151ce2da1678a1eff31'
+  version '1.2.12'
+  sha256 'c58747a5ecaca0c0720928db6d4a0d8f1eaa712b92bd1e272fbeb643c5dacbd2'
 
   url 'https://download.zerotier.com/dist/ZeroTier%20One.pkg'
   appcast 'https://github.com/zerotier/ZeroTierOne/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.