### PR TITLE
Update pritunl to 1.0.1804.90

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,6 +1,6 @@
 cask 'pritunl' do
-  version '1.0.1653.28'
-  sha256 'dc1349921f62f7ca88c4102ca6611ae1f743467b0fce2a99bca1d927edc56835'
+  version '1.0.1804.90'
+  sha256 '8427a2e76fdaa257bdc0e5b9aa7ed7698720b85b8ab81d9299e62e5a1896ef49'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.