### PR TITLE
Update coteditor to 3.5.0

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -9,8 +9,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.4.4'
-    sha256 '0bfad99f17cda9bc721dea21b06bc53bdcd26c8de8df544e851a35e12f5c6b26'
+    version '3.5.0'
+    sha256 '07d2b1724a8feda56dfcffe6ccb2d34b943f863db367b608010eace63d322213'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.