### PR TITLE
Update macupdater to 1.3.6

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.3.5'
-  sha256 'e6e0f4ec88c088b268371aa32aeb7b93bf27a56c0e52dcdb4a886720696f2636'
+  version '1.3.6'
+  sha256 '6ec464a3c3db9f0ae9fac6ebc5f71ec34c71381baee3ec9937860b10c6b89c34'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.