### PR TITLE
Update journey to 2.8.0

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,9 +1,9 @@
 cask 'journey' do
-  version '2.7.0'
-  sha256 'b0bbf5041857f89b8c38c6889eb14457764e4da1884410cf62bf7ebcd3d4329f'
+  version '2.8.0'
+  sha256 '4ca5feaaeaebd0789e4378b63065db8e3ed896df1da80636b342775f69d29bb7'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
-  url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-x64-#{version}.dmg"
+  url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-#{version}.dmg"
   appcast 'https://github.com/2-App-Studio/journey-releases/releases.atom'
   name 'Journey'
   homepage 'https://2appstudio.com/journey/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.