### PR TITLE
Update munki to 3.4.1.3557

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,6 +1,6 @@
 cask 'munki' do
-  version '3.3.1.3537'
-  sha256 '7077cef8baafd501911117327a511aad7b1bc54cf31113e5c6b7407340d3407f'
+  version '3.4.1.3557'
+  sha256 '3da472f032a2bd1e37ccaca9d8398f382fe5c0f16f654fe71fb632cd2b7e9bf8'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.