### PR TITLE
Update wickrme to 4.64.8

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,10 +1,10 @@
 cask 'wickrme' do
-  version '4.51.7'
-  sha256 'c8ec59d91c068e3f16a131cd98d657b12dca219cdabebf48f997c5d71603508b'
+  version '4.64.8'
+  sha256 'ab6fcdefac88630183784af03035c37dd67b3638f7031a16cffbf7a6b293eabe'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"
-  appcast 'https://me-download.wickr.com/#/version/me'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/5af5d569264b4cc68e1f5156e8f80fb9'
   name 'Wickr Me'
   homepage 'https://wickr.com/products/personal/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.