### PR TITLE
Update pacifist to 3.6.1

### DIFF
--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -3,8 +3,8 @@ cask 'pacifist' do
     version '3.2.17'
     sha256 'd38e12293bc6087ddb09275e3c5ab34faa670e87e9dd41e04a587dd387f7b1d3'
   else
-    version '3.6'
-    sha256 'e0571facfaebb843327426c2a356beb4b8c537aebce3b83848a0887453562f8c'
+    version '3.6.1'
+    sha256 'a884c8c0d16ca159bf7f90064247d7c00f4ebbd54ac86028bb57c0cbf666cf2a'
   end
 
   url "https://www.charlessoft.com/pacifist_download/Pacifist_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.