### PR TITLE
Update nosleep to 1.5.0

### DIFF
--- a/Casks/nosleep.rb
+++ b/Casks/nosleep.rb
@@ -1,9 +1,9 @@
 cask 'nosleep' do
-  version '1.4.0'
-  sha256 '29e7f771970dce41936372687a5160700e2208357ef1ce37d81ac95c9188efe8'
+  version '1.5.0'
+  sha256 '5e280d6268a26f292dd6ad308e5cafc9a2396861a43e53a01744ac78db987e2d'
 
   # github.com/integralpro/nosleep was verified as official when first introduced to the cask
-  url "https://github.com/integralpro/nosleep/releases/download/v#{version}/NoSleep-#{version}.dmg"
+  url 'https://github.com/integralpro/nosleep/releases/download/1.5/NoSleep-1.5.0.dmg'
   appcast 'https://github.com/integralpro/nosleep/releases.atom'
   name 'NoSleep'
   homepage 'https://integralpro.github.io/nosleep/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.