### PR TITLE
Update gobdokumente to 1.3.1

### DIFF
--- a/Casks/gobdokumente.rb
+++ b/Casks/gobdokumente.rb
@@ -6,7 +6,10 @@ cask 'gobdokumente' do
   url 'https://download.moapp.software/GoBDokumente.zip'
   appcast 'https://sparkle.moapp.software/gobdokumente.xml'
   name 'GoBDokumente'
+  name 'GoBDocuments'
   homepage 'https://gobdokumente.de/'
+
+  depends_on macos: '>= 10.11'
 
   app 'GoBDokumente.app'
 

--- a/Casks/gobdokumente.rb
+++ b/Casks/gobdokumente.rb
@@ -9,7 +9,7 @@ cask 'gobdokumente' do
   name 'GoBDocuments'
   homepage 'https://gobdokumente.de/'
 
-  depends_on macos: '>= 10.11'
+  depends_on macos: '>= :el_capitan'
 
   app 'GoBDokumente.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

added alternative name, depends_on macos