### PR TITLE
Update keycue to 9.1

### DIFF
--- a/Casks/keycue.rb
+++ b/Casks/keycue.rb
@@ -1,6 +1,6 @@
 cask 'keycue' do
-  version '9.0'
-  sha256 'ae6f2d7191377437cd5cee714c04909dae7fcd5dc9b7d4381212d332640013c8'
+  version '9.1'
+  sha256 '9d5d91b554347af86c5bc11b3d36f9ed421f4d1cededb766ae8e29448f24ff52'
 
   url "http://www.ergonis.com/downloads/products/keycue/KeyCue#{version.no_dots}-Install.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.