### PR TITLE
whoozle-android-file-transfer v3.4: add conflict with -nightly

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -8,7 +8,8 @@ cask 'whoozle-android-file-transfer' do
   name 'Android File Transfer'
   homepage 'https://whoozle.github.io/android-file-transfer-linux/'
 
-  conflicts_with cask: 'android-file-transfer'
+  conflicts_with cask: ['android-file-transfer',
+                        'whoozle-android-file-transfer-nightly']
 
   app 'Android File Transfer for Linux.app'
 end

--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -8,8 +8,10 @@ cask 'whoozle-android-file-transfer' do
   name 'Android File Transfer'
   homepage 'https://whoozle.github.io/android-file-transfer-linux/'
 
-  conflicts_with cask: ['android-file-transfer',
-                        'whoozle-android-file-transfer-nightly']
+  conflicts_with cask: [
+                         'android-file-transfer',
+                         'whoozle-android-file-transfer-nightly',
+                       ]
 
   app 'Android File Transfer for Linux.app'
 end


### PR DESCRIPTION

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Please merge after https://github.com/Homebrew/homebrew-cask-versions/pull/6052