### PR TITLE
Update macs-fan-control to 1.4.11

### DIFF
--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -1,9 +1,10 @@
 cask 'macs-fan-control' do
-  version '1.4.10'
-  sha256 'c07d71e1b3660c508f0f03f91be2fec0bf81efb2e680114478d16bb90c3039eb'
+  version '1.4.11'
+  sha256 'ad5fb8bd6e17180b90491c121681c7905e673b76399f6ba1c38c23a2c3214e7b'
 
-  url 'https://www.crystalidea.com/downloads/macsfancontrol.zip'
-  appcast 'https://www.crystalidea.com/macs-fan-control/release-notes'
+  # github.com/crystalidea/macs-fan-control was verified as official when first introduced to the cask
+  url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version}/macsfancontrol.zip"
+  appcast 'https://github.com/crystalidea/macs-fan-control/releases.atom'
   name 'Macs Fan Control'
   homepage 'https://www.crystalidea.com/macs-fan-control'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.