### PR TITLE
Update eiskaltdcpp to 2.2.10-228-macOS10.11

### DIFF
--- a/Casks/eiskaltdcpp.rb
+++ b/Casks/eiskaltdcpp.rb
@@ -1,6 +1,6 @@
 cask 'eiskaltdcpp' do
-  version '2.2.10-196-macOS10.13'
-  sha256 '4d5a69e3c5eb4428ba0fa7dda8817203c5befabbb6c9f8b4e1124f19823adfcf'
+  version '2.2.10-228-macOS10.11'
+  sha256 '045b17cdd530e229ab513df93d1011a549ea3567a9a533a4b145ced87ff020b4'
 
   url "https://downloads.sourceforge.net/eiskaltdcpp/EiskaltDC++-#{version}-x86_64.dmg"
   appcast 'https://sourceforge.net/projects/eiskaltdcpp/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.