### PR TITLE
Update whalebird to 2.1.1

### DIFF
--- a/Casks/whalebird.rb
+++ b/Casks/whalebird.rb
@@ -1,6 +1,6 @@
 cask 'whalebird' do
-  version '2.1.0'
-  sha256 '204bdd8ab045b07e1e261be99d8f6cca553ba87ea30eddc9ca51e59363a5aa31'
+  version '2.1.1'
+  sha256 'd12d2887f3e8e23d7be82d2cefd550b6fb9a2b1c14ded4f6572be36d6a2e048f'
 
   # github.com/h3poteto/whalebird-desktop was verified as official when first introduced to the cask
   url "https://github.com/h3poteto/whalebird-desktop/releases/download/#{version}/Whalebird-#{version}-darwin-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.