### PR TITLE
Update unity-ios-support-for-editor to 2018.2.3f1,1431a7d2ced7

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2018.2.2f1,c18cef34cbcd'
-  sha256 '5ba688713ed5b8b251252b580192136cd0966b933416ffc7e3016fde547853d5'
+  version '2018.2.3f1,1431a7d2ced7'
+  sha256 '20ab7ecfe4305bc314618de34f252ecb425bcd1ec1902420f0d53f5ce233383e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.