### PR TITLE
Update setapp to 1.18.1,1539860348

### DIFF
--- a/Casks/setapp.rb
+++ b/Casks/setapp.rb
@@ -1,6 +1,6 @@
 cask 'setapp' do
-  version '1.17,1537866884'
-  sha256 '5ce806cd0f6960e10ccc9759587fce49e8dc1ac3c46348d71738434aad6db65c'
+  version '1.18.1,1539860348'
+  sha256 'bc240c0c64ff352fe17011408db00c85c5571cba0fb266d59655623e14eea9e0'
 
   # devmate.com/com.setapp.InstallSetapp was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.setapp.InstallSetapp/#{version.before_comma}/#{version.after_comma}/InstallSetapp-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.