### PR TITLE
Update frostwire to 6.7.4

### DIFF
--- a/Casks/frostwire.rb
+++ b/Casks/frostwire.rb
@@ -1,6 +1,6 @@
 cask 'frostwire' do
-  version '6.7.1'
-  sha256 '62429ff4b787b2b35e1c9852b49a4cea7f0dfc29c0f035dd6e0bf6914afcdb60'
+  version '6.7.4'
+  sha256 '3e762e5c4af5e93e16d81c51b4a790bda52cc4e53cee2bd207cbeeced38eb980'
 
   # downloads.sourceforge.net/frostwire was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/frostwire/frostwire-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.