### PR TITLE
Update mailmate to 5523

### DIFF
--- a/Casks/mailmate.rb
+++ b/Casks/mailmate.rb
@@ -8,6 +8,8 @@ cask 'mailmate' do
   name 'MailMate'
   homepage 'https://freron.com/'
 
+  auto_updates true
+
   app 'MailMate.app'
   binary "#{appdir}/MailMate.app/Contents/Resources/emate"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.