### PR TITLE
Update navicat-for-mariadb to 12.1.5

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.4'
-  sha256 '804c5047a75c6ff8e8ed82d31473c89a5aec7d9ad2d1d5fe57f1e9c972a2b326'
+  version '12.1.5'
+  sha256 'c966dbdfdbc4a8759b71d6d08a288322ec76ce0de3fdad4f7b80c64e29b6adab'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.