### PR TITLE
Update lunar to 2.1.1

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.1.0'
-  sha256 '612192931fb81efb2b900b1829a45675ee005d75fea4d74f9906cc11315d492b'
+  version '2.1.1'
+  sha256 'a5547a105788a00faef15040d7ef3497cd8ddec686976ccb0c5d82630907b2ea'
 
   url "https://lunarapp.site/Lunar-#{version}.dmg"
   appcast 'https://lunarapp.site/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.