### PR TITLE
Update mullvadvpn to 2018.5

### DIFF
--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -1,11 +1,11 @@
 cask 'mullvadvpn' do
-  version '2018.4'
-  sha256 'a6102d263018dd86c235d98e43da38c2b3e9da3aba38662f1fd85cf70df00099'
+  version '2018.5'
+  sha256 '52ac732a0260cb38d302876bd4bb4d2b2f0e00b8dea3809be659e7939c24782f'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"
   appcast 'https://github.com/mullvad/mullvadvpn-app/releases.atom'
-  name 'Mullvad'
+  name 'Mullvad VPN'
   homepage 'https://mullvad.net/'
 
   conflicts_with cask: 'mullvad-vpn-beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.