### PR TITLE
Update iridient-developer to 3.3.1

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.3.0'
-  sha256 '9eed6e134c8868ee99a63024f02c7b15b19577809ae566dd9495c5f264dc957e'
+  version '3.3.1'
+  sha256 'b5f05e9772a9d7f77676f5f757a51e4817f0a1e741fbb935f7812d671fd7c5bc'
 
   url "https://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'https://www.iridientdigital.com/products/rawdeveloper_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.