### PR TITLE
Update kstars to 2.9.8

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask 'kstars' do
-  version '2.9.6'
-  sha256 '7c2d237a543d88acf426f71cc4e60cb3097e458a61a6f4965058143fa86a71f5'
+  version '2.9.8'
+  sha256 'a01ca011d8c796e8357e3a81520548bcec9b5e788c4d930fe727aaf236c65e90'
 
   # indilib.org/jdownloads/kstars was verified as official when first introduced to the cask
   url "http://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.