### PR TITLE
Update outline-manager to 1.1.6

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.1.5'
-  sha256 '90c93e5b5b680da1fb98987f7b921921ba84cc1d1c715a13ccf543d137e65b56'
+  version '1.1.6'
+  sha256 'bb05d86527f1c2eb90ba46f445e99381863424f9c97b2a5ab6453da24328e119'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.