### PR TITLE
Update freesmug-chromium to 69.0.3497.81

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '68.0.3440.106'
-  sha256 '317d25d3896075b6d39330f9839e0eb986a0b0884996e39b5f316b5dc532f43f'
+  version '69.0.3497.81'
+  sha256 '44d9c03110cf642ac26b3c3e1ad0263c208c764fb4e1346af7522f302498aaac'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.