### PR TITLE
Update openconnect-gui to 1.5.3

### DIFF
--- a/Casks/openconnect-gui.rb
+++ b/Casks/openconnect-gui.rb
@@ -8,5 +8,5 @@ cask 'openconnect-gui' do
   name 'OpenConnect-GUI'
   homepage 'https://openconnect.github.io/openconnect-gui/'
 
-  app 'openconnect-gui/#{version}/OpenConnect-GUI.app'
+  app "openconnect-gui/#{version}/OpenConnect-GUI.app"
 end

--- a/Casks/openconnect-gui.rb
+++ b/Casks/openconnect-gui.rb
@@ -1,9 +1,9 @@
 cask 'openconnect-gui' do
-  version '1.5.1'
-  sha256 'b2c338cfe9d0725bee98893225449e27cf7e337d43b0f8b08aec96de6f761f08'
+  version '1.5.3'
+  sha256 'b4e5c8618cb327cd3ba612a25976d7df7b49f612669f90488d8c680e32f8f61f'
 
   # github.com/openconnect/openconnect-gui was verified as official when first introduced to the cask
-  url "https://github.com/openconnect/openconnect-gui/releases/download/v#{version}/openconnect-gui-#{version}-Darwin.dmg"
+  url "https://github.com/openconnect/openconnect-gui/releases/download/v#{version}/openconnect-gui-#{version}.high_sierra.bottle.tar.gz"
   appcast 'https://github.com/openconnect/openconnect-gui/releases.atom'
   name 'OpenConnect-GUI'
   homepage 'https://openconnect.github.io/openconnect-gui/'

--- a/Casks/openconnect-gui.rb
+++ b/Casks/openconnect-gui.rb
@@ -8,5 +8,5 @@ cask 'openconnect-gui' do
   name 'OpenConnect-GUI'
   homepage 'https://openconnect.github.io/openconnect-gui/'
 
-  app 'openconnect-gui.app'
+  app 'openconnect-gui/#{version}/OpenConnect-GUI.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.