### PR TITLE
Update marginnote to 3.1.6

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,12 +1,14 @@
 cask 'marginnote' do
-  version '3.1.5'
-  sha256 '39c9418cfa5dec63c4e244a59c8c35a881b60f9c5e260315103e83531ccf13f8'
+  version '3.1.6'
+  sha256 '057475204ac179bc07fd186aefb69e923336c490aceec1cf77f2f5e997701019'
 
   # s3.amazonaws.com/marginnote-product/macapp was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/marginnote-product/macapp/MarginNote#{version.major}.dmg"
   appcast 'https://updates.devmate.com/QReader.MarginStudyMac.xml'
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'
+
+  auto_updates true
 
   app "MarginNote #{version.major}.app"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.