### PR TITLE
Update mindjet-mindmanager to 11.2.116

### DIFF
--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -1,6 +1,6 @@
 cask 'mindjet-mindmanager' do
-  version '11.2.111'
-  sha256 '68dc4bdd407d770d03d9e7bfc215a87f1ea49d555b2d34b80f370332859fdee6'
+  version '11.2.116'
+  sha256 '1226a9425d9ec6703516e78af7c406f1415624808e9f4afc06e14585f4ab4474'
 
   url "https://download.mindjet.com/Mac/Mindjet_MindManager_Mac_#{version}.dmg"
   name 'Mindjet Mindmanager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.