### PR TITLE
Update gisto to 1.9.98

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.9.87'
-  sha256 'b4ef8d0e2066c9dd089d1b87557651adbfc6bde0f39b236fe4544c5b9a6e9412'
+  version '1.9.98'
+  sha256 'e7990fc61589b446cefc1d580b8c80252754fcd90853e8deb525f8bb79bfad2c'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.