### PR TITLE
Update coteditor to 3.6.7

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -9,8 +9,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.6.6'
-    sha256 'fa7da46c1c66eeb201ec342a97229fd5853d67a08ef48ef7ceadfcb085e722f4'
+    version '3.6.7'
+    sha256 '849d6f70eb8b6620658c37843792243075e2414d32044bffa22964345c2e750a'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.