### PR TITLE
Update gretl to 2018c

### DIFF
--- a/Casks/gretl.rb
+++ b/Casks/gretl.rb
@@ -1,6 +1,6 @@
 cask 'gretl' do
-  version '2018b'
-  sha256 'f51628416425bdc6242cf2d69ac7cac337e6aa6805e9a54a4ec3324091a6cfc2'
+  version '2018c'
+  sha256 '7f216f933632beefde51ce8fe8d619b9764b0964b0a5d46f84e47f113f59ba07'
 
   url "https://downloads.sourceforge.net/gretl/gretl-#{version}-quartz.pkg"
   appcast 'https://sourceforge.net/projects/gretl/rss?path=/gretl'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.