### PR TITLE
Update mixxx to 2.1.3

### DIFF
--- a/Casks/mixxx.rb
+++ b/Casks/mixxx.rb
@@ -1,6 +1,6 @@
 cask 'mixxx' do
-  version '2.1.2'
-  sha256 'cb6f4d93c74f4336e222e7c2f250d260b364a42309e5c431a8213f7952ac3ef5'
+  version '2.1.3'
+  sha256 'db2b6ee5840b0e311f33b77e9937c0402e37c6b27647a59d344be830bd416e10'
 
   url "https://downloads.mixxx.org/mixxx-#{version}/mixxx-#{version}-osxintel.dmg"
   appcast 'https://www.mixxx.org/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.