### PR TITLE
Update google-chrome to 71.0.3578.20

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,5 +1,5 @@
 cask 'google-chrome' do
-  version '70.0.3538.67'
+  version '71.0.3578.20'
   sha256 '8ea5efb18326a8900b1ca53acfae46b40e6a4b2ba25b9c957db6c1ea59d50654'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.