### PR TITLE
Update redcine-x-pro to 50.5

### DIFF
--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -1,12 +1,13 @@
 cask 'redcine-x-pro' do
-  version '50.0.0,43840'
-  sha256 'c617328a331cf2c1dc10fd71e9a0827516b2de6c6cd71404f913d621a77564f1'
+  version '50.5'
+  sha256 '443b4e92e8b4c23dad9478f96e8d88159944d904e61d07ad41e402377cc8aafe'
 
-  url "http://downloads.red.com/software/rcx/mac/release/#{version.major}.#{version.after_comma}/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
+  # s3.amazonaws.com/red-4/ was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/red-4/downloads/software/rcx/REDCINE-X_PRO_Build_#{version}.pkg"
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'
 
-  pkg "REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
+  pkg "REDCINE-X_PRO_Build_#{version}.pkg"
 
   uninstall pkgutil: [
                        'com.red.pkg.REDCINE-X PRO',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.