### PR TITLE
Update icons8 to 5.6.5

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -1,7 +1,7 @@
 cask 'icons8' do
   # note: "8" is not a version number, but an intrinsic part of the product name
-  version '5.6.4'
-  sha256 '01dd5ca5fbc412ba8a515200d6f50e7b27a1e696257af0ac87e293758e8e55bd'
+  version '5.6.5'
+  sha256 '1775c821b5d90d52540da4cb52b4618b4732d11509c84feaf3978f3be78753dc'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
   appcast 'https://desktop.icons8.com/updates/mac/icons8_cast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.