### PR TITLE
Update decrediton to 1.3.0

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,6 +1,6 @@
 cask 'decrediton' do
-  version '1.2.1'
-  sha256 'eedeb515b02c4711e05ac685849a538a6e32911bdffe358313113068600efe44'
+  version '1.3.0'
+  sha256 '77753257c7ebaf1b3f77f0d6445d227dff20edd770702ee290140e42250b12aa'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.