### PR TITLE
Update eiskaltdcpp to 2.2.10-196-macOS10.13

### DIFF
--- a/Casks/eiskaltdcpp.rb
+++ b/Casks/eiskaltdcpp.rb
@@ -1,8 +1,8 @@
 cask 'eiskaltdcpp' do
-  version '2.3.0-v2.2.10-62-ge42c04e'
-  sha256 '1463fd447ffd16d9f3af96b0d2306a728d580e59bc7b9a45fcbe895c99c5432c'
+  version '2.2.10-196-macOS10.13'
+  sha256 '4d5a69e3c5eb4428ba0fa7dda8817203c5befabbb6c9f8b4e1124f19823adfcf'
 
-  url "https://downloads.sourceforge.net/eiskaltdcpp/EiskaltDC++-#{version}-x86_64-qt5.dmg"
+  url "https://downloads.sourceforge.net/eiskaltdcpp/EiskaltDC++-#{version}-x86_64.dmg"
   appcast 'https://sourceforge.net/projects/eiskaltdcpp/rss'
   name 'EiskaltDC++'
   homepage 'https://sourceforge.net/projects/eiskaltdcpp/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.