### PR TITLE
Update banking-4x to 6.10.4.6820

### DIFF
--- a/Casks/banking-4x.rb
+++ b/Casks/banking-4x.rb
@@ -1,7 +1,7 @@
 cask 'banking-4x' do
   # note: "4x" is not a version number, but an intrinsic part of the product name
-  version '6.10.3.6676'
-  sha256 'ac9f05d4aaf1e176f873953fe2381ee2dbb0339f7275e8f388c45c4c8f92312a'
+  version '6.10.4.6820'
+  sha256 'a461876779e5a0fb126b07e8ff77367af995c2d0d0cf0e932120fe5b7c5cc0c8'
 
   url 'https://subsembly.com/download/MacBanking.pkg'
   appcast 'https://subsembly.com/banking4x-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.