### PR TITLE
Update monero-wallet to 0.13.0.3

### DIFF
--- a/Casks/monero-wallet.rb
+++ b/Casks/monero-wallet.rb
@@ -1,6 +1,6 @@
 cask 'monero-wallet' do
-  version '0.12.3.0'
-  sha256 '90a9fa02e7bcef653b034f8a0365f16ec96cd553791546df2200a3c2591d5104'
+  version '0.13.0.3'
+  sha256 'c4da9847d65f5d1051522833c7518b7137cdcbb69399ec0aac4036371f293d29'
 
   url "https://downloads.getmonero.org/gui/monero-gui-mac-x64-v#{version}.tar.bz2"
   appcast 'https://github.com/monero-project/monero-gui/releases.atom'


### PR DESCRIPTION
Their github shows it as a pre-release but the [website shows this as the current release version](https://getmonero.org/downloads/#mac).  This is important because there was a [network upgrade October 18th](https://www.reddit.com/r/Monero/comments/9lcdme/), this older version will show an error and not properly connect to the network.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Apologies, this is my first contribution and I did not include the version in the commit message.  I will redo it if necessary.

While the github shows this as a pre-release, I feel like this should be an exception since the "stable" version no longer works correctly with the October 18th network update.