### PR TITLE
Update 360safe to 1.2.6

### DIFF
--- a/Casks/360safe.rb
+++ b/Casks/360safe.rb
@@ -1,6 +1,6 @@
 cask '360safe' do
-  version '1.2.5'
-  sha256 '060b8c532710513eae7a8c37e8bb59008bb16d7a943798bd8519027e0e18a0fc'
+  version '1.2.6'
+  sha256 'bf161080b20bc1550e30d705075088f1f77b35aa88192c32cce25e532e09b6f4'
 
   url "https://free.360totalsecurity.com/totalsecurity/mac/360ts_mac_#{version}.dmg"
   appcast 'https://www.360totalsecurity.com/en/version/360-total-security-mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.