### PR TITLE
Update telegram to 4.4-140043

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.3.4-139634'
-  sha256 '0d6689d8e3465f41599bd84030d3faafc7f4f9cefdc596cb03f1f1f40013e423'
+  version '4.4-140043'
+  sha256 'd8f1eb4da385c9b68581bc3d96c89f4848c87abd3cce628b616cb0d6ed65844c'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.