### PR TITLE
Update clashx to 1.6.7

### DIFF
--- a/Casks/clashx.rb
+++ b/Casks/clashx.rb
@@ -1,11 +1,18 @@
 cask 'clashx' do
-  version '1.6.6'
-  sha256 '35e3264a339fae29e59783b8e15349d356242a9006a891da35cd677f63b80119'
+  version '1.6.7'
+  sha256 '23c22d0fe856e19c758dfb5859a03b84f8d8373f7a6436918c08a7a61aa3a7ee'
 
   url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   appcast 'https://github.com/yichengchen/clashX/releases.atom'
   name 'ClashX'
   homepage 'https://github.com/yichengchen/clashX'
 
+  auto_updates true
+
   app 'ClashX.app'
+
+  zap trash: [
+               '~/Library/Preferences/com.west2online.ClashX.plist',
+               '~/Library/Logs/ClashX',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.