### PR TITLE
Update fastonosql to 1.17.9

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.17.8'
-  sha256 '1816be96a955b6b66884fb4a1b8a12c7772942024cc62801393b6ef7ad87d612'
+  version '1.17.9'
+  sha256 '4df200937d890f3130f11bf0336df0438c5994acdc1022989e35cfe528498d4a'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.