### PR TITLE
Update amazon-workspaces to 2.4.10

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,6 +1,6 @@
 cask 'amazon-workspaces' do
-  version :latest
-  sha256 :no_check
+  version '2.4.10'
+  sha256 '0ba1895985bfd45333ecaa20fc4b516ffc019e62d950a4dc4f35cf2e0f71777b'
 
   # d2td7dqidlhjx7.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.