### PR TITLE
Update poll-everywhere to 2.17.0

### DIFF
--- a/Casks/poll-everywhere.rb
+++ b/Casks/poll-everywhere.rb
@@ -1,6 +1,6 @@
 cask 'poll-everywhere' do
-  version '2.16.0'
-  sha256 'b6142eb60f3671c359545f16670d17c3cc5ed309d6eba91e68ec4a18190ed3b8'
+  version '2.17.0'
+  sha256 'fddfe9efe8c9df77529234095ec815e4ea3db8b784460ecd6fc439724bf1b39d'
 
   # amazonaws.com/polleverywhere-app was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/polleverywhere-app/mac-stable/#{version}/pollev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.