### PR TITLE
Update together to 1.4.3

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,4 +1,4 @@
-cask 'together' do
+cask 'keep-it' do
   version '1.4.3'
   sha256 'c940df2c8af03825ed408c59c448b749499fb87b420f8a98c07d1618084dd398'
 

--- a/Casks/together.rb
+++ b/Casks/together.rb
@@ -1,20 +1,17 @@
 cask 'together' do
-  version '3.8.8'
-  sha256 '689992d5d84f1137cbbd23e9b9114dd56545fbe8df40310ea19b715c447fbae2'
+  version '1.4.3'
+  sha256 'c940df2c8af03825ed408c59c448b749499fb87b420f8a98c07d1618084dd398'
 
-  url "https://reinventedsoftware.com/together/downloads/Together_#{version}.dmg"
-  appcast "https://reinventedsoftware.com/together/downloads/Together#{version.major}.xml"
-  name 'Together'
-  homepage 'https://reinventedsoftware.com/together/'
+  url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
+  appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'
+  name 'Keep It'
+  homepage 'https://reinventedsoftware.com/keepit/'
 
-  app "Together #{version.major}.app"
+  app 'Keep It.app'
 
   zap trash: [
-               "~/Library/Application Support/Together #{version.major}",
-               '~/Library/Caches/Together',
-               "~/Library/Caches/com.reinvented.Together#{version.major}",
-               "~/Library/Preferences/com.reinvented.Together#{version.major}.shared.plist",
-               "~/Library/Preferences/com.reinvented.Together#{version.major}.plist",
-               "~/Library/Saved Application State/com.reinvented.Together#{version.major}.savedState",
+               '~/Library/Containers/com.reinvented.Keep-It-Indexing',
+               '~/Library/Containers/com.reinvented.Keep-It-Metadata',
+               '~/Library/Containers/com.reinvented.Keep It',
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.