### PR TITLE
added Deeper for Mojave v2.3.5

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -25,9 +25,12 @@ cask 'deeper' do
   elsif MacOS.version == :high_sierra
     version '2.3.3'
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
-  else
+  elsif MacOS.version == :mojave
     version '2.3.5'
-    sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
+    sha256 '8a8a6dec420ec7dd04eedec6400b5a2b40f4db60da628e817b61322761b91f08'
+  else
+    version '2.3.6'
+    sha256 '8a8a6dec420ec7dd04eedec6400b5a2b40f4db60da628e817b61322761b91f08'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -25,11 +25,8 @@ cask 'deeper' do
   elsif MacOS.version == :high_sierra
     version '2.3.3'
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
-  elsif MacOS.version == :mojave
-    version '2.3.5'
-    sha256 '8a8a6dec420ec7dd04eedec6400b5a2b40f4db60da628e817b61322761b91f08'
   else
-    version '2.3.6'
+    version '2.3.5'
     sha256 '8a8a6dec420ec7dd04eedec6400b5a2b40f4db60da628e817b61322761b91f08'
   end
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

