### PR TITLE
Update daedalus to 0.11.0

### DIFF
--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -4,6 +4,7 @@ cask 'daedalus' do
 
   # update-cardano-mainnet.iohk.io was verified as official when first introduced to the cask
   url "https://update-cardano-mainnet.iohk.io/daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
+  appcast 'https://github.com/input-output-hk/daedalus/releases.atom'
   name 'Daedalus'
   homepage 'https://daedaluswallet.io/'
 

--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -1,13 +1,13 @@
 cask 'daedalus' do
-  version '0.11.0'
+  version '0.11.0,1.3.0:2260'
   sha256 '6ad90da2053f06f9f0e35c2ae05a8620094b83c6a6a5401c201a1e5abcc22ae4'
 
   # update-cardano-mainnet.iohk.io was verified as official when first introduced to the cask
-  url "https://update-cardano-mainnet.iohk.io/daedalus-#{version}-cardano-sl-1.3.0-mainnet-macos-2260.pkg"
+  url "https://update-cardano-mainnet.iohk.io/daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
   name 'Daedalus'
   homepage 'https://daedaluswallet.io/'
 
-  pkg "daedalus-#{version}-cardano-sl-1.3.0-mainnet-macos-2260.pkg"
+  pkg "daedalus-#{version}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
 
   uninstall pkgutil: 'org.Daedalus.pkg',
             delete:  '/Applications/Daedalus.app'

--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -7,7 +7,7 @@ cask 'daedalus' do
   name 'Daedalus'
   homepage 'https://daedaluswallet.io/'
 
-  pkg "daedalus-#{version}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
+  pkg "daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
 
   uninstall pkgutil: 'org.Daedalus.pkg',
             delete:  '/Applications/Daedalus.app'

--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -2,8 +2,8 @@ cask 'daedalus' do
   version '0.11.0,1.3.0:2260'
   sha256 '6ad90da2053f06f9f0e35c2ae05a8620094b83c6a6a5401c201a1e5abcc22ae4'
 
-  # update-cardano-mainnet.iohk.io was verified as official when first introduced to the cask
-  url "https://update-cardano-mainnet.iohk.io/daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
+  # github.com/input-output-hk/daedalus was verified as official when first introduced to the cask
+  url "https://github.com/input-output-hk/daedalus/releases/download/#{version.before_comma}/daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"
   appcast 'https://github.com/input-output-hk/daedalus/releases.atom'
   name 'Daedalus'
   homepage 'https://daedaluswallet.io/'

--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -1,15 +1,15 @@
 cask 'daedalus' do
-  version '1.1.1.952'
-  sha256 'f5262107b30f5617018fec7bff42982484f3af3623f8169d98500dfb7d495b84'
+  version '0.11.0'
+  sha256 '6ad90da2053f06f9f0e35c2ae05a8620094b83c6a6a5401c201a1e5abcc22ae4'
 
-  # amazonaws.com/update-cardano-mainnet.iohk.io was verified as official when first introduced to the cask
-  url "https://s3-ap-southeast-1.amazonaws.com/update-cardano-mainnet.iohk.io/Daedalus-installer-#{version}.pkg"
+  # update-cardano-mainnet.iohk.io was verified as official when first introduced to the cask
+  url "https://update-cardano-mainnet.iohk.io/daedalus-#{version}-cardano-sl-1.3.0-mainnet-macos-2260.pkg"
   name 'Daedalus'
   homepage 'https://daedaluswallet.io/'
 
-  pkg "Daedalus-installer-#{version}.pkg"
+  pkg "daedalus-#{version}-cardano-sl-1.3.0-mainnet-macos-2260.pkg"
 
-  uninstall pkgutil: 'org.daedalus.pkg',
+  uninstall pkgutil: 'org.Daedalus.pkg',
             delete:  '/Applications/Daedalus.app'
 
   zap trash: [


### PR DESCRIPTION
Versioning for daedalus has been a little weird, this seeming downgrade is actually an upgrade. https://daedaluswallet.io/release-notes/

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
