### PR TITLE
Update surge to 3.0.2-736

### DIFF
--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -1,10 +1,11 @@
 cask 'surge' do
-  version :latest
-  sha256 :no_check
+  version '3.0.2-736'
+  sha256 'ac4b66af29120354dace6ce6c3b78346b10081bc42ae7873095406cbfbfc462b'
 
-  url 'https://nssurge.com/mac/v3/Surge-latest.zip'
+  url "https://www.nssurge.com/mac/v#{version.major}/Surge-#{version}.zip"
+  appcast "https://www.nssurge.com/mac/v#{version.major}/appcast.xml"
   name 'Surge'
   homepage 'https://nssurge.com/'
 
-  app 'Surge 3.app'
+  app "Surge #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.