### PR TITLE
Update taskwarrior-pomodoro to 1.8.0

### DIFF
--- a/Casks/taskwarrior-pomodoro.rb
+++ b/Casks/taskwarrior-pomodoro.rb
@@ -1,9 +1,8 @@
 cask 'taskwarrior-pomodoro' do
-  version '1.7.0'
-  sha256 '5909e42e31a6b545d8e549f000433ca677708f0c4178e1fcd60b8f890ad61adf'
+  version '1.8.0'
+  sha256 '307f017d1ad14721637196e27af00fe2428e4afa8c10bc238b70e8277ccd0486'
 
-  # coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro was verified as official when first introduced to the cask
-  url "https://coddingtonbear-public.s3.amazonaws.com/github/taskwarrior-pomodoro/releases/taskwarrior-pomodoro-#{version}.dmg"
+  url "https://github.com/coddingtonbear/taskwarrior-pomodoro/releases/download/v#{version}/taskwarrior-pomodoro-#{version}.dmg"
   appcast 'https://github.com/coddingtonbear/taskwarrior-pomodoro/releases.atom'
   name 'Taskwarrior-Pomodoro'
   homepage 'https://github.com/coddingtonbear/taskwarrior-pomodoro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.