### PR TITLE
Update stereo-tool to 9.11

### DIFF
--- a/Casks/stereo-tool.rb
+++ b/Casks/stereo-tool.rb
@@ -1,6 +1,6 @@
 cask 'stereo-tool' do
-  version '9.02'
-  sha256 '06a469887634b3969d5774f51c1f3598f4772450dfcc9bfb15581d7eafdb4047'
+  version '9.11'
+  sha256 '707e4466f97db8b3a39ac39d80c3bb6cb40782e0f7e241c19027fdbdb28e95da'
 
   url 'https://www.stereotool.com/download/stereo_tool.zip'
   appcast 'https://www.stereotool.com/documentation/8.50/version_history/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.