### PR TITLE
Add Photosync.app V3.2.4

### DIFF
--- a/Casks/photosync.rb
+++ b/Casks/photosync.rb
@@ -1,6 +1,6 @@
 cask 'photosync' do
-  version '3.2.4'
-  sha256 'da491ac3b2de9ae526075d43074af20f5586359271cedfdfc047beb689184f18'
+  version '3.3'
+  sha256 '83c068387fabc3b6d59d693231b7975ff5365103eb01a9d8ab0f1d7c43be8b06'
 
   url "https://www.photosync-app.com/tl_files/photosync/publish/mac/photosync_#{version.dots_to_underscores}.dmg"
   appcast 'https://download.photosync-app.com/xml/photosyncmac-updates-standalone.xml'

--- a/Casks/photosync.rb
+++ b/Casks/photosync.rb
@@ -1,6 +1,6 @@
 cask 'photosync' do
-  version '3.3'
-  sha256 '83c068387fabc3b6d59d693231b7975ff5365103eb01a9d8ab0f1d7c43be8b06'
+  version '3.3.1'
+  sha256 '7c3238c45bb4ef46c5055f60b64394f8cbe78759b0bf1e18dd968dcf8c317392'
 
   url "https://www.photosync-app.com/tl_files/photosync/publish/mac/photosync_#{version.dots_to_underscores}.dmg"
   appcast 'https://download.photosync-app.com/xml/photosyncmac-updates-standalone.xml'

--- a/Casks/photosync.rb
+++ b/Casks/photosync.rb
@@ -4,7 +4,7 @@ cask 'photosync' do
 
   url "https://www.photosync-app.com/tl_files/photosync/publish/mac/photosync_#{version.dots_to_underscores}.dmg"
   appcast 'https://download.photosync-app.com/xml/photosyncmac-updates-standalone.xml'
-  name 'PhotoSync Companion for macOS'
+  name 'PhotoSync Companion'
   homepage 'https://www.photosync-app.com/photosync/en/home.html'
 
   app 'PhotoSync.app'

--- a/Casks/photosync.rb
+++ b/Casks/photosync.rb
@@ -1,0 +1,11 @@
+cask 'photosync' do
+  version '3.2.4'
+  sha256 'da491ac3b2de9ae526075d43074af20f5586359271cedfdfc047beb689184f18'
+
+  url "https://www.photosync-app.com/tl_files/photosync/publish/mac/photosync_#{version.dots_to_underscores}.dmg"
+  appcast 'https://download.photosync-app.com/xml/photosyncmac-updates-standalone.xml'
+  name 'PhotoSync Companion for macOS'
+  homepage 'https://www.photosync-app.com/photosync/en/home.html'
+
+  app 'PhotoSync.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


Just a heads up - although not in homebrew-cask already, Photosync is in the [Mac App Store](https://itunes.apple.com/gb/app/photosync-transfer-and-backup-photos-videos/id418818452?mt=12) (although as far as I can tell its the same executable) . Considering this could be downloaded via `mas` - should this be in homebrew-cask also? (I felt it was worthwhile to point this out ahead of time)