### PR TITLE
Update lockrattler to 4.15,2018.11

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.14,2018.11'
-  sha256 '92a1607c41e43d243b8bf5c2886d86feec1947f705862b07deafb704956053fe'
+  version '4.15,2018.11'
+  sha256 '6622386f8d83dc9efefb8c03a4dbfc18e7928d89ffc2ec3e2feb9473e8f410c9'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.