### PR TITLE
Update chatology to 1.2

### DIFF
--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,6 +1,6 @@
 cask 'chatology' do
-  version '1.1.3'
-  sha256 'c00918bc330bcdfd385f006e624dabfc98bce2815b21b4d44d1b64a2fa9e343b'
+  version '1.2'
+  sha256 'cff0d2a0e5b42be9ed3210d696662e83c052a85e35afce6b2b0a372cc7508f88'
 
   url "http://cdn.flexibits.com/Chatology_#{version}.zip"
   appcast 'https://flexibits.com/chatology/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.