### PR TITLE
Update libreoffice-language-pack to 6.1.2

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,558 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '6.1.1'
+  version '6.1.2'
 
   language 'af' do
-    sha256 '1122521decd09729461bbacbb1aa1ed0a120dfc6f60fee092b7cf112274a4268'
+    sha256 '4d64d22807a87c99fe4e529a8f12751f962e1196422d37f3f78357c0a3b04b90'
     'af'
   end
 
   language 'am' do
-    sha256 'db75df70cf98dc90b103cc69e06bf37fdf8449765d80d2a5ee6fd6e2dee374d3'
+    sha256 '4597e91fd588237740fcde9f4c6833717618a2a8eba4fdb7aa41c220ca558399'
     'am'
   end
 
   language 'ar' do
-    sha256 '6861e39730eea740b3ca086b3be5f630d0682a2eb374fcb135c0093aafc87447'
+    sha256 '664edcf63cf96b4ab31c73371d6eae3872aa86f4aece0043d47174483601bb12'
     'ar'
   end
 
   language 'as' do
-    sha256 '52799fc4bfe62cf59c2bb4609fc15106e9d245af8352b36e45330d5ccaf3fd9c'
+    sha256 'e5ce684acc90717657345b868579953cbca544ab0e26e0e4ef50469cb76b85df'
     'as'
   end
 
   language 'ast' do
-    sha256 '6bf484bf304c53f3893d70dcb95440b83c04da1c9035e068deab996fdc476e56'
+    sha256 '9165e3545a250c51aebe29f2a08c9654434fabdac5c37efac6cc5f3572090456'
     'ast'
   end
 
   language 'be' do
-    sha256 '85ddd8c8d431a14217c3d39ea367896bd88d224882c1dfaca288cb4458169835'
+    sha256 '8ca9500ee0ca19453c8550b233b902341c14f62bbecb4263c97f18e7aa995747'
     'be'
   end
 
   language 'bg' do
-    sha256 '1148649edb61893427232fa07d8a5845b930bcb4c21b016cf8e094206fbfac08'
+    sha256 'd91cb6f30b98d789b977cce119be22ae564b7fe01ab21dfeaa1235b46a1e01ca'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '17584c546c595413ff7469cce915139fd4002f0571c62eee6b9249e4a98d9937'
+    sha256 '3a52c34f86012ecc73e95151f703d6259f526a71325fe58aacf83fa72ea97bbe'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '1593b10c2ed04c3baebe26d4c5d69f1e8878eac78f112c4cda5664b1f1f1ef12'
+    sha256 '3f2fed3119261529d8511df2146257e331b76b0eea46c8edbcf79fddd3eae37d'
     'bn'
   end
 
   language 'bo' do
-    sha256 'bca2aea06dc9b89f36b693a608e2905a718850f75f7107980e6aa34b927b5040'
+    sha256 '844806ef0901e159f6f0c906ea352d1889ce72c300aed7caccb44e2c72d3767d'
     'bo'
   end
 
   language 'br' do
-    sha256 '54465f7f8d32be71809def066e731089a4a80be762808dccfd14277f9266bc7f'
+    sha256 '19145b93c8f8c6755ab25744aab14f036838d80bd19278b81b87ccc03e269546'
     'br'
   end
 
   language 'brx' do
-    sha256 '9f46e28861d06c53e6ba6d428e718ff699c36cfaa9ce9ccec6fbacc764535a38'
+    sha256 '6b7a042cbdb83efc5e6a14b7a9878fefb1e323c889bdd8f5c6fd7683eb6ab732'
     'brx'
   end
 
   language 'bs' do
-    sha256 '612afe072919a4d69d32d1c48e5aad7a08e3c507410dddb34ffc13f4c12dee59'
+    sha256 '74f3accae5de265dfe9b151bfe038d71608330e6d026c01553b7c0a792c2d842'
     'bs'
   end
 
   language 'ca' do
