### PR TITLE
Update manager to 18.10.21

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.20'
-  sha256 'e8d0d7b458d312a2dce6026f010ab58e3af6c43296832c3bc38c87d0225cf866'
+  version '18.10.21'
+  sha256 '2dde94cc7765e39ed5b84b65fc3ac707ff9199aef613d5f619843f6450bc6168'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.