### PR TITLE
Update metasploit to 4.17.19+20181019094701

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,6 +1,6 @@
 cask 'metasploit' do
-  version '4.17.18+20181012094640'
-  sha256 '404109d3077639345490761415bc2461ccf6548aa08c17fc1bfb8a44d24244fa'
+  version '4.17.19+20181019094701'
+  sha256 '8d5044e88c716a542e99b9618fdb6642b2b0231d184fed8dbe23582c15c0c774'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.