### PR TITLE
Update ui-browser to 2.8.0

### DIFF
--- a/Casks/ui-browser.rb
+++ b/Casks/ui-browser.rb
@@ -1,6 +1,6 @@
 cask 'ui-browser' do
-  version '2.7.0'
-  sha256 '0974aaf84862600383a64ec7ddf95ee8f0d0c623f5d07479f624fee864034425'
+  version '2.8.0'
+  sha256 '4ce26e6b10223b3216148af7a81e79ee6eb4fb8e04621484b8b78c56b61c5c00'
 
   url "https://pfiddlesoft.com/uibrowser/downloads/UIBrowser#{version.no_dots}.dmg"
   name 'UI Browser'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.