### PR TITLE
Update chatmate-for-whatsapp to 4.3.1,482:1537891987

### DIFF
--- a/Casks/chatmate-for-whatsapp.rb
+++ b/Casks/chatmate-for-whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'chatmate-for-whatsapp' do
-  version '4.2.4,470:1518834547'
-  sha256 '0959e533dad25ad0d8fa1ba6e59e55b0e7ef6c97d8a28a59dd4fdaca9f46d4fd'
+  version '4.3.1,482:1537891987'
+  sha256 'af6b75282d8b0c0782246f771a4718675616cbdc6b62682a9e055641ab1e5ac7'
 
   # dl.devmate.com/net.coldx.mac.WhatsApp was verified as official when first introduced to the cask
   url "https://dl.devmate.com/net.coldx.mac.WhatsApp/#{version.after_comma.before_colon}/#{version.after_colon}/ChatMateforWhatsApp-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.