### PR TITLE
Update quicken to 5.8.2,58.24609.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.8.0,58.24400.100'
-  sha256 'c4c183d015583ecbb3e93cc7e2c419f80c5e8adde2d6bc82f307a2791de4ef35'
+  version '5.8.2,58.24609.100'
+  sha256 '5a8983206e311cccd35a6d87517137464ff4dda8dd4df806f1e104cb1c0e1901'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.