### PR TITLE
Update gifox to 010601.03

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -2,9 +2,9 @@ cask 'gifox' do
   version '010601.03'
   sha256 'b0dea197c7c0f1533de4ca2d0402247780bc0463eecdfd8dfa3928f81e5399a9'
 
-  # s3.eu-central-1.amazonaws.com/dstlalgzor/gifox was verified as official when first introduced to the cask
-  url "https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/#{version}.dmg"
-  appcast 'https://s3.eu-central-1.amazonaws.com/dstlalgzor/gifox/appcast.xml'
+  # d1hsvn1xu03mmy.cloudfront.net/gifox was verified as official when first introduced to the cask
+  url "https://d1hsvn1xu03mmy.cloudfront.net/gifox/#{version}.dmg"
+  appcast 'https://d1hsvn1xu03mmy.cloudfront.net/gifox/appcast.xml'
   name 'gifox'
   homepage 'https://gifox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/issues/51224