### PR TITLE
Update gisto to 1.10.13

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.12'
-  sha256 '12917b25ae9e1298d703f1a3e6e2a51d8671fcd3f2def4dd216108a312572a2f'
+  version '1.10.13'
+  sha256 'e7ecb0f93c2953c8a16a8919b6ae7befad69822c9f01ed4e68a961f3841c2f4f'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.