### PR TITLE
Update airtame to 3.3.1

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '3.3.0'
-  sha256 'abdfb0527a2997dd7048341f3ace2ba034e30c47848b3c1c99882540ac81c6e9'
+  version '3.3.1'
+  sha256 '47ad9fb1698d52cb8f8c62865f561579d4686dfddad6a7cdbb47959d53dd3023'
 
   url "https://downloads-cdn.airtame.com/application/ga/osx_x64/releases/airtame-application-#{version}.dmg"
   name 'Airtame'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.