### PR TITLE
Update instead to 3.2.2

### DIFF
--- a/Casks/instead.rb
+++ b/Casks/instead.rb
@@ -1,6 +1,6 @@
 cask 'instead' do
-  version '3.2.1'
-  sha256 '34ca0aac226f4c2f87cb0db4217e09c8deed2a29c6d7d67871bef1087796caa7'
+  version '3.2.2'
+  sha256 '2d460eefea97bc78d245393aba0c08a1167f0ce4426f643ebd828d111109cffe'
 
   # github.com/instead-hub/instead was verified as official when first introduced to the cask
   url "https://github.com/instead-hub/instead/releases/download/#{version}/Instead-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.