### PR TITLE
Update praat to 6.0.43

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.0.42'
-  sha256 'ce5909447974f0bfbd5f4241d71106f48efa966916610018a8885725d583d826'
+  version '6.0.43'
+  sha256 '3742754d7fc3d42f0023f670bd4eb2cc125aa910df1c0a71cccf771cb9fc4332'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.