### PR TITLE
Update a-better-finder-rename to 10.31

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,6 +1,6 @@
 cask 'a-better-finder-rename' do
   version '10.31'
-  sha256 'b4135907cb54514add2fd95993918d9d51cc0f937984fb09dc4972fa89fca3e4'
+  sha256 '6d1a29d63a3275664cedcef13b8c8c046bd89d94ba90302fb1c5761d57e21fc1'
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.