### PR TITLE
Update plex-media-player to 2.18.0.893-48795f25

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.17.0.890-7d18e33d'
-  sha256 '962ef5680f4b3fe759ded974d5f9d0cdcf1d34a3d75a6fd50f0e5439c899087b'
+  version '2.18.0.893-48795f25'
+  sha256 'f91407ce47501a01d0d70cc8491ef09f56b2cd3996d12a6a59b50d920dfa9750'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.