### PR TITLE
Update sourcetrail to 2018.3.55

### DIFF
--- a/Casks/sourcetrail.rb
+++ b/Casks/sourcetrail.rb
@@ -1,6 +1,6 @@
 cask 'sourcetrail' do
-  version '2018.3.13'
-  sha256 '9d3f7d04ed167b662446c0e497d50abbcada280680a60ea589a7c42b989be609'
+  version '2018.3.55'
+  sha256 '4e4fc500c8cd1a6a408f7314b3a47ddf3c1651acb44e6791b7a3d55048c2b45f'
 
   url "https://www.sourcetrail.com/downloads/#{version}/osx/64bit"
   appcast 'https://raw.githubusercontent.com/CoatiSoftware/SourcetrailBugTracker/master/README.md'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.