### PR TITLE
Update mediathekview to 13.2.1

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,6 +1,6 @@
 cask 'mediathekview' do
-  version '13.2.0'
-  sha256 '0f2eea2cd6ae188c16ecebe220e372cb27ed2e1e5307c447e9f1d1b060296155'
+  version '13.2.1'
+  sha256 'a32240691662b1e56c5a4e1adf3c67e48352f66c25321acf3980b9fbd6b8f80a'
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}.dmg"
   appcast 'https://mediathekview.de/changelog/index.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.