### PR TITLE
Update brave-browser to 0.55.20

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -4,7 +4,7 @@ cask 'brave-browser' do
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"
-  appcast 'https://github.com/brave/brave-browser/releases.atom'
+  appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml'
   name 'Brave'
   homepage 'https://brave.com/'
 

--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.55.18'
-  sha256 '6991ff0aceb1826505e1c5cf98b2b45b12b51b149c73bbf7fb329bdbf9d83414'
+  version '0.55.20'
+  sha256 'a922197e96d4a4a499a708f48757a60db7ff750ca358922aec83185fd5eb4bc2'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.