### PR TITLE
Fix hash for vuescan 9.6.16 (again)

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
   version '9.6.16'
-  sha256 '8c350abc5301a52f030a3141edbf7e5d4521df4c4392b931ef6eb91919d9d5b2'
+  sha256 'b25a8f9af06ed10365370f04ba12072805f5b48fbb8cf3694707fc8c09df86b9'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.