### PR TITLE
Update sysex-librarian to 1.4

### DIFF
--- a/Casks/sysex-librarian.rb
+++ b/Casks/sysex-librarian.rb
@@ -1,6 +1,6 @@
 cask 'sysex-librarian' do
-  version '1.3.1'
-  sha256 '8c1c56a2161b33a8451324eb1c05b7ca9b56abaf713129c511af6357873df834'
+  version '1.4'
+  sha256 'e35dde64dfbfaa1a4cdaa73113c08a7578a3f6c3b31b532e08d35c58f091623e'
 
   url "https://www.snoize.com/SysExLibrarian/SysExLibrarian_#{version.dots_to_underscores}.zip"
   appcast 'https://www.snoize.com/SysExLibrarian/SysExLibrarian.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.