### PR TITLE
Update wifispoof to 3.4.2

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,6 +1,6 @@
 cask 'wifispoof' do
-  version '3.4.1'
-  sha256 '8c9d157877ecb397ef10d660b2fbf548efd3bd23bfe5ee3b43fc2ee86cdc176b'
+  version '3.4.2'
+  sha256 'f97d70666a37cde907392378366256f0bf99bde01a573e90d72facedd5ac8620'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.