### PR TITLE
Update aquaskk to 4.7.0

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,6 +1,6 @@
 cask 'aquaskk' do
-  version '4.6.1'
-  sha256 '13b3470dee548cea3cd5431551edaf8f1a1b6bc1eff948b530d11aad584dcf58'
+  version '4.7.0'
+  sha256 '386434b025e62bf399d7ceb408e6f85212c82bed54e778a6dc187a8ef2dc9a27'
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.pkg"
   appcast 'https://github.com/codefirst/aquaskk/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.