### PR TITLE
Update bbc-iplayer-downloads to 2.6.1

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -1,6 +1,6 @@
 cask 'bbc-iplayer-downloads' do
-  version '2.5.8'
-  sha256 '8e8bd6d4aa884d29b379ef1b905a6a87276caad4f5810e51a904f4fdef97990e'
+  version '2.6.1'
+  sha256 '8b48d70db98ac2206e2a253b658bc8ed8631cefe1ec4ed3ba03a346e3c6b6209'
 
   # live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com/releases/darwin-x64/BBCiPlayerDownloads-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.