### PR TITLE
Update sqlworkbenchj to 124.1

### DIFF
--- a/Casks/sqlworkbenchj.rb
+++ b/Casks/sqlworkbenchj.rb
@@ -1,6 +1,6 @@
 cask 'sqlworkbenchj' do
-  version '124'
-  sha256 '2173c7f00172bef3fed23e7f57e168a9d156c72c311af032ba469139f80d9fe9'
+  version '124.1'
+  sha256 '27682b2defaea60d4e6af5919202f486d1f3ee2d7c434e4e40f85dc020edae66'
 
   url "http://www.sql-workbench.net/Workbench-Build#{version}-Mac.tgz"
   appcast 'http://www.sql-workbench.net/wb_news.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.