### PR TITLE
Update knockknock to 2.0.1

### DIFF
--- a/Casks/knockknock.rb
+++ b/Casks/knockknock.rb
@@ -1,6 +1,6 @@
 cask 'knockknock' do
-  version '2.0.0'
-  sha256 '80873e95b66dee363828b386f08d759675ce85bf02e21484aacd95f2dc3ae0e5'
+  version '2.0.1'
+  sha256 '67916905ccd03b1339db578583ea72dbcec88caccd51b61300ad9561b124b393'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/KnockKnock_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.