### PR TITLE
Update gisto to 1.10.17

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.16'
-  sha256 'e39df10e8e1cbe359f3a300739fdc7f3c3c3af0bb37d5b54840d55350fe3afb6'
+  version '1.10.17'
+  sha256 '8c95961fab98b6c7f70e70971597b6ad461884beeea17ea44d03896e797cac2a'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.