### PR TITLE
Update vuescan to 9.6.14

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.6.13'
-  sha256 '1cc0bf81d5958bc186d22305c99fbe5fb725d709b92609bf8282cf99d1a4ce94'
+  version '9.6.14'
+  sha256 '95ac1b67b384b20f6dc0742800d3fe479d6a9b768d868f84180067ead02e5e2b'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.