### PR TITLE
Update surge to 3.0.3-754

### DIFF
--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -1,11 +1,14 @@
 cask 'surge' do
-  version '3.0.3-753'
-  sha256 'd31ae640c04bd5d5b84f8fd8a096e932a821df328e2d90b960537a999b48024e'
+  version '3.0.3-754'
+  sha256 'f99ad05f684e2ecc6bb2441f74a42776969ebfc4e169ec8e64ff3d64be1ccf95'
 
   url "https://www.nssurge.com/mac/v#{version.major}/Surge-#{version}.zip"
   appcast "https://www.nssurge.com/mac/v#{version.major}/appcast.xml"
   name 'Surge'
   homepage 'https://nssurge.com/'
+
+  auto_updates true
+  depends_on macos: '>= :el_capitan'
 
   app "Surge #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.