### PR TITLE
Update qcma to 0.4.1,-1

### DIFF
--- a/Casks/qcma.rb
+++ b/Casks/qcma.rb
@@ -1,9 +1,9 @@
 cask 'qcma' do
-  version '0.4.1'
-  sha256 'f920aeb3497285af12e2e105977347675e5a46df505bfa32cec32965eea6a960'
+  version '0.4.1,-1'
+  sha256 'fc286229be41cbeb83fdb8800231f67d8f2f0d51c2fca07f09c7f6e9d4eecca7'
 
   # github.com/codestation was verified as official when first introduced to the cask
-  url "https://github.com/codestation/qcma/releases/download/v#{version}/Qcma_#{version}.dmg"
+  url "https://github.com/codestation/qcma/releases/download/v#{version.before_comma}/Qcma_#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://github.com/codestation/qcma/releases.atom'
   name 'Qcma'
   homepage 'https://codestation.github.io/qcma/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.