### PR TITLE
Update stattransfer to 14

### DIFF
--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -6,7 +6,7 @@ cask 'stattransfer' do
   name 'Stat/Transfer'
   homepage 'https://stattransfer.com/'
 
-  pkg "st_installer_v#{version}.pkg"
+  pkg "st_installer#{version}.pkg"
 
   uninstall pkgutil: 'com.circlesys.pkg'
 end

--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -1,6 +1,6 @@
 cask 'stattransfer' do
-  version '13'
-  sha256 'a4a4372982fba0ebb4896b30d6bd51abf740ceda0bcf17f3603cc8843b2222dc'
+  version '14'
+  sha256 'b4d40db39f2ddae23622336771b0dfb27e874ba885320d2fe75482783342bfe6'
 
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'
   name 'Stat/Transfer'

--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -8,5 +8,5 @@ cask 'stattransfer' do
 
   pkg "st_installer#{version}.pkg"
 
-  uninstall pkgutil: 'com.circlesys.pkg'
+  uninstall pkgutil: "com.circlesys.v#{version}.pkg"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.