### PR TITLE
Remove unneeded URL fix.

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -2,7 +2,7 @@ cask 'intel-power-gadget' do
   version '3.5.3,655065'
   sha256 'a148715a956f1049a81a420244c919cf6f1678bbece9f79a42167c5485e83ded'
 
-  url "https://software.intel.com/file/#{version.after_comma}/download?#.dmg"
+  url "https://software.intel.com/file/#{version.after_comma}/download"
   name 'Intel Power Gadget'
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
 


### PR DESCRIPTION
This is no longer needed with https://github.com/Homebrew/brew/pull/4662.