### PR TITLE
Update kubernetic to 2.2.0

### DIFF
--- a/Casks/kubernetic.rb
+++ b/Casks/kubernetic.rb
@@ -1,6 +1,6 @@
 cask 'kubernetic' do
-  version '2.0.16'
-  sha256 'c0c682e6ebd338d2db8d1cb09dd6cb4308c5b1356febff691afb04dec944dad6'
+  version '2.2.0'
+  sha256 'cee18e0c77a14270949248a0e5fc7405bc49f8467d70e34f9b4f5e89119ee7c6'
 
   # s3-eu-west-1.amazonaws.com/kubernetic was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/kubernetic/Kubernetic-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.