### PR TITLE
Update shotcut to 18.11.13

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,9 +1,9 @@
 cask 'shotcut' do
-  version '18.10.08'
-  sha256 '2d498db8071e7d0d98fc240e2a97f75eadf28c3039d07e30aa8d0d05052aeff5'
+  version '18.11.13'
+  sha256 'cf37baedea06e78eb8773b4930860443537c228337e11c81c61cd598a61c560a'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
-  url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-x86_64-#{version.no_dots}.dmg"
+  url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg"
   appcast 'https://github.com/mltframework/shotcut/releases.atom'
   name 'Shotcut'
   homepage 'https://www.shotcut.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.