### PR TITLE
Update get-iplayer-automator to 1.13.16.b20181016001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,6 +1,6 @@
 cask 'get-iplayer-automator' do
-  version '1.13.15.b20180908001'
-  sha256 '456c3147b90f874478aa5566b21e1f235090aa8d58ea3a10c50c78590ebaa488'
+  version '1.13.16.b20181016001'
+  sha256 '48badf60b62d55297b297479d3028d9ffe6c05b6988903f8dd6776ed6c215095'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.