### PR TITLE
Update navicat-for-mysql to 12.1.4

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.3'
-  sha256 'ed60fe6058f6e22944103e32f90b9c1372b6c5c27b4f28323e5f1e87d3e57303'
+  version '12.1.4'
+  sha256 '8229e2cb035ca36c780d4bb448c030ef83fab56926f15bd87763fbfe00e3ea76'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.