### PR TITLE
cocktail: fix sha256

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -37,7 +37,7 @@ cask 'cocktail' do
     appcast 'https://www.maintain.se/downloads/sparkle/highsierra/highsierra.xml'
   else
     version '12.0.1'
-    sha256 '6a00bae70a5befa7fb9467c1320e8818939e5f074deadd70177021fbf4694b07'
+    sha256 'a77cda30300b7ea943908dd57df365ce2cdf1d801230f0fc2fb9954fefb1c93f'
 
     url "https://www.maintain.se/downloads/sparkle/mojave/Cocktail_#{version}.zip"
     appcast 'https://www.maintain.se/downloads/sparkle/mojave/mojave.xml'


### PR DESCRIPTION
Previous sha256 was wrong (notice how it was the same in the `:high_sierra` and `else` cases).