### PR TITLE
Update manager to 18.8.30

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.8.19'
-  sha256 '81760d16b646b80ca89c989bfddde9f5fd455381cf3a9aba77d17f03357a3e9b'
+  version '18.8.30'
+  sha256 '222c66f7c0bf6bd8ec6f0707ae1f0759ef67eaa83f3db5941750b56922a5c3ab'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.