### PR TITLE
Update quodlibet to 4.2.0

### DIFF
--- a/Casks/quodlibet.rb
+++ b/Casks/quodlibet.rb
@@ -1,6 +1,6 @@
 cask 'quodlibet' do
-  version '4.1.0'
-  sha256 'e4605153e17727ba413339616115c159d53dfca7920a295670f72e58bd9e762e'
+  version '4.2.0'
+  sha256 'd0ce491acdd0828c07746a6239b9bb63b3876e499e8b24bca73a024e19b34558'
 
   # github.com/quodlibet/quodlibet was verified as official when first introduced to the cask
   url "https://github.com/quodlibet/quodlibet/releases/download/release-#{version}/QuodLibet-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.