### PR TITLE
Update shotcut to 18.09.15

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '18.08.14'
-  sha256 '9903adda54e00c845df9fccc8ad20dc2965c6fd1f09ecca9be75ddc3a448135a'
+  version '18.09.15'
+  sha256 'fe15736abf2be290147022fa197aaf1bdc99bf13659246c8666681ffb9197a80'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-x86_64-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.