### PR TITLE
Update whatpulse to 2.8.4

### DIFF
--- a/Casks/whatpulse.rb
+++ b/Casks/whatpulse.rb
@@ -1,6 +1,6 @@
 cask 'whatpulse' do
-  version '2.8.3'
-  sha256 'b5184481d783e13a1abedf94c0abce53554c18c852e6fdfc7a5a2041483b7777'
+  version '2.8.4'
+  sha256 '68b3caf929e99d87d0344d344a9e104a5c3c601ef8dc2bbdf5275cfb1c2f8e3f'
 
   url "https://static.whatpulse.org/files/whatpulse-mac-#{version}.dmg"
   appcast 'https://static.whatpulse.org/etc/version-info.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.