### PR TITLE
Update telegram to 4.3.2-138752

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.3.1-138345'
-  sha256 '3d8793b5acf995b4016b1714efb18b9ebfbf822cbf1ca42f056cda989a536f8f'
+  version '4.3.2-138752'
+  sha256 '726d18a191b73fe1ba2e31d8a7a4f6e32baf4cf0a3e67f650c49f1a7fe7835a8'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.