### PR TITLE
Update routeconverter to 2.24.42

### DIFF
--- a/Casks/routeconverter.rb
+++ b/Casks/routeconverter.rb
@@ -1,8 +1,8 @@
 cask 'routeconverter' do
-  version '2.23'
-  sha256 'd1eef2e465017b9e69f1d8283b2394899eaf4cfa2b604114095c1b7f25917eca'
+  version '2.24.42'
+  sha256 '145c312f077c904fc717c6650bacff0b5a00a2f7f77ccc03f78259adc46d763f'
 
-  url "https://static.routeconverter.com/download/previous-releases/#{version}/RouteConverterMac.app.zip"
+  url 'https://static.routeconverter.com/download/RouteConverterMac.app.zip'
   appcast 'https://static.routeconverter.com/download/previous-releases/'
   name 'RouteConverter'
   homepage 'https://www.routeconverter.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.