### PR TITLE
Add Nocturnal.app v0.2.1

### DIFF
--- a/Casks/nocturnal.rb
+++ b/Casks/nocturnal.rb
@@ -1,0 +1,13 @@
+cask 'nocturnal' do
+  version '0.2.1'
+  sha256 '97c0672b815bdf678e80a4585e3cf73844c0927fcfcd2beea4a00adcb197bb85'
+
+  url "https://github.com/HarshilShah/Nocturnal/releases/download/#{version}/Nocturnal.zip"
+  appcast 'https://github.com/HarshilShah/Nocturnal/releases.atom'
+  name 'Nocturnal'
+  homepage 'https://github.com/HarshilShah/Nocturnal'
+
+  depends_on macos: '>= :mojave'
+
+  app 'Nocturnal.app'
+end


### PR DESCRIPTION
Added Nocturnal, an app to toggle dark mode on macOS Mojave (and later) with one click.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
