### PR TITLE
Docker.app 18: keep for yosemite-el capitan compat

### DIFF
--- a/Casks/docker@18.rb
+++ b/Casks/docker@18.rb
@@ -1,0 +1,50 @@
+cask 'docker@18' do
+  version '18.06.1-ce-mac73,26764'
+  sha256 '3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5'
+
+  url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
+  appcast 'https://download.docker.com/mac/stable/appcast.xml'
+  name 'Docker Community Edition'
+  name 'Docker CE'
+  homepage 'https://www.docker.com/community-edition'
+
+  auto_updates true
+  depends_on macos: '>= :yosemite'
+
+  app 'Docker.app'
+
+  uninstall delete:    [
+                         '/Library/PrivilegedHelperTools/com.docker.vmnetd',
+                         '/private/var/tmp/com.docker.vmnetd.socket',
+                         '/usr/local/bin/docker',
+                         '/usr/local/bin/docker-compose',
+                         '/usr/local/bin/docker-credential-osxkeychain',
+                         '/usr/local/bin/docker-machine',
+                         '/usr/local/bin/hyperkit',
+                         '/usr/local/bin/notary',
+                         '/usr/local/bin/vpnkit',
+                       ],
+            launchctl: [
+                         'com.docker.helper',
+                         'com.docker.vmnetd',
+                       ],
+            quit:      'com.docker.docker'
+
+  zap trash: [
+               '/usr/local/bin/docker-compose.backup',
+               '/usr/local/bin/docker-machine.backup',
+               '/usr/local/bin/docker.backup',
+               '~/Library/Application Scripts/com.docker.helper',
+               '~/Library/Caches/KSCrashReports/Docker',
+               '~/Library/Caches/com.docker.docker',
+               '~/Library/Caches/com.plausiblelabs.crashreporter.data/com.docker.docker',
+               '~/Library/Containers/com.docker.docker',
+               '~/Library/Containers/com.docker.helper',
+               '~/Library/Group Containers/group.com.docker',
+               '~/Library/Preferences/com.docker.docker.plist',
+             ],
+      rmdir: [
+               '~/Library/Caches/KSCrashReports',
+               '~/Library/Caches/com.plausiblelabs.crashreporter.data',
+             ]
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

This PR brings back old Docker.app 18.06.1 for compatibility with Yosemite and El Capitan (renamed to `docker@18`) since Docker 2.0.0 requires at least 10.12 Sierra (see #55265 ).