### PR TITLE
token_reference.md: misleading tokens

### DIFF
--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -137,12 +137,18 @@ Cask taps have naming conventions specific to each tap.
 
 [Homebrew/cask-eid](https://github.com/Homebrew/homebrew-cask-eid/blob/master/CONTRIBUTING.md#naming-eid-casks)
 
-# Token Overlap
+# Special Affixes
 
-## With another Cask
+A few situations require a prefix or suffix to be added to the token.
+
+## Token Overlap With Another Cask
 
 When the token for a new Cask would otherwise conflict with the token of an already existing Cask, the nature of that overlap dictates the token (for possibly both Casks). See [Forks and Apps with Conflicting Names](../development/adding_a_cask.md#forks-and-apps-with-conflicting-names) for information on how to proceed.
 
-## With a formula
+## Token Overlap With a Formula
 
 If a Homebrew formula and a Homebrew-Cask cask both exist with the same token and they both refer to the same app — respectively a CLI and a GUI — and the GUI app is simply a wrapper of the CLI tool but has been decided to provide enough value to warrant the inclusion of both the formula and the cask, the cask will have the `-app` suffix. This is the only instance where an `-app` suffix is allowed, precisely so the “why” is clear when you know the rule.
+
+## Potentially Misleading Name
+
+If the token for a piece of unofficial software that interacts with a popular service would make it look official and the vendor is not authorised to use the name, [a prefix must be added](../development/adding_a_cask.md#forks-and-apps-with-conflicting-names) for disambiguation.


### PR DESCRIPTION
PR that prompted the rule: https://github.com/Homebrew/homebrew-cask/pull/51702.