### PR TITLE
Update invisionsync to 1.8.8,689

### DIFF
--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -1,8 +1,9 @@
 cask 'invisionsync' do
-  version '1.8.5,686'
-  sha256 '14d79e7ba4d8e91e2dddad38354110f53e42195dddb93a435d3d545ccffa1173'
+  version '1.8.8,689'
+  sha256 '67e27b0221d1f6c597e2d3541b9a2fc11f1d9dfa53fe357ef0de2e1e83b80c38'
 
   url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.after_comma}.zip"
+  appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml'
   name 'InVision Sync'
   homepage 'https://www.invisionapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.