### PR TITLE
Update digital-power-station to 2.2.0.9,2018.08

### DIFF
--- a/Casks/digital-power-station.rb
+++ b/Casks/digital-power-station.rb
@@ -1,6 +1,6 @@
 cask 'digital-power-station' do
-  version '2.2.0.8,2018.08'
-  sha256 'a83af79889dd88e976b5b166fb7a91aa7c8da92d98a40e2e0960e54c49ec0945'
+  version '2.2.0.9,2018.08'
+  sha256 '251573a04075f85d458f7bf55b05dc2dd29a7afbccf03ab4a93ff9a845f23ff0'
 
   url "https://bongiovidps.com/wp-content/uploads/#{version.after_comma.dots_to_slashes}/Bongiovi_DPS_Mac_#{version.before_comma}.zip"
   appcast 'https://bongiovidps.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.