### PR TITLE
Update clover-configurator to 5.2.1.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.2.0.1'
-  sha256 'afed4c08d0bc3c8b017e75847c22d516adbd4a2be904cd4facf4889b8836bce8'
+  version '5.2.1.0'
+  sha256 '03e344e4ccc8e6f5042dcd1da38e199bb34f0cb4df7fc5d16531d3eddbfa0d06'
 
   url 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/builds-data/CCG.zip'
   appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.