### PR TITLE
Update blockstack to 0.33.2

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.33.0'
-  sha256 'ab369911658f74c003e52c22f07fda4efbbd97bf93b8bd5aad1e5e2590a115f8'
+  version '0.33.2'
+  sha256 'f73c494fd2e32bb9860389713d45e6b998e6a52a14dee1464935c5ec4bfe1aba'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.