### PR TITLE
Update appcleaner version option

### DIFF
--- a/Casks/appcleaner.rb
+++ b/Casks/appcleaner.rb
@@ -2,6 +2,9 @@ cask 'appcleaner' do
   if MacOS.version <= :mavericks
     version '2.3'
     sha256 '69da212e2972e23e361c93049e4b4505d7f226aff8652192125f078be7eecf7f'
+  elsif MacOS.version <= :sierra
+    version '3.4'
+    sha256 '0c60d929478c1c91e0bad76d3c04795665c07a05e45e33321db845429c9aefa8'
   else
     version '3.5'
     sha256 '9a67033977622f8523c6d11315fd646b4b3b7b2675ec7c10b37b4d5f5602acb3'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
The website shows that the new version 3.5 is only for High Sierra and up. I've added back version 3.4 for Yosemite to Sierra.