### PR TITLE
Update netron to 2.0.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.0.5'
-  sha256 '4e45e4b96c460a38edaa517e2f823684c7965a2194a974f88b9d8f2bfa1845c0'
+  version '2.0.6'
+  sha256 '3ac5fcd07443a0eff7e007e8046ecd0ab48b4ae263a61031133d8bff7a66b5f5'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.