### PR TITLE
Update qr-journal to 1.7.1

### DIFF
--- a/Casks/qr-journal.rb
+++ b/Casks/qr-journal.rb
@@ -1,6 +1,6 @@
 cask 'qr-journal' do
-  version '1.6'
-  sha256 'f263d0fab5a6ca5dee751cb249d5d2c1472285e10d08bc66c125841c0f603948'
+  version '1.7.1'
+  sha256 'a6b83e99dceddaf5f8183abbcaa56fe93755f74f21457eea878cd3e68ac9144e'
 
   url "https://www.joshjacob.com/mac-development/QRJournal#{version}.dmg"
   name 'QR Journal'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.