### PR TITLE
Update manager to 18.7.97

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.7.95'
-  sha256 'b008ff88f45c860069944a3294c7e3aaac6364192884b3dd22766ccfc3419f48'
+  version '18.7.97'
+  sha256 '9b9cad72d4edd984529ddc00e6572ec18bc056bcfdb9965264a0efe845e8adf9'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.