### PR TITLE
insync: update to 1.5.1 and declare auto_updates

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,11 +1,12 @@
 cask 'insync' do
-  version '1.4.8.37107'
-  sha256 'fed63763b047469ec76a15db51ad0643e6ff05dddef27f5a4f7d40476aa1d889'
+  version '1.5.1.37343'
+  sha256 '7bfa4cfc326d5fdb55a861aab4484023512c0e098123f879c79ef1583ae45f63'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   name 'Insync'
   homepage 'https://www.insynchq.com/'
 
+  auto_updates true
   conflicts_with cask: 'insync-beta'
 
   app 'Insync.app'


### PR DESCRIPTION
Patch versions (e.g., 1.4.8 -> 1.4.9) are automatically updated when the program starts.

However, as described in [the release note of 1.5.1](https://forums.insynchq.com/t/new-insync-version-1-5-1/12439), 1.4.x users won't be updated to 1.5.1 automatically, so I submit this PR.

Just tested it - there's a major change in it UI; the sync functionality works as usual.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version). - 1.5.1 is shown on https://www.insynchq.com/