### PR TITLE
Update spamsieve to 2.9.34

### DIFF
--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -1,8 +1,9 @@
 cask 'spamsieve' do
-  version '2.9.33'
-  sha256 '709b65bbc3b825885bc8f9fe1e43b62f43f8a24d3604e586e95e903647470b40'
+  version '2.9.34'
+  sha256 '72a209bb0b09bacf6190b086116e838ad27a5fa4996887ee5e2dee5d8cbb59d6'
 
   url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
+  appcast 'https://c-command.com/spamsieve/'
   name 'SpamSieve'
   homepage 'https://c-command.com/spamsieve/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.