### PR TITLE
Update lockrattler to 4.11,2018.09

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,13 +1,13 @@
 cask 'lockrattler' do
-  version '4.10,2018.08'
-  sha256 'fc2d94ad45a99e783f64f0338d03f7fa61012df4d8fb51bb40ff92160330458e'
+  version '4.11,2018.09'
+  sha256 '08b5d208c11a97c2150580c3deb1dd82e3f90d9c1fd20e28c825be0b22f64aea'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
-  url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}p#{version.before_comma.minor}.zip"
+  url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"
   name 'Lock Rattler'
   homepage 'https://eclecticlight.co/'
 
   depends_on macos: '>= :el_capitan'
 
-  app "lockrattler#{version.before_comma.major}p#{version.before_comma.minor}/LockRattler.app"
+  app "lockrattler#{version.before_comma.major}#{version.before_comma.minor}/LockRattler.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.