### PR TITLE
Update unity to 2018.2.9f1,2207421190e9

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2018.2.6f1,c591d9a97a0b'
-  sha256 'c57df491262586407aff9555db6df7f019afc85c019fc5dbf1fc5d1930754748'
+  version '2018.2.9f1,2207421190e9'
+  sha256 '5c5461ba90864b868ec69ef576f46cd1fe59f0500aff2adb908fdbdbe802c4b8'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.