### PR TITLE
Update airdisplay to 3.1

### DIFF
--- a/Casks/airdisplay.rb
+++ b/Casks/airdisplay.rb
@@ -1,6 +1,6 @@
 cask 'airdisplay' do
-  version '3.0.3'
-  sha256 'db84a66fe3522929a0afa58a4fe0189977baded89df0035ead1ccd334f7b8126'
+  version '3.1'
+  sha256 '8e5743026352c982ecdd948b203026579b0d7f96442b203827372f1a8c3b2206'
 
   url "https://www.avatron.com/updates/software/airdisplay/ad#{version.no_dots}.zip"
   appcast 'https://avatron.com/updates/software/airdisplay/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.