### PR TITLE
Update station to 1.28.1

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.27.1'
-  sha256 '7ec8945fde1431fae37746276b8e321b9fb75defc5c60e3331a178ade0866e1f'
+  version '1.28.1'
+  sha256 '53f1fdbb090ef8944eb824117bd657f316057fcd366c4a69e86e06a9dfa9a8d9'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.