### PR TITLE
Update unity-windows-support-for-editor to 2018.2.12f1,0a46ddfcfad4

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.2.11f1,38bd7dec5000'
-  sha256 '59332a6fe8b96328cd0d5907914d099231ae74b7a330867d1544a4659a355d18'
+  version '2018.2.12f1,0a46ddfcfad4'
+  sha256 '055c38a26fcaa69938d754b13fce0a1e2ebc00c2305d26b7c3a04f111ea8bc04'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.