### PR TITLE
Update lbry to 0.25.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.25.0'
-  sha256 '524c713406dd2d6f8bd12ef01d0d5922e3912455dfcd02e87681f95ce27e63e4'
+  version '0.25.1'
+  sha256 '5fb92b87d561cfaf0e4a9edf5dfa99f678e27718bfefc145f64c5943f4630146'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.