### PR TITLE
Update lehreroffice to 2018.15.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '18.14.4'
-  sha256 'ff84a8884246ce34ec1b537e168241fa191a6fb9667eae28189a296b07f47e05'
+  version '2018.15.0'
+  sha256 'e976138b1817bf0345c30c245e812312f3a8900760948ec65828744301577d73'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.