### PR TITLE
Update netron to 2.4.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.4.2'
-  sha256 'a9013b6103b98c1734fe61f8b1c7f9e72c5d8558fbe27cefc14bb437ae5e5208'
+  version '2.4.3'
+  sha256 '8920ad6425b4ba12fdff442332f3ba81593411cd7bfb31c604c077590d34ec4a'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.