### PR TITLE
Update authy to 1.7.0

### DIFF
--- a/Casks/authy.rb
+++ b/Casks/authy.rb
@@ -1,6 +1,6 @@
 cask 'authy' do
-  version '1.6.0'
-  sha256 'd8d4fe46e0e3cf39c3296e0c97d626cdfebc4be5e8eb141c1bca14e8eaf2cfb5'
+  version '1.7.0'
+  sha256 '299dbd31fe5ae65891b4fc04c3e87e41fc5fbdfb0b63b1c5fb33d60ace815fef'
 
   # s3.amazonaws.com/authy-electron-repository-production was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/#{version}/darwin/x64/Authy%20Desktop-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.