### PR TITLE
Update mobile-mouse-server to 3.5.0

### DIFF
--- a/Casks/mobile-mouse-server.rb
+++ b/Casks/mobile-mouse-server.rb
@@ -1,6 +1,6 @@
 cask 'mobile-mouse-server' do
-  version '3.4.0'
-  sha256 'b380fe7caab689fbcdb372f0e1e291a1a089995de3219f790d205c4819ec9f62'
+  version '3.5.0'
+  sha256 '0192e8b7546e31d73beab011c43fc98a13d42de8b1c15fb6003950da043ea39d'
 
   url "https://mobilemouse.com/downloads/OS_X_Server_#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.