### PR TITLE
Update signal to 1.17.2

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.17.1'
-  sha256 '9921c93b2aa2fea9acc77a232ac6fb6378cca3aad2700e2c9df2a81e457db088'
+  version '1.17.2'
+  sha256 'd1cfd312605abca5a0965f225a32c3a39fbcb66b7114932439b06c2f12ca2fe5'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.