### PR TITLE
Rename correto to corretto v8,8u192

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,4 +1,4 @@
-cask 'correto' do
+cask 'corretto' do
   version '8,8u192'
   sha256 '5836ca06194bee33a476bd9412ef810a8e8a98eb0202553567933b70f3aa17e4'
 


### PR DESCRIPTION
The cask for Amazon Corretto was added as `correto` instead of `corretto`, this corrects the naming.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

