### PR TITLE
Add Casks for PROS

### DIFF
--- a/Casks/pros-editor.rb
+++ b/Casks/pros-editor.rb
@@ -1,0 +1,27 @@
+cask 'pros-editor' do
+  version '1.30.0'
+  sha256 'dcc9764c1a3ab3f1c6ac0b9482b09d4f23ebf67e7fc5191ff3c3cb3a7290e29c'
+
+  # github.com/purduesigbots/atom was verified as official when first introduced to the cask
+  url "https://github.com/purduesigbots/atom/releases/download/v#{version}/pros-editor-mac.zip"
+  appcast 'https://github.com/purduesigbots/atom/releases.atom'
+  name 'PROS Editor'
+  homepage 'https://pros.cs.purdue.edu/'
+
+  depends_on cask: 'pros'
+  depends_on formula: 'cquery'
+
+  app 'PROS Editor.app'
+  binary "#{appdir}/PROS Editor.app/Contents/Resources/app/apm/bin/apm", target: 'pros-apm'
+  binary "#{appdir}/PROS Editor.app/Contents/Resources/app/atom.sh", target: 'pros-editor'
+
+  zap trash: [
+               '~/.pros-editor',
+               '~/Library/Application Support/PROS',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/edu.purdue.cs.pros.ide.sfl*',
+               '~/Library/Caches/edu.purdue.cs.pros.ide',
+               '~/Library/Preferences/edu.purdue.cs.pros.ide.helper.plist',
+               '~/Library/Preferences/edu.purdue.cs.pros.ide.plist',
+               '~/Library/Saved Application State/edu.purdue.cs.pros.ide.savedState',
+             ]
+end

--- a/Casks/pros.rb
+++ b/Casks/pros.rb
@@ -1,0 +1,18 @@
+cask 'pros' do
+  version '3.1.0'
+  sha256 '0f3394afa80e8975213c1a109ab99e1785a07b4dda568c9926439ae3d8738643'
+
+  # github.com/purduesigbots/pros-cli was verified as official when first introduced to the cask
+  url "https://github.com/purduesigbots/pros-cli3/releases/download/#{version}/pros-cli-mac.zip"
+  appcast 'https://github.com/purduesigbots/pros-cli3/releases.atom'
+  name 'PROS CLI'
+  homepage 'https://pros.cs.purdue.edu'
+
+  depends_on formula: 'openssl'
+  depends_on cask: 'gcc-arm-embedded'
+
+  app 'PROS CLI.app'
+  binary "#{appdir}/PROS CLI.app/Contents/MacOS/prosv5"
+  binary "#{appdir}/PROS CLI.app/Contents/MacOS/intercept-c++"
+  binary "#{appdir}/PROS CLI.app/Contents/MacOS/intercept-cc"
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


Hey there, I'm one of the developers for the [PROS ecosystem](https://pros.cs.purdue.edu), and we'd like to move our main distribution method for MacOS to homebrew/homebrew cask. I'm not sure whether I'm supposed to add two casks at once, but they're very closely related to one another (the editor depends on the CLI), so I figured it would be better to add them both here instead of opening two PRs at once. Thanks for your consideration.

Note: one of the casks is called the PROS CLI, but due to various reasons, we distribute it as a .app bundle