### PR TITLE
Update vuescan to 9.6.15

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.6.14'
-  sha256 'b50332c09ee0f1f2de54f54a90cde0ada1d00b3da8139801f815d3a45d9d5130'
+  version '9.6.15'
+  sha256 '13e09b319ce57f70d8dd14ca082cf1d5bc9444c73579f284e015b76ff12446ac'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/old-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.