### PR TITLE
Update livechat to 3.6.2

### DIFF
--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -1,6 +1,6 @@
 cask 'livechat' do
-  version :latest
-  sha256 :no_check
+  version '3.6.2'
+  sha256 'c1594987737b2ef6403018608a186ee6231674a43dd894043a513462a090d848'
 
   url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
   appcast 'https://www.livechatinc.com/download/Mac/appcast-3.x.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.