### PR TITLE
Update manager to 18.7.85

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.80'
-  sha256 'e6f9b33ea810f72dc58aabb7a3906523b17de1fbbc8407e92484d3f3228bff3e'
+  version '18.7.85'
+  sha256 '7ef8fe1c4556e13093710262dd479855724331a070e1864b59d481f9835b2feb'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.