### PR TITLE
Version update homebrew cask packetsender to 5.8.6

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,9 +1,9 @@
 cask 'packetsender' do
-  version '5.7.52'
-  sha256 'abd6a9994c35207918749b642ea743356083454c059c3774c23ce4e37f36d5cd'
+  version '5.8.6'
+  sha256 '3dc8514d9bf0dd4957fab5f852b76d9b56703090d7a724c7f765db67c1c458fb'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
-  url "https://github.com/dannagle/PacketSender/releases/download/v#{version}/PacketSender_v#{version}.dmg"
+  url "https://github.com/dannagle/PacketSender/releases/download/v5.8.5/PacketSender_v#{version}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'


### PR DESCRIPTION
Note the url is correct. The git tag says v5.8.5 though the mac version is v5.8.6 higher (minor mojave prob was found during release testing). 

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

