### PR TITLE
Update workflowy to 1.1.2

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.1.1'
-  sha256 '8e22e4308f9f0b03816e5201a1024b15b67dfae09fea4e987d5718a5de4218ee'
+  version '1.1.2'
+  sha256 '432f4de9fb76d6bc00b63d592b5947f2c2d282690a6e07dc0f42b2aefd05334b'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.