### PR TITLE
Update qt-creator to 4.7.2

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.7.1'
-  sha256 'e49e92d735dd6901edcdccd580a1755d85606cc0766867f2e148e726b1772254'
+  version '4.7.2'
+  sha256 '2b262bb733a2794d69451d9de101223fff22e685fc74b29e07c7d84ce5d1d361'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.