### PR TITLE
Update openshot-video-editor to 2.4.3

### DIFF
--- a/Casks/openshot-video-editor.rb
+++ b/Casks/openshot-video-editor.rb
@@ -1,6 +1,6 @@
 cask 'openshot-video-editor' do
-  version '2.4.2'
-  sha256 'be8d67b2f5b07bdd23a4cd7877f961cef42c8b1d08b39a7f7c25fa5b1ceaf398'
+  version '2.4.3'
+  sha256 'e3b2b7175e6cd596c7c5676d4a254cd2a4a27f943bb5941120d3c0c18f19d53c'
 
   # github.com/OpenShot/openshot-qt was verified as official when first introduced to the cask
   url "https://github.com/OpenShot/openshot-qt/releases/download/v#{version}/OpenShot-v#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.