### PR TITLE
Update flinto to 26.0.4

### DIFF
--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -1,6 +1,6 @@
 cask 'flinto' do
-  version '26.0.3'
-  sha256 '5aea4dd637c5e6787d0238f1830c8681748680e9607d04f060e93dd0c3d95855'
+  version '26.0.4'
+  sha256 '35d7ba472ec4d26f9bc6a0c51ee8a67f18b37805615c0466896352fdd8b4bf76'
 
   url "https://www.flinto.com/assets/Flinto-#{version}.dmg"
   appcast 'https://www.flinto.com/appcast.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.