### PR TITLE
Update screens to 4.5.8,21990:1534770107

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,6 +1,6 @@
 cask 'screens' do
-  version '4.5.7,21954:1531418883'
-  sha256 'faa6dc779025a14356a4417ee2b8899b234e5086337d38f1f0d470a4ed079ca7'
+  version '4.5.8,21990:1534770107'
+  sha256 '0ae39ff95d0c0aaaed0e7ac9586237b776df6607d143db727f3f0da9d8db5f61'
 
   # dl.devmate.com/com.edovia.screens4.mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.edovia.screens4.mac/#{version.after_comma.before_colon}/#{version.after_colon}/Screens#{version.major}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.