### PR TITLE
Update netron to 2.5.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.5.5'
-  sha256 '006e12ad5ab2da99d317db1a541ec8b90da504b86fa24c757d9df8765f160838'
+  version '2.5.6'
+  sha256 '67d438ac4680c6009f96580048206a165ae649d004e88e0c814d2147cc78a4f2'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.