### PR TITLE
Update sound-control to 2.2.5

### DIFF
--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -1,6 +1,6 @@
 cask 'sound-control' do
-  version '2.2.4'
-  sha256 '248b1dce993d001735335992c035115815be8dd1f3a7975bed3a746405eab560'
+  version '2.2.5'
+  sha256 'edc0d7901f886ab4ed153f17edcd48e0384f9532822d6fbe2a07a3ec166b56e6'
 
   # staticz.net was verified as official when first introduced to the cask
   url "http://staticz.net/downloads/SoundControl_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.