### PR TITLE
Update goofy to 3.3.4

### DIFF
--- a/Casks/goofy.rb
+++ b/Casks/goofy.rb
@@ -1,6 +1,6 @@
 cask 'goofy' do
-  version '3.3.3'
-  sha256 'f3c69ce23b9b0981e0ad4610707c4b51c1e45666d064cd4fb3155aada6cd5e82'
+  version '3.3.4'
+  sha256 '175a5e629128fc5163378217fd4fe4122de768b67c93982abff645d0c33d1e19'
 
   # github.com/danielbuechele/goofy was verified as official when first introduced to the cask
   url "https://github.com/danielbuechele/goofy/releases/download/v#{version}/Goofy-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.