### PR TITLE
Update suidguardng to 1.0.6,a

### DIFF
--- a/Casks/suidguardng.rb
+++ b/Casks/suidguardng.rb
@@ -1,10 +1,11 @@
 cask 'suidguardng' do
-  version '1.0.6'
-  sha256 '47fcfbf2278cf23da46cb56f07b98647dc21b24d4e574a56713da371b688f7cd'
+  version '1.0.6,a'
+  sha256 '3437c1ef64c16fd909f0aca89b7ce865cede2a3a38617b398898fc7c218b6276'
 
-  url "http://www.suidguard.com/downloads/SUIDGuardNG-#{version.no_dots}.pkg"
+  url "https://github.com/sektioneins/SUIDGuard/releases/download/v#{version.before_comma}#{version.after_comma}/SUIDGuardNG-#{version.before_comma}-for-10.11.4.kext.zip"
+  appcast 'https://github.com/sektioneins/SUIDGuard/releases.atom'
   name 'SUIDGuardNG'
-  homepage 'http://www.suidguard.com/stories/index.html'
+  homepage 'https://github.com/sektioneins/SUIDGuard'
 
   depends_on macos: '<= :yosemite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.