### PR TITLE
Update exodus to 1.58.1

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '1.57.0'
-  sha256 'c819350938f9f7348662942e49c8367aae7bd0568ff7a889b0fd64bfc18ab1c3'
+  version '1.58.1'
+  sha256 '53cb8fc95cf80b8f202375a065295195ed67bcb02b2652f7b55b8ad7bc0b0d50'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.