### PR TITLE
Update mps to 2018.2,182.1378

### DIFF
--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -1,5 +1,5 @@
 cask 'mps' do
-  version '2018.2,182.1322'
+  version '2018.2,182.1378'
   sha256 '8fed93ef5f980c52155f4f4c091c8b42a1a4695943e6799a1cc31bc49169761a'
 
   url "https://download.jetbrains.com/mps/#{version.before_comma.major_minor}/MPS-#{version.before_comma}-macos-jdk-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.