### PR TITLE
Update hypo to 0.5.8

### DIFF
--- a/Casks/hypo.rb
+++ b/Casks/hypo.rb
@@ -1,6 +1,6 @@
 cask 'hypo' do
-  version '0.5.6'
-  sha256 'd18f2e44dd23265280fb8eb28015006c93c5bbf98794437fbd7acd4f531028ae'
+  version '0.5.8'
+  sha256 '98686cc17a5973875d23682a3fbc00d98818c4a9dc8bab4ac90322f1af5d42ed'
 
   # hypo.github.io was verified as official when first introduced to the cask
   url "https://hypo.github.io/HypoAppPublic/hypo-#{version}.app.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.