### PR TITLE
Update audio-hijack to 3.5.5

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -1,6 +1,6 @@
 cask 'audio-hijack' do
-  version '3.5.4'
-  sha256 'ed28ffd22a32dce437f7a2c37430eae2e1520c50e83fb4ede19939c517130809'
+  version '3.5.5'
+  sha256 '88ecd6dd773a8634a8b594c71911cd8e3d629fa0f06c0a4902cba2c51f66802d'
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   appcast 'https://www.rogueamoeba.com/audiohijack/releasenotes.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.