### PR TITLE
Update manager to 18.10.7

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.0'
-  sha256 '4afce5673fcf4c004d71623588804151dd92980d95ee5061040c3113c7613408'
+  version '18.10.7'
+  sha256 '69dbfd10bb66b5a846318f0590a47c73fe957aad7d73e1db425b05f25778445e'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.