### PR TITLE
Update softorino-youtube-converter to 2.0.23,1538666747

### DIFF
--- a/Casks/softorino-youtube-converter.rb
+++ b/Casks/softorino-youtube-converter.rb
@@ -1,6 +1,6 @@
 cask 'softorino-youtube-converter' do
-  version '2.0.19,1534503733'
-  sha256 'cce0c71cac8cf1695e14e39711d70e5ce2e0e71b6b61c777e6e9e130c7f5e31e'
+  version '2.0.23,1538666747'
+  sha256 '069ae9b5170763821ca633bf69b597e70d36bbfe468c211799a74912a017acae'
 
   # devmate.com/com.softorino.syc2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.syc2/#{version.before_comma}/#{version.after_comma}/SYC2-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.