### PR TITLE
Update flinto to 26.0

### DIFF
--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -1,6 +1,6 @@
 cask 'flinto' do
-  version '25.8'
-  sha256 'aecc199b631a4131401d1887be6ddddd74d68254df2196a3bafedf13d377cca7'
+  version '26.0'
+  sha256 'eb7f4cbdeab548957a6ae294cfbe9a6e40b78711be9ed46400537faa70addeef'
 
   url "https://www.flinto.com/assets/Flinto-#{version}.dmg"
   appcast 'https://www.flinto.com/appcast.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.