### PR TITLE
Update surge to 3.0.4-759

### DIFF
--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -1,6 +1,6 @@
 cask 'surge' do
-  version '3.0.3-754'
-  sha256 'f99ad05f684e2ecc6bb2441f74a42776969ebfc4e169ec8e64ff3d64be1ccf95'
+  version '3.0.4-759'
+  sha256 'a00b22afc61caefdf513d30a1588bfe227c29ca16762c501e1cc104677c6c214'
 
   url "https://www.nssurge.com/mac/v#{version.major}/Surge-#{version}.zip"
   appcast "https://www.nssurge.com/mac/v#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.