### PR TITLE
Update vscodium@1.27.2 hash

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
   version '1.27.2'
-  sha256 '53dee2011c3447756ceb4abe7c8b24b0d75bd55575ff4c1f56d853ff92004e7a'
+  sha256 '12eab5a0387aa3042ee1e2f1dd6dd8b5ed68ef7f20f1b08eefee172ab209aa4c'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCode-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
The binary was updated (again, sorry) so the hash has changed.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.