### PR TITLE
Update istopmotion to 3.8.2-16057

### DIFF
--- a/Casks/istopmotion.rb
+++ b/Casks/istopmotion.rb
@@ -3,7 +3,7 @@ cask 'istopmotion' do
   sha256 'eb31319488346e12d6f95b7be9d61d911eaaf0228f22b6053ee0be8f6902f520'
 
   url "https://cdn.boinx.com/software/istopmotion/Boinx_iStopMotion_#{version}.app.zip"
-  appcast 'https://boinx.com/d/connect/histories/istopmotion'
+  appcast 'https://sparkle.boinx.com/appcast.lasso?appName=iStopMotion'
   name 'iStopMotion'
   homepage 'https://boinx.com/istopmotion/mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.