### PR TITLE
Update 1password to 7.2.1

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,6 +1,6 @@
 cask '1password' do
-  version '7.2'
-  sha256 'acf6f9077db9ddd636ba26de14cb17ef276f23f581abda3b21d6617c17ba83c1'
+  version '7.2.1'
+  sha256 '3ec43f6015f03768922982f067ee49fb776a6bbbeada6c3518480ede0ae039cb'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.