### PR TITLE
Fix bad SHA256 for vuescan to 9.6.16

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
   version '9.6.16'
-  sha256 '93598183343f7e0c7c7b13331e7f1151bf997eaa197389276a13efaf74b3fc89'
+  sha256 '8c350abc5301a52f030a3141edbf7e5d4521df4c4392b931ef6eb91919d9d5b2'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'

--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
   version '9.6.16'
-  sha256 '6d9dbffc19a46b39063f285eafce54e54e9e07b2aef5f110848e0c938c23d6e6'
+  sha256 '93598183343f7e0c7c7b13331e7f1151bf997eaa197389276a13efaf74b3fc89'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.