### PR TITLE
Update manager to 18.8.63

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.8.54'
-  sha256 'd02e60eaddc18920ee440ccab9a1e58879eff67ab7a1999e5e04307e0d220c29'
+  version '18.8.63'
+  sha256 'ea4a921214f7ddc05eb7f98435ba35f47d2d2f432af34a6dea2fa7225c1cf1d3'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.