### PR TITLE
Update xca to 2.1.1

### DIFF
--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,6 +1,6 @@
 cask 'xca' do
   version '2.1.1'
-  sha256 '69692384d4239daf6e95b4d06bcf589eed33c829940a7d9ea74409a7fe937a01'
+  sha256 'd376bba09657477a20b89b324154c7a76bd3360df37488153727f5d0861a857f'
 
   # github.com/chris2511/xca was verified as official when first introduced to the cask
   url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.