### PR TITLE
Fix CoolTerm.app not found inside nested .dmg

### DIFF
--- a/Casks/coolterm.rb
+++ b/Casks/coolterm.rb
@@ -6,5 +6,7 @@ cask 'coolterm' do
   name 'CoolTerm'
   homepage 'https://freeware.the-meiers.org/'
 
+  container nested: 'CoolTermMac.dmg'
+
   app 'CoolTerm.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The .zip file at url must have changed such that the application is now nested inside a .dmg.