### PR TITLE
Update join-together to 7.8.3

### DIFF
--- a/Casks/join-together.rb
+++ b/Casks/join-together.rb
@@ -1,6 +1,6 @@
 cask 'join-together' do
-  version '7.8.1'
-  sha256 '1726dfdfa48f36011dfd6ef1dc4b7054f89c58ac959cc22984eabb8454d9a4f7'
+  version '7.8.3'
+  sha256 '09461af1b3c2252d04a1c00d4e0d108e164e3a079a16aeb19b8131dcbf7e9953'
 
   url "https://dougscripts.com/itunes/scrx/jointogether#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/jointogether_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.