### PR TITLE
Update foxitreader to 2.4.4.0903

### DIFF
--- a/Casks/foxitreader.rb
+++ b/Casks/foxitreader.rb
@@ -1,6 +1,6 @@
 cask 'foxitreader' do
-  version '2.4.1.0609'
-  sha256 'a92e4c2af2f22381651f255603816704a265e961b485b7f4b95c50c7b8e66151'
+  version '2.4.4.0903'
+  sha256 '18d32ad8a01879aedc54c190df13cdb48a2932aa565fea12e242d087800c3e5f'
 
   url "https://cdn09.foxitsoftware.com/pub/foxit/reader/desktop/mac/#{version.major}.x/#{version.major_minor}/en_us/FoxitReader.#{version}.enu.setup.pkg"
   name 'Foxit Reader'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

`brew cask style --fix foxitreader` gave me this:

```
± |cask_repair_update-foxitreader ✓| → brew cask style --fix foxitreader
==> Installing or updating 'rubocop-cask' gem
Building native extensions.  This could take a while...
ERROR:  Error installing rubocop-cask:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -r ./siteconf20181102-62458-1c93k9u.rb extconf.rb
creating Makefile

current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
make "DESTDIR=" clean

current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
make "DESTDIR="
make: *** No rule to make target `/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/include/ruby-2.3.0/universal-darwin18/ruby/config.h', needed by `adj_matrix.o'.  Stop.

make failed, exit code 2

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/extensions/universal-darwin-18/2.3.0/jaro_winkler-1.5.1/gem_make.out
Error: Failed to install/update the 'rubocop-cask' gem.
```