### PR TITLE
Update go-server to 18.9.0-7478

### DIFF
--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,6 +1,6 @@
 cask 'go-server' do
-  version '18.7.0-7121'
-  sha256 '150bf7b079ff0514405eda355b224ca9ef73b62129622828f049342a36beaf37'
+  version '18.9.0-7478'
+  sha256 'a43f46776bb10aa94bae35b095f1ef72450e737ff9a1004d268868038957d25c'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.