### PR TITLE
Update crypt to 3,20100429

### DIFF
--- a/Casks/crypt.rb
+++ b/Casks/crypt.rb
@@ -1,12 +1,11 @@
 cask 'crypt' do
-  version '3'
+  version '3,20100429'
   sha256 'e9e82ad331fe26a26ddb9625a9e1ac8e65086770c1abf4bfa503c8336bdf37bd'
 
-  # voluntary.net.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://voluntary.net.s3.amazonaws.com/Crypt#{version}_20100429.zip"
-  appcast 'https://voluntary.net/crypt/'
+  url "https://voluntarylabs.org/crypt/binaries/Crypt#{version.before_comma}_#{version.after_comma}.zip"
+  appcast 'https://voluntarylabs.org/crypt/index.html'
   name 'Crypt'
-  homepage 'https://voluntary.net/crypt/'
+  homepage 'https://voluntarylabs.org/crypt/index.html'
 
-  app "Crypt#{version}.app"
+  app "Crypt#{version.before_comma}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.