### PR TITLE
Update hexels to 3.1.3

### DIFF
--- a/Casks/hexels.rb
+++ b/Casks/hexels.rb
@@ -1,6 +1,6 @@
 cask 'hexels' do
-  version '3.1.2'
-  sha256 '197d85e228d9c18807d4a4dde16b8d75bea5200f2506b8bfe83129080d66fb4c'
+  version '3.1.3'
+  sha256 'c66a202cb5953dc653fa396966f641da757ce66f010c3f2f6a0c67871331ee38'
 
   # s3.amazonaws.com/mset/download/release was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/mset/download/release/hexels_install_#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.