### PR TITLE
Update aquaskk to 4.6.0

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,6 +1,6 @@
 cask 'aquaskk' do
-  version '4.5.0'
-  sha256 '4d88e3b7902d4b44f013fa56757f1a9402bd1bb0402bfbcd490b13063800a130'
+  version '4.6.0'
+  sha256 '58ae310d88f3ad37140ca00d09b4d4c921f43f7d2c54608ca4b422151ba31e58'
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.pkg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.