### PR TITLE
Update riverdesign-sparkle to 2.7.1

### DIFF
--- a/Casks/riverdesign-sparkle.rb
+++ b/Casks/riverdesign-sparkle.rb
@@ -1,6 +1,6 @@
 cask 'riverdesign-sparkle' do
-  version '2.6.3'
-  sha256 '15268166f2d8aa130883d722972e3c1db24649214a83e0ca78f5e71d124bdbaa'
+  version '2.7.1'
+  sha256 '349e0344531a174b088e562169295d3f921040151465873461a99864737d4054'
 
   url 'https://sparkleapp.com/update/Sparkle.zip'
   appcast 'https://sparkleapp.com/update/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.