### PR TITLE
Update freesmug-chromium to 69.0.3497.100

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '69.0.3497.92'
-  sha256 '438324b5990547846eb7ccd87027527bf32047d7e7cf76826684b2a9ab752c67'
+  version '69.0.3497.100'
+  sha256 'd1868d09ab50599826ac04bc72ced93ce59a21a16583b6fd2c12dc867f154fe0'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.