### PR TITLE
Update geogebra to 6.0.498.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.496.0'
-  sha256 '6f5425038281de19c681913b6c971f45f88ad9266c378f79050d624290e4c54a'
+  version '6.0.498.0'
+  sha256 '8b1884648df0d94660ff58b83eb86662157ea6dfdbcb382977a14202df6e4a7d'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   name 'GeoGebra'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.