### PR TITLE
Update checksum for amadeus-pro

### DIFF
--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -1,6 +1,6 @@
 cask 'amadeus-pro' do
   version '2.5.1'
-  sha256 'd40cc747b90201379fc6509a8673644546e2ae80ef2d0e90e91e76c2bf2ab5a2'
+  sha256 'fc4189dbadc4da8078d586b9453170e84e974816000bf66e22dcd0e8612789a6'
 
   # amazonaws.com/AmadeusPro2 was verified as official when first introduced to the cask
   url 'http://s3.amazonaws.com/AmadeusPro2/AmadeusPro.zip'


### PR DESCRIPTION
The checksum for the file downloaded from the website (https://hairersoft.com/pro.html) differs from the checksum in the current version of the cask file. This updates the checksum specified to match that of the download.

I'm not sure why this happened, maybe the author pushed a hotfix?

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.