### PR TITLE
Update unity-windows-support-for-editor to 2018.2.6f1,c591d9a97a0b

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.2.5f1,3071d1717b71'
-  sha256 '4cd7d64ed1443f7c10dfe671acded7a523d0dc34f659d57c42edc91596014871'
+  version '2018.2.6f1,c591d9a97a0b'
+  sha256 '008d22184c61152f800cdefcc5b8a19b13f74d34694ce39a8bc2952f21898e8b'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.