### PR TITLE
Update splashtop-business to 3.2.6.0

### DIFF
--- a/Casks/splashtop-business.rb
+++ b/Casks/splashtop-business.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-business' do
-  version '3.2.4.0'
-  sha256 '9f6479f313a0db992ba95412c2653e6843dc04356f9102611c61972cc5f7437a'
+  version '3.2.6.0'
+  sha256 '1408b4b6ce872f53b729075465434e00cfe061f4880bb89d28abba3065e03360'
 
   # d17kmd0va0f0mp.cloudfront.net/macclient/STB was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STB/Splashtop_Business_Mac_INSTALLER_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.