### PR TITLE
Update qlab to 4.3.1

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,6 +1,6 @@
 cask 'qlab' do
-  version '4.3'
-  sha256 '4e801498e63a9ad1137c3f3e549f0c1d450bd5f20ceaae9d597d8461628a0327'
+  version '4.3.1'
+  sha256 'dc4b6a00e14e7fbaea1c2202646742bb832df75bacaeb49353f361fabb1e1464'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.