### PR TITLE
Update nucleo to 2.4.5

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,6 +1,6 @@
 cask 'nucleo' do
-  version '2.4.3'
-  sha256 '514dcfe5461825dbe9b37a8a810fb636af4cd16a82517aef1e43b7d3e4ad398c'
+  version '2.4.5'
+  sha256 'd8b4c62e326028ee0fc558f5d7a7210cbb26f74b677b61e1326426e446b5ece9'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.