### PR TITLE
Update unity-linux-support-for-editor to 2018.2.3f1,1431a7d2ced7

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.2.2f1,c18cef34cbcd'
-  sha256 '49ec21b201a40a39798311657fc8cb2c137aefa9190e8f1f8968cae9d4a5f8ba'
+  version '2018.2.3f1,1431a7d2ced7'
+  sha256 '87fbec4d7ef76e99212bd9d957d6c5ca61dcc4db6a0ca4f79074a25845e4e502'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.