### PR TITLE
Update loginputmac to 1.18,2768

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '1.17,2766'
-  sha256 '8ceae77712d165e6e4b74d36fc3d3177de4536e908b1354c3f38a549c8a64d4e'
+  version '1.18,2768'
+  sha256 'd3f87ba0a1249ff6a81af2f90fe034ff8f283a1bdb39d6b19dc08a88b66ce41c'
 
   # ebypiovrn28j.maimaim.ai was verified as official when first introduced to the cask
   url "https://ebypiovrn28j.maimaim.ai/LogInputMac#{version.after_comma}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.