### PR TITLE
Update postman to 6.3.0

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,6 +1,6 @@
 cask 'postman' do
-  version '6.2.5'
-  sha256 '3577f13e026aa766de354e9565a3113453aedd38d65ee352400d6dbc1e8e5105'
+  version '6.3.0'
+  sha256 '40cf40545ce587f736b5debe9dd046825fdfd31823430de661ec81136190b6c0'
 
   # dl.pstmn.io/download/version was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.