### PR TITLE
Update minishift to 1.23.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,6 +1,6 @@
 cask 'minishift' do
-  version '1.22.0'
-  sha256 '8c2938db8cacfc3042aebfe429587f7f99247828d7cf83805c07fb3ba1d427f7'
+  version '1.23.0'
+  sha256 '2e1e51fc115cd3dbd295430a8a47e4245ab39706505aba7f2f42e525de4e7a74'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.