### PR TITLE
Update jetbrains-toolbox to 1.11.4231

### DIFF
--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'jetbrains-toolbox' do
-  version '1.11.4269'
-  sha256 '7681d2729e924d7f1f15b6a9472a0637ee6e4a09855e76caec883a945a2bf28c'
+  version '1.11.4231'
+  sha256 '0aabedd2e88f71cb65d7c803148a956a8890bbf0035a67212dbbdb5e96a310ae'
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.