### PR TITLE
Update securesafe to 2.4.5

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,10 +1,12 @@
 cask 'securesafe' do
-  version '2.4.4'
-  sha256 '9d326dc606b334f4380eb755399d82c836cd8754a4f41239e946b2be909dda05'
+  version '2.4.5'
+  sha256 'd6f617ba60b05814453ccd22636e0b24962d34f7bbf14d75bd3dd344271d7efe'
 
   url "https://www.securesafe.com/downloads/SecureSafe_#{version}.pkg"
   name 'SecureSafe'
   homepage 'https://www.securesafe.com/'
+
+  depends_on macos: '>= :sierra'
 
   pkg "SecureSafe_#{version}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.