### PR TITLE
Update netron to 2.3.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.3.0'
-  sha256 '3e9785de87b7843d7ea1a524b9161ec173dc4c69b7aa2103a838846eb421045f'
+  version '2.3.2'
+  sha256 'fe4bbb11df13af7b3342132712c76cc2f0b427aa1eecd8f3e890219a0ed8b066'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.