### PR TITLE
Update unity-android-support-for-editor to 2018.2.4f1,cb262d9ddeaf

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2018.2.3f1,1431a7d2ced7'
-  sha256 '1ffa25fbb4d35e6f166a1f7c6e7240921680acf03366c4d087a938b66b7a7cf8'
+  version '2018.2.4f1,cb262d9ddeaf'
+  sha256 'e7b5c51875a65286fb2258f56ba0f3ccabd56f443409d3385aefe7bbb901d9a8'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.