### PR TITLE
Update qownnotes to 18.08.6,b3767-171840

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.08.5,b3761-175210'
-  sha256 'bd9276c44a8b39597c1321c91286f5d69042d1fb920867df774614077a647aed'
+  version '18.08.6,b3767-171840'
+  sha256 '385534075916f201a63aa86a4f582b2f5461bac975aef8f66df4c5ad4c1b2c80'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.