### PR TITLE
Update netron to 2.1.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.1.3'
-  sha256 '0c75ca3c80d9618188b1fded4ff99f8ee5089ec831b1dc385a169a2cb06a35cf'
+  version '2.1.4'
+  sha256 '38976c39cd7831246d19f6ac41120aba50e8a6de916b8371959cafbb32ad53ad'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.