### PR TITLE
Update iteleport-connect to 6.0.0.2

### DIFF
--- a/Casks/iteleport-connect.rb
+++ b/Casks/iteleport-connect.rb
@@ -1,9 +1,9 @@
 cask 'iteleport-connect' do
   version '6.0.0.2'
-  sha256 '834098a95c95183782e498de6427e3106b867a1f1793e4fe1306bb065baa732f'
+  sha256 '2a845a052dfa04ae8a5c26da918944082f4a3a43ba3804cb8a078a77ad9f3b4c'
 
-  url "http://www.iteleportmobile.com/download/iTeleport%20Connect.v#{version}.app.zip"
-  appcast 'http://www.iteleportmobile.com/download/sparkle.xml'
+  url "https://www.iteleportmobile.com/download/iTeleport%20Installer.v#{version}.dmg"
+  appcast 'https://www.iteleportmobile.com/connect'
   name 'iTeleport Connect'
   homepage 'http://www.iteleportmobile.com/connect'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.