### PR TITLE
Update origami-studio to 2.5

### DIFF
--- a/Casks/origami-studio.rb
+++ b/Casks/origami-studio.rb
@@ -1,6 +1,6 @@
 cask 'origami-studio' do
-  version :latest
-  sha256 :no_check
+  version '2.5'
+  sha256 '3d47d5119184bbb59125d7ed2c75a75c375d8a0e04a7ce3dcb0604a83c649482'
 
   # fb.me/getorigamistudio was verified as official when first introduced to the cask
   url 'https://fb.me/getorigamistudio'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.