### PR TITLE
Update netron to 2.1.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.1.2'
-  sha256 'fa92f672211a00df1b1a2e329f3279878ce41dd1aca4bf357690c687c26a1a1d'
+  version '2.1.3'
+  sha256 '0c75ca3c80d9618188b1fded4ff99f8ee5089ec831b1dc385a169a2cb06a35cf'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.