### PR TITLE
Update virtualbox-extension-pack to 5.2.18,124319

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-extension-pack' do
-  version '5.2.16,123759'
-  sha256 'dcb3b24d28c30749e6c073e102719ba16700fc9fe4e7a25de9503976b6774bf5'
+  version '5.2.18,124319'
+  sha256 '3ecb43c71502741f4eb790576c608eb65cd424bcf3dfdb56471e4a2cac806f68'
 
   url "https://download.virtualbox.org/virtualbox/#{version.before_comma}/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack"
   appcast 'https://download.virtualbox.org/virtualbox/LATEST.TXT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.