### PR TITLE
Update gzdoom to 3.6.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '3.5.1'
-  sha256 'cb22dafebafc87a66487c9c66889b487be48063f91354eb42476caa49ff6f34a'
+  version '3.6.0'
+  sha256 'd5d33724e80233a41de74279dc549d80e34f1089af444dcd4d4538070ccda280'
 
   url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.