### PR TITLE
Add IBM Data Server Driver for ODBC and CLI 10.5.0.5

### DIFF
--- a/Casks/ibm-data-server-driver-for-odbc-and-cli.rb
+++ b/Casks/ibm-data-server-driver-for-odbc-and-cli.rb
@@ -6,12 +6,12 @@ cask 'ibm-data-server-driver-for-odbc-and-cli' do
   name 'IBM Data Server Driver for ODBC and CLI'
   homepage 'http://www-01.ibm.com/support/docview.wss?uid=swg21418043'
 
-  binary "#{appdir}/#{name[0]}/bin/db2cli"
-  binary "#{appdir}/#{name[0]}/bin/db2diag"
-  binary "#{appdir}/#{name[0]}/bin/db2drdat"
-  binary "#{appdir}/#{name[0]}/bin/db2dsdcfgfill"
-  binary "#{appdir}/#{name[0]}/bin/db2level"
-  binary "#{appdir}/#{name[0]}/bin/db2support"
-  binary "#{appdir}/#{name[0]}/bin/db2trc"
-  artifact 'clidriver', target: "#{appdir}/#{name[0]}"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2cli"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2diag"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2drdat"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2dsdcfgfill"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2level"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2support"
+  binary "#{appdir}/IBM Data Server Driver for ODBC and CLI/bin/db2trc"
+  artifact 'clidriver', target: "#{appdir}/IBM Data Server Driver for ODBC and CLI"
 end

--- a/Casks/ibm-data-server-driver-for-odbc-and-cli.rb
+++ b/Casks/ibm-data-server-driver-for-odbc-and-cli.rb
@@ -1,0 +1,17 @@
+cask 'ibm-data-server-driver-for-odbc-and-cli' do
+  version '10.5.0.5'
+  sha256 '66875721d96ac39b7ca39540245cc6f6f08b4cf7d0d2e55bf6b8fa1838705b8a'
+
+  url 'https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/macos64_odbc_cli.tar.gz'
+  name 'IBM Data Server Driver for ODBC and CLI'
+  homepage 'http://www-01.ibm.com/support/docview.wss?uid=swg21418043'
+
+  binary "#{appdir}/#{name[0]}/bin/db2cli"
+  binary "#{appdir}/#{name[0]}/bin/db2diag"
+  binary "#{appdir}/#{name[0]}/bin/db2drdat"
+  binary "#{appdir}/#{name[0]}/bin/db2dsdcfgfill"
+  binary "#{appdir}/#{name[0]}/bin/db2level"
+  binary "#{appdir}/#{name[0]}/bin/db2support"
+  binary "#{appdir}/#{name[0]}/bin/db2trc"
+  artifact 'clidriver', target: "#{appdir}/#{name[0]}"
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Three remarks regarding this cask:
- The version number of this software is listed in the `<root>/license/odbc_notices.txt` file.
- The `name` stanza is also derived from the `odbc_notices.txt` file.
- By default, the unpacked directory is called `clidriver`. I found this meaningless and decided to rename the artefact to the `name` stanza.
