### PR TITLE
Update joplin to 1.0.110

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.109'
-  sha256 'f2a64a9ea97ff17c7fc0facff9669b509a3227ddf2bd8f38680415c3ccec0916'
+  version '1.0.110'
+  sha256 '3527ef7824caa91542169239a5e0a2c785ca4137db38d343c3b2a501dcf4dd6c'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.