### PR TITLE
Update ganache to 1.2.2

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,6 +1,6 @@
 cask 'ganache' do
-  version '1.2.1'
-  sha256 'cb03072aeea228ebd945dda30836cd4d38cb951cf94a72064255c6e075f36c58'
+  version '1.2.2'
+  sha256 '8e30bbefc304e464ebda416267c4d38758f02f64ac0981c09971a3d548e9c99f'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.