### PR TITLE
Update manager to 18.8.71

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.8.63'
-  sha256 'ea4a921214f7ddc05eb7f98435ba35f47d2d2f432af34a6dea2fa7225c1cf1d3'
+  version '18.8.71'
+  sha256 'fc49449cbd8af7fda8394a9fe03ae68b8c6d3229dff4e70372a78c18fdb812ee'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.