### PR TITLE
Update little-snitch to 4.2.2

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -1,6 +1,6 @@
 cask 'little-snitch' do
-  version '4.2.1'
-  sha256 '8ae25660d561789b7f55812266d60e3b96ca18ac0645e2c3fb668378292c4a8d'
+  version '4.2.2'
+  sha256 'abfd731508320457e8ad3049fed20f1fb65fd0b787016302ad6880a017ba5f1d'
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.