### PR TITLE
Update manager to 18.9.75

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.9.71'
-  sha256 '95cd0bc8e2b824b8e4487b853548dad7a10503c36d05b16c32dc190ff6704c7c'
+  version '18.9.75'
+  sha256 '7a171510203087eb720bddbf317c15df7d8b57e25a539b93810f8fb484a5e595'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.