### PR TITLE
Update onedrive to 18.131.0701.0008

### DIFF
--- a/Casks/onedrive.rb
+++ b/Casks/onedrive.rb
@@ -1,6 +1,6 @@
 cask 'onedrive' do
-  version '18.091.9506.0004'
-  sha256 '814bd894b4eacec8ac829526fcf7b4774226dd56c4a0eb5a7dea61ed12a30d49'
+  version '18.131.0701.0008'
+  sha256 '88355dda2a1443ea8617749e95b9aa760470fcd53cd69bd575ed77e53c5bd9a9'
 
   # oneclient.sfx.ms/Mac/Direct was verified as official when first introduced to the cask
   url "https://oneclient.sfx.ms/Mac/Direct/#{version}/OneDrive.pkg"

--- a/Casks/onedrive.rb
+++ b/Casks/onedrive.rb
@@ -1,6 +1,6 @@
 cask 'onedrive' do
-  version '18.131.0701.0008'
-  sha256 '88355dda2a1443ea8617749e95b9aa760470fcd53cd69bd575ed77e53c5bd9a9'
+  version '18.111.0603.0007'
+  sha256 'd4a083c148cd445e90980b5c63a3d82599e48772ae9987bbc82d2a02d0077461'
 
   # oneclient.sfx.ms/Mac/Direct was verified as official when first introduced to the cask
   url "https://oneclient.sfx.ms/Mac/Direct/#{version}/OneDrive.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.