### PR TITLE
Update radarr to 0.2.0.1120

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,6 +1,6 @@
 cask 'radarr' do
-  version '0.2.0.1067'
-  sha256 'bb0885cb03ad8b15811f1ff60439fafe45b699e51d47b6bc4c072242b18d2c78'
+  version '0.2.0.1120'
+  sha256 'dad152e1e345654e3a4c6ffb03a451987d7353070635bd17dfc312c4cea3460a'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.