### PR TITLE
Update qctools to 1.0

### DIFF
--- a/Casks/qctools.rb
+++ b/Casks/qctools.rb
@@ -1,8 +1,8 @@
 cask 'qctools' do
-  version '0.9'
-  sha256 'edc8971d7478e7f50e43d73e73addfed64ce3c5628fcbecbdaecd014d608484c'
+  version '1.0'
+  sha256 'ee4ab0803dc387ad4475544ba3f97ccd5126d3f237d5349bebae48bef18b85a9'
 
-  url "https://github.com/bavc/qctools/releases/download/v#{version.major_minor_patch}/QCTools_#{version}_mac.dmg"
+  url "https://github.com/bavc/qctools/releases/download/v#{version.major_minor_patch}/QCTools.Mac.-.QCTools_#{version}_mac.dmg"
   appcast 'https://github.com/bavc/qctools/releases.atom'
   name 'QCTools'
   homepage 'https://github.com/bavc/qctools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.