### PR TITLE
espresso 5.2 (correct sha256)

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,6 +1,6 @@
 cask 'espresso' do
   version '5.2.0'
-  sha256 '133d970a329dd440ccc607e6e2779cf48ddaddeefcc7b53a5047c89f0d2aac3a'
+  sha256 '062e7fafb547501cc44d92307f8350eafd46228a36ed362a9d8e8562151589ff'
 
   url "https://espressoapp.com/updates/archives/Espresso-#{version}.zip"
   appcast 'https://espressoapp.com/updates/'


### PR DESCRIPTION


> $ brew cask fetch espresso
> ==> Downloading external files for Cask espresso
> ==> Downloading https://espressoapp.com/updates/archives/Espresso-5.2.0.zip
> ######################################################################## 100.0%
> ==> Verifying checksum for Cask espresso
> ==> Note: running "brew update" may fix sha256 checksum errors
> Error: Checksum for Cask 'espresso' does not match.
> Expected: 133d970a329dd440ccc607e6e2779cf48ddaddeefcc7b53a5047c89f0d2aac3a
> Actual:   062e7fafb547501cc44d92307f8350eafd46228a36ed362a9d8e8562151589ff

