### PR TITLE
Update upthere-home to 1.1.31

### DIFF
--- a/Casks/upthere-home.rb
+++ b/Casks/upthere-home.rb
@@ -1,6 +1,6 @@
 cask 'upthere-home' do
-  version :latest
-  sha256 :no_check
+  version '1.1.31'
+  sha256 '778bc18879f6616c3a515374687be712bac1c816cb201116cd14ac3129f358fe'
 
   url 'https://upthere.com/apps/mac/UpthereHome.zip'
   appcast 'https://upthere.com/apps/mac/UpthereHome-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.