### PR TITLE
Update remembear to 1.1.1

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.1.0'
-  sha256 '158c7b6966ed65fed6f6fb6952f22c4a78427436dc1dc06e5795cc261fc24fcb'
+  version '1.1.1'
+  sha256 '9e47bc446f53dab17bece5e2baaf605ab4c9c36a818477f551dbda366d32f414'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.