### PR TITLE
 brewcask-ci: use formatter.headline

### DIFF
--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -98,7 +98,7 @@ module Hbc
         output = nil
 
         Travis.fold travis_id do
-          print "#{Tty.bold}#{Tty.yellow}#{name}#{Tty.reset} "
+          print Formatter.headline("#{name} ", color: :yellow)
 
           real_stdout = $stdout.dup
 


### PR DESCRIPTION
Little bit easier to parse and makes the commands similar to the output of `test-bot` on travis and jenkins.

https://travis-ci.org/Homebrew/homebrew-cask/builds/412920809