### PR TITLE
Update mightytext to 4.2.0

### DIFF
--- a/Casks/mightytext.rb
+++ b/Casks/mightytext.rb
@@ -1,6 +1,6 @@
 cask 'mightytext' do
-  version '3.91.2'
-  sha256 '882cbe86911050bca30c293523b7156106cd05237e509e3fd171d317e933d5b5'
+  version '4.2.0'
+  sha256 'fe47c32999ed1d98fa0f8824b345a2a0776f5342f8170ddb71a26e26049698d9'
 
   url "https://dl-desktop.mightytext.net/MightyText-#{version}.dmg"
   name 'MightyText'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.