### PR TITLE
Update clipy to 1.2.1

### DIFF
--- a/Casks/clipy.rb
+++ b/Casks/clipy.rb
@@ -1,6 +1,6 @@
 cask 'clipy' do
-  version '1.1.5'
-  sha256 '58b49c5a63fcee8d9636922911d24055e85ecbe10cec3d2a4a86c6a377f44ab1'
+  version '1.2.1'
+  sha256 'dfbb66ce3135fbaa2d64eaeea99a63e63485e322c9746045a1098b1696a1ecd5'
 
   # github.com/Clipy/Clipy was verified as official when first introduced to the cask
   url "https://github.com/Clipy/Clipy/releases/download/#{version}/Clipy_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.