### PR TITLE
Update tad to 0.9.0

### DIFF
--- a/Casks/tad.rb
+++ b/Casks/tad.rb
@@ -1,13 +1,21 @@
 cask 'tad' do
-  version '0.8.5'
-  sha256 'd18ee34912d9730dfd8608a0063aaadac83ed56ae168e2659650f7133142eacb'
+  version '0.9.0'
+  sha256 '55cd0d6557418ba4e072ad4fbcb1619f0df05842c6567ed4cbee37aa3c1d6f9b'
 
   # github.com/antonycourtney/tad was verified as official when first introduced to the cask
-  url "https://github.com/antonycourtney/tad/releases/download/v#{version}/tad-#{version}.dmg"
+  url "https://github.com/antonycourtney/tad/releases/download/v#{version}/Tad-#{version}.dmg"
   appcast 'https://github.com/antonycourtney/tad/releases.atom'
   name 'Tad'
   homepage 'https://www.tadviewer.com/'
 
   app 'Tad.app'
   binary "#{appdir}/Tad.app/Contents/Resources/tad.sh", target: 'tad'
+
+  zap trash: [
+               '~/Library/Application Support/Tad',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.antonycourtney.tad.sfl*',
+               '~/Library/Logs/Tad',
+               '~/Library/Preferences/com.antonycourtney.tad.plist',
+               '~/Library/Saved Application State/com.antonycourtney.tad.savedState',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.