### PR TITLE
Update dupin to 2.14.1

### DIFF
--- a/Casks/dupin.rb
+++ b/Casks/dupin.rb
@@ -3,8 +3,8 @@ cask 'dupin' do
     version '2.7.4'
     sha256 '4aba53f356606614627d57f6a33c1ee9cf13ddf06c13e7ac8487b930cb647b85'
   else
-    version '2.14.0'
-    sha256 '5bba18216cdd01815df7c386d30c356f925b9bb264d3e0bc29c12d8eb7bdd791'
+    version '2.14.1'
+    sha256 'c4cd423768d2bd2982e10e965fcc8965dd78ce7b7e409a20f159a513573f6dd1'
 
     appcast 'https://dougscripts.com/itunes/itinfo/dupin_appcast.xml'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.