### PR TITLE
Update clockify to 2.1.6_35

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
   version '2.1.6_35'
-  sha256 'adf4e56de1b57664b6045cd157032b0a07c7b9836273e6689632851b0f6c92fc'
+  sha256 '528cb1676f74beee35b0d9f3d138875203be1740d4874a5f482df691ac70f77d'
 
   url "https://clockify.me/downloads/ClockifyDesktop_#{version.no_dots}.zip"
   name 'Clockify'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.