### PR TITLE
Revert appium desktop back to 1.7.1

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,9 +1,9 @@
 cask 'appium' do
-  version '1.8.0'
-  sha256 '80f04956a9f1c766aeef1efe08871285cd613186dbc2e512e49b846d1c97fd45'
+  version '1.7.1'
+  sha256 '1b8a90e9fadf279e0353fad7910fa1ec198bb7423f34643450b177924592c0ba'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
-  url "https://github.com/appium/appium-desktop/releases/download/#{version}/appium-desktop-#{version}-mac.zip"
+  url "https://github.com/appium/appium-desktop/releases/download/v#{version}/appium-desktop-#{version}-mac.zip"
   appcast 'https://github.com/appium/appium-desktop/releases.atom'
   name 'Appium Desktop'
   homepage 'https://appium.io/'


### PR DESCRIPTION
There are no downloadable release URL on for newer versions on the official [appium releases page](https://github.com/appium/appium-desktop/releases).

Basically, this reverts PR #54054.

Current result of execution `brew cask install appium` command:
```
==> Downloading https://github.com/appium/appium-desktop/releases/download/1.8.0/appium-desktop-1.8.0-mac.zip

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'appium' with message: Download failed: https://github.com/appium/appium-desktop/releases/download/1.8.0/appium-desktop-1.8.0-mac.zip
```

After making all changes to the cask:

- [ ✔️] `brew cask audit --download {{cask_file}}` is error-free.
- [ ✔️] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ✔️] The commit message includes the cask’s name and version.
- [ ✔️] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
