### PR TITLE
Update music-manager to 1.0.478.2698

### DIFF
--- a/Casks/music-manager.rb
+++ b/Casks/music-manager.rb
@@ -1,6 +1,6 @@
 cask 'music-manager' do
-  version '1.0.243.1116'
-  sha256 'e425d1724d092ae5ddfb28ad4304439754394b91ab3ff3063b66196d2ffe4bee'
+  version '1.0.478.2698'
+  sha256 '10b122b36c429e9ac448fa1edfb6082a341112f4d7823736ae73aa9c1e563fcd'
 
   url "https://dl.google.com/dl/androidjumper/mac/#{version.sub(%r{^\d+\.\d+\.}, '').delete('.')}/musicmanager.dmg"
   name 'Google Play Music Manager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.