-    sha256 '519cfa2329d46d5bed166f379b34ad83340a9a9a01b0bc001bfc1ecdd77de967'
+    sha256 '227202c20c8f5f6406d0eccb4cd2e67519309dd1daa264900b6c24ab597ea94b'
     'ca'
   end
 
   language 'cs' do
-    sha256 '41be395b299a689ce677c5318ea350101b93e0380bb4f091fb9af2f70eb2f5b3'
+    sha256 '60b868b6241a73fa9788534b6b6d40046d4d63cbe79101eea998f4599c3453d2'
     'cs'
   end
 
   language 'cy' do
-    sha256 '8d0c4a87975b00c68b098a083b032643b91e12d31fedf2c45fb2c05c6c637521'
+    sha256 'defccc54f5a6eabf880c285a31c5d1907646599f58ac957fc868187614f42fe3'
     'cy'
   end
 
   language 'da' do
-    sha256 '39534c497f4c18a4c527a1901aa9fe6850184a8dcf3d25a2c9bd8cb69037c364'
+    sha256 '8d3e88761dd743188451d3fe029169059b6a6a8c9ddc7051fd23cf7f582ac018'
     'da'
   end
 
   language 'de' do
-    sha256 'e97c07c3370e107a58a220a0cd79366cbad8f2fc87dabbbc3a788c9b2a01a7e7'
+    sha256 '8e7111a5e4bf33c9d5252f4f7b4be13cd66c7be127f9e1f81d329a646c19aa90'
     'de'
   end
 
   language 'dgo' do
-    sha256 'a41ed520c8b892e696ac808c4de3a1689f63a634c34cd39c2fbb082062ae85bd'
+    sha256 'dfe496f0408f6981d5b23e06d9532bbc52a8622ac6d54a00b0953886437f27bb'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '23b2d6e7dda9ac062e57ffd205c69f037eae2b53acdd8899302f8d8d852e2460'
+    sha256 '18b026461ac92366f7674f050855b2d8e9c818b1f97f6f212cf07f75f52e54e2'
     'dz'
   end
 
   language 'el' do
-    sha256 'e01150a3cec4beb21d289c4d43a0b2061b80429394c542c7ecae093dac42410e'
+    sha256 '251332bc1a3770fa5483bb3d77ededb85aad540a72682590e82931bd7041430a'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '50a20c98ec8d1fd7891fa955706566f2c754903c0a70a862c8022c9283299f61'
+    sha256 '1fbcdeac8186736c4bc5cbd43cf2332cc0305a3b5a2eb1242ce6a94b036e2f4a'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '9e3cff7ed1dd2f0fbd68843442534258b0081f90e55ecace621a97c1b1f0cf07'
+    sha256 '896124e85b6f758d15f7305d3d9dd02062de82dfa8b9f07d693bf13dadd1a618'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 'abc85144803edbb4ba3915f8ba07d656071778ce4ac359a451e755d5ba31d399'
+    sha256 '53e3714667ef2fd30adb3ed58c2ca19443c346c235e810851bbf33b57709a67c'
     'eo'
   end
 
   language 'es' do
-    sha256 '32078b8944f89c322a9c42824d6f823621c88fee4092e02eb5601910e795c96e'
+    sha256 'f27899d98cd4feb6aab7f3cb37458ecf9e292646e4075a3672508e74cc49b6b9'
     'es'
   end
 
   language 'et' do
-    sha256 '409fa0f188b64df934f8d675b4d16c6e30a39a2b8e245fb37aa6d8607a234543'
+    sha256 '440bc22f3810c6614e91a9564f668cb67cc517f96f03c310d706909182621e1a'
     'et'
   end
 
   language 'eu' do
-    sha256 '9e94a9db224748c9d088f0629c5bd96185f042df82ce7b210c5ae574a0f3f120'
+    sha256 'a6e69a0f057bd7c2783acaddb44b73041e166dae650de905ad5a1511e21f6f3a'
     'eu'
   end
 
   language 'fa' do
-    sha256 '53176a2f6be23e6f675e4c30426253a63612e7f824ae4cb4cea54f176121c058'
+    sha256 '157e8ed4d68f26567b49d909792ea541be09e2b5d05f2cb2df64b1b22b4a43fe'
     'fa'
   end
 
   language 'fi' do
