### PR TITLE
Update iridient-developer to 3.3.0

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.2.3'
-  sha256 '480add11528a77a13af15890912f595c87b82408dd2401d345bec445f2dfcce2'
+  version '3.3.0'
+  sha256 '9eed6e134c8868ee99a63024f02c7b15b19577809ae566dd9495c5f264dc957e'
 
   url "https://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'https://www.iridientdigital.com/products/rawdeveloper_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.