### PR TITLE
update onyx 3.5.0 require macOS mojave to install

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -25,7 +25,7 @@ cask 'onyx' do
   elsif MacOS.version == :high_sierra
     version '3.4.9'
     sha256 '60e4f56fb2e5457aca1aa1d2a9be95502a310b0de75112e91b7c89bf4a2be829'
-  else
+  elsif MacOS.version == :mojave
     version '3.5.0'
     sha256 'd30e59ab72b77c68cf417c9b521753b55d3a313a5ac45a81a09b5c6ceaebc45a'
   end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).