### PR TITLE
Update zoc to 7.20.2

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.20.1'
-  sha256 '9ab425a4887caf509ffe583848759911acf70788a94896733a2b325d50f6d1eb'
+  version '7.20.2'
+  sha256 'f6002ca85faabd19979502a6842cda86e6ac26396c6c75a4f338debf4b3b5f30'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.