### PR TITLE
Update vyprvpn to 2.18.1.6485

### DIFF
--- a/Casks/vyprvpn.rb
+++ b/Casks/vyprvpn.rb
@@ -1,6 +1,6 @@
 cask 'vyprvpn' do
-  version '2.18.0.6455'
-  sha256 '4983064b13ee8a999166e2bff2c929d9f8cc0a6a313b1652a25c29cb6cf08085'
+  version '2.18.1.6485'
+  sha256 '79376e00088aff7302d28440a9c484a843fa3d1ad8b70ab00bbb8f3e2b29f522'
 
   url "https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/#{version}/VyprVPN_v#{version}.dmg"
   name 'VyprVPN'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.