### PR TITLE
adoptopenjdk: add caveat pointing to the external tap

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -45,4 +45,11 @@ cask 'adoptopenjdk' do
   end
 
   uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+
+  caveats <<~EOS
+    More versions are available in the AdoptOpenJDK tap:
+      #{Formatter.url('https://github.com/AdoptOpenJDK/homebrew-openjdk')}
+
+      brew tap adoptopenjdk/openjdk
+  EOS
 end


### PR DESCRIPTION
cc @Homebrew/cask 

Ref: https://github.com/Homebrew/homebrew-cask/pull/53976#issuecomment-432023333, https://github.com/Homebrew/homebrew-cask/pull/53976#issuecomment-432271761

Upstream intends to have casks for a (current) minimum of 8 `adoptopenjdk` JDK versions + JRE versions.

This is more than we can or want to support.