### PR TITLE
Update wifispoof to 3.3.2

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,6 +1,6 @@
 cask 'wifispoof' do
-  version '3.3.1'
-  sha256 'c042c6aa19cd3afdda2276183581cff90572f85b606a3effa38b474b184e8ce1'
+  version '3.3.2'
+  sha256 'c4c4f35686f42a45526fc4e6db5a7ddd693f2849b1c19c4239fa9ebb3db89117'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.