### PR TITLE
Update tropy to 1.3.1

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.3.0'
-  sha256 '15542ec6a2df556b44a199c2f129d9843c6c7af3b31b3ef2b6999e6db0d208a7'
+  version '1.3.1'
+  sha256 'c1da860b588af5a6177d25c34b6663d9bbb8d32eba0098f6cf66fc2ef8969d71'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.