### PR TITLE
Update droplr to 5.5.2,224

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -7,6 +7,7 @@ cask 'droplr' do
   homepage 'https://droplr.com/'
 
   auto_updates true
+  depends_on macos: '>= :sierra'
 
   app 'Droplr.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.