### PR TITLE
Update aria2d to 1.2.1,1535339003

### DIFF
--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,6 +1,6 @@
 cask 'aria2d' do
-  version '1.2,1534341053'
-  sha256 '1e2649855f2d4c422c3c916be5d6b202d3dca069f979d2a42967208da29978c7'
+  version '1.2.1,1535339003'
+  sha256 '8338d48fa8c90c8f785568b7b16ca86613b6a8c64d107933a1bc72d6aa401e25'
 
   # dl.devmate.com/com.xjbeta.Aria2D was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.xjbeta.Aria2D/#{version.before_comma}/#{version.after_comma}/Aria2D-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.