### PR TITLE
Update subutaicontrolcenter to 7.2.2

### DIFF
--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -2,7 +2,6 @@ cask 'subutaicontrolcenter' do
   version '7.2.2'
   sha256 'd0c0801ed6978cfb5ed8a20d0cafdf73cc066589306781be5bfe05c56bcd2d2a'
 
-  # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://bazaar.subutai.io/rest/v1/cdn/raw?name=subutai-control-center.pkg&latest&download'
   appcast 'https://github.com/subutai-io/control-center/releases.atom'
   name 'Subutai Control Center'

--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -1,9 +1,9 @@
 cask 'subutaicontrolcenter' do
-  version '7.1.5'
-  sha256 '17e043558ea478fdab9b6b497a76412bbe58fb97efd43fabf0e894e74e6bdf97'
+  version '7.2.2'
+  sha256 'd0c0801ed6978cfb5ed8a20d0cafdf73cc066589306781be5bfe05c56bcd2d2a'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
-  url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-control-center.pkg'
+  url 'https://bazaar.subutai.io/rest/v1/cdn/raw?name=subutai-control-center.pkg&latest&download'
   appcast 'https://github.com/subutai-io/control-center/releases.atom'
   name 'Subutai Control Center'
   homepage 'https://subutai.io/'

--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -12,12 +12,6 @@ cask 'subutaicontrolcenter' do
 
   pkg 'subutai-control-center.pkg'
 
-  # This is a horrible hack to force the file extension.
-  # The backend code should be fixed so that this is not needed.
-  preflight do
-    system_command '/bin/mv', args: ['--', staged_path.join('get'), staged_path.join('subutai-control-center.pkg')]
-  end
-
   uninstall pkgutil: 'com.Subutai.Control.Center',
             delete:  '/Applications/SubutaiControlCenter.app'
 end

--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -12,6 +12,12 @@ cask 'subutaicontrolcenter' do
 
   pkg 'subutai-control-center.pkg'
 
+  # This is a horrible hack to force the file extension.
+  # The backend code should be fixed so that this is not needed.
+  preflight do
+    system_command '/bin/mv', args: ['--', staged_path.join('get'), staged_path.join('subutai-control-center.pkg')]
+  end
+
   uninstall pkgutil: 'com.Subutai.Control.Center',
             delete:  '/Applications/SubutaiControlCenter.app'
 end

--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -16,7 +16,7 @@ cask 'subutaicontrolcenter' do
   preflight do
     system_command '/bin/mv', args: ['--', staged_path.join('raw'), staged_path.join('subutai-control-center.pkg')]
   end
-  
+
   uninstall pkgutil: 'com.Subutai.Control.Center',
             delete:  '/Applications/SubutaiControlCenter.app'
 end

--- a/Casks/subutaicontrolcenter.rb
+++ b/Casks/subutaicontrolcenter.rb
@@ -11,6 +11,12 @@ cask 'subutaicontrolcenter' do
 
   pkg 'subutai-control-center.pkg'
 
+  # This is a horrible hack to force the file extension.
+  # The backend code should be fixed so that this is not needed.
+  preflight do
+    system_command '/bin/mv', args: ['--', staged_path.join('raw'), staged_path.join('subutai-control-center.pkg')]
+  end
+  
   uninstall pkgutil: 'com.Subutai.Control.Center',
             delete:  '/Applications/SubutaiControlCenter.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.