### PR TITLE
Update fotomagico to 5.6.2-22801

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,6 +1,6 @@
 cask 'fotomagico' do
-  version '5.6.1-22775'
-  sha256 '5b743c8ac5f41b59aba88ade398145883067688c8f0c9cf003a775b4290e5389'
+  version '5.6.2-22801'
+  sha256 '078309ddf13c12c65148f098b523c567e7f7a7e50c36201ba843736d7f416d8d'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/fotomagico'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.