### PR TITLE
Localized Skype for China

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,22 +1,23 @@
 cask 'skype' do
   name 'Skype'
-  language 'en', default: true do
+
+  language 'XW', default: true do
     version '8.34.0.78'
     sha256 '814b60d85381d4a6332944cdf5f67f0e067b01843821989e685e53b49e6edf80'
     # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
     url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
-    'en-US'
+    homepage 'https://www.skype.com/'
+    'XW'
   end
 
-  language 'zh' do
+  language 'CN' do
     version '7.59.37'
     sha256 '1f0ced6a3b50e9c43a684992a1d63d576eeb689e84ff6572a73105e9a92796cd'
-    # Sype in China has a different release version and homepage
+    # Skype in China has a different release version and homepage
     url "http://imgskype.gmw.cn/resource/uploadimg/mac/Skype_#{version}.dmg"
-    'zh-CN'
+    homepage 'http://skype.gmw.cn/'
+    'CN'
   end
-
-  homepage 'https://www.skype.com/'
 
   auto_updates true
 

--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,10 +1,21 @@
 cask 'skype' do
-  version '8.34.0.78'
-  sha256 '814b60d85381d4a6332944cdf5f67f0e067b01843821989e685e53b49e6edf80'
-
-  # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
-  url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
   name 'Skype'
+  language 'en', default: true do
+    version '8.34.0.78'
+    sha256 '814b60d85381d4a6332944cdf5f67f0e067b01843821989e685e53b49e6edf80'
+    # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
+    url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
+    'en-US'
+  end
+
+  language 'zh' do
+    version '7.59.37'
+    sha256 '1f0ced6a3b50e9c43a684992a1d63d576eeb689e84ff6572a73105e9a92796cd'
+    # Sype in China has a different release version and homepage
+    url "http://imgskype.gmw.cn/resource/uploadimg/mac/Skype_#{version}.dmg"
+    'zh-CN'
+  end
+
   homepage 'https://www.skype.com/'
 
   auto_updates true


### PR DESCRIPTION
There is a separate version of Skype for users in China, due to
network requirements (Government firewall). See #54999 for details

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
