### PR TITLE
Update blue-jeans to 2.7.0.450

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.5.1.33'
-  sha256 '20914226694e4a0734d85f8de9a42bc81e7166af933016de66e0a82dd5383e89'
+  version '2.7.0.450'
+  sha256 '19fbd138f41973e05b19b52da7531afc8a3895c4984e175470dd5c47cf886071'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   name 'Blue Jeans videoconferencing'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.