### PR TITLE
Revert "Update textmate to 2.0-rc.17"

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,6 +1,6 @@
 cask 'textmate' do
-  version '2.0-rc.17'
-  sha256 '6613e81308254b06811a235fe943d98cd6a009822a5d488f7035898dc36a4ce3'
+  version '2.0-rc.16'
+  sha256 '998c5b5aece79f2e27939149f8ed276e49aa1e5f451b359db977d55be2c1c873'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#54576

Download has been removed.