### PR TITLE
Update keka to 1.1.4

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,6 +1,6 @@
 cask 'keka' do
-  version '1.1.3'
-  sha256 'bfdb9082cac9c05fa144a13c65c66716a2518fe353d7e489084219b7faec5fe0'
+  version '1.1.4'
+  sha256 '2ceb89d6e90429659de4e3f387615f8215de0ec2530f6a5dd25f849a0cf1d587'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.