### PR TITLE
Update pharo-launcher to 1.4.6

### DIFF
--- a/Casks/pharo-launcher.rb
+++ b/Casks/pharo-launcher.rb
@@ -1,12 +1,10 @@
 cask 'pharo-launcher' do
-  version :latest
-  sha256 :no_check
+  version '1.4.6'
+  sha256 'dca14150cfa34871dc054277673658fa338a6bba8a48a9a8ad1835a8b92add94'
 
-  # ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac was verified as official when first introduced to the cask
-  url 'https://ci.inria.fr/pharo/view/Launcher/job/Publish-Launcher-stable-Mac/lastSuccessfulBuild/artifact/latest.dmg'
+  url "https://files.pharo.org/pharo-launcher/#{version}/PharoLauncher-#{version}-x64.dmg"
   name 'Pharo Launcher'
-  homepage 'https://github.com/pharo-project/pharo-launcher'
+  homepage 'http://pharo.org/download'
 
-  # Renamed to avoid conflict with pharo.
-  app 'Pharo.app', target: 'Pharo Launcher.app'
+  app 'PharoLauncher.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.