### PR TITLE
add spoilers to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -28,18 +28,31 @@ about: Create a report to help us improve
 
 #### Output of command with `--force --verbose --debug`
 
+<details>
+<summary>output</summary>
+
 ```
 {{replace this}}
 ```
+</details>
 
 #### Output of `brew cask doctor`
 
+<details>
+<summary>brew cask doctor</summary>
+
 ```
 {{replace this}}
 ```
+</details>
+
 
 #### Output of `brew tap`
 
+<details>
+<summary>brew tap</summary>
+
 ```
 {{replace this}}
 ```
+</details>


### PR DESCRIPTION
This adds spoilers to simplify reading of issues. Example: https://github.com/yurikoles/homebrew-cask/issues/1, which is clone of #51907 with use of this template.