### PR TITLE
Update AsciidocFX version to 1.6.3

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
   version '1.6.3'
-  sha256 '45d3f1ba5e07d96c094dee48438d92780171897a89066a42cd3fdbc5c38492d0'
+  sha256 'a7385ccd9ee17e039f0a41e3509b6cbc39192a6c23cabef08eb4e9f55f4f8e1f'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"

--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
-  version '1.6.2'
-  sha256 '149ccd0e030e7e8c3f30a1b1282174b4cbf932f406d12f80ec081598d4b69eb4'
+  version '1.6.3'
+  sha256 '45d3f1ba5e07d96c094dee48438d92780171897a89066a42cd3fdbc5c38492d0'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.