### PR TITLE
zulu 11.2.3:11.0.1

### DIFF
--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -1,8 +1,8 @@
 cask 'zulu' do
-  version '11.2.3:11.0.1'
+  version '11.2.3,11.0.1'
   sha256 '5e2364ae8e1f4d81b2253de3d52dee5701f8f7c31160fac2d23b4f1c371cff2b'
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.before_colon}-jdk#{version.after_colon}-macosx_x64.dmg",
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-jdk#{version.after_comma}-macosx_x64.dmg",
       referer: 'https://www.azul.com/downloads/zulu/zulu-mac/'
   name 'Azul Zulu Java Standard Edition Development Kit'
   homepage 'https://www.azul.com/downloads/zulu/zulu-mac/'
@@ -11,10 +11,10 @@ cask 'zulu' do
 
   postflight do
     system_command '/bin/mv',
-                   args: ['-f', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.before_colon}.jdk"],
+                   args: ['-f', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.before_comma}.jdk"],
                    sudo: true
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.before_colon}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk"],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.before_comma}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk"],
                    sudo: true
     system_command '/bin/ln',
                    args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk/Contents/Home", '/Library/Java/Home'],
@@ -26,7 +26,7 @@ cask 'zulu' do
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}",
             delete:  [
-                       "/Library/Java/JavaVirtualMachines/zulu-#{version.before_colon}.jdk",
+                       "/Library/Java/JavaVirtualMachines/zulu-#{version.before_comma}.jdk",
                        "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk",
                        '/Library/Java/Home',
                      ]

--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -1,8 +1,8 @@
 cask 'zulu' do
-  version '10.3,5:10.0.2'
-  sha256 'dfc5a9cae3fbfb45d565bcd067829b7273704c976ff00a63794c9f9742fe4f76'
+  version '11.2.3:11.0.1'
+  sha256 '5e2364ae8e1f4d81b2253de3d52dee5701f8f7c31160fac2d23b4f1c371cff2b'
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}+#{version.after_comma.before_colon}-jdk#{version.after_colon}-macosx_x64.dmg",
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.before_colon}-jdk#{version.after_colon}-macosx_x64.dmg",
       referer: 'https://www.azul.com/downloads/zulu/zulu-mac/'
   name 'Azul Zulu Java Standard Edition Development Kit'
   homepage 'https://www.azul.com/downloads/zulu/zulu-mac/'
@@ -11,10 +11,10 @@ cask 'zulu' do
 
   postflight do
     system_command '/bin/mv',
-                   args: ['-f', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.before_comma}+#{version.after_comma.before_colon}.jdk"],
+                   args: ['-f', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.before_colon}.jdk"],
                    sudo: true
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.before_comma}+#{version.after_comma.before_colon}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk"],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.before_colon}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk"],
                    sudo: true
     system_command '/bin/ln',
                    args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk/Contents/Home", '/Library/Java/Home'],
@@ -26,7 +26,7 @@ cask 'zulu' do
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}",
             delete:  [
-                       "/Library/Java/JavaVirtualMachines/zulu-#{version.before_comma}+#{version.after_comma.before_colon}.jdk",
+                       "/Library/Java/JavaVirtualMachines/zulu-#{version.before_colon}.jdk",
                        "/Library/Java/JavaVirtualMachines/zulu-#{version.major}.jdk",
                        '/Library/Java/Home',
                      ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This version of the package doesn't include a `+` in the name, so I've removed the comma from the version and the URL. I kept the colon in the version for consistency with what the package did before and the other Zulu packages, and in case the `+` version comes back.