### PR TITLE
Update resolume-arena to 6.1.0,61231

### DIFF
--- a/Casks/resolume-arena.rb
+++ b/Casks/resolume-arena.rb
@@ -1,6 +1,6 @@
 cask 'resolume-arena' do
-  version '6.0.11,61108'
-  sha256 '9d9498dd9f4fb844b88e603399df3581367ac19a039eb4e4fd06c1884c411e35'
+  version '6.1.0,61231'
+  sha256 'c336e94a6151dd3389622c8cce40349745fb843a6ccbd6daa3d55454d74f0f70'
 
   url "https://resolume.com/download/Resolume_Arena_#{version.major_minor_patch.dots_to_underscores}_rev_#{version.after_comma}_Installer.dmg"
   appcast 'https://resolume.com/update/arena_mac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.