### PR TITLE
Update lyricsx to 1.4.2,1946

### DIFF
--- a/Casks/lyricsx.rb
+++ b/Casks/lyricsx.rb
@@ -1,6 +1,6 @@
 cask 'lyricsx' do
-  version '1.4.1,1846'
-  sha256 'b7d93a65fd53de2d3f5a3673ffe49b44bb641f72907e74d5582b5676d25acb53'
+  version '1.4.2,1946'
+  sha256 '67de36ee6f596b184f6d331414b3a18994564a8ca4ba6a7f3d35bb3057eda267'
 
   url "https://github.com/ddddxxx/LyricsX/releases/download/v#{version.before_comma}/LyricsX_#{version.before_comma}+#{version.after_comma}.zip"
   appcast 'https://github.com/ddddxxx/LyricsX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.