### PR TITLE
Update macupdater to 1.3.0

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.2.10'
-  sha256 'c7a0049e5fb6b4baa86c2fc8381ea6b9af746542382692f335885d52a5a3fd99'
+  version '1.3.0'
+  sha256 'dadd71f8163f91980435b601470c8ba7ed0b66455965f464e4aeee5874595794'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.