### PR TITLE
Add PhotoSweeper X v3.2.2

### DIFF
--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,0 +1,13 @@
+cask 'photosweeper-x' do
+  version '3.2.2'
+  sha256 'e91d99749bdcda301f8f8c96262afc7c6867b090cdcc059bc59f6b768d292083'
+
+  url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
+  appcast 'https://overmacs.com/photosweeper/updates/photosweeper_update.xml'
+  name 'PhotoSweeper X'
+  homepage 'https://overmacs.com/'
+
+  app 'PhotoSweeper X.app'
+
+  zap trash: '~/Library/Preferences/com.overmacs.photosweeperpaddle.plist'
+end


### PR DESCRIPTION
[PhotoSweeper X](https://overmacs.com/)

> PhotoSweeper is a swift and powerful duplicate photo cleaner built to help you get rid of duplicate or similar photos on your Mac

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
