### PR TITLE
Update synergy to 1.10.1,b87:8941241e

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '1.10.0,b39:275cdc1c'
-  sha256 'dd4028c6166480ab544a2bcd781d158dd1c373cf28a0867cc5987ef9d091f3ca'
+  version '1.10.1,b87:8941241e'
+  sha256 '3e19d18a5ca30f8576d3c0bac861cb23f506044f2fe5872e715b0174076277a4'
 
   url "https://binaries.symless.com/synergy/v#{version.before_comma.major}-core-standard/v#{version.before_comma}-stable-#{version.after_colon}/synergy_#{version.before_comma}-stable_#{version.after_comma.before_colon}-#{version.after_colon}_macos.dmg"
   name 'Synergy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.