### PR TITLE
Update parallels-client to 16.5.1-20447

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,9 +1,9 @@
 cask 'parallels-client' do
-  version '16.2.4-19503'
-  sha256 '6f2822d45a9d67ce5ccacdb1f464d8658c9961ebe744db92df603aea717a7d47'
+  version '16.5.1-20447'
+  sha256 '2570e2ce6988d14ddb96e01b74f813deddc838ec12a66e3fc5afcdfcd98d3805'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
-  appcast "https://download.parallels.com/ras/v#{version.major}/RAS%20Client%20for%20Mac%20Changelog.txt"
+  appcast "https://download.parallels.com/ras/v#{version.major.minor}/RAS%20Client%20for%20Mac%20Changelog.txt"
   name 'Parallels Client'
   homepage 'https://www.parallels.com/products/ras/features/rdp-client/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.