### PR TITLE
Update melodics to 2.0.2198

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '7.1.4'
-  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
+  version '8.0.2'
+  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.0.2'
-  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
+  version '7.1.4'
+  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2152'
-  sha256 '2d33bbc900ff2c2dd95ad9da0679f9d142c00778e42c2ebf2697d4a4ab4a2030'
+  version '2.0.2198'
+  sha256 '3c611d73f68f4016e687f138c7ec4b1cd158657afa982ec63f95d7dfb2600f2f'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.