### PR TITLE
Update mailspring to 1.5.0

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,6 +1,6 @@
 cask 'mailspring' do
-  version '1.4.2'
-  sha256 'ffdc14f82a50c168213809bbab1508de6ffabcca14105ff33e3b773d23ff0d76'
+  version '1.5.0'
+  sha256 '5e7922b9bb734c21387e5f4da54274b6bc7b814162df4bf2dca33c0e129bc192'
 
   # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
   url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.