### PR TITLE
Update numi to 3.19,253:1537544968

### DIFF
--- a/Casks/numi.rb
+++ b/Casks/numi.rb
@@ -1,6 +1,6 @@
 cask 'numi' do
-  version '3.18.3,185:1529144261'
-  sha256 '115977662d8d6aa42db12b7f6c7d89d127f86a99a28f68a367cb760c6d0a7566'
+  version '3.19,253:1537544968'
+  sha256 '65868727510873dc86a773e91d0471a67c96d0c32a80de8e34878d3262816a46'
 
   # dl.devmate.com/com.dmitrynikolaev.numi was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.dmitrynikolaev.numi/#{version.after_comma.before_colon}/#{version.after_colon}/Numi-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.