### PR TITLE
Update hopper-debugger-server to 2.6

### DIFF
--- a/Casks/hopper-debugger-server.rb
+++ b/Casks/hopper-debugger-server.rb
@@ -1,6 +1,6 @@
 cask 'hopper-debugger-server' do
-  version '2.4'
-  sha256 '32879ffedbe88d172aa59c1cdb32cdba024d842c20d705458ea4279f5bc18dab'
+  version '2.6'
+  sha256 'dde3d5949a9550e4a62d135acfcd6cefa930c69d4ea07c6e4056d6e1cca136d3'
 
   url "https://www.hopperapp.com/HopperGDBServer/HopperDebuggerServer-#{version}.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.