### PR TITLE
Update skype to 8.28.0.41

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.27.0.85'
-  sha256 '8930bad466a2c3caeac260d45c8e14d3d16c517e168a063e1aeb6ac0456b197c'
+  version '8.28.0.41'
+  sha256 'b634d38aa28bb28b2b64792d5e5d981679c8535af41585649c34c48290436764'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.