### PR TITLE
Update barXtemp version to 1.3.3

### DIFF
--- a/Casks/barxtemp.rb
+++ b/Casks/barxtemp.rb
@@ -1,6 +1,6 @@
 cask 'barxtemp' do
-  version '1.3.2'
-  sha256 '85c8347ab8e7cbc8e7cf639317f3ff5df75feb9420bf94596dcfa05ac5914d16'
+  version '1.3.3'
+  sha256 '232286bc63a136ceca759addb6108a5b66d2b18d1db1df728c80296ec5847c65'
 
   # github.com/Gabriele91/barXtemp was verified as official when first introduced to the cask
   url "https://github.com/Gabriele91/barXtemp/releases/download/#{version}/barXtemp.app.zip"


### PR DESCRIPTION
Homebrew 1.7.7
Homebrew/homebrew-core (git revision 49a4e; last commit 2018-10-09)
Homebrew/homebrew-cask (git revision 33e4d; last commit 2018-10-09)

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version]
