### PR TITLE
Update mps to 2018.2.1,182.1378

### DIFF
--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -1,6 +1,6 @@
 cask 'mps' do
-  version '2018.2,182.1378'
-  sha256 '8fed93ef5f980c52155f4f4c091c8b42a1a4695943e6799a1cc31bc49169761a'
+  version '2018.2.1,182.1378'
+  sha256 '61599eef1e88abbaeac513d8fce7573dda1d2abcf5cd06c366c91ed6c24e3dac'
 
   url "https://download.jetbrains.com/mps/#{version.before_comma.major_minor}/MPS-#{version.before_comma}-macos-jdk-bundled.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=MPS&latest=true&type=release'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This PR has been created semi-automatically with the [jetbrains-cask-bot](https://github.com/leipert/jetbrains-cask-bot)

/cc @leipert