### PR TITLE
Update java to 11,28:55eed80b163941c8885ad9298e6d786a

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,6 +1,6 @@
 cask 'java' do
-  version '10.0.2,13:19aef61b38124481863b1413dce1855f'
-  sha256 '2db323c9c93e7fb63e2ed7e06ce8150c32d782e3d0704be6274ebb2d298193aa'
+  version '11,28:55eed80b163941c8885ad9298e6d786a'
+  sha256 'aa5fea6e2f009e63dd8a8d7f532104e6476195a49ee6dd0d2b11c64966d028cc'
 
   url "http://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_osx-x64_bin.dmg",
       cookies: {

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -7,7 +7,7 @@ cask 'java' do
                  'oraclelicense' => 'accept-securebackup-cookie',
                }
   name 'Java Standard Edition Development Kit'
-  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.major}-downloads-4416644.html"
+  homepage 'https://www.oracle.com/technetwork/java/javase/overview/index.html'
 
   # auto_updates true: JDK does not auto-update
   depends_on macos: '>= :yosemite'
@@ -81,7 +81,7 @@ cask 'java' do
              ]
 
   caveats do
-    license 'https://www.oracle.com/technetwork/java/javase/terms/license/index.html'
+    license 'https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html'
     <<~EOS
       This Cask makes minor modifications to the JRE to prevent issues with
       packaged applications, as discussed here:


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.