### PR TITLE
Update tuxera-ntfs to 2018

### DIFF
--- a/Casks/tuxera-ntfs.rb
+++ b/Casks/tuxera-ntfs.rb
@@ -1,6 +1,6 @@
 cask 'tuxera-ntfs' do
   version '2018'
-  sha256 '84af4075f0ceaf42040928447d9f77240e4c3ae4359837e113cf35115400a19a'
+  sha256 '73b8c1e7a19ae2f98aeb4f72d8d5f7ea2a81f07b2f2a49a5106ea0581756d9ac'
 
   url "https://download.tuxera.com/mac/tuxerantfs_#{version}.dmg"
   name 'Tuxera NTFS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.