### PR TITLE
Update visual-studio-code to 1.27.1,5944e81f3c46a3938a82c701f96d7a59b074cfdc

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code' do
-  version '1.27.0,7b9afc4196bda60b0facdf62cfc02815509b23d6'
-  sha256 'ff417c70b2bd47dd2309f73508d3b0a370967857a3faf9429d107c0677756a7a'
+  version '1.27.1,5944e81f3c46a3938a82c701f96d7a59b074cfdc'
+  sha256 'a6be0defb39730054066e102f5b007dcbb792a7abf134cc7879ec8d1fe48a841'
 
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.