### PR TITLE
Update 1password-cli to 0.5.3

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask '1password-cli' do
-  version '0.5.2'
-  sha256 'be48a883a882ef7f331d8e8a9811a611f6cd3f5a09ae3201e41e41d3c7a94be8'
+  version '0.5.3'
+  sha256 '2341376cd33760b89ba4bee82ddc5cf0de255ad2d12e3477f8442de00609b212'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.