### PR TITLE
Update netshade to 7.2.1

### DIFF
--- a/Casks/netshade.rb
+++ b/Casks/netshade.rb
@@ -1,6 +1,6 @@
 cask 'netshade' do
-  version '7.2'
-  sha256 'ada2f1e1b9a5b2dd814652bbab238b41683a3a4dd8ca7ef2003763f98606bfc8'
+  version '7.2.1'
+  sha256 '9a447695be84e1f2929bb2526ffc2e1fe05e23c2c74a739617e134ece52042ce'
 
   url "https://secure.raynersw.com/downloads/NetShade-#{version.dots_to_hyphens}.app.zip"
   appcast 'https://secure.raynersw.com/changelog.php?prod=ns&format=std&warnpay=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.