### PR TITLE
Update swinsian to 2.1.8

### DIFF
--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,6 +1,6 @@
 cask 'swinsian' do
-  version '2.1.7'
-  sha256 '7f56fea536eeae41c9273ae18d44e76a40789f5d9598d18d0b142bd4391c5f50'
+  version '2.1.8'
+  sha256 '5c1e72f3b28c404827cf0eb277237bdd2f1b167c65cee76b911240807f168b8f'
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.