### PR TITLE
Update understand to 5.0.953

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.0.951'
-  sha256 '10aac7ef2370845254e5e23c7ae2a137f93413db44da6470ba17b6b18792a61d'
+  version '5.0.953'
+  sha256 '3a8e51d62e84f2d930b4768e1249239b16bdd39d850d3979a31d0ba6125fde3d'
 
   url "http://latest.scitools.com/Understand/Understand-#{version}-MacOSX-x86.dmg"
   name 'SciTools Understand'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.