### PR TITLE
Update appcode to 2018.2,182.3911.53

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -1,5 +1,5 @@
 cask 'appcode' do
-  version '2018.2,182.3684.143'
+  version '2018.2,182.3911.53'
   sha256 '4b2cf2db8dcbceb9e4e471e55e69b9d87145cbed83a461bf32f52b4f187f2241'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.