### PR TITLE
Update fsnotes to 2.5.0

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.4.0'
-  sha256 '3a6e6dd01f8f5ecbbb85caa34c40b7bc3720973c643a470ff05e618bc6443e83'
+  version '2.5.0'
+  sha256 '6478f87962c1c5ce830278086d2adbc6756cb7f5c4495aceb873c7b2ce6acc5d'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version.major_minor}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.