### PR TITLE
Update graphql-playground to 1.7.0

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,6 +1,6 @@
 cask 'graphql-playground' do
-  version '1.6.3'
-  sha256 '6852aadc02bd1ae208953ddc9947164b4c3037029b9b00a635198ff7df99e8aa'
+  version '1.7.0'
+  sha256 '61d3dc658a885b21103f522afa18194deca0752202ccd6ca02e9d630869ce79f'
 
   url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prisma/graphql-playground/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.