### PR TITLE
Update istumbler to 103.36

### DIFF
--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -8,8 +8,8 @@ cask 'istumbler' do
     sha256 '71f6a6b0e255a853664ed4900835a42f2d23dcb05de35acfb3ac2ec1c5fb2edc'
     url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   else
-    version '103.4'
-    sha256 'cbff32e79e2d98a860c9ca04e67b6918987edb5063693f47c4071887aed87658'
+    version '103.36'
+    sha256 '347d6a871cd995a394c4934d05fdf2ed802b28caf7b77ad1f229ac1a4e8cf893'
     url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.