### PR TITLE
Update wifispoof to 3.3.1

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,6 +1,6 @@
 cask 'wifispoof' do
-  version '3.3'
-  sha256 'fcb97c902b2561408912b86a744ec70382465cea2287fb59342c041e30d8f646'
+  version '3.3.1'
+  sha256 'c042c6aa19cd3afdda2276183581cff90572f85b606a3effa38b474b184e8ce1'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.