### PR TITLE
Update recents to 2.0.1,4624

### DIFF
--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -1,6 +1,6 @@
 cask 'recents' do
-  version '2.0.0,2868'
-  sha256 '3d06bd577120758e4649916533eff3a7bb1a9bee2e6fc768416d5eb9439e1273'
+  version '2.0.1,4624'
+  sha256 'f1994d1b047079b55dd4a076d4fb08c047eeae1363de32b67ef66ce3e2d8f369'
 
   # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.