### PR TITLE
Update smartgit to 18.1.5

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '18.1.4'
-  sha256 '4537105929752cd91c0db3e1d4dd832b9dd8a9faa811fac021989c80b2232e0d'
+  version '18.1.5'
+  sha256 '52de2c0f4e4d529063da4c4f9f9de4eed425109139d7ba026944535eb3f0e0b7'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.