### PR TITLE
Update hstracker to 1.5.0

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.4.3'
-  sha256 '5a98f99756b8d70c44778445281bda605fb1e0b95020109d523aabf49094cfcb'
+  version '1.5.0'
+  sha256 '240b7aa516353ebd2fdcd986d6380df5497694d12236d62973f7bd4a8c727f18'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.