### PR TITLE
Update mongodb-compass-readonly to 1.15.2

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.14.6'
-  sha256 '9e6007a2bd3d642566cf8a1c50e938ed21b234f67f5296ad43ef037535941e44'
+  version '1.15.2'
+  sha256 '304d6787a1d50d351f37455c0b1744ff1c1c688c0f8b133fa6f3c006640e42f7'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass Readonly'


### PR DESCRIPTION
## [`Update mongodb-compass-readonly to 1.15.2`](https://github.com/Homebrew/homebrew-cask/commit/8290a92b8d807afe50f8e192db1cd4be6d75e683)
- [X] `brew cask audit --download lukephillippi/homebrew-cask/mongodb-compass-readonly` is error-free.
- [X] `brew cask style --fix Casks/mongodb-compass-readonly.rb` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256