### PR TITLE
Update navicat-for-sqlite to 12.1.7

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.6'
-  sha256 '87c30374a9c38b014a65d47c983bb6d045b0a1acb2c696010da17eabde5c71af'
+  version '12.1.7'
+  sha256 '809d07c4a52faaf1f7c7d56b3e8bfa8f09daafd23ac48b7a7e88e53f957dc29b'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.