### PR TITLE
 Updated Gemini2 to 303. Changed versioning numbering by MacPaw. 

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,14 +1,14 @@
 cask 'gemini' do
-  version '303,1537359522'
+  version '2.303,1537359522'
   sha256 '1d4c7371ab88aad0295bcdf055eac2c11d82a2e1a2a7932e17c98a18dc249531'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.macpaw.site.Gemini2/#{version.before_comma}/#{version.after_comma}/Gemini2-#{version.before_comma}.zip"
-  appcast "https://updates.devmate.com/com.macpaw.site.Gemini2.xml"
+  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.minor}/#{version.after_comma}/Gemini#{version.major}-#{version.minor}.zip"
+  appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml"
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'
 
-  app "Gemini 2.app"
+  app "Gemini #{version.major}.app"
 
   zap trash: [
                '~/Library/Application Support/Gemini 2',

--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,14 +1,14 @@
 cask 'gemini' do
-  version '2.4.8,1534165417'
-  sha256 'e77615d5fc9a53c6491964bc6922619553fc51b3666ee630b646244ee2f46b88'
+  version '303,1537359522'
+  sha256 '1d4c7371ab88aad0295bcdf055eac2c11d82a2e1a2a7932e17c98a18dc249531'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.before_comma}/#{version.after_comma}/Gemini#{version.major}-#{version.before_comma}.zip"
-  appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml"
+  url "https://dl.devmate.com/com.macpaw.site.Gemini2/#{version.before_comma}/#{version.after_comma}/Gemini2-#{version.before_comma}.zip"
+  appcast "https://updates.devmate.com/com.macpaw.site.Gemini2.xml"
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'
 
-  app "Gemini #{version.major}.app"
+  app "Gemini 2.app"
 
   zap trash: [
                '~/Library/Application Support/Gemini 2',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
