### PR TITLE
Update zeplin to 2.1.1 (539)

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,5 +1,5 @@
 cask 'zeplin' do
-  version '2.1.1 (539)'
+  version '2.1.1,539'
   sha256 '1c6a91cb776010fec7872c8ec32904644a8f72d1889bd10135dbb20521609681'
 
   url 'https://api.zeplin.io/urls/download-mac'

--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,8 +1,9 @@
 cask 'zeplin' do
-  version :latest
-  sha256 :no_check
+  version '2.1.1 (539)'
+  sha256 '1c6a91cb776010fec7872c8ec32904644a8f72d1889bd10135dbb20521609681'
 
   url 'https://api.zeplin.io/urls/download-mac'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'
   name 'Zeplin'
   homepage 'https://zeplin.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.