### PR TITLE
Update retroarch to 1.7.5

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask 'retroarch' do
   version '1.7.5'
-  sha256 '9bbedc943213f7602bba7dcf1056d92c9c4af92d7d00dbfcb98807e6c1829251'
+  sha256 '3784c4c182cec5ee56abbc9a8022bbe9107df9d16e14c777ada494d5119fb195'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   appcast 'https://buildbot.libretro.com/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.