### PR TITLE
Update macvim to 8.1.151

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -7,6 +7,7 @@ cask 'macvim' do
   name 'MacVim'
   homepage 'https://github.com/macvim-dev/macvim'
 
+  auto_updates true
   conflicts_with formula: 'macvim'
   depends_on macos: '>= :mountain_lion'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.