### PR TITLE
Update lyn to 1.10

### DIFF
--- a/Casks/lyn.rb
+++ b/Casks/lyn.rb
@@ -1,6 +1,6 @@
 cask 'lyn' do
-  version '1.9.8'
-  sha256 'bb8e8359b27fc549d2afd5567cf81daa2d90a06e87bd69c0f2ef51886e552e60'
+  version '1.10'
+  sha256 '25bacda3d4d6c23775ce259cf9237ccf017ef3fbbd8e35277c2344f8d23e5a06'
 
   url "https://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   appcast 'https://www.lynapp.com/lyn/update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.