### PR TITLE
Update netron to 2.5.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.5.0'
-  sha256 '1441fb990de9e3110895dbbc6de01c4e743038d2d5093bd8dc83bb4c3cbaa6e1'
+  version '2.5.1'
+  sha256 '739325cde1728bf9243bb0b7e3f6d4098b858e8321df4ce9dcdc803284713444'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.