### PR TITLE
Update cycling74-max to 8.0.0_180925

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '7.3.5_180307'
-  sha256 '53dc94069c4493856cf33ed6051366f3fa5250134cff93a9557c63b141884bd2'
+  version '8.0.0_180925'
+  sha256 'cdaeeedb5e65c67ea0fbce915218f4d0046bc5ce13ee6ffcdf9fde551418f61e'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.