### PR TITLE
Update mimolive to 4.3-26305

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,6 +1,6 @@
 cask 'mimolive' do
-  version '4.2.1-25918'
-  sha256 '60e28286ac660991323c988fcb256103bb31765c42fdcf279640437038505dc4'
+  version '4.3-26305'
+  sha256 'c1fb8ee47e4b8382c7a31fa490673c61fe3616b0bf5cfb8ac60fbfa41983f94b'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/mimolive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.