### PR TITLE
Update crashplan to 6.8.4,1525200006684_4

### DIFF
--- a/Casks/code42-crashplan.rb
+++ b/Casks/code42-crashplan.rb
@@ -1,4 +1,4 @@
-cask 'crashplan' do
+cask 'code42-crashplan' do
   version '6.8.4'
   sha256 '7c6c9b6a6363c62944b58799610e0ffa4dc953d3a5bba25e509f49e7bc1dc1a6'
 

--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -1,9 +1,9 @@
 cask 'crashplan' do
-  version '4.8.4'
-  sha256 'b2ffb640e1083ee95d5de93b627cbfbdbe53dae3dd59f5ae93723621a575991e'
+  version '6.8.4,1525200006684_4'
+  sha256 'b4722b49d04bab9001c07aba8906bd1883484eef5e428eb2be1099cc6381d015'
 
   # download.code42.com was verified as official when first introduced to the cask
-  url "https://download.code42.com/installs/mac/install/CrashPlan/CrashPlan_#{version}_Mac.dmg"
+  url "https://download.code42.com/installs/client_package_repository/#{version.before_comma}/Code42CrashPlan_#{version.before_comma}_#{version.after_comma}_Mac.pkg42"
   name 'CrashPlan'
   homepage 'https://www.crashplan.com/'
 

--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -9,7 +9,7 @@ cask 'crashplan' do
 
   auto_updates true
 
-  pkg 'Install CrashPlan.pkg'
+  pkg 'Install Code42 CrashPlan.pkg'
 
   uninstall launchctl: 'com.backup42.desktop',
             pkgutil:   'com.crashplan.app.pkg',

--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -1,6 +1,6 @@
 cask 'crashplan' do
   version '6.8.4'
-  sha256 'b4722b49d04bab9001c07aba8906bd1883484eef5e428eb2be1099cc6381d015'
+  sha256 '7c6c9b6a6363c62944b58799610e0ffa4dc953d3a5bba25e509f49e7bc1dc1a6'
 
   # download.code42.com was verified as official when first introduced to the cask
   url "https://download.code42.com/installs/mac/install/Code42CrashPlan/Code42CrashPlan_#{version}_Mac.dmg"

--- a/Casks/crashplan.rb
+++ b/Casks/crashplan.rb
@@ -1,9 +1,9 @@
 cask 'crashplan' do
-  version '6.8.4,1525200006684_4'
+  version '6.8.4'
   sha256 'b4722b49d04bab9001c07aba8906bd1883484eef5e428eb2be1099cc6381d015'
 
   # download.code42.com was verified as official when first introduced to the cask
-  url "https://download.code42.com/installs/client_package_repository/#{version.before_comma}/Code42CrashPlan_#{version.before_comma}_#{version.after_comma}_Mac.pkg42"
+  url "https://download.code42.com/installs/mac/install/Code42CrashPlan/Code42CrashPlan_#{version}_Mac.dmg"
   name 'CrashPlan'
   homepage 'https://www.crashplan.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.