### PR TITLE
Update kid3 to 3.6.2

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,7 +1,7 @@
 cask 'kid3' do
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  version '3.6.1'
-  sha256 '07844015af79674461e9cf46eef5991aac02cbeecd9dee9b88c33200b4a508e2'
+  version '3.6.2'
+  sha256 'ad458d7e25236fe534a0a63e185d5b9d542526f60cbd5e15d413324c6343b2f3'
 
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin.dmg"
   appcast 'https://sourceforge.net/projects/kid3/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.