### PR TITLE
Update microsoft-teams to 1.1.00.25655

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-teams' do
-  version '1.1.00.25455'
-  sha256 'ef3eedb53d2fdfc989c76e799e5b25657434a3fd676a5e1c36bb58d8f9bddb62'
+  version '1.1.00.25655'
+  sha256 '01d0de8575ab8eb8a65f7c39183b81174d6eb68b859ae5717780b9ec17ace587'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.dmg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.