### PR TITLE
Update graphql-playground to 1.8.3

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,6 +1,6 @@
 cask 'graphql-playground' do
-  version '1.8.2'
-  sha256 'f8e1717ba19fe6e93b5e5f65e7867c6ab356e422b498fac38b7dbc07eec77a38'
+  version '1.8.3'
+  sha256 'af57adb816d8f8fda148bbbeafacd10212e8ceb6ca893812853a51703e297300'
 
   url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prisma/graphql-playground/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.