### PR TITLE
Update mimolive to 4.4.1-26514

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,6 +1,6 @@
 cask 'mimolive' do
-  version '4.4-26484'
-  sha256 'd863e09c5c8a5eb9cd5692d9cc9127de0bf2e3aa38917fcb906f050cef09567b'
+  version '4.4.1-26514'
+  sha256 '4d7ff866e6c1044d99cedd61d72792d6d2af672635ec6fc91f242741906bf4b0'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://boinx.com/d/connect/histories/mimolive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.