### PR TITLE
Update bytecoin to 3.2.3

### DIFF
--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -1,6 +1,6 @@
 cask 'bytecoin' do
-  version '3.2.1'
-  sha256 '6e9d2e33e96350915cd4ef5c88c399d9e4b99661312e2e8ab130e9eb696a23b5'
+  version '3.2.3'
+  sha256 '561e098c20651718a923983e733817f860e31b856efb042b94adc4a3c9684c08'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.