### PR TITLE
Update resolutionator to 1.1.2

### DIFF
--- a/Casks/resolutionator.rb
+++ b/Casks/resolutionator.rb
@@ -1,6 +1,6 @@
 cask 'resolutionator' do
-  version '1.1.1'
-  sha256 'b4e0ba696aeee124c8d701371af71c4d1702fe0333fb955e3e5492d10f6ef679'
+  version '1.1.2'
+  sha256 'c0098c95e6aa8d828e14342393f51800a19c6807d25d36dc232a6f3d75f56216'
 
   url "https://manytricks.com/download/_do_not_hotlink_/resolutionator#{version.no_dots}.dmg"
   appcast 'https://manytricks.com/resolutionator/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.