### PR TITLE
Update robofont to 3.1

### DIFF
--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -1,6 +1,6 @@
 cask 'robofont' do
-  version '3.0'
-  sha256 '2f7dbd6d8f699e5365182d05fee16aff2c1724a50ad559989892e9402ac49fca'
+  version '3.1'
+  sha256 '82e03426bcae68c0712b6733f177c1f5b4376508eee67836be1729dbbc7ca77e'
 
   # static.typemytype.com/robofont was verified as official when first introduced to the cask
   url 'http://static.typemytype.com/robofont/RoboFont.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.