### PR TITLE
Update ipswdownloader to 2.7.0

### DIFF
--- a/Casks/ipswdownloader.rb
+++ b/Casks/ipswdownloader.rb
@@ -1,6 +1,6 @@
 cask 'ipswdownloader' do
-  version '2.6.6'
-  sha256 '00b6901c0e3d18f98a8dace757a56ad248914a9f7aaab24902e631c8d9f9259d'
+  version '2.7.0'
+  sha256 '76f1fbff4496bb836bce3706bd0488880d82c91494fd58a5dfc99a1d51d75989'
 
   url "http://downloads.igrsoft.com/downloads/ipswDownloader/ipswDownloader_#{version.no_dots}.zip"
   name 'ipswDownloader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.