### PR TITLE
Update stattransfer to 14

### DIFF
--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -1,6 +1,6 @@
 cask 'stattransfer' do
-  version '14'
-  sha256 :no_check # required as upstream package is updated in-place
+  version :latest
+  sha256 :no_check
 
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'
   name 'Stat/Transfer'

--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -1,6 +1,6 @@
 cask 'stattransfer' do
   version '14'
-  sha256 'b4d40db39f2ddae23622336771b0dfb27e874ba885320d2fe75482783342bfe6'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'
   name 'Stat/Transfer'

--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -1,5 +1,8 @@
 cask 'stattransfer' do
-  version :latest
+  version '14'
+  sha256 :no_check # required as upstream package is updated in-place
+
+
   sha256 :no_check
 
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'

--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -2,9 +2,6 @@ cask 'stattransfer' do
   version '14'
   sha256 :no_check # required as upstream package is updated in-place
 
-
-  sha256 :no_check
-
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'
   name 'Stat/Transfer'
   homepage 'https://stattransfer.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.