### PR TITLE
Updated Curio to add a version number, OS requirement, and SHA256 value

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -2,7 +2,7 @@ cask 'curio' do
   version '12.2.1'
   sha256 'bda3b8a787b89882d5e8850826bfe1ffad3c0f703b67ae8da10015cc3ec6ce40'
 
-  url 'https://zengobi.com/downloads/Curio.zip'
+  url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio12MarkdownAppcast.xml'
   name 'Curio'
   homepage 'https://zengobi.com/curio/'

--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,5 +1,5 @@
 cask 'curio' do
-  version '12.2.1'
+  version '12.02.10'
   sha256 'bda3b8a787b89882d5e8850826bfe1ffad3c0f703b67ae8da10015cc3ec6ce40'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"

--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,11 +1,13 @@
 cask 'curio' do
-  version :latest
-  sha256 :no_check
+  version '12.2.1'
+  sha256 'bda3b8a787b89882d5e8850826bfe1ffad3c0f703b67ae8da10015cc3ec6ce40'
 
   url 'https://zengobi.com/downloads/Curio.zip'
   appcast 'https://www.zengobi.com/appcasts/Curio12MarkdownAppcast.xml'
   name 'Curio'
   homepage 'https://zengobi.com/curio/'
+
+  depends_on macos: '>= :sierra'
 
   app 'Curio.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).