### PR TITLE
fix wrong depends_on macos stanzas

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -7,7 +7,7 @@ cask 'deckset' do
   name 'Deckset'
   homepage 'https://www.decksetapp.com/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   app 'Deckset.app'
 end

--- a/Casks/findings.rb
+++ b/Casks/findings.rb
@@ -7,7 +7,7 @@ cask 'findings' do
   name 'Findings'
   homepage 'http://findingsapp.com/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   app 'Findings.app'
 end

--- a/Casks/reveal.rb
+++ b/Casks/reveal.rb
@@ -7,7 +7,7 @@ cask 'reveal' do
   name 'Reveal'
   homepage 'https://revealapp.com/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   app 'Reveal.app'
 end

--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -8,7 +8,7 @@ cask 'screenflow' do
   homepage 'https://www.telestream.net/screenflow/'
 
   auto_updates true
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :sierra'
 
   app 'ScreenFlow.app'
 end

--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -8,7 +8,7 @@ cask 'screens' do
   name 'Screens'
   homepage 'https://edovia.com/screens-mac/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   app "Screens #{version.major}.app"
 

--- a/Casks/voodoopad.rb
+++ b/Casks/voodoopad.rb
@@ -8,7 +8,7 @@ cask 'voodoopad' do
   name 'VoodooPad'
   homepage 'https://www.voodoopad.com/'
 
-  depends_on macos: '>= :lion'
+  depends_on macos: '>= :sierra'
 
   app 'VoodooPad.app'
 end


### PR DESCRIPTION
this pull request updates casks that have wrong 'depends_on macos' stanzas