### PR TITLE
Update diskcatalogmaker to 7.4.4

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,8 +1,9 @@
 cask 'diskcatalogmaker' do
-  version :latest
-  sha256 :no_check
+  version '7.4.4'
+  sha256 'ae826bc83363c3955be7186b62f41fee3a57a0a641e1bb721e7c5abd08405cb2'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
+  appcast 'https://fujiwara.sakura.ne.jp/info/appcast/DiskCatalogMaker.xml'
   name 'DiskCatalogMaker'
   homepage 'https://diskcatalogmaker.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.