### PR TITLE
Update cctalk to 7.3.2,707

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -2,7 +2,6 @@ cask 'cctalk' do
   version '7.3.2,707'
   sha256 '6eb2d1dd2e7c245e5b005554aaae0ca70ca8e5a8c9969005eb682f4cebcbe43e'
 
-  # n1other.hjfile.cn was verified as official when first introduced to the cask
   url 'https://www.cctalk.com/webapi/basic/v1.1/version/down?apptype=1&terminalType=8&versionType=103',
       user_agent: :fake
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -5,6 +5,7 @@ cask 'cctalk' do
   # n1other.hjfile.cn was verified as official when first introduced to the cask
   url 'https://www.cctalk.com/webapi/basic/v1.1/version/down?apptype=1&terminalType=8&versionType=103',
       user_agent: :fake
+  appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'
 

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,16 +1,14 @@
 cask 'cctalk' do
-  version '7.3.1,692'
-  sha256 'e9e372308560f3438f56769cfc0918dfa725cc192a940fb7a307eb3c4f62ab58'
+  version '7.3.2,707'
+  sha256 '6eb2d1dd2e7c245e5b005554aaae0ca70ca8e5a8c9969005eb682f4cebcbe43e'
 
   # n1other.hjfile.cn was verified as official when first introduced to the cask
-  url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk.#{version.before_comma}-#{version.after_comma}.pkg"
-  appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'
+  url 'https://www.cctalk.com/webapi/basic/v1.1/version/down?apptype=1&terminalType=8&versionType=103',
+      user_agent: :fake
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'
 
   depends_on macos: '>= :yosemite'
 
-  pkg "CCtalk.#{version.before_comma}-#{version.after_comma}.pkg"
-
-  uninstall pkgutil: 'com.hujiang.mac.cctalk'
+  app 'CCtalk.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.