### PR TITLE
Update acorn to 6.2.0

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,8 +1,8 @@
 cask 'acorn' do
-  version '6.1.3'
-  sha256 'c465dcbc81dca03ef8a775114b90884a2354086ec7441dde579e0d0a5ea06d7f'
+  version '6.2.0'
+  sha256 '427f7aec4e0f058a49149f4348893d877c50e6e9ac2769ea0a18fc5db0e523e3'
 
-  url 'https://secure.flyingmeat.com/download/Acorn.zip'
+  url 'https://flyingmeat.com/download/Acorn.zip'
   appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml"
   name 'Acorn'
   homepage 'https://flyingmeat.com/acorn/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.