### PR TITLE
Update fastonosql to 1.20.1

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.20.0'
-  sha256 'f90252aa46ec3488136aecb22f0e29922e7fe75a5ade9fe75b56a7dd71204afb'
+  version '1.20.1'
+  sha256 '93490e5068336cbbb96cf9fda4c48e0295c7d051779ba9da95d46d5df95392f9'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.