### PR TITLE
add Brisyncv 1.0.0

### DIFF
--- a/Casks/brisync.rb
+++ b/Casks/brisync.rb
@@ -1,0 +1,13 @@
+cask 'brisync' do
+  version '1.0.0'
+  sha256 'f53b0099ddf6b508e6c4de8a036edaea05a4b233fe5ae4a37bf778958aee1e4d'
+
+  url "https://github.com/czarny/Brisync/releases/download/v#{version}/Brisync.zip"
+  appcast 'https://github.com/czarny/Brisync/releases.atom'
+  name 'Brisync'
+  homepage 'https://github.com/czarny/Brisync/'
+
+  app 'Brisync.app'
+
+  zap trash: '~/.brisync.json'
+end


### PR DESCRIPTION
Brisync lets you sync your built-in display brightness to a set of external monitors.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
