### PR TITLE
Update drawio to 9.3.1

### DIFF
--- a/Casks/drawio.rb
+++ b/Casks/drawio.rb
@@ -1,6 +1,6 @@
 cask 'drawio' do
-  version '8.8.0'
-  sha256 '07bcd4c3defb29f63892ee7d48bfa382c912abb8d6c3d4110528d7478c9ff2ac'
+  version '9.3.1'
+  sha256 'e9496988bc53d520d2a3ab9a5998bd79b4fdfc6f466a7e44d920c3ee7c3fdb27'
 
   # github.com/jgraph/drawio-desktop was verified as official when first introduced to the cask
   url "https://github.com/jgraph/drawio-desktop/releases/download/v#{version}/draw.io-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.