### PR TITLE
Update boom to 1.6.5,1539009345

### DIFF
--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -1,6 +1,6 @@
 cask 'boom' do
-  version '1.6.4,1519799556'
-  sha256 'ef741c3566189a4c53fdeafdc3989e832ea64f6299d4849a14bb6dba22a2afd1'
+  version '1.6.5,1539009345'
+  sha256 'fbf88089b91371288ca78016b22185fe0c1fe64939886b776821b3ff9ba4e06f'
 
   # devmate.com/com.globaldelight.Boom2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Boom2/#{version.before_comma}/#{version.after_comma}/Boom2-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.