### PR TITLE
Update stamp to 4.10.5

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.10.4'
-  sha256 '562a46c3b351d05e7c8d14df9c5899003c91878c6c5a4c827f0926d4eef9d945'
+  version '4.10.5'
+  sha256 '9c4076b50cd1bc3593d0351600a95ef9d3c0008eb6e8e698c67ff360b534ffaa'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/STAMP#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.