### PR TITLE
Update shotcut to 18.08.11

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,9 +1,9 @@
 cask 'shotcut' do
-  version '18.08.01'
-  sha256 'c4ec893bff456d4227f912a4133f38a5eaf3485c756c8e4ed17956f4442307aa'
+  version '18.08.11'
+  sha256 '03730516e8db82a11fe4a258738725ea000504a6cf4ef700de70c61b4aebac04'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
-  url "https://github.com/mltframework/shotcut/releases/download/v#{version.major_minor}/shotcut-macos-x86_64-#{version.no_dots}.dmg"
+  url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-x86_64-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.