### PR TITLE
Update postman to 6.4.4

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,6 +1,6 @@
 cask 'postman' do
-  version '6.4.2'
-  sha256 '7dd1124d9c2b7add3ea0ff55b74c0472a053994ee46c7abbd95cbba2c518ea02'
+  version '6.4.4'
+  sha256 'a39c62fe2bf9dc47f034db96f8ebba9a32d01388460658d012dbcd6831226df6'
 
   # dl.pstmn.io/download/version was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.