### PR TITLE
Update borgbackup to 1.1.7

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,6 +1,6 @@
 cask 'borgbackup' do
-  version '1.1.6'
-  sha256 '2a3660ed7a37bea073ff6242c1833613b3e07025476e174c3bbf2bf3210f4145'
+  version '1.1.7'
+  sha256 '2d99f204ff2686009f11889775ed4067f542927c77bf86a1adaa474af9f8b4fe'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.