### PR TITLE
Update twist to 1.5.0,4767

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.0.37,4652'
-  sha256 '0b1f27287dd2f57fb88722f2f684fdc0592acd5eadae18fd5f869034d97e2496'
+  version '1.5.0,4767'
+  sha256 '3829a02234f9be43aff2f1cc92f52f2479b2900f02ce4088eae42e4551d614aa'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.