### PR TITLE
Update filezilla to 3.36.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,6 +1,6 @@
 cask 'filezilla' do
-  version '3.35.2'
-  sha256 'e283486e618e929ff3fd5f0aa4fff24c41f39eaa5fffe7bcb8b6d631e36739ad'
+  version '3.36.0'
+  sha256 '878a4d86756eaa193a318a0b8021c8827301d75e33f4d0bd4ca8b8084b7b2431'
 
   url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.