### PR TITLE
Update signal to 1.16.2

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.16.0'
-  sha256 'dd2cb6b3d3b0069ee459dcc84fe277f5ad29b901e172f1c9649c3355a4346533'
+  version '1.16.2'
+  sha256 '0b8cfa51b5b6cfc9025f863974aac602c92eeeb8cef6ab81e272b9d0a277aa33'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.