### PR TITLE
Update imazing to 2.7.1,9531:1537534272

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.7.0,9517:1537292305'
-  sha256 '1052bce057fdf4a08853db0df5df4779b99452918d3b327e7d86c78b908cd517'
+  version '2.7.1,9531:1537534272'
+  sha256 'ec961d167bdda7c220f5fb0f604ecadcbf48f47cc2929a3aa9c5fde8e95995ea'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.