### PR TITLE
Update lehreroffice to 2018.16.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2018.15.0'
-  sha256 'e976138b1817bf0345c30c245e812312f3a8900760948ec65828744301577d73'
+  version '2018.16.0'
+  sha256 '3899688e4a7a5e35997636bb13ad1cdd39fe1828217aee26399e651801242e42'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.