### PR TITLE
Update owncloud to 2.4.3.10347,qt5.6.2

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -1,6 +1,6 @@
 cask 'owncloud' do
-  version '2.4.2.10200,qt5.6.2'
-  sha256 '7f3591c001702fed0cf9d16edc66af7944200238fff0400ec99e2cf3a42ef084'
+  version '2.4.3.10347,qt5.6.2'
+  sha256 '066820e2e6aac1bb9beac7dc7d7003f4b092cb62a6747b97881cb5922c12382d'
 
   url "https://download.owncloud.com/desktop/stable/ownCloud-#{version.after_comma}-#{version.before_comma}.pkg"
   appcast 'https://github.com/owncloud/client/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.