### PR TITLE
Update omniplan to 3.10.2

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,6 +1,6 @@
 cask 'omniplan' do
-  version '3.10'
-  sha256 '5fa8aac3347f540de924f60c96327fa519a0fb37435887cab086fe33acf137b8'
+  version '3.10.2'
+  sha256 'e045659e786edba3fa449dbbb33e294f3d94f29cc17845421f3c12ad77431ef3'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
   name 'OmniPlan'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.