### PR TITLE
Update citrix-receiver latest to citrix-workspace latest

### DIFF
--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -4,8 +4,8 @@ cask 'citrix-workspace' do
 
   # downloadplugins.citrix.com.edgesuite.net was verified as official when first introduced to the cask
   url 'http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixWorkspaceApp.dmg'
-  name 'Citrix Receiver'
-  homepage 'https://www.citrix.com/products/receiver/'
+  name 'Citrix Workspace'
+  homepage 'https://www.citrix.com/products/workspace-app/'
 
   pkg 'Install Citrix Workspace.pkg'
 

--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,27 +1,32 @@
-cask 'citrix-receiver' do
+cask 'citrix-workspace' do
   version :latest
   sha256 :no_check
 
   # downloadplugins.citrix.com.edgesuite.net was verified as official when first introduced to the cask
-  url 'http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixReceiverWeb.dmg'
+  url 'http://downloadplugins.citrix.com.edgesuite.net/Mac/CitrixWorkspaceApp.dmg'
   name 'Citrix Receiver'
   homepage 'https://www.citrix.com/products/receiver/'
 
-  pkg 'Install Citrix Receiver.pkg'
+  pkg 'Install Citrix Workspace.pkg'
 
   uninstall launchctl: [
                          'com.citrix.AuthManager_Mac',
                          'com.citrix.ReceiverHelper',
                          'com.citrix.ServiceRecords',
+                         'com.citrix.ctxusbd',
                        ],
             quit:      [
                          'Citrix.ServiceRecords',
                          'com.citrix.ReceiverHelper',
+                         'com.citrix.receiver.nomas',
                        ],
             pkgutil:   'com.citrix.ICAClient'
 
   zap trash: [
-               '~/Library/Application Support/Citrix Receiver',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.citrix.receiver.nomas.sfl*',
+               '~/Library/Application Support/com.citrix.receiver.nomas',
+               '~/Library/Caches/com.citrix.receiver.nomas',
+               '~/Library/Logs/Citrix Workspace',
                '~/Library/Preferences/com.citrix.receiver.nomas.plist',
                '~/Library/Preferences/com.citrix.receiver.nomas.plist.lockfile',
                '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].
---
Closes #52673 

Citrix Receiver has been renamed Citrix Workspace.