### PR TITLE
Update xtabulator to 2.007

### DIFF
--- a/Casks/xtabulator.rb
+++ b/Casks/xtabulator.rb
@@ -1,6 +1,6 @@
 cask 'xtabulator' do
-  version '2.006'
-  sha256 'efd6a40a2d0d853c8bfb75a821e67cbcbee628a1cd2de354a5dac3d2c4c458b6'
+  version '2.007'
+  sha256 '36ac96d1141f8ff428da8764574d13537e3885d31c1678b0fdecb1a0b4d5162c'
 
   url "https://www.bartastechnologies.com/products/xtabulator/sparkleupdates/#{version}.zip"
   appcast 'https://www.bartastechnologies.com/products/xtabulator/sparkleupdates/xtappcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.