### PR TITLE
skype-for-business version 16.22.0.175

### DIFF
--- a/Casks/skype-for-business.rb
+++ b/Casks/skype-for-business.rb
@@ -1,6 +1,6 @@
 cask 'skype-for-business' do
-  version '16.22.0.170'
-  sha256 '8662df78ec823f145d866a2a811aa39a3acd2ea20494eb1e1213da07f2649e72'
+  version '16.22.0.175'
+  sha256 '5d7b265631c304e21d39a2456cfc9e8932f36619504ec713809afe5d78085aac'
 
   url "https://download.microsoft.com/download/D/0/5/D055DA17-C7B8-4257-89A1-78E7BBE3833F/SkypeForBusinessInstaller-#{version}.pkg"
   name 'Skype for Business'


### PR DESCRIPTION
Was version 16.22.0.170.
Updated checksum.

Could not update with 'cask-repair skype-for-business' as the below prompt was looping after version confirmation:
"• ==> Installing or updating 'rubocop-cask' gem
• ==> Installing or updating 'rubocop-cask' gem
• ==> Installing or updating 'rubocop-cask' gem
• ==> Installing or updating 'rubocop-cask' gem
• ==> Installing or updating 'rubocop-cask' gem
---------------------------------------------------------------------------------------------------------------------------------------
Is everything correct? ([y]es / [n]o / [e]dit) "

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
