### PR TITLE
Update vivaldi to 2.0.1309.37

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.0.1309.29'
-  sha256 '6d354a3bacaec4756b8333d9935243697501434f2fe2a6fcb0538f6129b8d4c6'
+  version '2.0.1309.37'
+  sha256 '820df1024672c66907e5763665bb1211da9f0a870a53dae0e21ed7e7677c16f5'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.