### PR TITLE
Update vuescan to 9.6.20

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,8 +1,8 @@
 cask 'vuescan' do
-  version '9.6'
+  version '9.6.20'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://www.hamrick.com/files/vuex64#{version.no_dots}.dmg"
+  url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'
   name 'VueScan'
   homepage 'https://www.hamrick.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.