### PR TITLE
Update prusa-slic3r to 1.41.1,201810261144

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,6 +1,6 @@
 cask 'prusa-slic3r' do
-  version '1.41.0,201809010756'
-  sha256 '93ea481dd849d0c2ece2cc1d1df0631354c52a6ed5491b267ea524db664e1344'
+  version '1.41.1,201810261144'
+  sha256 'a3246a2f1e2cf37b7ae361bb5ae4c95a24f62fe1795e99946281b2d3b3afb9fc'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3rPE-#{version.before_comma}+full-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.