### PR TITLE
Update bee to 3.1.5,5468

### DIFF
--- a/Casks/bee.rb
+++ b/Casks/bee.rb
@@ -1,6 +1,6 @@
 cask 'bee' do
-  version '3.1.4,5464'
-  sha256 '32278ec30960b2d8932adba655649ee653c551e077153f90d4258fdf1b63fc29'
+  version '3.1.5,5468'
+  sha256 '1568a63516384fd62d9f746f8afe8f94bcec84ca0d25bf0b8f252eee2432509e'
 
   # bee-app.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://bee-app.s3.amazonaws.com/public/Bee-#{version.after_comma}-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.