### PR TITLE
Update bit-slicer to 1.7.9

### DIFF
--- a/Casks/bit-slicer.rb
+++ b/Casks/bit-slicer.rb
@@ -1,6 +1,6 @@
 cask 'bit-slicer' do
-  version '1.7.8'
-  sha256 '8e9b9398240f37e7da16c1c7328a1bd8a8a19f7e376c3144304ef51ed587f1b8'
+  version '1.7.9'
+  sha256 '5dd8ab04ac8ba019bbed906eb6f8efe5d6d6adcb8952eae9fe23bef5138cd420'
 
   # zgcoder.net was verified as official when first introduced to the cask
   url "https://zgcoder.net/software/bitslicer/dist/stable/Bit_Slicer_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.