### PR TITLE
Update qownnotes to 18.09.5,b3847-085027

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.09.4,b3844-111449'
-  sha256 '4fb5949b7eb357a67c5a36c3cd1f6618280611f06dfc9314659acd0c63a6429c'
+  version '18.09.5,b3847-085027'
+  sha256 '2496fac811ed547ec7dce7f28a5c45f156763d918769ebc5b1233fcc21a18b69'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.