### PR TITLE
Update usb-overdrive to 3.4

### DIFF
--- a/Casks/usb-overdrive.rb
+++ b/Casks/usb-overdrive.rb
@@ -6,8 +6,8 @@ cask 'usb-overdrive' do
     version '3.2'
     sha256 '5be1d46596f1e98e29a5634655f36fc3070ac08542c36cef77d8f516c883f6d7'
   else
-    version '3.3'
-    sha256 'aae9c1e92806090639ce50132fd214b0986dfa9a2687548f223575803ba0d28b'
+    version '3.4'
+    sha256 '8dd426c9bb2ab048269189acea143df9e77bbe106747f2a2d505d75e4079b340'
   end
 
   url "http://www.usboverdrive.com/download/USB-Overdrive-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.