### PR TITLE
Update dcp-o-matic-encode-server to 2.12.12

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.12.10'
-  sha256 'b5ff88898de8b7d4016d7e1b1f2215f7fbab09b7eec9f83c4884176176b0f699'
+  version '2.12.12'
+  sha256 '2ea4f46557eb69dbb837b532620ab9a69ec32b4432770607d091051dc25364fa'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.