### PR TITLE
Update graphql-playground to 1.6.3

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,8 +1,8 @@
 cask 'graphql-playground' do
-  version '1.6.2'
-  sha256 'a26effde7d740f35e1d5aaa2ec937a1989f6ae5fd9c86361210d5e333b4cc234'
+  version '1.6.3'
+  sha256 '6852aadc02bd1ae208953ddc9947164b4c3037029b9b00a635198ff7df99e8aa'
 
-  url "https://github.com/prismagraphql/graphql-playground/releases/download/#{version}/graphql-playground-electron-#{version}.dmg"
+  url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prismagraphql/graphql-playground/releases.atom'
   name 'GraphQL Playground'
   homepage 'https://github.com/prismagraphql/graphql-playground'

--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -3,9 +3,9 @@ cask 'graphql-playground' do
   sha256 '6852aadc02bd1ae208953ddc9947164b4c3037029b9b00a635198ff7df99e8aa'
 
   url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
-  appcast 'https://github.com/prismagraphql/graphql-playground/releases.atom'
+  appcast 'https://github.com/prisma/graphql-playground/releases.atom'
   name 'GraphQL Playground'
-  homepage 'https://github.com/prismagraphql/graphql-playground'
+  homepage 'https://github.com/prisma/graphql-playground'
 
   app 'GraphQL Playground.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.