### PR TITLE
Update brave-browser to 0.55.22

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.55.20'
-  sha256 'a922197e96d4a4a499a708f48757a60db7ff750ca358922aec83185fd5eb4bc2'
+  version '0.55.22'
+  sha256 '0993310db53755655e6e79487545652a954a8adace926efe95641edf36f053f3'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.