### PR TITLE
Update stamp to 4.10.4

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.9.0'
-  sha256 'b8812b22564d798133c86a9ca42095ae1e2d567bb8690c7eb81f10a73c2e9c02'
+  version '4.10.4'
+  sha256 '562a46c3b351d05e7c8d14df9c5899003c91878c6c5a4c827f0926d4eef9d945'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/STAMP#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.