### PR TITLE
Update flirc to 3.20.3

### DIFF
--- a/Casks/flirc.rb
+++ b/Casks/flirc.rb
@@ -1,6 +1,6 @@
 cask 'flirc' do
-  version :latest
-  sha256 :no_check
+  version '3.20.3'
+  sha256 'a804806a42baffc3c390afcc9afe56887e56b707c7c4cc6eb6b4d4297ccfa771'
 
   url 'https://flirc.tv/software/release/gui/mac/Flirc.dmg'
   appcast 'https://flirc.tv/software/release/gui/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.