### PR TITLE
Update decrediton to 1.3.1

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,6 +1,6 @@
 cask 'decrediton' do
-  version '1.3.0'
-  sha256 '77753257c7ebaf1b3f77f0d6445d227dff20edd770702ee290140e42250b12aa'
+  version '1.3.1'
+  sha256 '3aad8659b9713a9e787450ed3bdfe8f5f73cb31bb57bc35eb97bb72877d3ef8a'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.