### PR TITLE
Update gprojector to 2.3.2

### DIFF
--- a/Casks/gprojector.rb
+++ b/Casks/gprojector.rb
@@ -1,6 +1,6 @@
 cask 'gprojector' do
-  version '2.3.1'
-  sha256 'ec3e81494c288e7ce6c1b07d3382ec24ef6da42d87f1d67c35ab226052552df5'
+  version '2.3.2'
+  sha256 'f612670ac72be5597310fff80473d06c42215f77dff1e1b4e1a240eabb498430'
 
   url "https://www.giss.nasa.gov/tools/gprojector/download/G.ProjectorMacOS-#{version}.dmg"
   name 'G.Projector'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.