### PR TITLE
Update mollyguard to 1.0.0

### DIFF
--- a/Casks/mollyguard.rb
+++ b/Casks/mollyguard.rb
@@ -1,6 +1,6 @@
 cask 'mollyguard' do
-  version :latest
-  sha256 :no_check
+  version '1.0.0'
+  sha256 '1db2745811987d4dbb94aa586b91199eff3b5d715b684ab93c789231c0ca4f13'
 
   # dl.dropboxusercontent.com/s/e2l2dk2qz1u93cb was verified as official when first introduced to the cask
   url 'https://dl.dropboxusercontent.com/s/e2l2dk2qz1u93cb/MollyGuard.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.