### PR TITLE
Update parallels-client to 16.2.4-19503

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,6 +1,6 @@
 cask 'parallels-client' do
-  version '16.2.3-19419'
-  sha256 '6ca634274386a46578cd62696a6bf7f990ab003ad2e50d85e397e288b8375c71'
+  version '16.2.4-19503'
+  sha256 '6f2822d45a9d67ce5ccacdb1f464d8658c9961ebe744db92df603aea717a7d47'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
   appcast "https://download.parallels.com/ras/v#{version.major}/RAS%20Client%20for%20Mac%20Changelog.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.