### PR TITLE
Update intel-power-gadget 3.5.4,770353 SHA256 WITHOUT Version Change

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,6 +1,6 @@
 cask 'intel-power-gadget' do
   version '3.5.4,770353'
-  sha256 '761f7dd4de7cd7150e6abfedba08f4b1da3a04dc571992dd46b3aca6f699f734'
+  sha256 '54046d3a48d484f4e8723c4af170c51603085985210c3b9b18e51219ca2344ae'
 
   url "https://software.intel.com/file/#{version.after_comma}/download"
   name 'Intel Power Gadget'


### PR DESCRIPTION
It appears that the sha256 changed to `54046d3a48d484f4e8723c4af170c51603085985210c3b9b18e51219ca2344ae` for version `3.5.4,770353`

---
```
benc$ brew cask --debug --force upgrade intel-power-gadget
==> Upgrading 1 outdated package, with result:
intel-power-gadget 3.5.3,655065 -> 3.5.4,770353
==> Started upgrade process for Cask intel-power-gadget
==> Printing caveats
==> Caveats
To install and/or use intel-power-gadget you may need to enable their kernel extension in

  System Preferences → Security & Privacy → General

For more information refer to vendor documentation or the Apple Technical Note:

  https://developer.apple.com/library/content/technotes/tn2459/_index.html

==> Cask::Installer#fetch
==> Satisfying dependencies
==> Downloading
==> Downloading https://software.intel.com/file/770353/download
Already downloaded: /Users/benc/Library/Caches/Homebrew/downloads/b63a354bc5a683d4b3e28acdd2d21e3a731f1c06aed63b333c522b1a425314ed--Intel® Power Gadget 3.5.4.dmg
==> Checking quarantine support
/usr/bin/xattr
/usr/bin/swift /usr/local/Homebrew/Library/Homebrew/cask/utils/quarantine.swift
==> Quarantine is available.
==> Verifying Gatekeeper status of /Users/benc/Library/Caches/Homebrew/downloads/b63a354bc5a683d4b3e28acdd2d21e3a731f1c06aed63b333c522b1a425314ed--Intel® Power Gadget 3.5.4.dmg
/usr/bin/xattr -p com.apple.quarantine /Users/benc/Library/Caches/Homebrew/downloads/b63a354bc5a683d4b3e28acdd2d21e3a731f1c06aed63b333c522b1a425314ed--Intel\®\ Power\ Gadget\ 3.5.4.dmg
==> /Users/benc/Library/Caches/Homebrew/downloads/b63a354bc5a683d4b3e28acdd2d21e3a731f1c06aed63b333c522b1a425314ed--Intel® Power Gadget 3.5.4.dmg is quarantined
==> Downloaded to -> /Users/benc/Library/Caches/Homebrew/downloads/b63a354bc5a683d4b3e28acdd2d21e3a731f1c06aed63b333c522b1a425314ed--Intel® Power Gadget 3.5.4.dmg
==> Verifying SHA-256 checksum for Cask 'intel-power-gadget'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
==> Purging files for version 3.5.4,770353 of Cask intel-power-gadget
Error: Checksum for Cask 'intel-power-gadget' does not match.

Expected: 761f7dd4de7cd7150e6abfedba08f4b1da3a04dc571992dd46b3aca6f699f734
Actual:   54046d3a48d484f4e8723c4af170c51603085985210c3b9b18e51219ca2344ae
File:     /Users/benc/Library/Caches/Homebrew/downloads/b63a354bc5a683d4b3e28acdd2d21e3a731f1c06aed63b333c522b1a425314ed--Intel® Power Gadget 3.5.4.dmg

To retry an incomplete download, remove the file above.

/usr/local/Homebrew/Library/Homebrew/cask/verify.rb:21:in `all'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:159:in `verify'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:63:in `fetch'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:73:in `block in run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:41:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:41:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/abstract_command.rb:34:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:89:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:155:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:120:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:7:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:91:in `<main>'
Error: Kernel.exit
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:160:in `exit'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:160:in `rescue in run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:143:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:120:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:7:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:91:in `<main>'
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).