### PR TITLE
Update gisto to 1.10.12

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.11'
-  sha256 '900831490d8486e2870e8e6a5a10d4b0bb374176930a65a5da08bfe3316446ef'
+  version '1.10.12'
+  sha256 '12917b25ae9e1298d703f1a3e6e2a51d8671fcd3f2def4dd216108a312572a2f'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.