### PR TITLE
Update wingide to 6.1.2-1

### DIFF
--- a/Casks/wingide.rb
+++ b/Casks/wingide.rb
@@ -1,6 +1,6 @@
 cask 'wingide' do
-  version '6.1.1-1'
-  sha256 '932f14f0cc5dbbc81a26aa1b6ce08a152c05bae0a034f2f39bbe3384223ca00d'
+  version '6.1.2-1'
+  sha256 'c5b6d5fa60ee046eb41f73a305763df5f50838b41a8c7d00a8f1ac9bbf8c8f2c'
 
   url "https://wingware.com/pub/wingide/#{version.sub(%r{-\d+}, '')}/wingide-#{version}.dmg"
   name 'WingIDE'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.