-    sha256 '46debc9b739a9c87fab0dbd46994ce4faecea13c4145de9ab2a212753a185f24'
+    sha256 '6de12710c51677b59b99d6c8c50bd10f9f99d34d463cd64116011a338cf1bf77'
     'fi'
   end
 
   language 'fr' do
-    sha256 '2470683bfe2e4caddf91e8f47699c648fa5e0bf3237b9c879675e1e3e522fede'
+    sha256 '10bc39eaf5c51b8c0ae2a4c8208575e421a6042d00b75bb3655ec2323cb487ce'
     'fr'
   end
 
   language 'ga' do
-    sha256 'e6eacc304f969c8c8be03724893db6d0a715e3c0cb7d2c4e1ab7bd86639a1407'
+    sha256 '35d1721831145be8dba8b952bd690e223ee21ab470845d380dc15e59e69c3802'
     'ga'
   end
 
   language 'gd' do
-    sha256 'd472b106202aceb00bb00370b0609b81aa6ee76932e57089fd848d323a4ce943'
+    sha256 '322fedc06df7021cb1509ac7ce229b17de25a39c47d4b4041a62918522d54f01'
     'gd'
   end
 
   language 'gl' do
-    sha256 'cbeeb143448a05f28b942058385ee98a2616691630a60f4255aa5609a31cc141'
+    sha256 'dd9a471c2b7d2591393606aea50bc066167226d2bbe3efda6dcaab25bccf6d07'
     'gl'
   end
 
   language 'gu' do
-    sha256 'b436d48d79a04c06d9d7be0787f98591b862d9ad887d29e5feffe53cf2249da8'
+    sha256 '90e3fe77a60435b5834ab0ac7086d02c653f7c867d7c6038fd951c11f29eb765'
     'gu'
   end
 
   language 'gug' do
-    sha256 'c566cca25da19e8d41e1f33d34903d20928aa255cb9014382a950f5741b88387'
+    sha256 '6468b1d642a53fddb2ddfcb3f65864be0b940c319ff371b11c1f6cda86e0f347'
     'gug'
   end
 
   language 'he' do
-    sha256 '5ef3b627a67b79a93b6d55fef67b88fb3d220df7113817788bc8827adb87c126'
+    sha256 '1b7c2821e4a8d79059394b6920c3c77712c8dcf4045129d10b50085a88768031'
     'he'
   end
 
   language 'hi' do
-    sha256 'e5b1c818e4aa6a88f1da6d61459ec0eb2a16acb98e2c1f54a3acadeb35b657d6'
+    sha256 '144bf9e11bd19483b9f46b2fbb33803f3763b51601581fa61b681a7efdcadb26'
     'hi'
   end
 
   language 'hr' do
-    sha256 'a96288a9fc6aba6b29809c6d23986606b29aa9e2e76f0589b385c7fce04fff93'
+    sha256 '8944a1af53594a09ff1448a923dad6c88c57209ad76ae6e27271e6597ff0acf1'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '836f8b3b5b8df8b3f346e81bfde6e43ebd7ba4673ce70e85de09739276cbaae7'
+    sha256 'bbd8c89695bfafcb82f2cd12fe200af7363eb243da95ca80ca71758b4878d957'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '779314ad16aff4d729745d68e7f588481d17ddc1c0e7678d5d6a3f59961509fb'
+    sha256 'a8fa3eb16600de4521f3b130f4297feefbf735032e2e844ec83a76c6a3d48097'
     'hu'
   end
 
   language 'id' do
-    sha256 '60208172d3de25846ab5cffb3a2843b94a545ce2c446b6af645264fa9a0fc8e8'
+    sha256 'fc89f85e952b65251cc67b13a7ec0a9e0d5242f8edf0dfba3edb2d6b430a6c31'
     'id'
   end
 
   language 'is' do
