### PR TITLE
Update macmediakeyforwarder URL and checksum.

### DIFF
--- a/Casks/macmediakeyforwarder.rb
+++ b/Casks/macmediakeyforwarder.rb
@@ -1,8 +1,8 @@
 cask 'macmediakeyforwarder' do
   version '2.0'
-  sha256 '4941afa2ed60bf098e25a62d2ef3a42dfadcd38c18c39d4ae59cfd591ed63d1a'
+  sha256 '3eff3459f07ccecfb0bd1c456bf4d4a281af12550166863599d7230567a8ed31'
 
-  url "http://milgra.com/downloads/hsme/MacMediaKeyForwarder#{version}.zip"
+  url "http://milgra.com/downloads/mmkf/MacMediaKeyForwarder#{version}.zip"
   name 'Mac Media Key Forwarder'
   homepage 'http://milgra.com/mac-media-key-forwarder.html'
 


### PR DESCRIPTION
I'm not the developer of macmediakeyforwarder, and the developer doesn't publish any -SUMS files nor signs the downloads, so I cannot say why the checksum has changed :-1:

The URL changed recently from /hsme/ to /mmkf/ per the broader rename from HighSierraMediaKeyEnabler to MacMediaKeyForwarder (see also !54851, !54793, !54779), breaking the cask.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).