### PR TITLE
Update macdive to 2.10.3

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,6 +1,6 @@
 cask 'macdive' do
-  version '2.9.4'
-  sha256 'b6735e8e7538ef50f4f68b78cb4f3626ceecc7bfbb2607f2e799f78f262fc395'
+  version '2.10.3'
+  sha256 'ed58d680a99467f708a852accc16d397a5cb3ba647e790aeb9fa953541055868'
 
   url "http://mac-dive.com/shimmer/?download&appName=MacDive&appVariant=&appVersion=#{version}"
   appcast 'https://mac-dive.com/shimmer/?appcast&appName=MacDive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.