### PR TITLE
Update fldigi to 4.0.18,4.3.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.0.17,4.3.7'
-  sha256 '1508c2c8357739417a4917321f871bf388850af009dddb7f9fc08481d9136e41'
+  version '4.0.18,4.3.7'
+  sha256 '8c6b317d6825b664df192d87e726b7c7caba4dcf6722d8f362d4565b24622d0d'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_macos.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.