### PR TITLE
Update eaglefiler to 1.8.4

### DIFF
--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,18 +1,8 @@
 cask 'eaglefiler' do
-  if MacOS.version <= :leopard
-    version '1.5.10'
-    sha256 '809d2f5d4bf5898170e2884045250ba78cf6b111ab4814a95ae3786ae1f56d68'
-    url 'https://c-command.com/downloads/EagleFiler-1.5.10-tiger.dmg'
-  elsif MacOS.version <= :snow_leopard
-    version '1.8'
-    sha256 'c33eee9a919ca730f70dfe05f0ab88bb4173422d53f6efa5b2af21d62a286970'
-    url 'https://c-command.com/downloads/EagleFiler-1.8-snow-leopard.dmg'
-  else
-    version '1.8.4'
-    sha256 '7933b9f74f5917ac2e0f59d7f81dead4c2131c298ac1faefa831b21fd52a768b'
-    url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
-  end
+  version '1.8.4'
+  sha256 '7933b9f74f5917ac2e0f59d7f81dead4c2131c298ac1faefa831b21fd52a768b'
 
+  url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   appcast 'https://c-command.com/eaglefiler/help/version-history'
   name 'EagleFiler'
   homepage 'https://c-command.com/eaglefiler/'

--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,8 +1,19 @@
 cask 'eaglefiler' do
-  version '1.8.4'
-  sha256 '7933b9f74f5917ac2e0f59d7f81dead4c2131c298ac1faefa831b21fd52a768b'
+  if MacOS.version <= :leopard
+    version '1.5.10'
+    sha256 '809d2f5d4bf5898170e2884045250ba78cf6b111ab4814a95ae3786ae1f56d68'
+    url 'https://c-command.com/downloads/EagleFiler-1.5.10-tiger.dmg'
+  elsif MacOS.version <= :snow_leopard
+    version '1.8'
+    sha256 'c33eee9a919ca730f70dfe05f0ab88bb4173422d53f6efa5b2af21d62a286970'
+    url 'https://c-command.com/downloads/EagleFiler-1.8-snow-leopard.dmg'
+  else
+    version '1.8.4'
+    sha256 '7933b9f74f5917ac2e0f59d7f81dead4c2131c298ac1faefa831b21fd52a768b'
+    url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
+  end
 
-  url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
+  appcast 'https://c-command.com/eaglefiler/help/version-history'
   name 'EagleFiler'
   homepage 'https://c-command.com/eaglefiler/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

added macOS version-dependent version numbers and appcast