### PR TITLE
Update textual to 7.1.0,d1a23b2c8

### DIFF
--- a/Casks/textual.rb
+++ b/Casks/textual.rb
@@ -1,9 +1,9 @@
 cask 'textual' do
-  version '7.0.10,91ee6772a'
-  sha256 '667d86e74803703433685e2dbd3838e45e6b360541d199e53e1394b9f4195449'
+  version '7.1.0,d1a23b2c8'
+  sha256 '5015b317848de85d63b84db3360515643574b228d98f2dbbbd70e127763825f6'
 
   url "https://cached.codeux.com/textual/downloads/resources/builds/standard-release/Textual-#{version.after_comma}.dmg"
-  appcast 'https://help.codeux.com/textual/Direct-Download-Links.kb'
+  appcast 'https://textual-updates-backend.codeux.com/sparkle/feeds/v7/feed-one.xml'
   name 'Textual'
   homepage 'https://www.codeux.com/textual/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.