### PR TITLE
Update navicat-for-sql-server to 12.1.12

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.9'
-  sha256 '41512d07ac65f78b1630822d578fb641c413cd54afd9bf2a122bf62e4f3963ba'
+  version '12.1.12'
+  sha256 '6c1d240d87435778e9032697f37243e6dea7dc07ff5b4b15b4e05e3002afea36'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlserver-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.