### PR TITLE
Update minishift to 1.27.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,6 +1,6 @@
 cask 'minishift' do
-  version '1.26.1'
-  sha256 'f991309a496695d064102b2cab74d738a9ffc3db8dee8efda556939cbb3ce88c'
+  version '1.27.0'
+  sha256 '490939962f5cb7ad278aa8cd6ab66f80642711622777c4191997d1cf5525636d'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.