### PR TITLE
Update bytecoin to 3.2.4

### DIFF
--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -1,6 +1,6 @@
 cask 'bytecoin' do
-  version '3.2.3'
-  sha256 '561e098c20651718a923983e733817f860e31b856efb042b94adc4a3c9684c08'
+  version '3.2.4'
+  sha256 'e5b007e62a87de517c6e8cf56f3bdccd917ac8064c480258a31fa06ff3b97b30'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"

--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -2,7 +2,7 @@ cask 'bytecoin' do
   version '3.2.4'
   sha256 'e5b007e62a87de517c6e8cf56f3bdccd917ac8064c480258a31fa06ff3b97b30'
 
-  # github.com was verified as official when first introduced to the cask
+  # github.com/bcndev/bytecoin-gui was verified as official when first introduced to the cask
   url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"
   appcast 'https://github.com/bcndev/bytecoin-gui/releases.atom'
   name 'Bytecoin Wallet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.