### PR TITLE
Update blink1control to 2.2.0

### DIFF
--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -1,12 +1,12 @@
 cask 'blink1control' do
-  version '1.98'
-  sha256 '49c680f3ec174662cc00a4f4649074a891e8fc55b82aec284c5aade0efb44ce1'
+  version '2.2.0'
+  sha256 '068559a8a73185343a709b0ea42fa1a6303876a0a6813631652594a327f4f433'
 
-  # github.com/todbot/blink1 was verified as official when first introduced to the cask
-  url "https://github.com/todbot/blink1/releases/download/v#{version}/Blink1Control-mac.zip"
-  appcast 'https://github.com/todbot/blink1/releases.atom'
+  # github.com/todbot/Blink1Control2 was verified as official when first introduced to the cask
+  url "https://github.com/todbot/Blink1Control2/releases/download/v#{version}/Blink1Control#{version.major}-#{version}-mac.dmg"
+  appcast 'https://github.com/todbot/Blink1Control2/releases.atom'
   name 'Blink1Control'
   homepage 'https://blink1.thingm.com/'
 
-  app 'Blink1Control.app'
+  app "Blink1Control#{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.