### PR TITLE
Update camtasia to 2018.0.7,152

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,6 +1,6 @@
 cask 'camtasia' do
-  version '2018.0.5,149'
-  sha256 '3461e36371a26ac2ae67f554748a3e6707ca07a7ac76fc1f9c0bb10d528ae593'
+  version '2018.0.7,152'
+  sha256 '6d7f3b450f82ca338c8114e8f257194f4bc9103663d24936535037b8bee45a65'
 
   # rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.