### PR TITLE
Update dmm-player-for-chrome to 1.5.0.10

### DIFF
--- a/Casks/dmm-player-for-chrome.rb
+++ b/Casks/dmm-player-for-chrome.rb
@@ -8,6 +8,8 @@ cask 'dmm-player-for-chrome' do
 
   pkg "DMMPlayerForChromeInstaller_#{version.dots_to_underscores}.pkg"
 
-  uninstall pkgutil: ['com.apple.ScriptEditor.id.DMMPlayerForChrome*',
-                      '1022638813.chrome.player.dmm.com']
+  uninstall pkgutil: [
+                       'com.apple.ScriptEditor.id.DMMPlayerForChrome*',
+                       '1022638813.chrome.player.dmm.com',
+                     ]
 end

--- a/Casks/dmm-player-for-chrome.rb
+++ b/Casks/dmm-player-for-chrome.rb
@@ -1,6 +1,6 @@
 cask 'dmm-player-for-chrome' do
-  version '1.5.0.9'
-  sha256 '01773a09ae8d049bbd70a2d9753f16f5795b77621ad61b46f09e0e08b99207a0'
+  version '1.5.0.10'
+  sha256 'c9a564a31b8d29f72085c9b4eada52a03ca3fa0fd3cd50fed3a071c614ddef39'
 
   url "http://portalapp.dmm.com/silverlightplayer/dmm/m/#{version.dots_to_underscores}/DMMPlayerForChromeInstaller_#{version.dots_to_underscores}.pkg"
   name 'DMM Player for Chrome'

--- a/Casks/dmm-player-for-chrome.rb
+++ b/Casks/dmm-player-for-chrome.rb
@@ -8,5 +8,6 @@ cask 'dmm-player-for-chrome' do
 
   pkg "DMMPlayerForChromeInstaller_#{version.dots_to_underscores}.pkg"
 
-  uninstall pkgutil: 'com.apple.ScriptEditor.id.DMMPlayerForChrome*'
+  uninstall pkgutil: ['com.apple.ScriptEditor.id.DMMPlayerForChrome*',
+                      '1022638813.chrome.player.dmm.com']
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.