### PR TITLE
Update manager to 18.10.45

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.34'
-  sha256 'cdc5db48851b3a76ddaad217ac82c5993a4f36a846856a786b9bcefbe808d1eb'
+  version '18.10.45'
+  sha256 '8d6321d749fa53951ecb1655438885bf5e91970ad18193de819e6de2a016352d'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.