### PR TITLE
Update waterfox to 56.2.3

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.2.2'
-  sha256 '85ee47caa94e0fcbe0a8e0e24a219392ac3b0c1817c01665819d2ed984f8bda7'
+  version '56.2.3'
+  sha256 '7a30bebf4b076c1a6de34658ef107d6e8565caced5d07ae880e04ae87ca41b54'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.