### PR TITLE
Update macupdater to 1.3.3

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.3.2'
-  sha256 '2b658fcb888c8f4ddeacf0760b15a4d2255a17e781f66c9a6f887722652f668b'
+  version '1.3.3'
+  sha256 '4317af2befeddedb2ed5164842a3ae1722513d2a91e9af023cc255d5d97e1e62'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'

--- a/Casks/yasu.rb
+++ b/Casks/yasu.rb
@@ -1,7 +1,7 @@
 cask 'yasu' do
   if MacOS.version <= :el_capitan
-    version '3.0.4,504'
-    sha256 'f1bd1e48a2ff0e9839f4b21c651e89a4e18d8aa85a9b9fa8642f333ef5b0053b'
+    version '3.0.9,509'
+    sha256 'bc7716b2852cdbdc02aca085b5fa70cbf5a0983ed5ff1f489de0a86348527a0e'
     url "https://yasuformac.com/appcasts/10.11/yasuformac_#{version.after_comma}.zip",
         user_agent: :fake
     appcast 'https://yasuformac.com/appcasts/10.11/yasu.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.