### PR TITLE
Update adobe-dng-converter to 11.0

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -6,8 +6,8 @@ cask 'adobe-dng-converter' do
     version '9.6.1'
     sha256 '087eac5026667e4e6e3c156fd13243c9ea00f6c0238cbbb94d3099ae8772603f'
   else
-    version '10.5'
-    sha256 '050c6b2b44d03c6b469e6c938c7c6529934fe45132230f4f4e03831d3bc3ab8c'
+    version '11.0'
+    sha256 '47ad93da65d3a68ddca19c0dbc1b8574e3c0162eef80d485f7b343f7f3308df1'
   end
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.