### PR TITLE
Update lightworks to 14.5.0

### DIFF
--- a/Casks/lightworks.rb
+++ b/Casks/lightworks.rb
@@ -1,8 +1,8 @@
 cask 'lightworks' do
-  version '14.0.0'
-  sha256 '06d64bee517bfb13bbb1d5739dfd184fd2931bb8c1fab835bc066cbb6c41192d'
+  version '14.5.0'
+  sha256 '8b7d5890f7c0f2ede05d4de16a7a09e5bfc5b322690e70cbd2e481e3638e738c'
 
-  url "https://downloads.lwks.com/v#{version.major}/lightworks_v#{version}.dmg"
+  url "https://downloads.lwks.com/v#{version.major_minor.dots_to_hyphens}-new/lightworks_v#{version}.dmg"
   name 'Lightworks'
   homepage 'https://www.lwks.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.