### PR TITLE
Update qownnotes to 18.10.3,b3879-171438

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.10.2,b3868-155632'
-  sha256 'd1ac5c984a5be622c1cd16989467ad093e7f37efbefa23eb0664b05c9d644379'
+  version '18.10.3,b3879-171438'
+  sha256 'd93bb3d67afe7dec625e0f94a5846d317e3d9770943d5bfa37e08f425e3cf5c5'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.