### PR TITLE
Update isyncr to 5.14.9

### DIFF
--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -3,8 +3,8 @@ cask 'isyncr' do
     version '5.6.5'
     sha256 '8cd6b1c96a902d8810e52aab6a980424370237617bfd3ff574367ff1ce8d4f4e'
   else
-    version '5.14.0'
-    sha256 '68e65554b12083c35b0180c6535cefcc7897c0aa4902848dcf706459ecfab3ad'
+    version '5.14.9'
+    sha256 '886877b524148cd305189088b8cb54ee5599ab75186493d7e69624cc7d19fed6'
   end
 
   url "https://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.