### PR TITLE
Update kite to 0.20180828.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20180823.0'
-  sha256 '384c1fb35ad3f2297873d8e2bffa6d522cd7eed3578b2d98bd0e58d83f1dfd8d'
+  version '0.20180828.0'
+  sha256 '020a5c7e6a2c375ebb30658b8ee39eb2a3e74a9fa2bfd78fbbffdc5ec39e36b6'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.