### PR TITLE
Update flash-player-debugger-npapi to 31.0.0.108

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-npapi' do
-  version '30.0.0.154'
-  sha256 'b24a6df933d1c3cfc8647b54bcad5fd851b28ff9886d7dd04fdb54f44cfa79e9'
+  version '31.0.0.108'
+  sha256 '7196bd475b989505945bde5ec86c1792b056a6e6d5501b34ccae50f4fe6d93c8'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.