### PR TITLE
Update mudlet to 3.13.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '3.12.0'
-  sha256 '85274634936ce7c6443f0ef383294b9411046f64606595c13344fbc8c8bd9ebf'
+  version '3.13.0'
+  sha256 '9fc649f1de218c844bcdc8765bda55eb4a93265a7d8348095661a88b75694603'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.