### PR TITLE
Update loginputmac to 1.16.1,2758

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '7.1.4'
-  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
+  version '8.0.2'
+  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
 
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'

--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,7 +1,7 @@
 cask 'jump' do
-  version '8.0.2'
-  sha256 '62cf239c5f27a01bb86437b7b7bbfeac24511254e12c30feef867c3b349aa7c8'
-
+  version '7.1.4'
+  sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
+  
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'
   name 'Jump Desktop'

--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,7 +1,7 @@
 cask 'jump' do
   version '7.1.4'
   sha256 'daf3191556ffa7af4b50e809a2bc96bcd465aa59c5613381a68b0f13ad9087a8'
-  
+
   url 'https://jumpdesktop.com/downloads/jdmac'
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'
   name 'Jump Desktop'

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '1.15.1,2755'
-  sha256 'a0f277667f41bcfafa20dae87cfa2e017d33527ed2fe7358610f6503239af7ba'
+  version '1.16.1,2758'
+  sha256 '95577fba9ff26aaaba510a895f1bf3605100d3258e7dfcea0d803f3087a3832d'
 
   # nzhm461a0.qnssl.com was verified as official when first introduced to the cask
   url "https://nzhm461a0.qnssl.com/LogInputMac#{version.after_comma}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.