### PR TITLE
Update cozy-drive to 3.10.2

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.10.1'
-  sha256 'a5224f834f3251bad938b1ca84115baad2c600b82ea78ce543e355bfac5dd520'
+  version '3.10.2'
+  sha256 '9d79a873347ca0784596c205d96bacbf525e049c584f2b4ce343a939fc6a1fee'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.