### PR TITLE
Update telegram to 4.3.1-138336

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.3.1-138331'
-  sha256 '2e521fdfebcd453f0fb5fe3b556f30b73035b53bd86f73657037a47406603195'
+  version '4.3.1-138336'
+  sha256 '7ce381a316a2dad7b76c1f2cdd0eefa23bd6f24ec1eb7c7e7a9473b7a999a224'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #51391.