### PR TITLE
Update acorn to 6.2.3

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,6 +1,6 @@
 cask 'acorn' do
-  version '6.2.2'
-  sha256 'aadf0b8244b28b89723d1a421980f840647b384f11b5c6f7a95c02508f772306'
+  version '6.2.3'
+  sha256 '0be478b51f70a3667e12c8a5db56c63defd6f6f2947cb87b3622a063e3351837'
 
   url 'https://flyingmeat.com/download/Acorn.zip'
   appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.