### PR TITLE
Update crashplan to 4.8.4

### DIFF
--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -2,7 +2,8 @@ cask 'crashplan' do
   version '4.8.4'
   sha256 'b2ffb640e1083ee95d5de93b627cbfbdbe53dae3dd59f5ae93723621a575991e'
 
-  url "https://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_#{version}_Mac.dmg"
+  # download.code42.com was verified as official when first introduced to the cask
+  url "https://download.code42.com/installs/mac/install/CrashPlan/CrashPlan_#{version}_Mac.dmg"
   name 'CrashPlan'
   homepage 'https://www.crashplan.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.