### PR TITLE
Update unity-download-assistant to 2018.2.5f1,3071d1717b71

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.2.4f1,cb262d9ddeaf'
-  sha256 '97bf070da403b26fd904168f7a92c6b4e9f7227f11a0c10edc8522d4125fd805'
+  version '2018.2.5f1,3071d1717b71'
+  sha256 '62c0bce573b932bbf7c20a92024c84d2de4740729e341abe23840efe0136c24d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.