### PR TITLE
Update thingsmacsandboxhelper to 3.14

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -4,8 +4,6 @@ cask 'thingsmacsandboxhelper' do
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"
-  name 'Things Helper'
-  name "Things Helper for Things #{version.major}"
   name 'ThingsMacSandboxHelper'
   homepage "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things#{version.major}/"
 

--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -9,5 +9,5 @@ cask 'thingsmacsandboxhelper' do
   name 'ThingsMacSandboxHelper'
   homepage "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things#{version.major}/"
 
-  app 'Things Helper.app'
+  app 'ThingsMacSandboxHelper.app'
 end

--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -1,11 +1,13 @@
 cask 'thingsmacsandboxhelper' do
-  version '3.13'
-  sha256 '547d041ec327887d90d89a450d61c5c6fda538131c7590a924f003efc62753e6'
+  version '3.14'
+  sha256 '43daa0e9f093770cbeeff35e2d34925b08a5df688c3f560bdd8ed81d05e6b886'
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"
+  name 'Things Helper'
+  name "Things Helper for Things #{version.major}"
   name 'ThingsMacSandboxHelper'
   homepage "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things#{version.major}/"
 
-  app 'ThingsMacSandboxHelper.app'
+  app 'Things Helper.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.