### PR TITLE
Update geogebra to 6.0.489.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,12 +1,12 @@
 cask 'geogebra' do
-  version '6.0.392.0'
-  sha256 'cd8fc070d530dd515eb7ee793ba74a8027adbb60299ef51c23d8107efd914238'
+  version '6.0.489.0'
+  sha256 'fedacb89082315bedb32f7d4c667e95e57c38c6389e9c69422afddd8ffe42db5'
 
-  url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-MacOS-Portable-#{version.dots_to_hyphens}.pkg"
+  url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   name 'GeoGebra'
   homepage 'https://www.geogebra.org/'
 
-  pkg "GeoGebra-MacOS-Portable-#{version.dots_to_hyphens}.pkg"
+  app "GeoGebra Classic #{version.major}.app"
 
   uninstall quit:       'org.geogebra.mathapps',
             login_item: 'GeoGebra',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.