### PR TITLE
Update eddie to 2.16.3

### DIFF
--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -1,6 +1,6 @@
 cask 'eddie' do
-  version '2.15.2'
-  sha256 'bd5588d665d60a503c9e29b7831d7e16f8d9ca79f83c4ba100eedd381942fd19'
+  version '2.16.3'
+  sha256 'f4a073d0689bd1218886883bd0a8f1a93412aba2e844e652698cdd56ff2f4fb8'
 
   # eddie.website was verified as official when first introduced to the cask
   url "https://eddie.website/download/?platform=macos&arch=x64&ui=ui&format=disk.dmg&version=#{version}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.