### PR TITLE
Update byteball to 2.6.0

### DIFF
--- a/Casks/byteball.rb
+++ b/Casks/byteball.rb
@@ -1,6 +1,6 @@
 cask 'byteball' do
-  version '2.5.0'
-  sha256 '2c2044b41ff0e340506312e36599d9f790261eaa479183cb9fb1c74d07f17b1d'
+  version '2.6.0'
+  sha256 'cf73029f39882893829d5e471191059083f8f2d525c29ba2ff3f1eb40671ba95'
 
   # github.com/byteball/byteball was verified as official when first introduced to the cask
   url "https://github.com/byteball/byteball/releases/download/v#{version}/Byteball-osx64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.