### PR TITLE
Update mqttfx to 1.7.1

### DIFF
--- a/Casks/mqttfx.rb
+++ b/Casks/mqttfx.rb
@@ -1,6 +1,6 @@
 cask 'mqttfx' do
-  version '1.7.0'
-  sha256 'b0f3c044ed695d270f46b805a634047faa3540bfa39e35492435aff746905a6f'
+  version '1.7.1'
+  sha256 '544b6ac0afefb80b5a56c2a6f2411f999862fb8f0f20502c912f28a9d1aa3b4a'
 
   # jensd.de/apps/mqttfx was verified as official when first introduced to the cask
   url "https://www.jensd.de/apps/mqttfx/#{version}/mqttfx-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.