### PR TITLE
Update diskmaker-x to 8.0.1

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,6 +1,6 @@
 cask 'diskmaker-x' do
-  version '8'
-  sha256 '32b4600ae6a51ecfa819125dc85d179d632fba5e04b11d41235f6fe20e834ccf'
+  version '8.0.1'
+  sha256 'd541ece9cae7d6e46fe707132db55bf35b651082eb8694e6c6d6cc380c8cb977'
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   appcast 'https://diskmakerx.com/feed/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.