### PR TITLE
Update a-better-finder-rename to 10.35

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,6 +1,6 @@
 cask 'a-better-finder-rename' do
   version '10.35'
-  sha256 '262061e4b50c8d1d1b74e885b5967d695c28c070cf06395585b41e73b0529e49'
+  sha256 :no_check # required as upstream randomly uses two different downloads for a/b testing
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"

--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,6 +1,6 @@
 cask 'a-better-finder-rename' do
-  version '10.32'
-  sha256 :no_check # required as upstream randomly uses two different downloads for a/b testing
+  version '10.35'
+  sha256 '262061e4b50c8d1d1b74e885b5967d695c28c070cf06395585b41e73b0529e49'
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.