### PR TITLE
Update pdfpenpro to 1020.14,1539654756

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1012.1,1535510481'
-  sha256 '45eaf5d6ddd294758bc8834829ec88ebf09642987cb8da06aa94fd69d046a9a7'
+  version '1020.14,1539654756'
+  sha256 '19957e53d1fcd11311ed187e498a61fe4379cd213a63dc83a65fd92cf2b65f88'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.