### PR TITLE
Update bitshares to 2.0.181121

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,6 +1,6 @@
 cask 'bitshares' do
-  version '2.0.181010'
-  sha256 '2fb6b4d08f3f90ddb9dd7d193378107b561c23a95f38745233d93627d2fdf6f1'
+  version '2.0.181121'
+  sha256 '50a49b3460e29dd678b87cdf925cee1d904b16041fa606ec7e66505ad16310ec'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.