-    sha256 '0ad0d2b3d1606366691bc07d962c00518b06dfb557fbdffd2a1760f78986f4cc'
+    sha256 '180d86daed657506066e7ae46006a4bf6c3873d171f980063152440c39d2f013'
     'is'
   end
 
   language 'it' do
-    sha256 'b9e34e76bc440bfa4d3e6b89817746c17af7c613aaa362d0f46d78814b7af98f'
+    sha256 'b5a2b7c724231f9bc24eb69b354f3db908444021e84dc294231e06d3ab38b31f'
     'it'
   end
 
   language 'ja' do
-    sha256 'aba629cd330d30d429d599c667393b571b64e6894e3b95bd1d191d956602790e'
+    sha256 '31d0a22ce391756583b55c2819b71bc2ef6af718455f5508fa641eb011b8a8e9'
     'ja'
   end
 
   language 'ka' do
-    sha256 '06dba1057c1eeeea59363c596d275a640ddc73c7131d9675028f36bbb400eaca'
+    sha256 '9ff800c8615f5db24c72bef45792e53d4d729135be7162ef710f7726bb874dd7'
     'ka'
   end
 
   language 'kk' do
-    sha256 'cefd2e8c53de3928fcb673d98423cf97893d2f0159543871ce368352700ac6d3'
+    sha256 '263de7ef0299cab9d6e703d828573681c837c802fbbae0685e9269d72f6d6ed3'
     'kk'
   end
 
   language 'km' do
-    sha256 'd16da651c2bb491f47b5d6f41e94d7ac6f942e9310c4111f483d8ab9a74f435b'
+    sha256 '5d8dff1c610e1ac23bc0c59158e4f2c26a3b5c1c6ab0bd482dc7d201c4f83d89'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 'e6e376bb85da0c0e0e8cd36b46c889e9557d9a6cbe0b261cbd68dd12fb47a65c'
+    sha256 '9f7535605ba38e3b86876c290f45a3ab159be000f9805edc7912b9eb9805d31c'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'fb670037d69d6e3163f41eeb190b5fcf4efe8cfbb753a1d6933bfb1520c89f4a'
+    sha256 'c481b3160974f1633fe990879b01cab46b8783dd54af760ac4f680a3be1712c7'
     'kn'
   end
 
   language 'ko' do
-    sha256 '4034683618d2a9297dad53d512739dd2b8961b42a05d62c26bc15f3508be15b3'
+    sha256 '0ed0a01bd28361ea7cda9f7e714144984ba06ec0b5d9cec6b29c18df14829885'
     'ko'
   end
 
   language 'kok' do
-    sha256 '56b5dabfb2b3ee7b82a88a2077b517a614f363590b69dafefad3df4d2252167f'
+    sha256 '31dcba4f002d6f5b3d7530a641706ffa807e088bdd2fd841d9711e8d4dbd956d'
     'kok'
   end
 
   language 'ks' do
-    sha256 '1f8a9d872834cd88c3fae5cdbe7409bd388eaaf2204d819b6938581182deb48b'
+    sha256 '52117eddd34b6b3e6c89208f4077c7c4a50a98a004f4548d7a14e375596daa4e'
     'ks'
   end
 
   language 'lb' do
-    sha256 '01ba71ef49f45fc2d3a108ae813e8733a11dc6093fbcbc8b88b68212a34383db'
+    sha256 '626173f1c6c5a50494c380cf4677933c6579be1e357b5f9a917ea144b49312c7'
     'lb'
   end
 
   language 'lo' do
-    sha256 '232612a253a68fc372305c4ee8aa38600e7076e171dac85048f981ad9ba89d2d'
+    sha256 '81b7b1e8aea6e001b585d3acbbb77d0f1aa17181f35df572ae1a5e6f6d59ca17'
     'lo'
   end
 
   language 'lt' do
-    sha256 'ed68678538fd4c4dbd207632d8043a78b77587dd3a2384602449fa6f5f831198'
+    sha256 '73c7afcc6ad4280a2470ae055122d3466f802d68dc23f3d13255ecf786ee7d4d'
     'lt'
   end
 
   language 'lv' do
