### PR TITLE
Update nocturn to 1.6.6

### DIFF
--- a/Casks/nocturn.rb
+++ b/Casks/nocturn.rb
@@ -1,6 +1,6 @@
 cask 'nocturn' do
-  version '1.6.3'
-  sha256 'bfe4d9d3fcf8efe2a6814cacb47f14a177e30d58e02b21244387196eadc7c61f'
+  version '1.6.6'
+  sha256 '8635a2e59ea41b192aac0e3c47b54fd7a9e10b17fb4449d5f30df37d4ae4e923'
 
   url "https://github.com/k0kubun/Nocturn/releases/download/v#{version}/Nocturn-darwin-x64.zip"
   appcast 'https://github.com/k0kubun/Nocturn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.