### PR TITLE
Update isyncr to 5.14.10

### DIFF
--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -3,8 +3,8 @@ cask 'isyncr' do
     version '5.6.5'
     sha256 '8cd6b1c96a902d8810e52aab6a980424370237617bfd3ff574367ff1ce8d4f4e'
   else
-    version '5.14.9'
-    sha256 '886877b524148cd305189088b8cb54ee5599ab75186493d7e69624cc7d19fed6'
+    version '5.14.10'
+    sha256 '3952db5c64873cf63a5bfb6b308fd992f2eeb67cf838955fc200cd59640803aa'
   end
 
   url "https://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.