### PR TITLE
Update freesmug-chromium to 69.0.3497.92

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '69.0.3497.81'
-  sha256 '44d9c03110cf642ac26b3c3e1ad0263c208c764fb4e1346af7522f302498aaac'
+  version '69.0.3497.92'
+  sha256 '438324b5990547846eb7ccd87027527bf32047d7e7cf76826684b2a9ab752c67'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.