### PR TITLE
Update osculator to 3.2.2,84f792ed-e991-4279-9738-7bf0b2d3a029

### DIFF
--- a/Casks/osculator.rb
+++ b/Casks/osculator.rb
@@ -1,6 +1,6 @@
 cask 'osculator' do
-  version '3.1.2-63-gb9634423,2356a19f-47c4-4689-9f3b-5f5c83d6c85f'
-  sha256 '5868d7dcc1a6121945ee69286fc26e1c70a04e4e118e5ec05a877d74a8a2c722'
+  version '3.2.2,84f792ed-e991-4279-9738-7bf0b2d3a029'
+  sha256 '1fa1407b1bd19e05429ac74a3161bc7ec795798cc8ca6f8112b743855bc4ba2b'
 
   # distribution.wildora.net was verified as official when first introduced to the cask
   url "https://distribution.wildora.net/products/osculator-v#{version.major}/revisions/#{version.after_comma}/osculator-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.