### PR TITLE
Update filezilla to 3.37.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,6 +1,6 @@
 cask 'filezilla' do
-  version '3.36.0'
-  sha256 '878a4d86756eaa193a318a0b8021c8827301d75e33f4d0bd4ca8b8084b7b2431'
+  version '3.37.0'
+  sha256 '54f5d6f33c0842c96bc9d532bb03ce2d6022f2a62211add9410e28d80275d69e'
 
   url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.