### PR TITLE
Update endnote to 9

### DIFF
--- a/Casks/endnote.rb
+++ b/Casks/endnote.rb
@@ -8,7 +8,7 @@ cask 'endnote' do
 
   container nested: "Install EndNote X#{version}.app/Contents/Resources/EndNote.zip"
 
-  suite "EndNote X#{version}"
+  suite "EndNote"
 
   zap trash: [
                '/Library/Application Support/ResearchSoft/EndNote',

--- a/Casks/endnote.rb
+++ b/Casks/endnote.rb
@@ -1,5 +1,5 @@
 cask 'endnote' do
-  version '8'
+  version '9'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "http://download.endnote.com/downloads/X#{version}/EndNoteX#{version}Installer.dmg"

--- a/Casks/endnote.rb
+++ b/Casks/endnote.rb
@@ -8,7 +8,7 @@ cask 'endnote' do
 
   container nested: "Install EndNote X#{version}.app/Contents/Resources/EndNote.zip"
 
-  suite "EndNote"
+  suite 'EndNote'
 
   zap trash: [
                '/Library/Application Support/ResearchSoft/EndNote',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.