### PR TITLE
Update ledger-live to 1.1.6

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.1.5'
-  sha256 '94ffc05b4406b2c718af119334e97f449481dc72d58114df0f284c3ac70aff1f'
+  version '1.1.6'
+  sha256 '022a561cfcd3a0de728ab13d5d541e07bfcdfa0e2a418300cd2aae6bf03304b4'
 
   # github.com/LedgerHQ/ledger-live-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.