### PR TITLE
Update kitematic to 0.17.5

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -1,6 +1,6 @@
 cask 'kitematic' do
-  version '0.17.3'
-  sha256 'f7822079a1c1747dabeebd95a57f46d50847f77d3f567862e7b624bff309bd2c'
+  version '0.17.5'
+  sha256 'dd697ee05d520e9dbbddb6177ca66a84a02eceb863d24845d1f787d226036e9d'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"

--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -8,7 +8,7 @@ cask 'kitematic' do
   name 'Kitematic'
   homepage 'https://kitematic.com/'
 
-  app 'Kitematic (Beta).app'
+  app 'Kitematic.app'
 
   zap trash: [
                '~/Kitematic',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.