### PR TITLE
Update kite to 0.20180816.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180815.0'
-  sha256 'b3f83fdba21b93b4214c6942ff845669adb569e3f85ed93681bdcf5678420924'
+  version '0.20180816.0'
+  sha256 '37c43de2c2accf65550d314e8a648b96eca941c13b781996d14c34cdc9acd163'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.