### PR TITLE
Update textexpander to 6.2.7

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,6 +1,6 @@
 cask 'textexpander' do
-  version '6.2.6'
-  sha256 '9516038d25490a5c6e2529e0c81cc686d0bd1475504bbe21e46921bc0d51739e'
+  version '6.2.7'
+  sha256 'a0489a644f0499c0d98051bb7213647d09a602d0f1d0e11173cfbee3fea834b6'
 
   # cdn.textexpander.com/mac was verified as official when first introduced to the cask
   url "https://cdn.textexpander.com/mac/TextExpander_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.