### PR TITLE
Update datadog-agent to 6.6.0-1

### DIFF
--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -12,7 +12,7 @@ cask 'datadog-agent' do
 
   preflight do
     require 'etc'
-    File.open('/tmp/datadog-install-user', 'w') { |f| f.write(Etc.getlogin) }
+    File.write('/tmp/datadog-install-user', Etc.getlogin)
   end
 
   uninstall launchctl: 'com.datadoghq.agent',

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -1,6 +1,6 @@
 cask 'datadog-agent' do
-  version '6.1.2-1'
-  sha256 'e2399cc9ddbf9f2ffecd32b48698857d1fd23cd504bd3527f0bb73c94d83542f'
+  version '6.6.0-1'
+  sha256 '7192d6ce534a34c47818de3535ef491306e26a339b0e6d7edd61112e607abe2c'
 
   # s3.amazonaws.com/dd-agent was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dd-agent/datadog-agent-#{version}.dmg"

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -14,7 +14,9 @@ cask 'datadog-agent' do
     File.open('/tmp/datadog-install-user', 'w') { |f| f.write(Etc.getlogin) }
   end
 
-  uninstall pkgutil: 'com.datadoghq.agent'
+  uninstall launchctl: 'com.datadoghq.agent',
+            delete:    '/Applications/Datadog Agent.app',
+            pkgutil:   'com.datadoghq.agent'
 
   zap trash: '/opt/datadog-agent'
 

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -4,6 +4,7 @@ cask 'datadog-agent' do
 
   # s3.amazonaws.com/dd-agent was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dd-agent/datadog-agent-#{version}.dmg"
+  appcast 'https://github.com/DataDog/datadog-agent/releases.atom'
   name 'Datadog Agent'
   homepage 'https://www.datadoghq.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.