### PR TITLE
Update midi-monitor to 1.4

### DIFF
--- a/Casks/midi-monitor.rb
+++ b/Casks/midi-monitor.rb
@@ -1,6 +1,6 @@
 cask 'midi-monitor' do
-  version '1.3.2'
-  sha256 '1b2f0a2e1892247c3a5c0c9fc48c682dfcbd4e15881a26eeaaf6026c7f61f24c'
+  version '1.4'
+  sha256 '3f521120eacb7d7181bf2ac9ddc04f7eaecc99bdd6ba6b4c38a4802ed7551cd2'
 
   url "https://www.snoize.com/MIDIMonitor/MIDIMonitor_#{version.dots_to_underscores}.zip"
   appcast 'https://www.snoize.com/MIDIMonitor/MIDIMonitor.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.