### PR TITLE
Update mycrypto to 1.3.1

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.3.0'
-  sha256 '225ee4b12e2f0de504c1079eddf19bcd54d077fdd49e08deede7719662eb0f36'
+  version '1.3.1'
+  sha256 '3c1c8fa223407a14235fae5f3f953c9fd76571e7c3c217f2d0c1267f057172ad'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.