### PR TITLE
Update remote-desktop-manager-free to 5.5.1.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '5.5.0.0'
-  sha256 '02d1bc79496bc287787e4e4f86be1b5afd701d5f379d7e96a8c6b32cbad24fc8'
+  version '5.5.1.0'
+  sha256 '85276530b543cf82695bd2512f79108116a3ebc48892b239f194cbd48ae57fb4'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "http://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.