### PR TITLE
Update qownnotes to 18.11.3,b3932-162936

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.11.2,b3917-200406'
-  sha256 '61aab0a42c92c271761a804930dd54311fb01ed473cf124702966bcf1fc4f03e'
+  version '18.11.3,b3932-162936'
+  sha256 '9ecbf794716c89e651853835ac6fe7875ecf8ad06195a4728a5742ecef2cb0e6'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.