### PR TITLE
Update displaycal to 3.7.1.1

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,6 +1,6 @@
 cask 'displaycal' do
-  version '3.7.0.0'
-  sha256 '52511c75b22762dfd058b6973b6044a40be5fbf97a3ab2829df973d43a03284e'
+  version '3.7.1.1'
+  sha256 '08f62b3492f169049339b251ea209f75398bbe960125fa8e2fefad9f6aaab119'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.