### PR TITLE
The gfortran package has been moved to a new URL

### DIFF
--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -4,14 +4,14 @@ cask 'gfortran' do
     sha256 'eb817bce64bf9032595e09166bdaaf740c83bf7258f900b79cd6786437bacbf4'
 
     # coudert.name/software was verified as official when first introduced to the cask
-    url "http://coudert.name/software/gfortran-#{version}-ElCapitan.dmg"
+    url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-ElCapitan.dmg"
     pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
   else
     version '6.3'
     sha256 '38b81bc878dba41cfdbb0c335aec5a97554a5d1766fb3e3ca6be7da0df9e8e09'
 
     # coudert.name/software was verified as official when first introduced to the cask
-    url "http://coudert.name/software/gfortran-#{version}-Sierra.dmg"
+    url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-Sierra.dmg"
     pkg 'gfortran.pkg'
   end
 

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -17,6 +17,7 @@ cask 'gfortran' do
 
   name 'gfortran'
   homepage 'https://gcc.gnu.org/wiki/GFortranBinaries'
+  appcast 'https://github.com/fxcoudert/gfortran-for-macOS/releases.atom'
 
   conflicts_with formula: 'gcc'
   depends_on macos: '>= :el_capitan'

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -3,14 +3,14 @@ cask 'gfortran' do
     version '6.1'
     sha256 'eb817bce64bf9032595e09166bdaaf740c83bf7258f900b79cd6786437bacbf4'
 
-    # coudert.name/software was verified as official when first introduced to the cask
+    # github.com/fxcoudert/gfortran-for-macOS was verified as official when first introduced to the cask
     url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-ElCapitan.dmg"
     pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
   else
     version '6.3'
     sha256 '38b81bc878dba41cfdbb0c335aec5a97554a5d1766fb3e3ca6be7da0df9e8e09'
 
-    # coudert.name/software was verified as official when first introduced to the cask
+    # github.com/fxcoudert/gfortran-for-macOS was verified as official when first introduced to the cask
     url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-Sierra.dmg"
     pkg 'gfortran.pkg'
   end

--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -15,9 +15,9 @@ cask 'gfortran' do
     pkg 'gfortran.pkg'
   end
 
+  appcast 'https://github.com/fxcoudert/gfortran-for-macOS/releases.atom'
   name 'gfortran'
   homepage 'https://gcc.gnu.org/wiki/GFortranBinaries'
-  appcast 'https://github.com/fxcoudert/gfortran-for-macOS/releases.atom'
 
   conflicts_with formula: 'gcc'
   depends_on macos: '>= :el_capitan'


### PR DESCRIPTION
See https://www.coudert.name/software.html. The original url will 404, e.g. http://coudert.name/software/gfortran-6.3-Sierra.dmg

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version. (_I'm not changing the version of gfortran_)
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).