### PR TITLE
Update segger-embedded-studio-for-arm to 4.10

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '3.52a'
-  sha256 'f6b7aa74c491f4a7bc07b94ec5e52cb2d9d924e6287dba23307e9ef0179f7086'
+  version '4.10'
+  sha256 'f2a2ca13370b31845d2d25f8f799a4718c90c2d59232e1e7895caa15b776e124'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   name 'SEGGER Embedded Studio for ARM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.