### PR TITLE
Update macupdater to 1.3.1

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.3.0'
-  sha256 'dadd71f8163f91980435b601470c8ba7ed0b66455965f464e4aeee5874595794'
+  version '1.3.1'
+  sha256 '62ea2a76db3540ba2887d6145ebdb5fb4066437e6445edfead233cdd4fd971f1'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.