### PR TITLE
Update dcp-o-matic-kdm-creator to 2.12.9

### DIFF
--- a/Casks/dcp-o-matic-kdm-creator.rb
+++ b/Casks/dcp-o-matic-kdm-creator.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-kdm-creator' do
-  version '2.12.8'
-  sha256 '667adcd74582bdf91e694b11a71ccea43b8b6b5c51db78de6fb2d3dc137592f0'
+  version '2.12.9'
+  sha256 '5aa525ce5964ac439cd3ea8e7c69cd3147e0bc46fe21bed9d82af1afbca82ab7'
 
   url "https://dcpomatic.com/dl.php?id=osx-kdm&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.