### PR TITLE
Update signal to 1.18.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.17.3'
-  sha256 '63f92d29f4b047e69afcd3b993769e80491db18da5e610aef2cb333d4379bd93'
+  version '1.18.0'
+  sha256 '75a5e10e6819fe7dbad6a6161040caa846c25d25e86782287c0a88b482729dd6'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.