### PR TITLE
Update outline-manager to 1.1.5

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.1.4'
-  sha256 '5699b69d828f2ec4f3d62000ee97515e37e14f89ad8e296d12451e09258a090f'
+  version '1.1.5'
+  sha256 '90c93e5b5b680da1fb98987f7b921921ba84cc1d1c715a13ccf543d137e65b56'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.