### PR TITLE
Update icab to 5.8.6

### DIFF
--- a/Casks/icab.rb
+++ b/Casks/icab.rb
@@ -1,6 +1,6 @@
 cask 'icab' do
-  version '5.8.5'
-  sha256 'dded84c2d0b1bc8d734002eb6fb1eb608cebc0417499f5587a95f8df78f7c940'
+  version '5.8.6'
+  sha256 '8ef3f51a54a129b9edf193f8f5d251888981b41bd829d3d457ef6b7930c4a125'
 
   # icab.clauss-net.de was verified as official when first introduced to the cask
   url "http://icab.clauss-net.de/icab/iCab_#{version}_Intel.zip"
@@ -10,5 +10,5 @@ cask 'icab' do
 
   depends_on macos: '>= :lion'
 
-  app "iCab #{version} (64+32 Bit Intel Version for macOS 10.7-10.13)/iCab.app"
+  app "iCab #{version} (64+32 Bit Intel Version for macOS 10.7-10.14)/iCab.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.