### PR TITLE
Fix error with space in file path (cask box-drive, currently on commit 424615a02e3f5442c6fb36665f4adeea4f36a8bb)

### DIFF
--- a/Casks/box-drive.rb
+++ b/Casks/box-drive.rb
@@ -13,7 +13,7 @@ cask 'box-drive' do
 
   uninstall pkgutil:   'com.box.desktop.installer.*',
             launchctl: 'com.box.desktop.*',
-            script:    '/Library/Application\ Support/Box/uninstall_box_drive',
+            script:    '/Library/Application Support/Box/uninstall_box_drive',
             quit:      [
                          'com.box.Box-Local-Com-Server',
                          'com.box.desktop',

--- a/Casks/box-drive.rb
+++ b/Casks/box-drive.rb
@@ -13,7 +13,7 @@ cask 'box-drive' do
 
   uninstall pkgutil:   'com.box.desktop.installer.*',
             launchctl: 'com.box.desktop.*',
-            script:    '/Library/Application Support/Box/uninstall_box_drive',
+            script:    '/Library/Application\ Support/Box/uninstall_box_drive',
             quit:      [
                          'com.box.Box-Local-Com-Server',
                          'com.box.desktop',
@@ -23,7 +23,7 @@ cask 'box-drive' do
                        ]
 
   zap trash: [
-               '~/Library/Application Support/Box/Box',
+               '~/Library/Application\ Support/Box/Box',
                '~/Library/Logs/Box/Box',
                '~/Library/Containers/com.box.desktop.findersyncext',
              ]


### PR DESCRIPTION
brew cask remove box-drive is currently broken due to broken path. This should fix it

(Since this is such a minor fix for something that's already broken, I haven't run local tests)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
