### PR TITLE
Update dawn to 2.11.0

### DIFF
--- a/Casks/dawn.rb
+++ b/Casks/dawn.rb
@@ -1,6 +1,6 @@
 cask 'dawn' do
-  version '2.10.0,20180904-1516'
-  sha256 '1e04d9fbe30787a9c304b2137238e46f25fa900f5efac3b07efd3ac532375895'
+  version '2.11.0,20181121-0820'
+  sha256 'f717757e75b2a3e706ed292d749e29c2e4231812e6683d37379fd07975f568e9'
 
   # alfred.diamond.ac.uk/DawnDiamond was verified as official when first introduced to the cask
   url "https://alfred.diamond.ac.uk/DawnDiamond/#{version.major_minor}/downloads/builds-release/DawnDiamond-#{version.before_comma}.v#{version.after_comma}-mac64.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

`brew cask style` aborted with the following error:

```
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- jaro_winkler (LoadError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.57.2/lib/rubocop/string_util.rb:3:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.57.2/lib/rubocop.rb:21:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.57.2/lib/rubocop.rb:21:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.57.2/exe/rubocop:6:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin/rubocop:22:in `load'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin/rubocop:22:in `<main>'
Error: style check failed
```