### PR TITLE
Update apache-directory-studio to 2.0.0.v20180908-M14

### DIFF
--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -1,6 +1,6 @@
 cask 'apache-directory-studio' do
-  version '2.0.0.v20170904-M13'
-  sha256 '17df069735317034737a51439e463e61a1f8e283ea464e299ef023d68cc15dc3'
+  version '2.0.0.v20180908-M14'
+  sha256 '845392529c86e52697c1edac1f0603261324ff2a649e697dbdf566ee5f5f8e5e'
 
   url "http://www.apache.org/dyn/closer.cgi?path=/directory/studio/#{version}/ApacheDirectoryStudio-#{version}-macosx.cocoa.x86_64.dmg"
   appcast 'http://apache.mirror.serversaustralia.com.au/directory/studio/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.