### PR TITLE
Update neteasemusic to 1.5.10_628

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,9 +1,9 @@
 cask 'neteasemusic' do
-  version '1.5.9_622'
-  sha256 '1c64dbb3d22f3bf7eea99d207b9bc850f75de02653d3e7b484d2855099122ade'
+  version '1.5.10_628'
+  sha256 '0e08ebc0c150be979cbf47ef7c3fe9e5046d129a0a324ce26016f5a2cf050129'
 
   # d1.music.126.net was verified as official when first introduced to the cask
-  url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_officialsite.dmg"
+  url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"
   name 'NetEase cloud music'
   name '网易云音乐'
   homepage 'https://music.163.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.