### PR TITLE
restore stable netnewswire and rename new netnewswire

### DIFF
--- a/Casks/netnewswire-evergreen.rb
+++ b/Casks/netnewswire-evergreen.rb
@@ -1,0 +1,14 @@
+cask 'netnewswire-evergreen' do
+  version '5.0d3'
+  sha256 'b0ae90ac9a3e2f01856ed8679aa1fb10993c48d62b59c6230be381a350667702'
+
+  url "https://ranchero.com/downloads/NetNewsWire#{version}.zip"
+  appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'
+  name 'NetNetsWire'
+  homepage 'https://ranchero.com/netnewswire/'
+
+  auto_updates true
+  depends_on macos: '>= :high_sierra'
+
+  app 'NetNewsWire.app'
+end

--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,14 +1,16 @@
 cask 'netnewswire' do
-  version '5.0d3'
-  sha256 'b0ae90ac9a3e2f01856ed8679aa1fb10993c48d62b59c6230be381a350667702'
+  version '4.1.0-546'
+  sha256 '5198e5f52fa1fc7a951212760e17cefae14fe6b4e8aaf291c5c0818a14df8fb7'
 
-  url "https://ranchero.com/downloads/NetNewsWire#{version}.zip"
-  appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'
-  name 'NetNetsWire'
-  homepage 'https://ranchero.com/netnewswire/'
-
-  auto_updates true
-  depends_on macos: '>= :high_sierra'
+  url "https://cdn.netnewswireapp.com/releases/NetNewsWire-#{version}.zip"
+  appcast 'https://updates.blackpixel.com/updates?app=nnw'
+  name 'NetNewsWire'
+  homepage 'http://netnewswireapp.com/'
 
   app 'NetNewsWire.app'
+
+  zap trash: [
+               '~/Library/Application Scripts/com.blackpixel.netnewswire',
+               '~/Library/Containers/com.blackpixel.netnewswire',
+             ]
 end


### PR DESCRIPTION
i am trying to fix the situation created by '#51690'

i didn't realize that a cask named 'netnewswire' already existed in the repository. therefore a cask for a stable product has been overwritten with a cask for an alpha version of an upcoming new project.

this pull request restores the netnewswire cask to the state is was before #51690 and renames the new cask for netnewswire/evergreen to netnewswire-evergreen