### PR TITLE
safe-exam-browser: New cask

### DIFF
--- a/Casks/safe-exam-browser.rb
+++ b/Casks/safe-exam-browser.rb
@@ -1,0 +1,18 @@
+cask 'safe-exam-browser' do
+  version '2.1.3'
+  sha256 '57cdaf387378b0944050f652ab6451c1319cb5b3ab3b2f83cbd3755b085c2401'
+
+  # downloads.sourceforge.net was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/seb/SafeExamBrowser-#{version}.dmg"
+  appcast 'https://sourceforge.net/projects/seb/rss?path=/seb-macosx'
+  name 'Safe Exam Browser'
+  homepage 'https://safeexambrowser.org/'
+
+  app 'Safe Exam Browser.app'
+
+  zap trash: [
+               '~/Library/Caches/org.safeexambrowser.Safe-Exam-Browser',
+               '~/Library/Logs/Safe Exam Browser',
+               '~/Library/Preferences/org.safeexambrowser.Safe-Exam-Browser.plist',
+             ]
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->
As a student, I've been forced to use this internet browser under exams.  The browser takes control of the system in a way that I won't be able to interact with the underlying system, i.g. Finder, Calculator, Safari, etc.  It acts as a full sized application, and I can't CMD+tab out.

I use Casks for all my application installs if possible, and found it natural to submit this.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
