### PR TITLE
Update malwarebytes to 3.5.26.1796

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '3.4.29.1587'
-  sha256 'b004f3d3d744a7980f9626da105298b0fb54d17c16e4d9248f5633d3f7a67a24'
+  version '3.5.26.1796'
+  sha256 '977678b259a2d61a25331728f5295ea3213842427891c18852a027a0fca26293'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.