### PR TITLE
Update netron to 2.2.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.2.4'
-  sha256 '810f171f444c908fffb51edd87b1a706de5d89eed5129bdbb870efe5e6a6d930'
+  version '2.2.6'
+  sha256 '42c0d0857102dff725eb5117835281b55da7ce02eda9e012b65174d0210249ca'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.