### PR TITLE
Update stack to 2.4.1.70454

### DIFF
--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -1,6 +1,6 @@
 cask 'stack' do
-  version '2.2.4.163'
-  sha256 '4ace1320a2adc7530ab1e4b97c4892b1a5c8882fc0fa233259e07acdfeb85b0c'
+  version '2.4.1.70454'
+  sha256 '41daf141ffe51fe2c6357e6fe9a289303323c4b5421da89673878e0bfe475bed'
 
   # transip.net/stack was verified as official when first introduced to the cask
   url "https://mirror.transip.net/stack/software/osx/stack-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.