### PR TITLE
Update paintcode to 3.4.1

### DIFF
--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,6 +1,6 @@
 cask 'paintcode' do
-  version '3.4'
-  sha256 '9617c04cd1dd998d6a3f2fb0aeb0f6eb599d7d4a261b02207d8dac58812a6257'
+  version '3.4.1'
+  sha256 '2498dc7c402dde4f478f92642ef0fbdbbd01cebb483e9faacefcb2d106d4c3f2'
 
   # pixelcut.com/paintcode was verified as official when first introduced to the cask
   url "https://www.pixelcut.com/paintcode#{version.major}/paintcode.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.