### PR TITLE
Update faw-circle to 2.2.0-RC1

### DIFF
--- a/Casks/faw-circle.rb
+++ b/Casks/faw-circle.rb
@@ -1,8 +1,8 @@
 cask 'faw-circle' do
-  version '2.1.0-RC3'
-  sha256 '8d5cbcddb79f05c5bc463889fada3fac773d277d4fb246beb1a38181ad751e93'
+  version '2.2.0-RC1'
+  sha256 '249fb0456845f21bc858df5ac50e4810df60ce1f3bef43ffd0d5acb20f496e8a'
 
-  url "https://futureaudioworkshop.com/downloads/Circle-#{version}-setup.dmg"
+  url "https://futureaudioworkshop.com/wp-content/uploads/2018/10/Circle-#{version}-setup-macOS.zip"
   name 'FAW Circle'
   homepage 'https://futureaudioworkshop.com/circle/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.