### PR TITLE
Add Nheko v0.5.2

### DIFF
--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -3,7 +3,8 @@ cask 'nheko' do
   sha256 '76eb8b542a224cfa989c995a08654d8e993324b770024f912d8983a2d3520c26'
 
   # bintray.com/mujx/matrix was verified as official when first introduced to the cask
-  url 'https://bintray.com/mujx/matrix/download_file?file_path=nheko%2Fv0.5.2%2Fnheko-v0.5.2.dmg'
+  url "https://bintray.com/mujx/matrix/download_file?file_path=nheko%2Fv#{version}%2Fnheko-v#{version}.dmg"
+  appcast 'https://github.com/mujx/nheko/releases.atom'
   name 'Nheko'
   homepage 'https://github.com/mujx/nheko'
 

--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -2,6 +2,7 @@ cask 'nheko' do
   version '0.5.2'
   sha256 '76eb8b542a224cfa989c995a08654d8e993324b770024f912d8983a2d3520c26'
 
+  # bintray.com/mujx/matrix was verified as official when first introduced to the cask
   url 'https://bintray.com/mujx/matrix/download_file?file_path=nheko%2Fv0.5.2%2Fnheko-v0.5.2.dmg'
   name 'Nheko'
   homepage 'https://github.com/mujx/nheko'

--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -1,0 +1,10 @@
+cask 'nheko' do
+  version '0.5.2'
+  sha256 '76eb8b542a224cfa989c995a08654d8e993324b770024f912d8983a2d3520c26'
+
+  url 'https://bintray.com/mujx/matrix/download_file?file_path=nheko%2Fv0.5.2%2Fnheko-v0.5.2.dmg'
+  name 'Nheko'
+  homepage 'https://github.com/mujx/nheko'
+
+  app 'Nheko.app'
+end


### PR DESCRIPTION
Add Nheko.app v0.5.2
This pr adds the Matrix chat client Nheko written in C++/Qt.
Nheko is open-sourced but offers this build app for MacOS.