### PR TITLE
Update deeper to 2.3.2

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -23,8 +23,8 @@ cask 'deeper' do
     version '2.2.3'
     sha256 '33fee21b65279e4459b6469dbc68f0c6df91663ed26d6b62042b21883efda0ed'
   else
-    version '2.3.1'
-    sha256 'afbc4ac3362fea2f7f08e66320daa6be4d66d73201af06073fe32c938e585f74'
+    version '2.3.2'
+    sha256 '0210a8e6342fd7aee7cd606c46bbd1ce02271745a26557871fe3216494a73fdb'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.