### PR TITLE
Update unity-linux-support-for-editor to 2018.2.6f1,c591d9a97a0b

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.2.5f1,3071d1717b71'
-  sha256 'a7e9d5bba58edc0968e4a30a72456f559e49378e3242ee8519e19b6f9dc93465'
+  version '2018.2.6f1,c591d9a97a0b'
+  sha256 'e139f418dcb2149051ed6f28adf1c4d78370e8a582a896c098b786607629cffd'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.