### PR TITLE
Update electorrent to 2.4.0

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,6 +1,6 @@
 cask 'electorrent' do
-  version '2.3.1'
-  sha256 '31bd50f59a77dd78b13fb951e43c0e5bb38ae5faa08908cae23e86cee2b465db'
+  version '2.4.0'
+  sha256 '95ebe44128aea36c7ecc15986bf50b4181087d0afb5b66ba3dba68b64b49bb3e'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.