### PR TITLE
Update dcp-o-matic-encode-server to 2.12.9

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.12.8'
-  sha256 '52568aac3b9d8988e8aa08da9b9c955b64bc4bc2daaeb8ba8a64063c2f52e765'
+  version '2.12.9'
+  sha256 '9d1e2792d5a78c1c2ecf5b48670192fa88955511b6117a8485918579b7efec19'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.