### PR TITLE
Update 1password to 7.2.2

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,6 +1,6 @@
 cask '1password' do
-  version '7.2.1'
-  sha256 '3ec43f6015f03768922982f067ee49fb776a6bbbeada6c3518480ede0ae039cb'
+  version '7.2.2'
+  sha256 '6584c3c0b013c37d7f463c35dedd79717d554f71c4a827604097557414fe463b'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.