### PR TITLE
Switch suspicious-package v3.3.2 to using HTTPS

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -2,10 +2,10 @@ cask 'suspicious-package' do
   version '3.3.2'
   sha256 '4c93e23b660a590dba80dda69eb0f8a1543f70d12f954d88c61a5d2f0c4c32a0'
 
-  url 'http://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
-  appcast 'http://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist'
+  url 'https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
+  appcast 'https://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist'
   name 'Suspicious Package'
-  homepage 'http://www.mothersruin.com/software/SuspiciousPackage/'
+  homepage 'https://www.mothersruin.com/software/SuspiciousPackage/'
 
   auto_updates true
 


### PR DESCRIPTION
To ensure transport security and prevent man-in-the-middle attacks
formulas should default to https, otherwise an attacker may be able to
intercept the request and replace the response with a malicious payload.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).