### PR TITLE
Update mailplane to 4.4516

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -3,7 +3,7 @@ cask 'mailplane' do
   sha256 '8a4272daee8c38b4235cd824b8ca52a49e5562a22d72c27571ed869d5611df1f'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.dots_to_underscores}.tbz"
-  appcast "https://mailplaneapp.com/releases/mailplane#{version.major}.html"
+  appcast 'https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=4565&shortVersionString=4.0.6'
   name 'Mailplane'
   homepage 'https://mailplaneapp.com/'
 

--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,6 +1,6 @@
 cask 'mailplane' do
   version '4.0.6,4565'
-  sha256 '8a4272daee8c38b4235cd824b8ca52a49e5562a22d72c27571ed869d5611df1f'
+  sha256 'e08021f097ef9972eb92ed5629f7791531cd175e9eb73a459f5bc60a69d01e8d'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
   appcast "https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}"

--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,9 +1,9 @@
 cask 'mailplane' do
-  version '4.4516'
+  version '4.0.6,4565'
   sha256 '8a4272daee8c38b4235cd824b8ca52a49e5562a22d72c27571ed869d5611df1f'
 
-  url "https://update.mailplaneapp.com/builds/Mailplane_#{version.dots_to_underscores}.tbz"
-  appcast 'https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=4565&shortVersionString=4.0.6'
+  url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
+  appcast 'https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}'
   name 'Mailplane'
   homepage 'https://mailplaneapp.com/'
 

--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -3,7 +3,7 @@ cask 'mailplane' do
   sha256 '8a4272daee8c38b4235cd824b8ca52a49e5562a22d72c27571ed869d5611df1f'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
-  appcast 'https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}'
+  appcast "https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}"
   name 'Mailplane'
   homepage 'https://mailplaneapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.