### PR TITLE
Update mp3gain-express to 2.2

### DIFF
--- a/Casks/mp3gain-express.rb
+++ b/Casks/mp3gain-express.rb
@@ -1,6 +1,6 @@
 cask 'mp3gain-express' do
-  version '2.1'
-  sha256 'bde9b129a87525a7e39e11176bdb9045346a822e2b18539a72446de53f9bb472'
+  version '2.2'
+  sha256 '261b3a0de62a3fd1b688a9ba7c01964a8ebff32f872105fe05a8eb02b1249a80'
 
   url "https://projects.sappharad.com/mp3gain/mp3gain_mac#{version.no_dots}.zip"
   appcast 'https://projects.sappharad.com/mp3gain/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.