### PR TITLE
Update astropad-studio to 2.2.0

### DIFF
--- a/Casks/astropad-studio.rb
+++ b/Casks/astropad-studio.rb
@@ -1,6 +1,6 @@
 cask 'astropad-studio' do
-  version '2.0'
-  sha256 '60fa3e3922d91767881eb3137b50060ba4f7e314073281ad939b8af75130eff2'
+  version '2.2.0'
+  sha256 '5867212a921f4bfbbc2657b616ff1282450fc4cc0769c4055e526fdd8e5cc46c'
 
   url "https://astropad.com/downloads/AstropadStudio-#{version}.zip"
   appcast 'https://astropad.com/downloads/studio-sparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.