### PR TITLE
Update istumbler to 103.36

### DIFF
--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -17,5 +17,7 @@ cask 'istumbler' do
   name 'iStumbler'
   homepage 'https://istumbler.net/'
 
+  auto_updates true
+
   app 'iStumbler.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.