### PR TITLE
Add marmaduke build of Chromium 69.0.3497.92

### DIFF
--- a/Casks/marmaduke-chromium.rb
+++ b/Casks/marmaduke-chromium.rb
@@ -1,0 +1,12 @@
+cask 'marmaduke-chromium' do
+  version '69.0.3497.92'
+  sha256 '7dfbf451334367447032bb67b608611346b3a785c6901d99679c47540f1c1359'
+
+  # https://github.com/macchrome/macstable/releases/ was verified as official when first introduced to the cask
+  url "https://github.com/macchrome/macstable/releases/download/v#{version}-r576753-macOS/Chromium.#{version}.sync.app.zip"
+  appcast 'https://github.com/macchrome/macstable/releases.atom'
+  name 'Chromium'
+  homepage 'https://github.com/macchrome/macstable/releases'
+  app 'Chromium.app'
+end
+

--- a/Casks/marmaduke-chromium.rb
+++ b/Casks/marmaduke-chromium.rb
@@ -7,6 +7,6 @@ cask 'marmaduke-chromium' do
   appcast 'https://github.com/macchrome/macstable/releases.atom'
   name 'Chromium'
   homepage 'https://github.com/macchrome/macstable/releases'
+
   app 'Chromium.app'
 end
-


### PR DESCRIPTION
Unlike the freesmug builds, these stable builds include video
codecs (H.264 for example) and widevine to watch Netflix and friends.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
