### PR TITLE
Update zulip to 2.3.6

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,6 +1,6 @@
 cask 'zulip' do
-  version '2.3.5'
-  sha256 'cc308d749481cb2c75d77c3e2f6142c3dd51ceb2641880bdb6442b7b8a142b46'
+  version '2.3.6'
+  sha256 'd272239ee32f22e39da7e4c34b073d06ec7ede3860adc6a367f355a60f6ab69f'
 
   # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.