### PR TITLE
Add new Cask for SpiderOak Share 1.0.0

### DIFF
--- a/Casks/share.rb
+++ b/Casks/share.rb
@@ -1,6 +1,6 @@
 cask 'share' do
-  version '1.0.0'
-  sha256 '3a2eea9b7e87e80ecf0ffeee9e54b83af0729ec42dcf0a875e81b8ef144dc628'
+  version :latest
+  sha256 :no_check
 
   url 'https://spideroak.com/release/share'
   name 'SpiderOak Share'

--- a/Casks/share.rb
+++ b/Casks/share.rb
@@ -1,4 +1,4 @@
-cask 'spideroak-share' do
+cask 'share' do
   version '1.0.0'
   sha256 '3a2eea9b7e87e80ecf0ffeee9e54b83af0729ec42dcf0a875e81b8ef144dc628'
 

--- a/Casks/spideroak-share.rb
+++ b/Casks/spideroak-share.rb
@@ -8,7 +8,7 @@ cask 'spideroak-share' do
 
   depends_on macos: '>= :sierra'
 
-  app 'Share.app'  ]
+  app 'Share.app'
 
   zap trash: [
                '~/Library/Logs/Share',

--- a/Casks/spideroak-share.rb
+++ b/Casks/spideroak-share.rb
@@ -1,0 +1,22 @@
+cask 'spideroak-share' do
+  version '1.0.0'
+  sha256 '3a2eea9b7e87e80ecf0ffeee9e54b83af0729ec42dcf0a875e81b8ef144dc628'
+
+  url 'https://spideroak.com/release/share'
+  name 'SpiderOak Share'
+  homepage 'https://spideroak.com/spideroak-share/'
+
+  depends_on macos: '>= :mountain_lion'
+
+  app 'Share.app'
+
+  uninstall trash: [
+                     '/Applications/Share.app',
+                   ]
+
+  zap trash: [
+               '~/Library/Logs/Share',
+               '~/Library/Preferences/com.spideroak.share.plist',
+               '~/Library/Saved Application State/com.spideroak.share.savedState',
+             ]
+end

--- a/Casks/spideroak-share.rb
+++ b/Casks/spideroak-share.rb
@@ -8,11 +8,7 @@ cask 'spideroak-share' do
 
   depends_on macos: '>= :sierra'
 
-  app 'Share.app'
-
-  uninstall trash: [
-                     '/Applications/Share.app',
-                   ]
+  app 'Share.app'  ]
 
   zap trash: [
                '~/Library/Logs/Share',

--- a/Casks/spideroak-share.rb
+++ b/Casks/spideroak-share.rb
@@ -6,7 +6,7 @@ cask 'spideroak-share' do
   name 'SpiderOak Share'
   homepage 'https://spideroak.com/spideroak-share/'
 
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :sierra'
 
   app 'Share.app'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->
https://spideroak.support/hc/en-us/articles/360018928512-Share-1-0-0-Release-Notes-07-Nov-2018

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference]. (I considered "share" too generic)
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
