### PR TITLE
Update onedrive to 18.172.0826.0013

### DIFF
--- a/Casks/onedrive.rb
+++ b/Casks/onedrive.rb
@@ -1,6 +1,6 @@
 cask 'onedrive' do
-  version '18.151.0729.0014'
-  sha256 '4ceda67aa004b2cf6c36494bda8a187a465a6f8140a057209419aae7e9c2c65e'
+  version '18.172.0826.0013'
+  sha256 'f490ef51f9f080c5562be6100c494babe6a83e2030a9dca4f59b8d705b52f8eb'
 
   # oneclient.sfx.ms/Mac/Direct was verified as official when first introduced to the cask
   url "https://oneclient.sfx.ms/Mac/Direct/#{version}/OneDrive.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.