### PR TITLE
Update chronycontrol to 1.3.0

### DIFF
--- a/Casks/chronycontrol.rb
+++ b/Casks/chronycontrol.rb
@@ -1,9 +1,9 @@
 cask 'chronycontrol' do
-  version '1.2.2'
-  sha256 'f00367056ecc6b8b2f03a961b8f64c562b8fc15c9f0816950fe1574d26990b7e'
+  version '1.3.0'
+  sha256 'f605626dcb6581e1915342c22b7c425909738cdd548ba822f70d742d441da7d5'
 
   url "https://www.whatroute.net/software/chronycontrol-#{version}.zip"
-  appcast 'https://whatroute.net/chronycontrol.html'
+  appcast 'https://www.whatroute.net/chronycontrolappcast.xml'
   name 'ChronyControl'
   homepage 'https://whatroute.net/chronycontrol.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.