### PR TITLE
Update adobe-air to 31.0.0.96

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,6 +1,6 @@
 cask 'adobe-air' do
-  version '30.0.0.107'
-  sha256 '17be984bf8fc2d24f5db70b044a07da682f4bbd4394684c56f33b5101c2d0c72'
+  version '31.0.0.96'
+  sha256 '19d80a7b2100bd2449848796814d52bedab5c629753f8f2d9b61b7e1b3d4a0b2'
 
   url "https://airdownload.adobe.com/air/mac/download/#{version.major_minor}/AdobeAIR.dmg"
   appcast 'https://helpx.adobe.com/au/air/kb/archived-air-sdk-version.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.