-    sha256 '1c5e5f2ee8fd53ae5feb906b3df2ebc0ac37ef7b0d515a77cca1059b295fbb75'
+    sha256 'df127d41cf803e0caf66ebb4583c0d23e346189d5a6f179120a363352ff08398'
     'lv'
   end
 
   language 'mai' do
-    sha256 'eff75898bd5f87ae581c1ad5e388bcc113c2abbb7d1353696fa374cd71220489'
+    sha256 '4e30e7e3551fc0cfd2054fdfa50e8b9042e94a84453df6db1ea4b79a3bce8858'
     'mai'
   end
 
   language 'mk' do
-    sha256 '08bb71ec34dd78d2abe36b804e03f54531e4ee1dff12815ac8c94bfd9a6a8871'
+    sha256 '1e8b3274af1e9833cca3f3282cc563df9f562efa71c7cc27d4eab23cf65b4c1f'
     'mk'
   end
 
   language 'ml' do
-    sha256 'b448d15ac902440aa4d66577172006fca517d2ef74b617d71473f940028b0896'
+    sha256 '1cafa45fb9c273c1b6f94287d4bc10c29e672df4d31a327f42645f6572e63602'
     'ml'
   end
 
   language 'mn' do
-    sha256 '141c19b05f451c92cc710eaf5150ffdf61fd9e497e0fdc5aa24401c161811531'
+    sha256 '383aa90ce3c3cbf6c40d1d04bde7ed0ec4d21d594d46ffb5cddbab20ce7a096c'
     'mn'
   end
 
   language 'mni' do
-    sha256 '5694abd4739158a824df22bc86d38367da553abaf15a0df4913e7bf485050a00'
+    sha256 '30f6e3ef135f0e025ecf22b6bdc7ad7fee3c6a1f2838a52bafb0faa5b43f5471'
     'mni'
   end
 
   language 'mr' do
-    sha256 '4e524f00b09cab4793658247653f964010550dc08820652c103ac5302d1626a0'
+    sha256 '56bfaf1f6abfd0184c8c38991dd20f6a28eec8c74d02788ed88042479c0f84aa'
     'mr'
   end
 
   language 'my' do
-    sha256 'bdc173202baf179bb3eb9756388b9792375ae1e08b74030429925b69a071a0bf'
+    sha256 'f561fa5a9f138bf03536ca69713b485ab045ccbdfa962b359a96d0c3e6c45217'
     'my'
   end
 
   language 'nb' do
-    sha256 '93c1c3ae7aab9f7129c014ca8617fc855a2a3c957e5aa11c61035b1d9bccedb5'
+    sha256 '1c826a26b025035873084eb6eb601a4ea67a12401916e5ce9d6c68d325069f3c'
     'nb'
   end
 
   language 'ne' do
-    sha256 '67214a142573e197dc47c1d1dd90a18c28cb0b5b79848aa6286ec3a2d0d715b2'
+    sha256 '766823c8bf4e3b05b0bf0bf4da53cb88aad66b80e3fd440c934f1462a9bde078'
     'ne'
   end
 
   language 'nl' do
-    sha256 '4eedb62c79865f9427c0bd295e436611b867287b9daaee16b7f29dfa6740468d'
+    sha256 'd474baa934292b61bfb437fb7d365e002e2f98e31ec222f188e9cb4f4d3c03b2'
     'nl'
   end
 
   language 'nn' do
-    sha256 'd267d50a80657e04265b6e73db44ca936cb18fc47fb49f9fd61f67817212f556'
+    sha256 '4b613a6c67e8a81ed2235007d86c58e57756167d605040d472833dc50000887e'
     'nn'
   end
 
   language 'nr' do
-    sha256 '8a2b9f5e349688da925b6a435adce910096489a10c9d3bde37a681070cee36cd'
+    sha256 '28af677c56c56fe49bf01f42b2f773f5ed70435e93a07b6fc8bc90d80cdb5702'
     'nr'
   end
 
   language 'nso' do
