### PR TITLE
Update android-studio to 3.2.0.26,181.5014246

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '3.1.4.0,173.4907809'
-  sha256 'cac5ad1a3177dc442b74aea41cb93a1311d2b0df9338a294e4d332ed2b39a94d'
+  version '3.2.0.26,181.5014246'
+  sha256 'a3499a64970bf97d95a3bb27ebe571a56cee77510fa8a6d4745d6fbc24d252e1'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.