### PR TITLE
Update cacher to 1.6.13

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '1.6.11'
-  sha256 '8787ff8b0cacfdade89c72baab5d7652fde802d0e6eeadc52046dafa210c39ab'
+  version '1.6.13'
+  sha256 'cfcdf9d2da6b2bcdb04ea0afc4bf3b49efa5c888dd0282551b3343fe09754de3'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.