### PR TITLE
Update mcgimp-std to 2.10.4

### DIFF
--- a/Casks/mcgimp-std.rb
+++ b/Casks/mcgimp-std.rb
@@ -1,6 +1,6 @@
 cask 'mcgimp-std' do
-  version '2.10'
-  sha256 'fe8f5e5a461ad120f2da7704a98baab5633308cd6c9c1f6550b08eec0e94d5a0'
+  version '2.10.4'
+  sha256 '34d396976d4ac95b5dc83f2a6e631d72f06bbf6c1087d608a0373e55c313aae5'
 
   url "https://www.partha.com/downloads/McGimp-#{version}-std.app.zip"
   name 'McGimp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.