### PR TITLE
Update vuo-editor to 1.2.8

### DIFF
--- a/Casks/vuo-editor.rb
+++ b/Casks/vuo-editor.rb
@@ -1,8 +1,8 @@
 cask 'vuo-editor' do
-  version '1.2.7'
-  sha256 '7210b425fded394733c7b00e4cd5ba6128bd41e21b5ba83108473d771d1443ca'
+  version '1.2.8'
+  sha256 'd3d427667bdb206a1b90163690e1f90907cb468d0ffa17d1b7bf7a49df338cf5'
 
-  url "https://vuo.org/sites/default/files/vuo-#{version}-editor.zip"
+  url "https://vuo.org/sites/default/files/release/vuo-#{version}-editor.zip"
   appcast 'https://vuo.org/releases.rss'
   name 'Vuo'
   homepage 'https://vuo.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.