### PR TITLE
Update origami-studio to 131604203

### DIFF
--- a/Casks/origami-studio.rb
+++ b/Casks/origami-studio.rb
@@ -8,7 +8,7 @@ cask 'origami-studio' do
   name 'Origami Studio'
   homepage 'https://origami.design/'
 
-  depends_on macos: '>= 10.12'
+  depends_on macos: '>= :sierra'
 
   app 'Origami Studio.app'
 end

--- a/Casks/origami-studio.rb
+++ b/Casks/origami-studio.rb
@@ -1,6 +1,6 @@
 cask 'origami-studio' do
-  version '2.5'
-  sha256 '3d47d5119184bbb59125d7ed2c75a75c375d8a0e04a7ce3dcb0604a83c649482'
+  version '131604203'
+  sha256 'ba26f6b289adb6d883074c0e42e385b867dff42df4b356a15a2f431e7cac4967'
 
   # fb.me/getorigamistudio was verified as official when first introduced to the cask
   url 'https://fb.me/getorigamistudio'

--- a/Casks/origami-studio.rb
+++ b/Casks/origami-studio.rb
@@ -8,5 +8,7 @@ cask 'origami-studio' do
   name 'Origami Studio'
   homepage 'https://origami.design/'
 
+  depends_on macos: '>= 10.12'
+
   app 'Origami Studio.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.