### PR TITLE
Update kapow to 1.5.8

### DIFF
--- a/Casks/kapow.rb
+++ b/Casks/kapow.rb
@@ -1,6 +1,6 @@
 cask 'kapow' do
-  version '1.5.7'
-  sha256 '282c9c42a0852e159d8e83ca1cefff1d12c807afbe2eb40b6041d6f780465ec4'
+  version '1.5.8'
+  sha256 'd254ae782bee0d0e88d254d44e4dcec9bc471847645822647bb8fa85b258cee6'
 
   url "https://gottcode.org/kapow/Kapow_#{version}.dmg"
   name 'Kapow'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.