### PR TITLE
Update understand to 5.0.955

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.0.954'
-  sha256 'b422190bcc6c7c4a09ba9f4a232d314bd017ca046aeb3e90eee093af208e1f26'
+  version '5.0.955'
+  sha256 'ecc2d19595ed0293f69a98c555aa5a0f24036702836477efbe888b0b63468f55'
 
   url "http://latest.scitools.com/Understand/Understand-#{version}-MacOSX-x86.dmg"
   name 'SciTools Understand'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.