### PR TITLE
Update doubletwist to 3.2.0

### DIFF
--- a/Casks/doubletwist.rb
+++ b/Casks/doubletwist.rb
@@ -1,11 +1,10 @@
 cask 'doubletwist' do
-  version '3.1.2'
-  sha256 '47975cc7517a6cf8c90362536a7feb53f0ff8af7d45866481d37cad2fcae4dac'
+  version '3.2.0'
+  sha256 '426a4468c79a99bdcf51d1be9601b7ebe5222fcc97d38b38d80b8116b75a8b13'
 
-  url "http://download.doubletwist.com/releases/mac/dT-#{version}-kronos-patch1-r11040/doubleTwist.dmg"
-  appcast 'http://download.doubletwist.com/mac/appcast.xml'
+  url 'http://download.doubletwist.com/mac/doubleTwist.dmg'
   name 'doubleTwist'
-  homepage 'https://www.doubletwist.com/'
+  homepage 'https://www.doubletwist.com/desktop'
 
   app 'doubleTwist.app'
 

--- a/Casks/doubletwist.rb
+++ b/Casks/doubletwist.rb
@@ -1,6 +1,6 @@
 cask 'doubletwist' do
-  version '3.2.0'
-  sha256 '426a4468c79a99bdcf51d1be9601b7ebe5222fcc97d38b38d80b8116b75a8b13'
+  version :latest
+  sha256 :no_check
 
   url 'http://download.doubletwist.com/mac/doubleTwist.dmg'
   name 'doubleTwist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.