### PR TITLE
Update dupin to 2.14.0

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,8 +3,8 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.13.1'
-    sha256 '56d6c70355beaf1fe06c483dbe457d125782e185af7047cbcb28145535f58784'
+    version '2.14.0'
+    sha256 '5bba18216cdd01815df7c386d30c356f925b9bb264d3e0bc29c12d8eb7bdd791'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.