### PR TITLE
Update netron to 2.5.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.5.3'
-  sha256 'ed8aaeb79bb3008a81b9ccf95ca24bfc24608ae0b6e25a29c23fdd39df04553f'
+  version '2.5.4'
+  sha256 'da85c12bf2e387e037e05de24dfa87d4caa8eab38af6319e5b7ea2b3d0ae3deb'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.