### PR TITLE
Update touchosc-editor to 1.8.5

### DIFF
--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-editor' do
-  version '1.8.2'
-  sha256 '37d22796d50199719b7a6e618817ebb5113ea15b3dc2a9686ca60f14774cfd81'
+  version '1.8.5'
+  sha256 '0873ee00f6e7e135d3dc704fd2f072e29e02b5a6d863851370e81c657a788643'
 
   url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
   name 'TouchOSC Editor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.