### PR TITLE
Update lehreroffice-zusatz to 2018.16.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.15.0'
-  sha256 '6774c30c2b91c34fa09244e33bb6762c6d9bf0785e9d55cae7feefe9ea45e018'
+  version '2018.16.0'
+  sha256 '6cf07a32d8720686eb37ce6ffb6c9709c4b73df08b6c3d1d4b88bf8c25a00602'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.