### PR TITLE
Update taskwarrior-pomodoro to 1.8.0

### DIFF
--- a/Casks/taskwarrior-pomodoro.rb
+++ b/Casks/taskwarrior-pomodoro.rb
@@ -1,6 +1,6 @@
 cask 'taskwarrior-pomodoro' do
   version '1.8.0'
-  sha256 '307f017d1ad14721637196e27af00fe2428e4afa8c10bc238b70e8277ccd0486'
+  sha256 '07aad9949cf7ec5752d5da87333c52f07654b0c480b18779afaec0f5debb488a'
 
   url "https://github.com/coddingtonbear/taskwarrior-pomodoro/releases/download/v#{version}/taskwarrior-pomodoro-#{version}.dmg"
   appcast 'https://github.com/coddingtonbear/taskwarrior-pomodoro/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.