### PR TITLE
Update ieasemusic to 1.3.1

### DIFF
--- a/Casks/ieasemusic.rb
+++ b/Casks/ieasemusic.rb
@@ -1,6 +1,6 @@
 cask 'ieasemusic' do
-  version '1.3.0'
-  sha256 'b84b785b881f74b3c451f1f80a47f7e2e8f972e040ddc786713bebeead430ae2'
+  version '1.3.1'
+  sha256 'd0106c5f501c378e8287e93cd7d68d7f2c7960cd29154eb9592435bd0c95f527'
 
   url "https://github.com/trazyn/ieaseMusic/releases/download/v#{version}/ieaseMusic-#{version}-mac.dmg"
   appcast 'https://github.com/trazyn/ieaseMusic/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.