### PR TITLE
Update manager to 18.10.97

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.10.91'
-  sha256 'c3671f63f623b45c77e51aedc346d51fcb9bf7ce8080ac9a32b6f299dbaa25cb'
+  version '18.10.97'
+  sha256 'bb6849fee87ae4c1ff432ae19beec13feb37acb59554e0649f3fac4ce298ec31'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.