### PR TITLE
Update geogebra to 6.0.509.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.507.0'
-  sha256 'ddcae8af2cd5dce8465fa1947619647235c8fee5ab89ffc3a42fa4670525be3c'
+  version '6.0.509.0'
+  sha256 '26cc016667921fa956bebcd00e10b72924624247fe44b9dc7955601a85b2895d'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   name 'GeoGebra'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.