### PR TITLE
Update file-juicer to 4.67

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,6 +1,6 @@
 cask 'file-juicer' do
   version '4.67'
-  sha256 'f50f1538fcad459b331cfd73d8c633fdbd806f6f69e346592f1182b2eb0813b9'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
   appcast 'https://echoone.com/filejuicer/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.