### PR TITLE
Update coteditor to 3.6.1

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -9,8 +9,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.6.0'
-    sha256 'ac627e706abaecb8dd38c502fd4f1851727904f45decad979fdeaaa5f1f56cb2'
+    version '3.6.1'
+    sha256 '87eeabce6ef6c90df4dcd652d3fe91b7501ca1223b63a44f6be60ae64b145ecf'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.