### PR TITLE
Update zoomus to 4.1.30477.0820

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.1.27695.0702'
-  sha256 '839ba26e98b9be3f4f63ab76e4ef6fe1bcb0b5010c95062015b2cb342eceb8bb'
+  version '4.1.30477.0820'
+  sha256 '4bceb5fead00cc9ff76f0996ddec0ad00c9542b71332eb1a2d3d33eb90d69de4'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   name 'Zoom.us'
@@ -10,7 +10,16 @@ cask 'zoomus' do
 
   pkg 'zoomusInstaller.pkg'
 
-  uninstall delete: '/Applications/zoom.us.app'
+  uninstall delete: [
+                      '/Applications/zoom.us.app',
+                      '/Applications/zoom.us.app/Contents/Frameworks/Transcode.app',
+                      '/Applications/zoom.us.app/Contents/Frameworks/ZMScreenshot.app',
+                      '/Applications/zoom.us.app/Contents/Frameworks/ZoomOpener.app',
+                    ],
+            quit:   [
+                      'us.zoom.ZoomOpener',
+                      'us.zoom.xos',
+                    ]
 
   zap trash: [
                '~/Desktop/Zoom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.