### PR TITLE
Update daylite to 6.5.5

### DIFF
--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -1,5 +1,5 @@
 cask 'daylite' do
-  if MacOS.version <= :mojave
+  if MacOS.version <= :high_sierra
     version '6.5.5'
     sha256 '529477859f49bcca08c0704522338201bc0b64de5d58f650c3011d5e711aa223'
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.dmg"

--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -5,8 +5,8 @@ cask 'daylite' do
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.dmg"
     pkg 'Install Daylite & Mail Assistant.pkg'
   else
-    version '6.6.1'
-    sha256 '6dfca8f331b03dd61e612884dce10c94d76465cf2392292eab5f3f42a9b800e6'
+    version '6.6.2'
+    sha256 'c92f73d42c889e172fb917c0782dc744452d1da128b74a888aaa57f2d4be64f6'
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.pkg"
     pkg "daylitedma#{version.no_dots}.pkg"
   end

--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -1,13 +1,19 @@
 cask 'daylite' do
-  version '6.6'
-  sha256 'dde1ebdc27b4a63c763c901004520401c984a4c1fb06c2a40a93ef5b11095b8b'
+  if MacOS.version <= :mojave
+    version '6.5.5'
+    sha256 '529477859f49bcca08c0704522338201bc0b64de5d58f650c3011d5e711aa223'
+    url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.dmg"
+    pkg 'Install Daylite & Mail Assistant.pkg'
+  else
+    version '6.6.1'
+    sha256 '529477859f49bcca08c0704522338201bc0b64de5d58f650c3011d5e711aa223'
+    url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.pkg"
+    pkg "daylitedma#{version.no_dots}.pkg"
+  end
 
-  url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.pkg"
   appcast 'https://www.marketcircle.com/appcasts/daylite.xml'
   name 'Daylite'
   homepage 'https://www.marketcircle.com/'
-
-  pkg "daylitedma#{version.no_dots}.pkg"
 
   uninstall pkgutil:   [
                          'com.marketcircle.pkg.DLBase',

--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -6,7 +6,7 @@ cask 'daylite' do
     pkg 'Install Daylite & Mail Assistant.pkg'
   else
     version '6.6.1'
-    sha256 '529477859f49bcca08c0704522338201bc0b64de5d58f650c3011d5e711aa223'
+    sha256 '6dfca8f331b03dd61e612884dce10c94d76465cf2392292eab5f3f42a9b800e6'
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.pkg"
     pkg "daylitedma#{version.no_dots}.pkg"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.