### PR TITLE
Update propresenter to 6.3.6_b16192

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,6 +1,6 @@
 cask 'propresenter' do
   version '6.3.6_b16192'
-  sha256 '7ec4c5b0bed011f56ed5a9b8252043ee55994d259e3bbf19c9d3509c3c069fd9'
+  sha256 '06321bfb5ede71576108a37fcbb767cfd6b7217a0598be8ced7fe002b17a8027'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.