### PR TITLE
Update lockrattler to 4.13,2018.11

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.12,2018.10'
-  sha256 '549f84f64ece05c2b39a07ea51d81a1c3136bdc89234f6320a1acab7a0f3583d'
+  version '4.13,2018.11'
+  sha256 '9bb9db89c608bea98aede1fbbf8da905ddebec9c6c02c15f58d3c8d55c621c1c'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.