### PR TITLE
Update netron to 2.2.7

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.2.6'
-  sha256 '42c0d0857102dff725eb5117835281b55da7ce02eda9e012b65174d0210249ca'
+  version '2.2.7'
+  sha256 '81b975ba1a0f50793b44dc75287e54218aa58c13ceb8c2c834871ae59f9e4e08'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.