### PR TITLE
Update activedock to 176,1536031893

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '152,1534506339'
-  sha256 'cfbca91c29574fbd99ae06b96a9a1ae56e53109e9932e4971dceafcad91107af'
+  version '176,1536031893'
+  sha256 'ae6f8d070c44b5db84a0df608c5852a59f4d307364470247ee0bbf27bbf1a2e1'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.