### PR TITLE
Update noteplan to 1.6.29,53

### DIFF
--- a/Casks/noteplan.rb
+++ b/Casks/noteplan.rb
@@ -1,6 +1,6 @@
 cask 'noteplan' do
-  version '1.6.27,51'
-  sha256 '34cae69c6290e33f88fa76ba3ebfab9ba2823a6c22d975f560cf78d700520210'
+  version '1.6.29,53'
+  sha256 'a7007adc7947ab30532e0292b1e17486f18dda5803c993f75d9a5e03f9353b92'
 
   # rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.