### PR TITLE
Update vinoteka to 3.6.3

### DIFF
--- a/Casks/vinoteka.rb
+++ b/Casks/vinoteka.rb
@@ -1,6 +1,6 @@
 cask 'vinoteka' do
-  version '3.6.2'
-  sha256 '94640e140edb6f2fd7375c6315d300b865047e6e60e3247d237cfbdac702e438'
+  version '3.6.3'
+  sha256 '71df513b314119da87cc962aab62b2048c86273a3961e78dca24c3f29342dc71'
 
   url 'http://download.vinotekasoft.com/Vinoteka.zip'
   appcast 'http://download.vinotekasoft.com/vinoteka_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.