### PR TITLE
Add Send Anywhere v8.7.19

### DIFF
--- a/Casks/send-anywhere.rb
+++ b/Casks/send-anywhere.rb
@@ -1,0 +1,10 @@
+cask 'send-anywhere' do
+  version '8.7.19'
+  sha256 'fdc06913486b2aed22da3ce56c1de5fd2be2dc07da6592487e3fcd05c464ab31'
+
+  url 'https://update.send-anywhere.com/osx_downloads/Send%20Anywhere.dmg'
+  name 'Send Anywhere'
+  homepage 'https://send-anywhere.com/'
+
+  app 'Send Anywhere.app'
+end

--- a/Casks/send-anywhere.rb
+++ b/Casks/send-anywhere.rb
@@ -1,6 +1,6 @@
 cask 'send-anywhere' do
-  version '8.7.19'
-  sha256 'fdc06913486b2aed22da3ce56c1de5fd2be2dc07da6592487e3fcd05c464ab31'
+  version :latest
+  sha256 :no_check
 
   url 'https://update.send-anywhere.com/osx_downloads/Send%20Anywhere.dmg'
   name 'Send Anywhere'


### PR DESCRIPTION
Adding Send Anywhere to casks since MAS version is outdated. (available on MAS is v8.4.24)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
