### PR TITLE
Update duet to 2.0.3.8

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,6 +1,6 @@
 cask 'duet' do
-  version '2.0.3.1'
-  sha256 '905f62b3af2c39d22dc1563dab8ee86b27b7c4457947875a7aec10800d016d87'
+  version '2.0.3.8'
+  sha256 'fc65cdc1baf0eaf80d301e1378ff83e29ba9282a350429205c2ebe87983af613'
 
   # duet.nyc3.cdn.digitaloceanspaces.com/Mac was verified as official when first introduced to the cask
   url "https://duet.nyc3.cdn.digitaloceanspaces.com/Mac/#{version.major_minor.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.