### PR TITLE
Update barxtemp to 1.3.3

### DIFF
--- a/Casks/barxtemp.rb
+++ b/Casks/barxtemp.rb
@@ -1,6 +1,11 @@
 cask 'barxtemp' do
-  version '1.3.3'
-  sha256 '232286bc63a136ceca759addb6108a5b66d2b18d1db1df728c80296ec5847c65'
+  if MacOS.version <= :high_sierra
+    version '1.3.2'
+    sha256 '85c8347ab8e7cbc8e7cf639317f3ff5df75feb9420bf94596dcfa05ac5914d16'
+  else
+    version '1.3.3'
+    sha256 '232286bc63a136ceca759addb6108a5b66d2b18d1db1df728c80296ec5847c65'
+  end
 
   # github.com/Gabriele91/barXtemp was verified as official when first introduced to the cask
   url "https://github.com/Gabriele91/barXtemp/releases/download/#{version}/barXtemp.app.zip"
@@ -8,7 +13,7 @@ cask 'barxtemp' do
   name 'barXtemp'
   homepage 'https://gabriele91.github.io/barXtemp/'
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :yosemite'
 
   app 'barXtemp.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.