### PR TITLE
Update sound-siphon to 3.0.3

### DIFF
--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -4,7 +4,7 @@ cask 'sound-siphon' do
 
   # staticz.net was verified as official when first introduced to the cask
   url "http://staticz.net/downloads/SoundSiphon_#{version}.dmg"
-  appcast 'http://staticz.net/updates/soundsiphon3.rss'
+  appcast "http://staticz.net/updates/soundsiphon#{version.major}.rss"
   name 'SoundSiphon'
   homepage 'https://staticz.com/soundsiphon/'
 

--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -4,7 +4,7 @@ cask 'sound-siphon' do
 
   # staticz.net was verified as official when first introduced to the cask
   url "http://staticz.net/downloads/SoundSiphon_#{version}.dmg"
-  appcast '/Users/julian/Library/Caches/Homebrew/downloads/8d687f4f2'
+  appcast 'http://staticz.net/updates/soundsiphon3.rss'
   name 'SoundSiphon'
   homepage 'https://staticz.com/soundsiphon/'
 

--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -4,6 +4,7 @@ cask 'sound-siphon' do
 
   # staticz.net was verified as official when first introduced to the cask
   url "http://staticz.net/downloads/SoundSiphon_#{version}.dmg"
+  appcast '/Users/julian/Library/Caches/Homebrew/downloads/8d687f4f2'
   name 'SoundSiphon'
   homepage 'https://staticz.com/soundsiphon/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.