### PR TITLE
Update fsnotes to 2.0.6

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,9 +1,9 @@
 cask 'fsnotes' do
-  version '2.0.5,_b164'
-  sha256 '96c6366a5cde519ba4097f7faed23b706ef4f4106a9bf6854b2c1f13a98696c1'
+  version '2.0.6'
+  sha256 '91dcb6671c5cc7e69c60b114a25a0f89e27f9ff237df99d2fcd0611a275ab028'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
-  url "https://github.com/glushchenko/fsnotes/releases/download/#{version.before_comma}/FSNotes_#{version.before_comma}#{version.after_comma}.zip"
+  url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"
   appcast 'https://github.com/glushchenko/fsnotes/releases.atom'
   name 'FSNotes'
   homepage 'https://fsnot.es/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.