### PR TITLE
Update zeplin to 2.2.3,582

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.2.1,573'
-  sha256 '2e76848e6c40153d6e33da6652bd237293bab00424f7f0f51775033300a35bf5'
+  version '2.2.3,582'
+  sha256 '9b21ceff44464aff534e5cf5f889398a64a00a8c9e74df275765ff9652d02b8e'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.