### PR TITLE
Update scrutiny to 8.1.16

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.1.15'
-  sha256 '9d2dff90df2ab410e180e0173079046a2c15d0caca1332e06f590f18bbece2c2'
+  version '8.1.16'
+  sha256 '5b91057d1ea8b622d02b61be86dcf6467b6e615ae763b77fffa424f798bc7481'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.