### PR TITLE
Update triumph to 2.6.8

### DIFF
--- a/Casks/triumph.rb
+++ b/Casks/triumph.rb
@@ -1,6 +1,6 @@
 cask 'triumph' do
-  version :latest
-  sha256 :no_check
+  version '2.6.8'
+  sha256 '840ff9ec554f4a758df267825a4129d3e4a1072ca0d08e155fb419e7836a528f'
 
   url 'https://triumph.aurchitect.com/downloads/Triumph.zip'
   appcast 'https://triumph.aurchitect.com/sufeed.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.