### PR TITLE
Update geotag to 4.4.1

### DIFF
--- a/Casks/geotag.rb
+++ b/Casks/geotag.rb
@@ -1,13 +1,13 @@
 cask 'geotag' do
-  version '4.4'
-  sha256 '5ab97b2e09bab7386b5c66a8a389797a3f3b8e42dadde4863ad418695596efbe'
+  version '4.4.1'
+  sha256 'e87ac3a09ed5294117d22627067722bb6c774d32bba950cc279b4818c9226818'
 
   url "https://www.snafu.org/GeoTag/GeoTag-#{version}.dmg"
   appcast 'https://www.snafu.org/GeoTag/'
   name 'GeoTag'
   homepage 'https://www.snafu.org/GeoTag/'
 
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :sierra'
   depends_on formula: 'exiftool'
 
   app 'GeoTag.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.