### PR TITLE
Update dendroscope to 3.5.10

### DIFF
--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -19,6 +19,6 @@ cask 'dendroscope' do
   end
 
   caveats do
-    depends_on_java 
+    depends_on_java
   end
 end

--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -1,6 +1,6 @@
 cask 'dendroscope' do
-  version '3.5.9'
-  sha256 '63d3f42a7143710d40c2b5d4cf9a80e98820f92bf43eb16f4617dcf2d0f5b6c6'
+  version '3.5.10'
+  sha256 '6fcf8a60e481f6880bf05966013cea02ebb512c0dbc0505d4c7759c129e7ce2c'
 
   # ab.inf.uni-tuebingen.de/data/software/dendroscope3 was verified as official when first introduced to the cask
   url "http://ab.inf.uni-tuebingen.de/data/software/dendroscope3/download/Dendroscope_macos_#{version.dots_to_underscores}.dmg"
@@ -19,6 +19,6 @@ cask 'dendroscope' do
   end
 
   caveats do
-    depends_on_java
+    depends_on java: ['11', 'openjdk 11']
   end
 end

--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -19,6 +19,6 @@ cask 'dendroscope' do
   end
 
   caveats do
-    depends_on java: ['11', 'openjdk 11']
+    depends_on_java 
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.