### PR TITLE
Update anaconda to 5.3.0

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,6 +1,6 @@
 cask 'anaconda' do
-  version '5.2.0'
-  sha256 'c8089121dc89ffe8f9a0c01205bab75a112821a13d413152d6690f5eef094afa'
+  version '5.3.0'
+  sha256 'bc073b6e6d3b2ef29d01a2caf1de7c206c95968231ef0492d958eae1a314b4e9'
 
   url "https://repo.anaconda.com/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"
   name 'Continuum Analytics Anaconda'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

------

~Could not run `brew cask style --fix anaconda.rb` due to Ruby issues, but modifications were minimal and work normally on my machine.~

Edit: `brew cask style` now runs successfully and with no offenses. As an FYI for `rubocop` gem issues, see my thread here: https://discourse.brew.sh/t/how-to-make-homebrew-use-non-system-ruby/3130.

Anaconda 5.3.0 still working normally.
