### PR TITLE
Update yujitach-menumeters 1.9.7 sha256 checksum

### DIFF
--- a/Casks/yujitach-menumeters.rb
+++ b/Casks/yujitach-menumeters.rb
@@ -1,6 +1,6 @@
 cask 'yujitach-menumeters' do
   version '1.9.7'
-  sha256 'a7a87ae10906d5555763bd889c688a275e8d75d43ba92c17bb432065a2239a51'
+  sha256 '6cf2f7b312c1c13f74e9d56082f48b50b7ca5909ee3589df916a65818ac390d9'
 
   # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
   url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version}.zip"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
The release notes have been updated to say:
`(The zip file attached includes minor fixes in the next three commits.)`
Unfortunately, since this is prefPane application, [Virustotal](https://www.virustotal.com/#/file/6cf2f7b312c1c13f74e9d56082f48b50b7ca5909ee3589df916a65818ac390d9/details) is not able to verify a signature.