### PR TITLE
Update isubtitle to 3.1.2

### DIFF
--- a/Casks/isubtitle.rb
+++ b/Casks/isubtitle.rb
@@ -1,6 +1,6 @@
 cask 'isubtitle' do
-  version '3.1.1'
-  sha256 '05acbe95fd72f449147ba0d1e298b9feba041a9adc9319d00938daf1c890e700'
+  version '3.1.2'
+  sha256 '3d973f7a5913c5a9444ea66a11da848970e714ed75b11953bf1939264b6fb2fb'
 
   url "http://www.bitfield.se/isubtitle#{version.major}/download/iSubtitle_#{version}.zip"
   appcast "http://www.bitfield.se/isubtitle#{version.major}/changelog.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.