### PR TITLE
Update penc to 0.4.1

### DIFF
--- a/Casks/penc.rb
+++ b/Casks/penc.rb
@@ -1,6 +1,6 @@
 cask 'penc' do
-  version '0.3.3'
-  sha256 '800a9a07e4c998b631b3da776add8b4bb93bcac64974190d328d0fdcb81ecd7f'
+  version '0.4.1'
+  sha256 '89c4b239189e13993a0d5189e7eafdc9652dde41fe2edaea4746abb779e3c014'
 
   # github.com/dgurkaynak/Penc was verified as official when first introduced to the cask
   url "https://github.com/dgurkaynak/Penc/releases/download/#{version}/Penc-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.