### PR TITLE
Update vnc-server to 6.3.1

### DIFF
--- a/Casks/vnc-server.rb
+++ b/Casks/vnc-server.rb
@@ -1,6 +1,6 @@
 cask 'vnc-server' do
-  version '6.2.1'
-  sha256 '7c105880fffee5cd350d713adee7ca8bef029325799f9bc483043ca27de503cd'
+  version '6.3.1'
+  sha256 '7fa075d50cf9d88a8c0cfd5a121c48b689a567e6a65d5f8b2601ae1718c0640a'
 
   url "https://www.realvnc.com/download/file/vnc.files/VNC-Server-#{version}-MacOSX-x86_64.pkg"
   name 'Real VNC Server'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.