### PR TITLE
Update parallels-toolbox to 2.6.1-1620

### DIFF
--- a/Casks/parallels-toolbox.rb
+++ b/Casks/parallels-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'parallels-toolbox' do
-  version '2.6.0-1613'
-  sha256 'cecea01d4ab0d13a00587cdfa3312f102ab2ebc281bf8a622eeb7f824e0e94ef'
+  version '2.6.1-1620'
+  sha256 'e6ce77029e3e7dc0a0fb48a769ca0b252420271c6c9ac0a7b9931bb1e7480e8a'
 
   url "https://download.parallels.com/toolbox/v#{version.major}/#{version}/ParallelsToolbox-#{version}.dmg"
   name 'Parallels Toolbox'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.