### PR TITLE
Update fsnotes to 2.3

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.2.3'
-  sha256 'd6cd8bfc8e7cb4557abd753c6e9443179140ed161cfe18f60e4a55b59143e0d3'
+  version '2.3'
+  sha256 'c5e18b2c561af15ea977d06d4586ad12e6e14b2ccaeb26588eaa0d3f0c893adf'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.