### PR TITLE
Update freefilesync to 10.5

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '10.4'
-  sha256 '57e00106e0ae4e215ea97c89cdf2680db5ffba8caa8d97176da9bc54ccee9ac7'
+  version '10.5'
+  sha256 'c2a20db194373ed0db15e929cbf14497c0ba82f62b4e9e12a990029861e73860'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.