### PR TITLE
Add OpenJFX v11

### DIFF
--- a/Casks/openjfx.rb
+++ b/Casks/openjfx.rb
@@ -1,0 +1,25 @@
+cask 'openjfx' do
+  version '11'
+  sha256 'adabd9332993519e8ad69c5412a9acb00443e3b80a15c3d372a99b064a94873c'
+
+  # `download2.gluonhq.com/openjfx` was verified as official when first introduced to the cask.
+  url "http://download2.gluonhq.com/openjfx/#{version}/openjfx-#{version}_osx-x64_bin-sdk.zip"
+  name 'OpenJFX'
+  homepage 'https://openjfx.io/'
+
+  # `/Library/Java/Extensions` is the Apple-recommended location for system-wide Java extension
+  # libraries on macOS, as documented at `https://developer.apple.com/library/archive/qa/qa1170/_in-
+  # dex.html` in its section on 'Extension Libraries:'
+  postflight do
+    FileUtils.cp_r(staged_path.to_s, '/Library/Java/Extensions/OpenJFX')
+  end
+
+  uninstall_postflight do
+    FileUtils.rm_rf ['/Library/Java/Extensions/OpenJFX']
+  end
+
+  caveats do
+    # Per a statement at the bottom of `https://openjfx.io/openjfx-docs/`:
+    depends_on_java '11'
+  end
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:  

- [x] `brew cask audit --download {{cask_file}}` is error-free.  
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.  (All offenses except a `Cask/HompageMatchesUrl` violation fixed; guidance requested on fixing that last one.)  
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Revives #52565 since, as mentioned [here](https://discourse.brew.sh/t/is-anybody-already-working-on-an-openjfx-cask/3083/9?u=randomdsdevel) by me in [the Discourse thread initially proposing the cask's addition](
https://discourse.brew.sh/t/is-anybody-already-working-on-an-openjfx-cask/3083/), OpenJFX isn't easily available as a single package on Maven Central.  I have a few modifications, though, but those are open for discussion.  