### PR TITLE
Update fsnotes to 2.0.9

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.0.8'
-  sha256 'a7978c4236bf9ff7c9e6b9ce9148d4772aac7dca2fda8e6fb449530e11d2384d'
+  version '2.0.9'
+  sha256 '9028464c9aebb4b0b3bec2461a983cb7266dbfd4cf1c28178e5289db6e08b027'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.