### PR TITLE
Update banking-4x to 6.10.9,6900

### DIFF
--- a/Casks/banking-4x.rb
+++ b/Casks/banking-4x.rb
@@ -1,7 +1,7 @@
 cask 'banking-4x' do
   # note: "4x" is not a version number, but an intrinsic part of the product name
-  version '6.10.8,6892'
-  sha256 'df4584ce42c6eb128eb4f838e0edb4162d40e45130d4b62fcff474c4ca11d11e'
+  version '6.10.9,6900'
+  sha256 '7525f9d94ed6df1ea7d22d97d5feb7f346abfb56e8f3022ac1b80add46276f44'
 
   url 'https://subsembly.com/download/MacBanking.pkg'
   appcast 'https://subsembly.com/banking4x-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.