### PR TITLE
Update pluralsight to 1.9.248

### DIFF
--- a/Casks/pluralsight.rb
+++ b/Casks/pluralsight.rb
@@ -1,6 +1,6 @@
 cask 'pluralsight' do
-  version '1.8.234'
-  sha256 '55a2051c41457620d8de06cfde0aae9157b6a989d0aeb5e387fdb67e185e6298'
+  version '1.9.248'
+  sha256 '687983b46b66385017beab0595b68e7d6d501cc3841e96d36b62d74331954a77'
 
   url "https://macapp.pluralsight.com/installpluralsight#{version}.dmg"
   appcast 'https://macapp.pluralsight.com/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.