### PR TITLE
Update gpxsee to 6.2

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '6.0'
-  sha256 'add4bce54b6937743246d18d6c85cdb7f9bb228e07c23cfdee0237468e3e8dab'
+  version '6.2'
+  sha256 '830c3f763e3f2ee2a1a56b5e888036dd393638e060650962b7d4ebae6ca43a44'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.