### PR TITLE
Update chatmate-for-facebook to 4.3.1,482:1537946763

### DIFF
--- a/Casks/chatmate-for-facebook.rb
+++ b/Casks/chatmate-for-facebook.rb
@@ -1,6 +1,6 @@
 cask 'chatmate-for-facebook' do
-  version '4.2.4,470:1518834838'
-  sha256 '790fedb66aeaf1acc34df97f204e19841035bf8f74cc7a4299cb9989c15bcf06'
+  version '4.3.1,482:1537946763'
+  sha256 '7e658246e0ac4c35c36de5f730f5f2fca6c644f25cb134d165167e38c4b7771e'
 
   # dl.devmate.com/net.coldx.mac.Facebook was verified as official when first introduced to the cask
   url "https://dl.devmate.com/net.coldx.mac.Facebook/#{version.after_comma.before_colon}/#{version.after_colon}/ChatMateforFacebook-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.