### PR TITLE
Update opensesame to 3.2.5

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,6 +1,6 @@
 cask 'opensesame' do
-  version '3.2.4'
-  sha256 '560c94f2e4d0060240a10c4f9b688c6cbcf980ce384f20c0fc5e53bfbc28b289'
+  version '3.2.5'
+  sha256 'eb297484a9c1ea245ddd9d5392cdd39d557ac5337032309791dac63a2be9aeb5'
 
   # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
   url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.