### PR TITLE
Update qownnotes to 18.10.5,b3893-154658

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.10.4,b3884-075416'
-  sha256 '1a12adb29bc0e1ffa4fad556d9126f8a92815bb18fe2494c81ee49ea15cc0554'
+  version '18.10.5,b3893-154658'
+  sha256 'c742d7ef98ba489ffeac7df422dbc4a6c9cba5ce14d17136917e026baff7430f'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.