### PR TITLE
Update omniweb to 5.11.2

### DIFF
--- a/Casks/omniweb.rb
+++ b/Casks/omniweb.rb
@@ -3,6 +3,7 @@ cask 'omniweb' do
   sha256 'f1179f1dcf96ed7b2732a18049c79c4043131b267deabb06b5a10c19f1ce750f'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.4/OmniWeb-#{version}.dmg"
+  appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniWeb#{version.major}"
   name 'OmniWeb'
   homepage 'https://www.omnigroup.com/more/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.