### PR TITLE
Update mediathekview to 13.1.1

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,6 +1,6 @@
 cask 'mediathekview' do
-  version '13.1.0'
-  sha256 '6396e3279ef5306f735b0a09890e610012bbe97a946a8de7ed0ebdd6949a7b44'
+  version '13.1.1'
+  sha256 '5266e92735d262faaf1705c2c8339936edfc1cd830291928257eb4dd70742e57'
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}.dmg"
   appcast 'https://mediathekview.de/changelog/index.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.