### PR TITLE
Update cloudcompare to 2.9.1

### DIFF
--- a/Casks/cloudcompare.rb
+++ b/Casks/cloudcompare.rb
@@ -1,6 +1,6 @@
 cask 'cloudcompare' do
-  version :latest
-  sha256 :no_check
+  version '2.9.1'
+  sha256 'c5223b04265802c90a8f81455e80d26f3406881e9e273372390eb42e37d4c62e'
 
   # asmaloney.com/download/cloudcompare-mac-os-x was verified as official when first introduced to the cask
   url 'https://asmaloney.com/download/cloudcompare-mac-os-x/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.