### PR TITLE
Update physicseditor to 1.8.2

### DIFF
--- a/Casks/physicseditor.rb
+++ b/Casks/physicseditor.rb
@@ -1,6 +1,6 @@
 cask 'physicseditor' do
-  version '1.8.0'
-  sha256 '2d97266cf30a5dd6d56758d9f50aada38e8b35c9c804a90dfa96019629005346'
+  version '1.8.2'
+  sha256 'af8cb5c6c752ef4cb626d1fa9577a28d33a9216fb6a100ceb9f2bb20b22e97cc'
 
   url "https://www.codeandweb.com/download/physicseditor/#{version}/PhysicsEditor-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/PhysicsEditor/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.