### PR TITLE
Update nucleo to 2.4.2

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,6 +1,6 @@
 cask 'nucleo' do
-  version '2.4.1'
-  sha256 'ac25a324fd3e3c3516df0c8a37df44a776a9d1b8c02ba0eeebe9d30e0f0b9852'
+  version '2.4.2'
+  sha256 'd3e3db16f7381f683141ee35ca320936ebbc9690402e84d7391832403d2244cc'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.