### PR TITLE
Update sbrowserq to 3.5

### DIFF
--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -1,6 +1,6 @@
 cask 'sbrowserq' do
-  version '3.4'
-  sha256 '06e126cfcc80e2442260c291508b82d6a2d722246f51e7b795b15534ec4b7f93'
+  version '3.5'
+  sha256 'd62efea257215b019421f13b947e4dcb161fb35e1694454b140dc70c5f0fef99'
 
   url "http://park.geocities.jp/sbrowser_q/SbrowserQ_V#{version}_mac.dmg"
   name 'SbrowserQ'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.