### PR TITLE
Update deckset to 2.0.7,2500

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -1,6 +1,6 @@
 cask 'deckset' do
-  version '2.0.6,2495'
-  sha256 '399f455d58bf26fab2c03124453f1524afa92358a820a42976f6dc53a2290176'
+  version '2.0.7,2500'
+  sha256 'd5149edf26b4c8e2c20dbfe34dc5a6eb805eea486f1c7be885141ad713a88026'
 
   url "https://dl.decksetapp.com/Deckset+#{version.before_comma}+(#{version.after_comma}).dmg"
   appcast 'https://dl.decksetapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.