### PR TITLE
Update Netnewswire to 5.0d7

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,6 +1,6 @@
 cask 'netnewswire' do
-  version '5.0d6'
-  sha256 'befe574f33664b7b625d373623d786f124da890df514989407cafc6633dd6e5d'
+  version '5.0d7'
+  sha256 'db2dd7363c910f1e6a6c4fc9734cfb9d13cffd3d1b30f9501d3a9a2be63b0b9f'
 
   url "https://ranchero.com/downloads/NetNewsWire#{version}.zip"
   appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.