### PR TITLE
Update netron to 2.4.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.4.5'
-  sha256 '59fa862f52ff86f13c0fd8d55cb391ba2823f35000f0325b35925349aab2218f'
+  version '2.4.6'
+  sha256 'ff41517dbb79eae924a66e71f4da52bc1058ce0c749200ef02dc9fcb99d6eb39'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.