### PR TITLE
Update zoc to 7.21.2

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.21.1'
-  sha256 '596dc212ada220e51a6bc0142c2b2abb0eff1655bbc8a72a34e0e9debae89012'
+  version '7.21.2'
+  sha256 'a3adb6f9491ce22478ed2e5a6c4e605a47e6662c440677ee6b84fcce81eecf24'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.