### PR TITLE
Update netron to 1.9.8

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '1.9.6'
-  sha256 '4f49c67d6ab2c70efdc022bce2e49a521c8f8b2200cf2a9179479d8214eede08'
+  version '1.9.8'
+  sha256 '8c4726f2978b4f32886f54d39570b555e45b1c2ffae19a919542b27c89c46a1e'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.