### PR TITLE
Update vuescan to 9.6.16

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,9 +1,9 @@
 cask 'vuescan' do
-  version '9.6.15'
-  sha256 '13e09b319ce57f70d8dd14ca082cf1d5bc9444c73579f284e015b76ff12446ac'
+  version '9.6.16'
+  sha256 '6d9dbffc19a46b39063f285eafce54e54e9e07b2aef5f110848e0c938c23d6e6'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
-  appcast 'https://www.hamrick.com/old-versions.html'
+  appcast 'https://www.hamrick.com/alternate-versions.html'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/pull/51900