### PR TITLE
Update popo to 2.6.9,5655

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
-  version '2.6.8,5653'
-  sha256 'e3ce86e5575540a41528e6ae94b4197f34c248c94551ff71d108dcf088ee212a'
+  version '2.6.9,5655'
+  sha256 'f487a4148123a735850e6d616a64fc658615691216122e00a48fbc2dff7b071f'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores.before_comma}.dmg"
   name 'NetEase POPO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.