### PR TITLE
Update manager to 18.7.79

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.78'
-  sha256 '44c2da33866b8fad4e616f102686a210ccdd49b82a1fd8994e52ca90501f6cb5'
+  version '18.7.79'
+  sha256 '732259253d6af71a1ba820c91182278d6dba9d39e5ceb9a23af13608f09e3f80'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.