### PR TITLE
Update simpholders to 3.0.2,2193

### DIFF
--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -1,8 +1,8 @@
 cask 'simpholders' do
-  version '2.2'
-  sha256 '0f12b0076f2bef08cd3129916a6fbe6f92bd7601a96bc787bfc0c5feda4b4d4a'
+  version '3.0.2,2193'
+  sha256 'dad98153c02153591d67b45af06021fe9481fbf6eba0f42e8cfb7b0ea9288583'
 
-  url "https://simpholders.com/site/assets/files/1968/simpholders_#{version.dots_to_underscores}.dmg"
+  url "https://simpholders.com/site/assets/files/#{version.after_comma}/simpholders_#{version.before_comma.dots_to_underscores}.dmg"
   appcast 'https://simpholders.com/releases/'
   name 'SimPholders'
   homepage 'https://simpholders.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.