### PR TITLE
Update controllermate to 4.11.1

### DIFF
--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -35,7 +35,6 @@ cask 'controllermate' do
             delete:    [
                          '/Library/Extensions/ControllerMate.kext,/Library/Application Support/ControllerMate/',
                          '/Library/LaunchAgents/com.orderedbytes.ControllerMateHelper.plist',
-                         '/Library/StagedExtensions/Library/Extensions/ControllerMate.kext',
                          '/Applications/ControllerMate.app',
                          '/private/var/db/receipts/com.orderedbytes.controllermate.*',
                        ]

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,8 +1,5 @@
 cask 'controllermate' do
-  if MacOS.version <= :el_capitan
-    version '4.9.10'
-    sha256 '4f24f5763e96b0b0e959197dba5cc064928b59b74d49210bf5a484f4f9766d38'
-  elsif MacOS.version == :sierra
+  if MacOS.version <= :sierra
     version '4.10.4'
     sha256 'fdeb37ca8df145d927b9daef6dfa22ef6d1535f9ad1459c4f4ffcb52fbc19c3b'
   else
@@ -16,7 +13,7 @@ cask 'controllermate' do
   name 'ControllerMate'
   homepage 'https://www.orderedbytes.com/controllermate/'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :sierra'
 
   pkg '#temp#/ControllerMate.sparkle_interactive.pkg'
 

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,5 +1,8 @@
 cask 'controllermate' do
-  if MacOS.version <= :sierra
+  if MacOS.version <= :el_capitan
+    version '4.9.10'
+    sha256 '4f24f5763e96b0b0e959197dba5cc064928b59b74d49210bf5a484f4f9766d38'
+  elsif MacOS.version == :sierra
     version '4.10.4'
     sha256 'fdeb37ca8df145d927b9daef6dfa22ef6d1535f9ad1459c4f4ffcb52fbc19c3b'
   else
@@ -13,7 +16,7 @@ cask 'controllermate' do
   name 'ControllerMate'
   homepage 'https://www.orderedbytes.com/controllermate/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :mountain_lion'
 
   pkg '#temp#/ControllerMate.sparkle_interactive.pkg'
 

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -28,10 +28,26 @@ cask 'controllermate' do
                          'com.orderedbytes.driver.CMUSBDevices',
                          'com.orderedbytes.driver.ControllerMateFamily',
                        ],
-            pkgutil:   'com.orderedbytes.controllermate.*',
+            pkgutil:   [
+                         'com.orderedbytes.controllermate.*',
+                         'com.orderedbytes.controllermate.ControllerMate.pkg',
+                         'com.orderedbytes.controllermate.ControllerMateHelper.pkg',
+                         'com.orderedbytes.controllermate.ControllerMateKext.pkg',
+                         'com.orderedbytes.controllermate.ControllerMate_keyboard.pkg',
+                         'com.orderedbytes.controllermate.ControllerMate_none.pkg',
+                         'com.orderedbytes.controllermate.ControllerMate_pointer.pkg',
+                         'com.orderedbytes.controllermate.com.orderedbytes.ControllerMateHelper.pkg',
+                       ],
             signal:    [
                          ['TERM', "com.orderedbytes.ControllerMate#{version.major}"],
                          ['TERM', 'com.orderedbytes.ControllerMateHelper'],
+                       ],
+            delete:    [
+                         '/Library/Extensions/ControllerMate.kext,/Library/Application Support/ControllerMate/',
+                         '/Library/LaunchAgents/com.orderedbytes.ControllerMateHelper.plist',
+                         '/Library/StagedExtensions/Library/Extensions/ControllerMate.kext',
+                         '/Applications/ControllerMate.app ',
+                         '/private/var/db/receipts/com.orderedbytes.controllermate.*',
                        ]
 
   zap trash: [
@@ -39,6 +55,7 @@ cask 'controllermate' do
                '~/Library/Caches/com.orderedbytes.ControllerMate4',
                '~/Library/Logs/ControllerMate MIDI',
                '~/Library/Logs/ControllerMate',
+               '/Applications/ControllerMate.app',
              ]
 
   caveats do

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -28,16 +28,6 @@ cask 'controllermate' do
                          'com.orderedbytes.driver.CMUSBDevices',
                          'com.orderedbytes.driver.ControllerMateFamily',
                        ],
