### PR TITLE
Update remembear to 1.1.0

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.0.5'
-  sha256 '5f69738acff0c843df47ad9a8472ca4c17c68c5e215598c61ba52990b142fc25'
+  version '1.1.0'
+  sha256 '158c7b6966ed65fed6f6fb6952f22c4a78427436dc1dc06e5795cc261fc24fcb'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.