### PR TITLE
Update alva to 0.8.0

### DIFF
--- a/Casks/alva.rb
+++ b/Casks/alva.rb
@@ -1,6 +1,6 @@
 cask 'alva' do
-  version '0.7.0'
-  sha256 'a834429e38d4d3b7fc5805d58c76b7e141b64f9fbe57c032c7e9c5628a24892b'
+  version '0.8.0'
+  sha256 '20efe3613780c3a42fa1af7f3f0db7297bc01927753970134f5abcb538413b54'
 
   # github.com/meetalva/alva was verified as official when first introduced to the cask
   url "https://github.com/meetalva/alva/releases/download/v#{version}/Alva-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.