### PR TITLE
Update glip to 18.08.1

### DIFF
--- a/Casks/glip.rb
+++ b/Casks/glip.rb
@@ -1,9 +1,9 @@
 cask 'glip' do
-  version '17.11.2'
-  sha256 '4c1e07c627b44e792db069169a7ef6dc27f75f849de8746299728a9635829830'
+  version '18.08.1'
+  sha256 '14dcb0ab33bce1984dddf3425d8fb587411b8a0abf3a11f210025ef09890145a'
 
   # downloads.ringcentral.com/glip/rc was verified as official when first introduced to the cask
-  url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/Glip-#{version}.dmg"
+  url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral-#{version}.dmg"
   name 'Glip'
   homepage 'https://glip.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.