### PR TITLE
Update tiny to 1.0.8

### DIFF
--- a/Casks/tiny.rb
+++ b/Casks/tiny.rb
@@ -1,6 +1,6 @@
 cask 'tiny' do
-  version :latest
-  sha256 :no_check
+  version '1.0.8'
+  sha256 'da10d22eb1e7c35b809bb8fa81a2d16017c18b6f883adfddb5f8e458bee5dbc2'
 
   # kaomojiformac.github.io was verified as official when first introduced to the cask
   url 'https://kaomojiformac.github.io/tiny-download/Tiny.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.