### PR TITLE
Add SpotSpot v3.1.1, a Spotify mini-player for Mac

### DIFF
--- a/Casks/spotspot.rb
+++ b/Casks/spotspot.rb
@@ -2,10 +2,11 @@ cask 'spotspot' do
   version '3.1.1'
   sha256 'a50858471d5cfc866ccf83107865f2291b2ea2ad9022e570062d002d1fe3749d'
 
-  url 'https://github.com/will-stone/SpotSpot/releases/download/v3.1.1/SpotSpot-3.1.1.dmg'
+  # github.com/will-stone/SpotSpot was verified as official when first introduced to the cask
+  url "https://github.com/will-stone/SpotSpot/releases/download/v#{version}/SpotSpot-#{version}.dmg"
   appcast 'https://github.com/will-stone/SpotSpot/releases.atom'
   name 'SpotSpot'
-  homepage 'https://github.com/will-stone/SpotSpot'
+  homepage 'https://will-stone.github.io/SpotSpot/'
 
   app 'SpotSpot.app'
 end

--- a/Casks/spotspot.rb
+++ b/Casks/spotspot.rb
@@ -1,0 +1,11 @@
+cask 'spotspot' do
+  version '3.1.1'
+  sha256 'a50858471d5cfc866ccf83107865f2291b2ea2ad9022e570062d002d1fe3749d'
+
+  url 'https://github.com/will-stone/SpotSpot/releases/download/v3.1.1/SpotSpot-3.1.1.dmg'
+  appcast 'https://github.com/will-stone/SpotSpot/releases.atom'
+  name 'SpotSpot'
+  homepage 'https://github.com/will-stone/SpotSpot'
+
+  app 'SpotSpot.app'
+end


### PR DESCRIPTION
SpotSpot is a Spotify mini-player for macOS

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x] The commit message includes the cask’s name and version.
- [ x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ x] Named the cask according to the [token reference].
- [ x] `brew cask install {{cask_file}}` worked successfully.
- [ x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ x] Checked there are no [open pull requests] for the same cask.
- [ x] Checked the cask was not [already refused].
- [ x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
