### PR TITLE
Update iterm2 to 3.2.2

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.1'
-  sha256 '00d6bd333ea5819c6a2e8139ea63a28d1b44e7a07da2fde537c7516e3353c31d'
+  version '3.2.2'
+  sha256 'c97702eba2b943e800fd8417b780596c35cfccef2e579a6b6a6203efea40e745'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.