### PR TITLE
Update vscodium to 1.29.1

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.29.0'
-  sha256 'da4e050b96cf4d8696a1068d2878d729f5edfddda19b9d04c1bb763c83fa3f88'
+  version '1.29.1'
+  sha256 '59a14afc417d23532c3b75f62bacf051c8ae437ec97a5a2d1599e58a7bb60e01'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCode-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.