### PR TITLE
Update blockstack to 0.34.1

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.33.2'
-  sha256 'f73c494fd2e32bb9860389713d45e6b998e6a52a14dee1464935c5ec4bfe1aba'
+  version '0.34.1'
+  sha256 '08cc726239ca2e1b9edee05c88c8978baaec862e08fe0df3333da700554b27c3'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.