### PR TITLE
Update unity-android-support-for-editor to 2018.2.5f1,3071d1717b71

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2018.2.4f1,cb262d9ddeaf'
-  sha256 'e7b5c51875a65286fb2258f56ba0f3ccabd56f443409d3385aefe7bbb901d9a8'
+  version '2018.2.5f1,3071d1717b71'
+  sha256 '31b209dd8f9329f17777bf04b492b11410a89d02e7a7ad2f692238a84d2160a7'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.