### PR TITLE
Update lehreroffice to 2018.14.2

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2018.14.0'
-  sha256 '264fbce64c1ed0e2bf98da419e8b43eca1974ddc1eedb3bff01736558e9f1ed2'
+  version '2018.14.2'
+  sha256 '12beea418a8eea40aa0aa2dcf43d38a8b44dacf111665654d4dec4be0098c6f0'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.