### PR TITLE
Update activedock to 189,1540061961

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '178,1536924717'
-  sha256 '1b4cfb4a1cff4322f3bdd4f604b6de68e794f4385d001b2ed8daf91e25519446'
+  version '189,1540061961'
+  sha256 'd0370888e8efa451ecec9ec4521755a583bcd0000f5c29bc73f80fd8b3630dd1'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.