### PR TITLE
Update unity-windows-support-for-editor to 2018.2.4f1,cb262d9ddeaf

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.2.2f1,c18cef34cbcd'
-  sha256 '64017ab5f5ec64f36157811e5fad23759220d7a45ce7c35c0738fa72041393b9'
+  version '2018.2.4f1,cb262d9ddeaf'
+  sha256 '464bae30ca694d07020979eb74e50cd15cef960d883dc01a48b08ac1e2a330f0'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.