### PR TITLE
Update porting-kit to 2.9.526

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,6 +1,6 @@
 cask 'porting-kit' do
-  version '2.9.516'
-  sha256 '1639e72beab4241fcdca80d260be8bebc958387477137e48f8f31d3d8aa9f602'
+  version '2.9.526'
+  sha256 '385631b3040701326230c085e521190f31fcc2a089c4a915640542576a662973'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.