-    sha256 '85019e3353fe7c48d361f03b84d3d58567633aee1d07aaef89fd5cd1830b71c0'
+    sha256 'cce9b8e0f746c3e2f87e9e7329feef38b992e510f94d1f451a4731d9c1435a99'
     'nso'
   end
 
   language 'oc' do
-    sha256 '3adb37cdb92086f6580b515a1677fd44d1ec14fa2f60bc41e3525a955b8ff7f1'
+    sha256 'cce936773c36f2c5a88004dabf32b873ed3dfcdbd533650c5a08eb5393e63d55'
     'oc'
   end
 
   language 'om' do
-    sha256 '1a46979d98b8262f7233ec0a4f15bd79e2c9c4eefefd4b022522b001706040ca'
+    sha256 '7c3b93f224f4b78b40cbce90965b1909ad8baa4d447b60daee561e69815fee3b'
     'om'
   end
 
   language 'or' do
-    sha256 '224ef292b36a0ef681e851979721b3a2069513784bbe925af9ac903e194edb48'
+    sha256 'bdd06c5eb7d9f98f4197bb590cba14be89c79116d834b8850d2ed4d30a278a99'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '5d62724c18bab73bea2d67f6e7ae7d5ded8bd0b28771d92c17b231de559c999a'
+    sha256 '70e593b2883074e28cf3f921eb4a9abd928c2b529870c86c8b8ae16ab3a7e8e0'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '1a6dc910818cb7694df5023b0ea609b0b38bdab8a9c6f5832bc26eca2c0fad32'
+    sha256 '7a3a082c5176e63570f4342000f1ebb25d59843f2ceec847728a821c902ccb2e'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'a21910b109eaef70e1994a3bb1decca66c358fd7dbd6e687a6012876988c0ebe'
+    sha256 '788e1ae2220dac60a9e62efeb2d256c012c4b151275a8a66db163b2aaf8b7252'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'cc7a0851b84631b46548049aa1dfe240e6c21220faff193bb978ba37efd799c2'
+    sha256 '4b2e5e4e3ec5f9199f3df61c9fb952ceb34a7fa210b8635c273d9c8dc612b098'
     'pt'
   end
 
   language 'ro' do
-    sha256 'f7f7993c3c79e496b857954ac99d326eeb2c52387dbbf4fcf0ad7b2052dcd7ec'
+    sha256 '656103ca97c09eba8e7da3903291c012d704326fad4696150e81423405f60e85'
     'ro'
   end
 
   language 'ru' do
-    sha256 '989e20c7189bec52cf736522939cf8772387327997307210251093ea4d397d4c'
+    sha256 '372885fb348e83f66736369779bf9b5be8f2fdd8efea088a6f5c142fe7be6b4c'
     'ru'
   end
 
   language 'rw' do
-    sha256 'bf1667363896608b2d192ae6a5db8fced8aff607fed3a68eeeb17f496a84388b'
+    sha256 '3b458a93e5d83a68b6b29cda869de1f2a08fa06526eab5448dfe890e48949dbe'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '33d74e1112c4a0406e69c473268632ecd1b3a4622cc671c70c8a8978b68d830a'
+    sha256 '8d3bd7ce1ba5d68c0c96faf457decc14236f9a3733a0edfebbd476267263b1b9'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 'd3399518c098f841837f6e264c51ecadddabd4376872e2c64f2f6f8bffd8d28c'
+    sha256 '03e794eb0232e523d54745b419180214d712103af9a315e1c8918b18fb757caf'
     'sat'
   end
 
   language 'sd' do
-    sha256 '37b8dfb374f2c0ef534945c6dd2c2830bd5cc7bad38802a6d97a136a97954158'
+    sha256 '78a13e25b8a1cbc9f1430da5701cb5ba4f7f1c1feabbab2e769d860150e02537'
     'sd'
   end
 
   language 'si' do
-    sha256 '75c675c16f06dd1402f99922c51914ac882b49f4192cc300a4bd7253024a12b3'
+    sha256 '141675f26bbbedf8ca559b250063f1490f3dce474885994cad626717f4c97326'
     'si'
   end
 
   language 'sid' do
