### PR TITLE
Update gas-mask to 0.8.6

### DIFF
--- a/Casks/gas-mask.rb
+++ b/Casks/gas-mask.rb
@@ -7,5 +7,7 @@ cask 'gas-mask' do
   name 'Gas Mask'
   homepage 'http://clockwise.ee/'
 
+  auto_updates true
+
   app 'Gas Mask.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.