### PR TITLE
Update atext to 2.25.2

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,5 +1,5 @@
 cask 'atext' do
-  version '2.24'
+  version '2.25.2'
   sha256 '702826bac3cc0275b5a69f17302601a2788d3dd48f32d0afcb4f4d06606a2c63'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'

--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,6 +1,6 @@
 cask 'atext' do
   version '2.24'
-  sha256 '3be1ea68e1c860de1ce97a5c1881b92d9f981392fb1d0567c843ce53cf8a0d5b'
+  sha256 '702826bac3cc0275b5a69f17302601a2788d3dd48f32d0afcb4f4d06606a2c63'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.