### PR TITLE
Update ticktick to 2.7.01,76

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.7.00,75'
-  sha256 '4f1ccb373b2fab3b9804232b832ee1b8810d61b2d78459b56bb02805483b51d9'
+  version '2.7.01,76'
+  sha256 'd5f39541a619fafa896c0f8cc9667326a07d6d1a454001cbdc1d668850e3309b'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.