### PR TITLE
Update coronasdk to 2018.3326

### DIFF
--- a/Casks/coronasdk.rb
+++ b/Casks/coronasdk.rb
@@ -1,6 +1,6 @@
 cask 'coronasdk' do
-  version '2017.3184'
-  sha256 '54fe7dfd2e9e67a948e08fc4f50c77136d22b4bdeb23f48b13ecb123da1098ae'
+  version '2018.3326'
+  sha256 'f02dde42feaaec458e7ad170a9474693864148a5a1e01fbf828f4c6b9208a89d'
 
   url "https://developer.coronalabs.com/sites/default/files/Corona-#{version}.dmg"
   name 'Corona SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.