### PR TITLE
Update aerial to 1.4.3

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.4.2'
-  sha256 'b01425014c25a3203bbd8cd0d051d28de2d96f512b0f68238712968f202813a9'
+  version '1.4.3'
+  sha256 '0610317f10097367099d9ec8f1ac00b141275bb2576cfa84d80cc49c3c07e114'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.