### PR TITLE
Update standard-notes to 2.3.8

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
-  version '2.3.7'
-  sha256 '3b158efd9d0536b8393616e276260e2427e179e94a4d8e4b91865aefef035b76'
+  version '2.3.8'
+  sha256 '53fb0b050d386ebeaf2cef0f4b4e948f1e41975acaf2319a0ecc4965c09eaba6'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.