### PR TITLE
Update typora to 0.9.9.19.3

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.19.1'
-  sha256 'c105d4a7496cacc314fc580e814e157e84b3db22e3eef16766fc885bca100087'
+  version '0.9.9.19.3'
+  sha256 'faf2e70a90e708defbb2b5c6b73e8380cbd77f8f5fe4613172b53ca0caf57765'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.