### PR TITLE
Update ganttproject to 2.8.9,r2335

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,6 +1,6 @@
 cask 'ganttproject' do
-  version '2.8.8,r2308'
-  sha256 '6f6b026207abb3bd5ec1602e1fd762edb77aafcf390a50fd673c5b54862ab02b'
+  version '2.8.9,r2335'
+  sha256 '9991d419cf30d8c85ce828102f71e07885530b4a7fae3ad9e0c0ae764ea7f237'
 
   # github.com/bardsoftware/ganttproject was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.