### PR TITLE
Update smartsvn to 11.0.0

### DIFF
--- a/Casks/smartsvn.rb
+++ b/Casks/smartsvn.rb
@@ -1,6 +1,6 @@
 cask 'smartsvn' do
-  version '9.3.2'
-  sha256 '69dee11c1230e1ec59b0022552c6dd26788d810295315be82e0f0186bacf8925'
+  version '11.0.0'
+  sha256 'f330c30be85dd5df101c2414f8c9f003f7305c786fbaabd3bafa5d506f78e329'
 
   url "https://www.smartsvn.com/downloads/smartsvn/smartsvn-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.smartsvn.com/documents/smartsvn/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.