### PR TITLE
Update omnioutliner to 5.3.4

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,6 +1,6 @@
 cask 'omnioutliner' do
-  version '5.3.3'
-  sha256 'bf656fbf46f61c18881146430c64cf2f6d170f53b3d32ab2576b58237c68e6d7'
+  version '5.3.4'
+  sha256 'dd329a070980ae6fe1aa9c55d398a2ab5b6192082455e7eb3526a9fccb3eaf42'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.