### PR TITLE
Update subutaip2p to 8.0.1

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -1,9 +1,9 @@
 cask 'subutaip2p' do
-  version '8.0'
-  sha256 '3d9b6c5585496c3b81592c81e6cb770fc7299e2641db24c511bb343939d152fb'
+  version '8.0.1'
+  sha256 '39a1810c94668e6063ae8048df08120703e0590271905dc653aeaa84226615ad'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
-  url 'https://cdn.subutai.io:8338/kurjun/rest/raw/get?name=subutai-p2p.pkg'
+  url 'https://bazaar.subutai.io/rest/v1/cdn/raw?name=subutai-p2p.pkg&latest&download'
   appcast 'https://github.com/subutai-io/p2p/releases.atom'
   name 'Subutai P2P'
   homepage 'https://subutai.io/'

--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -15,7 +15,7 @@ cask 'subutaip2p' do
   # This is a horrible hack to force the file extension.
   # The backend code should be fixed so that this is not needed.
   preflight do
-    system_command '/bin/mv', args: ['--', staged_path.join('get'), staged_path.join('subutai-p2p.pkg')]
+    system_command '/bin/mv', args: ['--', staged_path.join('raw'), staged_path.join('subutai-p2p.pkg')]
   end
 
   uninstall pkgutil:   [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.