### PR TITLE
Update liteide to 35.1

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,9 +1,9 @@
 cask 'liteide' do
-  version '34.2,5.9.5'
-  sha256 '4cee36757151c41ab3299be32edba2542fce12dca7801946123d8fd9f082bdcc'
+  version '35.1'
+  sha256 'bb6b9623cb57ef1d92572cbc2cac858e5d2ff5032777752a97f094e041cab2cc'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
-  url "https://github.com/visualfc/liteide/releases/download/x#{version.before_comma}/liteidex#{version.before_comma}.macosx-qt#{version.after_comma}.zip"
+  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.9.5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom'
   name 'LiteIDE'
   homepage 'http://liteide.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.