### PR TITLE
Update texnicle to 2.3.1

### DIFF
--- a/Casks/texnicle.rb
+++ b/Casks/texnicle.rb
@@ -1,9 +1,9 @@
 cask 'texnicle' do
-  version '2.3.0'
-  sha256 '4909f36a7e741c68fa5104209f860b61594327ba751a5c8c5007ea690fd4b91f'
+  version '2.3.1'
+  sha256 '0cdc81a0b7578f6656f2437cb24ffa390f556aa7b25a6fd9e4b90ed9a4dc5986'
 
   url "http://www.bobsoft-mac.de/resources/TeXnicle/#{version.major_minor}/TeXnicle.app.#{version}.zip"
-  appcast 'http://www.bobsoft-mac.de/profileInfo.php'
+  appcast 'http://www.bobsoft-mac.de/texnicle_appcast.xml'
   name 'TeXnicle'
   homepage 'http://www.bobsoft-mac.de/texnicle/texnicle.html'
 

--- a/Casks/texnicle.rb
+++ b/Casks/texnicle.rb
@@ -7,5 +7,15 @@ cask 'texnicle' do
   name 'TeXnicle'
   homepage 'http://www.bobsoft-mac.de/texnicle/texnicle.html'
 
+  auto_updates true
+  depends_on macos: '>= :mavericks'
+
   app 'TeXnicle.app'
+
+  zap trash: [
+               '~/Library/Application Support/TeXnicle',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.bobsoft.texnicle.sfl*',
+               '~/Library/Caches/com.bobsoft.TeXnicle',
+               '~/Library/Preferences/com.bobsoft.TeXnicle.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.