### PR TITLE
Update xld to 2018.10.19

### DIFF
--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -1,6 +1,6 @@
 cask 'xld' do
-  version '2018.10.01'
-  sha256 '4928203ba1d8d0e091f85033a9adf496ce09b1d3231e585f579036063ceb125d'
+  version '2018.10.19'
+  sha256 '3f49f4c1669b6c9f1ae7f6e1919526bc539971ce8b1a880ac581da3bb3f84b2c'
 
   # sourceforge.net/xld was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/xld/xld-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.