### PR TITLE
Update netron to 1.9.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '1.9.3'
-  sha256 '12c600d7b5a396caedc130c6573cf6fd03607a576883e30ce1cd496019212ba1'
+  version '1.9.4'
+  sha256 'd940c7096eac795114eb70babe46748e7355c9609bfd36a8bdf708bb6e3717fb'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.