### PR TITLE
Update airserver to 7.1.6

### DIFF
--- a/Casks/airserver.rb
+++ b/Casks/airserver.rb
@@ -1,6 +1,6 @@
 cask 'airserver' do
-  version '7.1.4'
-  sha256 '4dc33693c68fedc8bbd93b54e23da8879f744feb130451e4a5bb4b5b6f1a47d3'
+  version '7.1.6'
+  sha256 'fb0cc085ad911a9821db8d10a2eb2b41b3685e862bc2ad919e58f5b1c9f6d139'
 
   url "http://dl.airserver.com/mac/AirServer-#{version}.dmg"
   appcast 'https://www.airserver.com/downloads/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.