### PR TITLE
Update post-haste to 2.6.4,2640

### DIFF
--- a/Casks/post-haste.rb
+++ b/Casks/post-haste.rb
@@ -1,6 +1,6 @@
 cask 'post-haste' do
-  version '2.6.3,2630'
-  sha256 'effe6fd53599e039dcc9b636cf6f0c09c72edbc1f2913213a426a762a079f60d'
+  version '2.6.4,2640'
+  sha256 '94e4edd41e0ead7f06150bbd3ad257b562289146e89d33bfda1341b0c67768bf'
 
   url "https://www.digitalrebellion.com/download/posthaste?version=#{version.after_comma}"
   name 'Post Haste'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.