### PR TITLE
Update unity-linux-support-for-editor to 2018.2.15f1,65e0713a5949

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.2.13f1,83fbdcd35118'
-  sha256 'c61316ec0fab896d57367791d67ec8ec03eddc4c8c7f0947434dd69d5b1694d9'
+  version '2018.2.15f1,65e0713a5949'
+  sha256 'c850b5a9b8f210e297b3b5cf225bec3badba5a52d425f0ab92165d1a02d7fbff'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.