### PR TITLE
Update mudlet to 3.11.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '3.10.2'
-  sha256 'f0b23ece582bfd8d45819e1185792f1f1809c5c894c0b4e652bf7e234b8651eb'
+  version '3.11.1'
+  sha256 '2376c197f352c45c351bb698d79fdc4d3fe085424263e1fdafb6e3617ae3184c'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.