### PR TITLE
Update cutter to 1.7.2

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,9 +1,9 @@
 cask 'cutter' do
-  version '1.7.1'
-  sha256 'f407e87c0cd221e69da8eae94c424d095fec57f7cb6541b7674ca1c6854777fa'
+  version '1.7.2'
+  sha256 '875e06b266427c4e5251e247307f17370bc42cca0933aabdccb9d79b7a73995b'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
-  url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}.dmg"
+  url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"
   appcast 'https://github.com/radareorg/cutter/releases.atom'
   name 'Cutter'
   homepage 'https://radare.org/cutter/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.