### PR TITLE
Update rambox to 0.6.2

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,6 +1,6 @@
 cask 'rambox' do
-  version '0.6.1'
-  sha256 'aa9d20ecfef8a8c1f2c2e9c55917e447bb2cdb0b58870eb6abd00cd66b9089c2'
+  version '0.6.2'
+  sha256 'f83028d7875636aef457c9e5254846f84276551edaf74f6d283d846c5c2544c8'
 
   # github.com/ramboxapp/community-edition was verified as official when first introduced to the cask
   url "https://github.com/ramboxapp/community-edition/releases/download/#{version}/Rambox-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.