### PR TITLE
Update qgroundcontrol to 3.4.4

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,6 +1,6 @@
 cask 'qgroundcontrol' do
-  version '3.4.2'
-  sha256 '03d9f2cffa5735ee92935974a993273fa60fa44df3a57a02b0f83306f63e7558'
+  version '3.4.4'
+  sha256 '2926371d4385d0bd66917c95b4ce62d91969350fcf943ff16367da412c06c380'
 
   # github.com/mavlink/qgroundcontrol was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.