### PR TITLE
Update coverload to 1.2.1-420

### DIFF
--- a/Casks/coverload.rb
+++ b/Casks/coverload.rb
@@ -1,6 +1,6 @@
 cask 'coverload' do
-  version '1.2.0-353'
-  sha256 '0f9c39af1049963ff3faf34ed4d0a58b8745287b2489b20fb4d8312b126a444b'
+  version '1.2.1-420'
+  sha256 '903403754aa04590e843c8460881dabb52e1989b1c31bb1a0dc866d8848ec53b'
 
   # amazonaws.com/coverloadapp.com was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/coverloadapp.com/Uploads/CoverLoad-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.