### PR TITLE
Update imazing to 2.6.4,9302:1534860536

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.6.4,9302:1534429886'
-  sha256 '9ddf6e284195a41c140b68bc858069bec537a249271466e4d11ed2281f2e277d'
+  version '2.6.4,9302:1534860536'
+  sha256 'b68a31d0f23786e6920b5082e6eacc45364b6be9821d86c49360982be533abb0'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
The version updated by #50922 results in 404 now. According to [appcast](https://updates.devmate.com/com.DigiDNA.iMazing2Mac.xml), the latest version should be `1534860536`.

![image](https://user-images.githubusercontent.com/1430856/44894982-d6dc7480-ad24-11e8-8bcc-f78d41f0ac18.png)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).