### PR TITLE
Update hider to 2.4.9,1536932077

### DIFF
--- a/Casks/hider.rb
+++ b/Casks/hider.rb
@@ -1,6 +1,6 @@
 cask 'hider' do
-  version '2.4.7,1527148372'
-  sha256 'd41a442075fde63a087a97654e047989b0de3a993b27859a4c0c3ff31b4886a6'
+  version '2.4.9,1536932077'
+  sha256 '4a292ccafc4f5abab106a37e608ece909a200f704926a9ee9ca3dbbfc644352e'
 
   # dl.devmate.com/com.macpaw.site.Hider was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Hider#{version.major}/#{version.before_comma}/#{version.after_comma}/MacPawHider#{version.major}-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.