### PR TITLE
Updated version of "phocus" to 3.3.6

### DIFF
--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -1,8 +1,8 @@
 cask 'phocus' do
-  version '3.1.5'
-  sha256 'ac51c94f95b8aec3d64daf94b259a1f926ba64aba82ddd7d047ddc32b72dea92'
+  version '3.3.6'
+  sha256 '1bed922bae1e0bf9da2d24b17af026566f5c58b5d3c8d596929176d87c46c610'
 
-  url "http://static.hasselblad.com/2017/04/Phocus-#{version}.dmg"
+  url "http://static.hasselblad.com/2018/05/Phocus-#{version}.dmg"
   name 'Hasselblad Phocus'
   homepage 'https://www.hasselblad.com/software/phocus'
 

--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -1,8 +1,8 @@
 cask 'phocus' do
-  version '3.3.6'
+  version '3.3.6,2018.05'
   sha256 '1bed922bae1e0bf9da2d24b17af026566f5c58b5d3c8d596929176d87c46c610'
 
-  url "http://static.hasselblad.com/2018/05/Phocus-#{version}.dmg"
+  url "http://static.hasselblad.com/#{version.after_comma.dots_to_slashes}/Phocus-#{version.before_comma}.dmg"
   name 'Hasselblad Phocus'
   homepage 'https://www.hasselblad.com/software/phocus'
 


### PR DESCRIPTION
Note : the path to the .dmg changes according to the date of publication of the update (2017/04 -> 2018/05).

After making all changes to the cask:

- [x] `brew cask audit --download phocus.rb` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
