### PR TITLE
Update resolume-avenue to 6.1.1,61422

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,6 +1,6 @@
 cask 'resolume-avenue' do
-  version '6.0.11,60828'
-  sha256 '5b377a9be3d132a8695635475f27f0cff505f2063255641848d9e4b7842a10f4'
+  version '6.1.1,61422'
+  sha256 '0d52f3df97cf82e7ba6929801becf62ec503b12c1d57262fdf2ab3d816ff32ac'
 
   url "https://resolume.com/download/Resolume_Avenue_#{version.major_minor_patch.dots_to_underscores}_rev_#{version.after_comma}_Installer.dmg"
   appcast 'https://resolume.com/update/avenue_mac.xml'

--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -9,7 +9,11 @@ cask 'resolume-avenue' do
 
   pkg 'Resolume Avenue Installer.pkg'
 
-  uninstall pkgutil:   'com.resolume.pkg.ResolumeAvenue.*',
+  uninstall pkgutil:   [
+                         'com.resolume.pkg.ResolumeAvenue.*',
+                         'com.resolume.pkg.ResolumeDXV',
+                         'com.resolume.pkg.ResolumeQuickLook',
+                       ],
             delete:    "/Applications/Resolume Avenue #{version.major}",
             launchctl: 'com.resolume.avenue',
             signal:    ['TERM', 'com.resolume.avenue']


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.