### PR TITLE
Update pulse-sms to 3.1.2

### DIFF
--- a/Casks/pulse-sms.rb
+++ b/Casks/pulse-sms.rb
@@ -1,6 +1,6 @@
 cask 'pulse-sms' do
-  version '3.0.1'
-  sha256 '81543693032fe763e0f2344e176da4e01d0aa799610c6724818454eb0c7747e4'
+  version '3.1.2'
+  sha256 '73d0af3f311032add5e0a69e45b1bf965bcc1cb377704a165b6cfbb6d79cd8f1'
 
   # github.com/klinker-apps/messenger-desktop was verified as official when first introduced to the cask
   url "https://github.com/klinker-apps/messenger-desktop/releases/download/v#{version}/pulse-sms-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.