### PR TITLE
Update cubicsdr to 0.2.5

### DIFF
--- a/Casks/cubicsdr.rb
+++ b/Casks/cubicsdr.rb
@@ -1,6 +1,6 @@
 cask 'cubicsdr' do
-  version '0.2.4'
-  sha256 'bdbb2cce55b4a70351527bcaca0b62b4e360ffdece269a20c107e68f229c33cf'
+  version '0.2.5'
+  sha256 '9180e56e84a1d78935fb13ce362e3b8636a96b38d0695748078b43f9f6c3cb2c'
 
   # github.com/cjcliffe/CubicSDR was verified as official when first introduced to the cask
   url "https://github.com/cjcliffe/CubicSDR/releases/download/#{version}/CubicSDR-#{version}-Darwin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.