### PR TITLE
Update doomsday-engine to 2.0.3 (rollback to stable)

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,10 +1,9 @@
 cask 'doomsday-engine' do
-  version '2.1.0-build2774'
-  sha256 '37b4b4ab75dcf3122ebcfd7b4d04122c3a04af0af27f21354b766d1ae808c2f0'
+  version '2.0.3'
+  sha256 '0a6258ed1c061b3a80f1573c7845bce39cd8c8d66ade8d3f29531b7cc658e9d5'
 
-  # sourceforge.net/deng was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/deng/doomsday_#{version}_x86_64.dmg"
-  appcast 'https://sourceforge.net/projects/deng/rss'
+  url "http://files.dengine.net/archive/doomsday_#{version}_x86_64.dmg"
+  appcast 'http://api.dengine.net/1/builds/feed'
   name 'Doomsday Engine'
   homepage 'https://dengine.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.