### PR TITLE
Update joplin to 1.0.105

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.104'
-  sha256 '018e1b3ba4bb66de0a2550f3c9c16c7dbccce551820fa32133fb3054b7423011'
+  version '1.0.105'
+  sha256 '2d2691728ed4a05287e6c67d87935cd9fc444062497d253a3ed77db114cf9f7d'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.