### PR TITLE
Update manager to 18.10.87

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.84'
-  sha256 '1f384396907d11a6d88f300aeac2b8260cb98a809094f90794939bb75fa93d3b'
+  version '18.10.88'
+  sha256 'f8ee398f509e9944d7da8d13b108db419173a94ddebbbc732598349270d19b0e'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.