### PR TITLE
Update trinity to 0.3.6

### DIFF
--- a/Casks/trinity.rb
+++ b/Casks/trinity.rb
@@ -1,6 +1,6 @@
 cask 'trinity' do
-  version '0.3.5'
-  sha256 '20afa7563294ddef8e5bdbcc8527417341bb3e356cb9c8edddcbdf0b824037da'
+  version '0.3.6'
+  sha256 '6df89a0c160859a166eb9029c5546c54da76c027d19e6f0e0bb47aa2d1c8ee3c'
 
   # github.com/iotaledger/trinity-wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/trinity-wallet/releases/download/#{version}/trinity-desktop-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.