### PR TITLE
Update mathpix-snipping-tool to 1.3.48

### DIFF
--- a/Casks/mathpix-snipping-tool.rb
+++ b/Casks/mathpix-snipping-tool.rb
@@ -3,8 +3,17 @@ cask 'mathpix-snipping-tool' do
   sha256 '5159384a19502bacbe2fb0bc3b6a5938e1900c1901b4d356655b7764a450998b'
 
   url "https://mathpix.com/dmg/SnippingTool-v#{version}.dmg"
+  appcast 'https://mathpix.com/appcast.xml'
   name 'Mathpix Snipping Tool'
   homepage 'https://mathpix.com/'
 
   app 'Mathpix Snipping Tool.app'
+
+  zap trash: [
+               '~/Library/Application Support/com.mathpix.snipping-tool-noappstore',
+               '~/Library/Caches/com.crashlytics.data/com.mathpix.snipping-tool-noappstore',
+               '~/Library/Caches/io.fabric.sdk.mac.data/com.mathpix.snipping-tool-noappstore',
+               '~/Library/Caches/com.mathpix.snipping-tool-noappstore',
+               '~/Library/Preferences/com.mathpix.snipping-tool-noappstore.plist',
+             ]
 end

--- a/Casks/mathpix-snipping-tool.rb
+++ b/Casks/mathpix-snipping-tool.rb
@@ -7,6 +7,8 @@ cask 'mathpix-snipping-tool' do
   name 'Mathpix Snipping Tool'
   homepage 'https://mathpix.com/'
 
+  auto_updates true
+
   app 'Mathpix Snipping Tool.app'
 
   zap trash: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.