### PR TITLE
Update ableton-live-lite to 10.0.5

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '10.0.4'
-  sha256 'ec34a283cd1bfceeef9f631d0f0a136f05037a5b086a511a45eba8cf917aa652'
+  version '10.0.5'
+  sha256 '3afacecf373116337f4d48bc21b2ce720c11fa3925d47aa5ed83f1289aeb378a'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.