### PR TITLE
Update postman to 6.5.2

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,6 +1,6 @@
 cask 'postman' do
-  version '6.4.4'
-  sha256 'a39c62fe2bf9dc47f034db96f8ebba9a32d01388460658d012dbcd6831226df6'
+  version '6.5.2'
+  sha256 'bcc69d18d563a5b3e12c49284bba8ad16bd91672748642049a23ad47f22c9f3c'
 
   # dl.pstmn.io/download/version was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.