### PR TITLE
Update ticktick to 2.7.51,81

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.7.50,77'
-  sha256 'a0ce491936bf4ea79f5111144555b13d1cb77bfa05d6e4413da7332b9326acf7'
+  version '2.7.51,81'
+  sha256 '69f9459bf2536f441ab94700fee54bd6b5c9c93b87ad5d15e8b518abdb02b39e'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.