### PR TITLE
doc: update OSDN URL rules

### DIFF
--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -1,11 +1,11 @@
 cask 'letterfix' do
-  version '2.6.0,68346'
+  version '2.6.0'
   sha256 '89de44a2b0e6cb43915d9584615226811f939a42aed6d2a14ba099de18db2768'
 
-  url "http://onet.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
-  appcast 'https://ja.osdn.net/projects/letter-fix/releases/rss'
+  url "https://osdn.net/dl/letter-fix/LetterFix-#{version}.dmg"
+  appcast 'https://osdn.net/projects/letter-fix/releases/rss'
   name 'LetterFix'
-  homepage 'https://osdn.jp/projects/letter-fix/'
+  homepage 'https://osdn.net/projects/letter-fix/'
 
   pkg "LetterFix-#{version.before_comma}.pkg"
 

--- a/Casks/miditrail.rb
+++ b/Casks/miditrail.rb
@@ -1,10 +1,9 @@
 cask 'miditrail' do
-  version '1.2.3,68138'
+  version '1.2.3'
   sha256 '6be8c1928ae71d3713d884dbaa9e18e243f1c03ae4840bb3936321baf287e6f5'
 
-  # dl.osdn.jp/miditrail was verified as official when first introduced to the cask
-  url "http://dl.osdn.jp/miditrail/#{version.after_comma}/MIDITrail-Ver.#{version.before_comma}-macOS.zip"
-  appcast 'https://ja.osdn.net/projects/miditrail/releases/rss'
+  url "https://osdn.net/dl/miditrail/MIDITrail-Ver.#{version}-macOS.zip"
+  appcast 'https://osdn.net/projects/miditrail/releases/rss'
   name 'MIDITrail'
   homepage 'https://osdn.net/projects/miditrail/'
 

--- a/Casks/nndd.rb
+++ b/Casks/nndd.rb
@@ -1,11 +1,11 @@
 cask 'nndd' do
-  version '2.4.3,62201'
+  version '2.4.3'
   sha256 '6a73dcad2e73d877ad1503ed1162cae1a1c84f21d1abaa6aaf9b31bb2fbca531'
 
-  url "http://dl.osdn.jp/nndd/#{version.after_comma}/NNDD_v#{version.before_comma.dots_to_underscores}.dmg"
-  appcast 'https://ja.osdn.net/projects/nndd/releases/rss'
+  url "https://osdn.net/dl/nndd/NNDD_v#{version.dots_to_underscores}.dmg"
+  appcast 'https://osdn.net/projects/nndd/releases/rss'
   name 'NNDD'
-  homepage 'https://osdn.jp/projects/nndd/'
+  homepage 'https://osdn.net/projects/nndd/'
 
   depends_on cask: 'adobe-air'
 

--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -62,13 +62,11 @@ We prefer URLs of this format:
 https://downloads.sourceforge.net/{{project_name}}/{{filename}}.{{ext}}
 ```
 
-Or, if it’s from [OSDN](https://osdn.jp/):
+Or, if it’s from [OSDN](https://osdn.net/):
 
 ```
-http://{{subdomain}}.osdn.jp/{{project_name}}/{{release_id}}/{{filename}}.{{ext}}
+https://osdn.net/dl/{{project_name}}/{{filename}}.{{ext}}
 ```
-
-`{{subdomain}}` is typically of the form `dl` or `{{user}}.dl`.
 
 If these formats are not available, and the application is macOS-exclusive (otherwise a command-line download defaults to the Windows version) we prefer the use of this format:
 


### PR DESCRIPTION
Ref: https://github.com/Homebrew/brew/pull/5052

Affected Casks:
- letterfix
- miditrail
- nndd
