### PR TITLE
Update mtmr to 0.18.5

### DIFF
--- a/Casks/mtmr.rb
+++ b/Casks/mtmr.rb
@@ -1,6 +1,6 @@
 cask 'mtmr' do
-  version '0.18.4'
-  sha256 '38a26761f72ac2ee60cc11fcf9563290d1f361219ca05db83c9170cde2d48060'
+  version '0.18.5'
+  sha256 'd5bb6ff746fbd0322dd4bcf51cf1c7b1f625eff4fbbb23009822fdfb3db53d7c'
 
   url "https://github.com/Toxblh/MTMR/releases/download/v#{version}/MTMR.#{version}.dmg"
   appcast 'https://github.com/Toxblh/MTMR/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.