### PR TITLE
Update navicat-for-mariadb to 12.1.7

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.5'
-  sha256 'c966dbdfdbc4a8759b71d6d08a288322ec76ce0de3fdad4f7b80c64e29b6adab'
+  version '12.1.7'
+  sha256 '357a595272eff7903b228ecb8bfa45bab9b06f5dcd9b0be30f76cae939158e74'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.