### PR TITLE
Update downie to 3.4.8,1894

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.4.8,1888'
-  sha256 '1e3c72c70c523c8b18e82052049a7f69fa3cca72a709397f61ee63f2d5d31650'
+  version '3.4.8,1894'
+  sha256 'c1a633c5e7fc9059bb47ab59488c54e574dde2830436575aadcd7049d7018d1e'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.