### PR TITLE
Update google-earth-pro to 7.3.2.5495

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -8,14 +8,14 @@ cask 'google-earth-pro' do
 
   pkg "Install Google Earth Pro #{version}.pkg"
 
-  uninstall pkgutil: 'com.Google.GoogleEarthPro'
+  uninstall pkgutil: ['com.Google.GoogleEarthPro',
+                      'com.google.pkg.Keystone']
 
-  zap trash:   [
-                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.googleearthpro.sfl*',
-                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.googleearthupdatehelper.sfl*',
-                 '~/Library/Application Support/Google Earth',
-                 '~/Library/Caches/Google Earth',
-                 '~/Library/Caches/com.Google.GoogleEarthPro',
-               ],
-      pkgutil: 'com.google.pkg.Keystone'
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.googleearthpro.sfl*',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.googleearthupdatehelper.sfl*',
+               '~/Library/Application Support/Google Earth',
+               '~/Library/Caches/Google Earth',
+               '~/Library/Caches/com.Google.GoogleEarthPro',
+             ]
 end

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -12,6 +12,7 @@ cask 'google-earth-pro' do
                         'com.google.pkg.Keystone'],
             launchctl: [
                          'com.google.keystone.agent',
+                         'com.google.keystone.system.agent',
                          'com.google.keystone.daemon',
                        ]
 

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -8,8 +8,12 @@ cask 'google-earth-pro' do
 
   pkg "Install Google Earth Pro #{version}.pkg"
 
-  uninstall pkgutil: ['com.Google.GoogleEarthPro',
-                      'com.google.pkg.Keystone']
+  uninstall pkgutil:   ['com.Google.GoogleEarthPro',
+                        'com.google.pkg.Keystone'],
+            launchctl: [
+                         'com.google.keystone.agent',
+                         'com.google.keystone.daemon',
+                       ]
 
   zap trash: [
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.googleearthpro.sfl*',

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask 'google-earth-pro' do
-  version '7.3.2.5491'
-  sha256 'a3a2699cdea4502b42ee6c82831331152d2b3188dc75dce612bf452ba2e793e6'
+  version '7.3.2.5495'
+  sha256 '89fce86496593405f2d1c4817246a59a45695a19dca878c91b6d259e84f4e49e'
 
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg'
   name 'Google Earth Pro'

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -8,8 +8,10 @@ cask 'google-earth-pro' do
 
   pkg "Install Google Earth Pro #{version}.pkg"
 
-  uninstall pkgutil:   ['com.Google.GoogleEarthPro',
-                        'com.google.pkg.Keystone'],
+  uninstall pkgutil:   [
+                         'com.Google.GoogleEarthPro',
+                         'com.google.pkg.Keystone',
+                       ],
             launchctl: [
                          'com.google.keystone.agent',
                          'com.google.keystone.system.agent',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.