### PR TITLE
Update prezi-classic to 6.14.0

### DIFF
--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -1,6 +1,6 @@
 cask 'prezi-classic' do
-  version '6.13.1'
-  sha256 '9870c55a6e7f9d6163bb45e8a4eadb39192319219638941b08a9eb10841750fb'
+  version '6.14.0'
+  sha256 'ed9cc68796e4a055fa01cd28ab593370b6f4d87a937237e2f23f7fba9c70f332'
 
   url "https://desktopassets.prezi.com/mac/pd6/releases/Prezi_Classic_#{version}.dmg"
   name 'Prezi Classic'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.