### PR TITLE
update ticktick to 2.7.00,75

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.6.50,74'
-  sha256 '7e920331e19b2b902c6d8581fa9eb11ad1da08d87a9b61d4fd0f0eabe4eaccdb'
+  version '2.7.00,75'
+  sha256 '4f1ccb373b2fab3b9804232b832ee1b8810d61b2d78459b56bb02805483b51d9'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
