### PR TITLE
Update phocus to 3.3.7,2018.10

### DIFF
--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -1,6 +1,6 @@
 cask 'phocus' do
-  version '3.3.6,2018.05'
-  sha256 '1bed922bae1e0bf9da2d24b17af026566f5c58b5d3c8d596929176d87c46c610'
+  version '3.3.7,2018.10'
+  sha256 '495244f22eba22da844ffc1b670a16cc0d20fd0603ff0f6aa1cd6792854bcc17'
 
   url "http://static.hasselblad.com/#{version.after_comma.dots_to_slashes}/Phocus-#{version.before_comma}.dmg"
   name 'Hasselblad Phocus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.