### PR TITLE
Update netron to 2.5.8

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.5.7'
-  sha256 '0c25fb5c8f54b77bc1205a68ffff1a32e7fbdd7d5eccdcc27bf2fee8ea42f200'
+  version '2.5.8'
+  sha256 'f64ade141bcf7bc53025eaf72afd17cc1497e7c494dc470b66b68af911c787d3'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.