### PR TITLE
Update scap-workbench to 1.2.0

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,6 +1,6 @@
 cask 'scap-workbench' do
   version '1.2.0'
-  sha256 'cf24fe103e975700532105bf32c741bfd54e4f3b9512435b2e970df607b541de'
+  sha256 '5acd7e167c8c5f874dc7b0980f9d36b4ea5832307c50b7ea0fd7cfc662dc7f55'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
   url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version.sub(%r{-.+}, '')}/scap-workbench-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.