### PR TITLE
Update popo to 2.6.8,5648

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
-  version '2.6.7,5615'
-  sha256 'a24c516110a1aafc329e909f4e566cb6d1674ef4724649d0ac750b6ce691cd7f'
+  version '2.6.8,5648'
+  sha256 'f29d8134eb5bda259e1615d6d581781582cd0539dfded1267ed04dbc0ea9deda'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores.before_comma}.dmg"
   name 'NetEase POPO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.