### PR TITLE
gtt-taskbar 0.3.6 (new cask)

### DIFF
--- a/Casks/gtt-taskbar.rb
+++ b/Casks/gtt-taskbar.rb
@@ -1,0 +1,11 @@
+cask 'gtt-taskbar' do
+  version '0.3.6'
+  sha256 'ef1c549bdf3f36a5d3e4ead4a2f3540cdb081990dd301d5394ac462580c6b22e'
+
+  url "https://github.com/kriskbx/gitlab-time-tracker-taskbar/releases/download/v#{version}/gtt-taskbar-darwin-x64-#{version}.zip"
+  appcast 'https://github.com/krisbx/gitlab-time-tracker-taskbar/releases.atom'
+  name 'Gitlab time tracker taskbar'
+  homepage 'https://github.com/kriskbx/gitlab-time-tracker-taskbar'
+
+  app 'gtt-taskbar.app'
+end


### PR DESCRIPTION
Adds https://github.com/kriskbx/gitlab-time-tracker-taskbar to homebrew-cask for easier installation. Only a beta version is available ATM. It's an electron app that adds a menubar item.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
