### PR TITLE
Update splashtop-streamer to 3.2.6.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-streamer' do
-  version '3.2.4.0'
-  sha256 '0f3e2d63aea84b4f43b58bd4732b30b94c8f4f98fe664b04c18bfeb00b6b497a'
+  version '3.2.6.0'
+  sha256 'b69cf91c0c908f5fd69c8ae3a361b261eeed308647de629c1d447f7d49e6eac9'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -10,7 +10,7 @@ cask 'splashtop-streamer' do
 
   pkg 'Splashtop Streamer.pkg'
 
-  uninstall signal:    ['KILL', 'com.splashtop.Splashtop-Streamer'],
+  uninstall quit:      'com.splashtop.Splashtop-Streamer',
             launchctl: [
                          'com.splashtop.streamer-daemon',
                          'com.splashtop.streamer-for-user',

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -10,7 +10,7 @@ cask 'splashtop-streamer' do
 
   pkg 'Splashtop Streamer.pkg'
 
-  uninstall signal:    ['QUIT', 'com.splashtop.Splashtop-Streamer'],
+  uninstall signal:    ['TERM', 'com.splashtop.Splashtop-Streamer'],
             launchctl: [
                          'com.splashtop.streamer-daemon',
                          'com.splashtop.streamer-for-user',

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -10,7 +10,7 @@ cask 'splashtop-streamer' do
 
   pkg 'Splashtop Streamer.pkg'
 
-  uninstall quit:      'com.splashtop.Splashtop-Streamer',
+  uninstall signal:    ['QUIT', 'com.splashtop.Splashtop-Streamer'],
             launchctl: [
                          'com.splashtop.streamer-daemon',
                          'com.splashtop.streamer-for-user',

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -10,7 +10,7 @@ cask 'splashtop-streamer' do
 
   pkg 'Splashtop Streamer.pkg'
 
-  uninstall signal:    ['TERM', 'com.splashtop.Splashtop-Streamer'],
+  uninstall signal:    ['KILL', 'com.splashtop.Splashtop-Streamer'],
             launchctl: [
                          'com.splashtop.streamer-daemon',
                          'com.splashtop.streamer-for-user',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.