### PR TITLE
Update resolume-avenue to 6.0.11,60828

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -13,8 +13,8 @@ cask 'resolume-avenue' do
             delete:    "/Applications/Resolume Avenue #{version.major}",
             launchctl: 'com.resolume.avenue'
 
-  zap trash: [
-               'com.resolume.pkg.ResolumeDXV',
-               'com.resolume.pkg.ResolumeQuickLook',
-             ]
+  zap pkgutil: [
+                 'com.resolume.pkg.ResolumeDXV',
+                 'com.resolume.pkg.ResolumeQuickLook',
+               ]
 end

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,8 +1,8 @@
 cask 'resolume-avenue' do
-  version '6.0.10'
-  sha256 'e7108e74286796dfd78a4387a38efd75fc7ab6b38650b3490b2e6b8fed763c9d'
+  version '6.0.11,60828'
+  sha256 '5b377a9be3d132a8695635475f27f0cff505f2063255641848d9e4b7842a10f4'
 
-  url "https://resolume.com/download/Resolume_Avenue_#{version.major_minor_patch.dots_to_underscores}_Installer.dmg"
+  url "https://resolume.com/download/Resolume_Avenue_#{version.major_minor_patch.dots_to_underscores}_rev_#{version.after_comma}_Installer.dmg"
   appcast 'https://resolume.com/update/avenue_mac.xml'
   name 'Resolume Avenue'
   homepage 'https://resolume.com/'

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -11,7 +11,8 @@ cask 'resolume-avenue' do
 
   uninstall pkgutil:   "com.resolume.pkg.ResolumeAvenue#{version.major}",
             delete:    "/Applications/Resolume Avenue #{version.major}",
-            launchctl: 'com.resolume.avenue'
+            launchctl: 'com.resolume.avenue',
+            quit:      'com.resolume.avenue'
 
   zap pkgutil: [
                  'com.resolume.pkg.ResolumeDXV',

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -9,8 +9,8 @@ cask 'resolume-avenue' do
 
   pkg 'Resolume Avenue Installer.pkg'
 
-  uninstall pkgutil: "com.resolume.pkg.ResolumeAvenue#{version.major}",
-            delete:  "/Applications/Resolume Avenue #{version.major}",
+  uninstall pkgutil:   "com.resolume.pkg.ResolumeAvenue#{version.major}",
+            delete:    "/Applications/Resolume Avenue #{version.major}",
             launchctl: 'com.resolume.avenue'
 
   zap trash: [

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -9,10 +9,10 @@ cask 'resolume-avenue' do
 
   pkg 'Resolume Avenue Installer.pkg'
 
-  uninstall pkgutil:   "com.resolume.pkg.ResolumeAvenue#{version.major}",
+  uninstall pkgutil:   "com.resolume.pkg.ResolumeAvenue.*",
             delete:    "/Applications/Resolume Avenue #{version.major}",
             launchctl: 'com.resolume.avenue',
-            quit:      'com.resolume.avenue'
+            signal:    ['TERM', 'com.resolume.avenue']
 
   zap pkgutil: [
                  'com.resolume.pkg.ResolumeDXV',

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -10,7 +10,8 @@ cask 'resolume-avenue' do
   pkg 'Resolume Avenue Installer.pkg'
 
   uninstall pkgutil: "com.resolume.pkg.ResolumeAvenue#{version.major}",
-            delete:  "/Applications/Resolume Avenue #{version.major}"
+            delete:  "/Applications/Resolume Avenue #{version.major}",
+            launchctl: 'com.resolume.avenue'
 
   zap trash: [
                'com.resolume.pkg.ResolumeDXV',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.