### PR TITLE
Update navicat-for-postgresql to 12.1.12

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '12.1.9'
-  sha256 'fb7e00933171a92441a86a672b43306785abdd837f29f580c83a81e727b070b9'
+  version '12.1.12'
+  sha256 '8d1b821e59d22608b7316bcacd3fcc0fb7989bcb30207781c370f08b37a187d1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-postgresql-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.