### PR TITLE
Update netron to 2.3.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.3.4'
-  sha256 '3cb6a5de9039bc07596b3f9d1ca9912101445c58066852fbfbc6373acbb6bd78'
+  version '2.3.5'
+  sha256 '5255c7124252321449164d7be635564d092803c07d76eadde75a141e0b47dadf'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.