### PR TITLE
Update securityspy to 4.2.8

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,6 +1,6 @@
 cask 'securityspy' do
-  version '4.2.6'
-  sha256 '97b79af1a78bcf00f828806494c40c4dc782e524888b2ff9dd379f324088bf97'
+  version '4.2.8'
+  sha256 'e80cc98a5b571fac36959a39eeddbe71c8d9e1a4dc471152f01744cfe610cb39'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.