### PR TITLE
Update operadriver to 2.38

### DIFF
--- a/Casks/operadriver.rb
+++ b/Casks/operadriver.rb
@@ -1,6 +1,6 @@
 cask 'operadriver' do
-  version '2.37'
-  sha256 'd7220fef597a6e7da28c594a82fe0edab8449d6992ef28a20cd1fa4173d02fd3'
+  version '2.38'
+  sha256 'e2e309ecd89a9f1a2dfef790a4a1e71ac2b8374ccdebd2f2bc51f1e971a72b85'
 
   url "https://github.com/operasoftware/operachromiumdriver/releases/download/v.#{version}/operadriver_mac64.zip"
   appcast 'https://github.com/operasoftware/operachromiumdriver/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.