### PR TITLE
Update story-writer to 6.2.1

### DIFF
--- a/Casks/story-writer.rb
+++ b/Casks/story-writer.rb
@@ -1,6 +1,6 @@
 cask 'story-writer' do
-  version '6.0.3'
-  sha256 'd3897870331439d2427e5c073c8e36c8886e5d5479076ddbb23718549695ed99'
+  version '6.2.1'
+  sha256 '1cf5c9ad77ecbcd36829965a7929638ef010773d28f021b0368781473f510f73'
 
   # github.com/suziwen/markdownxiaoshujiang was verified as official when first introduced to the cask
   url "https://github.com/suziwen/markdownxiaoshujiang/releases/download/v#{version}/Story-writer-osx64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.