### PR TITLE
Update servetome to 4.0.0165

### DIFF
--- a/Casks/servetome.rb
+++ b/Casks/servetome.rb
@@ -3,7 +3,7 @@ cask 'servetome' do
   sha256 '65bfacbb58d86c95bd05ebdfd81c37242593144046d4c66cdf70b1b97d032251'
 
   url "http://downloads.zqueue.com/ServeToMe-v#{version}.dmg"
-  appcast 'https://www.zqueue.com/servetome/changehistory.html'
+  appcast 'https://www.zqueue.com/servetome/mac_appcast.xml'
   name 'ServeToMe'
   homepage 'https://www.zqueue.com/servetome/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.