-            pkgutil:   [
-                         'com.orderedbytes.controllermate.*',
-                         'com.orderedbytes.controllermate.ControllerMate.pkg',
-                         'com.orderedbytes.controllermate.ControllerMateHelper.pkg',
-                         'com.orderedbytes.controllermate.ControllerMateKext.pkg',
-                         'com.orderedbytes.controllermate.ControllerMate_keyboard.pkg',
-                         'com.orderedbytes.controllermate.ControllerMate_none.pkg',
-                         'com.orderedbytes.controllermate.ControllerMate_pointer.pkg',
-                         'com.orderedbytes.controllermate.com.orderedbytes.ControllerMateHelper.pkg',
-                       ],
             signal:    [
                          ['TERM', "com.orderedbytes.ControllerMate#{version.major}"],
                          ['TERM', 'com.orderedbytes.ControllerMateHelper'],
@@ -46,7 +36,7 @@ cask 'controllermate' do
                          '/Library/Extensions/ControllerMate.kext,/Library/Application Support/ControllerMate/',
                          '/Library/LaunchAgents/com.orderedbytes.ControllerMateHelper.plist',
                          '/Library/StagedExtensions/Library/Extensions/ControllerMate.kext',
-                         '/Applications/ControllerMate.app ',
+                         '/Applications/ControllerMate.app',
                          '/private/var/db/receipts/com.orderedbytes.controllermate.*',
                        ]
 
@@ -55,7 +45,6 @@ cask 'controllermate' do
                '~/Library/Caches/com.orderedbytes.ControllerMate4',
                '~/Library/Logs/ControllerMate MIDI',
                '~/Library/Logs/ControllerMate',
-               '/Applications/ControllerMate.app',
              ]
 
   caveats do

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -1,12 +1,22 @@
 cask 'controllermate' do
-  version '4.10.6'
-  sha256 'f5093f29532e072e821758dd3cd3ef93bfafe8372b0db19342a15eb515422df7'
+  if MacOS.version <= :el_capitan
+    version '4.9.10'
+    sha256 '4f24f5763e96b0b0e959197dba5cc064928b59b74d49210bf5a484f4f9766d38'
+  elsif MacOS.version == :sierra
+    version '4.10.4'
+    sha256 'fdeb37ca8df145d927b9daef6dfa22ef6d1535f9ad1459c4f4ffcb52fbc19c3b'
+  else
+    version '4.11.1'
+    sha256 'dd95d0b2abd6c23148092c96593fb303befc374c6a912afad57efb48b0a1e04b'
+  end
 
   # amazonaws.com/orderedbytes was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/orderedbytes/ControllerMate#{version.no_dots}.zip"
   appcast 'https://www.orderedbytes.com/sparkle/appcast_cm460.xml'
   name 'ControllerMate'
   homepage 'https://www.orderedbytes.com/controllermate/'
+
+  depends_on macos: '>= :high_sierra'
 
   pkg '#temp#/ControllerMate.sparkle_interactive.pkg'
 

--- a/Casks/controllermate.rb
+++ b/Casks/controllermate.rb
@@ -2,7 +2,7 @@ cask 'controllermate' do
   if MacOS.version <= :el_capitan
     version '4.9.10'
     sha256 '4f24f5763e96b0b0e959197dba5cc064928b59b74d49210bf5a484f4f9766d38'
-  elsif MacOS.version == :sierra
+  elsif MacOS.version <= :sierra
     version '4.10.4'
     sha256 'fdeb37ca8df145d927b9daef6dfa22ef6d1535f9ad1459c4f4ffcb52fbc19c3b'
   else


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.