### PR TITLE
Update the-mut to 4.1.0

### DIFF
--- a/Casks/the-mut.rb
+++ b/Casks/the-mut.rb
@@ -1,6 +1,6 @@
 cask 'the-mut' do
-  version '4.0.0'
-  sha256 '95a805ae455aeae67f2d3a0db2210cf4a25adefe5a9d01ab724ced3d36d1a555'
+  version '4.1.0'
+  sha256 '4fcad3b6b24b76fe322b9e3b3a210abcc843a9bf2b54ca3eab4b21abd5104223'
 
   # m-lev.com/uploads was verified as official when first introduced to the cask
   url "http://m-lev.com/uploads/TheMUT_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.