### PR TITLE
Update lulu to 1.0.0

### DIFF
--- a/Casks/lulu.rb
+++ b/Casks/lulu.rb
@@ -1,10 +1,10 @@
 cask 'lulu' do
-  version '0.9.9'
-  sha256 '3a133fc29b7274e5624d4c5ea2508e34d6c655bb49d452ad8a28918683cfaa0b'
+  version '1.0.0'
+  sha256 'bb89c4f770aa526a2a1a8c6fa6f63f1c80b5491e0cc0ea621e8fff2014263e0d'
 
-  # github.com/objective-see/LuLu was verified as official when first introduced to the cask
-  url "https://github.com/objective-see/LuLu/releases/download/#{version}/LuLu_#{version.dots_to_underscores}.zip"
-  appcast 'https://github.com/objective-see/LuLu/releases.atom'
+  # bitbucket.org/objective-see was verified as official when first introduced to the cask
+  url "https://bitbucket.org/objective-see/deploy/downloads/LuLu_#{version}.zip"
+  appcast 'https://objective-see.com/products/changelogs/LuLu.txt'
   name 'LuLu'
   homepage 'https://objective-see.com/products/lulu.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://objective-see.com/products/lulu.html

The current download on the homepage is newer than the GitHub release.