### PR TITLE
Update healthi to 3.1.1

### DIFF
--- a/Casks/healthi.rb
+++ b/Casks/healthi.rb
@@ -1,6 +1,6 @@
 cask 'healthi' do
-  version '3.1.0'
-  sha256 'bb12bb70fda7b9e5b17c008fcd58ee397729ee29395b6b94514473e509849f2b'
+  version '3.1.1'
+  sha256 '03b4187a432fb8f7d24c0286403f75f243fa1653eda3362fe459ea4d54229f15'
 
   url "https://github.com/pablopunk/healthi-app/releases/download/#{version}/healthi.app.zip"
   appcast 'https://github.com/pablopunk/healthi-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.