### PR TITLE
Update gisto to 1.10.6

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.5'
-  sha256 'e3def1a5950b3c34db6393e8e78316445311f00079e073fc875876b21f5e1a0b'
+  version '1.10.6'
+  sha256 '9243326f7cb0818c63b97740974b06b1d4841f9098e2061d2427310258670676'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.