### PR TITLE
Update Scrivener to 3.1.1

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,6 +1,6 @@
 cask 'scrivener' do
-  version '3.0.3,3032'
-  sha256 '776aa7a4ed46f6894bce4a15b4f4a53ea31044b6f2192fbd29234b3ddfd0c24a'
+  version '3.1.1,9852'
+  sha256 'e97b0b1382bc4ad60b814a5e50d410b8e0e88bcad88e561d3ee7207fd83a4d99'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://scrivener.s3.amazonaws.com/mac_updates/Scrivener_1012_#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
