### PR TITLE
Update surge to 3.0.3-753

### DIFF
--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -1,6 +1,6 @@
 cask 'surge' do
-  version '3.0.2-736'
-  sha256 'ac4b66af29120354dace6ce6c3b78346b10081bc42ae7873095406cbfbfc462b'
+  version '3.0.3-753'
+  sha256 'd31ae640c04bd5d5b84f8fd8a096e932a821df328e2d90b960537a999b48024e'
 
   url "https://www.nssurge.com/mac/v#{version.major}/Surge-#{version}.zip"
   appcast "https://www.nssurge.com/mac/v#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.