### PR TITLE
Update mailmate to 5552

### DIFF
--- a/Casks/mailmate.rb
+++ b/Casks/mailmate.rb
@@ -1,10 +1,10 @@
 cask 'mailmate' do
-  version '5523'
-  sha256 '3c23876b7a7b94656f2dad7d6476f85f175fc4e9cb8256d479a3ba447676acbe'
+  version '5552'
+  sha256 'd3f566de83759eab01b20725ba91b1432915afa23e76277748efdc4ffe1021ed'
 
   # mailmate-app.com was verified as official when first introduced to the cask
   url "https://updates.mailmate-app.com/archives/MailMate_r#{version}.tbz"
-  appcast 'https://updates.mailmate-app.com/10.13/release'
+  appcast 'https://updates.mailmate-app.com/beta_release_notes'
   name 'MailMate'
   homepage 'https://freron.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.