### PR TITLE
Update iboostup to 6.3.20

### DIFF
--- a/Casks/iboostup.rb
+++ b/Casks/iboostup.rb
@@ -1,6 +1,6 @@
 cask 'iboostup' do
-  version '6.0.11'
-  sha256 'cd235a7599e40411b5525478d495819dd647cec8aac25dbbaa691a2b591c2ae3'
+  version '6.3.20'
+  sha256 '1a23b99225390ed2892697904b97c726ad3584e656b27a4a29adbe87c1dfe7f0'
 
   url 'https://www.iboostup.com/iboostup.dmg'
   appcast 'https://www.iboostup.com/updates'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.