### PR TITLE
Update gramps to 5.0.0-2

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,6 +1,6 @@
 cask 'gramps' do
-  version '4.2.8-1'
-  sha256 '0dcb09ec5d40c9e42b26223a30d74d57450572ececad8cb25a3d4ee8e1a3f80a'
+  version '5.0.0-2'
+  sha256 '6a1c66361108b9a82d13138c440a518a34af105e336c7ef0c3716b36a53758ac'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.