### PR TITLE
Update slic3r to 1.3.0

### DIFF
--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -1,8 +1,8 @@
 cask 'slic3r' do
-  version '1.2.9'
-  sha256 '2e8579791192332bb2ee6dce860d78edd4bb010ff06d0d7692dedee641a1bc1c'
+  version '1.3.0'
+  sha256 'a50dbe78c4648dfcd0ffec46335554c9fa3348dd494a1f6c2b60406aea57b5cb'
 
-  url "https://dl.slic3r.org/mac/slic3r-osx-uni-#{version.dots_to_hyphens}-stable.dmg"
+  url "https://dl.slic3r.org/mac/slic3r-#{version}.dmg"
   appcast 'https://dl.slic3r.org/mac/'
   name 'Slic3r'
   homepage 'http://slic3r.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.