### PR TITLE
Update workflowy to 1.1.6

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.1.5'
-  sha256 'e7526d369ba67bae8842885410a7dde914c1872236c2c16441927f490098a848'
+  version '1.1.6'
+  sha256 'd93a1c7a80982ff0f95f9576228bd7d6eb08e9aa1ea1910ddd3abc63def039c5'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.