### PR TITLE
Update unity-webgl-support-for-editor to 2018.2.11f1,38bd7dec5000

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.2.6f1,c591d9a97a0b'
-  sha256 '2694e96d49b143655b45496d4d3380e261899d7acc741a8985531cd2c6755cfc'
+  version '2018.2.11f1,38bd7dec5000'
+  sha256 '50919ddb7a105f1ebe3db11ea7ae44349c1f3b632b3a4bb19313e3d87b459177'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.