### PR TITLE
Update android-studio to 3.1.4.0,173.4907809

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '3.1.3.0,173.4819257'
-  sha256 'd4a8502c5aabfc5477ff30dfffe296bf705bd7e62650a76796b646a8f28b5e5c'
+  version '3.1.4.0,173.4907809'
+  sha256 'cac5ad1a3177dc442b74aea41cb93a1311d2b0df9338a294e4d332ed2b39a94d'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.