-    sha256 'b7224fa5a6edf53e94a77b2749702163f0ea1a89eb576e378435d785d1b3a479'
+    sha256 '2d019a92c8c7099a2eb81b427f132448ce6007f23272dcabe62c88f81e3477a4'
     'sid'
   end
 
   language 'sk' do
-    sha256 'b6b0d7726368487aacea101f9b4e945b6f61dff3ab26e5f9f26bc892a25572e9'
+    sha256 'ff37b53e1c1bbcc9940846344228116c194b5d8d664590d542126a98bccfdc29'
     'sk'
   end
 
   language 'sl' do
-    sha256 'd37a1e5db766d47c3d2cb208c0afb9e675921255f309eeec81560494bc20b0ef'
+    sha256 '4ee1c7fede0e0a04640cd27419268885a1e853ef06aee338b8016ab9634742f1'
     'sl'
   end
 
   language 'sq' do
-    sha256 '32d7c7de733bbc94bb3e6889b079fea7a55530409acf8bec7be5b75e4ccda202'
+    sha256 'c951bc8bcf066dfa0ccff01877067b9905054b6c61266ecc5711e72462068c33'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 'c9a5f84f832e8d565a019b1bcc66ad686641dc7cd0715957b29234e97ce3f8b7'
+    sha256 'b35fc80262851dc33d763b8977b40d773397e065d9de71d9f04d43d54953734d'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 '1bd8b1e983f4bd31faa165d780ae2059342d4667067c80475b413e2a2b719192'
+    sha256 '3df23582a9b5f224ac81ff5eefb996b666dbc73775a20c1c11667c0e5e28eca8'
     'sr'
   end
 
   language 'ss' do
-    sha256 '1f2f4e16349caa5537419471e7e2b21d64b3f5c228dce77dd939f8b674decf6d'
+    sha256 '14fa988c994928160db7de0014614d8d6a912ea98eaab6126aff23edacdf4a69'
     'ss'
   end
 
   language 'st' do
-    sha256 '66dfcb949aa0d0dc323dee4441f8124e6ac0392146c235904e2cf8aca506fd68'
+    sha256 '511581f1829ab5da636dd80ca3d9a31835252436c8eeff22cd4ac2ca532bf754'
     'st'
   end
 
   language 'sv' do
-    sha256 '467517c25c14ef8994b6dcd74dc8d552bd93f665df607f6f859731f092688d0d'
+    sha256 '8777ba411f8e5f5b4a73d26deb99d2dbe9b3b7442ed217b9945fc91160b0fcee'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'ab321aedd396100063daf8f2faa39b12be8ccb8e6e08392108fc09eb2790f23c'
+    sha256 'e10d397ea41c5d00019c4bfee658bb938cacabb548d5020408c1694de3c754ce'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '0c845843e46474b88193dc092b0d780d6747645fd2e2dbe5f60f460007cd1a11'
+    sha256 'be5b4da4eaa4aef96ee61c988e24c44787c18f4b59a971e541ab013aa86f165a'
     'ta'
   end
 
   language 'te' do
-    sha256 'c1d391cf57571bc68ec644291e5e6dde4ce2d8aadeb0a863791ed1fd32684c1c'
+    sha256 '026a2e14b98aa3bbcbda1981fcf015b423236b92b28c503b3b9b16fcb944df78'
     'te'
   end
 
   language 'tg' do
-    sha256 '395f01403cbb6992f48415d64a23862cc02a08f87b58418879a92a7e88aa360f'
+    sha256 '2a239691ba20238b4648dbc5ec7eda39fa1dd07641348498c09d603da24df0ab'
     'tg'
   end
 
   language 'th' do
-    sha256 '999d56d14a4cc1fd0b2b9c81e8fe065be2a30147cfefd625e8e3d873e7958c12'
+    sha256 'e69ab2248e0fff06f9b12faa0fa079a21c502c308f74a27f628d0093d71f8ea4'
     'th'
   end
 
   language 'tn' do
