### PR TITLE
Update reborn to 0.5.53

### DIFF
--- a/Casks/reborn.rb
+++ b/Casks/reborn.rb
@@ -1,6 +1,6 @@
 cask 'reborn' do
-  version '0.5.50'
-  sha256 'e0a6d9f8b3839a484f831dd964d29a928882e42b8abcfe925b3a77d70de541e3'
+  version '0.5.53'
+  sha256 'b93d4a14cd21337912cf4923df4a25b3597582558d77562bba72c3d30f64ca76'
 
   url "https://github.com/langyanduan/Reborn/releases/download/#{version}/Reborn.zip"
   appcast 'https://github.com/langyanduan/Reborn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.