### PR TITLE
Update keep-it to 1.5.5

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,11 +1,13 @@
 cask 'keep-it' do
-  version '1.5.3'
-  sha256 'ea4f0fef7279942cff345fbb138c4f108bc8d2c822985644d37b06323f1c0ac6'
+  version '1.5.5'
+  sha256 'a1e07da55c6225958bb372d925f0c43a7293f4230931e150cbcb9e5f0e318c63'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'
   name 'Keep It'
   homepage 'https://reinventedsoftware.com/keepit/'
+
+  depends_on macos: '>= :high_sierra'
 
   app 'Keep It.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.