### PR TITLE
Update exist-db 4.3.1 to require Java 8+

### DIFF
--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -12,6 +12,6 @@ cask 'exist-db' do
   zap trash: '~/Library/Application Support/org.exist'
 
   caveats do
-    depends_on_java '8'
+    depends_on_java '8+'
   end
 end


### PR DESCRIPTION
eXist previously had incompatibilities with Java 9 and 10, so the eXist developers recommended sticking to Java 8, but these issues have now been solved. eXist is compiled on Java 8, so the version dependency is now "8+".

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).