### PR TITLE
world-of-tanks: add 'uk' and 'be' to cis region

### DIFF
--- a/Casks/world-of-tanks.rb
+++ b/Casks/world-of-tanks.rb
@@ -1,9 +1,9 @@
 cask 'world-of-tanks' do
-  version '2.0.21'
+  version '2.0.28'
 
   # wot.gcdn.co was verified as official when first introduced to the cask
-  language 'AT', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LI', 'LT', 'LV', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR' do
-    sha256 'ea319273e269e1554439d5ac2cc1e189b685f6c619444bb855f3358b68596008'
+  language 'AT', 'BG', 'CH', 'CZ', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LI', 'LT', 'LV', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR' do
+    sha256 '48c916f90eb16a1821480e23c3bf3e054767e065370a9ac3927bc0f44686e89a'
 
     url 'https://wot.gcdn.co/eu/files/osx/worldoftanks_eu.dmg'
     appcast 'https://wot.gcdn.co/eu/files/osx/WoT_OSX_update_eu.xml'
@@ -11,7 +11,7 @@ cask 'world-of-tanks' do
   end
 
   language 'CA', 'US', default: true do
-    sha256 '133b3f3271eb957a4eea59cd59a6f79d2c4376a4297a980d8c9232ae9419a995'
+    sha256 '23c2e97b89eeabd45aa5a6250e87b15c9f17757271f615e013453fea3949ac60'
 
     url 'https://wot.gcdn.co/us/files/osx/worldoftanks_na.dmg'
     appcast 'https://wot.gcdn.co/us/files/osx/WoT_OSX_update_na.xml'
@@ -19,15 +19,15 @@ cask 'world-of-tanks' do
   end
 
   language 'CN', 'ID', 'IN', 'JP', 'KR', 'PH', 'SG', 'TH', 'TW', 'VN' do
-    sha256 'c394a6a9a96914d72a035ccaa061840755f697099a5ff79417e3a5a213f060a2'
+    sha256 '5947d1081a07fadc9e3eb1741fead59a98b6e89c86a2b3fb5356cef77e83e6ca'
 
     url 'https://wot.gcdn.co/sea/files/osx/worldoftanks_asia.dmg'
     appcast 'https://wot.gcdn.co/sea/files/osx/WoT_OSX_update_asia.xml'
     homepage 'https://worldoftanks.asia/'
   end
 
-  language 'RU' do
-    sha256 '02d817184f4fd6268c59d68fc7d9ca039262d1fce997df14b5fdabb202dbaf7f'
+  language 'AZ', 'BE', 'HY', 'KK', 'KY', 'RU', 'UK', 'UZ', 'TG' do
+    sha256 'fffe998183e552560ff37eae77629441ad17cbe6c9ed1af692ad0542a659d04f'
 
     url 'https://wot.gcdn.co/ru/files/osx/worldoftanks_ru.dmg'
     appcast 'https://wot.gcdn.co/ru/files/osx/WoT_OSX_update_ru.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I'm not sure why other languages are spelled in capital letters, for me only 'uk' works.