### PR TITLE
Update wordmark to 3.0.1-beta.8

### DIFF
--- a/Casks/wordmark.rb
+++ b/Casks/wordmark.rb
@@ -1,6 +1,6 @@
 cask 'wordmark' do
-  version '3.0.1-beta.7'
-  sha256 '1a7010fc1b9c131a654112eab9eaeeb02c8143f23aacc93584727ce95a861d85'
+  version '3.0.1-beta.8'
+  sha256 '39f0763829ea7eb96bf2718adf1d5e29899f904a5a5eb6d853f6a83be5de2ce6'
 
   # github.com/wordmark/wordmark was verified as official when first introduced to the cask
   url "https://github.com/wordmark/wordmark/releases/download/v#{version}/wordmark-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.