### PR TITLE
libreoffice-language-pack: install manually

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -568,10 +568,17 @@ cask 'libreoffice-language-pack' do
 
   preflight do
     system_command '/usr/bin/osascript', args: ['-e', <<~APPLESCRIPT]
-      if application "LibreOffice" is not running
-        tell application "LibreOffice" to activate
+      try
+        if application "LibreOffice" is not running
+          with timeout of 30 seconds
+            tell application "LibreOffice" to activate
+          end timeout
+        end if
         tell application "LibreOffice" to quit
-      end if
+      on error
+        -- Ignore errors (probably running under Travis)
+        return 0
+      end try
     APPLESCRIPT
     system_command '/usr/bin/tar', args: ['-C', "#{appdir}/LibreOffice.app/", '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
     system_command '/usr/bin/touch', args: ["#{appdir}/LibreOffice.app/Contents/Resources/extensions"]

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -566,7 +566,9 @@ cask 'libreoffice-language-pack' do
 
   installer manual: 'LibreOffice Language Pack.app'
 
-  caveats <<~EOS
-    #{token} assumes LibreOffice is installed in '#{appdir}'. If it is not, you’ll need to run '#{staged_path}/LibreOffice Language Pack.app' manually.
-  EOS
+  # Not actually necessary, since it would be deleted anyway.
+  # It is present to make clear an uninstall was not forgotten
+  # and that for this cask it is indeed this simple.
+  # See https://github.com/Homebrew/homebrew-cask/pull/52893
+  uninstall delete: "#{staged_path}/#{token}"
 end

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -564,30 +564,9 @@ cask 'libreoffice-language-pack' do
 
   depends_on cask: 'libreoffice'
 
-  stage_only true
-
-  preflight do
-    system_command '/usr/bin/osascript', args: ['-e', <<~APPLESCRIPT]
-      try
-        if application "LibreOffice" is not running
-          with timeout of 30 seconds
-            tell application "LibreOffice" to activate
-          end timeout
-        end if
-        tell application "LibreOffice" to quit
-      on error
-        -- Ignore errors (probably running under Travis)
-        return 0
-      end try
-    APPLESCRIPT
-    system_command '/usr/bin/tar', args: ['-C', "#{appdir}/LibreOffice.app/", '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
-    system_command '/usr/bin/touch', args: ["#{appdir}/LibreOffice.app/Contents/Resources/extensions"]
-  end
+  installer manual: 'LibreOffice Language Pack.app'
 
   caveats <<~EOS
-    LibreOffice MUST be opened at least once before installing #{token}.
-    This Cask will do it for you.
-
     #{token} assumes LibreOffice is installed in '#{appdir}'. If it is not, you’ll need to run '#{staged_path}/LibreOffice Language Pack.app' manually.
   EOS
 end

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -567,11 +567,20 @@ cask 'libreoffice-language-pack' do
   stage_only true
 
   preflight do
+    system_command '/usr/bin/osascript', args: ['-e', <<~APPLESCRIPT]
+      if application "LibreOffice" is not running
+        tell application "LibreOffice" to activate
+        tell application "LibreOffice" to quit
+      end if
+    APPLESCRIPT
     system_command '/usr/bin/tar', args: ['-C', "#{appdir}/LibreOffice.app/", '-xjf', "#{staged_path}/LibreOffice Language Pack.app/Contents/tarball.tar.bz2"]
     system_command '/usr/bin/touch', args: ["#{appdir}/LibreOffice.app/Contents/Resources/extensions"]
   end
 
   caveats <<~EOS
+    LibreOffice MUST be opened at least once before installing #{token}.
+    This Cask will do it for you.
+
     #{token} assumes LibreOffice is installed in '#{appdir}'. If it is not, you’ll need to run '#{staged_path}/LibreOffice Language Pack.app' manually.
   EOS
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

--

LibreOffice Language Pack, when manually executed, runs LibreOffice at least once (using AppleScript) before inserting the language files. This is to trigger Gatekeeper and thus cheat the code signature assessment.

This pull request ~~adds this step to the `preflight` block.~~ changes this Cask to manual installation.

Fixes #52758 , fixes #52883 .

~~(source for the fix: `Contents/osx_install.applescript` inside the Cask's DMG)~~