### PR TITLE
Update soulver to 2.6.8-5949

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -7,6 +7,7 @@ cask 'soulver' do
   name 'Soulver'
   homepage 'https://www.acqualia.com/soulver/'
 
+  auto_updates true
   depends_on macos: '>= :yosemite'
 
   app 'Soulver.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

References https://github.com/Homebrew/homebrew-cask/issues/52868.