### PR TITLE
Update netron to 2.3.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.3.3'
-  sha256 '0993084698ff0ff41cb9418f4bceea6f1443ed4792ecbadabca6c5f792bc3cf8'
+  version '2.3.4'
+  sha256 '3cb6a5de9039bc07596b3f9d1ca9912101445c58066852fbfbc6373acbb6bd78'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.