### PR TITLE
Update aquaskk to 4.6.1

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,6 +1,6 @@
 cask 'aquaskk' do
-  version '4.6.0'
-  sha256 '58ae310d88f3ad37140ca00d09b4d4c921f43f7d2c54608ca4b422151ba31e58'
+  version '4.6.1'
+  sha256 '13b3470dee548cea3cd5431551edaf8f1a1b6bc1eff948b530d11aad584dcf58'
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.pkg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.