### PR TITLE
Update photosweeper-x to 3.2.4

### DIFF
--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,6 +1,6 @@
 cask 'photosweeper-x' do
-  version '3.2.2'
-  sha256 'e91d99749bdcda301f8f8c96262afc7c6867b090cdcc059bc59f6b768d292083'
+  version '3.2.4'
+  sha256 'e0b3bb40178066b6d333a3f87c6ba853819e98aba7d1419d0529c981e16ef03c'
 
   url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
   appcast 'https://overmacs.com/photosweeper/updates/photosweeper_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.