### PR TITLE
Update pascom-client to 42.R34_99e005c

### DIFF
--- a/Casks/pascom-client.rb
+++ b/Casks/pascom-client.rb
@@ -1,6 +1,6 @@
 cask 'pascom-client' do
-  version '7.18.00.R'
-  sha256 'd7ba387aeae826c5e7c229cdf272ec623a8e16ab9dfb22dbf4256888558b98cb'
+  version '42.R34_99e005c'
+  sha256 '5c5df293b5d6229f1404d1fae083faf141498c6f0159342dc7c4d9b723ee5afd'
 
   url "https://download.pascom.net/release-archive/client/stable/pascom%20Client-#{version}.dmg"
   name 'pascom Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.