### PR TITLE
Update gisto to 1.10.5

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
   version '1.10.5'
-  sha256 '1435b12c75777a97ddd3e28577fcd54247015326954e6aebb1befb72f2e5f66c'
+  sha256 'e3def1a5950b3c34db6393e8e78316445311f00079e073fc875876b21f5e1a0b'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.