### PR TITLE
Update canary to 2.10,432

### DIFF
--- a/Casks/canary.rb
+++ b/Casks/canary.rb
@@ -1,6 +1,6 @@
 cask 'canary' do
-  version '2.09,430'
-  sha256 '9dced03eced6cd9d019030a2895d111cb25880c0e91924cfdc4a079ba65c7f7c'
+  version '2.10,432'
+  sha256 '0fb6de1a53b6d1180a0a62c3a3e105106823dc8def04a12d0c0fa8549fc605a2'
 
   # rink.hockeyapp.net/api was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/b36ac4a380ea4907940c2054f6163050/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.