### PR TITLE
Update pyfa to 2.5.1,yc120.10-1.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.5.0,yc120.10-1.0'
-  sha256 '1924a6c9f184c14ecffc3fcecb58a8261fdf64ab86114e6a183b53c5f82bdb53'
+  version '2.5.1,yc120.10-1.0'
+  sha256 '70c1b126b9a393fc026c9d537414966910eace7213b9c27d2971344598659174'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.