### PR TITLE
Update mailbutler to 2.2-10112

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2.1.3-9666'
-  sha256 '53ea2df680b7e258d6e8caa37a1658b5480aecfa5d1ed1a3bef5319fdb519b17'
+  version '2.2-10112'
+  sha256 '8625fea4d460109af005e45ca3d8af918ea7a2839aafb9dc4111d95a0d183bf1'
 
   # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-data.s3.amazonaws.com/downloads/Mailbutler_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.