### PR TITLE
Update joplin to 1.0.115

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.114'
-  sha256 '0989ce51db00e47fd88c498ca946e17c653272aa9d761c7586bda3e044083371'
+  version '1.0.115'
+  sha256 'e5b4912ad1e1a036051ef31cc1f9c0edeae9addd53b4f341d3c8eab7a6ba0586'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.