### PR TITLE
Upgrade chatty to 0.9.2

### DIFF
--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -1,6 +1,6 @@
 cask 'chatty' do
-  version '0.9.1'
-  sha256 '50d4e1c05d32e15bf0147cbeee26e54f9bc56d4084ed060482f60f6499fe81ff'
+  version '0.9.2'
+  sha256 '574ca8b70e101c3e16a60aac16b407a3334b36dac64181a0ff5ebf9f8467fa11'
 
   # github.com/chatty/chatty was verified as official when first introduced to the cask
   url "https://github.com/chatty/chatty/releases/download/v#{version}/Chatty_#{version}.zip"


### PR DESCRIPTION
Updated to 0.9.2

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

