### PR TITLE
Update freesmug-chromium to 68.0.3440.106

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '68.0.3440.84'
-  sha256 '7a4a27a52c12a1fe6b88193d0af1a1235262016b219ac9389db738eabbfb6bff'
+  version '68.0.3440.106'
+  sha256 '317d25d3896075b6d39330f9839e0eb986a0b0884996e39b5f316b5dc532f43f'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.