### PR TITLE
Update rainlendar-pro to 2.14.2

### DIFF
--- a/Casks/rainlendar-pro.rb
+++ b/Casks/rainlendar-pro.rb
@@ -1,6 +1,6 @@
 cask 'rainlendar-pro' do
-  version '2.13.1'
-  sha256 '22fc298423a0bc9c2e3ab8b0752ba353eed2cdd38695cda24d542b138ad511a9'
+  version '2.14.2'
+  sha256 'ad23714e3bdad978d5449239281be7e109528c8bec53c6a0adfd45054f2bcc84'
 
   url "https://www.rainlendar.net/download/Rainlendar-Pro-#{version}.dmg"
   name 'Rainlendar Pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.