### PR TITLE
Fix battle-net (latest) to set installer permissions to 'a+x'

### DIFF
--- a/Casks/battle-net.rb
+++ b/Casks/battle-net.rb
@@ -15,6 +15,10 @@ cask 'battle-net' do
 
   installer manual: 'Battle.net-Setup.app'
 
+  preflight do
+    set_permissions "#{staged_path}/Battle.net-Setup.app", 'a+x'
+  end
+
   uninstall delete: '/Applications/Battle.net.app'
 
   zap trash: [


### PR DESCRIPTION
Fixes the error: `LSOpenURLsWithRole() failed with error -10810 for the file /usr/local/Caskroom/battle-net/latest/Battle.net-Setup.app`

By setting the `installer manual: 'Battle.net-Setup.app'` to be executable `a+x`.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256