### PR TITLE
Update do-not-disturb to 1.3.0

### DIFF
--- a/Casks/do-not-disturb.rb
+++ b/Casks/do-not-disturb.rb
@@ -1,6 +1,6 @@
 cask 'do-not-disturb' do
-  version '1.2.2'
-  sha256 '1e0e185b098c8dc764abcedd63eeab490af2b7c4b77445a87f37bf9e88b90d95'
+  version '1.3.0'
+  sha256 '000e3ce8f5abd1313bbb603c401a1be0b5cf4f11644d36f1d5d382745079fdc3'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/DoNotDisturb_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.