### PR TITLE
Update sogouinput to 48a,1535352534

### DIFF
--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -1,13 +1,13 @@
 cask 'sogouinput' do
-  version '46b,1519980135'
-  sha256 '63c8d2fef4d54ef5c72dffd573c0be89efa518d94373b88debb30cb7ac97191b'
+  version '48a,1535352534'
+  sha256 '8699b3e9080b7aaee2a19950b40e86a3f54b7ff8b09308aba116d26643bc63be'
 
-  url "http://cdn2.ime.sogou.com/dl/index/#{version.after_comma}/sogou_mac_#{version.before_comma}.dmg"
+  url "http://cdn2.ime.sogou.com/dl/index/#{version.after_comma}/sogou_mac_#{version.before_comma}.zip"
   name 'Sogou Input Method'
   name '搜狗输入法'
   homepage 'https://pinyin.sogou.com/mac/'
 
-  installer manual: '安装搜狗输入法.app'
+  installer manual: 'sogou_mac_48a.app'
 
   uninstall delete:    [
                          '/Library/Input Methods/SogouInput.app',


### PR DESCRIPTION
this update fix performance issues in macos mojave
and download file type changed from dmg to zip

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
