### PR TITLE
Update dcp-o-matic-player to 2.12.9

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.12.8'
-  sha256 '90c94b31fa7f7e90f633d00f7a92cf916811be730d1224e981f3ee1dc27224e2'
+  version '2.12.9'
+  sha256 '3edc777985cad02fabf251cafcfd2d3b95743f8728d3639055a7fbe82dc9464c'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.