### PR TITLE
Update textadept to 10.1

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,6 +1,6 @@
 cask 'textadept' do
-  version '10.0'
-  sha256 '22429aaf231e5be44857c274659a37bc6940d153079d5b21744672c29c8c19a9'
+  version '10.1'
+  sha256 'cd168a79d54ac2e49bc87b1fd8ccbeabe520de26c1cc88b171610b6a2e8b6286'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
   appcast 'https://foicica.com/textadept/feed'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.