### PR TITLE
Update qownnotes to 18.10.2,b3868-155632

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.10.1,b3863-171214'
-  sha256 '8db4297dfb66bd997aa5d5ae87838ab8e8fe9014ee4aeadfba2b71c4f6c6999a'
+  version '18.10.2,b3868-155632'
+  sha256 'd1ac5c984a5be622c1cd16989467ad093e7f37efbefa23eb0664b05c9d644379'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.