### PR TITLE
Update ableton-live-intro to 10.0.5

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-intro' do
-  version '10.0.4'
-  sha256 'baacf60916938a7013ad567fa220263fb566e60d63d01d66defc38fd8481835b'
+  version '10.0.5'
+  sha256 '524d8aa918ad6f155a7a3c2352e49605e6e4ba6f4aa5171031e0e71c17a0ad51'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.