### PR TITLE
Update kega-fusion to 3.63i

### DIFF
--- a/Casks/kega-fusion.rb
+++ b/Casks/kega-fusion.rb
@@ -2,7 +2,7 @@ cask 'kega-fusion' do
   version '3.63i'
   sha256 'f329d3c700a4b1f66e49753f91d27182b1e67bdd0e9bd16c6347f989aa7131ba'
 
-  url "https://www.carpeludum.com/download/Fusion#{version.no_dots}.zip"
+  url "https://www.carpeludum.com/wp-content/files/Fusion#{version.no_dots}.zip"
   name 'Kega Fusion'
   homepage 'https://www.carpeludum.com/kega-fusion/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.