### PR TITLE
Update horos to 3.3.1

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -6,8 +6,8 @@ cask 'horos' do
     version '2.0.2'
     sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
   else
-    version '3.3.0'
-    sha256 '6dfe7eb8c5d9a281519659876c4f9c9cb0bb7b0977c577eac17405fdb8ef6310'
+    version '3.3.1'
+    sha256 'b036fcd361c255f95ea8e28558a545b9df7a9e9eeeab7558d7e1c66a5dea3a7f'
   end
 
   url "https://horosproject.org/horos-content/Horos#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.