### PR TITLE
vagrant-vmware-utility 1.0.4: Fix the `pkg` case.

### DIFF
--- a/Casks/vagrant-vmware-utility.rb
+++ b/Casks/vagrant-vmware-utility.rb
@@ -8,7 +8,7 @@ cask 'vagrant-vmware-utility' do
   name 'Vagrant VMware Utility'
   homepage 'https://www.vagrantup.com/vmware/downloads.html'
 
-  pkg 'VagrantVmwareUtility.pkg'
+  pkg 'VagrantVMwareUtility.pkg'
 
   uninstall script:  {
                        executable: 'uninstall.tool',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**: N/A

