### PR TITLE
Update expo-xde to 2.25.0

### DIFF
--- a/Casks/expo-xde.rb
+++ b/Casks/expo-xde.rb
@@ -1,6 +1,6 @@
 cask 'expo-xde' do
-  version '2.24.4'
-  sha256 'bd2d7d7f66bbb44c522a7550671216dc8ea680478c7e09c9f7bcc739b1daa288'
+  version '2.25.0'
+  sha256 'acc7048dcd9763e6924850595b325a4c38c9d28ab1c07dd07f2bc6058476ed2a'
 
   # github.com/expo/xde was verified as official when first introduced to the cask
   url "https://github.com/expo/xde/releases/download/v#{version}/xde-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.