### PR TITLE
Update photo-supreme-single-user to 4.2.1

### DIFF
--- a/Casks/photo-supreme-single-user.rb
+++ b/Casks/photo-supreme-single-user.rb
@@ -1,6 +1,6 @@
 cask 'photo-supreme-single-user' do
-  version '4.2'
-  sha256 'ec63937b0abccd8a5647f47c366782a8532d6d02a945077cfb4a95adf74215a7'
+  version '4.2.1'
+  sha256 '8ec93633f3822ed5ead2153652add69cb76b830a6e2bb8f39011fb62d8e78aa0'
 
   url "http://trial.idimager.com/PhotoSupreme_V#{version.major}.pkg"
   name 'Photo Supreme Single User'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.