### PR TITLE
Update rcloneosx to 1.6.5

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask 'rcloneosx' do
-  version '1.6.3'
-  sha256 '7dd1cf203382a7d4cd71dd18495410aa58ddfcff478884e5cdadd9eb807b60ef'
+  version '1.6.5'
+  sha256 '8ded0b44654f6d484e19703e756ef281a8663a09cad8659680a48864cdca2742'
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/RcloneOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.