### PR TITLE
Update unity-webgl-support-for-editor to 2018.2.4f1,cb262d9ddeaf

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.2.3f1,1431a7d2ced7'
-  sha256 '50931ba47f5c9256aeed9d879fb94cc8078744d68683c03fa44c639d7a0e5b76'
+  version '2018.2.4f1,cb262d9ddeaf'
+  sha256 'fe1b545e0c7bd3a957b91e87fa15c94d4bf41f1953c9146b633e023db7d5066d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.