### PR TITLE
Updated cevelop to v1.10.1

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,6 +1,6 @@
 cask 'cevelop' do
-  version '1.10.0-201807191318'
-  sha256 '41063f21af93638deb2f950631d666b447f375dc144e8ce0e948e925fb19452c'
+  version '1.10.1-201809130538'
+  sha256 'fde8a9309582738873b8b10988bbf47fb6fb97dfaefc584a1fc75ef8e4633eb5'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/'


### PR DESCRIPTION
This pull request updates the cask for the Cevelop C++ IDE to v1.10.1.

Editing an existing cask

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).