### PR TITLE
Update minizincide to 2.2.1

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask 'minizincide' do
-  version '2.2.0'
-  sha256 '0cd1e9e85e70ecd84ce30046cecc03e7abe625b1a0925636011bab9ff500b686'
+  version '2.2.1'
+  sha256 'afa1423b30bd6718e130c7a74ce213198fe96ae3f2599b9bc773a8cd81138e4b'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.