### PR TITLE
Update vox to 3.3.4

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,6 +1,6 @@
 cask 'filezilla' do
-  version '3.37.3'
-  sha256 '6dcb449f198481b2d3639f47efaf4684f0beea801184c1d1f64943383bc4810c'
+  version '3.37.4'
+  sha256 'bc2c4ba4959beb61a7a19496fbc0510c76c0d6c0e76cf5d276e865cec39e2c11'
 
   url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client'

--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,6 +1,6 @@
 cask 'vox' do
-  version '3.3.2'
-  sha256 'd07942089a2c616f80a845954a7daf4257d6d83eba59906f58c93871588afa22'
+  version '3.3.4'
+  sha256 '3924248033f0e28b30091dc150f272a662c7b930cd6b778a1be6e549bbf6923c'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.Vox/Vox.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.