### PR TITLE
Update reaper to 5.96.200,5.962

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,8 +1,8 @@
 cask 'reaper' do
-  version '5.961'
-  sha256 '7b10b0e1fde20ceadfb9538a67f09a623bbb8706c2f8351a999c313100cffe08'
+  version '5.96.200,5.962'
+  sha256 'fcf2b34cc479093c2b9c8c37c78a6633769b2e20d6864165398a13124f454dc9'
 
-  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
+  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'
   name 'REAPER'
   homepage 'https://www.reaper.fm/'

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -2,7 +2,7 @@ cask 'reaper' do
   version '5.96.200'
   sha256 'fcf2b34cc479093c2b9c8c37c78a6633769b2e20d6864165398a13124f454dc9'
 
-  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"
+  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'
   name 'REAPER'
   homepage 'https://www.reaper.fm/'

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,5 +1,5 @@
 cask 'reaper' do
-  version '5.96.200,5.962'
+  version '5.96.200'
   sha256 'fcf2b34cc479093c2b9c8c37c78a6633769b2e20d6864165398a13124f454dc9'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.