### PR TITLE
Update qgroundcontrol to 3.4.1

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,6 +1,6 @@
 cask 'qgroundcontrol' do
-  version '3.4.0'
-  sha256 'cc0a4ca5268edbb2d2ed2490b1b432a93ab61ad3690503b3188fa71af4833694'
+  version '3.4.1'
+  sha256 'cd3dc9e6ef8f5775f6d49c606d6145c4097f3a950ed3ab0a1c378bf810459020'
 
   # github.com/mavlink/qgroundcontrol was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.