### PR TITLE
Update rapidweaver to 8.0.3,20142.1535117845

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,14 +1,14 @@
 cask 'rapidweaver' do
-  version '7.5.5,18814.1513161980'
-  sha256 '0da43f39cc2d16bda314cf8e57faddb7660068b315281c21b99a836323b29fd0'
+  version '8.0.3,20142.1535117845'
+  sha256 '050bd8040786835240dc173c37e0195b14de4361568bb5b72a16e3a237d144b3'
 
   # devmate.com/com.realmacsoftware.rapidweaver was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.realmacsoftware.rapidweaver/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver-#{version.after_comma.major}.zip"
-  appcast 'https://updates.devmate.com/com.realmacsoftware.rapidweaver.xml'
+  url "https://dl.devmate.com/com.realmacsoftware.rapidweaver#{version.major}/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver#{version.major}-#{version.after_comma.major}.zip"
+  appcast "https://updates.devmate.com/com.realmacsoftware.rapidweaver#{version.major}.xml"
   name 'RapidWeaver'
   homepage 'https://www.realmacsoftware.com/rapidweaver/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   app "RapidWeaver #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.