### PR TITLE
Update mucommander to 0.9.3

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -8,7 +8,9 @@ cask 'mucommander' do
   name 'muCommander'
   homepage 'https://www.mucommander.com/'
 
-  depends_on java: '1.8'
-
   app 'muCommander.app'
+
+  caveats do
+    depends_on_java '8'
+  end
 end

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,12 +1,14 @@
 cask 'mucommander' do
-  version '0.9.2'
-  sha256 '54486fba723d3d54084414e31337b010c2f28fc4820cefc01cad65e4a5a84744'
+  version '0.9.3'
+  sha256 'cb74e0f857ff5bac804be0548e331de0dbfb9fa74acf948a095bdf2b256a4b34'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"
   appcast 'https://github.com/mucommander/mucommander/releases.atom'
   name 'muCommander'
   homepage 'https://www.mucommander.com/'
+
+  depends_on java: '1.8'
 
   app 'muCommander.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.