### PR TITLE
Update annotation-edit to 1.9.99

### DIFF
--- a/Casks/annotation-edit.rb
+++ b/Casks/annotation-edit.rb
@@ -1,6 +1,6 @@
 cask 'annotation-edit' do
-  version '1.9.95.5'
-  sha256 '5cdc22a84303643223b10e79a815a24c8de1648a44ec82b65ac64392a0b41eaf'
+  version '1.9.99'
+  sha256 'f1377b99ea0ae627dfc7fe0399d59f4475ccef7cf38adfbf46ec1bdbf2d517da'
 
   url 'http://www.zeitanker.com/common/Annotation_Edit.zip'
   appcast 'http://zeitanker.com/updates.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.