### PR TITLE
Update qownnotes to 18.08.1,b3726-074743

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.08.0,b3715-184052'
-  sha256 'b844602137e095bf2d011d249a1a8e9c62c5b0cb0dacc82bb2ab8da4e4a548a4'
+  version '18.08.1,b3726-074743'
+  sha256 '272e62f3aabffac198b0e87961f076027a53c8c2823382e081fa15b9244610d8'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.