### PR TITLE
Update mailplane to 4.1.0,4642

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,6 +1,6 @@
 cask 'mailplane' do
-  version '4.0.6,4565'
-  sha256 'e08021f097ef9972eb92ed5629f7791531cd175e9eb73a459f5bc60a69d01e8d'
+  version '4.1.0,4642'
+  sha256 'ba1a98b9f85dfa2362aa59732c7d7e8c62408fb82bfa6dbb535e8c9b0e049612'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
   appcast "https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.