### PR TITLE
Update balsamiq-mockups to 3.5.16

### DIFF
--- a/Casks/balsamiq-mockups.rb
+++ b/Casks/balsamiq-mockups.rb
@@ -1,6 +1,6 @@
 cask 'balsamiq-mockups' do
-  version '3.5.15'
-  sha256 'a10414150a04cdc571efcb8c351366811834fcd514b1e2756f8e4e19cb6e43f4'
+  version '3.5.16'
+  sha256 '5a80ea9169ffcc10b5dfa601b53fa7cc18795451ada4e1c11755fca06428ec05'
 
   url "https://builds.balsamiq.com/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"
   appcast 'https://builds.balsamiq.com/mockups-desktop/version.jsonp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.