### PR TITLE
Update retas-studio.rb

### DIFF
--- a/Casks/retas-studio.rb
+++ b/Casks/retas-studio.rb
@@ -1,11 +1,20 @@
 cask 'retas-studio' do
-  version '6.6.0'
-  sha256 '387d299ac77dad4a4116605e492e7c69614c463cde2ce5df439caaa55c9befb5'
+  version '1.8.2'
+  sha256 '55069bfd6ece3bacde37db2eef4fe37c013e0d6f3aed026e3894ed197fa392a2'
 
-  # clip-studio.com was verified as official when first introduced to the cask
-  url "https://www.clip-studio.com/clip_site/rental/rental_download/rsrental/dl?f=lib/retasstudio/data/#{version.no_dots}/RS_#{version.no_dots}_app.dmg"
-  name 'RETAS STUDIO'
-  homepage 'http://www.retasstudio.net/'
+  # clip-studio.net was verified as official when first introduced to the cask
+  url "http://vd.clipstudio.net/clipcontent/paint/app/182/CSP_#{version.no_dots}m_app.pkg"
+  name 'CLIP STUDIO PAINT'
+  homepage 'http://www.clip-studio.com/clip_site/clipstudiopaint/'
 
-  app 'RETAS STUDIO.app'
+  pkg 'CSP_#{version.no_dots}m_app.pkg'
+  
+  uninstall pkgutil: [
+                       'jp.co.CELSYS.ClipStudioPaint.Support.100.pkg',
+                       'jp.co.CELSYS.ClipStudioPaint.150.pkg',
+                       'jp.co.CELSYS.ClipStudioPaint.Common.160.pkg',
+                       'jp.co.CELSYS.CertMdul.150.pkg',
+                       'jp.co.CELSYS.AggregateMdul.150.pkg',
+                       'jp.co.CELSYS.ClipStudio.150.pkg',
+                     ]  
 end


### PR DESCRIPTION
RETAS STUDIO has been failing to install because of a SHA-only change for quite some time. its unsigned, so i can't send an update and it seems hard to get confirmation from the developer. furthermore 'RETAS STUDIO' seems deprecated, and 'CLIP STUDIO PAINT' seems to be their official successor app. so i propose updating the cask to the newest version of CLIP STUDIO PAINT
