### PR TITLE
Secure URLs

### DIFF
--- a/Casks/245cloud.rb
+++ b/Casks/245cloud.rb
@@ -6,7 +6,7 @@ cask '245cloud' do
   url "https://github.com/fukajun/245cloud-app/releases/download/v#{version}/245cloud-#{version}-darwin-x64.zip"
   appcast 'https://github.com/fukajun/245cloud-app/releases.atom'
   name '245cloud'
-  homepage 'http://245cloud.com/'
+  homepage 'https://245cloud.com/'
 
   app '245cloud-darwin-x64/245cloud.app'
 end

--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -2,7 +2,7 @@ cask 'context-free' do
   version '3.0.11.3'
   sha256 '5baae1cf7487ea0902f781f0891d3f7dc2c01071ab9546a1e2523676ea45c0da'
 
-  url "http://www.contextfreeart.org/download/ContextFree#{version}.dmg"
+  url "https://www.contextfreeart.org/download/ContextFree#{version}.dmg"
   appcast 'https://github.com/MtnViewJohn/context-free/releases.atom'
   name 'Context Free'
   homepage 'https://www.contextfreeart.org/'

--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -4,9 +4,9 @@ cask 'find-any-file' do
 
   # files.tempel.org.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.tempel.org.s3.amazonaws.com/FindAnyFile_#{version}.zip"
-  appcast 'http://apps.tempel.org/FindAnyFile/appcast.xml'
+  appcast 'https://apps.tempel.org/FindAnyFile/appcast.xml'
   name 'Find Any File'
-  homepage 'http://apps.tempel.org/FindAnyFile/'
+  homepage 'https://apps.tempel.org/FindAnyFile/'
 
   app 'Find Any File.app'
 

--- a/Casks/flash-decompiler-trillix.rb
+++ b/Casks/flash-decompiler-trillix.rb
@@ -2,7 +2,8 @@ cask 'flash-decompiler-trillix' do
   version '5.3.1301'
   sha256 '5b1313197c1e311db7aefc1764785187a5f5fd39ea5aa689587761ff42232d9e'
 
-  url 'http://www.flash-decompiler.com/download/flash_decompiler.dmg'
+  # cdn.eltima.com was verified as official when first introduced to the cask
+  url 'https://cdn.eltima.com/download/flash_decompiler.dmg'
   appcast 'https://cdn.eltima.com/download/fd-mac-update/fd-mac.xml'
   name 'Flash Decompiler Trillix'
   homepage 'http://www.flash-decompiler.com/mac.html'

--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -2,9 +2,8 @@ cask 'flash-npapi' do
   version '31.0.0.122'
   sha256 '3623841c45ff06fafc9709a87d5a63ff867e8d67251ad5c87f4cdb4940875346'
 
-  # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.adobe.com/get/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
-  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml'
+  url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox)'
   homepage 'https://get.adobe.com/flashplayer/'
 

--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -2,9 +2,8 @@ cask 'flash-player-debugger-npapi' do
   version '31.0.0.122'
   sha256 '37f55c7803e3f21fbbcf29d6021eb8dfc58875deccc2919b27bbcc4a4326037b'
 
-  # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
-  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml'
+  url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 

--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -2,9 +2,8 @@ cask 'flash-player-debugger-ppapi' do
   version '31.0.0.122'
   sha256 'efa6dfb54d886a7b573f1c5ede7a5692de4d2cae80fcdbf4eccd79fd99ec8a43'
 
-  # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
-  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml'
+  url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'
   name 'Adobe Flash Player PPAPI (plugin for Opera and chromium) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 

--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -2,9 +2,8 @@ cask 'flash-player-debugger' do
   version '31.0.0.122'
   sha256 '5845325e56195309e8711dd389b50cc882e0f50f4bd2d40d2f016a4482466b7e'
 
-  # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
-  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml'
+  url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'
   name 'Adobe Flash Player projector content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -2,9 +2,8 @@ cask 'flash-player' do
   version '31.0.0.122'
   sha256 'c5d3d45367ffe83228ded03594aa0073a47c3aa2b62fa1225e3a18accf4463e0'
 
-  # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
-  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml'
+  url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'
   name 'Adobe Flash Player projector'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 

--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -3,7 +3,7 @@ cask 'flash-ppapi' do
   sha256 '5f280fc219ee12b7a3431f6bd0064dcb2a642bb4466c9b8071a59254221c574f'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
