### PR TITLE
Update aerial to 1.4.2

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.4.1'
-  sha256 'fc1e51bced2b21be74793f4ea6aa86961cc931dde22c8a25e84d69b237055413'
+  version '1.4.2'
+  sha256 'b01425014c25a3203bbd8cd0d051d28de2d96f512b0f68238712968f202813a9'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.