### PR TITLE
Update blockstack to 0.31.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.30.1'
-  sha256 '1539b2342d9e4cc4dd6a925e0520a2b941920aa6472c55e64654cc1a5b6b846b'
+  version '0.31.0'
+  sha256 '33f22c66ded29d5c288275c18cf512483a9c354441530077b45d184c90369d70'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.