### PR TITLE
Update slicer to 4.10.0.27501,896287

### DIFF
--- a/Casks/slicer.rb
+++ b/Casks/slicer.rb
@@ -1,6 +1,6 @@
 cask 'slicer' do
-  version '4.8.1.26813,738961'
-  sha256 '3ed4c47aa032ed12dbba4151a55362c4d8a83a4bb2b03cb1026660053bdcd25a'
+  version '4.10.0.27501,896287'
+  sha256 '986b771a6d269cab3742a6cc565bb53f4f4221083adfb51cdfcd840016bcca42'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.