### PR TITLE
Update manager to 18.8.80

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.8.71'
-  sha256 'fc49449cbd8af7fda8394a9fe03ae68b8c6d3229dff4e70372a78c18fdb812ee'
+  version '18.8.80'
+  sha256 '52521acc2294e833e4e296996f5b9aeead77d5f57e47b605a5b7c44b0eb65ddc'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.