### PR TITLE
Update silo to 2.5.6b

### DIFF
--- a/Casks/silo.rb
+++ b/Casks/silo.rb
@@ -1,8 +1,9 @@
 cask 'silo' do
-  version '2.5.5'
-  sha256 '7d0a4af414dcfe623a76da5d23fa324651913b2258062e998274e336eb8c29f2'
+  version '2.5.6b'
+  sha256 'e50cbcf455906504fce52b3f2086145effa1395841122d2aefe8ea756f9f00fb'
 
   url "https://nevercenter.com/silo/download_file/filearchive/Install_Silo_#{version.dots_to_underscores}_mac.dmg"
+  appcast 'https://nevercenter.com/silo/release_notes/'
   name 'Silo'
   homepage 'https://nevercenter.com/silo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.