### PR TITLE
Update sabaki to 0.35.1

### DIFF
--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,6 +1,6 @@
 cask 'sabaki' do
-  version '0.35.0'
-  sha256 '0174a3da32a0896c4296ed57a3b423d411984efa6e6abc771ac0f9641001e84f'
+  version '0.35.1'
+  sha256 'c70229f75ced3b45d5b1b79224fdda3eceadcda352f50c2c4815c7043b192951'
 
   # github.com/SabakiHQ/Sabaki was verified as official when first introduced to the cask
   url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-x64.7z"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.