### PR TITLE
Update navicat-for-sqlite to 12.1.12

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.9'
-  sha256 '981c895373c54f01f6e414918b9b09370f40a0e17d97ce538ec1725306ff4b88'
+  version '12.1.12'
+  sha256 'd12a2d0c5af4144540d0896bd4fb1c30f70fe28e10c5c7618ff7f15857c5e345'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/products/navicat-for-sqlite-release-note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.