### PR TITLE
Update amazon-workdocs to 1.2.203.37

### DIFF
--- a/Casks/amazon-workdocs.rb
+++ b/Casks/amazon-workdocs.rb
@@ -10,5 +10,6 @@ cask 'amazon-workdocs' do
 
   pkg 'Amazon WorkDocs.pkg'
 
-  uninstall pkgutil: 'com.amazon.aws.AmazonWorkDocs'
+  uninstall pkgutil: 'com.amazon.aws.AmazonWorkDocs',
+            quit:    'com.amazon.AmazonWorkDocs'
 end

--- a/Casks/amazon-workdocs.rb
+++ b/Casks/amazon-workdocs.rb
@@ -1,6 +1,6 @@
 cask 'amazon-workdocs' do
-  version :latest
-  sha256 :no_check
+  version '1.2.203.37'
+  sha256 'c97c669e2982009115e51602b7ad801b4801d0b44df9283c7492f6b1405fc5d0'
 
   # d28gdqadgmua23.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d28gdqadgmua23.cloudfront.net/mac/Amazon%20WorkDocs.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.