### PR TITLE
Update dusty to 0.7.3

### DIFF
--- a/Casks/dusty.rb
+++ b/Casks/dusty.rb
@@ -1,6 +1,6 @@
 cask 'dusty' do
-  version '0.7.1'
-  sha256 '210489ae281460ab4c90e1c66998bbee8887020c73da699e356df6f26a482cb6'
+  version '0.7.3'
+  sha256 '6cf61f0dcdc541de123ffd1d8e035eb3fc36e51b626a072355df76c3efd15af9'
 
   url "https://github.com/gamechanger/dusty/releases/download/#{version}/dusty.tar.gz"
   appcast 'https://github.com/gamechanger/dusty/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.