### PR TITLE
Update navicat-for-sqlite to 12.1.8

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.7'
-  sha256 '809d07c4a52faaf1f7c7d56b3e8bfa8f09daafd23ac48b7a7e88e53f957dc29b'
+  version '12.1.8'
+  sha256 '61c9f46cb8a015988d176345325327407419496243379fd605182471c7335dd4'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.