### PR TITLE
Update nti-shadow to 5.0.0.55

### DIFF
--- a/Casks/nti-shadow.rb
+++ b/Casks/nti-shadow.rb
@@ -6,7 +6,7 @@ cask 'nti-shadow' do
   name "NTI Shadow #{version.major} for Mac"
   homepage 'http://www.nticorp.com/en/us/product/shadow_5_mac.asp'
 
-  app 'NTI Shadow.app'
+  app "NTI Shadow #{version.major}.app"
 
   zap trash: [
                '~/Library/Preferences/com.achieva.NTIShadow41.plist',

--- a/Casks/nti-shadow.rb
+++ b/Casks/nti-shadow.rb
@@ -1,6 +1,6 @@
 cask 'nti-shadow' do
-  version '5.0.0.52'
-  sha256 'fb432cf051ecdf0a84000ab10c945a80e940188c33f8938465102d786f388ee2'
+  version '5.0.0.55'
+  sha256 'b25772787a1e900a8ef33cbad6c9c354bcf7d73d92f742440871bc20f4116df5'
 
   url "https://ftp4.nticorp.com/update/NTI_Shadow_#{version}_Free_Update_Mac.dmg"
   name "NTI Shadow #{version.major} for Mac"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.