### PR TITLE
Update recents to 2.0.2,4781

### DIFF
--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -1,6 +1,6 @@
 cask 'recents' do
-  version '2.0.1,4624'
-  sha256 'f1994d1b047079b55dd4a076d4fb08c047eeae1363de32b67ef66ce3e2d8f369'
+  version '2.0.2,4781'
+  sha256 '0dd9cf23b0bf5ef611a85281daf7a5b4b6bbfb4f8c3fb2065f64a29c87f445e8'
 
   # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.