### PR TITLE
Update goland to 2018.2.3,182.4505.32

### DIFF
--- a/Casks/goland.rb
+++ b/Casks/goland.rb
@@ -1,6 +1,6 @@
 cask 'goland' do
-  version '2018.2.2,182.4129.57'
-  sha256 '6699513cad20dc9e75a00f278ca1448e2a696cfc7d27741195bc6816bdb06faa'
+  version '2018.2.3,182.4505.32'
+  sha256 '3ba98fbd7a538c7244642a0b24bbc5f636e4e8b2956600e996a0cbec0a975edb'
 
   url "https://download.jetbrains.com/go/goland-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=GO&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.