### PR TITLE
Update electron-fiddle to 0.3.0

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.2.0'
-  sha256 'ba8fd554c615a9867f4144922b1d9e5df515b1586f82efc8cbd1aa6ce5508aec'
+  version '0.3.0'
+  sha256 '96cc50d0f3a8b3a58ca1e55093d0c20fb387f74c437ccbce88ae05796a7eb514'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/electron-fiddle-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.