-  appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pep.xml'
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'
   name 'Adobe Flash Player PPAPI (plugin for Opera and Chromium)'
   homepage 'https://get.adobe.com/flashplayer/otherversions/'
 

--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -3,7 +3,7 @@ cask 'ghost-browser' do
   sha256 'fb84349fe735087bc4a3f72f5d45b69c7c1a99bde68b6d365edaa8e507936b46'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"
+  url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"
   name 'Ghost Browser'
   homepage 'https://ghostbrowser.com/download/'
 

--- a/Casks/grids.rb
+++ b/Casks/grids.rb
@@ -2,10 +2,10 @@ cask 'grids' do
   version '5.0.1'
   sha256 'f43c6f46ac8acbec0273cd098086d916512fbef9ca3c14e43fc2930a1b5df93d'
 
-  url "http://gridsapp.net/bin/Grids_#{version}.zip"
-  appcast 'http://gridsapp.net/appcast.json'
+  url "https://gridsapp.net/bin/Grids_#{version}.zip"
+  appcast 'https://gridsapp.net/appcast.json'
   name 'Grids'
-  homepage 'http://gridsapp.net/'
+  homepage 'https://gridsapp.net/'
 
   auto_updates true
 

--- a/Casks/iconizer.rb
+++ b/Casks/iconizer.rb
@@ -6,7 +6,7 @@ cask 'iconizer' do
   url "https://github.com/raphaelhanneken/iconizer/releases/download/#{version}/Iconizer.dmg"
   appcast 'https://github.com/raphaelhanneken/iconizer/releases.atom'
   name 'Iconizer'
-  homepage 'http://raphaelhanneken.github.io/iconizer/'
+  homepage 'https://raphaelhanneken.github.io/iconizer/'
 
   app 'Iconizer.app'
 end

--- a/Casks/jedict.rb
+++ b/Casks/jedict.rb
@@ -2,9 +2,9 @@ cask 'jedict' do
   version '5.0.4'
   sha256 '37b1dc2c70048a3f5d0b1f92fa8c535af270f7471dac58987ff4a5e73a480a74'
 
-  url "http://jedict.com/Downloads/JEDict#{version.no_dots}.dmg"
+  url "https://jedict.com/Downloads/JEDict#{version.no_dots}.dmg"
   name 'Jedict'
-  homepage 'http://jedict.com/'
+  homepage 'https://jedict.com/'
 
   app 'JEDict.app'
 end

--- a/Casks/jollysfastvnc.rb
+++ b/Casks/jollysfastvnc.rb
@@ -2,7 +2,7 @@ cask 'jollysfastvnc' do
   version '1.54'
   sha256 '2d205f98db9afaef25e591166a82aab84263df9def3214eea53af423f43e8017'
 
-  url 'http://www.jinx.de/JollysFastVNC_files/JollysFastVNC.current.dmg'
+  url 'https://www.jinx.de/JollysFastVNC_files/JollysFastVNC.current.dmg'
   appcast 'https://www.jinx.de/JollysFastVNC.update.11.i386.xml'
   name 'JollysFastVNC'
   homepage 'https://www.jinx.de/JollysFastVNC.html'

--- a/Casks/kega-fusion.rb
+++ b/Casks/kega-fusion.rb
@@ -2,9 +2,9 @@ cask 'kega-fusion' do
   version '3.63i'
   sha256 'f329d3c700a4b1f66e49753f91d27182b1e67bdd0e9bd16c6347f989aa7131ba'
 
-  url "http://www.carpeludum.com/download/Fusion#{version.no_dots}.zip"
+  url "https://www.carpeludum.com/download/Fusion#{version.no_dots}.zip"
   name 'Kega Fusion'
-  homepage 'http://www.carpeludum.com/kega-fusion/'
+  homepage 'https://www.carpeludum.com/kega-fusion/'
 
   app "Fusion#{version.no_dots}/Kega Fusion.app"
 

--- a/Casks/kerio-connect.rb
+++ b/Casks/kerio-connect.rb
@@ -3,7 +3,7 @@ cask 'kerio-connect' do
   sha256 'a771933ead0810f5b195c3a77a94b0e41c6beb81cc2cf3002e90e73186575da5'
 
   # cdn.kerio.com was verified as official when first introduced to the cask
-  url "http://cdn.kerio.com/dwn/connect/connect-#{version.before_comma}/kerio-connect-#{version.before_comma}-#{version.after_comma}-mac.dmg"
+  url "https://cdn.kerio.com/dwn/connect/connect-#{version.before_comma}/kerio-connect-#{version.before_comma}-#{version.after_comma}-mac.dmg"
   name 'Kerio Connect'
   homepage 'https://www.kerio.de/products/kerio-connect'
 

