### PR TITLE
Update virtualhostx to 8.3.4,80_40

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.1.1,80_34'
-  sha256 '0a9f99f85118f1ce3f0192004b6524e7a3e62b88de3061d3969c1b94062ed84d'
+  version '8.3.4,80_40'
+  sha256 '27d1a3de664d3aeb85f4dd7938712a4c2ab23d1ab181f40e980b65d641d248f7'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.