### PR TITLE
Update rest to 1.13.1

### DIFF
--- a/Casks/rest.rb
+++ b/Casks/rest.rb
@@ -1,6 +1,6 @@
 cask 'rest' do
-  version :latest
-  sha256 :no_check
+  version '1.13.1'
+  sha256 'f2057ec2e901755db68156d36cf0df97421d2c7c9cb1c4d66c4573e015143b05'
 
   url 'https://dist.resttimer.com/mac/Rest.dmg'
   appcast 'https://resttimer.com/appcast/rest.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.