### PR TITLE
Update arq to 5.13.1

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '5.12.2'
-  sha256 '42c04688688417ef5301a2ce43d5bda67b474f5fe7b185358829c807da20a59c'
+  version '5.13.1'
+  sha256 '7e60b44340dda4c53f11c6f310dcab67d5a2871a5e7acba207984950decb7ac0'
 
   url "https://www.arqbackup.com/download/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arq#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.