### PR TITLE
Update m3unify to 1.11.3

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,6 +1,6 @@
 cask 'm3unify' do
-  version '1.11.0'
-  sha256 'ce68bd4383187dff12a08a06cf229ce26bf3255e9f0b5606363dd746d16f1a2a'
+  version '1.11.3'
+  sha256 'a55b678e2e27c0a14512ecf28444d6685463e2c4d7bf31a3e31f6f8480d9a46e'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.