### PR TITLE
Update bytecoin to 3.3.2

### DIFF
--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -1,6 +1,6 @@
 cask 'bytecoin' do
-  version '3.2.4'
-  sha256 'e5b007e62a87de517c6e8cf56f3bdccd917ac8064c480258a31fa06ff3b97b30'
+  version '3.3.2'
+  sha256 '661f8753120114dd25ff8a70446def8fc5234c25f063d02d103db45d87088c44'
 
   # github.com/bcndev/bytecoin-gui was verified as official when first introduced to the cask
   url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.