### PR TITLE
Update ledger-live to 1.2.5

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.2.3'
-  sha256 'f954d9b6e56f111b15de5e396051a9262cf3ff15837bc0d3a78ec6645b7a7eeb'
+  version '1.2.5'
+  sha256 '15e8a9f62d02b9ee2f7cc306d2cc34af1027207264ec4f8672d4adacb48d3902'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.