### PR TITLE
Update xact to 2.47

### DIFF
--- a/Casks/xact.rb
+++ b/Casks/xact.rb
@@ -1,6 +1,6 @@
 cask 'xact' do
-  version '2.46'
-  sha256 '8d6736203d1e6289f9542e3db0a249c232e1f09c0fe85712a0ab33196ee9de95'
+  version '2.47'
+  sha256 '76074593c88a6bae7d938fc794768af5284fc7262085bd757af99405ca98e9a8'
 
   url "http://xact.scottcbrown.org/xACT#{version}.zip"
   appcast 'http://xactupdate.scottcbrown.org/xACT.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.