### PR TITLE
Update navicat-for-mariadb to 12.1.8

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.7'
-  sha256 '357a595272eff7903b228ecb8bfa45bab9b06f5dcd9b0be30f76cae939158e74'
+  version '12.1.8'
+  sha256 '339da2e0da540c5d4ecf629408ea076ed072ea3f192e3c9a177c6d7bc98446c2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.