### PR TITLE
Update cyberduck to 6.7.1.28683

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,6 +1,6 @@
 cask 'cyberduck' do
-  version '6.7.0.28613'
-  sha256 '624cab96feda6c9910899814943c22a6e81bb5383d6be7115f36b43e84b52a9e'
+  version '6.7.1.28683'
+  sha256 'e51c3e7d27456e7c6460aa611eb74c5589ee530a541e3ec64b4b6d7ddf1e3fe0'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.