### PR TITLE
Update subutaip2p to 7.1.0

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -1,6 +1,6 @@
 cask 'subutaip2p' do
-  version '7.0.0'
-  sha256 '1da9728bd538b7782f71aa742a69c2202faa25593e22dce37a39993504f8e021'
+  version '7.1.0'
+  sha256 'a55ebeb26c871d18020084c02860d7e36a613ccfc49b40c2b1f0cf31afbe4298'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-p2p.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.