### PR TITLE
Update qownnotes to 18.10.1,b3863-171214

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.10.0,b3857-113458'
-  sha256 'f09613589f9f91ebdeabb5f4afc0bc4b563800aceb3c0d44e959a779305042b8'
+  version '18.10.1,b3863-171214'
+  sha256 '8db4297dfb66bd997aa5d5ae87838ab8e8fe9014ee4aeadfba2b71c4f6c6999a'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.