### PR TITLE
Update netron to 2.4.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.4.8'
-  sha256 '64ff539b85e21aa9a6f1df2631aaf510e2d833167c11042ddf6405fe1ad80726'
+  version '2.4.9'
+  sha256 '2a191205b7f269720ea3f88acd8aaffb24d2b2c328e5778c44334b22f70b5ca8'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.