### PR TITLE
fix missing depends_on macos stanzas

### DIFF
--- a/Casks/archiver.rb
+++ b/Casks/archiver.rb
@@ -8,5 +8,7 @@ cask 'archiver' do
   name 'Archiver'
   homepage 'http://archiverapp.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Archiver.app'
 end

--- a/Casks/autodmg.rb
+++ b/Casks/autodmg.rb
@@ -7,6 +7,8 @@ cask 'autodmg' do
   name 'AutoDMG'
   homepage 'https://github.com/MagerValp/AutoDMG'
 
+  depends_on macos: '>= :sierra'
+
   app 'AutoDMG.app'
 
   zap trash: [

--- a/Casks/barsoom.rb
+++ b/Casks/barsoom.rb
@@ -8,7 +8,6 @@ cask 'barsoom' do
   homepage 'https://www.seense.com/barsoom/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Barsoom.app'

--- a/Casks/barsoom.rb
+++ b/Casks/barsoom.rb
@@ -9,5 +9,7 @@ cask 'barsoom' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Barsoom.app'
 end

--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -6,5 +6,7 @@ cask 'birdfont' do
   name 'BirdFont'
   homepage 'https://birdfont.org/'
 
+  depends_on macos: '>= :sierra'
+
   app 'BirdFontNonCommercial.app'
 end

--- a/Casks/cocoarestclient.rb
+++ b/Casks/cocoarestclient.rb
@@ -8,5 +8,7 @@ cask 'cocoarestclient' do
   name 'CocoaRestClient'
   homepage 'https://mmattozzi.github.io/cocoa-rest-client/'
 
+  depends_on macos: '>= :sierra'
+
   app 'CocoaRestClient.app'
 end

--- a/Casks/energybar.rb
+++ b/Casks/energybar.rb
@@ -7,5 +7,7 @@ cask 'energybar' do
   name 'EnergyBar'
   homepage 'https://github.com/billziss-gh/EnergyBar'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'EnergyBar.app'
 end

--- a/Casks/fanny.rb
+++ b/Casks/fanny.rb
@@ -6,5 +6,7 @@ cask 'fanny' do
   name 'FannyWidget'
   homepage 'http://fannywidget.com/'
 
+  depends_on macos: '>= :sierra'
+
   app "Fanny #{version}/Fanny.app"
 end

--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -7,6 +7,8 @@ cask 'flinto' do
   name 'Flinto'
   homepage 'https://www.flinto.com/mac'
 
+  depends_on macos: '>= :sierra'
+
   app 'Flinto.app'
 
   uninstall pkgutil: 'com.flinto.*'

--- a/Casks/haptickey.rb
+++ b/Casks/haptickey.rb
@@ -7,5 +7,7 @@ cask 'haptickey' do
   name 'HapticKey'
   homepage 'https://github.com/niw/HapticKey'
 
+  depends_on macos: '>= :sierra'
+
   app 'HapticKey.app'
 end

--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -9,5 +9,7 @@ cask 'harvest' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Harvest.app'
 end

--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -8,7 +8,6 @@ cask 'harvest' do
   homepage 'https://www.getharvest.com/mac-time-tracking'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Harvest.app'

--- a/Casks/haskell-for-mac.rb
+++ b/Casks/haskell-for-mac.rb
@@ -9,7 +9,6 @@ cask 'haskell-for-mac' do
   homepage 'http://haskellformac.com/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Haskell.app'

--- a/Casks/haskell-for-mac.rb
+++ b/Casks/haskell-for-mac.rb
@@ -10,6 +10,8 @@ cask 'haskell-for-mac' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Haskell.app'
 
   zap trash: [

--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -7,5 +7,7 @@ cask 'jamf-migrator' do
   name 'JamfMigrator'
   homepage 'https://github.com/jamfprofessionalservices/JamfMigrator'
 
+  depends_on macos: '>= :sierra'
+
   app 'jamf-migrator.app'
 end

--- a/Casks/jupyter-notebook-viewer.rb
+++ b/Casks/jupyter-notebook-viewer.rb
@@ -7,5 +7,7 @@ cask 'jupyter-notebook-viewer' do
   name 'Jupyter Notebook Viewer'
   homepage 'https://github.com/tuxu/nbviewer-app'
 
+  depends_on macos: '>= :sierra'
+
   app 'Jupyter Notebook Viewer.app'
 end

--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -9,6 +9,8 @@ cask 'kaleidoscope' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Kaleidoscope.app'
   binary "#{appdir}/Kaleidoscope.app/Contents/Resources/bin/ksdiff"
 

--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -8,7 +8,6 @@ cask 'kaleidoscope' do
   homepage 'https://www.kaleidoscopeapp.com/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Kaleidoscope.app'

--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -7,6 +7,8 @@ cask 'kitty' do
   name 'kitty'
   homepage 'https://github.com/kovidgoyal/kitty'
 
+  depends_on macos: '>= :sierra'
+
   app 'kitty.app'
 
   zap trash: [

--- a/Casks/latest.rb
+++ b/Casks/latest.rb
@@ -7,5 +7,7 @@ cask 'latest' do
   name 'Latest'
   homepage 'https://max.codes/latest'
 
+  depends_on macos: '>= :sierra'
+
   app 'Latest.app'
 end

--- a/Casks/marsedit.rb
+++ b/Casks/marsedit.rb
@@ -7,5 +7,7 @@ cask 'marsedit' do
   name 'MarsEdit'
   homepage 'https://red-sweater.com/marsedit/'
 
+  depends_on macos: '>= :sierra'
+
   app 'MarsEdit.app'
 end

--- a/Casks/night-owl.rb
+++ b/Casks/night-owl.rb
@@ -9,5 +9,9 @@ cask 'night-owl' do
   name 'YoruFukurou'
   homepage 'https://sites.google.com/site/yorufukurou/home-en'
 
+  depends_on macos: '>= :mojave'
+
+  depends_on macos: '>= :sierra'
+
   app 'Night Owl.app'
 end

--- a/Casks/night-owl.rb
+++ b/Casks/night-owl.rb
@@ -9,8 +9,6 @@ cask 'night-owl' do
   name 'YoruFukurou'
   homepage 'https://sites.google.com/site/yorufukurou/home-en'
 
-  depends_on macos: '>= :mojave'
-
   depends_on macos: '>= :sierra'
 
   app 'Night Owl.app'

--- a/Casks/nightowl.rb
+++ b/Casks/nightowl.rb
@@ -7,5 +7,7 @@ cask 'nightowl' do
   name 'NightOwl'
   homepage 'https://nightowl.kramser.xyz/'
 
+  depends_on macos: '>= :mojave'
+
   app 'NightOwl.app'
 end

--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -6,6 +6,8 @@ cask 'omniplan' do
   name 'OmniPlan'
   homepage 'https://www.omnigroup.com/omniplan/'
 
+  depends_on macos: '>= :sierra'
+
   app 'OmniPlan.app'
 
   zap trash: [

--- a/Casks/overkill.rb
+++ b/Casks/overkill.rb
@@ -7,6 +7,8 @@ cask 'overkill' do
   name 'Overkill'
   homepage 'https://github.com/KrauseFx/overkill-for-mac'
 
+  depends_on macos: '>= :sierra'
+
   app 'Overkill.app'
 
   zap trash: '~/Library/Preferences/com.krausefx.Overkill.plist'

--- a/Casks/penc.rb
+++ b/Casks/penc.rb
@@ -8,5 +8,7 @@ cask 'penc' do
   name 'Penc'
   homepage 'https://dgurkaynak.github.io/Penc/'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'Penc.app'
 end

--- a/Casks/plant.rb
+++ b/Casks/plant.rb
@@ -9,5 +9,7 @@ cask 'plant' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Plant.app'
 end

--- a/Casks/plant.rb
+++ b/Casks/plant.rb
@@ -8,7 +8,6 @@ cask 'plant' do
   homepage 'https://plantapp.io/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Plant.app'

--- a/Casks/plistedit-pro.rb
+++ b/Casks/plistedit-pro.rb
@@ -7,6 +7,8 @@ cask 'plistedit-pro' do
   name 'PlistEdit Pro'
   homepage 'https://www.fatcatsoftware.com/plisteditpro/'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'PlistEdit Pro.app'
   binary "#{appdir}/PlistEdit Pro.app/Contents/MacOS/pledit"
 

--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -7,6 +7,8 @@ cask 'propresenter' do
   name 'ProPresenter'
   homepage 'https://www.renewedvision.com/propresenter.php'
 
+  depends_on macos: '>= :sierra'
+
   app "ProPresenter #{version.major}.app"
 
   zap trash: [

--- a/Casks/protonvpn.rb
+++ b/Casks/protonvpn.rb
@@ -7,6 +7,8 @@ cask 'protonvpn' do
   name 'ProtonVPN'
   homepage 'https://protonvpn.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'ProtonVPN.app'
 
   uninstall launchctl: 'ch.protonvpn.ProtonVPNStarter',

--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -8,5 +8,7 @@ cask 'renamer' do
   name 'Renamer'
   homepage 'http://renamer.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Renamer.app'
 end

--- a/Casks/rhodes-kite.rb
+++ b/Casks/rhodes-kite.rb
@@ -7,5 +7,7 @@ cask 'rhodes-kite' do
   name 'Kite Compositor'
   homepage 'https://kiteapp.co/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Kite.app'
 end

--- a/Casks/shifty.rb
+++ b/Casks/shifty.rb
@@ -8,6 +8,8 @@ cask 'shifty' do
   name 'Shifty'
   homepage 'http://shifty.natethompson.io/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Shifty.app'
 
   uninstall launchctl: 'io.natethompson.ShiftyHelper',

--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -9,6 +9,8 @@ cask 'sketch' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Sketch.app'
 
   zap trash: [

--- a/Casks/sketch.rb
+++ b/Casks/sketch.rb
@@ -8,7 +8,6 @@ cask 'sketch' do
   homepage 'https://www.sketchapp.com/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Sketch.app'

--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -8,7 +8,6 @@ cask 'smooze' do
   homepage 'https://smooze.co/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'Smooze.app'

--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -9,6 +9,8 @@ cask 'smooze' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'Smooze.app'
 
   uninstall login_item: 'Smooze',

--- a/Casks/soduto.rb
+++ b/Casks/soduto.rb
@@ -7,5 +7,7 @@ cask 'soduto' do
   name 'Soduto'
   homepage 'https://soduto.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Soduto.app'
 end

--- a/Casks/teacode.rb
+++ b/Casks/teacode.rb
@@ -8,7 +8,6 @@ cask 'teacode' do
   homepage 'https://www.apptorium.com/teacode'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'TeaCode.app'

--- a/Casks/teacode.rb
+++ b/Casks/teacode.rb
@@ -9,5 +9,7 @@ cask 'teacode' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'TeaCode.app'
 end

--- a/Casks/totals.rb
+++ b/Casks/totals.rb
@@ -7,5 +7,7 @@ cask 'totals' do
   name 'Totals'
   homepage 'http://www.kedisoft.com/totals/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Totals.app'
 end

--- a/Casks/touche.rb
+++ b/Casks/touche.rb
@@ -8,6 +8,8 @@ cask 'touche' do
   name 'Touché'
   homepage 'https://red-sweater.com/touche/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Touché.app'
 
   zap trash: [

--- a/Casks/unlox.rb
+++ b/Casks/unlox.rb
@@ -7,5 +7,7 @@ cask 'unlox' do
   name 'Unlox'
   homepage 'https://unlox.it/get'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'Unlox.app'
 end

--- a/Casks/vanilla.rb
+++ b/Casks/vanilla.rb
@@ -8,5 +8,7 @@ cask 'vanilla' do
   name 'Vanilla'
   homepage 'http://matthewpalmer.net/vanilla/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Vanilla.app'
 end

--- a/Casks/versions.rb
+++ b/Casks/versions.rb
@@ -7,5 +7,7 @@ cask 'versions' do
   name 'Versions'
   homepage 'https://versionsapp.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Versions.app'
 end

--- a/Casks/webponize.rb
+++ b/Casks/webponize.rb
@@ -8,5 +8,7 @@ cask 'webponize' do
   name 'WebPonize'
   homepage 'https://webponize.org/'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'WebPonize.app'
 end

--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -9,7 +9,6 @@ cask 'wwdc' do
   homepage 'https://wwdc.io/'
 
   auto_updates true
-
   depends_on macos: '>= :sierra'
 
   app 'WWDC.app'

--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -10,6 +10,8 @@ cask 'wwdc' do
 
   auto_updates true
 
+  depends_on macos: '>= :sierra'
+
   app 'WWDC.app'
 
   zap trash: [


### PR DESCRIPTION
i've added 
depends_on macos
stanzas to all casks where they were missing and the actual requirements of the app are higher than 10.11