### PR TITLE
Update microsoft-office to 16.16.18081201

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -1,10 +1,11 @@
 cask 'microsoft-office' do
-  version '16.16.18091001'
-  sha256 '7be78064e71591406a36ab0db2c813a21d9a09a8fcf1ae0bf454a53eb433abb7'
+  version '16.17.18090901'
+  sha256 '3ef365a5809f13d14dd3986f2cf90fbc39e149ae8b7591feb55cd1cebfc5d02a'
 
   # officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac was verified as official when first introduced to the cask
   url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_#{version}_Installer.pkg"
-  name 'Microsoft Office 2016'
+  appcast 'https://docs.microsoft.com/en-us/officeupdates/update-history-office-for-mac'
+  name 'Microsoft Office'
   homepage 'https://products.office.com/mac/microsoft-office-for-mac/'
 
   auto_updates true
@@ -12,8 +13,10 @@ cask 'microsoft-office' do
   pkg "Microsoft_Office_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
+                         'com.microsoft.office.licensingV2.pkg',
                          'com.microsoft.package.Fonts',
                          'com.microsoft.package.Frameworks',
+                         'com.microsoft.package.Microsoft_AutoUpdate.app',
                          'com.microsoft.package.Microsoft_Excel.app',
                          'com.microsoft.package.Microsoft_OneNote.app',
                          'com.microsoft.package.Microsoft_Outlook.app',
@@ -21,10 +24,13 @@ cask 'microsoft-office' do
                          'com.microsoft.package.Microsoft_Word.app',
                          'com.microsoft.package.Proofing_Tools',
                          'com.microsoft.pkg.licensing',
+                         'com.microsoft.OneDrive',
                        ],
             launchctl: [
-                         'com.microsoft.office.licensing.helper',
+                         'com.microsoft.autoupdate.helpertool',
+                         'com.microsoft.autoupdate.helper',
                          'com.microsoft.office.licensingV2.helper',
+                         'com.microsoft.OneDriveUpdaterDaemon',
                        ],
             delete:    [
                          '/Applications/Microsoft Excel.app',
@@ -32,6 +38,7 @@ cask 'microsoft-office' do
                          '/Applications/Microsoft Outlook.app',
                          '/Applications/Microsoft PowerPoint.app',
                          '/Applications/Microsoft Word.app',
+                         '/Applications/OneDrive.app',
                        ]
 
   zap trash:     [
@@ -42,6 +49,7 @@ cask 'microsoft-office' do
                    '~/Library/Application Scripts/com.microsoft.Word',
                    '~/Library/Application Scripts/com.microsoft.errorreporting',
                    '~/Library/Application Scripts/com.microsoft.onenote.mac',
+                   '~/Library/Application Support/com.microsoft.OneDrive',
                    '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.excel.sfl*',
                    '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.powerpoint.sfl*',
                    '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.word.sfl*',
@@ -49,6 +57,8 @@ cask 'microsoft-office' do
                    '~/Library/Caches/Microsoft/uls/com.microsoft.autoupdate2',
                    '~/Library/Caches/com.microsoft.autoupdate.fba',
                    '~/Library/Caches/com.microsoft.autoupdate2',
+                   '~/Library/Caches/com.microsoft.OneDrive',
+                   '~/Library/Caches/com.microsoft.OneDriveUpdater',
                    '~/Library/Containers/com.microsoft.Excel',
                    '~/Library/Containers/com.microsoft.Office365ServiceV2',
                    '~/Library/Containers/com.microsoft.Outlook',
@@ -58,28 +68,24 @@ cask 'microsoft-office' do
                    '~/Library/Containers/com.microsoft.onenote.mac',
                    '~/Library/Cookies/com.microsoft.autoupdate.fba.binarycookies',
                    '~/Library/Cookies/com.microsoft.autoupdate2.binarycookies',
+                   '~/Library/Cookies/com.microsoft.OneDrive.binarycookies',
+                   '~/Library/Cookies/com.microsoft.OneDriveUpdater.binarycookies',
                    '~/Library/Group Containers/UBF8T346G9.Office',
+                   '~/Library/Group Containers/UBF8T346G9.OfficeOneDriveSyncIntegration',
                    '~/Library/Group Containers/UBF8T346G9.OfficeOsfWebHost',
+                   '~/Library/Group Containers/UBF8T346G9.OneDriveStandaloneSuite',
                    '~/Library/Group Containers/UBF8T346G9.ms',
                    '~/Library/Preferences/com.microsoft.Excel.plist',
                    '~/Library/Preferences/com.microsoft.Powerpoint.plist',
                    '~/Library/Preferences/com.microsoft.Word.plist',
                    '~/Library/Preferences/com.microsoft.autoupdate.fba.plist',
                    '~/Library/Preferences/com.microsoft.autoupdate2.plist',
+                   '~/Library/Preferences/com.microsoft.office.plist',
                    '~/Library/Saved Application State/com.microsoft.autoupdate2.savedState',
                    '~/Library/Saved Application State/com.microsoft.office.setupassistant.savedState',
                  ],
       rmdir:     [
                    '~/Library/Caches/Microsoft/uls',
                    '~/Library/Caches/Microsoft',
-                 ],
-      launchctl: [
-                   'com.microsoft.autoupdate.helpertool',
-                   'com.microsoft.autoupdate.helper',
-                   'com.microsoft.OneDriveUpdaterDaemon',
-                 ],
-      pkgutil:   [
-                   'com.microsoft.package.Microsoft_AutoUpdate.app',
-                   'com.microsoft.OneDrive',
                  ]
 end

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -1,15 +1,15 @@
 cask 'microsoft-office' do
-  version '16.15.18070902'
-  sha256 '2caa050dcc2a95f90f57449f9ab5b173437fa2580f282f4c1513a83918e49ffa'
+  version '16.16.18091001'
+  sha256 '7be78064e71591406a36ab0db2c813a21d9a09a8fcf1ae0bf454a53eb433abb7'
 
   # officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac was verified as official when first introduced to the cask
-  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_2016_#{version}_Installer.pkg"
+  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_#{version}_Installer.pkg"
   name 'Microsoft Office 2016'
   homepage 'https://products.office.com/mac/microsoft-office-for-mac/'
 
   auto_updates true
 
-  pkg "Microsoft_Office_2016_#{version}_Installer.pkg"
+  pkg "Microsoft_Office_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
                          'com.microsoft.package.Fonts',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.