### PR TITLE
Update firestormos to 5.1.7.55786

### DIFF
--- a/Casks/firestormos.rb
+++ b/Casks/firestormos.rb
@@ -1,8 +1,8 @@
 cask 'firestormos' do
-  version '5.0.11.53634'
-  sha256 'f1737cde527eab73822075fd72c6e0ce568d737c557bc854a248c60a10c40ed5'
+  version '5.1.7.55786'
+  sha256 '64d65c8e472e9d3de4cccc80bee158f72c09fec7c186b7e9dd43029934cf6a9a'
 
-  url "https://downloads.firestormviewer.org/mac/Phoenix-FirestormOS-Releasex64-#{version.dots_to_hyphens}.dmg"
+  url "https://downloads.firestormviewer.org/mac/Phoenix-FirestormOS-Releasex64_#{version.dots_to_underscores}_x86_64.dmg"
   name 'Phoenix Firestorm viewer for Second Life'
   homepage 'https://www.firestormviewer.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.