### PR TITLE
Update mailspring to 1.5.2

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,6 +1,6 @@
 cask 'mailspring' do
-  version '1.5.1'
-  sha256 '39bfcd3aa82e42675eaff2645a15f7634ceea493e79bfd97011cb66039bc1200'
+  version '1.5.2'
+  sha256 '8c0a098d297bc9116bfa9f9939996ddca61ff839be748395d871b3696b3b765e'
 
   # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
   url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.