### PR TITLE
Update greenfoot to 3.5.2

### DIFF
--- a/Casks/greenfoot.rb
+++ b/Casks/greenfoot.rb
@@ -1,6 +1,6 @@
 cask 'greenfoot' do
-  version '3.5.1'
-  sha256 'e89a05e59635329b2e94d72354f78afa307c406e35604c65fda3bb48ab84b0dc'
+  version '3.5.2'
+  sha256 'a94184dfd2e344bfabcb3bd561ec0a5126205575cd34f247c8ca2f2fba63a29b'
 
   url "https://www.greenfoot.org/download/files/Greenfoot-mac-#{version.no_dots}.zip"
   name 'Greenfoot'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.