### PR TITLE
Update opera to 56.0.3051.104

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -9,4 +9,10 @@ cask 'opera' do
   auto_updates true
 
   app 'Opera.app'
+
+  zap trash: [
+    '~/Library/Application Support/com.operasoftware.Opera'
+    '~/Library/Caches/com.operasoftware.Opera'
+    '~/Library/Saved Application State/com.operasoftware.Opera.savedState'
+  ]
 end

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -11,8 +11,8 @@ cask 'opera' do
   app 'Opera.app'
 
   zap trash: [
-    '~/Library/Application Support/com.operasoftware.Opera'
-    '~/Library/Caches/com.operasoftware.Opera'
-    '~/Library/Saved Application State/com.operasoftware.Opera.savedState'
-  ]
+               '~/Library/Application Support/com.operasoftware.Opera',
+               '~/Library/Caches/com.operasoftware.Opera',
+               '~/Library/Saved Application State/com.operasoftware.Opera.savedState',
+             ]
 end

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '56.0.3051.102'
-  sha256 '33c9266a41d1c4daf227950198c89548995e88001e120368d444233dc0d0045f'
+  version '56.0.3051.104'
+  sha256 '018217a2620364ce3d7bed23ee38e66b07e2fd5aec4344fd4e45b7766a9c2223'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.