### PR TITLE
Update vox to 3.3.2

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,6 +1,6 @@
 cask 'vox' do
-  version '3.3.1'
-  sha256 '9217769f35c36ee4873639ffe664b832040f6069c0ee8ea0b7e236138b23ee2c'
+  version '3.3.2'
+  sha256 'd07942089a2c616f80a845954a7daf4257d6d83eba59906f58c93871588afa22'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.