### PR TITLE
Update zulip to 2.3.5

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,6 +1,6 @@
 cask 'zulip' do
-  version '2.3.3'
-  sha256 '33f50ff39582a22b515c2d6c03073b6e1f98283e0f99355354c9bab25954486b'
+  version '2.3.5'
+  sha256 'cc308d749481cb2c75d77c3e2f6142c3dd51ceb2641880bdb6442b7b8a142b46'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.