### PR TITLE
Update vscodium to 1.28.2

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.28.1'
-  sha256 '45f994c728499b99cb442f993d8abb5d861042e4879b66695845dd363d125cf0'
+  version '1.28.2'
+  sha256 '4476514525d7198c85be614fe20e2fe83cb46e46b0104c33424485c8c66bc477'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCode-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.