### PR TITLE
Update mactracker to 7.7.5

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -7,5 +7,7 @@ cask 'mactracker' do
   name 'Mactracker'
   homepage 'https://mactracker.ca/'
 
+  auto_updates true
+
   app 'Mactracker.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.