### PR TITLE
Update securityspy to 4.2.9

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,6 +1,6 @@
 cask 'securityspy' do
-  version '4.2.8'
-  sha256 'e80cc98a5b571fac36959a39eeddbe71c8d9e1a4dc471152f01744cfe610cb39'
+  version '4.2.9'
+  sha256 'a9ead279bdc3ec7a4aba9bae454c6b27605959ca174a8c84c1f63f4fa7cab88b'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.