### PR TITLE
Update the-hit-list to 1.1.32,367

### DIFF
--- a/Casks/the-hit-list.rb
+++ b/Casks/the-hit-list.rb
@@ -1,6 +1,6 @@
 cask 'the-hit-list' do
-  version '1.1.31,363'
-  sha256 'e1313860db752b2be1f17dad267417eac569e4ed3bc54d32c7545ea086772443'
+  version '1.1.32,367'
+  sha256 'd64787b451782b99581345926c84bf8c838da3a8a493b62b347c6986e3986e40'
 
   url "https://distrib.karelia.com/downloads/TheHitList-#{version.after_comma}.zip"
   appcast 'https://launch.karelia.com/appcast.php?product=9&appname=The+Hit+List'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.