### PR TITLE
Update kactus to 0.3.13

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,9 +1,9 @@
 cask 'kactus' do
-  version '0.3.12'
-  sha256 'da53c899364c28fa1363c0fd5f5e3d2803c3507301cd12a8b8068ecfa630c8bf'
+  version '0.3.13'
+  sha256 'b765c066f0e6073a7a0605fdedf48e5df1a358b988057e929a7fac366ce29eb0'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
-  url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus.zip"
+  url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"
   appcast 'https://github.com/kactus-io/kactus/releases.atom'
   name 'Kactus'
   homepage 'https://kactus.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.