### PR TITLE
Update chatology to 1.2.2

### DIFF
--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,6 +1,6 @@
 cask 'chatology' do
-  version '1.2'
-  sha256 'cff0d2a0e5b42be9ed3210d696662e83c052a85e35afce6b2b0a372cc7508f88'
+  version '1.2.2'
+  sha256 'b5175e5330ad26f6a43c6be078245ad3137aa80bf766a280573f9b7ef62eb139'
 
   # d60ism0l33mmr.cloudfront.net was verified as official when first introduced to the cask
   url "https://d60ism0l33mmr.cloudfront.net/Chatology_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.