### PR TITLE
Update pencil2d to 0.6.2

### DIFF
--- a/Casks/pencil2d.rb
+++ b/Casks/pencil2d.rb
@@ -1,6 +1,6 @@
 cask 'pencil2d' do
-  version '0.6.1.1'
-  sha256 'bce374e85b2d49641cf3325aeb91f5cdfaaa02c2defc83c95092e1f8c56e4bb9'
+  version '0.6.2'
+  sha256 '5661d6cbaadfc4542ce584966ae5075d44fbf00dd430b9d854210db9b9cf3fff'
 
   # github.com/pencil2d/pencil was verified as official when first introduced to the cask
   url "https://github.com/pencil2d/pencil/releases/download/v#{version}/pencil2d-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.