### PR TITLE
Update freefilesync to 10.6

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '10.6'
-  sha256 '5b94686935da5160228bb1965f2dafd22894e23a1c8a0bef1709f222645c26cd'
+  sha256 '00adc3e3fb32a9d1e8d7e8204524460c03624b7238b2b9877d3474670a01bba1'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '10.6'
-  sha256 '00adc3e3fb32a9d1e8d7e8204524460c03624b7238b2b9877d3474670a01bba1'
+  sha256 :no_check
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.