### PR TITLE
Update netron to 2.6.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.6.4'
-  sha256 '5593faa0f5ef6b9d4463b6f78fd3f4f733b7ac7ba0368d6b1570c1ece45918b5'
+  version '2.6.5'
+  sha256 '75269825ce41285b3334c88089dd2a0d99c0a78cd5a388c2c4084135d42d15d7'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.