### PR TITLE
Update qownnotes to 18.08.5,b3761-175210

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.08.4,b3750-093847'
-  sha256 'a297a0e963496553c88204be339c10755de8a4d0b3c7a631123163903eae66e4'
+  version '18.08.5,b3761-175210'
+  sha256 'bd9276c44a8b39597c1321c91286f5d69042d1fb920867df774614077a647aed'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.