### PR TITLE
Update jbrowse to 1.15.4

### DIFF
--- a/Casks/jbrowse.rb
+++ b/Casks/jbrowse.rb
@@ -1,6 +1,6 @@
 cask 'jbrowse' do
-  version '1.15.3'
-  sha256 '8b8b584362d01fdb77eb4e9e4b96a215c8f684db26bd97d3dd44b27dfa71e5fa'
+  version '1.15.4'
+  sha256 '2377ddf29d2453fa6360cb181901c474fc0e84be8e750959d742617b8e540bc5'
 
   # github.com/GMOD/jbrowse was verified as official when first introduced to the cask
   url "https://github.com/GMOD/jbrowse/releases/download/#{version}-release/JBrowse-#{version}-desktop-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.