### PR TITLE
Update vivaldi to 2.0.1309.42

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.0.1309.40'
-  sha256 'bdb33a34eadd9e1572df7092dc30b2ca6610df67047c71f647a09a5627d59faf'
+  version '2.0.1309.42'
+  sha256 '91dba1da3cf7f14fa99d5a6626943b7442109dffcefd7f56763481addda797fd'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.