### PR TITLE
Update gemini to 2.4.8,1534165417

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,6 +1,6 @@
 cask 'gemini' do
-  version '2.4.7,1531762923'
-  sha256 'f953d8451e5d1ec53dcccafe51ed6ba2a9d6a1d890c1ee4eae3d584f5b9aad13'
+  version '2.4.8,1534165417'
+  sha256 'e77615d5fc9a53c6491964bc6922619553fc51b3666ee630b646244ee2f46b88'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.before_comma}/#{version.after_comma}/Gemini#{version.major}-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.