### PR TITLE
Update tribler to 7.1.2

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,6 +1,6 @@
 cask 'tribler' do
-  version '7.1.0'
-  sha256 'd4551ddf95023e827f93d5408ca0fc959afe9c69c68dc15673cdd16934773b51'
+  version '7.1.2'
+  sha256 'eb0d12302b29dc5a3dedcb74222dc38ea5c226badb0f08ef0976b35fc7d5f795'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.