### PR TITLE
Update fly to 4.2.1

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,6 +1,6 @@
 cask 'fly' do
-  version '4.0.0'
-  sha256 '5f8e18c84d4301e11290651127a1238a87f55fb16fd1ba48486a858778101888'
+  version '4.2.1'
+  sha256 'b31665b68f7158a8c4a6fefa97272781e8e28852e0163f47161b3010fd0ae8c0'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.