### PR TITLE
Update gotofile to 1.3.3

### DIFF
--- a/Casks/gotofile.rb
+++ b/Casks/gotofile.rb
@@ -1,6 +1,6 @@
 cask 'gotofile' do
-  version '1.3.2'
-  sha256 '9185ecaf4039b1d16274b23e52282b97c57581e1f3757fc58dacb4e103a1584a'
+  version '1.3.3'
+  sha256 '3eb0f1887517b1dca97a1ffc4818c5a16c98c9323174db71fa07521fe105fedd'
 
   url "http://www.soma-zone.com/download/files/GoToFile_#{version}.tbz"
   appcast 'https://somazonecom.ipage.com/soma-zone.com/GoToFile/a/appcast_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.