### PR TITLE
Update lrtimelapse to 5.0.8

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,6 +1,6 @@
 cask 'lrtimelapse' do
-  version '5.0.6'
-  sha256 'ece40b8ddf494b7226743796a47a279a7bac6aef02a1beaf6e7030a088590d3f'
+  version '5.0.8'
+  sha256 'fcb97bb4817dec040ab72527e0bdeb02c375c363f8525dee0ff8134d5a54c28a'
 
   url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/"
   name 'LRTimelapse'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.