### PR TITLE
Update droplr to 5.5.2,224

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version '5.5.2,220'
-  sha256 '098e267ef0142083a2ac8495cfe556480db3a282ba0b4493d731f222b4f675d6'
+  version '5.5.2,224'
+  sha256 '82ac292b2dda6cf3b31490db57b51250680aeeb2c55eb4aa47d9926a6f6eab98'
 
   url "https://files.droplr.com/apps/mac/Droplr-#{version.after_comma}.zip"
   name 'Droplr'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.