### PR TITLE
Update sound-control to 2.2.4

### DIFF
--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -7,7 +7,7 @@ cask 'sound-control' do
   name 'Sound Control'
   homepage 'https://staticz.com/soundcontrol/'
 
-  pkg 'Sound Control Installer.pkg'
+  app 'Sound Control.app'
 
   uninstall launchctl: 'com.staticz.soundcontrol.*',
             quit:      'com.staticz.SoundControl',

--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -10,6 +10,5 @@ cask 'sound-control' do
   app 'Sound Control.app'
 
   uninstall launchctl: 'com.staticz.soundcontrol.*',
-            quit:      'com.staticz.SoundControl',
-            pkgutil:   'com.staticz.installer.soundcontrol.*'
+            quit:      'com.staticz.SoundControl'
 end

--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -1,9 +1,9 @@
 cask 'sound-control' do
-  version '2.2.3'
-  sha256 'ca282e493693910b0d94e61828a391cd18503957b34b0d6f6bb442b0068e5214'
+  version '2.2.4'
+  sha256 '248b1dce993d001735335992c035115815be8dd1f3a7975bed3a746405eab560'
 
   # staticz.net was verified as official when first introduced to the cask
-  url "http://staticz.net/downloads/SoundControlInstaller_#{version}.dmg"
+  url "http://staticz.net/downloads/SoundControl_#{version}.dmg"
   name 'Sound Control'
   homepage 'https://staticz.com/soundcontrol/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.