### PR TITLE
Update android-platform-tools to 28.0.1

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,6 +1,6 @@
 cask 'android-platform-tools' do
-  version '28.0.0'
-  sha256 '1d5ecc7370b3423ce428ae14e295dc2480f548f4a861b6770ee7835ad98c3d92'
+  version '28.0.1'
+  sha256 '3bc833ae3f4bd831af03811f2d1be540c2eb2eb9a17de9398b0a06dc5af6fa84'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.