### PR TITLE
Update little-snitch to 4.2.3

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -1,6 +1,6 @@
 cask 'little-snitch' do
-  version '4.2.2'
-  sha256 'abfd731508320457e8ad3049fed20f1fb65fd0b787016302ad6880a017ba5f1d'
+  version '4.2.3'
+  sha256 '3e311732928690b2d566bc59b306c8f2c81b2d31d68052a350fb37b880c2e409'
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.