### PR TITLE
Update wavesurfer to 1.8.8p5

### DIFF
--- a/Casks/wavesurfer.rb
+++ b/Casks/wavesurfer.rb
@@ -1,6 +1,6 @@
 cask 'wavesurfer' do
   version '1.8.8p5'
-  sha256 '798f0eb2c542742892d1541554ff58245040b49c450ba93fbdcaacca129e8dca'
+  sha256 'f14765e4b5ee015c9199081de75934900c55358af8925e8debc345023b91aa96'
 
   url "https://downloads.sourceforge.net/wavesurfer/wavesurfer-#{version}-osx-i386.dmg"
   appcast 'https://sourceforge.net/projects/wavesurfer/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.