### PR TITLE
Update bookmacster to 2.9.2

### DIFF
--- a/Casks/bookmacster.rb
+++ b/Casks/bookmacster.rb
@@ -1,5 +1,5 @@
 cask 'bookmacster' do
-  version '2.9.3'
+  version '2.9.2'
   sha256 '93dc3ca9eea5af68f741a443415cd99967347b86705f0df058fa9baecf127e3f'
 
   url 'https://sheepsystems.com/bookmacster/BookMacster.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.