### PR TITLE
Remove `container nested:` from `coolterm`.

### DIFF
--- a/Casks/coolterm.rb
+++ b/Casks/coolterm.rb
@@ -6,7 +6,5 @@ cask 'coolterm' do
   name 'CoolTerm'
   homepage 'https://freeware.the-meiers.org/'
 
-  container nested: 'CoolTermMac.dmg'
-
   app 'CoolTerm.app'
 end


### PR DESCRIPTION
Reverts https://github.com/Homebrew/homebrew-cask/pull/51774.

---

Do not merge until https://github.com/Homebrew/brew/pull/4897 is in a stable tag.