### PR TITLE
Update banking-4x to 6.10.8,6892

### DIFF
--- a/Casks/banking-4x.rb
+++ b/Casks/banking-4x.rb
@@ -1,7 +1,7 @@
 cask 'banking-4x' do
   # note: "4x" is not a version number, but an intrinsic part of the product name
-  version '6.10.7,6848'
-  sha256 'bc6b168fe9f307d753a65944fadd371eef681950b1241e4d1c6025a564966a24'
+  version '6.10.8,6892'
+  sha256 'df4584ce42c6eb128eb4f838e0edb4162d40e45130d4b62fcff474c4ca11d11e'
 
   url 'https://subsembly.com/download/MacBanking.pkg'
   appcast 'https://subsembly.com/banking4x-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.