### PR TITLE
Update graphicconverter to 10.6.6,3228

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,6 +1,6 @@
 cask 'graphicconverter' do
-  version '10.6.5,3200'
-  sha256 '052c0b15cc870481bdddab1d383d3457bf7fb4a670346952f9043b79e44e1a3d'
+  version '10.6.6,3228'
+  sha256 '4d13670be3b619706a2592ca5c232365c6add04e700d8bb4212c3d6d857eb48a'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.