### PR TITLE
Fix app name in Fanny.app v1.0.3 cask

### DIFF
--- a/Casks/fanny.rb
+++ b/Casks/fanny.rb
@@ -6,5 +6,5 @@ cask 'fanny' do
   name 'FannyWidget'
   homepage 'http://fannywidget.com/'
 
-  app "Fanny #{version}/fanny.app"
+  app "Fanny #{version}/Fanny.app"
 end


### PR DESCRIPTION
The Fanny cask wouldn't install in case-sensitive filesystems because the app is "Fanny.app", but the cask looks for "fanny.app". Fix the case.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses: I am using macOS Mojave. The gem's native libraries fail to build due to missing kernel headers.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).