### PR TITLE
Update editready to 2.1.6

### DIFF
--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -3,7 +3,7 @@ cask 'editready' do
   sha256 'f3b16ff2519d9bb789835a7eaab532c7c11cec9bc5d4afcd412db6a9e20e9876'
 
   url "https://www.divergentmedia.com/fileRepository/EditReady%20#{version}.dmg"
-  name 'divergent media EditReady'
+  name 'Divergent Media EditReady'
   homepage 'https://www.divergentmedia.com/editready'
 
   app 'EditReady.app'

--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -2,7 +2,7 @@ cask 'editready' do
   version '2.1.6'
   sha256 'f3b16ff2519d9bb789835a7eaab532c7c11cec9bc5d4afcd412db6a9e20e9876'
 
-  url "https://www.divergentmedia.com/filedownload/editready%20#{version}.dmg"
+  url "https://www.divergentmedia.com/fileRepository/EditReady%20#{version}.dmg"
   name 'divergent media EditReady'
   homepage 'https://www.divergentmedia.com/editready'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/issues/51828