### PR TITLE
Update rocket-chat to 2.13.2

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask 'rocket-chat' do
-  version '2.13.1'
-  sha256 '7b498835dd7f8a608c16c914ecc9554620b5da6714acbf1deca021189f40c036'
+  version '2.13.2'
+  sha256 '016d5629816ff476570d37346be78351ae03e3c09a154a2346f1da2fb376a76d'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.