### PR TITLE
Update rationalplan-viewer to 4.16.7500

### DIFF
--- a/Casks/rationalplan-viewer.rb
+++ b/Casks/rationalplan-viewer.rb
@@ -1,6 +1,6 @@
 cask 'rationalplan-viewer' do
-  version '4.15.7389'
-  sha256 '73945254e36c5bd7839421a7f02962db1cfe033b6a0a3962f2c7be3c3929537d'
+  version '4.16.7500'
+  sha256 'bef88b3b183c5c9a3120f154996139f11ca3f279b1a428218483306d3905d723'
 
   url "http://www.rationalplan.com/download/RationalPlan-Viewer-#{version}.dmg"
   name 'RationalPlan Viewer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.