### PR TITLE
Update weiyun to 3.0.1.371_c31767

### DIFF
--- a/Casks/weiyun.rb
+++ b/Casks/weiyun.rb
@@ -1,6 +1,6 @@
 cask 'weiyun' do
-  version '3.0.1.360.30127'
-  sha256 '58c4b865422b2e173b15e3ce26ff087bc6915aeffd356d992fdc2a3d8b130d7e'
+  version '3.0.1.371_c31767'
+  sha256 'e968dc136aaf9552a382bbb20ad6451e4bfe9e402475957defef36cae86ec917'
 
   # dldir1.qq.com/weiyun was verified as official when first introduced to the cask
   url "https://dldir1.qq.com/weiyun/Weiyun_Mac_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.