### PR TITLE
Update cozy-drive to 3.10.4

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.10.3'
-  sha256 '1f13e3d2e94c72b4332db4da760fdb8a168e4176e97d0dc496a8d78a818c34fd'
+  version '3.10.4'
+  sha256 '65bed44bea1802dcbd5a039459bdd1b9dc817b90f9610c0ac02d37df4aa057ba'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.