### PR TITLE
Update ableton-live-standard to 10.0.3

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard' do
-  version '10.0.2'
-  sha256 'a91ccd50a0c0b5712d8672cd31da9710f54d9a1b64c6bb2d3ea29709e178d272'
+  version '10.0.3'
+  sha256 '4d14b7139582a7c63e85a42bddd1eec04de03c8cb122f9ab6d37daf6e2e06978'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.