### PR TITLE
Update brave to 0.23.79

### DIFF
--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,6 +1,6 @@
 cask 'brave' do
-  version '0.23.77'
-  sha256 '0f9e2f0e03d6591d585f95f829807534d3c6d8b079baff4c18cd5047c2e6a36c'
+  version '0.23.79'
+  sha256 'a8dab88628b17af041e8034df6f28edfea5f64167dd0ca941018d8bb159c5d47'
 
   # github.com/brave/browser-laptop was verified as official when first introduced to the cask
   url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.