### PR TITLE
Update FontBase to v2.6.2

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.6.0'
-  sha256 '42028aeb93edacf1e84cc0b5b047ac50165dc6f75278f2b2a39361156847eb1a'
+  version '2.6.2'
+  sha256 '6bfa4ffdd7bb2d52f9fd1e4902a1c28156af54764cb20f047dc51c22e4f84e78'
 
   url "http://releases.fontba.se/mac/FontBase-#{version}.dmg"
   name 'FontBase'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

`brew cask style --fix {{cask_file}}` 👇

```
Error: Unable to resolve dependency: user requested 'did_you_mean (= 1.0.0)'
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:231:in `search_for'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:283:in `block in sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `each'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `sort_by'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `with_index'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:277:in `sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:52:in `block in sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:69:in `with_no_such_dependency_error_handling'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:51:in `sort_dependencies'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:165:in `initial_state'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:106:in `start_resolution'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:64:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:42:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/resolver.rb:188:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/request_set.rb:385:in `resolve'
/Library/Ruby/Site/2.3.0/rubygems/request_set.rb:397:in `resolve_current'
/Library/Ruby/Site/2.3.0/rubygems.rb:245:in `finish_resolve'
/Library/Ruby/Site/2.3.0/rubygems/rdoc.rb:15:in `<top (required)>'
/Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Library/Ruby/Site/2.3.0/rubygems/commands/install_command.rb:280:in `load_hooks'
/Library/Ruby/Site/2.3.0/rubygems/commands/install_command.rb:156:in `execute'
/usr/local/Homebrew/Library/Homebrew/utils.rb:230:in `install_gem!'
/usr/local/Homebrew/Library/Homebrew/utils.rb:238:in `install_gem_setup_path!'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/style.rb:21:in `block in install_rubocop'
/usr/local/Homebrew/Library/Homebrew/utils.rb:407:in `capture_stderr'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/style.rb:19:in `install_rubocop'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/style.rb:11:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/abstract_command.rb:34:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:89:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:155:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:120:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:7:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:89:in `<main>'
```
