### PR TITLE
Update freesmug-chromium to 70.0.3538.110

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '70.0.3538.102'
-  sha256 '170b5b5dc3b7f4cc72ed3cf223126780a2d79710a1d2c58c1865b4c6ba5041af'
+  version '70.0.3538.110'
+  sha256 '3b5da493f67afa576b253fc066c6bef3f0658ffd551a873f9ce832da77c6baeb'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.