### PR TITLE
Update manager to 18.10.20

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.15'
-  sha256 '7e3dd8eedb1856fb20ca3c82e13ac7fb6057dd917ae95cfc2cf835f40ddcf88c'
+  version '18.10.20'
+  sha256 'e8d0d7b458d312a2dce6026f010ab58e3af6c43296832c3bc38c87d0225cf866'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.