### PR TITLE
Update hostbuddy to 2.0.2,20_3

### DIFF
--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,9 +1,9 @@
 cask 'hostbuddy' do
-  version '2.0.2,20_3'
+  version '2.0.3'
   sha256 'ae9a55245b8995a2cbdf3db4db434fd82795cc60dded4a952369c141aa00d012'
 
   # downloads-clickonideas.netdna-ssl.com/hostbuddy was verified as official when first introduced to the cask
-  url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy#{version.after_comma}.zip"
+  url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy_#{version}.zip"
   appcast 'https://shine.clickontyler.com/appcast.php?id=41'
   name 'Hostbuddy'
   homepage 'https://clickontyler.com/hostbuddy/'

--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,10 +1,10 @@
 cask 'hostbuddy' do
-  version '2.0.0'
-  sha256 '2460ad27a95603ca1a8ea5170e690ce0e98b66682480ad6711902dfb7feea312'
+  version '2.0.2,20_3'
+  sha256 'ae9a55245b8995a2cbdf3db4db434fd82795cc60dded4a952369c141aa00d012'
 
   # downloads-clickonideas.netdna-ssl.com/hostbuddy was verified as official when first introduced to the cask
-  url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy_#{version}.zip"
-  appcast 'https://shine.clickontyler.com/appcast.php?id=22'
+  url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy#{version.after_comma}.zip"
+  appcast 'https://shine.clickontyler.com/appcast.php?id=41'
   name 'Hostbuddy'
   homepage 'https://clickontyler.com/hostbuddy/'
 

--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,9 +1,9 @@
 cask 'hostbuddy' do
-  version '2.0.3'
+  version '2.0.2,20_3'
   sha256 'ae9a55245b8995a2cbdf3db4db434fd82795cc60dded4a952369c141aa00d012'
 
   # downloads-clickonideas.netdna-ssl.com/hostbuddy was verified as official when first introduced to the cask
-  url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy_#{version}.zip"
+  url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy#{version.after_comma}.zip"
   appcast 'https://shine.clickontyler.com/appcast.php?id=41'
   name 'Hostbuddy'
   homepage 'https://clickontyler.com/hostbuddy/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.