### PR TITLE
Update libreoffice to 6.1.2

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '6.1.1'
-  sha256 'a4c1c66ceabca45cba21163c56d321b2959b8185dbd2040aa362a794ac6078db'
+  version '6.1.2'
+  sha256 'e22460b1500b8b44c3bb477792f4537b9480cc969ed56202cff767423282148d'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.