### PR TITLE
Update qownnotes to 18.08.10,b3796-173927

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.08.9,b3788-101614'
-  sha256 'dec92ef6a354550fe77da85a5cc6dfc56694718623652709ea57d9c5df281778'
+  version '18.08.10,b3796-173927'
+  sha256 '24b972ce545ef0a2762b3116962d7384dbb49ac9ce40023a4569cda6ce3c3ba0'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.