### PR TITLE
Update wire to 3.3,2858

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,14 +1,14 @@
 cask 'wire' do
-  version '3.1.2822'
-  sha256 '969feb5757b956583d6da33445b840e51fa616924208eb941cb6e1610e0d90c4'
+  version '3.3,2858'
+  sha256 '51fe55be66830abf4ec82fc090077f5a5cdaf90664b57c28732d5f24771f6751'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
-  url "https://github.com/wireapp/wire-desktop/releases/download/release%2F#{version}/wire-#{version}.pkg"
+  url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version.after_comma}/Wire.pkg"
   appcast 'https://github.com/wireapp/wire-desktop/releases.atom'
   name 'Wire'
   homepage 'https://wire.com/'
 
-  pkg "wire-#{version}.pkg"
+  pkg 'Wire.pkg'
 
   uninstall pkgutil: 'com.wearezeta.zclient.mac',
             signal:  [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.