### PR TITLE
Update powerphotos to 1.5.1

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -8,8 +8,8 @@ cask 'powerphotos' do
     sha256 'b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.5'
-    sha256 'e6e19e0a597bfab9b9d8deb4e23fabad7c6ebe0dfb86565da504df62d5ecc613'
+    version '1.5.1'
+    sha256 '7789932575e8aa09e0d4f0058dc64c3f01f6e32dd3c1ce8b5266c1cdd450a61d'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.