### PR TITLE
Update cocktail to 12.0.0.10

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -29,12 +29,18 @@ cask 'cocktail' do
 
     url "https://www.maintain.se/downloads/sparkle/sierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/sierra/sierra.xml'
-  else
+  elsif MacOS.version == :high_sierra
     version '11.6.3'
     sha256 '6a00bae70a5befa7fb9467c1320e8818939e5f074deadd70177021fbf4694b07'
 
     url "https://www.maintain.se/downloads/sparkle/highsierra/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/highsierra/highsierra.xml'
+  else
+    version '12.0.0.10'
+    sha256 'cd51763b12b44898877866a9683c3d4acc2ad984acb1c294dfe357e24d48dcfc'
+
+    url "https://www.maintain.se/downloads/sparkle/mojave/Cocktail_#{version}.zip"
+    appcast 'https://www.maintain.se/downloads/sparkle/mojave/mojave.xml'
   end
 
   name 'Cocktail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.