### PR TITLE
Update standard-notes to 2.3.3

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
-  version '2.3.2'
-  sha256 'cd35b4351900e3cb31716f837aa64e3d67eedf8b995eec328c70d868b9af1271'
+  version '2.3.3'
+  sha256 'd76be13820c3061d980a80b3cd82df07d06b68cdf0ff0b4eff9b904734e5639a'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.