### PR TITLE
Update navicat-for-mariadb to 12.1.12

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.9'
-  sha256 'f5279ccc4a3a62c3b087af6f6f7b45ba62eec39dc627ec0d4dbc81d7d80a378c'
+  version '12.1.12'
+  sha256 'ce36b6531706b3413ad30836e5b60cad7fe4dfee6e473136a897d8ee44d5e293'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/en/products/navicat-for-mariadb-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.