### PR TITLE
Update protonmail-unofficial to 0.5.9

### DIFF
--- a/Casks/protonmail-unofficial.rb
+++ b/Casks/protonmail-unofficial.rb
@@ -1,6 +1,6 @@
 cask 'protonmail-unofficial' do
-  version '0.5.8'
-  sha256 'e9a9583e629ca5762281f422ad7bebc2f7569de25e31eec69fe896af8e502023'
+  version '0.5.9'
+  sha256 '789d1e75195cfec1141727aed5b23aec9fb0c67dfa2346058c32982f07b3d745'
 
   url "https://github.com/protonmail-desktop/application/releases/download/v#{version}/protonmail-desktop-#{version}.dmg"
   appcast 'https://github.com/protonmail-desktop/application/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.