### PR TITLE
Update kitty to 0.12.2

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,6 +1,6 @@
 cask 'kitty' do
-  version '0.12.1'
-  sha256 'adeb930ef7a42a6d839e343a386e378bf5f400bc11031cd94a553cc8cae16c6d'
+  version '0.12.2'
+  sha256 'dcfa715f9eba613416d1bf290943651e2c4777ae0e0553dda4fabd04dca7f12f'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).