### PR TITLE
Update 1password to 7.1.1

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -2,7 +2,6 @@ cask '1password' do
   version '7.1.1'
   sha256 'ff60d1caf4a6ceb68e5ac90af76d558f8e2f4368606fef79027aa91fef479c98'
 
-  # 1password.com was verified as official when first introduced to the cask
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Ref: https://github.com/Homebrew/homebrew-cask-versions/pull/6197#issuecomment-418545426