### PR TITLE
Update mindjet-mindmanager to 11.2.111

### DIFF
--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -1,6 +1,6 @@
 cask 'mindjet-mindmanager' do
-  version '11.0.143'
-  sha256 '0ae43356adba76154ed0164b4cb6e5fea7e8484b72cb1858e6cae29694ab7f8c'
+  version '11.2.111'
+  sha256 '68dc4bdd407d770d03d9e7bfc215a87f1ea49d555b2d34b80f370332859fdee6'
 
   url "http://download.mindjet.com/Mac/Mindjet_MindManager_Mac_#{version}.dmg"
   name 'Mindjet Mindmanager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.