### PR TITLE
Update manager to 18.9.35

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.9.27'
-  sha256 '97f77a79dcd01a592ded484ff6c8b72450cf6d4928360df3c123c44e238cad31'
+  version '18.9.35'
+  sha256 '24a83e2ee1cbe7dca6b928889833ace932b0b5df8615d7df92f2d9ffa17a61f7'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.