### PR TITLE
Update parallels to 14.0.1-45154

### DIFF
--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -3,6 +3,7 @@ cask 'parallels' do
   sha256 '2d3157fa684c9e255927ae4a04f303107427a3ea166eea6ea86f0963cb24e4bb'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsDesktop-#{version}.dmg"
+  appcast 'http://www.corecode.io/cgi-bin/check_url_redirect/check_url_redirect.cgi?url=https://www.parallels.com/directdownload/pd/'
   name 'Parallels Desktop'
   homepage 'https://www.parallels.com/products/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.