### PR TITLE
Update unity-android-support-for-editor to 2018.2.2f1,c18cef34cbcd

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2018.2.1f1,1a9968d9f99c'
-  sha256 '81087ea769ca2d0f28f3bb530e91fd8fdc679966817975b59024763135f27a55'
+  version '2018.2.2f1,c18cef34cbcd'
+  sha256 'cca8cea21fb7d0974e1e325c4827d1b9ebab37070b12043dcb551a26c6241525'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.