### PR TITLE
Update daedalus to 0.11.1,1.3.1:2887

### DIFF
--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -1,6 +1,6 @@
 cask 'daedalus' do
-  version '0.11.0,1.3.0:2260'
-  sha256 '6ad90da2053f06f9f0e35c2ae05a8620094b83c6a6a5401c201a1e5abcc22ae4'
+  version '0.11.1,1.3.1:2887'
+  sha256 '51f8783822a1690663c2b349c58c68165fdde5ce72065bb9d419a21335497c5e'
 
   # github.com/input-output-hk/daedalus was verified as official when first introduced to the cask
   url "https://github.com/input-output-hk/daedalus/releases/download/#{version.before_comma}/daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.