### PR TITLE
Update sourcetree to 3.0_200

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -1,15 +1,21 @@
 cask 'sourcetree' do
+if MacOS.version <= :sierra
+  version '2.7.6'
+  sha256 'd60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e'
+  # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
+  url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}a.zip"
+else
   version '3.0_200'
   sha256 'ec5962fb17edcd4d67c6c486b3cdb7dcfe7ddc38c089f726cb9a7b1d0eff2d78'
-
-  # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
+    # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
   url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"
+end 
+
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastGroup1.xml'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 
   auto_updates true
-  depends_on macos: '>= :high_sierra'
 
   app 'Sourcetree.app'
   binary "#{appdir}/Sourcetree.app/Contents/Resources/stree"

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -7,7 +7,7 @@ if MacOS.version <= :sierra
 else
   version '3.0_200'
   sha256 'ec5962fb17edcd4d67c6c486b3cdb7dcfe7ddc38c089f726cb9a7b1d0eff2d78'
-    # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
+  # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
   url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"
 end 
 

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -1,21 +1,24 @@
 cask 'sourcetree' do
-if MacOS.version <= :sierra
-  version '2.7.6'
-  sha256 'd60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e'
-  # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
-  url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}a.zip"
-else
-  version '3.0_200'
-  sha256 'ec5962fb17edcd4d67c6c486b3cdb7dcfe7ddc38c089f726cb9a7b1d0eff2d78'
-  # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
-  url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"
-end 
+  if MacOS.version <= :sierra
+    version '2.7.6a'
+    sha256 'd60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e'
+
+    # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
+    url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
+  else
+    version '3.0_200'
+    sha256 'ec5962fb17edcd4d67c6c486b3cdb7dcfe7ddc38c089f726cb9a7b1d0eff2d78'
+
+    # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
+    url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"
+  end
 
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastGroup1.xml'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 
   auto_updates true
+  depends_on macos: '>= :el_capitan'
 
   app 'Sourcetree.app'
   binary "#{appdir}/Sourcetree.app/Contents/Resources/stree"

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -9,6 +9,7 @@ cask 'sourcetree' do
   homepage 'https://www.sourcetreeapp.com/'
 
   auto_updates true
+  depends_on macos: '>= :high_sierra'
 
   app 'Sourcetree.app'
   binary "#{appdir}/Sourcetree.app/Contents/Resources/stree"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.