### PR TITLE
Update mailmate to 5509

### DIFF
--- a/Casks/mailmate.rb
+++ b/Casks/mailmate.rb
@@ -1,9 +1,10 @@
 cask 'mailmate' do
-  version :latest
-  sha256 :no_check
+  version '5509'
+  sha256 'b1d5d3c26f8b12c747124e5d3670e0add3db67752fb8877ca36df130b86b60b8'
 
   # mailmate-app.com was verified as official when first introduced to the cask
-  url 'http://dl.mailmate-app.com/MailMate.tbz'
+  url "https://updates.mailmate-app.com/archives/MailMate_r#{version}.tbz"
+  appcast 'https://updates.mailmate-app.com/10.13/release'
   name 'MailMate'
   homepage 'https://freron.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.