### PR TITLE
Update icq to 3.0.16407

### DIFF
--- a/Casks/icq.rb
+++ b/Casks/icq.rb
@@ -1,6 +1,6 @@
 cask 'icq' do
-  version '3.0.16294'
-  sha256 '29646a71610d9130700885882f60092efe46b9d0ed721262e3ca154b9951ddbc'
+  version '3.0.16407'
+  sha256 '2fcb6d46e6e31ee6c511aa879b87af802dcec9da6adc94dfb0e519259a54cc7f'
 
   # mra.mail.ru/icq_mac3_update was verified as official when first introduced to the cask
   url 'https://mra.mail.ru/icq_mac3_update/icq.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.