### PR TITLE
Update unity-download-assistant to 2018.2.12f1,0a46ddfcfad4

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.2.11f1,38bd7dec5000'
-  sha256 '71b4d3446aafeec9c29ee3bc868690e988ade0e52b05cec33a32924b765fc7ee'
+  version '2018.2.12f1,0a46ddfcfad4'
+  sha256 'aca905b101f93ef85fc5a94f67e694a404a44e0392c1587e8648c2763946598e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.