### PR TITLE
Update patchwork to 3.11.3

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.11.0'
-  sha256 '800d8270a8da55422a87aba5bf38fc6dae1cd03ef65c19fab4e9d1b48c94601d'
+  version '3.11.3'
+  sha256 'c1610115379ee91e54da9ff3cc5ff35d459c773f1d84e5fee1bd7f69d56c68b0'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.