### PR TITLE
Update simplenote to 1.2.1

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,8 +1,8 @@
 cask 'simplenote' do
-  version '1.1.7'
-  sha256 '0be66fe9eed95548f3b855ec0e8ebdfd01c82db7c270c7db7547b6c37bed97a0'
+  version '1.2.1'
+  sha256 '8f4af5a584a1790fd6bb01ae258dfe13f0e76b00601121914ef974f94fbee4e1'
 
-  url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote.app.#{version}.zip"
+  url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.zip"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom'
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'

--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -7,7 +7,7 @@ cask 'simplenote' do
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'
 
-  app 'Simplenote.app'
+  app 'mac/Simplenote.app'
 
   zap trash: [
                '~/Library/Application Support/Simplenote',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.