### PR TITLE
Update genome-workbench to 2.12.10

### DIFF
--- a/Casks/genome-workbench.rb
+++ b/Casks/genome-workbench.rb
@@ -1,6 +1,6 @@
 cask 'genome-workbench' do
-  version '2.12.5'
-  sha256 'd6ef76f4133b9157c4c3d90f823d0a0d306b9ebc76dcc3fe21bbb46c7540dbae'
+  version '2.12.10'
+  sha256 '77ff3fb398c41c08141dcc46894ca64bef89fffe53ab1539d77803b94700aadf'
 
   url "ftp://ftp.ncbi.nlm.nih.gov/toolbox/gbench/ver-#{version}/gbench-macos64-10.10-#{version}.dmg"
   name 'Genome Workbench'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.