### PR TITLE
Update proxifier to 2.22.1

### DIFF
--- a/Casks/proxifier.rb
+++ b/Casks/proxifier.rb
@@ -1,5 +1,5 @@
 cask 'proxifier' do
-  version '2.22'
+  version '2.22.1'
   sha256 'fe998ac7bbbfcf2bf6cc422e84099a11439711fa4a86618970dade62107c2d0d'
 
   url 'https://www.proxifier.com/distr/ProxifierMac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.