### PR TITLE
Update mailplane to 4.4516

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -7,6 +7,7 @@ cask 'mailplane' do
   name 'Mailplane'
   homepage 'https://mailplaneapp.com/'
 
+  auto_updates true
   depends_on macos: '>= :sierra'
 
   app 'Mailplane.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.