### PR TITLE
Update softu2f to 0.0.18

### DIFF
--- a/Casks/softu2f.rb
+++ b/Casks/softu2f.rb
@@ -1,6 +1,6 @@
 cask 'softu2f' do
-  version '0.0.17'
-  sha256 '5587405776f3249732099059b7e8bc880bf67e7c1647f453ce77b727c0bcd052'
+  version '0.0.18'
+  sha256 '035eea8b9a1b28b639a2f582904f085c6b7f7fe1dfe05d82e7c460a341cd7e32'
 
   url "https://github.com/github/SoftU2F/releases/download/#{version}/SoftU2F.pkg"
   appcast 'https://github.com/github/SoftU2F/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.