### PR TITLE
Update manager to 18.8.7

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.8.4'
-  sha256 '10b8e41b9fb1bbba242b789472a1bff0f4cf27d469ba6318b8caadf47dfcab0c'
+  version '18.8.7'
+  sha256 '2b9711091411ff0e73ae69c2f76837c9e956f52d4c913dca12291419a13721d2'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.