### PR TITLE
Use specific link for Plug upgrade

### DIFF
--- a/Casks/plug.rb
+++ b/Casks/plug.rb
@@ -6,8 +6,8 @@ cask 'plug' do
   else
     version '2.0.19'
     sha256 '418d1adcf0ca099e7d02f9773df133c8c3276f1e65c47ff60f587861fa07d063'
-    url "https://www.plugformac.com/updates/plug#{version.major}/Plug-latest.dmg"
-    appcast "https://www.plugformac.com/updates/plug#{version.major}/sparklecast.xml"
+    url 'https://www.plugformac.com/updates/plug2/Plug-2067.dmg'
+    appcast 'https://www.plugformac.com/updates/plug#{version.major}/sparklecast.xml'
   end
 
   name 'Plug'


### PR DESCRIPTION
- [x] `brew cask audit --download plug` is error-free.
- [x] `brew cask style --fix plug` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Corrected https://github.com/Homebrew/homebrew-cask/pull/52449.

Edit: I'm a contributor to the Plug project, and got the specific version URL. Due to the sha conflict without this change, it means that the previous link using the version wasn't working.