### PR TITLE
Update deepstream to 3.1.5

### DIFF
--- a/Casks/deepstream.rb
+++ b/Casks/deepstream.rb
@@ -1,6 +1,6 @@
 cask 'deepstream' do
-  version '3.1.3'
-  sha256 'c690d1374028bb7fbb3d000bac64176e0cc93a50b15909d186e77ab0a154f055'
+  version '3.1.5'
+  sha256 'a22cc87c6639b626d8dd390e9af6bb05d88fb6c61b0d67d607fb9ee7f3a3b0b2'
 
   # github.com/deepstreamIO/deepstream.io was verified as official when first introduced to the cask
   url "https://github.com/deepstreamIO/deepstream.io/releases/download/v#{version}/deepstream.io-mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.