### PR TITLE
Update ssh-tunnel-manager to 227.006,1478083232

### DIFF
--- a/Casks/ssh-tunnel-manager.rb
+++ b/Casks/ssh-tunnel-manager.rb
@@ -1,5 +1,5 @@
 cask 'ssh-tunnel-manager' do
-  version '227.007,1476730358'
+  version '227.006,1478083232'
   sha256 '11c8b7ca6f3a79b2cefdfc665a6cc6d5aaf2dac199e9380f44c3e1aea191c41a'
 
   # dl.devmate.com/org.tynsoe.sshtunnelmanager was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.