### PR TITLE
Update tableplus to 1.0,156

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '1.0,150'
-  sha256 '0ec9682c512e5878b3fe7e9117551869556dcfcdeeb9be0c88c645a76ec05d81'
+  version '1.0,156'
+  sha256 'd8b387240e31b985d5bc49d44ff4592f7d1e8a51c2b51025602cdd069e849609'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.