### PR TITLE
Update spriteilluminator to 1.5.2

### DIFF
--- a/Casks/spriteilluminator.rb
+++ b/Casks/spriteilluminator.rb
@@ -1,6 +1,6 @@
 cask 'spriteilluminator' do
-  version '1.5.0'
-  sha256 '59f623fc31a7ab4412434d126929c4fecd7f85432562e019476c1cbe8a4c8e2f'
+  version '1.5.2'
+  sha256 '90b2702e5315784113546a95113455423d4814aa2eccef63a5dec979bec78431'
 
   url "https://www.codeandweb.com/download/spriteilluminator/#{version}/SpriteIlluminator-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/SpriteIlluminator/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.