### PR TITLE
Update manager to 18.11.29

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.11.25'
-  sha256 '64c93f6ab2ce51427fd47ad2857e800196fde7a4f46252fd44b4fc52f225aee5'
+  version '18.11.29'
+  sha256 '4d7a0c76ac01c9303ee31b0e8da859e01a7a0ad6d0a8bee01a2e469abc31b0f1'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.