### PR TITLE
not_a_discoverability_service.md: remove ranking example

### DIFF
--- a/doc/faq/not_a_discoverability_service.md
+++ b/doc/faq/not_a_discoverability_service.md
@@ -1,11 +1,10 @@
 # Homebrew-Cask is not a discoverability service
 
-Ever since the inception of Homebrew-Cask, various requests fell under the umbrella of this reply. Though a somewhat popular request, after careful consideration on multiple occasions we’ve always come back to the same conclusion: we’re not a discoverability service and our users are expected to have reasonable knowledge about the apps they’re installing through us before doing so.
+From the inception of Homebrew-Cask, various requests fell under the umbrella of this reply. Though a somewhat popular request, after careful consideration on multiple occasions we’ve always come back to the same conclusion: we’re not a discoverability service and our users are expected to have reasonable knowledge about the apps they’re installing through us before doing so.
 
 Examples of requests under this same theme:
 
 + [Separate by categories](https://github.com/Homebrew/homebrew-cask/issues/5425).
-+ [Rank by popularity](https://github.com/Homebrew/homebrew-cask/issues/4323).
 + [Add descriptions](https://github.com/Homebrew/homebrew-cask/issues/16089).
 
 Amongst other things, the logistics of such requests are unsustainable for Homebrew-Cask. Before making a request of this nature, you must read through those issues, as well as any other issues they link to, to get a full understanding of why that is the case, and why “but project *x* does *y*” arguments aren’t applicable, and not every package manager is the same.


### PR DESCRIPTION
We’ve implemented statistics, so this example is no longer applicable.