### PR TITLE
Update qownnotes to 18.09.4,b3844-111449

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.09.3,b3840-110934'
-  sha256 'eb8b86949e775442f43333dc58029835075871f842b42a3720b3481967b82373'
+  version '18.09.4,b3844-111449'
+  sha256 '4fb5949b7eb357a67c5a36c3cd1f6618280611f06dfc9314659acd0c63a6429c'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.