### PR TITLE
Update idefrag to 5.3.1

### DIFF
--- a/Casks/idefrag.rb
+++ b/Casks/idefrag.rb
@@ -3,8 +3,8 @@ cask 'idefrag' do
     version '5.1.3'
     sha256 '4b695c04f491b8f9f60a1fb43836164960f7d95f82aaa38d1e3b7dd4eacd7d5c'
   else
-    version '5.3.0'
-    sha256 'e7004d8399779629da2b628703876383d7ef641026cab23d5afa58cb81460ca6'
+    version '5.3.1'
+    sha256 'b13be0fa76805e6ae363c7a8be370ed2c1865b0ac675ac77f3619d0c1dfe5cc3'
   end
 
   url "https://coriolis-systems.com/downloads/iDefrag-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.