### PR TITLE
deezer 0.16.6: advertise auto-updating

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,7 +1,7 @@
 cask 'deezer' do
   version '0.16.6'
   sha256 'd2d727ad7d56416f4f6b703ff4bbed881e6cd7b2b6c9eba6ccf4c3e43a90c387'
-  
+
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   name 'Deezer'
   homepage 'https://www.deezer.com/download'

--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,10 +1,12 @@
 cask 'deezer' do
   version '0.16.6'
   sha256 'd2d727ad7d56416f4f6b703ff4bbed881e6cd7b2b6c9eba6ccf4c3e43a90c387'
-
+  
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   name 'Deezer'
   homepage 'https://www.deezer.com/download'
+
+  auto_updates true
 
   app 'Deezer.app'
 


### PR DESCRIPTION
This reflects the fact deezer does have self-update. Not sure if it qualifies though, because there's no "Check for updates" menu item and self-update is performed behind the scenes.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
