### PR TITLE
Update gimp to 2.10.6

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,6 +1,6 @@
 cask 'gimp' do
-  version '2.10.4'
-  sha256 'f7b73608b9f476f168962d34f8de09b6f3bb80c98f03159cdd98145f54f9696b'
+  version '2.10.6'
+  sha256 '52fe241b69d5353c546ffac008d89328fa3126d8f2557642c4661ba68e4ad6c8'
 
   url "https://download.gimp.org/pub/gimp/v#{version.major_minor}/osx/gimp-#{version}-x86_64.dmg"
   name 'GIMP'

--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -6,10 +6,10 @@ cask 'gimp' do
   name 'GIMP'
   homepage 'https://www.gimp.org/'
 
-  app "Gimp-#{version.major_minor}.app"
+  app "GIMP-#{version.major_minor}.app"
 
   postflight do
-    set_permissions "#{appdir}/Gimp-#{version.major_minor}.app/Contents/MacOS/gimp", 'a+rx'
+    set_permissions "#{appdir}/GIMP-#{version.major_minor}.app/Contents/MacOS/gimp", 'a+rx'
   end
 
   zap trash: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.