### PR TITLE
Update manager to 18.10.81

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.76'
-  sha256 'b2ef902a03e30b042aa7a784d55d2bec08902573f29d2a750226338d0dd915c1'
+  version '18.10.81'
+  sha256 '30e857c4f82fb13408ea39e97b5b19bde21704edb555dcbaadfa555aec58c7f4'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.