### PR TITLE
Update hstracker to 1.5.1c

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.5.1b'
-  sha256 '54080a7b92ce62c19ecdd582880d9ce76fde4b5a185115ae128c93b9e9b09095'
+  version '1.5.1c'
+  sha256 'cca7c50389d330ed41b68fdeffe88c95252e369049c5c1c7cf59464582c1f150'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.