### PR TITLE
Update opera to 55.0.2994.44

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '55.0.2994.37'
-  sha256 'f5342ade296dd361e54f78f42ef1a74fbf67e36f68887d3e1949a2f402707c34'
+  version '55.0.2994.44'
+  sha256 '8db0ae1d0d106e93e6192713e76850fecbd474e84b0ac8fe1883ff9bd719cb81'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
