### PR TITLE
Update manager to 18.8.4

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.8.2'
-  sha256 'fe7722b13d0b853d77f7857e3dd814228f260e796a43166c15547609c1c6c73c'
+  version '18.8.4'
+  sha256 '10b8e41b9fb1bbba242b789472a1bff0f4cf27d469ba6318b8caadf47dfcab0c'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.