### PR TITLE
Update weka to 3.8.3

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,6 +1,6 @@
 cask 'weka' do
-  version '3.9.2'
-  sha256 'dc5051bd460f16abc0a63ad4039a75a15aa442f2de4d043e44e91e33e7d28115'
+  version '3.8.3'
+  sha256 'f13fdbaa34969722138308afc40951b8c741e51a4ce01823b1a7c9a08a779dab'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-oracle-jvm.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.