### PR TITLE
Update noise-machine to 1.14

### DIFF
--- a/Casks/noise-machine.rb
+++ b/Casks/noise-machine.rb
@@ -1,12 +1,12 @@
 cask 'noise-machine' do
   if MacOS.version <= :snow_leopard
     version '1.05'
-    sha256 '501415e60204b77e8e15b46ea08c3f8526cfeb28e6ca11c647b7bffb1f3b9d28'
-    url 'http://www.publicspace.net/download/NoiseMachine_Snow_Leopard.dmg'
+    sha256 '72a9759388f05d4880c5c1020215f6ba01ecfbe2e574787c08adf375be192229'
+    url 'http://www.publicspace.net/download/signedNM_SL.zip'
   else
-    version '1.13'
-    sha256 '4e64af7d633fcf90620bd70b26f266ab127e91d3abd099dafb366cf2b570532e'
-    url 'http://www.publicspace.net/download/NoiseMachine.dmg'
+    version '1.14'
+    sha256 'c45197362b0c8e781505ca534952f5d75761fef6a59e356da9a84ac9905973d6'
+    url 'http://www.publicspace.net/download/signedNM.zip'
   end
 
   appcast 'http://www.publicspace.net/app/nm.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.