### PR TITLE
Update netron to 2.6.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.6.0'
-  sha256 '0932560c10b61afb4230286138d56c89f367f340371862d1c40ac769de94e28f'
+  version '2.6.3'
+  sha256 'f5cea9d4fe04c88e61ef6ac8ee9e3fb775fbfdbef2f83e1e59b743a646b1d889'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.