### PR TITLE
Update phoenix-slides to 1.4.3

### DIFF
--- a/Casks/phoenix-slides.rb
+++ b/Casks/phoenix-slides.rb
@@ -1,6 +1,6 @@
 cask 'phoenix-slides' do
-  version '1.4.2'
-  sha256 'bde43c827972b8539198a0838e59e5d8f0fb3376a767eb04e467b584c832d239'
+  version '1.4.3'
+  sha256 'ef150da77dc578cfdaaf94fd7680d4b09107d3cdf217e71f7065eb02bf5be934'
 
   # github.com/gobbledegook/creevey was verified as official when first introduced to the cask
   url "https://github.com/gobbledegook/creevey/releases/download/v#{version}/phoenix-slides-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.