### PR TITLE
Update macbreakz to 5.33

### DIFF
--- a/Casks/macbreakz.rb
+++ b/Casks/macbreakz.rb
@@ -1,6 +1,6 @@
 cask 'macbreakz' do
-  version '5.32'
-  sha256 '217bc617625b3e56da23c6f9d4e553d5f0cb8ffe3bc402be1f6efbbef6825089'
+  version '5.33'
+  sha256 'b03a578755d9df2be021653508f24171c5a33da275235dc74b78f8af0ffc1703'
 
   url "http://www.publicspace.net/download/MacBreakZ#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_mb#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.