### PR TITLE
Add Emacs.app v26.1-2 without linking ctags

### DIFF
--- a/Casks/emacs-without-ctags.rb
+++ b/Casks/emacs-without-ctags.rb
@@ -1,0 +1,23 @@
+cask 'emacs-without-ctags' do
+  version '26.1-2'
+  sha256 '2ea8d0b0055d5d0ba604771dbb2f9731dd5c815776eec6a9bca3c44d7ab40d99'
+
+  url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
+  appcast 'https://emacsformacosx.com/atom/release'
+  name 'Emacs'
+  homepage 'https://emacsformacosx.com/'
+
+  conflicts_with formula: ['emacs']
+
+  app 'Emacs.app'
+  binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
+
+  zap trash: [
+               '~/Library/Caches/org.gnu.Emacs',
+               '~/Library/Preferences/org.gnu.Emacs.plist',
+               '~/Library/Saved Application State/org.gnu.Emacs.savedState',
+             ]
+end

--- a/Casks/emacs-without-ctags.rb
+++ b/Casks/emacs-without-ctags.rb
@@ -7,7 +7,7 @@ cask 'emacs-without-ctags' do
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 
-  conflicts_with formula: ['emacs']
+  conflicts_with formula: 'emacs'
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'


### PR DESCRIPTION
Since emacs in homebrew-core refers to Cask as the canonical install
we should mirror it's behaviour or at least provide an option to do so.

Emacs in homebrew-core doesn't link ctags by default letting users
install their own, this Casks does too.

There was a similar pull request #33664. But I like to argue that not linking ctags
is far more reasonable behaviour. It's easier to let Emacs point to etags, which is 
still linked by default, if so desired than having to patch your environment for all other programs relying on a specific version of ctags. 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
