### PR TITLE
Update marginnote to 3.1.5

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,9 +1,10 @@
 cask 'marginnote' do
-  version '3.1.4'
-  sha256 '05cbea2a0d0b8fbf5940a1b3039d9f7610fa7156d85cbe5dc15fb46ae1f63588'
+  version '3.1.5'
+  sha256 '39c9418cfa5dec63c4e244a59c8c35a881b60f9c5e260315103e83531ccf13f8'
 
   # s3.amazonaws.com/marginnote-product/macapp was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/marginnote-product/macapp/MarginNote#{version.major}.dmg"
+  appcast 'https://updates.devmate.com/QReader.MarginStudyMac.xml'
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.