### PR TITLE
Update printnode to 4.19.0

### DIFF
--- a/Casks/printnode.rb
+++ b/Casks/printnode.rb
@@ -2,7 +2,7 @@ cask 'printnode' do
   version '4.19.0'
   sha256 'b9a5903168832858afbda81453c58c40920762bb1003c2520e2299a35a2d64e6'
 
-  url "https://app.printnode.com/bundles/printnodemain/downloads/printnode/#{version}/PrintNode-#{version}.dmg"
+  url "https://dl.printnode.com/client/printnode/#{version}/PrintNode-#{version}.dmg"
   appcast 'https://www.printnode.com/download'
   name 'PrintNode'
   homepage 'https://www.printnode.com/'

--- a/Casks/printnode.rb
+++ b/Casks/printnode.rb
@@ -1,6 +1,6 @@
 cask 'printnode' do
   version '4.19.0'
-  sha256 'b9a5903168832858afbda81453c58c40920762bb1003c2520e2299a35a2d64e6'
+  sha256 '2fd9cebf22dfc33bb49f39a82e363ea94626cfa2791b833026944f9809879805'
 
   url "https://dl.printnode.com/client/printnode/#{version}/PrintNode-#{version}.dmg"
   appcast 'https://www.printnode.com/download'

--- a/Casks/printnode.rb
+++ b/Casks/printnode.rb
@@ -1,8 +1,9 @@
 cask 'printnode' do
-  version '4.18.6'
-  sha256 '69470c0dcbcd13cd000e934a84e4ef1812b82cc37c067de61cfa5cec196e47dd'
+  version '4.19.0'
+  sha256 'b9a5903168832858afbda81453c58c40920762bb1003c2520e2299a35a2d64e6'
 
   url "https://app.printnode.com/bundles/printnodemain/downloads/printnode/#{version}/PrintNode-#{version}.dmg"
+  appcast 'https://www.printnode.com/download'
   name 'PrintNode'
   homepage 'https://www.printnode.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.