### PR TITLE
Update zotero to 5.0.54

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.53'
-  sha256 '0c6315b06e6d45f6ea676079a10bb96c6a31aaec6665aa739ce97960b0022961'
+  version '5.0.54'
+  sha256 'e3d2ec5d8467da8089cce470cdcf988d0414417c26773dd450181502037e4f66'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.