### PR TITLE
Update securedownloadmanager to 3.2

### DIFF
--- a/Casks/securedownloadmanager.rb
+++ b/Casks/securedownloadmanager.rb
@@ -1,6 +1,6 @@
 cask 'securedownloadmanager' do
-  version :latest
-  sha256 :no_check
+  version '3.2'
+  sha256 'eb633b849e797a4ddf6ddf6911b3e13337a9ec49ad7c75952dd1a6d741107af5'
 
   url 'https://e5.onthehub.com/Static/Installers/SDM.dmg'
   appcast 'https://rink.hockeyapp.net/api/2/apps/acef21d15575493385e86659a2bb7e55'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.