### PR TITLE
Update protege to 5.5.0-beta-4

### DIFF
--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -1,6 +1,6 @@
 cask 'protege' do
-  version '5.2.0'
-  sha256 'a6f1c06f8740489c51245683e50493d62b7b019ffc409c137eb511a8d1d140be'
+  version '5.5.0-beta-4'
+  sha256 '7ca43f07b6a6bc086e428bfe1e23d0a725177636a32ee41ca6f1b5bb2f36d9a0'
 
   # github.com/protegeproject/protege-distribution was verified as official when first introduced to the cask
   url "https://github.com/protegeproject/protege-distribution/releases/download/v#{version}/Protege-#{version}-os-x.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.