### PR TITLE
Update flash-npapi to 31.0.0.148

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '31.0.0.122'
-  sha256 '3623841c45ff06fafc9709a87d5a63ff867e8d67251ad5c87f4cdb4940875346'
+  version '31.0.0.148'
+  sha256 'a498cd2ab6ce57b97f0f9e2d4945eeca98af14ad14fbf5fb3ff304e63e8727a4'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'

--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -1,6 +1,6 @@
 cask 'whoozle-android-file-transfer' do
-  version '3.6'
-  sha256 '1123c01677e884c1193872b599a2b1639c7fd6084d71b0ab17e726b92bfae58f'
+  version '3.7'
+  sha256 '463c7ddd0828010b9b3f6b2705efc4b4986502c6b6e8e1abc2c148cc59528ee9'
 
   # github.com/whoozle/android-file-transfer-linux was verified as official when first introduced to the cask
   url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version}/AndroidFileTransferForLinux.dmg"
@@ -15,4 +15,5 @@ cask 'whoozle-android-file-transfer' do
 
   app 'Android File Transfer for Linux.app'
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"
+  binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-mount"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.