### PR TITLE
Fix depends_on, uninstall and zap stanzas in ibm-cloud-cli v0.10.1.

### DIFF
--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -9,6 +9,12 @@ cask 'ibm-cloud-cli' do
   name 'IBM Cloud CLI'
   homepage 'https://clis.ng.bluemix.net/ui/home.html'
 
+  # depends_on, uninstall and zap are based on the idt-installer script found at:
+  # https://github.com/IBM-Cloud/ibm-cloud-developer-tools/blob/334ec5c/linux-installer/idt-installer
+  depends_on cask: 'docker'
+  depends_on formula: 'kubectl'
+  depends_on formula: 'kubernetes-helm'
+
   pkg "IBM_Cloud_CLI_#{version}.pkg"
 
   uninstall_postflight do
@@ -49,10 +55,16 @@ cask 'ibm-cloud-cli' do
 
   uninstall pkgutil: 'com.ibm.cloud.cli',
             delete:  [
-                       '/usr/local/Bluemix',
                        '/usr/local/bin/bluemix',
+                       '/usr/local/bin/bx',
                        '/usr/local/bin/bluemix-analytics',
+                       '/usr/local/Bluemix',
                      ]
+
+  zap trash: [
+               '~/.bluemix',
+               '/usr/local/ibmcloud',
+             ]
 
   caveats do
     files_in_usr_local

--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -9,8 +9,6 @@ cask 'ibm-cloud-cli' do
   name 'IBM Cloud CLI'
   homepage 'https://clis.ng.bluemix.net/ui/home.html'
 
-  # depends_on, uninstall and zap are based on the idt-installer script found at:
-  # https://github.com/IBM-Cloud/ibm-cloud-developer-tools/blob/334ec5c/linux-installer/idt-installer
   depends_on cask: 'docker'
   depends_on formula: 'kubectl'
   depends_on formula: 'kubernetes-helm'
@@ -59,12 +57,10 @@ cask 'ibm-cloud-cli' do
                        '/usr/local/bin/bx',
                        '/usr/local/bin/bluemix-analytics',
                        '/usr/local/Bluemix',
+                       '/usr/local/ibmcloud',
                      ]
 
-  zap trash: [
-               '~/.bluemix',
-               '/usr/local/ibmcloud',
-             ]
+  zap trash: '~/.bluemix'
 
   caveats do
     files_in_usr_local


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Is it possible to add a flag (or something similar) to this cask to install plugins?
The IBM Cloud Developer Tools installer (found [here](https://github.com/IBM-Cloud/ibm-cloud-developer-tools/blob/master/linux-installer/idt-installer)) installs various plugins on top of the pkg.
A separate cask might be overkill for that purpose.