### PR TITLE
Update iterm2 to 3.2.0

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.7'
-  sha256 'd5496b3c42fe2eaf65befef7d6d6682cde3e8cd1f042f63343f821e8582b1ede'
+  version '3.2.0'
+  sha256 '7d4862976f6e5dbf29a7193dc090d6c17c549daf47a373a8a97ae306870a22a4'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'
@@ -9,7 +9,7 @@ cask 'iterm2' do
   homepage 'https://www.iterm2.com/'
 
   auto_updates true
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :sierra'
 
   app 'iTerm.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
While not mentioned in the changelog for this version, I have double checked that the minimum macOS version has been updated to 10.12 (Sierra). This is based on changes introduced in 3.2.0beta6.