### PR TITLE
Update mountain to 1.6.6

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '7.1.4'
-  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
+  version '8.0.2'
+  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.0.2'
-  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
+  version '7.1.4'
+  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/mountain.rb
+++ b/Casks/mountain.rb
@@ -1,6 +1,6 @@
 cask 'mountain' do
-  version '1.6.5'
-  sha256 '86140c5469683ed64e9f275240e4e5e157b4b84b39aed65157e412e287c2c9dc'
+  version '1.6.6'
+  sha256 '22496566734b7b610a24e3c7700b123a17c5502fdc1562d35d65c04ecf5e7070'
 
   url 'https://appgineers.de/mountain/files/Mountain.zip'
   appcast 'https://appgineers.de/mountain/files/mountaincast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.