### PR TITLE
whoozle-android-file-transfer: update to 3.6, install aft-mtp-cli binary

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -1,6 +1,6 @@
 cask 'whoozle-android-file-transfer' do
-  version '3.5'
-  sha256 'e16aa8f682c663b1517f179c3031779f85efe6bcc0bd63c8dc7d2f66cd8a2f13'
+  version '3.6'
+  sha256 '1123c01677e884c1193872b599a2b1639c7fd6084d71b0ab17e726b92bfae58f'
 
   # github.com/whoozle/android-file-transfer-linux was verified as official when first introduced to the cask
   url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version}/AndroidFileTransferForLinux.dmg"
@@ -14,4 +14,5 @@ cask 'whoozle-android-file-transfer' do
                        ]
 
   app 'Android File Transfer for Linux.app'
+  binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"
 end


### PR DESCRIPTION
Same PR for nightly: https://github.com/Homebrew/homebrew-cask-versions/pull/6502

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256