### PR TITLE
Update adapter to 2.1.6

### DIFF
--- a/Casks/adapter.rb
+++ b/Casks/adapter.rb
@@ -2,7 +2,7 @@ cask 'adapter' do
   version '2.1.6'
   sha256 'ef2de9f0795cd446d26a4de1180b2580402abe8e5f13368e42d8da39eadde729'
 
-  url "http://downloads.macroplant.com/Adapter-#{version}.dmg"
+  url "https://assets.macroplant.com/download/4/Adapter-#{version}.dmg"
   appcast "https://macroplant.com/adapter/mac/v#{version.major}/appcast"
   name 'Adapter'
   homepage 'https://macroplant.com/adapter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/issues/51631