### PR TITLE
Update mullvadvpn to 2018.2

### DIFF
--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -13,5 +13,6 @@ cask 'mullvadvpn' do
 
   pkg "MullvadVPN-#{version}.pkg"
 
-  uninstall pkgutil: 'net.mullvad.vpn'
+  uninstall pkgutil:   'net.mullvad.vpn',
+            launchctl: 'net.mullvad.daemon'
 end

--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -11,13 +11,7 @@ cask 'mullvadvpn' do
 
   conflicts_with cask: 'mullvad-vpn-beta'
 
-  app 'MullvadVPN.app'
+  pkg "MullvadVPN-#{version}.pkg"
 
-  zap trash: [
-               '~/Library/Application Support/MullvadVPN',
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mullvad.vpn.sfl*',
-               '~/Library/Logs/MullvadVPN',
-               '~/Library/Preferences/net.mullvad.vpn.plist',
-               '~/Library/Preferences/net.mullvad.vpn.helper.plist',
-             ]
+  uninstall pkgutil: 'net.mullvad.vpn'
 end

--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -1,9 +1,9 @@
 cask 'mullvadvpn' do
-  version '2018.1'
-  sha256 '9a0c912ed0cf2222649f9367c6cfea338e02c737865bd556f230353096c49f37'
+  version '2018.2'
+  sha256 '9a3436e566cd7577e78cfe87a77b874ce631da1502dc09914e14ca49ad26642f'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
-  url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.dmg"
+  url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"
   appcast 'https://github.com/mullvad/mullvadvpn-app/releases.atom'
   name 'Mullvad'
   homepage 'https://mullvad.net/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.