### PR TITLE
Update cacher to 1.5.14

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '1.5.13'
-  sha256 'e75f1432e594198b58280771a2e9016430fda95e51bcee5d8a46c406f563f79d'
+  version '1.5.14'
+  sha256 '9ce41baab4d89de51dd0d372a920b9ded591a740097134ba20414a42fbdca415'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.