### PR TITLE
Update vscodium to 1.28.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.27.2'
-  sha256 '12eab5a0387aa3042ee1e2f1dd6dd8b5ed68ef7f20f1b08eefee172ab209aa4c'
+  version '1.28.0'
+  sha256 '6dd5a70bc5de60b9f05d4126f7fab27a87dad9f07ab896bba58beb5121ac3086'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCode-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.