### PR TITLE
Update taskpaper to 3.8.1

### DIFF
--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,6 +1,6 @@
 cask 'taskpaper' do
-  version '3.7.7'
-  sha256 '927026589ce92ff78146c363c86ba566b710de42bcb06c27395ddf7b2a36c4e8'
+  version '3.8.1'
+  sha256 '06ad9a1ad7419ca9f99bafccc5462c51ce592f5c28cefa919887f97590681b42'
 
   url "https://www.taskpaper.com/assets/app/TaskPaper-#{version}.dmg"
   appcast 'https://www.taskpaper.com/assets/app/TaskPaper.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.