### PR TITLE
Update dbschema to 8.0.8

### DIFF
--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -1,6 +1,6 @@
 cask 'dbschema' do
   version '8.0.8'
-  sha256 '8ed50395dd40eaca7b557588db2d04f4f6fb72cabebb30037613c809b6209777'
+  sha256 'fd961b6dc4b46dbc3942fc9250ce9c4e9486bb267ec1f55414ec4f6a555d9a99'
 
   url "https://www.dbschema.com/download/DbSchema_macos_#{version.dots_to_underscores}.tgz"
   name 'DbSchema'

--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -1,6 +1,6 @@
 cask 'dbschema' do
   version '8.0.8'
-  sha256 'fd961b6dc4b46dbc3942fc9250ce9c4e9486bb267ec1f55414ec4f6a555d9a99'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.dbschema.com/download/DbSchema_macos_#{version.dots_to_underscores}.tgz"
   name 'DbSchema'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.