### PR TITLE
Update cacher to 1.5.13

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '1.5.12'
-  sha256 '853a92940891074d7216f9d35963634a00938b1e29faa71c99d3224cfdf2ba43'
+  version '1.5.13'
+  sha256 'e75f1432e594198b58280771a2e9016430fda95e51bcee5d8a46c406f563f79d'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.