### PR TITLE
Update micloud to 0.1.25

### DIFF
--- a/Casks/micloud.rb
+++ b/Casks/micloud.rb
@@ -1,6 +1,6 @@
 cask 'micloud' do
-  version '0.1.19'
-  sha256 'b862efef50fd177c53861625f08090bc2b8eea6a2de32a3375d6e38963d196e6'
+  version '0.1.25'
+  sha256 'e6220b871412f76467beb881cdda13ac4c9b827833772577db994e9157aa91aa'
 
   # update.micloud.xiaomi.net/download was verified as official when first introduced to the cask
   url "https://update.micloud.xiaomi.net/download/#{version}/osx_64/MiCloud-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.