### PR TITLE
Update manager to 18.9.53

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.9.50'
-  sha256 '2b8cbf8cd3fa7f46e2ac5fab12eb3f36e7e66ceae8934b647882bde318307750'
+  version '18.9.53'
+  sha256 '9ee71f72bce47772f60f27a118c3a678d439d334a3a7892bf769caed8d9f5d8b'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.