### PR TITLE
Update mailspring to 1.4.1

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,6 +1,6 @@
 cask 'mailspring' do
-  version '1.3.0'
-  sha256 '24f2c157cb7cb4b44638044529111cd0b275629873e454d4b9caa42354eef7d8'
+  version '1.4.1'
+  sha256 '011c2372e64fcc3258865f911a06382fd23b72baec9447e49f7615671d790798'
 
   # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
   url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.