### PR TITLE
Update silo to 2.5.5

### DIFF
--- a/Casks/silo.rb
+++ b/Casks/silo.rb
@@ -1,8 +1,8 @@
 cask 'silo' do
-  version '2.3.1'
-  sha256 'd06603810d3c9c3d78f6607a3e2466bb8fd6aa67727004ef4889cfa3b904704d'
+  version '2.5.5'
+  sha256 '7d0a4af414dcfe623a76da5d23fa324651913b2258062e998274e336eb8c29f2'
 
-  url "https://nevercenter.com/download/Install_Silo_#{version.dots_to_underscores}_mac.zip"
+  url "http://nevercenter.com/silo/download_file/filearchive/Install_Silo_#{version.dots_to_underscores}_mac.dmg"
   name 'Silo'
   homepage 'https://nevercenter.com/silo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.