### PR TITLE
Update vectoraster to 7.3.2

### DIFF
--- a/Casks/vectoraster.rb
+++ b/Casks/vectoraster.rb
@@ -1,6 +1,6 @@
 cask 'vectoraster' do
-  version '7.3.1'
-  sha256 '4998eeeb0660df95d73c903c23292fa7135b2f7866e4933f102a3b9ae627e9a1'
+  version '7.3.2'
+  sha256 'dd11d5b0b68e96f6bf9fcb0dbbbe7d86ce974a102c2770a23da196b0da3d0c1d'
 
   url "https://www.lostminds.com/downloads/vectoraster#{version.major}.dmg"
   appcast "https://www.lostminds.com/vectoraster#{version.major}/version_history.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.