### PR TITLE
Update ryver to 1.3.2

### DIFF
--- a/Casks/ryver.rb
+++ b/Casks/ryver.rb
@@ -1,6 +1,6 @@
 cask 'ryver' do
-  version '1.2.0'
-  sha256 'de9a89fab748a1b5c1077b5710c222591129e8730f45eeda41fb3b7b37b30a4e'
+  version '1.3.2'
+  sha256 '949abb92a3df5034fd8c81e1fe78a9c7bd7be2ad699bef9d423ad3a39cd48d54'
 
   # d3vkb1nw20iqfq.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3vkb1nw20iqfq.cloudfront.net/mac/Ryver-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.