### PR TITLE
Update visual-studio-code to 1.26.0,4e9361845dc28659923a300945f84731393e210d

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code' do
-  version '1.25.1,1dfc5e557209371715f655691b1235b6b26a06be'
-  sha256 '765d6303312f0b08627c9dc2f777e8a4e73309d190ecdf49082cc8985b50edb5'
+  version '1.26.0,4e9361845dc28659923a300945f84731393e210d'
+  sha256 '07c2d678596e4e1f0bdf35b7d72a6d46851bf169d89f134fa73ff4f9007efbc3'
 
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.