### PR TITLE
Update imazing to 2.8.1,9825:1542055466

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.8.0,9798:1541504472'
-  sha256 '92c6c455dee5dd870686c568acedb50e370e1ebafb4c1d22320f76cfee8f1938'
+  version '2.8.1,9825:1542055466'
+  sha256 '7b45e68a356d09939bc9a00051c90cb571aafe0021f8d5d5769f2d5840eb6233'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.