### PR TITLE
Update captin to 1.0.17,93:1539867062

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.16,92:1538968026'
-  sha256 '77af05154b3ef3fb7eb16ac2cc932f600b8feee30115ee4175dd966102a03043'
+  version '1.0.17,93:1539867062'
+  sha256 'dd89ab1c7d6c640e6b4b6e1e8cd3db83ca4edf33574bab07ae79ae40c32733d6'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.