### PR TITLE
Update minizincide to 2.2.0

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask 'minizincide' do
-  version '2.1.7'
-  sha256 '6446323ed5dec8ba7ce7007683d3b35565eee6603169d2351e6f826197cad371'
+  version '2.2.0'
+  sha256 '0cd1e9e85e70ecd84ce30046cecc03e7abe625b1a0925636011bab9ff500b686'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.