### PR TITLE
Update ticktick to 2.7.50,77

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.7.01,76'
-  sha256 'd5f39541a619fafa896c0f8cc9667326a07d6d1a454001cbdc1d668850e3309b'
+  version '2.7.50,77'
+  sha256 'a0ce491936bf4ea79f5111144555b13d1cb77bfa05d6e4413da7332b9326acf7'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.