### PR TITLE
Update coderunner to 3.0.1

### DIFF
--- a/Casks/coderunner.rb
+++ b/Casks/coderunner.rb
@@ -1,6 +1,6 @@
 cask 'coderunner' do
-  version '3.0'
-  sha256 'd452c388e857f7bb0af242b2e981e988d64b62489027e172791dde92c3089e32'
+  version '3.0.1'
+  sha256 '31976c2551102eb07c3c20b578664a0697a92299c53a4956bc7353c7440a81fa'
 
   # dktfof1z89xc1.cloudfront.net was verified as official when first introduced to the cask
   url "https://dktfof1z89xc1.cloudfront.net/CodeRunner-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.