### PR TITLE
Update endicia to 2.18.4,753

### DIFF
--- a/Casks/endicia.rb
+++ b/Casks/endicia.rb
@@ -1,6 +1,6 @@
 cask 'endicia' do
-  version '2.18.3,752'
-  sha256 'c124cc9afa96df68c0c880e7bf20cda844be439df17d8ecbea81a44e56403c28'
+  version '2.18.4,753'
+  sha256 '55095e6388c80ab65651ff875d952a55b3fab2f26a7901a2d3e316eaf70282b5'
 
   url "https://download.endiciaformac.com/EndiciaForMac#{version.before_comma.no_dots}v#{version.after_comma}.dmg"
   appcast 'https://s3.amazonaws.com/endiciaformac/EndiciaForMacSparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.