### PR TITLE
Update picat to 2.4#8

### DIFF
--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,8 +1,8 @@
 cask 'picat' do
-  version '2.4'
+  version '2.4#8'
   sha256 'f8f6efc24ec8a39e528679b3ad2ef1e509e4c81fe776488f0b952cb5b7030783'
 
-  url "http://picat-lang.org/download/picat#{version.no_dots}_macx.tar.gz"
+  url "http://picat-lang.org/download/picat#{version.split('#').first.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt'
   name 'Picat'
   homepage 'http://www.picat-lang.org/'

--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,8 +1,8 @@
 cask 'picat' do
-  version '2.4#8'
+  version '2.4.8'
   sha256 'f8f6efc24ec8a39e528679b3ad2ef1e509e4c81fe776488f0b952cb5b7030783'
 
-  url "http://picat-lang.org/download/picat#{version.split('#').first.no_dots}_macx.tar.gz"
+  url "http://picat-lang.org/download/picat#{version.major_minor.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt'
   name 'Picat'
   homepage 'http://www.picat-lang.org/'

--- a/Casks/picat.rb
+++ b/Casks/picat.rb
@@ -1,6 +1,6 @@
 cask 'picat' do
   version '2.4'
-  sha256 '6b9233145122984873511416bc69bea952ee74ba274e1fe1d0ec946c453f8f9f'
+  sha256 'f8f6efc24ec8a39e528679b3ad2ef1e509e4c81fe776488f0b952cb5b7030783'
 
   url "http://picat-lang.org/download/picat#{version.no_dots}_macx.tar.gz"
   appcast 'http://picat-lang.org/updates.txt'


### PR DESCRIPTION
Release version 2.4#8, August 16, 2018.
audit for picat: passed

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses. (Failed to install/update the 'rubocop-cask' gem.)
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
