### PR TITLE
Update prusa-slic3r to 1.41.1-rc,201810051336

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,6 +1,6 @@
 cask 'prusa-slic3r' do
-  version '1.41.0,201809010756'
-  sha256 '93ea481dd849d0c2ece2cc1d1df0631354c52a6ed5491b267ea524db664e1344'
+  version '1.41.1-rc,201810051336'
+  sha256 '94d0c0351a70ab3e68241cb9c627fda3f3aafd014d772295425205483692b057'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3rPE-#{version.before_comma}+full-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.