### PR TITLE
Update melodics to 2.0.2359

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2356'
-  sha256 '65ddee95e4c9554b485b6ceaf56aae321eb97627b7b5c3e5185e0ee911aaf6d2'
+  version '2.0.2359'
+  sha256 '11b80dd9502f8d1b50c2487344411bcb689792dc31f15668e36affb67aba41da'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.