### PR TITLE
Update outline-manager to 1.1.9

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.1.8'
-  sha256 'e776d3c0472f7185b4ec4d45695ff2c70b89c6ea893efb9db362af4d15977c9d'
+  version '1.1.9'
+  sha256 '4d5f4e5e2265f0601483957f4ab3d26e69f508adcf6f61f230bad0174b649629'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.