### PR TITLE
Update minecraft-server to 1.13.1 and new URL scheme

### DIFF
--- a/Casks/minecraft-server.rb
+++ b/Casks/minecraft-server.rb
@@ -1,9 +1,8 @@
 cask 'minecraft-server' do
-  version '1.12.2'
-  sha256 'fe1f9274e6dad9191bf6e6e8e36ee6ebc737f373603df0946aafcded0d53167e'
+  version '1.13.1'
+  sha256 '2ea6047e7651c429228340acd7d1e35f4f6c7af42f59f92b0b1cd476561253d1'
 
-  # s3.amazonaws.com/Minecraft.Download was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/Minecraft.Download/versions/#{version}/minecraft_server.#{version}.jar"
+  url 'https://launcher.mojang.com/v1/objects/fe123682e9cb30031eae351764f653500b7396c9/server.jar'
   name 'Minecraft Server'
   homepage 'https://minecraft.net/'
 
@@ -21,7 +20,7 @@ cask 'minecraft-server' do
     IO.write shimscript, <<~EOS
       #!/bin/sh
       cd '#{config_dir}' && \
-        exec /usr/bin/java -Xmx1024M -Xms1024M -jar '#{staged_path}/minecraft_server.#{version}.jar' nogui
+        exec /usr/bin/java -Xmx1024M -Xms1024M -jar '#{staged_path}/server.jar' nogui
     EOS
   end
 

--- a/Casks/minecraft-server.rb
+++ b/Casks/minecraft-server.rb
@@ -1,8 +1,10 @@
 cask 'minecraft-server' do
-  version '1.13.1'
+  version '1.13.1,fe123682e9cb30031eae351764f653500b7396c9'
   sha256 '2ea6047e7651c429228340acd7d1e35f4f6c7af42f59f92b0b1cd476561253d1'
 
-  url 'https://launcher.mojang.com/v1/objects/fe123682e9cb30031eae351764f653500b7396c9/server.jar'
+  # launcher.mojang.com was verified as official when first introduced to the cask
+  url "https://launcher.mojang.com/v#{version.major}/objects/#{version.after_comma}/server.jar"
+  appcast 'https://minecraft.net/en-us/download/server/'
   name 'Minecraft Server'
   homepage 'https://minecraft.net/'
 


### PR DESCRIPTION
Using the official URL from https://minecraft.net/en-us/download/server/ which breaks from the older traditional URLs and filename used by Mojang - now it's just `server.jar` with the URL containing the file's SHA-1 hash.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
Received an error when running:
```
==> Installing or updating 'rubocop-cask' gem
Fetching: public_suffix-3.0.3.gem (100%)
Successfully installed public_suffix-3.0.3
Fetching: rubocop-0.59.2.gem (100%)
Successfully installed rubocop-0.59.2
Fetching: rubocop-cask-0.22.0.gem (100%)
Successfully installed rubocop-cask-0.22.0
3 gems installed
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rainbow (LoadError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.59.2/lib/rubocop.rb:4:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.59.2/exe/rubocop:6:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin/rubocop:22:in `load'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin/rubocop:22:in `<main>'
Error: style check failed
```
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
