### PR TITLE
Update clashx to 1.6.1

### DIFF
--- a/Casks/clashx.rb
+++ b/Casks/clashx.rb
@@ -1,6 +1,6 @@
 cask 'clashx' do
-  version '1.5.5'
-  sha256 '94e078d9c0bc6835cf0039a4f5d59b1444eef5edb5c72972485d431879f62052'
+  version '1.6.1'
+  sha256 '8b02bb3207390c9b8b3f0b9cbc75e041b2a7f7c16e91a8951f22586081f851f0'
 
   url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   appcast 'https://github.com/yichengchen/clashX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.