### PR TITLE
Update wireshark-chmodbpf to 2.6.4

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,6 +1,6 @@
 cask 'wireshark-chmodbpf' do
-  version '2.6.3'
-  sha256 '5f919d58ba1286631f2a878d7ec5acf430680f57d3d630d76e096077b4494418'
+  version '2.6.4'
+  sha256 '3c347c3ffdbab2d7a358bb4a231e18ef730eb87175c80db7e2fd61b25e8a6d51'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.wireshark.org/download/osx/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.