### PR TITLE
Upgrade Aria2D to Latest

### DIFF
--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,9 +1,9 @@
 cask 'aria2d' do
-  version '1.2.1,1535339003'
-  sha256 '8338d48fa8c90c8f785568b7b16ca86613b6a8c64d107933a1bc72d6aa401e25'
+  version :latest
+  sha256 :no_check
 
   # dl.devmate.com/com.xjbeta.Aria2D was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.xjbeta.Aria2D/#{version.before_comma}/#{version.after_comma}/Aria2D-#{version.before_comma}.zip"
+  url 'https://dl.devmate.com/com.xjbeta.Aria2D/Aria2D.zip'
   appcast 'https://updates.devmate.com/com.xjbeta.Aria2D.xml'
   name 'Aria2D'
   homepage 'https://github.com/xjbeta/Aria2D'

--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,9 +1,9 @@
 cask 'aria2d' do
-  version :latest
-  sha256 :no_check
+  version '1.2.4,1538136711'
+  sha256 'b13a5ca5897c3b6614e1ff974cf43f6293db91697cdb4bec4eb8b31ab4d1d527'
 
   # dl.devmate.com/com.xjbeta.Aria2D was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.xjbeta.Aria2D/Aria2D.zip'
+  url "https://dl.devmate.com/com.xjbeta.Aria2D/#{version.before_comma}/#{version.after_comma}/Aria2D-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.xjbeta.Aria2D.xml'
   name 'Aria2D'
   homepage 'https://github.com/xjbeta/Aria2D'


### PR DESCRIPTION
The author stopped offering download for previous versions, instead, now he provides a general url. So here I'm updating for this.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
