### PR TITLE
Update iterm2 to 3.2.5

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.4'
-  sha256 '584274f5ba3d3660931fe7a1e1d9169a2a708d36aa5cb4c79dd41bce4dcff101'
+  version '3.2.5'
+  sha256 'ec1ee603de1f8665d67781df98857c7feeb72461729f7cab2fabcecc19cf7268'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.