### PR TITLE
Update deeper to 2.3.3

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -22,8 +22,11 @@ cask 'deeper' do
   elsif MacOS.version == :sierra
     version '2.2.3'
     sha256 '33fee21b65279e4459b6469dbc68f0c6df91663ed26d6b62042b21883efda0ed'
-  else
+  elsif MacOS.version == :high_sierra
     version '2.3.3'
+    sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
+  else
+    version '2.3.5'
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   end
 
@@ -42,6 +45,7 @@ cask 'deeper' do
                       :el_capitan,
                       :sierra,
                       :high_sierra,
+                      :mojave,
                     ]
 
   app 'Deeper.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.