### PR TITLE
Update seafile-client to 6.2.4

### DIFF
--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -1,6 +1,6 @@
 cask 'seafile-client' do
-  version '6.2.3'
-  sha256 '58b1b1f7a35dca7b92cf0db8e080ea70497fd88bea4b6f56704e443be935c954'
+  version '6.2.4'
+  sha256 '5412715344d257b7268111a642c6d22f8de0ca88ec5e07de2e8954856651566c'
 
   # seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seafile-client-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.