### PR TITLE
Set auto_updates for OpenEmu Cask

### DIFF
--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -13,6 +13,8 @@ cask 'openemu' do
   name 'OpenEmu'
   homepage 'http://openemu.org/'
 
+  auto_updates true
+
   app 'OpenEmu.app'
 
   zap trash: [


### PR DESCRIPTION
OpenEmu checks & updates at startup if a new version is available,
and it has "Check for Updates..." in its app menu.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
