### PR TITLE
Update simple-hub to 5.6.1-1777

### DIFF
--- a/Casks/simple-hub.rb
+++ b/Casks/simple-hub.rb
@@ -7,6 +7,8 @@ cask 'simple-hub' do
   name 'Simple Hub'
   homepage 'https://www.simplecontrol.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Simple Hub.app'
 
   zap trash: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.