### PR TITLE
Update lockrattler to 4.14,2018.11

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.13,2018.11'
-  sha256 '9bb9db89c608bea98aede1fbbf8da905ddebec9c6c02c15f58d3c8d55c621c1c'
+  version '4.14,2018.11'
+  sha256 '92a1607c41e43d243b8bf5c2886d86feec1947f705862b07deafb704956053fe'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.