### PR TITLE
Update molotov to 3.0.0

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '2.3.0'
-  sha256 '5331c05c49d6af9123539e4a339740f6c39a26aacc7654a17d010a960aeecd6c'
+  version '3.0.0'
+  sha256 '77f921fd91d35ced1197e3854385052497645ca6b5fd33b1d3cabad880dca789'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.