### PR TITLE
Update plex-media-player to 2.21.0.914-4839cbf2

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.20.0.909-46413dd1'
-  sha256 'cc20d9398afd7e87cff8a3785a40e8ee86013d9b2bb3f7acde04fc67b2eda909'
+  version '2.21.0.914-4839cbf2'
+  sha256 '6f7d52072dd9a352b5bc606e7d5b2e723cabaa1069fbae741f576ae538c01b21'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.