### PR TITLE
Update gpxsee to 5.17

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '5.16'
-  sha256 'd07ccd90cdc82e3cd23fb44b1ad0e3d5ef343d972cd35a0a783ad3510b0b72d2'
+  version '5.17'
+  sha256 '0503c956b55e71ce163ec11c0d83020287f1e269b85fdc352b6cf538d978ef21'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.