### PR TITLE
Update Etcher to version 1.4.8

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,4 +1,4 @@
-cask 'etcher' do
+cask 'balenaetcher' do
   version '1.4.8'
   sha256 'b2e4577dd50561cdbfd45540c0506acd67d362ba1a571e80974863cef2135d76'
 

--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -1,12 +1,12 @@
 cask 'etcher' do
-  version '1.4.6'
-  sha256 '753ecccfe4054823ddd4bc90cb64c27178b58aff4264ebe57dbbcafd9a166e46'
+  version '1.4.8'
+  sha256 'b2e4577dd50561cdbfd45540c0506acd67d362ba1a571e80974863cef2135d76'
 
-  # github.com/resin-io/etcher was verified as official when first introduced to the cask
-  url "https://github.com/resin-io/etcher/releases/download/v#{version}/Etcher-#{version}.dmg"
-  appcast 'https://github.com/resin-io/etcher/releases.atom'
+  # github.com/balena-io/etcher was verified as official when first introduced to the cask
+  url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"
+  appcast 'https://github.com/balena-io/etcher/releases.atom'
   name 'Etcher'
-  homepage 'https://etcher.io/'
+  homepage 'https://balena.io/etcher'
 
   app 'Etcher.app'
 

--- a/Casks/etcher.rb
+++ b/Casks/etcher.rb
@@ -8,12 +8,12 @@ cask 'etcher' do
   name 'Etcher'
   homepage 'https://balena.io/etcher'
 
-  app 'Etcher.app'
+  app 'balenaEtcher.app'
 
   zap trash: [
-               '~/Library/Application Support/etcher',
-               '~/Library/Preferences/io.resin.etcher.helper.plist',
-               '~/Library/Preferences/io.resin.etcher.plist',
-               '~/Library/Saved Application State/io.resin.etcher.savedState',
+               '~/Library/Application Support/balena-etcher',
+               '~/Library/Preferences/io.balena.etcher.helper.plist',
+               '~/Library/Preferences/io.balena.etcher.plist',
+               '~/Library/Saved Application State/io.balena.etcher.savedState',
              ]
 end


### PR DESCRIPTION
Note that [resin-io changed names](https://www.balena.io/blog/resin-io-changes-name-to-balena-releases-open-source-edition/) and this update reflects that.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
