### PR TITLE
Update keystore-explorer to 5.4.0

### DIFF
--- a/Casks/keystore-explorer.rb
+++ b/Casks/keystore-explorer.rb
@@ -1,6 +1,6 @@
 cask 'keystore-explorer' do
-  version '5.3.2'
-  sha256 'd06c1300dea98c1188b0ffb34cac6653bd3e08048f860f56f51e142fea9aaced'
+  version '5.4.0'
+  sha256 '399e7dad4a645725cc001de01a07a851aed96bff1eb7c3bdaab0ab6494427f51'
 
   # github.com/kaikramer/keystore-explorer was verified as official when first introduced to the cask
   url "https://github.com/kaikramer/keystore-explorer/releases/download/v#{version}/kse-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.