### PR TITLE
Update navicat-for-sql-server to 12.1.8

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.7'
-  sha256 '5d178018a7e77a0c70473d09a659e2b4dbf997ff3a9afdf78beead2e1ff87c36'
+  version '12.1.8'
+  sha256 '2bc4940e24e9082a8bf213eeb1cc5256261ab61701dc7e8f19f716438fc3dbe1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.