### PR TITLE
Update actprinter to 3.2.4

### DIFF
--- a/Casks/actprinter.rb
+++ b/Casks/actprinter.rb
@@ -1,6 +1,6 @@
 cask 'actprinter' do
   version '3.2.4'
-  sha256 'c770888630b05faa53f3e3746765264b70a792d65077865f70101be0098b0835'
+  sha256 '515dc587a96fa94b23c2b4847b8421991232447b8a37d9760847a3505a72a912'
 
   # actprinter.com was verified as official when first introduced to the cask
   url "http://www.actprinter.com/mac/ACTPrinter%20for%20Mac%20#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.