### PR TITLE
Update dictionaries to 1.2.7,252:1540657812

### DIFF
--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -1,6 +1,6 @@
 cask 'dictionaries' do
-  version '1.2.6,241:1525016854'
-  sha256 'a9a1beb18231ac83af757da86f49383569911700f25ca353498775640a126ef5'
+  version '1.2.7,252:1540657812'
+  sha256 'ab8e73f434e2bc15076bc9b6a160b616d7220c759d4f99d8e8dcb46b07f5d2dc'
 
   # dl.devmate.com/io.dictionaries.Dictionaries was verified as official when first introduced to the cask
   url "https://dl.devmate.com/io.dictionaries.Dictionaries/#{version.after_comma.before_colon}/#{version.after_colon}/Dictionaries-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.