### PR TITLE
Java 11+28:  Remove now–non-applicable DSL code.  

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -29,13 +29,15 @@ cask 'java' do
                    sudo: true
   end
 
-  uninstall pkgutil:   [
-                         "com.oracle.jdk-#{version.before_comma}",
-                       ],
-            delete:    [
-                         "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
-                         '/Library/Java/Home',
-                         '/Library/Java/MacOS',
-                       ],
-            rmdir:     "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk"
+  uninstall pkgutil: "com.oracle.jdk-#{version.before_comma}",
+            delete:  [
+                       "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
+                       '/Library/Java/Home',
+                       '/Library/Java/MacOS',
+                     ],
+            rmdir:   "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk"
+
+  caveats do
+    license 'https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html'
+  end
 end

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -15,18 +15,6 @@ cask 'java' do
   pkg "JDK #{version.before_comma}.pkg"
 
   postflight do
-    system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
-                   sudo: true
-    system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
-                   sudo: true
-    system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
-                   sudo: true
-    system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
-                   sudo: true
     system_command '/bin/ln',
                    args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
                    sudo: true
@@ -43,53 +31,11 @@ cask 'java' do
 
   uninstall pkgutil:   [
                          "com.oracle.jdk-#{version.before_comma}",
-                         'com.oracle.jre',
-                       ],
-            launchctl: [
-                         'com.oracle.java.Helper-Tool',
-                         'com.oracle.java.Java-Updater',
-                       ],
-            quit:      [
-                         'com.oracle.java.Java-Updater',
-                         'net.java.openjdk.cmd', # Java Control Panel
                        ],
             delete:    [
-                         '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin',
                          "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
-                         '/Library/PreferencePanes/JavaControlPanel.prefPane',
                          '/Library/Java/Home',
                          '/Library/Java/MacOS',
                        ],
             rmdir:     "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk"
-
-  zap trash: [
-               '/Library/Application Support/Oracle/Java',
-               '/Library/Preferences/com.oracle.java.Deployment.plist',
-               '/Library/Preferences/com.oracle.java.Helper-Tool.plist',
-               '~/Library/Application Support/Java/',
-               '~/Library/Application Support/Oracle/Java',
-               '~/Library/Caches/com.oracle.java.Java-Updater',
-               '~/Library/Caches/Oracle.MacJREInstaller',
-               '~/Library/Caches/net.java.openjdk.cmd',
-               '~/Library/Preferences/com.oracle.java.Java-Updater.plist',
-               '~/Library/Preferences/com.oracle.java.JavaAppletPlugin.plist',
-               '~/Library/Preferences/com.oracle.javadeployment.plist',
-             ],
-      rmdir: [
-               '/Library/Application Support/Oracle/',
-               '~/Library/Application Support/Oracle/',
-             ]
-
-  caveats do
-    license 'https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html'
-    <<~EOS
-      This Cask makes minor modifications to the JRE to prevent issues with
-      packaged applications, as discussed here:
-
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
-
-      If your Java application still asks for JRE installation, you might need
-      to reboot or logout/login.
-    EOS
-  end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.  
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.  (See below.)  
- [x] The commit message includes the cask’s name and version.  
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

~~Additionally, if **adding a new cask**:~~  

- [ ] ~~Named the cask according to the [token reference].~~  
- [ ] ~~`brew cask install {{cask_file}}` worked successfully.~~  
- [ ] ~~`brew cask uninstall {{cask_file}}` worked successfully.~~  
- [ ] ~~Checked there are no [open pull requests] for the same cask.~~  
- [ ] ~~Checked the cask was not [already refused].~~  
- [ ] ~~Checked the cask is submitted to [the correct repo].~~  

(N/A; not submitting a new cask.)  

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(Prompted by [this Discourse thread](https://discourse.brew.sh/t/homebrew-cask-java-packaging-puzzlement/3085/2).)  I based these changes on what's left in the copy of `/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Info.plist` distributed by upstream and as installed outside of Homebrew Cask, but let me know if any of these changes are either too aggressive or too conservative.  As for the newly-introduced `brew cask style` violations, I'm not sure how they popped out of me just deleting some surrounding code, but please suggest a fix for them.  