### PR TITLE
Update unity-download-assistant to 2018.2.2f1,c18cef34cbcd

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.2.1f1,1a9968d9f99c'
-  sha256 'b6aaedd4c57e5dca599b1be87380bcf17b8372f6af09ef560f0c76abe1f365e1'
+  version '2018.2.2f1,c18cef34cbcd'
+  sha256 'd3e6688a4f36108ee0d1ccfc96a10764cd38bf0c8dbaea50109a8acc5ba8da29'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.