### PR TITLE
Update lingon-x to 6.3.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,6 +1,14 @@
 cask 'lingon-x' do
-  version '6.3.2'
-  sha256 'b5f60becd9e5afa2ea8f094c4d0e268b5dd16d6727babbe37c4588569a67dbad'
+  if MacOS.version <= :el_capitan
+    version '4.3.9'
+    sha256 '85d5b7e28f3b404b285d11e35311dbb7d9cc23df20ebb089c08a7483e37e62ef'
+  elsif MacOS.version <= :sierra
+    version '5.2.9'
+    sha256 '7169aaa861626f62112c6ac24256226cd5a5f3b73dade41a4a803232d5942063'
+  else
+    version '6.3.2'
+    sha256 'b5f60becd9e5afa2ea8f094c4d0e268b5dd16d6727babbe37c4588569a67dbad'
+  end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.