### PR TITLE
Update manageengine-mibbrowser to 5.2,9229779

### DIFF
--- a/Casks/manageengine-mibbrowser.rb
+++ b/Casks/manageengine-mibbrowser.rb
@@ -1,6 +1,6 @@
 cask 'manageengine-mibbrowser' do
   version '5.2,9229779'
-  sha256 '21c277bf2a242050e344c8954437c669171692e8e6c05eebf3cc13290b5fb253'
+  sha256 'c6b84158988af9a4d93de263b683e00a2aae9af9e8fbd54c7a22e0d9e9b56893'
 
   url "https://www.manageengine.com/products/mibbrowser-free-tool/#{version.after_comma}/ManageEngine_MibBrowser_FreeTool.dmg"
   name 'ManageEngine MibBrowser'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.