### PR TITLE
Update superduper to 3.1.7,112

### DIFF
--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -1,9 +1,10 @@
 cask 'superduper' do
-  version :latest
-  sha256 :no_check
+  version '3.1.7,112'
+  sha256 '62861de305bac5fe9f123619d7cd5ec0251f018d296ec1e0f6a13c4f68bc3be9'
 
   # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'
+  appcast 'https://versioncheck.blacey.com/superduper/version.xml?VSN=100'
   name 'SuperDuper!'
   homepage 'http://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.