### PR TITLE
Update impactor to 0.9.48

### DIFF
--- a/Casks/impactor.rb
+++ b/Casks/impactor.rb
@@ -1,6 +1,6 @@
 cask 'impactor' do
-  version '0.9.47'
-  sha256 'a0176201bf44360aaee1407c1b7ca51d667bf98bd7442af7d4084e048f8d2006'
+  version '0.9.48'
+  sha256 '61e36266357d8e56af8909f4d605e2f00a14b37ae68f87d122e4e0b02fbbcaab'
 
   # cache.saurik.com/impactor was verified as official when first introduced to the cask
   url "https://cache.saurik.com/impactor/mac/Impactor_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.