### PR TITLE
Update qownnotes to 18.11.0,b3903-123204

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.10.5,b3893-154658'
-  sha256 'c742d7ef98ba489ffeac7df422dbc4a6c9cba5ce14d17136917e026baff7430f'
+  version '18.11.0,b3903-123204'
+  sha256 '7bfb82292e1054de134cb07b402d7678e06605275b1e84741c3b9c43b57e98c1'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.