### PR TITLE
Update wordpresscom to 3.5.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '3.4.0'
-  sha256 '8eb3ff1ce27e959e7f01c801e3718c5581506a2d61a8d80e2d5c0f8cc52e32bf'
+  version '3.5.0'
+  sha256 'ebf5d2cadec6a3278694159c612eeafa6d0847eaf04e1a3b1d564368db7343f9'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=dmg&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.