### PR TITLE
Update netron to 2.6.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.6.0'
-  sha256 '0932560c10b61afb4230286138d56c89f367f340371862d1c40ac769de94e28f'
+  version '2.6.1'
+  sha256 'fef92c6dcaba0a982796f85bb0b7db0fb1ec401d9e084e0d9f53f47dabcc1d50'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.