### PR TITLE
Update microsoft-office to 16.19.18110915

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -4,7 +4,7 @@ cask 'microsoft-office' do
 
   # officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac was verified as official when first introduced to the cask
   url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_#{version}_Installer.pkg"
-  name 'Microsoft Office for Mac'
+  name 'Microsoft Office'
   homepage 'https://products.office.com/mac/microsoft-office-for-mac/'
 
   auto_updates true

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -1,19 +1,21 @@
 cask 'microsoft-office' do
-  version '16.15.18070902'
-  sha256 '2caa050dcc2a95f90f57449f9ab5b173437fa2580f282f4c1513a83918e49ffa'
+  version '16.19.18110915'
+  sha256 '15e2e11412cd606091da03921060248d51b7d39fa30eea81430d536298440b3f'
 
   # officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac was verified as official when first introduced to the cask
-  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_2016_#{version}_Installer.pkg"
-  name 'Microsoft Office 2016'
+  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Office_#{version}_Installer.pkg"
+  name 'Microsoft Office for Mac'
   homepage 'https://products.office.com/mac/microsoft-office-for-mac/'
 
   auto_updates true
 
-  pkg "Microsoft_Office_2016_#{version}_Installer.pkg"
+  pkg "Microsoft_Office_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
+                         'com.microsoft.package.OneDrive',
                          'com.microsoft.package.Fonts',
                          'com.microsoft.package.Frameworks',
+                         'com.microsoft.package.Microsoft_AutoUpdate.app',
                          'com.microsoft.package.Microsoft_Excel.app',
                          'com.microsoft.package.Microsoft_OneNote.app',
                          'com.microsoft.package.Microsoft_Outlook.app',
@@ -25,13 +27,6 @@ cask 'microsoft-office' do
             launchctl: [
                          'com.microsoft.office.licensing.helper',
                          'com.microsoft.office.licensingV2.helper',
-                       ],
-            delete:    [
-                         '/Applications/Microsoft Excel.app',
-                         '/Applications/Microsoft OneNote.app',
-                         '/Applications/Microsoft Outlook.app',
-                         '/Applications/Microsoft PowerPoint.app',
-                         '/Applications/Microsoft Word.app',
                        ]
 
   zap trash:     [
@@ -53,15 +48,19 @@ cask 'microsoft-office' do
                    '~/Library/Containers/com.microsoft.Office365ServiceV2',
                    '~/Library/Containers/com.microsoft.Outlook',
                    '~/Library/Containers/com.microsoft.Powerpoint',
+                   '~/Library/Containers/com.microsoft.com.microsoft.RMS-XPCService',
                    '~/Library/Containers/com.microsoft.Word',
                    '~/Library/Containers/com.microsoft.errorreporting',
+                   '~/Library/Containers/com.microsoft.netlib.shipassertprocess',
                    '~/Library/Containers/com.microsoft.onenote.mac',
                    '~/Library/Cookies/com.microsoft.autoupdate.fba.binarycookies',
                    '~/Library/Cookies/com.microsoft.autoupdate2.binarycookies',
                    '~/Library/Group Containers/UBF8T346G9.Office',
+                   '~/Library/Group Containers/UBF8T346G9.OfficeOneDriveSyncIntegration',
                    '~/Library/Group Containers/UBF8T346G9.OfficeOsfWebHost',
                    '~/Library/Group Containers/UBF8T346G9.ms',
                    '~/Library/Preferences/com.microsoft.Excel.plist',
+                   '~/Library/Preferences/com.microsoft.Outlook.plist',
                    '~/Library/Preferences/com.microsoft.Powerpoint.plist',
                    '~/Library/Preferences/com.microsoft.Word.plist',
                    '~/Library/Preferences/com.microsoft.autoupdate.fba.plist',
@@ -76,6 +75,7 @@ cask 'microsoft-office' do
       launchctl: [
                    'com.microsoft.autoupdate.helpertool',
                    'com.microsoft.autoupdate.helper',
+                   'com.microsoft.update.agent',
                    'com.microsoft.OneDriveUpdaterDaemon',
                  ],
       pkgutil:   [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additional notes:
* The package is now known as *Microsoft Office for Mac*
* `uninstall` key `pkg` should include OneDrive.app and Microsoft_AutoUpdate.app
* `uninstall` key `delete` shouldn't be necessary anymore (`pkg` should suffice)
* `zap` key `trash` is adjusted based on [official uninstallation guide](https://support.office.com/en-us/article/uninstall-office-for-mac-eefa1199-5b58-43af-8a3d-b73dc1a8cae3)