### PR TITLE
Update bitshares to 2.0.180815

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,6 +1,6 @@
 cask 'bitshares' do
-  version '2.0.180814'
-  sha256 '70d9451f0f3b44576205710f37e20143b7e91be09c00af43d33bf7c96b895717'
+  version '2.0.180815'
+  sha256 'a05731fd1e89a6ec76f28c66b1b0cc3ad53a2c7947588592d6e4319f2a16abd9'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.