### PR TITLE
Update rhodes-kite to 1.9.5

### DIFF
--- a/Casks/rhodes-kite.rb
+++ b/Casks/rhodes-kite.rb
@@ -1,6 +1,6 @@
 cask 'rhodes-kite' do
-  version '1.9.4'
-  sha256 'e88912172dd9e501775c480bb93c773bb48e942044bccd9a57be38a96124295b'
+  version '1.9.5'
+  sha256 '41df64c8815e070eee0d2132012fe7b4aed29324e195362538a99c9edf817906'
 
   url "https://kiteapp.co/downloads/Kite-#{version}.zip"
   appcast 'https://api.kiteapp.co/kite_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.