### PR TITLE
Update dungeon-crawl-stone-soup-console to 0.22.0

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-console' do
-  version '0.21.1'
-  sha256 '43c3b8fbef69f801b223d2c8a0d9bcbd23e04369e8462d0f4bf389f84cdc9638'
+  version '0.22.0'
+  sha256 '711e6cccd17598c88b042ee61ffbaa17f3f20a983be4c952179e6a93fb698e4e'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-console-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.