### PR TITLE
Update qt-creator to 4.7.1

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.7.0'
-  sha256 '3fdcb30220b39cb9b7c22721435b044559dfdb273675a632abd9ffba1f2501b7'
+  version '4.7.1'
+  sha256 'e49e92d735dd6901edcdccd580a1755d85606cc0766867f2e148e726b1772254'
 
   url "http://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.