### PR TITLE
Update dcp-o-matic-player to 2.12.12

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.12.10'
-  sha256 'bb18cd6b719be1536f4cbff506960afd2f9a9e04d6be8d07edf4fd4da281e7aa'
+  version '2.12.12'
+  sha256 'b3f94bd88964e9c4ffe36502d38ef43f6a23fb17d5e61b9df378a58d4d25fdc0'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.