### PR TITLE
Add Retroarch Metal v1.7.5

### DIFF
--- a/Casks/retroarch-metal.rb
+++ b/Casks/retroarch-metal.rb
@@ -1,0 +1,17 @@
+cask 'retroarch-metal' do
+  version '1.7.5'
+  sha256 '9cd87282512d4bf33dea57f6fa8e21b78127185ce11b62ff40552ead427ff453'
+
+  url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch_Metal.dmg"
+  appcast 'https://buildbot.libretro.com/stable/'
+  name 'RetroArch Metal'
+  homepage 'https://www.libretro.com/'
+
+  conflicts_with cask: 'retroarch retroarch-cg'
+
+  app 'RetroArch.app'
+
+  zap trash: [
+               '~/Library/Application Support/RetroArch',
+             ]
+end

--- a/Casks/retroarch-metal.rb
+++ b/Casks/retroarch-metal.rb
@@ -11,7 +11,5 @@ cask 'retroarch-metal' do
 
   app 'RetroArch.app'
 
-  zap trash: [
-               '~/Library/Application Support/RetroArch',
-             ]
+  zap trash: '~/Library/Application Support/RetroArch'
 end


### PR DESCRIPTION
Added Retroarch with a Metal backend.

Conflicts with other Retroarch versions due to some hardcoded assets
paths which mean the app must be installed as 'Retroarch.app'

Added zap to remove cached data

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