--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -3,7 +3,7 @@ cask 'kstars' do
   sha256 'a01ca011d8c796e8357e3a81520548bcec9b5e788c4d930fe727aaf236c65e90'
 
   # indilib.org/jdownloads/kstars was verified as official when first introduced to the cask
-  url "http://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"
+  url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"
   name 'KStars'
   homepage 'https://edu.kde.org/kstars/'
 

--- a/Casks/lightpaper.rb
+++ b/Casks/lightpaper.rb
@@ -4,9 +4,9 @@ cask 'lightpaper' do
 
   # hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8?format=zip'
-  appcast 'http://links.ashokgelal.com/lp-mac-update-feed'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/789cfa8846464727ae0fdb176ec8d3c8'
   name 'LightPaper'
-  homepage 'http://lightpaper.42squares.in/'
+  homepage 'https://getlightpaper.com/'
 
   app 'LightPaper.app'
 end

--- a/Casks/macwinzipper.rb
+++ b/Casks/macwinzipper.rb
@@ -2,9 +2,9 @@ cask 'macwinzipper' do
   version '2.5.3.1'
   sha256 '33de61cfb8d2bef18eac623681a7b1b35c8980c6d7e7ed77f0205765e5d79f7d'
 
-  url "http://tidajapan.com/files/MacWinZipper-#{version}.dmg?download"
+  url "https://tida.me/files/MacWinZipper-#{version}.dmg?download"
   name 'MacWinZipper'
-  homepage 'http://tidajapan.com/macwinzipper'
+  homepage 'https://tida.me/macwinzipper'
 
   app 'MacWinZipper.app'
 end

--- a/Casks/mail-designer.rb
+++ b/Casks/mail-designer.rb
@@ -2,9 +2,10 @@ cask 'mail-designer' do
   version '2.6.6'
   sha256 '16c113d4d5167953f8145ffb4571adaff08dc352aebc27bd4cc51df5513093f3'
 
+  # download.equinux.com was verified as official when first introduced to the cask
   url "https://download.equinux.com/files/other/Mail_Designer_#{version}.zip"
   name 'Mail Designer'
-  homepage 'http://maildesigner.equinux.com/'
+  homepage 'https://www.maildesigner365.com/'
 
   app 'Mail Designer.app'
 end

--- a/Casks/mylio.rb
+++ b/Casks/mylio.rb
@@ -5,7 +5,7 @@ cask 'mylio' do
   # myliodownloads.s3-website-us-east-1.amazonaws.com was verified as official when first introduced to the cask
   url 'http://myliodownloads.s3-website-us-east-1.amazonaws.com/mylio.dmg'
   name 'Mylio'
-  homepage 'http://mylio.com/'
+  homepage 'https://mylio.com/'
 
   app 'Mylio.app'
 end

--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -3,7 +3,7 @@ cask 'papers' do
   sha256 '15c226fd763479319fe115c710d1ee40180a7d8137954da71cf777b9ae0dfd7c'
 
   # appcaster.papersapp.com/apps/mac/production/download was verified as official when first introduced to the cask
-  url "http://appcaster.papersapp.com/apps/mac/production/download/#{version.after_comma}/papers_#{version.before_comma.no_dots}_#{version.after_comma}.dmg"
+  url "https://appcaster.papersapp.com/apps/mac/production/download/#{version.after_comma}/papers_#{version.before_comma.no_dots}_#{version.after_comma}.dmg"
   appcast 'https://appcaster.papersapp.com/apps/mac/production/appcast.xml'
   name 'Papers'
   homepage 'https://www.readcube.com/papers/'

--- a/Casks/pdfkey-pro.rb
+++ b/Casks/pdfkey-pro.rb
@@ -3,7 +3,7 @@ cask 'pdfkey-pro' do
   sha256 'c00cd822f0453d87fb296858dc2e85f7617c96c3b67123711a2396ffc2fb46cd'
 
   url 'https://pdfkey.com/PDFKeyPro.dmg'
-  appcast 'http://pdfkey.com/PDFKeyProUpdateFX.xml'
+  appcast 'https://pdfkey.com/PDFKeyProUpdateFX.xml'
   name 'PDFKey Pro'
   homepage 'https://pdfkey.com/'
 

