### PR TITLE
Update bitwarden to 1.10.0

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,6 +1,6 @@
 cask 'bitwarden' do
-  version '1.9.0'
-  sha256 'e7ebc57f8e5429befd2ad9b16326447b50829dda177a3d030b06490e29d135e3'
+  version '1.10.0'
+  sha256 'e153d74b823e3e35518b5eec37baa8df5d8fdc96f854fd40282854e6bbf21917'
 
   # github.com/bitwarden/desktop was verified as official when first introduced to the cask
   url "https://github.com/bitwarden/desktop/releases/download/v#{version}/bitwarden-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.