### PR TITLE
Update Dash cask to version 4.4.0

### DIFF
--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -1,6 +1,6 @@
 cask 'dash' do
-  version '4.3.2'
-  sha256 'fcd9f71c45fa53b77a57134d342ed186b7d65ca88f434361c560ea964f04ecbd'
+  version '4.4.0'
+  sha256 '03083f654c4618c9f6895cd46774b16641909dcdcce517d180647795ad2056b3'
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
   appcast "https://kapeli.com/Dash#{version.major}.xml"


### PR DESCRIPTION
Updating [Dash](https://kapeli.com/dash) cask to version 4.4.0.

## Checklist

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).