### PR TITLE
Update superduper to 3.2.4,118

### DIFF
--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -1,6 +1,6 @@
 cask 'superduper' do
-  version '3.2.3,116'
-  sha256 'af4f27c4cfdc47f9d3f47054277f99691c7ea33dacfdaa75f6e97eb1dc7242d1'
+  version '3.2.4,118'
+  sha256 'a6af47ea7df3903ba7195dfb25eb57d4150b02d8a910c0a52ab7297fb588e3e9'
 
   # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.