### PR TITLE
Update airfoil to 5.8.1

### DIFF
--- a/Casks/airfoil.rb
+++ b/Casks/airfoil.rb
@@ -1,6 +1,6 @@
 cask 'airfoil' do
-  version '5.8.0'
-  sha256 'cb9f9624daba093f3a74158cdda59b975edcabd3b12bc2ec11a8b2af5e787cdb'
+  version '5.8.1'
+  sha256 '729781d3adeb4bd19952e4add465083f0b0b63312c0f7043a915354372d1f707'
 
   url 'https://rogueamoeba.com/airfoil/download/Airfoil.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Airfoil&platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.