### PR TITLE
Update virtualc64 to 3.0

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,7 +1,7 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '2.5'
-  sha256 '793135574ab960e40beff9c4be7bb5a484d3d0ac1ebf15120d0729fd5749c8e3'
+  version '3.0'
+  sha256 '1ea9c232aea4aa962174d972c19f2e1fca1699ac94e8241f1ac9cec310064d5d'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.