### PR TITLE
Update cctalk to 7.3.3,718

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -3,7 +3,9 @@ cask 'cctalk' do
   sha256 '96e08fb58f07aeb1b468ae1e7f29591e61396ebd5b428a8d56dafbc5c739f010'
 
   # n1other.hjfile.cn was verified as official when first introduced to the cask
-  url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk-#{version.before_comma}-#{version.after_comma}.dmg"
+  url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk-#{version.before_comma}-#{version.after_comma}.dmg",
+        user_agent: :fake
+
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,6 +1,6 @@
 cask 'cctalk' do
-  version '7.3.2,707'
-  sha256 '6eb2d1dd2e7c245e5b005554aaae0ca70ca8e5a8c9969005eb682f4cebcbe43e'
+  version '7.3.3,718'
+  sha256 '96e08fb58f07aeb1b468ae1e7f29591e61396ebd5b428a8d56dafbc5c739f010'
 
   # n1other.hjfile.cn was verified as official when first introduced to the cask
   url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk-#{version.before_comma}-#{version.after_comma}.dmg"

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -4,8 +4,7 @@ cask 'cctalk' do
 
   # n1other.hjfile.cn was verified as official when first introduced to the cask
   url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk-#{version.before_comma}-#{version.after_comma}.dmg",
-        user_agent: :fake
-
+      user_agent: :fake
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -2,8 +2,8 @@ cask 'cctalk' do
   version '7.3.2,707'
   sha256 '6eb2d1dd2e7c245e5b005554aaae0ca70ca8e5a8c9969005eb682f4cebcbe43e'
 
-  url 'https://www.cctalk.com/webapi/basic/v1.1/version/down?apptype=1&terminalType=8&versionType=103',
-      user_agent: :fake
+  # n1other.hjfile.cn was verified as official when first introduced to the cask
+  url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'http://f1.ct.hjfile.cn/api/AutoUpdate/newupdate/out/mac/cctalk/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.