### PR TITLE
Update epichrome to 2.2.2

### DIFF
--- a/Casks/epichrome.rb
+++ b/Casks/epichrome.rb
@@ -1,6 +1,6 @@
 cask 'epichrome' do
-  version '2.1.20'
-  sha256 'c2853e73d9b13ed59ee16a478e3e8ad7e27e1ebb8f18e03984a72e04830f6dfe'
+  version '2.2.2'
+  sha256 '320049b7f30ad02530e41dc870032dc45d67e1242422851a748451c792da0330'
 
   url "https://github.com/dmarmor/epichrome/releases/download/v#{version}/epichrome-#{version}.dmg"
   appcast 'https://github.com/dmarmor/epichrome/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.