### PR TITLE
Update mediaelch to 2.4.3-dev_2018-09-11_18-50_git-master-35ac397

### DIFF
--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,8 +1,9 @@
 cask 'mediaelch' do
-  version '2.4.2'
-  sha256 'f82d4c157ef64e25529744fb962771ce678a9e2e3a94b18b3d398dfa5b8b9452'
+  version '2.4.3-dev_2018-09-11_18-50_git-master-35ac397'
+  sha256 'a2544af96e0a42aaa2810266f2c6ea5e6118636f905f215a36f27753b8a161c6'
 
-  url "http://www.kvibes.de/releases/mediaelch/#{version}/MediaElch-#{version}.dmg"
+  # bintray.com/artifact/download/komet/MediaElch was verified as official when first introduced to the cask
+  url "https://bintray.com/artifact/download/komet/MediaElch/MediaElch_macOS_#{version}.dmg"
   appcast 'https://github.com/Komet/MediaElch/releases.atom'
   name 'MediaElch'
   homepage 'http://www.kvibes.de/en/mediaelch/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.