### PR TITLE
Update dungeon-crawl-stone-soup-tiles to 0.22.0

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.21.1'
-  sha256 'f9f646e8293872d8f647a53da771f633f3f939833b601af6e6acddb942c63472'
+  version '0.22.0'
+  sha256 '834ffe1a7de0a0164b43cbbee00ac870327b13c443b4d0fcf00f95d9e13c8fbb'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.