### PR TITLE
Update rcloneosx to 1.6.7

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask 'rcloneosx' do
-  version '1.6.5'
-  sha256 '8ded0b44654f6d484e19703e756ef281a8663a09cad8659680a48864cdca2742'
+  version '1.6.7'
+  sha256 'cb6c92d053d92229ab99777eae5d1b5598e651746e59fee720465f52e8eb792a'
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/RcloneOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.