### PR TITLE
Update jameica to 2.8.2

### DIFF
--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -1,6 +1,6 @@
 cask 'jameica' do
-  version '2.8.1'
-  sha256 'aff01580063d62548ab33994bf9ab8e74b7615c19ec9841a515f02a546a86b02'
+  version '2.8.2'
+  sha256 '055833018c04c7d1ca5617db4472c5bbde256b6a789769d2c8ef6648e3b88312'
 
   url "https://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64-#{version}.zip"
   name 'Jameica'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.