### PR TITLE
Update ghost-browser to 2.1.0.3

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,10 +1,11 @@
 cask 'ghost-browser' do
-  version '1.1.0.7'
-  sha256 '5113dcc38084f5e3baeb71258da133f3f8155478205358e62561c8fc7da4fef0'
+  version '2.1.0.3'
+  sha256 'fb84349fe735087bc4a3f72f5d45b69c7c1a99bde68b6d365edaa8e507936b46'
 
-  url "https://ghostbrowser.com/ghostdev/downloads/GhostBrowser-#{version}.dmg"
+  # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "http://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"
   name 'Ghost Browser'
-  homepage 'https://ghostbrowser.com/'
+  homepage 'https://ghostbrowser.com/download/'
 
   app 'Ghost Browser.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.