### PR TITLE
Update manager to 18.9.94

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.9.88'
-  sha256 '741d1c555854d94580761598338998521b66044361610773ba8820522b35c30a'
+  version '18.9.94'
+  sha256 'e0f4c2197e2e9fe3e3e7273ff9d020734c1e0779c4c789eab54c94c0a094b1e9'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.