### PR TITLE
Fixes #39739 - document 'unofficial' app naming conventions.

### DIFF
--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -153,4 +153,4 @@ If a Homebrew formula and a Homebrew Cask cask both exist with the same token an
 
 If the token for a piece of unofficial software that interacts with a popular service would make it look official and the vendor is not authorised to use the name, [a prefix must be added](../development/adding_a_cask.md#forks-and-apps-with-conflicting-names) for disambiguation.
 
-In cases that the prefix is ambiguous and would make the app appear official, the `-unofficial` suffix may be used.
+In cases where the prefix is ambiguous and would make the app appear official, the `-unofficial` suffix may be used.

--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -152,3 +152,7 @@ If a Homebrew formula and a Homebrew Cask cask both exist with the same token an
 ## Potentially Misleading Name
 
 If the token for a piece of unofficial software that interacts with a popular service would make it look official and the vendor is not authorised to use the name, [a prefix must be added](../development/adding_a_cask.md#forks-and-apps-with-conflicting-names) for disambiguation.
+
+In most cases, the prefix should be the vendor's name. For example, `google-play-music-desktop-player` is unofficial, so [its cask was renamed to `marshallofsound-google-play-music-player`](https://github.com/Homebrew/homebrew-cask/pull/39923).
+
+In cases that the prefix is ambiguous and would make the app appear official, the `unofficial-` prefix may be used.

--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -153,6 +153,4 @@ If a Homebrew formula and a Homebrew Cask cask both exist with the same token an
 
 If the token for a piece of unofficial software that interacts with a popular service would make it look official and the vendor is not authorised to use the name, [a prefix must be added](../development/adding_a_cask.md#forks-and-apps-with-conflicting-names) for disambiguation.
 
-In most cases, the prefix should be the vendor's name. For example, `google-play-music-desktop-player` is unofficial, so [its cask was renamed to `marshallofsound-google-play-music-player`](https://github.com/Homebrew/homebrew-cask/pull/39923).
-
-In cases that the prefix is ambiguous and would make the app appear official, the `unofficial-` prefix may be used.
+In cases that the prefix is ambiguous and would make the app appear official, the `-unofficial` suffix may be used.

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -211,7 +211,7 @@ Before submitting a trial, make sure it can be made into a full working version 
 
 ### Forks and Apps with Conflicting Names
 
-Forks should have the vendor’s name as a prefix on the Cask’s file name and token. For unrelated Apps that share a name, the most popular one (usually the one already present) stays unprefixed. Since this can be subjective, if you disagree with a decision open an issue and make your case to the maintainers.
+Forks should have the vendor’s name as a prefix on the Cask’s file name and token. For unrelated Apps that share a name, the most popular one (usually the one already present) stays unprefixed. Since this can be subjective, if you disagree with a decision, open an issue and make your case to the maintainers.
 
 ### Unofficial, Vendorless, and Walled Builds
 


### PR DESCRIPTION
Documentation changes only. I'm hoping this description is clear enough to fix #39739. 

If it's not clear or this should be documented elsewhere, I'm happy to adjust it!