### PR TITLE
Update wifi-explorer to 2.5.1

### DIFF
--- a/Casks/wifi-explorer.rb
+++ b/Casks/wifi-explorer.rb
@@ -1,6 +1,6 @@
 cask 'wifi-explorer' do
-  version '2.5'
-  sha256 '28994dc73e78440544e0340f13eedea20eb6097763a3fdb44ef272d4a969fc43'
+  version '2.5.1'
+  sha256 '305c86f339dae6afa18bc788ba4cb2fba067c97aed88888c31cd7475ac61b87d'
 
   url 'https://www.adriangranados.com/downloads/wifiexplorer.zip'
   appcast 'https://www.adriangranados.com/appcasts/wifiexplorercast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.