### PR TITLE
Update hands-off to 3.2.10

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '3.2.9'
-  sha256 '218bf7f5f68bcdaa3cf4a3974b42f36b70a8a57efc3c2bc6638c517ec2f3c845'
+  version '3.2.10'
+  sha256 'b270f765950790bd7bc15959cb010ebb4442629e51340514448226cc74e2e3b4'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.