### PR TITLE
Update get-backup-pro to 3.4.7

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,6 +1,6 @@
 cask 'get-backup-pro' do
-  version '3.4.6'
-  sha256 '50b0bb9a6be1120bf730f3c832e615714754b79fcc9c5db6ea115500456b2675'
+  version '3.4.7'
+  sha256 'd77d2708ce692e438ed3833f6bea31451dcbb87a1163c5665b72f9db88bd7de6'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"


### PR DESCRIPTION
The `get-backup-pro` is currently failing the checksum verification. They released 3.4.7 and updated the zip file on the same URL.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).