### PR TITLE
zeplin.rb: remove download location comment

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -2,7 +2,6 @@ cask 'zeplin' do
   version :latest
   sha256 :no_check
 
-  # downloads can be found at https://support.zeplin.io/quick-start/downloading-mac-and-windows-apps
   url 'https://api.zeplin.io/urls/download-mac'
   name 'Zeplin'
   homepage 'https://zeplin.io/'


### PR DESCRIPTION
Noticed downloads are (now?) clearly available at the bottom of the page.