### PR TITLE
Update gisto to 1.10.0

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.9.98'
-  sha256 'e7990fc61589b446cefc1d580b8c80252754fcd90853e8deb525f8bb79bfad2c'
+  version '1.10.0'
+  sha256 '6ec8cfc61ef908ea814d23f7ac768d50f15d1fc33d5bdb01cf4816c5bf30608d'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.