### PR TITLE
Update coqide to 8.8.2

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,6 +1,6 @@
 cask 'coqide' do
-  version '8.8.1'
-  sha256 '80b51cef6156872f95230c68dd7f3406619f52b6b49daad2b7def7d0d6c721a3'
+  version '8.8.2'
+  sha256 '6722222127a1d986bed21721464b22aae181a4a17756e9000e95937cd5c597df'
 
   # github.com/coq/coq was verified as official when first introduced to the cask
   url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version}-installer-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.