### PR TITLE
Update atext to 2.29

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,6 +1,6 @@
 cask 'atext' do
-  version '2.28.1'
-  sha256 '2db33e695b2b6f646c43c9c6d9e27893366ebbf74bfc0761ed6d205d6dd03984'
+  version '2.29'
+  sha256 '59b032f69f2e88b256315c1f1e80aa916880a2efbe2a187e608f077a13e1fc6d'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.