### PR TITLE
Update blockstack to 0.32.2

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,9 +1,9 @@
 cask 'blockstack' do
-  version '0.32.0'
-  sha256 '7c7f6daf55a20700e641003d865863befe0976413d6a0cafa356c7ec1faff46e'
+  version '0.32.2'
+  sha256 '61784582c2f35a5644a014d4a8a5607c25ca74179127e79fa57be4b7f1cd97bc'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
-  url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version.major_minor}.dmg"
+  url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"
   appcast 'https://github.com/blockstack/blockstack-browser/releases.atom'
   name 'Blockstack'
   homepage 'https://blockstack.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.