### PR TITLE
Update textadept to 10.0

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,6 +1,6 @@
 cask 'textadept' do
   version '10.0'
-  sha256 '86a08c2acde892a3e24fcd5b4bd0125d81670b1dde1b64f2ad4fb61211aa80b5'
+  sha256 '22429aaf231e5be44857c274659a37bc6940d153079d5b21744672c29c8c19a9'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
   appcast 'https://foicica.com/textadept/feed'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.