### PR TITLE
Add HOMEBREW_DEVELOPER flag to contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ $ git remote add "${github_user}" "https://github.com/${github_user}/homebrew-ca
 
 4: Switch to a new branch (ie. `new-feature`), and work from there: `git checkout -b new-feature`.
 
+5: Prevent automatic switching of git branches by setting the `HOMEBREW_DEVELOPER` variable: `export HOMEBREW_DEVELOPER=1`
 
 ## Adding a Cask
 


### PR DESCRIPTION
I was trying to create a cask and couldn't install it until I discovered that it automatically switches to the master branch unless you set this environment variable. Ideally, this would be set automatically like it is in the main repo.