### PR TITLE
Update emacs: remove `ctags` binary and formula conflict

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -7,11 +7,10 @@ cask 'emacs' do
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 
-  conflicts_with formula: ['emacs', 'ctags']
+  conflicts_with formula: 'emacs'
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: 'emacs'
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ctags"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #52113.