### PR TITLE
Update geoda to 1.12.1.129

### DIFF
--- a/Casks/geoda.rb
+++ b/Casks/geoda.rb
@@ -4,7 +4,7 @@ cask 'geoda' do
 
   # s3-us-west-2.amazonaws.com/geodasoftware was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/geodasoftware/GeoDa#{version}-Installer.dmg"
-  appcast 'https://github.com/GeoDaCenter/geoda/releases.atom'
+  appcast 'https://geodacenter.github.io/download.html'
   name 'GeoDa'
   homepage 'https://geodacenter.github.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.