### PR TITLE
Update scidavis to 1.23

### DIFF
--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -1,6 +1,6 @@
 cask 'scidavis' do
   version '1.23'
-  sha256 'ab2c7fa6dba4304ecb250aa94f27725b55f5d3ec413c86d4fb043c3a22f41c0d'
+  sha256 '5b3925dfdf0b5dcda9d2a9929b5ae8a9f83cb6130389cea2a9248e84e396fdf2'
 
   url "https://downloads.sourceforge.net/scidavis/scidavis-#{version}.pkg"
   appcast 'https://sourceforge.net/projects/scidavis/rss.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.