### PR TITLE
Update unity-webgl-support-for-editor to 2018.2.12f1,0a46ddfcfad4

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.2.11f1,38bd7dec5000'
-  sha256 '50919ddb7a105f1ebe3db11ea7ae44349c1f3b632b3a4bb19313e3d87b459177'
+  version '2018.2.12f1,0a46ddfcfad4'
+  sha256 '81a819aa17af319ae07915f88a6fb6fc08859ad24053b26762e4400a67960ddb'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.