### PR TITLE
Restore phantomjs

### DIFF
--- a/Casks/phantomjs.rb
+++ b/Casks/phantomjs.rb
@@ -6,7 +6,6 @@ cask 'phantomjs' do
   url "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{version}-macosx.zip"
   name 'PhantomJS'
   homepage 'http://phantomjs.org/'
-  license :bsd
 
   binary "phantomjs-#{version}-macosx/bin/phantomjs"
 end

--- a/Casks/phantomjs.rb
+++ b/Casks/phantomjs.rb
@@ -1,0 +1,12 @@
+cask 'phantomjs' do
+  version '2.1.1'
+  sha256 '538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1'
+
+  # bitbucket.org/ariya/phantomjs was verified as official when first introduced to the cask
+  url "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{version}-macosx.zip"
+  name 'PhantomJS'
+  homepage 'http://phantomjs.org/'
+  license :bsd
+
+  binary "phantomjs-#{version}-macosx/bin/phantomjs"
+end

--- a/Casks/phantomjs.rb
+++ b/Casks/phantomjs.rb
@@ -8,4 +8,8 @@ cask 'phantomjs' do
   homepage 'http://phantomjs.org/'
 
   binary "phantomjs-#{version}-macosx/bin/phantomjs"
+
+  caveats do
+    discontinued
+  end
 end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -32,7 +32,6 @@
   "pandoc": "homebrew/core",
   "pgloader": "homebrew/core",
   "pgweb": "homebrew/core",
-  "phantomjs": "homebrew/core",
   "purescript": "homebrew/core",
   "python": "homebrew/core",
   "python3": "homebrew/core",


### PR DESCRIPTION
phantomjs can no longer be built by homebrew as a dependency, qt@5.5, no longer builds on MacOS X 10.14 Mojave. Homebrew/homebrew-core#32402 suggests removing it and migrating back to the Cask. This PR supports that recommendation. A separate PR to homebrew-core will add this Cask to the `tap_migrations.json` for core.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).