-    sha256 '27ebab15df87be3b5cb17f7f39d5d86b5d9edca355a8e42bda8f14a4dbc11db2'
+    sha256 'e7f3ddd4ca043d52aca95341d7b3667ea6a8c05cff2985d52c0c60c0ca33a062'
     'tn'
   end
 
   language 'tr' do
-    sha256 '1cb2f45d924a2033833d2804e66748abf0a74fc97ca08cc70a810e80b9ee6d2b'
+    sha256 'c224ba65f8f2c224dab1086f3e4f98b8adf2984ab005d99136d91901ac9ba276'
     'tr'
   end
 
   language 'ts' do
-    sha256 '1bfef3199d50122a7cd31d87da93f38f54a0c609e0cbdf67f7811f29bdf78b57'
+    sha256 '24379fea1c727471716f949dfa67ca38113de947e65f26618f29c5a305272f6d'
     'ts'
   end
 
   language 'tt' do
-    sha256 '9e3ce76af38474ef1d2e9d7eea2f2f66dbd1b9cc4560e87a7b17c424b6f90627'
+    sha256 'df9dd3dcdf363661e5e7e547198ef732fd41d3bf67aaef32a4c2115c59333ed7'
     'tt'
   end
 
   language 'ug' do
-    sha256 'deef73c668435c5cb80185ed43c25a3c1196cd4b7b6aa294e9703ccd00377623'
+    sha256 '48140433815a3d8f10d7befa4d54133622dac0f7d2086e3621f6d7c72b75a230'
     'ug'
   end
 
   language 'uk' do
-    sha256 'eea6d09e7bd74b5df2b2bad8fa0a78bd3c4ffa799ef3c1431b5d5e85382dbc84'
+    sha256 '1a7e72754724bcf689d05202b5ed1c53d29b69bb46be0f7cb26f91981cde03b0'
     'uk'
   end
 
   language 'uz' do
-    sha256 '57066ce9a14b6702ca920eb868095ef0348146438ee7309b824810dc18fd50d5'
+    sha256 '2d09008052e7a33286d736cfacec328c8881e527dbe0797fa28ce30e43a647bc'
     'uz'
   end
 
   language 've' do
-    sha256 'acc6160743d1a7e64e3ceaa453e576473903a545b35c788701f0a49472cd4af7'
+    sha256 '2712f2eac335c87919341db8bc9d518b554e3c94d89db2cb78a284f63ed8dd3d'
     've'
   end
 
   language 'vec' do
-    sha256 '865f910b687a67ad6739e7e0de682d0f582df949e111b9c7ba033064ddc98366'
+    sha256 '438ed6bfe8db89d40fe8715560017b2fcf5ab30f589963229003ba36d81c3940'
     'vec'
   end
 
   language 'vi' do
-    sha256 '0acc4d52af233ad8e6e5526c004fe86b9ae2e7857eb0c43e749de6e35ae1cc25'
+    sha256 '921d4c6e1577a9e289ab56834d37c1905a0361b955414948b2a9bc50c882b855'
     'vi'
   end
 
   language 'xh' do
-    sha256 '50cfdda259ae65f1c35394dfa7081d81548d618443ba584e770acf4265cd9a04'
+    sha256 '88388f40576ab314036749ef22f417b97ce291b025f6668907377eee5450ec3c'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 '152cad604741e982a7b0f7ac662ca2c8ed39b83733fcde02bf18e01ff8fbfc6b'
+    sha256 '2ce9a006b867c25683d38d79f8c43da77153a64655c0b31ef2ce967ba79c2365'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 'dd7d8a75d7ed8ce63e1c73128443a19a8df7c276e51b120d2a1f034126056ea8'
+    sha256 '4515e2841e68947fc956a2a2bc6b0170c33aac01ae32ed2d5ae500a35f00037f'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 'bb00c583be67438bf8024f03862016bdd14e286ad9617edd72e03348620cda73'
+    sha256 'c64bc89b2da5a47fa06621076110eded7a7bd9641a64fe1ad705ab62459be806'
     'zu'
   end
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
