### PR TITLE
Update mudlet to 3.14.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '3.14.0'
-  sha256 'f9f7423a80cfa69f0b280ec5a137358ac170112122f4e8661ef8249ad9edae7d'
+  version '3.14.1'
+  sha256 'dedd4d63067e5f343a5ef3072d773e28ad8cd32913b6d18d9bf6b199270c275f'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.