### PR TITLE
Update retroarch to 1.7.5

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask 'retroarch' do
   version '1.7.5'
-  sha256 '9bbedc943213f7602bba7dcf1056d92c9c4af92d7d00dbfcb98807e6c1829251'
+  sha256 'b73726965ceb5a55aa89508c29c4fafc2b82709dbcf919230127098279f28a5f'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   appcast 'https://buildbot.libretro.com/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Note: I have noticed that the file changes fairly frequently. The sha256 will likely change again before a new version of retroarch is released. The most recent timestamp ([see here](https://buildbot.libretro.com/stable/1.7.5/apple/osx/x86_64/)) is October 22, and it was a week or two earlier last time.