### PR TITLE
Update manager to 18.11.11

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.11.9'
-  sha256 '2440d031421eef5bdf9d8a6b8da5f5b0684eebc323c9c3f887dcd91b6e4d7623'
+  version '18.11.11'
+  sha256 'f40cd7dee98394256c7869a646f5a7e693cb4ce71b04e54bbb37b18b156996d3'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.