### PR TITLE
Update tableplus to 1.0,121

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '1.0,120'
-  sha256 '9d96634d8e9eaa4101825bec60de35921cd8090b40b95093665ff65b2d255d80'
+  version '1.0,121'
+  sha256 '2f63de93d1c42c837cc8f95b287f3fc119a200754accbf828f728d87e96d1de1'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.