### PR TITLE
Revert "Update wire to 3.3,2858 (#51852)"

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,14 +1,14 @@
 cask 'wire' do
-  version '3.3,2858'
-  sha256 '51fe55be66830abf4ec82fc090077f5a5cdaf90664b57c28732d5f24771f6751'
+  version '3.1.2822'
+  sha256 '969feb5757b956583d6da33445b840e51fa616924208eb941cb6e1610e0d90c4'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
-  url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version.after_comma}/Wire.pkg"
+  url "https://github.com/wireapp/wire-desktop/releases/download/release%2F#{version}/wire-#{version}.pkg"
   appcast 'https://github.com/wireapp/wire-desktop/releases.atom'
   name 'Wire'
   homepage 'https://wire.com/'
 
-  pkg 'Wire.pkg'
+  pkg "wire-#{version}.pkg"
 
   uninstall pkgutil: 'com.wearezeta.zclient.mac',
             signal:  [


### PR DESCRIPTION
This reverts commit 11724dbf7681131b51e42bc087124c71d1378ba3.

This release has been removed.