### PR TITLE
Update auryo to 2.2.1

### DIFF
--- a/Casks/auryo.rb
+++ b/Casks/auryo.rb
@@ -1,6 +1,6 @@
 cask 'auryo' do
-  version '2.1.2'
-  sha256 '39b04ffc45a4e2e67d066545d48b32c60d4b0d7741d72bc343eea5c5e20e022a'
+  version '2.2.1'
+  sha256 '3725030b00e8ba75d6514fd9c4c56cedb69b406042bd8c6b1e6c7bc33d55ffee'
 
   # github.com/Superjo149/auryo was verified as official when first introduced to the cask
   url "https://github.com/Superjo149/auryo/releases/download/v#{version}/Auryo-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.