### PR TITLE
Add gpg-suite-pinentry 2018.5

### DIFF
--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -10,7 +10,7 @@ cask 'gpg-suite-pinentry' do
   auto_updates true
   conflicts_with cask: [
                          'gpg-suite',
-                         'gpg-suite-nightly'
+                         'gpg-suite-nightly',
                        ]
   depends_on macos: '>= :sierra'
 

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -95,20 +95,13 @@ cask 'gpg-suite-pinentry' do
                  },
                ]
 
-  uninstall pkgutil: 'org.gpgtools.pinentry*',
+  uninstall pkgutil: 'org.gpgtools.pinentry.*',
             quit:    'org.gpgtools.pinentry-mac',
             delete:  '/usr/local/MacGPG2'
 
-  zap trash: ['~/Library/Preferences/org.gpgtools.common.plist']
+  zap trash: '~/Library/Preferences/org.gpgtools.common.plist'
 
   caveats do
     files_in_usr_local
-    <<~EOS
-      You can now set this as your pinentry program by adding the following line to ~/.gnupg/gpg-agent.conf:
-        pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
-
-      The "Save in Keychain" option is enabled by default, it can be disabled with the following command:
-        defaults write org.gpgtools.common UseKeychain -bool false
-    EOS
   end
 end

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -8,7 +8,10 @@ cask 'gpg-suite-pinentry' do
   homepage 'https://gpgtools.org/'
 
   auto_updates true
-  conflicts_with cask: ['gpg-suite', 'gpg-suite-nightly']
+  conflicts_with cask: [
+                         'gpg-suite',
+                         'gpg-suite-nightly'
+                       ]
   depends_on macos: '>= :sierra'
 
   pkg 'Install.pkg',

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -1,0 +1,114 @@
+cask 'gpg-suite-pinentry' do
+  version '2018.5'
+  sha256 'c66ecf48ccf709f704f02097cf9d68ba97b0efba24f7a0b7b46adfd1133cb86a'
+
+  url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
+  appcast 'https://gpgtools.org/releases/gka/appcast.xml'
+  name 'GPG Suite Pinentry'
+  homepage 'https://gpgtools.org/'
+
+  auto_updates true
+  conflicts_with cask: ['gpg-suite', 'gpg-suite-nightly']
+  depends_on macos: '>= :sierra'
+
+  pkg 'Install.pkg',
+      choices: [
+                 {
+                   'choiceIdentifier' => 'installer_choice_1', # preinstall.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_2', # Libmacgpg_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_3', # LibmacgpgXPC_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_4', # GPGMail_14_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_5', # GPGMail_13_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_6', # GPGMail_12_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_7', # GPGMailLoader_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_8', # GPGServices_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_9', # GPGKeychain_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_10', # GPGPreferences_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_11', # MacGPG2.1_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_12', # Updater_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_13', # pinentry_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_14', # version.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_15', # key.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_16', # CheckPrivateKey.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+               ]
+
+  uninstall pkgutil: 'org.gpgtools.pinentry*',
+            quit:    'org.gpgtools.pinentry-mac',
+            delete:  '/usr/local/MacGPG2'
+
+  zap trash: ['~/Library/Preferences/org.gpgtools.common.plist']
+
+  caveats do
+    files_in_usr_local
+    <<~EOS
+      You can now set this as your pinentry program by adding the following line to ~/.gnupg/gpg-agent.conf:
+        pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
+
+      The "Save in Keychain" option is enabled by default, it can be disabled with the following command:
+        defaults write org.gpgtools.common UseKeychain -bool false
+    EOS
+  end
+end


### PR DESCRIPTION
Add gpg-suite-pinentry 2018.5. This installs only the pinentry package from gpg-suite.

This cask installs only pinentry from gpg-suite which can be considered a more up-to-date version (1.1.0) of pinentry-mac available in homebrew.

The reason for this cask is that [GPGTools/pinentry-mac](https://github.com/GPGTools/pinentry-mac) (a.k.a. pinentry-mac v0.9.4 from homebrew) is no longer updated and a more up-to-date pinentry is located at [GPGTools/pinentry](https://github.com/GPGTools/pinentry) (v1.1.0). However, there are no releases for the up-to-date pinentry apart from it being bundled in gpg-suite. As such it seemed appropriate to create this cask with this naming. I'm open to alternatives and will update the PR accordingly.

Another reason is that, in its default configuration, gpg-suite is intrusive as it modifies the users `PATH` and sets a high priority for it's own `gpg`-binaries and also installs a Mail plugin, etc. It's more preferable to only install pinentry and use gpg from homebrew.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
