### PR TITLE
Update captin to 1.0.16,92:1538968026

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.14,87:1532235836'
-  sha256 '43466e6d5f7d37f63d6ff2547b3a19fc822ecb98953123032195d68a2661b093'
+  version '1.0.16,92:1538968026'
+  sha256 '77af05154b3ef3fb7eb16ac2cc932f600b8feee30115ee4175dd966102a03043'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.