### PR TITLE
Update fastonosql to 1.19.3

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.17.9'
-  sha256 '4df200937d890f3130f11bf0336df0438c5994acdc1022989e35cfe528498d4a'
+  version '1.19.3'
+  sha256 '87f40e8d497195e71e1c8ee4634f87a4fdb051915ce61a6442758e232a45ea3a'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.