### PR TITLE
Update cuppa to 1.8.1

### DIFF
--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -1,6 +1,6 @@
 cask 'cuppa' do
-  version '1.8'
-  sha256 '53b5441b277073c78a3f885e08009ef55f288b1577a035b0f2a038d8504ab7a9'
+  version '1.8.1'
+  sha256 '1355d94fb6648b056011beb120f6cd72803e0530c9286efbd46883eaa357253d'
 
   url "https://www.nathanatos.com/software/downloads/Cuppa-#{version}.zip"
   appcast 'https://www.nathanatos.com/software/cuppa.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.