### PR TITLE
Update sqlpro-for-postgres to 1.0.302

### DIFF
--- a/Casks/sqlpro-for-postgres.rb
+++ b/Casks/sqlpro-for-postgres.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-postgres' do
-  version '1.0.127'
-  sha256 'dfee118e7003485cfb863ae7603173ad8c95064d585c8d9435af66745b25e8f6'
+  version '1.0.302'
+  sha256 'da9c723cb9212b6077b8965b9d66a90b877dc32117649695a427cf6edc17fac1'
 
   # d3fwkemdw8spx3.cloudfront.net/postgres was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/postgres/SQLProPostgres.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.