### PR TITLE
Update Brave.app to 0.55.18

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,4 +1,4 @@
-cask 'brave' do
+cask 'brave-browser' do
   version '0.55.18'
   sha256 '6991ff0aceb1826505e1c5cf98b2b45b12b51b149c73bbf7fb329bdbf9d83414'
 

--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -11,7 +11,7 @@ cask 'brave' do
   auto_updates true
   depends_on macos: '>= :mavericks'
 
-  app 'Brave.app'
+  app 'Brave Browser.app'
 
   zap trash: [
                '~/Library/Application Support/brave',

--- a/Casks/brave.rb
+++ b/Casks/brave.rb
@@ -1,10 +1,10 @@
 cask 'brave' do
-  version '0.25.2'
-  sha256 '3d37ffd33a75d7d125f70611c0dab5ca49f283ce7282aede4608750627f410ac'
+  version '0.55.18'
+  sha256 '6991ff0aceb1826505e1c5cf98b2b45b12b51b149c73bbf7fb329bdbf9d83414'
 
-  # github.com/brave/browser-laptop was verified as official when first introduced to the cask
-  url "https://github.com/brave/browser-laptop/releases/download/v#{version}dev/Brave-#{version}.dmg"
-  appcast 'https://github.com/brave/browser-laptop/releases.atom'
+  # github.com/brave/brave-browser was verified as official when first introduced to the cask
+  url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"
+  appcast 'https://github.com/brave/brave-browser/releases.atom'
   name 'Brave'
   homepage 'https://brave.com/'
 


### PR DESCRIPTION
New Github repository: https://github.com/brave/brave-browser
New version number: 0.55.18

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).