### PR TITLE
Update gisto to 1.10.1

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.0'
-  sha256 '6ec8cfc61ef908ea814d23f7ac768d50f15d1fc33d5bdb01cf4816c5bf30608d'
+  version '1.10.1'
+  sha256 '829e2a3bd453310aff1b35441aace0ced44bfcb789d0adae5bc5bd8636dbf325'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.