### PR TITLE
Update rubitrack-pro to 5.1

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,6 +1,6 @@
 cask 'rubitrack-pro' do
-  version '5.0.7'
-  sha256 '57d3f2989e9f0c4ccb97b8d8cf8c758edbdbd67ba233355b8b1bde94cc8701ff'
+  version '5.1'
+  sha256 '1b2096f3b6144430d34d7a93180a95cb849852fe51d3301d184f8934e78fd129'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.