### PR TITLE
Update joshaven-winbox to 3.11

### DIFF
--- a/Casks/joshaven-winbox.rb
+++ b/Casks/joshaven-winbox.rb
@@ -1,8 +1,8 @@
 cask 'joshaven-winbox' do
   version '3.11'
-  sha256 'a2fc14d3eec133df7638f1e0697bacc7a80a5dbf90ea80be935512f9ed673d6d'
+  sha256 'cfed9f359ca2b565879d83d922768ed64e4549391757186317b15729c447142c'
 
-  url "http://joshaven.com/Winbox4Mac_#{version}.dmg"
+  url "http://joshaven.com/Winbox4Mac_#{version}_FixHS.dmg"
   appcast 'http://joshaven.com/resources/tools/winbox-for-mac/'
   name 'Winbox4Mac'
   homepage 'http://joshaven.com/resources/tools/winbox-for-mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #51614.