### PR TITLE
Update rocket to 1.4.1,48:1538003507

### DIFF
--- a/Casks/rocket.rb
+++ b/Casks/rocket.rb
@@ -1,6 +1,6 @@
 cask 'rocket' do
-  version '1.4,45:1516764069'
-  sha256 '3d1df422ced7200610ce929369c1851e6328b83069829687e21f618ebf829d95'
+  version '1.4.1,48:1538003507'
+  sha256 '3121ef948d5fecb399634ea0687a6fc526429d631b4fc1e828028e62a2124a91'
 
   # dl.devmate.com/net.matthewpalmer.Rocket was verified as official when first introduced to the cask
   url "https://dl.devmate.com/net.matthewpalmer.Rocket/#{version.after_comma.before_colon}/#{version.after_colon}/Rocket-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.