### PR TITLE
Update understand to 5.0.962

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -2,7 +2,7 @@ cask 'understand' do
   version '5.0.962'
   sha256 '38dddc572b73bd15fda47c7deb7426f3022f1a47fb8b4018134c5ec518bf3478'
 
-  url "http://builds.scitools.com/all_builds/b#{version.minor}/Understand/Understand-#{version}-MacOSX-x86.dmg"
+  url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'
 

--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,8 +1,8 @@
 cask 'understand' do
-  version '5.0.961'
-  sha256 '0264747541f964afe0eef19bd6cf9afebaaa43073fabf5c4ac340b8323e0a0d8'
+  version '5.0.962'
+  sha256 '38dddc572b73bd15fda47c7deb7426f3022f1a47fb8b4018134c5ec518bf3478'
 
-  url "http://latest.scitools.com/Understand/Understand-#{version}-MacOSX-x86.dmg"
+  url "http://builds.scitools.com/all_builds/b#{version.split(//).last(3).join}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'
 

--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -2,7 +2,7 @@ cask 'understand' do
   version '5.0.962'
   sha256 '38dddc572b73bd15fda47c7deb7426f3022f1a47fb8b4018134c5ec518bf3478'
 
-  url "http://builds.scitools.com/all_builds/b#{version.split(//).last(3).join}/Understand/Understand-#{version}-MacOSX-x86.dmg"
+  url "http://builds.scitools.com/all_builds/b#{version.minor}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.