### PR TITLE
Update filezilla to 3.38.0

### DIFF
--- a/Casks/filezilla.rb
+++ b/Casks/filezilla.rb
@@ -1,6 +1,6 @@
 cask 'filezilla' do
-  version '3.37.4'
-  sha256 'bc2c4ba4959beb61a7a19496fbc0510c76c0d6c0e76cf5d276e865cec39e2c11'
+  version '3.38.0'
+  sha256 'aa11893fc66e06f7bb3f4e735ece572d052cba363e129a8898030c98e46e8b14'
 
   url "https://download.filezilla-project.org/client/FileZilla_#{version}_macosx-x86.app.tar.bz2"
   appcast 'https://filezilla-project.org/versions.php?type=client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).