### PR TITLE
Update universal-media-server to 7.6.1

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,6 +1,6 @@
 cask 'universal-media-server' do
-  version '7.6.0'
-  sha256 'f277a2cb40d641575ef636fd65a4635eaceffe1c07f75447825f75330575cb28'
+  version '7.6.1'
+  sha256 'af391504322df025d586efaaa386bb2d6bdb05be41805069f13cba625d5d40a2'
 
   # sourceforge.net/unimediaserver was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/unimediaserver/Official%20Releases/OS%20X/UMS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.