### PR TITLE
Update letterfix to 2.7.0.1,70082

### DIFF
--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -1,8 +1,8 @@
 cask 'letterfix' do
-  version '2.6.0,68346'
-  sha256 '89de44a2b0e6cb43915d9584615226811f939a42aed6d2a14ba099de18db2768'
+  version '2.7.0.1,70082'
+  sha256 '0eadd2aef702d9f940df8376d9a47101d4792fd59b083c6b53de0f93044e7048'
 
-  url "http://onet.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
+  url "http://rwthaachen.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
   appcast 'https://ja.osdn.net/projects/letter-fix/releases/rss'
   name 'LetterFix'
   homepage 'https://osdn.jp/projects/letter-fix/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.