### PR TITLE
Update imageoptim to 1.8.1

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,6 +1,6 @@
 cask 'imageoptim' do
-  version '1.8.0'
-  sha256 'a674f8f0cf09eda0e0f725da0e95dbdf929bec6e06dd087f38ee4d7e6858b568'
+  version '1.8.1'
+  sha256 '1f937dd5d13b066fb5fbec9fbd125ab7cd1d1cfe42cc2fe41e5896390835f9c5'
 
   url "https://imageoptim.com/ImageOptim#{version}.tar.bz2"
   appcast 'https://imageoptim.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.