### PR TITLE
Update yojimbo to 4.1.3

### DIFF
--- a/Casks/yojimbo.rb
+++ b/Casks/yojimbo.rb
@@ -1,6 +1,6 @@
 cask 'yojimbo' do
-  version '4.1.2'
-  sha256 '4c11c2c7cdb1ce513d58d6c1f0474541e7fa312cd07288eefad21024a134c9b6'
+  version '4.1.3'
+  sha256 '6bc8f4dd2095c6e9f7a6315cfa092da8e1f9b51b1ad46fda8a5c5d4ec5b1de86'
 
   # amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/Yojimbo_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.