### PR TITLE
Update path-finder to 8.3.5

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '8.3.4'
-  sha256 '65ecb40e0d00603f99fdb9a63f62136d95640417f3c2cf0e8c933063d0db9da6'
+  version '8.3.5'
+  sha256 '40ec6267e36fa4c88f89c6ae43b634bbcabb9d9c0194341f5acd8cb87ed18a0b'
 
   url 'https://get.cocoatech.com/PF8.dmg'
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.