### PR TITLE
Added mono dependency for Duplicati cask

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -7,6 +7,8 @@ cask 'duplicati' do
   name 'Duplicati'
   homepage 'https://www.duplicati.com/'
 
+  depends_on formula: 'mono'
+
   app 'Duplicati.app'
 
   zap trash: [


### PR DESCRIPTION
After making all changes to the cask:
Mono is needed for duplicati. When installing duplicati before this PR, you needed to install mono, this just adds the dependency on mono.

- [ X ] `brew cask audit --download {{cask_file}}` is error-free.
- [ X ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ / ] The commit message includes the cask’s name and version.
- [ X ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
