### PR TITLE
Update iterm2 to 3.2.1

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.0'
-  sha256 '7d4862976f6e5dbf29a7193dc090d6c17c549daf47a373a8a97ae306870a22a4'
+  version '3.2.1'
+  sha256 '00d6bd333ea5819c6a2e8139ea63a28d1b44e7a07da2fde537c7516e3353c31d'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.