### PR TITLE
omnidisksweeper: add version switch

### DIFF
--- a/Casks/omnidisksweeper.rb
+++ b/Casks/omnidisksweeper.rb
@@ -1,8 +1,22 @@
 cask 'omnidisksweeper' do
-  version :latest
-  sha256 :no_check
+  if MacOS.version <= :lion
+    version '1.8'
+    sha256 '04e6da65a21294e9ee49da370ad2f617bf668001d2aecb9cc7579d1b8f02f613'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.6/OmniDiskSweeper-#{version}.dmg"
+  elsif MacOS.version <= :el_capitan
+    version '1.9'
+    sha256 '4dfcdb29bbae8b7eba22d010cb2fd2aab0547c1a1df632bc9c1ee77be206f09b'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.8/OmniDiskSweeper-#{version}.dmg"
+  elsif MacOS.version <= :sierra
+    version '1.10'
+    sha256 '0d8f5b7ff075fca4503a41e1ea898a145001f3f602f6b53ffb310e0a465af080'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniDiskSweeper-#{version}.dmg"
+  else
+    version :latest
+    sha256 :no_check
+    url 'https://www.omnigroup.com/download/latest/OmniDiskSweeper'
+  end
 
-  url 'https://www.omnigroup.com/download/latest/OmniDiskSweeper'
   name 'OmniDiskSweeper'
   homepage 'https://www.omnigroup.com/more/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

___

Starting with version 1.11, OmniDiskSweeper [requires macOS High Sierra](https://www.omnigroup.com/more) or higher. This PR restores support for Sierra by adding a version matrix as published on the upstream homepage.

I ultimately decided to include cases for ~~Leopard and~~ Lion because they almost certainly will never receive another update. They are therefore unlikely to pose a maintenance burden.

**Edit:** Removed the Leopard leg.
