### PR TITLE
Update splice to 3.3.8

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,6 +1,6 @@
 cask 'splice' do
-  version '3.3.7'
-  sha256 '95bb9ac207fa3e0126ffbf04cdc01dc137661619c9e3796dc0669825e7ae4e2a'
+  version '3.3.8'
+  sha256 'a679d155caf1b3630f882b9c739f91e4ec37be860ab358ab2b327333650ee663'
 
   # splicedesktop.s3-us-west-1.amazonaws.com was verified as official when first introduced to the cask
   url 'https://splicedesktop.s3-us-west-1.amazonaws.com/darwin/stable/Splice.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.