### PR TITLE
Update ripcord to 0.3.5

### DIFF
--- a/Casks/ripcord.rb
+++ b/Casks/ripcord.rb
@@ -1,6 +1,6 @@
 cask 'ripcord' do
-  version '0.3.4'
-  sha256 '5608630070fe4e71256befad7f6c259ba25f7323afa59dd282d33105555c4770'
+  version '0.3.5'
+  sha256 'e75af18e8160b6a70d3f97d1a4e1097f5d4b925ed55561ee3e0a9f2bbe681e23'
 
   url "https://cancel.fm/dl/Ripcord_Mac_#{version}.zip"
   appcast 'https://cancel.fm/ripcord/updates/v1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.