### PR TITLE
Add shadowsocksx-ng-r.app v1.4.3-R8-build3

### DIFF
--- a/Casks/shadowsocksx-ng-r.rb
+++ b/Casks/shadowsocksx-ng-r.rb
@@ -12,6 +12,10 @@ cask 'shadowsocksx-ng-r' do
 
   app 'ShadowsocksX-NG-R8.app'
 
+  postflight do
+    system_command "#{appdir}/ShadowsocksX-NG-R8.app/Contents/Resources/install_helper.sh"
+  end
+
   uninstall delete:    '/Library/Application Support/ShadowsocksX-NG',
             launchctl: [
                          'com.qiuyuzhou.shadowsocksX-NG.http',

--- a/Casks/shadowsocksx-ng-r.rb
+++ b/Casks/shadowsocksx-ng-r.rb
@@ -2,7 +2,7 @@ cask 'shadowsocksx-ng-r' do
   version '1.4.3-R8-build3'
   sha256 'f0f85355b7447d21105cf22f0d5f80a08c4d81841d7d45bfdc6090cd01a9f013'
 
-  url 'https://github.com/qinyuhang/ShadowsocksX-NG-R/releases/download/1.4.3-R8-build3/ShadowsocksX-NG-R8.dmg'
+  url "https://github.com/qinyuhang/ShadowsocksX-NG-R/releases/download/#{version}/ShadowsocksX-NG-R8.dmg"
   appcast 'https://github.com/qinyuhang/ShadowsocksX-NG-R/releases.atom'
   name 'ShadowsocksX-NG-R'
   homepage 'https://github.com/qinyuhang/ShadowsocksX-NG-R/'

--- a/Casks/shadowsocksx-ng-r.rb
+++ b/Casks/shadowsocksx-ng-r.rb
@@ -5,7 +5,6 @@ cask 'shadowsocksx-ng-r' do
   url 'https://github.com/qinyuhang/ShadowsocksX-NG-R/releases/download/1.4.3-R8-build3/ShadowsocksX-NG-R8.dmg'
   appcast 'https://github.com/qinyuhang/ShadowsocksX-NG-R/releases.atom'
   name 'ShadowsocksX-NG-R'
-  name 'ShadowsocksX-NG-R8'
   homepage 'https://github.com/qinyuhang/ShadowsocksX-NG-R/'
 
   conflicts_with cask: 'shadowsocksx'
@@ -30,7 +29,6 @@ cask 'shadowsocksx-ng-r' do
                '~/.ShadowsocksX-NG',
                '~/Library/Application Support/ShadowsocksX-NG',
                '~/Library/Caches/com.qiuyuzhou.ShadowsocksX-NG',
-
                '~/Library/Preferences/com.qiuyuzhou.ShadowsocksX-NG.plist',
              ]
 end

--- a/Casks/shadowsocksx-ng-r.rb
+++ b/Casks/shadowsocksx-ng-r.rb
@@ -1,0 +1,36 @@
+cask 'shadowsocksx-ng-r' do
+  version '1.4.3-R8-build3'
+  sha256 'f0f85355b7447d21105cf22f0d5f80a08c4d81841d7d45bfdc6090cd01a9f013'
+
+  url 'https://github.com/qinyuhang/ShadowsocksX-NG-R/releases/download/1.4.3-R8-build3/ShadowsocksX-NG-R8.dmg'
+  appcast 'https://github.com/qinyuhang/ShadowsocksX-NG-R/releases.atom'
+  name 'ShadowsocksX-NG-R'
+  name 'ShadowsocksX-NG-R8'
+  homepage 'https://github.com/qinyuhang/ShadowsocksX-NG-R/'
+
+  conflicts_with cask: 'shadowsocksx'
+  depends_on macos: '>= :el_capitan'
+
+  app 'ShadowsocksX-NG-R8.app'
+
+  uninstall delete:    '/Library/Application Support/ShadowsocksX-NG',
+            launchctl: [
+                         'com.qiuyuzhou.shadowsocksX-NG.http',
+                         'com.qiuyuzhou.shadowsocksX-NG.kcptun',
+                         'com.qiuyuzhou.shadowsocksX-NG.local',
+                         'com.qiuyuzhou.ShadowsocksX-NG.LaunchHelper',
+                       ],
+            quit:      'com.qiuyuzhou.ShadowsocksX-NG',
+            script:    {
+                         executable: '/Library/Application Support/ShadowsocksX-NG/proxy_conf_helper',
+                         args:       ['--mode', 'off'],
+                       }
+
+  zap trash: [
+               '~/.ShadowsocksX-NG',
+               '~/Library/Application Support/ShadowsocksX-NG',
+               '~/Library/Caches/com.qiuyuzhou.ShadowsocksX-NG',
+
+               '~/Library/Preferences/com.qiuyuzhou.ShadowsocksX-NG.plist',
+             ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

> It’s a repo with no code (they’re only taking advantage of the free binary hosting) that only states in the README “Remove due to regulation” (whatever that means).
> It only delivers pre-releases,
> and it’s a fork of more popular software that has been updated more recently.

The cask was already refused and locked at #45068. But here're the reasons to bring it back:

1. It's a repo with code under [`develop`](https://github.com/qinyuhang/ShadowsocksX-NG-R/tree/develop) branch.
2. [Shadowsocks](https://github.com/shadowsocks/shadowsocks-iOS) / [ShadowsocksX-NG](https://github.com/shadowsocks/ShadowsocksX-NG) are clients under [Shadowsocks](https://en.wikipedia.org/wiki/Shadowsocks) protocol (aka SS). The [ShadowsocksX-NG-R](https://github.com/qinyuhang/ShadowsocksX-NG-R) however, though being "a fork of more popular software that has been updated more recently", yet was developed with [ShadowsocksR](https://en.wikipedia.org/wiki/Shadowsocks#ShadowsocksR) (aka SSR), a fork of the original protocol that claimed to be superior in terms of security (by adding obfuscation) and stability. The SSR protocol and ShadowsocksX-NG-R software are both widely used in the wild as far as I know.
3. As I stated before, though this artifact was tagged as `Pre-release`, it is in broadly use and expected to have fewer updates lately. That's also the reason to commit it into `homebrew-cask` instead of `homebrew-cask-versions` since this version of release was "fixed" somehow.

Please take a look again. @vitorgalvao