### PR TITLE
Update sqleditor to 3.3.12

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,6 +1,6 @@
 cask 'sqleditor' do
-  version '3.3.11'
-  sha256 '468d9bf4df2d6372ea6fc128392f3bdc529502ed87a2f2df6eb63cf933490951'
+  version '3.3.12'
+  sha256 'bba8e8a622ba8940c35cbd54eb4211afda82cfef3e1e799310e55ac6ad3e4ec0'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.