### PR TITLE
Update acronis-true-image to 2019

### DIFF
--- a/Casks/acronis-true-image.rb
+++ b/Casks/acronis-true-image.rb
@@ -1,5 +1,5 @@
 cask 'acronis-true-image' do
-  version '2018'
+  version '2019'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dl.acronis.com/u/AcronisTrueImage#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.