### PR TITLE
Update lockrattler to 4.12,2018.10

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.11,2018.09'
-  sha256 '08b5d208c11a97c2150580c3deb1dd82e3f90d9c1fd20e28c825be0b22f64aea'
+  version '4.12,2018.10'
+  sha256 '549f84f64ece05c2b39a07ea51d81a1c3136bdc89234f6320a1acab7a0f3583d'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.