### PR TITLE
Update prosys-opc-ua-client to 3.1.6-322

### DIFF
--- a/Casks/prosys-opc-ua-client.rb
+++ b/Casks/prosys-opc-ua-client.rb
@@ -1,6 +1,6 @@
 cask 'prosys-opc-ua-client' do
-  version '3.1.4-293'
-  sha256 '113c53f233fb3acd5f0ec8fd9b647180a6f067981f2253861bd14f6faf8d7599'
+  version '3.1.6-322'
+  sha256 'ab90d83a8dcdd399baebba3999034806f4a1360c64861b00aadebbad689103cc'
 
   url "https://www.prosysopc.com/opcua/apps/JavaClient/dist/#{version}/prosys-opc-ua-client-#{version}.dmg"
   appcast 'https://downloads.prosysopc.com/opc-ua-client-downloads.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.