### PR TITLE
Update mailbutler to 2.1.3-9666

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2.1.2-9650'
-  sha256 'cb4f1dc6612710f634df118b2eb054c1369e74d0a52814908e2efd9f3450bcfc'
+  version '2.1.3-9666'
+  sha256 '53ea2df680b7e258d6e8caa37a1658b5480aecfa5d1ed1a3bef5319fdb519b17'
 
   # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-data.s3.amazonaws.com/downloads/Mailbutler_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.