### PR TITLE
Change channel to stable from latest for media-center

### DIFF
--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -2,7 +2,7 @@ cask 'media-center' do
   version '24.00.56'
   sha256 'e9fe2e1755f533c898b5d201081feb5b786c9fd0c9cb3c466f57631c0f6c82ef'
 
-  url "https://files.jriver.com/mediacenter/channels/v#{version.major}/latest/MediaCenter#{version.no_dots}.dmg"
+  url "https://files.jriver.com/mediacenter/channels/v#{version.major}/stable/MediaCenter#{version.no_dots}.dmg"
   name 'JRiver Media Center'
   homepage 'https://www.jriver.com/'
 


### PR DESCRIPTION
Changed latest back to stable in the url. [Again](https://github.com/Homebrew/homebrew-cask/pull/52314).
Because I assume not every latest build is stable.
On download page macOS links are always stable.
And not every build from forum is posted to download page.
Also when using auto updater in app for stable channel, it updates only to stable builds, skipping forum builds.
Homebrew Cask docs [says](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) that 

> Stable versions live in the main repository

Pinging @core-code who did this changes. Please explain why its needed.
Thanks.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256