### PR TITLE
Update studio-3t to 2018.4.6

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2018.4.5'
-  sha256 'eb8ea302d4dc587aa51eed6d2ced67155fbe997146616c13c9239c160dae869b'
+  version '2018.4.6'
+  sha256 'c57f97bea517843544ea5c7506c7970f4d578882bf89115e3e6047a4df865948'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.