### PR TITLE
Update inboxer to 1.1.4

### DIFF
--- a/Casks/inboxer.rb
+++ b/Casks/inboxer.rb
@@ -1,9 +1,9 @@
 cask 'inboxer' do
-  version '1.1.3'
-  sha256 '533c5f52fc56ea61434d92cbcf6b475159a5c15b7f96304a748e84df4a6cdc2b'
+  version '1.1.4'
+  sha256 '680ee3b321e485ead62338d81e43ee25d077d5c3451a724867c741d287efc47f'
 
   # github.com/denysdovhan/inboxer was verified as official when first introduced to the cask
-  url "https://github.com/denysdovhan/inboxer/releases/download/#{version}/Inboxer-#{version}.dmg"
+  url "https://github.com/denysdovhan/inboxer/releases/download/v#{version}/Inboxer-#{version}.dmg"
   appcast 'https://github.com/denysdovhan/inboxer/releases.atom'
   name 'inboxer'
   homepage 'https://denysdovhan.com/inboxer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.