### PR TITLE
Update tabula to 1.2.1

### DIFF
--- a/Casks/tabula.rb
+++ b/Casks/tabula.rb
@@ -1,6 +1,6 @@
 cask 'tabula' do
-  version '1.2.0'
-  sha256 '14de2ac043fa6bb1180eb2217c3405e49c0f01cc2142a422e880522a30374e67'
+  version '1.2.1'
+  sha256 '7f0270ce3db17cfa14a8a111de9fbf39fbdd330d9784796daf13019d08cac140'
 
   # github.com/tabulapdf/tabula was verified as official when first introduced to the cask
   url "https://github.com/tabulapdf/tabula/releases/download/v#{version.major_minor_patch}/tabula-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.