### PR TITLE
Update command-tab-plus to 1.64,287:1533745486

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.63,283:1533534865'
-  sha256 '6d2c7b0f5697dd734b1ee1af5ed6e1961f7fb838a831b8a89dd58bc446786fb2'
+  version '1.64,287:1533745486'
+  sha256 'd10d4a9074d3dafacce05b4138145daa30619268d672ed8a150dca20aa03a809'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.