### PR TITLE
Update imazing-mini to 2.7.1,9566:1538240027

### DIFF
--- a/Casks/imazing-mini.rb
+++ b/Casks/imazing-mini.rb
@@ -1,6 +1,6 @@
 cask 'imazing-mini' do
-  version '2.6.4,9274:1533432561'
-  sha256 'bb80cc556f5c78123bf3603ff92d6bf543d97348f91887a89f35b4c1e3436b20'
+  version '2.7.1,9566:1538240027'
+  sha256 'd6c51a77da7a9dc3a9a37ec832f6609ed8e8a0938b8474ff9ec259cfa02981ae'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac.Mini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac.Mini/#{version.after_comma.before_colon}/#{version.after_colon}/iMazingMini2forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.