### PR TITLE
Update qcad to 3.21.3

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,11 +1,11 @@
 cask 'qcad' do
-  version '3.21.2'
+  version '3.21.3'
 
   if MacOS.version <= :mavericks
     sha256 '9155a11b10991dbeb5bac5a15b810354d0462f13bee8317e4327765d83582466'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.13.dmg"
   else
-    sha256 '2c267dba49b68db33717a3773804182896d7633ded07ed2c8fe32947c3540061'
+    sha256 'dbc0dff4d7106c686a7f3b9d1ed80de2e82bb64e7901b8fd7d42018d2e6a39cc'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.10-10.13.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.