### PR TITLE
Update thebrain to 9.1.18.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,6 +1,6 @@
 cask 'thebrain' do
-  version '9.1.15.0'
-  sha256 '569199a6d3d8ca064744682b82868dfd3719dce696a918d6abe552c86e5d3c76'
+  version '9.1.18.0'
+  sha256 '05bc47b98d230ac790fc622a5b18a23b72d8873ec752cb5bc437e81ab47c8d5b'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   name 'TheBrain'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.