### PR TITLE
Update recents to 2.0.1,4624

### DIFF
--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -1,19 +1,15 @@
 cask 'recents' do
-if MacOS.version <= :sierra
-  version '1.9.6,1544'
-  sha256 '85abaa9daddc1d6ed8c487f9ba8d4d995a0ef49320ffb016c329076f30c5b933'
-  # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/2799?format=zip'
-else
   version '2.0.1,4624'
   sha256 'f1994d1b047079b55dd4a076d4fb08c047eeae1363de32b67ef66ce3e2d8f369'
+  
   # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"
-end 
 
   appcast 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b'
   name 'Recents'
   homepage 'http://recentsapp.com/'
-
+  
+  depends_on macos: '>= :high_sierra'
+  
   app 'Recents.app'
 end

--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -1,15 +1,14 @@
 cask 'recents' do
   version '2.0.1,4624'
   sha256 'f1994d1b047079b55dd4a076d4fb08c047eeae1363de32b67ef66ce3e2d8f369'
-  
+
   # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"
-
   appcast 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b'
   name 'Recents'
   homepage 'http://recentsapp.com/'
-  
+
   depends_on macos: '>= :high_sierra'
-  
+
   app 'Recents.app'
 end

--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -1,14 +1,19 @@
 cask 'recents' do
+if MacOS.version <= :sierra
+  version '1.9.6,1544'
+  sha256 '85abaa9daddc1d6ed8c487f9ba8d4d995a0ef49320ffb016c329076f30c5b933'
+  # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
+  url 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/2799?format=zip'
+else
   version '2.0.1,4624'
   sha256 'f1994d1b047079b55dd4a076d4fb08c047eeae1363de32b67ef66ce3e2d8f369'
-
   # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"
+end 
+
   appcast 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b'
   name 'Recents'
   homepage 'http://recentsapp.com/'
-
-  depends_on macos: '>= :high_sierra'
 
   app 'Recents.app'
 end

--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -8,5 +8,7 @@ cask 'recents' do
   name 'Recents'
   homepage 'http://recentsapp.com/'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'Recents.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.