### PR TITLE
Update spotify with version and sha256 for the current release 1.0.92…

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,6 +1,6 @@
 cask 'spotify' do
-  version :latest
-  sha256 :no_check
+  version '1.0.92.390.g2ce5ec7d'
+  sha256 '399f999d8b4c3a80d01dfe9c74482688e651836afe81192289eadc29570f4175'
 
   # scdn.co was verified as official when first introduced to the cask
   url 'https://download.scdn.co/Spotify.dmg'


### PR DESCRIPTION
…though spotify does not have named paths for each version.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
