### PR TITLE
Update teamdrive to 4.6.4.2182

### DIFF
--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -1,19 +1,19 @@
 cask 'teamdrive' do
-  version '4.5.5.1833'
-  sha256 '908ac820af13010111057b8e3a8d6811307296ecc09b9c90becb50e8a71feecf'
+  version '4.6.4.2182'
+  sha256 'd210193bdc0e8dc0f060a4414a2dec1f0048de2f99c52b91b1a782c04e2fde19'
 
   # s3download.teamdrive.net.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.10.5/Install-TeamDrive-#{version}_TMDR.dmg"
+  url "http://s3download.teamdrive.net.s3.amazonaws.com/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.13.4/Install-TeamDrive-#{version}_TMDR.dmg"
   name 'TeamDrive'
   homepage 'https://www.teamdrive.com/'
 
   installer script: {
-                      executable: "Install-TeamDrive-#{version}_TMDR.app/Contents/MacOS/osx-intel",
+                      executable: "Install-TeamDrive-#{version}_TMDR.app/Contents/MacOS/osx-x86_64",
                       args:       ['--unattendedmodeui', 'none', '--mode', 'unattended'],
                     }
 
   uninstall script: {
-                      executable: '/Applications/TeamDrive/uninstall.app/Contents/MacOS/osx-intel',
+                      executable: '/Applications/TeamDrive/uninstall.app/Contents/MacOS/osx-x86_64',
                       args:       ['--mode', 'unattended'],
                     },
             signal: [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Note: Even though the url contains now "mac-10.13.4" the [page](https://www.teamdrive.com/en/download/) still claims compatibility with Mac OS X 10.10+