### PR TITLE
Update macmoney to 3.8.3

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '7.1.4'
-  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
+  version '8.0.2'
+  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.0.2'
-  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
+  version '7.1.4'
+  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/macmoney.rb
+++ b/Casks/macmoney.rb
@@ -1,8 +1,9 @@
 cask 'macmoney' do
-  version '3.7.3'
-  sha256 'ecd89e3f8f266c9dc005020471c84032f0061d003a8e447a481505bfe487ffa5'
+  version '3.8.3'
+  sha256 'd62724e09370f213930ec7e375e7e037da4014ec10e5b15bb37e50f364d7bb17'
 
-  url "https://www.devon.riceball.net/downloads/macmoney#{version.no_dots}.zip"
+  url "https://www.devon.riceball.net/downloads/MacMoney_#{version}.dmg"
+  appcast 'https://www.devon.riceball.net/display.php?file=m01_dl'
   name 'MacMoney'
   homepage 'https://www.devon.riceball.net/display.php?file=m01'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.