### PR TITLE
Update activedock to 190,1540738589

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,12 +1,14 @@
 cask 'activedock' do
-  version '189,1540061961'
-  sha256 'd0370888e8efa451ecec9ec4521755a583bcd0000f5c29bc73f80fd8b3630dd1'
+  version '190,1540738589'
+  sha256 'acf8a9c9712c01e6d7ec30406a80c83085ad364160729242816263186788147c'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"
   appcast 'https://updates.devmate.com/com.sergey-gerasimenko.ActiveDock.xml'
   name 'ActiveDock'
   homepage 'https://www.noteifyapp.com/activedock/'
+
+  depends_on macos: '>= :sierra'
 
   app 'ActiveDock.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.