### PR TITLE
Update textmate to 2.0-rc.13

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,6 +1,6 @@
 cask 'textmate' do
-  version '2.0-rc.10'
-  sha256 'b8058fd562701b3bb7aab6bb7b1f3a5ac752f153fe258121aa54033cb154d20b'
+  version '2.0-rc.13'
+  sha256 'ae978646fbabf8c05009439a43c21100035aff6d945e57fc5fed99a409b9222b'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.