### PR TITLE
google-cloud-sdk (latest): fix git cred symlink

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -13,7 +13,7 @@ cask 'google-cloud-sdk' do
   binary 'google-cloud-sdk/bin/bq'
   binary 'google-cloud-sdk/bin/docker-credential-gcloud'
   binary 'google-cloud-sdk/bin/gcloud'
-  binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', target: 'git-credential-gcloud'
+  binary 'google-cloud-sdk/bin/git-credential-gcloud.sh', target: 'git-credential-gcloud.sh'
   binary 'google-cloud-sdk/bin/gsutil'
 
   uninstall delete: "#{staged_path}/#{token}" # Not actually necessary, since it would be deleted anyway. It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.


### PR DESCRIPTION
Current cask formula for gcloud incorrectly symlinks git-credential-gcloud.sh
by dropping the ".sh" extension. This causes discrepancy between the Homebrew
installation vs the official tarball installation. Without the .sh extension,
the documentation and instructions for using Google Cloud Source Repositories
are broken.

Changing this should have no implications since (1) users don't directly call
into this symbolic link (2) git is able to still match to the executable even
when it has the ".sh" extension and the git-config value doesn't include it.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256