### PR TITLE
Update to version 3.7

### DIFF
--- a/Casks/espionage.rb
+++ b/Casks/espionage.rb
@@ -1,6 +1,6 @@
 cask 'espionage' do
-  version '3.6.6'
-  sha256 '3bf87d0e9a85035a3e602f152644f47b52957bb097c9dbabbd66f33e6e3b1aa6'
+  version '3.7.0'
+  sha256 '58e66ac38db30d30bc0f3c669167a13017724a93bb47409e8edb38fecafbe4ba'
 
   url 'https://www.espionageapp.com/Espionage.dmg'
   appcast "https://updates.taoeffect.com/espionage#{version.major}/appcast.xml"


### PR DESCRIPTION
Am getting errors trying to install this cask due to the change in SHA256 sum for new version. Verified that the provided hash matches the .dmg downloaded from the link, and that the file inside matches the hash provided by the developer on their site: https://www.taoeffect.com/blog/2018/10/espionage-3-7-released/

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
