### PR TITLE
Update dingtalk to 4.5.5.5

### DIFF
--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,6 +1,6 @@
 cask 'dingtalk' do
-  version '4.5.5'
-  sha256 '3a1d8e4ab854ee7ff076e24e8e4e25e27b21b94e5f18f330870511160908c5c5'
+  version '4.5.5.5'
+  sha256 '2108599e128697b998c4f2b04ae7d45f3f6277fbb2ebe1c1b8b4f214bf8303ee'
 
   # download.alicdn.com/dingtalk-desktop was verified as official when first introduced to the cask
   url "https://download.alicdn.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.