### PR TITLE
Update cursorsense to 2.0.1

### DIFF
--- a/Casks/cursorsense.rb
+++ b/Casks/cursorsense.rb
@@ -1,6 +1,6 @@
 cask 'cursorsense' do
-  version '2.0'
-  sha256 '1dc68c102f5aab32397aba73d209607dc2215f0a809d2d65ddf8161d5dca5910'
+  version '2.0.1'
+  sha256 'c7567d46ae2fde4d80d9713c1323da543ec1b26753996b37624993bcbd32a9c1'
 
   url "https://plentycom.jp/ctrl/files_cs/CursorSense#{version}.dmg"
   appcast 'https://plentycom.jp/en/cursorsense/download.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.