### PR TITLE
Update hubstaff to 1.4.2-8d78ff24

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version :latest
-  sha256 :no_check
+  version '1.4.2-8d78ff24'
+  sha256 'b388bede05079f2e0bb9f8804846c010c70b47263c7cd23a893a2f62f135ee99'
 
   url 'https://app.hubstaff.com/download/osx'
   appcast 'https://app.hubstaff.com/appcast.xml'

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,8 +1,8 @@
 cask 'hubstaff' do
-  version '1.4.2-8d78ff24'
+  version '1.4.2,8d78ff24'
   sha256 'b388bede05079f2e0bb9f8804846c010c70b47263c7cd23a893a2f62f135ee99'
 
-  url 'https://app.hubstaff.com/download/osx'
+  url "https://app.hubstaff.com/download/344-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'
   name 'Hubstaff'
   homepage 'https://hubstaff.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.