### PR TITLE
Update bbedit to 12.5

### DIFF
--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -1,14 +1,18 @@
 cask 'bbedit' do
-  version '12.5'
-  sha256 'ab40f9f3177a23851b9607cfd6ac427dfec4982330a08a1b22cd7ed438548114'
-
+  if MacOS.version <= :el_capitan
+    version '12.1.6'
+    sha256 '23b9fc6ef5c03cbcab041566503c556d5baf56b2ec18f551e6f0e9e6b48dc690'
+  else
+    version '12.5'
+    sha256 'ab40f9f3177a23851b9607cfd6ac427dfec4982330a08a1b22cd7ed438548114'
+  end
   # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml'
   name 'BBEdit'
   homepage 'https://www.barebones.com/products/bbedit/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :el_capitan'
 
   app 'BBEdit.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.