### PR TITLE
Update screenflick to 2.7.38

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,6 +1,6 @@
 cask 'screenflick' do
-  version '2.7.37'
-  sha256 '786bed4f46aa7361dbab447b2fa631e2f4d2fe0cd9beedbb1105d701190038ef'
+  version '2.7.38'
+  sha256 'a14fec78920a1992d836460235baed164592e112d4c1f9d742383779d3ab1962'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.