### PR TITLE
Update paperspace to 6.5.0.4

### DIFF
--- a/Casks/paperspace.rb
+++ b/Casks/paperspace.rb
@@ -1,6 +1,6 @@
 cask 'paperspace' do
-  version '6.2.0.11'
-  sha256 'a855b9c3ccfabb58a4eabdfc091c8c8d09ab47eea27f56989bddfbedb0d76001'
+  version '6.5.0.4'
+  sha256 '1ccec2ce4fafc11b1d95486934584d6974f6eaa212a502b197f79e28298f2e47'
 
   # s3-us-west-1.amazonaws.com/ps-receiver was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/ps-receiver/darwin/Paperspace-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.