### PR TITLE
Update navicat-for-mysql to 12.1.9

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.8'
-  sha256 'd8685c8093ad6e19b609f8f9457dda736d0791604e0d6798462a889272d14f12'
+  version '12.1.9'
+  sha256 'b09e956ade07bc71a30e66c71468d65e9d1313b614d1e5781f447fad04fb86a6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mysql-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.