### PR TITLE
Update nottingham to 4.0.0,7

### DIFF
--- a/Casks/nottingham.rb
+++ b/Casks/nottingham.rb
@@ -1,6 +1,6 @@
 cask 'nottingham' do
-  version '3.1.0,5'
-  sha256 '54c861844846d8a1d21b089db0c33e4d9041f94d8b14c51900e5d59c6b3e7f05'
+  version '4.0.0,7'
+  sha256 '8914dface9e4f36845ce3455ed7bec3e0fc86f69f399ae00ada00299582cbf33'
 
   # downloads-clickonideas.netdna-ssl.com/nottingham was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/nottingham/nottingham#{version.major}_#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.