### PR TITLE
Update bluej to 4.1.4

### DIFF
--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -1,6 +1,6 @@
 cask 'bluej' do
-  version '4.1.3'
-  sha256 'f7fdd3c94912cec06da69f8db482f7f41ad115026e73f767c1ff62d18ce60081'
+  version '4.1.4'
+  sha256 '996f9d991aaa8fa56d3757fca45bf05d2c2fd80a5b51611588e7c802ab8e2d47'
 
   url "https://www.bluej.org/download/files/BlueJ-mac-#{version.no_dots}.zip"
   name 'BlueJ'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.