### PR TITLE
Bytecoin-gui downloading url has moved to github

### DIFF
--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -1,8 +1,10 @@
 cask 'bytecoin' do
-  version '3.0.0'
-  sha256 '3bbafa6560f30b692184d2c59e0bdb55a38d4e3f8d6215605f7b46fcad7d0d50'
+  version '3.2.1'
+  sha256 '6e9d2e33e96350915cd4ef5c88c399d9e4b99661312e2e8ab130e9eb696a23b5'
 
-  url "https://bytecoin.org/storage/wallets/bytecoin_wallet/bytecoin-desktop-#{version}-macos.zip"
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"
+  appcast "https://github.com/bcndev/bytecoin-gui/releases.atom"
   name 'Bytecoin Wallet'
   homepage 'https://bytecoin.org/'
 

--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -4,7 +4,7 @@ cask 'bytecoin' do
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"
-  appcast "https://github.com/bcndev/bytecoin-gui/releases.atom"
+  appcast 'https://github.com/bcndev/bytecoin-gui/releases.atom'
   name 'Bytecoin Wallet'
   homepage 'https://bytecoin.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This commit tends to be a fix on the source downloading url but not a deliberate update, so it didn't include the cask's version though the original one is outdated.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
