### PR TITLE
Update evernote to 7.5_457109

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -12,8 +12,8 @@ cask 'evernote' do
     version '7.2.3_456885'
     sha256 'eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97'
   else
-    version '7.4_456999'
-    sha256 'c4e792c7c9ee0ed6c244d1d6f416567d8b8d3c2bf313e2175c6e84bade3a1608'
+    version '7.5_457109'
+    sha256 '1a5a424072ad35d4bf0f82f33dca398a45466b64b981c3cfbb72dd54acebd23a'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/issues/52420