### PR TITLE
Update sciebo to qt5.6.2-2.4.3.2161

### DIFF
--- a/Casks/sciebo.rb
+++ b/Casks/sciebo.rb
@@ -1,6 +1,6 @@
 cask 'sciebo' do
-  version 'qt5.6.2-2.4.2.2144'
-  sha256 'b0928d80192b87a069df13db04a4b6ae83d460cbbf2574a926d868098a212eb6'
+  version 'qt5.6.2-2.4.3.2161'
+  sha256 '2fb6120746ae86d0d4eade2c4cd867e45b21d492f1b1e046ba4bf6701dd59139'
 
   url "https://www.sciebo.de/install/sciebo-#{version}.pkg"
   name 'sciebo'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.