### PR TITLE
Update extraterm to 0.37.1

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,6 +1,6 @@
 cask 'extraterm' do
-  version '0.37.0'
-  sha256 '8b379d63badb8a386ceaa4e07fb92ee7d08ad06378737264456d1e631fbe8902'
+  version '0.37.1'
+  sha256 'ee4d1426569ca7174f75afb293043dc17df871676f62afefeaca04b4feea6849'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.