### PR TITLE
Update manager to 18.7.88

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.87'
-  sha256 'f988547c660543851c6009d4392f28b54e9d11bf9f10557e36e0960eecc4de36'
+  version '18.7.88'
+  sha256 'fc673d63ebd5a0f8e073250171ae7784cb6e24477bebbd2214c63f8593827710'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.