### PR TITLE
Update jbrowse to 1.15.1

### DIFF
--- a/Casks/jbrowse.rb
+++ b/Casks/jbrowse.rb
@@ -1,8 +1,10 @@
 cask 'jbrowse' do
-  version '1.12.3'
-  sha256 '4b9c6ab17c7a00ffb8a60cac73774391a83b5a8833bcf2672172878ee81e08dc'
+  version '1.15.1'
+  sha256 'b56f0275d890f2c38c7410273f7c52c10df35972f34f1867492ad626854951f1'
 
-  url "https://jbrowse.org/releases/JBrowse-#{version}/JBrowse-#{version}-desktop-osx.zip"
+  # github.com/GMOD/jbrowse was verified as official when first introduced to the cask
+  url 'https://github.com/GMOD/jbrowse/releases/download/1.15.1-release/JBrowse-1.15.1-desktop-darwin-x64.zip'
+  appcast 'https://github.com/GMOD/jbrowse/releases.atom'
   name 'jbrowse'
   homepage 'https://jbrowse.org/'
 

--- a/Casks/jbrowse.rb
+++ b/Casks/jbrowse.rb
@@ -3,10 +3,10 @@ cask 'jbrowse' do
   sha256 'b56f0275d890f2c38c7410273f7c52c10df35972f34f1867492ad626854951f1'
 
   # github.com/GMOD/jbrowse was verified as official when first introduced to the cask
-  url 'https://github.com/GMOD/jbrowse/releases/download/1.15.1-release/JBrowse-1.15.1-desktop-darwin-x64.zip'
+  url "https://github.com/GMOD/jbrowse/releases/download/#{version}-release/JBrowse-#{version}-desktop-darwin-x64.zip"
   appcast 'https://github.com/GMOD/jbrowse/releases.atom'
   name 'jbrowse'
   homepage 'https://jbrowse.org/'
 
-  app 'JBrowseDesktop-darwin-x64/JBrowseDesktop.app'
+  app "JBrowse-#{version}-desktop-darwin-x64/JBrowse-#{version}-desktop.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.