### PR TITLE
Update capture-one to 11.3.1

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,8 +1,8 @@
 cask 'capture-one' do
-  version '11.3.0'
-  sha256 'ab70176355cd13c61e86f78b1f5e269185504657728b2dfbdd9f27b2eb9b22a6'
+  version '11.3.1'
+  sha256 'd13b8508ccf7dcf3bd9f94d738aa4e8118bb7e3fa84f295d89456fc74b085d60'
 
-  url "http://downloads.phaseone.com/73bc2bdb-c7e0-45ec-bffc-3b2ec2adeb03/English/CaptureOne.Mac.#{version}.dmg"
+  url "http://downloads.phaseone.com/e7f45a0e-447c-4878-84fb-bca6db2de475/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'
   homepage 'https://www.phaseone.com/en/Products/Software/Capture-One-Pro/Whats-new.aspx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.