### PR TITLE
Update joshaven-winbox to 3.17

### DIFF
--- a/Casks/joshaven-winbox.rb
+++ b/Casks/joshaven-winbox.rb
@@ -1,6 +1,6 @@
 cask 'joshaven-winbox' do
-  version '3.11_FixHS'
-  sha256 'cfed9f359ca2b565879d83d922768ed64e4549391757186317b15729c447142c'
+  version '3.17'
+  sha256 '4015b86a9cf1af94099827b64687c3d46f9c9cd0c6371446ee14d7a1d4fc0378'
 
   url "https://joshaven.com/Winbox4Mac_#{version}.dmg"
   appcast 'https://joshaven.com/resources/tools/winbox-for-mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.