### PR TITLE
Update ckan-app to 1.25.2

### DIFF
--- a/Casks/ckan-app.rb
+++ b/Casks/ckan-app.rb
@@ -1,6 +1,6 @@
 cask 'ckan-app' do
-  version '1.25.1'
-  sha256 'e7c3e36f66aca11decc0a3e9f0102152f097a13a98ec8d952a97f148ec5e368f'
+  version '1.25.2'
+  sha256 '7037b719e9cb8a4c34e432372b4897f25764bab8a2c948270073ffecd2a872ae'
 
   url "https://github.com/KSP-CKAN/CKAN/releases/download/v#{version}/CKAN.dmg"
   appcast 'https://github.com/KSP-CKAN/CKAN/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.