### PR TITLE
Update cutter to 1.7.1

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.7'
-  sha256 'dd889c015cf9a6d89709fdf849d455287a748fe18bb40fe7ebaf44bcaf1d4184'
+  version '1.7.1'
+  sha256 'f407e87c0cd221e69da8eae94c424d095fec57f7cb6541b7674ca1c6854777fa'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.