### PR TITLE
Update droplr to 5.5.2,220

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,9 +1,8 @@
 cask 'droplr' do
-  version '5.0.0,206'
-  sha256 '4362d360173a1bec7501055883a3edbf4253eea790059087d9174774284d52f4'
+  version '5.5.2,220'
+  sha256 '098e267ef0142083a2ac8495cfe556480db3a282ba0b4493d731f222b4f675d6'
 
-  # files.droplr.com.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://files.droplr.com.s3.amazonaws.com/apps/mac/Droplr+#{version.after_comma}.zip"
+  url "https://files.droplr.com/apps/mac/Droplr-#{version.after_comma}.zip"
   name 'Droplr'
   homepage 'https://droplr.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.