### PR TITLE
Update lehreroffice-zusatz to 2018.14.3

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.14.2'
-  sha256 '8ae820ebef1b1635495db0da6eb9225a871689af3025e801bb270e36bd71190f'
+  version '2018.14.3'
+  sha256 '525524f8054f3b0b4d2dd7a8841c542c1221086630c589f23bc428174194c6b1'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.