### PR TITLE
Update unity-webgl-support-for-editor to 2018.2.15f1,65e0713a5949

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.2.13f1,83fbdcd35118'
-  sha256 '38970e27d26c420904a5a823bb13d5f44a1a28c457da79b20e847b92658fd1df'
+  version '2018.2.15f1,65e0713a5949'
+  sha256 'e2ffd07256a54fc915458d15c3d8aa5e5dec7a4a373afdd23aa2e88bcac77f9f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.