### PR TITLE
Update scidavis to 1.23.2

### DIFF
--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -12,7 +12,7 @@ cask 'scidavis' do
 
   pkg "scidavis-#{version}.pkg"
 
-  uninstall pkgutil: 'SciDAVis'
+  uninstall delete: '/Applications/scidavis.app'
 
   zap trash: '~/Library/Saved Application State/net.sourceforge.scidavis.savedState'
 end

--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -1,6 +1,6 @@
 cask 'scidavis' do
-  version '1.23'
-  sha256 '5b3925dfdf0b5dcda9d2a9929b5ae8a9f83cb6130389cea2a9248e84e396fdf2'
+  version '1.23.2'
+  sha256 '5549e1f400a4d36df3d1f3750f4b66820409ccad1c748f700dac0299f55f7f82'
 
   # downloads.sourceforge.net/scidavis was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scidavis/scidavis-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.