### PR TITLE
Update kite to 0.20180823.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180822.0'
-  sha256 '764e83c1d625a555f7d30a6b6c330d28f4623ec16c5fa4e216cd8bc62e8a938a'
+  version '0.20180823.0'
+  sha256 '384c1fb35ad3f2297873d8e2bffa6d522cd7eed3578b2d98bd0e58d83f1dfd8d'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.