### PR TITLE
Update studio-3t to 2018.4.4

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2018.4.3'
-  sha256 '5a71cacc09bdde4d0dc1dbb631815488058690da068eb4aa49e4096f35861e05'
+  version '2018.4.4'
+  sha256 'ebf7baceb8a7f4480741e39a24dd3c719955088d00be8ffe117763d099ad4076'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.