### PR TITLE
Update neteasemusic to 1.5.10_636

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask 'neteasemusic' do
-  version '1.5.10_632'
-  sha256 '2e3698584e10a2360b5c3703b0c12c6a03af7cafe1d77c3fd802373c2f14fa37'
+  version '1.5.10_636'
+  sha256 '2fd699256de9aba57bbc417a6918c48536d9bdde92957cc798338b5555013f13'
 
   # d1.music.126.net was verified as official when first introduced to the cask
   url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.