### PR TITLE
Update opensong to 2.2.7,2.2.3-1075

### DIFF
--- a/Casks/opensong.rb
+++ b/Casks/opensong.rb
@@ -8,6 +8,5 @@ cask 'opensong' do
   name 'OpenSong'
   homepage 'http://www.opensong.org/'
 
-  app "OpenSong V#{version}/OpenSongOSX-Cocoa.app"
-  app "Opensong V#{version}/OpenSongOSX.app"
+  app 'OpenSongOSX.app'
 end

--- a/Casks/opensong.rb
+++ b/Casks/opensong.rb
@@ -1,9 +1,9 @@
 cask 'opensong' do
-  version '2.1.2'
-  sha256 '5ed3da5801c2539b87c3ce8125a1b440a6d50129b675182685892e1c46d0ad1b'
+  version '2.2.7,2.2.3-1075'
+  sha256 'b347c7c9e1c5a152e943e3e06e0bbf50b43ea41680bae75aa191764b00f50181'
 
   # sourceforge.net/opensong was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/opensong/OpenSongOSX-V#{version}.dmg"
+  url "https://downloads.sourceforge.net/opensong/OpenSong/V#{version.before_comma}/OpenSongOSX-V#{version.after_comma}.dmg"
   appcast 'https://sourceforge.net/projects/opensong/rss'
   name 'OpenSong'
   homepage 'http://www.opensong.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.