--- a/Casks/pibakery.rb
+++ b/Casks/pibakery.rb
@@ -6,7 +6,7 @@ cask 'pibakery' do
   url "https://github.com/davidferguson/pibakery/releases/download/v#{version}/PiBakery.pkg"
   appcast 'https://github.com/davidferguson/pibakery/releases.atom'
   name 'PiBakery'
-  homepage 'http://www.pibakery.org/'
+  homepage 'https://www.pibakery.org/'
 
   pkg 'PiBakery.pkg'
 

--- a/Casks/qxmledit.rb
+++ b/Casks/qxmledit.rb
@@ -6,7 +6,7 @@ cask 'qxmledit' do
   url "https://downloads.sourceforge.net/qxmledit/QXmlEdit-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/qxmledit/rss'
   name 'QXmlEdit'
-  homepage 'http://qxmledit.org/'
+  homepage 'https://qxmledit.org/'
 
   app 'QXmlEdit.app'
 end

--- a/Casks/silo.rb
+++ b/Casks/silo.rb
@@ -2,7 +2,7 @@ cask 'silo' do
   version '2.5.5'
   sha256 '7d0a4af414dcfe623a76da5d23fa324651913b2258062e998274e336eb8c29f2'
 
-  url "http://nevercenter.com/silo/download_file/filearchive/Install_Silo_#{version.dots_to_underscores}_mac.dmg"
+  url "https://nevercenter.com/silo/download_file/filearchive/Install_Silo_#{version.dots_to_underscores}_mac.dmg"
   name 'Silo'
   homepage 'https://nevercenter.com/silo/'
 

--- a/Casks/snip.rb
+++ b/Casks/snip.rb
@@ -2,9 +2,9 @@ cask 'snip' do
   version '2.0_5771'
   sha256 '2e9c2863d4412dbfa1323c1f2cb056c6a81b77d520c8b2a732cade1e7b40df00'
 
-  url "http://snip.qq.com/resources/Snip_V#{version}.dmg"
+  url "https://snip.qq.com/resources/Snip_V#{version}.dmg"
   name 'Snip'
-  homepage 'http://snip.qq.com/'
+  homepage 'https://snip.qq.com/'
 
   pkg "Snip_V#{version.sub(%r{^(\d+\.\d+).*}, '\1')}.pkg"
 

--- a/Casks/trash-it.rb
+++ b/Casks/trash-it.rb
@@ -4,7 +4,7 @@ cask 'trash-it' do
 
   url 'https://nonamescriptware.com/wp-content/uploads/Trashit.zip'
   name 'Trash It!'
-  homepage 'http://nonamescriptware.com/'
+  homepage 'https://nonamescriptware.com/'
 
   app "Trash It! #{version}/Drag app to Desktop/Trash It! #{version}.app"
 end

--- a/Casks/videobox.rb
+++ b/Casks/videobox.rb
@@ -2,10 +2,9 @@ cask 'videobox' do
   version '4.2.3'
   sha256 'c4cb71213dc3819a5e5b85fb824172ddafecf2e281157efe234e5d2288a51808'
 
-  # tastyapps.net was verified as official when first introduced to the cask
-  url "http://www.tastyapps.net/downloads/videobox_#{version}.dmg"
+  url "https://www.tastyapps.com/downloads/videobox_#{version}.dmg"
   name 'Videobox'
-  homepage 'https://www.tastyapps.com/videobox/'
+  homepage 'https://www.tastyapps.com/videobox.html'
 
   app 'Videobox.app'
 end

--- a/Casks/xdm.rb
+++ b/Casks/xdm.rb
@@ -2,10 +2,11 @@ cask 'xdm' do
   version '7.2.7'
   sha256 'b28d3aac96fe9a2ce161bdd4462fe270eac3dd3ce91828f0e308b9d77aa811b4'
 
+  # downloads.sourceforge.net/xdman was verified as official when first introduced to the cask
   url 'https://downloads.sourceforge.net/xdman/xdm-setup.dmg'
   appcast 'https://sourceforge.net/projects/xdman/rss'
   name 'Xtreme Download Manager'
-  homepage 'http://xdman.sourceforge.net/'
+  homepage 'https://xdman.sourceforge.io/'
 
   installer script: {
                       executable: "#{staged_path}/install",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
---

This was done by checking for in-place protocol upgrades, following permanent redirects to HTTPS and upgrading to known-good secure alternative (for sf.net URL). For Adobe downloads, the URLs were harmonised to use the same domain and root path for all Flash and sister products.
