### PR TITLE
Update asciidocfx to 1.6.9

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
-  version '1.6.8'
-  sha256 '297d4efa5d1624ea7cc889053081dbc4780f0160938f7111107eade2ac5ec31d'
+  version '1.6.9'
+  sha256 '2cb7492ace5fbe1a384954f7cc68fabf6d3b7f5dfd3f35cfe546a301869ea47f'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.