### PR TITLE
Update opera to 56.0.3051.102

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '56.0.3051.99'
-  sha256 '4984898f0fe0d4ceb95d5f06db492d18047584393fddfb7578f15c133d5f5128'
+  version '56.0.3051.102'
+  sha256 '33c9266a41d1c4daf227950198c89548995e88001e120368d444233dc0d0045f'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.