### PR TITLE
Change azure-data-studio binary target to azuredatastudio.

### DIFF
--- a/Casks/azure-data-studio.rb
+++ b/Casks/azure-data-studio.rb
@@ -11,7 +11,7 @@ cask 'azure-data-studio' do
   auto_updates true
 
   app 'Azure Data Studio.app'
-  binary "#{appdir}/Azure Data Studio.app/Contents/Resources/app/bin/code", target: 'azure-data-studio'
+  binary "#{appdir}/Azure Data Studio.app/Contents/Resources/app/bin/code", target: 'azuredatastudio'
 
   zap trash: [
                '~/Library/Application Support/azuredatastudio',


### PR DESCRIPTION
This new binary target matches the binary name on other platforms.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
