### PR TITLE
Update itubedownloader to 6.4.0.0,1537833301

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,6 +1,6 @@
 cask 'itubedownloader' do
-  version '6.3.8.1,1534445019'
-  sha256 '7364fb08b9c85507c3be309b7e603ba509bb33be07b2239e733927d1e79ebaab'
+  version '6.4.0.0,1537833301'
+  sha256 'df7e329a2ab0075bc91c0652f74d079d098dc058103fa71ed89c877824c756e7'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/#{version.before_comma.no_dots}/#{version.after_comma}/iTubeDownloader-#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.