### PR TITLE
Update jumpshare to 2.4.4

### DIFF
--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -1,8 +1,9 @@
 cask 'jumpshare' do
-  version :latest
-  sha256 :no_check
+  version '2.4.4'
+  sha256 '79d062a1b4d9ae069f7990b73ec7b153d8c4a7700620f60dda1311e05b3d3a56'
 
-  url 'https://apps.jumpshare.com/desktop/mac/Jumpshare.dmg'
+  # d21hi1or3tbtjm.cloudfront.net was verified as official when first introduced to the cask
+  url 'https://d21hi1or3tbtjm.cloudfront.net/desktop/mac/Jumpshare.zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/2e15b9ed1bad4078ac88b8fae1771bfb'
   name 'Jumpshare'
   homepage 'https://jumpshare.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.