### PR TITLE
Change adobe-acrobat-reader to use https

### DIFF
--- a/Casks/adobe-acrobat-reader.rb
+++ b/Casks/adobe-acrobat-reader.rb
@@ -2,7 +2,7 @@ cask 'adobe-acrobat-reader' do
   version '19.008.20071'
   sha256 '32bf967bfb96ec994623c9f914efb2a1fedd1e903aecc871e1e6a7998a74c18b'
 
-  url "http://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.no_dots}/AcroRdrDC_#{version.no_dots}_MUI.dmg"
+  url "https://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.no_dots}/AcroRdrDC_#{version.no_dots}_MUI.dmg"
   appcast 'https://get.adobe.com/reader/'
   name 'Adobe Acrobat Reader DC'
   homepage 'https://acrobat.adobe.com/us/en/acrobat/pdf-reader.html'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Switched download to use https over http for security reasons