### PR TITLE
Update subsurface to 4.8.3

### DIFF
--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,6 +1,6 @@
 cask 'subsurface' do
-  version '4.8.2'
-  sha256 '0a207890e23268df1fe381a99298e57cdbe87132714c78287390271bf023d641'
+  version '4.8.3'
+  sha256 'a798019d7c6ef9bc8c23b57f07440068361e16b78ddba6ea8b607b719fb1569b'
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   name 'Subsurface'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.