### PR TITLE
Update telegram to 4.5-141573

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.4.1-140477'
-  sha256 '27e732459c499b4ee40766e2a91a42e426cb112b0deb4743b8a8a0b92702db18'
+  version '4.5-141573'
+  sha256 '6d2a4155c75dc4f0ccb253ac98e06c4e51fe5d26e28a15ccfbf8ea96d442c0f2'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.