### PR TITLE
Update nvivo to 12.1.0.3068

### DIFF
--- a/Casks/nvivo.rb
+++ b/Casks/nvivo.rb
@@ -1,6 +1,6 @@
 cask 'nvivo' do
   version '12.1.0.3068'
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 'd0d61187f387e2a7ae6bac523673137bd2ef91624067cbe9d0355d5de2a622d7'
 
   url "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/#{version}/NVivo%20#{version.major}.dmg"
   appcast "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/appcast.xml"

--- a/Casks/nvivo.rb
+++ b/Casks/nvivo.rb
@@ -1,12 +1,13 @@
 cask 'nvivo' do
-  version '11'
+  version '12.1.0.3068'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "http://download.qsrinternational.com/Software/NVivo#{version}forMac/NVivo.dmg"
+  url "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/#{version}/NVivo%20#{version.major}.dmg"
+  appcast "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/appcast.xml"
   name 'NVivo'
   homepage 'http://www.qsrinternational.com/'
 
-  app 'NVivo.app'
+  app "NVivo #{version.major}.app"
 
   zap trash: [
                '~/Library/Caches/com.qsrinternational.NVivo',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.