### PR TITLE
Update securesafe to 2.4.4

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,10 +1,15 @@
 cask 'securesafe' do
-  version '2.2.4'
-  sha256 '403a009d56c3c9e891570ddf06f3499c86868a0ca9138f66b3a3718ad04742c0'
+  version '2.4.4'
+  sha256 '9d326dc606b334f4380eb755399d82c836cd8754a4f41239e946b2be909dda05'
 
-  url "https://www.securesafe.com/downloads/SecureSafe_#{version}.dmg"
+  url "https://www.securesafe.com/downloads/SecureSafe_#{version}.pkg"
   name 'SecureSafe'
   homepage 'https://www.securesafe.com/'
 
-  app 'SecureSafe.app'
+  pkg "SecureSafe_#{version}.pkg"
+
+  uninstall pkgutil: [
+                       'com.dswiss.securesafe.pkg.sync',
+                       'com.github.osxfuse.pkg.Core',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/pull/52081