### PR TITLE
Update sandvox to 2.10.12

### DIFF
--- a/Casks/sandvox.rb
+++ b/Casks/sandvox.rb
@@ -1,6 +1,6 @@
 cask 'sandvox' do
-  version :latest
-  sha256 :no_check
+  version '2.10.12'
+  sha256 '06fcaf1f26a67b19e87148118fe720422ef37148a6103fe7dda09cf944dd6dfb'
 
   url 'https://www.karelia.com/files/8/Sandvox.dmg'
   appcast 'https://launch.karelia.com/appcast.php?product=8&appname=Sandvox&version=29583&type=release_deploy&os=10.13.4'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.