### PR TITLE
secure URLs

### DIFF
--- a/Casks/accessmenubarapps.rb
+++ b/Casks/accessmenubarapps.rb
@@ -2,10 +2,10 @@ cask 'accessmenubarapps' do
   version '2.4'
   sha256 '1065fbb4ca009758d4f303ed2106bd82a5ae21233b478f50fea3ddaa318473ce'
 
-  url "http://www.ortisoft.de/resources/AccessMenuBarApps#{version}.dmg"
-  appcast 'http://www.ortisoft.de/accessmenubarapps/profileInfo.php'
+  url "https://www.ortisoft.de/resources/AccessMenuBarApps#{version}.dmg"
+  appcast 'https://www.ortisoft.de/accessmenubarapps/profileInfo.php'
   name 'AccessMenuBarApps'
-  homepage 'http://www.ortisoft.de/accessmenubarapps/'
+  homepage 'https://www.ortisoft.de/accessmenubarapps/'
 
   app 'AccessMenuBarApps.app'
 

--- a/Casks/across-lite.rb
+++ b/Casks/across-lite.rb
@@ -2,9 +2,9 @@ cask 'across-lite' do
   version '2.4.4,2442'
   sha256 '71e1b174415ea2582642f4861c0ae748b8afa1232c53adac5acddf5d5ea3a39b'
 
-  url "http://www.litsoft.com/across/alite/download/download.php/al#{version.after_comma}osx.dmg?os=macosx"
+  url "https://www.litsoft.com/across/alite/download/download.php/al#{version.after_comma}osx.dmg?os=macosx"
   name 'Across Lite'
-  homepage 'http://www.litsoft.com/across/alite/download/'
+  homepage 'https://www.litsoft.com/across/alite/download/'
 
   app 'Across Lite.app'
 end

--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -3,7 +3,7 @@ cask 'amadeus-pro' do
   sha256 'fc4189dbadc4da8078d586b9453170e84e974816000bf66e22dcd0e8612789a6'
 
   # amazonaws.com/AmadeusPro2 was verified as official when first introduced to the cask
-  url 'http://s3.amazonaws.com/AmadeusPro2/AmadeusPro.zip'
+  url 'https://s3.amazonaws.com/AmadeusPro2/AmadeusPro.zip'
   appcast 'https://s3.amazonaws.com/AmadeusPro2/versions.rtf'
   name 'Amadeus Pro'
   homepage 'https://www.hairersoft.com/pro.html'

--- a/Casks/angband.rb
+++ b/Casks/angband.rb
@@ -2,10 +2,10 @@ cask 'angband' do
   version '4.1.3'
   sha256 'b196392e8607dcc3a10ce66649762131f0bf6fdf7c981fed25bf214c84ed3905'
 
-  url "http://rephial.org/downloads/#{version.major_minor}/Angband-#{version}-osx.dmg"
-  appcast 'http://rephial.org/release/'
+  url "https://rephial.org/downloads/#{version.major_minor}/Angband-#{version}-osx.dmg"
+  appcast 'https://rephial.org/release/'
   name 'Angband'
-  homepage 'http://rephial.org/'
+  homepage 'https://rephial.org/'
 
   app 'Angband.app'
 end

--- a/Casks/doitim.rb
+++ b/Casks/doitim.rb
@@ -3,7 +3,7 @@ cask 'doitim' do
   sha256 'bf875f3b200540a708a8d4f404e98bc73b355b81a27183d091d31af73fe4f122'
 
   url "https://version.doit.im/dl/doit.im.#{version}.zip"
-  appcast 'http://doit.im/#download'
+  appcast 'https://doit.im/#download'
   name 'Doit.im'
   homepage 'https://doit.im/'
 

--- a/Casks/ebibookreader.rb
+++ b/Casks/ebibookreader.rb
@@ -2,9 +2,9 @@ cask 'ebibookreader' do
   version '1.3.6.0'
   sha256 '45744649ebc146a500571278839874fb1283fd87e06dd2120fbbfe805469b4da'
 
-  url 'http://haishin.ebookjapan.jp/contents/appli/reader/ebiBookReader.dmg'
+  url 'https://haishin.ebookjapan.jp/contents/appli/reader/ebiBookReader.dmg'
   name 'ebi.BookReader'
-  homepage 'http://www.ebookjapan.jp/ebj/reader/mac/'
+  homepage 'https://www.ebookjapan.jp/ebj/reader/mac/'
 
   pkg 'ebibookreader.pkg'
 

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -2,7 +2,7 @@ cask 'eclipse-platform' do
   version '4.9,201809060745'
   sha256 '22028f455a9745165c48f4d92045560f8995a5fbd9037d533939dace9b6e1ead'
 
-  url "http://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg"
+  url "https://download.eclipse.org/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg"
   name 'Eclipse SDK'
   homepage 'https://eclipse.org/eclipse/'
 

--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -4,7 +4,7 @@ cask 'eudic' do
 
   # static.frdic.com was verified as official when first introduced to the cask
   url 'https://static.frdic.com/pkg/eudicmac.dmg'
-  appcast 'http://www.eudic.net/update/eudic_mac.xml'
+  appcast 'https://www.eudic.net/update/eudic_mac.xml'
   name 'EuDic'
   name '欧路词典'
   homepage 'https://www.eudic.net/eudic/mac_dictionary.aspx'

--- a/Casks/freshback.rb
+++ b/Casks/freshback.rb
@@ -2,9 +2,9 @@ cask 'freshback' do
   version :latest
   sha256 :no_check
 
-  url 'http://arkanath.com/FreshBackMac/FreshBackMac.zip'
+  url 'https://arkanath.com/FreshBackMac/FreshBackMac.zip'
   name 'FreshBackMac'
-  homepage 'http://arkanath.com/FreshBackMac/'
+  homepage 'https://arkanath.com/FreshBackMac/'
 
   app 'FreshBackMac.app'
 end

--- a/Casks/hsang.rb
+++ b/Casks/hsang.rb
@@ -4,7 +4,7 @@ cask 'hsang' do
 
   # opd.gdl.netease.com was verified as official when first introduced to the cask
   url "https://opd.gdl.netease.com/HSAng_#{version}.dmg"
-  appcast 'http://hs.gameyw.netease.com/mac.xml'
+  appcast 'https://hs.gameyw.netease.com/mac.xml'
   name 'HSAng'
   homepage 'https://lushi.163.com/'
 

--- a/Casks/ibackupbot.rb
+++ b/Casks/ibackupbot.rb
@@ -2,9 +2,9 @@ cask 'ibackupbot' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.icopybot.com/iBackupBot-Setup.dmg'
+  url 'https://www.icopybot.com/iBackupBot-Setup.dmg'
   name 'iBackupBot'
-  homepage 'http://www.icopybot.com/itunes-backup-manager.htm'
+  homepage 'https://www.icopybot.com/itunes-backup-manager.htm'
 
   app 'iBackupBot.app'
 end

--- a/Casks/ios-console.rb
+++ b/Casks/ios-console.rb
@@ -2,7 +2,7 @@ cask 'ios-console' do
   version '1.0.2'
   sha256 '84e3c4fbf685744fddf7ab87ac9fcb7fbccbc0d82baf22351d500ed1616ae84f'
 
-  url "http://downloads.lemonjar.com/iosconsole_v#{version}.zip"
+  url "https://downloads.lemonjar.com/iosconsole_v#{version}.zip"
   appcast 'https://updates.lemonjar.com/iosconsole.xml'
   name 'iOS Console'
   homepage 'https://lemonjar.com/iosconsole/'

--- a/Casks/itch.rb
+++ b/Casks/itch.rb
@@ -3,7 +3,7 @@ cask 'itch' do
   sha256 '06a579b135203dd5da5a6e7a0665e4495a2501cf0dbe11f52f8447f3ccd090ca'
 
   # nuts.itch.zone was verified as official when first introduced to the cask
-  url 'http://nuts.itch.zone/download/osx'
+  url 'https://nuts.itch.zone/download/osx'
   appcast 'https://github.com/itchio/itch/releases.atom'
   name 'itch'
   homepage 'https://itch.io/app'

--- a/Casks/izip.rb
+++ b/Casks/izip.rb
@@ -2,7 +2,7 @@ cask 'izip' do
   version '3.3'
   sha256 '3b0d8a8540fe0cfd98fe0d772fb30d9b8ececf0b16cea3fc21fbb266b93a7e6b'
 
-  url "http://www.izip.com/izip_update_#{version.no_dots}.zip"
+  url "https://www.izip.com/izip_update_#{version.no_dots}.zip"
   appcast 'https://www.izip.com/updates'
   name 'iZip'
   homepage 'https://www.izip.com/'

--- a/Casks/jin.rb
+++ b/Casks/jin.rb
@@ -6,7 +6,7 @@ cask 'jin' do
   url "https://downloads.sourceforge.net/jin/jin/jin-#{version}/jin-#{version}-macosx-lion.dmg"
   appcast 'https://sourceforge.net/projects/jin/rss?path=/jin'
   name 'Jin'
-  homepage 'http://www.jinchess.com/'
+  homepage 'https://www.jinchess.com/'
 
   app 'Jin.app'
 end

--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -3,17 +3,17 @@ cask 'jitouch' do
   sha256 :no_check
 
   if MacOS.version <= :mountain_lion
-    url 'http://www.jitouch.com/jitouch_mountain_lion.zip'
+    url 'https://www.jitouch.com/jitouch_mountain_lion.zip'
   elsif MacOS.version <= :mavericks
-    url 'http://www.jitouch.com/jitouch_mavericks.zip'
+    url 'https://www.jitouch.com/jitouch_mavericks.zip'
   elsif MacOS.version <= :el_capitan
-    url 'http://www.jitouch.com/jitouch_el_capitan.zip'
+    url 'https://www.jitouch.com/jitouch_el_capitan.zip'
   else
-    url 'http://www.jitouch.com/jitouch_sierra.zip'
+    url 'https://www.jitouch.com/jitouch_sierra.zip'
   end
 
   name 'jitouch'
-  homepage 'http://www.jitouch.com/'
+  homepage 'https://www.jitouch.com/'
 
   prefpane 'jitouch/Jitouch.prefPane'
 

--- a/Casks/letterfix.rb
+++ b/Casks/letterfix.rb
@@ -2,7 +2,7 @@ cask 'letterfix' do
   version '2.7.0.1,70082'
   sha256 '0eadd2aef702d9f940df8376d9a47101d4792fd59b083c6b53de0f93044e7048'
 
-  url "http://rwthaachen.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
+  url "https://rwthaachen.dl.osdn.jp/letter-fix/#{version.after_comma}/LetterFix-#{version.before_comma}.dmg"
   appcast 'https://ja.osdn.net/projects/letter-fix/releases/rss'
   name 'LetterFix'
   homepage 'https://osdn.jp/projects/letter-fix/'

--- a/Casks/ltspice.rb
+++ b/Casks/ltspice.rb
@@ -4,7 +4,7 @@ cask 'ltspice' do
 
   url 'http://ltspice.analog.com/software/LTspiceIV.dmg'
   name 'LTspice'
-  homepage 'http://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html'
+  homepage 'https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html'
 
   app 'LTspice.app'
 

--- a/Casks/lunastudio.rb
+++ b/Casks/lunastudio.rb
@@ -2,7 +2,7 @@ cask 'lunastudio' do
   version :latest
   sha256 :no_check
 
-  url 'http://packages.luna-lang.org/darwin/lunaInstaller.zip'
+  url 'https://packages.luna-lang.org/darwin/lunaInstaller.zip'
   name 'Luna Studio'
   homepage 'https://www.luna-lang.org/'
 

--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -3,7 +3,7 @@ cask 'macpilot' do
   sha256 'aafe33934fb1a5a10c2e7e230b0bdd03865de604ba62dec599ef10920f57f578'
 
   url 'http://mirror.koingosw.com/products/macpilot/download/macpilot.dmg'
-  appcast 'http://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'
+  appcast 'https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'
   name 'MacPilot'
   homepage 'https://www.koingosw.com/products/macpilot/'
 

--- a/Casks/mapture.rb
+++ b/Casks/mapture.rb
@@ -2,9 +2,9 @@ cask 'mapture' do
   version '0.0.16'
   sha256 '54301ca09e3f781dd979fc41978ee2dc547c56bc5776d4b25876bad1ab37b85d'
 
-  url "http://anatoo.jp/mapture/Mapture-#{version}.app.zip"
+  url "https://anatoo.jp/mapture/Mapture-#{version}.app.zip"
   name 'Mapture'
-  homepage 'http://anatoo.jp/mapture/'
+  homepage 'https://anatoo.jp/mapture/'
 
   app "Mapture-#{version}.app"
 end

--- a/Casks/marker-import.rb
+++ b/Casks/marker-import.rb
@@ -4,7 +4,7 @@ cask 'marker-import' do
 
   # digitalrebellion.com was verified as official when first introduced to the cask
   url "https://www.digitalrebellion.com/download/markerimport?version=#{version.no_dots}"
-  appcast 'http://www.digitalrebellion.com/rss/appcasts/cnmi_appcast.xml'
+  appcast 'https://www.digitalrebellion.com/rss/appcasts/cnmi_appcast.xml'
   name 'Kollaborate Marker Import'
   homepage 'https://www.kollaborate.tv/resources'
 

--- a/Casks/night-owl.rb
+++ b/Casks/night-owl.rb
@@ -4,7 +4,7 @@ cask 'night-owl' do
 
   # aki-null.net was verified as official when first introduced to the cask
   url 'https://aki-null.net/yf/NightOwl.zip'
-  appcast 'http://sites.google.com/site/yorufukurou/distribution/appcast.xml'
+  appcast 'https://sites.google.com/site/yorufukurou/distribution/appcast.xml'
   name 'NightOwl'
   name 'YoruFukurou'
   homepage 'https://sites.google.com/site/yorufukurou/home-en'

--- a/Casks/nord-sample-editor.rb
+++ b/Casks/nord-sample-editor.rb
@@ -2,9 +2,9 @@ cask 'nord-sample-editor' do
   version '2.28'
   sha256 '659423f4f5b6169d3f7b926158b725ca517e5696a2479380fd1a10993ed10606'
 
-  url "http://www.nordkeyboards.com/sites/default/files/files/downloads/software/nord-sample-editor/Nord%20Sample%20Editor%20v#{version}.dmg"
+  url "https://www.nordkeyboards.com/sites/default/files/files/downloads/software/nord-sample-editor/Nord%20Sample%20Editor%20v#{version}.dmg"
   name 'Nord Sample Editor'
-  homepage 'http://www.nordkeyboards.com/downloads/software-tools/nord-sample-editor'
+  homepage 'https://www.nordkeyboards.com/downloads/software-tools/nord-sample-editor'
 
   app "Nord Sample Editor v#{version}.app"
 end

--- a/Casks/nord-sound-manager.rb
+++ b/Casks/nord-sound-manager.rb
@@ -2,9 +2,9 @@ cask 'nord-sound-manager' do
   version '7.32'
   sha256 '5711ec67216c421cd5e2c69e60846aafbfab7f682f3b80dff160de93bf933377'
 
-  url "http://www.nordkeyboards.com/sites/default/files/files/downloads/software/nord-sound-manager/Nord%20Sound%20Manager%20v#{version}.dmg"
+  url "https://www.nordkeyboards.com/sites/default/files/files/downloads/software/nord-sound-manager/Nord%20Sound%20Manager%20v#{version}.dmg"
   name 'Nord Sound Manager'
-  homepage 'http://www.nordkeyboards.com/downloads/software-tools/nord-sound-manager'
+  homepage 'https://www.nordkeyboards.com/downloads/software-tools/nord-sound-manager'
 
   app "Nord Sound Manager v#{version}.app"
 end

--- a/Casks/nscope.rb
+++ b/Casks/nscope.rb
@@ -2,9 +2,9 @@ cask 'nscope' do
   version '0.8.1'
   sha256 'fdc6bf8ad67e20eb20f5fb4757a80014675388421e5d8e7afa200fe5aa7cc415'
 
-  url "http://www.nscope.org/v#{version.no_dots}/mac/nScope.dmg"
+  url "https://www.nscope.org/v#{version.no_dots}/mac/nScope.dmg"
   name 'nScope'
-  homepage 'http://www.nscope.org/'
+  homepage 'https://www.nscope.org/'
 
   app 'nScope.app'
 end

--- a/Casks/pharo-launcher.rb
+++ b/Casks/pharo-launcher.rb
@@ -4,7 +4,7 @@ cask 'pharo-launcher' do
 
   url "https://files.pharo.org/pharo-launcher/#{version}/PharoLauncher-#{version}-x64.dmg"
   name 'Pharo Launcher'
-  homepage 'http://pharo.org/download'
+  homepage 'https://pharo.org/download'
 
   app 'PharoLauncher.app'
 end

--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -2,7 +2,7 @@ cask 'phocus' do
   version '3.3.7,2018.10'
   sha256 '495244f22eba22da844ffc1b670a16cc0d20fd0603ff0f6aa1cd6792854bcc17'
 
-  url "http://static.hasselblad.com/#{version.after_comma.dots_to_slashes}/Phocus-#{version.before_comma}.dmg"
+  url "https://static.hasselblad.com/#{version.after_comma.dots_to_slashes}/Phocus-#{version.before_comma}.dmg"
   name 'Hasselblad Phocus'
   homepage 'https://www.hasselblad.com/software/phocus'
 

--- a/Casks/pwnagetool.rb
+++ b/Casks/pwnagetool.rb
@@ -2,9 +2,9 @@ cask 'pwnagetool' do
   version '5.1.1'
   sha256 '84262734ad9f9186bce14a4f939d7ea290ed187782fdfa549a82c28bf837c808'
 
-  url "http://iphoneroot.com/download/PwnageTool_#{version}.dmg"
+  url "https://iphoneroot.com/download/PwnageTool_#{version}.dmg"
   name 'PwnageTool'
-  homepage 'http://iphoneroot.com/utilities/#PwnageTool'
+  homepage 'https://iphoneroot.com/utilities/#PwnageTool'
 
   app 'PwnageTool.app'
 end

--- a/Casks/rtx.rb
+++ b/Casks/rtx.rb
@@ -2,9 +2,9 @@ cask 'rtx' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.rtxapp.com/download'
+  url 'https://www.rtxapp.com/download'
   name 'RTX'
-  homepage 'http://www.rtxapp.com/mac/'
+  homepage 'https://www.rtxapp.com/mac/'
 
   app 'RTX.app'
 end

--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -5,7 +5,7 @@ cask 'slic3r' do
   url "https://dl.slic3r.org/mac/slic3r-#{version}.dmg"
   appcast 'https://dl.slic3r.org/mac/'
   name 'Slic3r'
-  homepage 'http://slic3r.org/'
+  homepage 'https://slic3r.org/'
 
   conflicts_with cask: 'prusa-slic3r'
 

--- a/Casks/solvespace.rb
+++ b/Casks/solvespace.rb
@@ -6,7 +6,7 @@ cask 'solvespace' do
   url "https://github.com/solvespace/solvespace/releases/download/v#{version}/solvespace.dmg"
   appcast 'https://github.com/solvespace/solvespace/releases.atom'
   name 'SolveSpace'
-  homepage 'http://solvespace.com/index.pl/'
+  homepage 'https://solvespace.com/index.pl/'
 
   app 'solvespace.app'
 end

--- a/Casks/spectrum.rb
+++ b/Casks/spectrum.rb
@@ -6,7 +6,7 @@ cask 'spectrum' do
   url "https://github.com/withspectrum/spectrum/releases/download/v#{version}/Spectrum-#{version}-mac.zip"
   appcast 'https://github.com/withspectrum/spectrum/releases.atom'
   name 'Spectrum'
-  homepage 'http://spectrum.chat/'
+  homepage 'https://spectrum.chat/'
 
   app 'Spectrum.app'
 end

--- a/Casks/sql-power-architect-jdbc.rb
+++ b/Casks/sql-power-architect-jdbc.rb
@@ -2,7 +2,7 @@ cask 'sql-power-architect-jdbc' do
   version '1.0.8'
   sha256 'a564e294aba5e7f4701717f8d36a898b06e6354000df332e5b6aa41377b06665'
 
-  url "http://download.sqlpower.ca/architect/#{version}/community/SQL-Power-Architect-OSX-#{version}.tar.gz"
+  url "https://download.sqlpower.ca/architect/#{version}/community/SQL-Power-Architect-OSX-#{version}.tar.gz"
   name 'SQL Power Architect Community edition'
   homepage 'https://www.sqlpower.ca/'
 

--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -2,9 +2,9 @@ cask 'tankix' do
   version 'visual1-31241'
   sha256 '99fb8d79a0549e94f3cf6d78938fd7e82d76754cb703ff36f4ee51af3278e443'
 
-  url "http://static.tankix.com/app/StandaloneOSXIntel64/#{version}/TankiX.dmg"
+  url "https://static.tankix.com/app/StandaloneOSXIntel64/#{version}/TankiX.dmg"
   name 'Tanki X'
-  homepage 'https://www.tankix.com/'
+  homepage 'http://www.tankix.com/'
 
   auto_updates true
 

--- a/Casks/wingfs.rb
+++ b/Casks/wingfs.rb
@@ -5,7 +5,7 @@ cask 'wingfs' do
   # s3.amazonaws.com/wingfs_downloads was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/wingfs_downloads/WingFS_#{version.major_minor}.dmg"
   name 'WingFS'
-  homepage 'http://p5.archiware.com/products/wingfs'
+  homepage 'https://p5.archiware.com/products/wingfs'
 
   conflicts_with cask: 'osxfuse'
 

--- a/Casks/xeora-cli.rb
+++ b/Casks/xeora-cli.rb
@@ -2,9 +2,9 @@ cask 'xeora-cli' do
   version '1.0.17506'
   sha256 '9da57f2b699a66d15c93a269651fbcbb7e0a6f3c008dec815c87c8658c1649c1'
 
-  url "http://www.xeora.org/Tools/CLI/xeora-cli_v#{version}_macos.tgz"
+  url "https://www.xeora.org/Tools/CLI/xeora-cli_v#{version}_macos.tgz"
   name 'Xeora CLI'
-  homepage 'http://www.xeora.org/'
+  homepage 'https://www.xeora.org/'
 
   depends_on cask: 'dotnet-sdk'
 

--- a/Casks/zxpinstaller.rb
+++ b/Casks/zxpinstaller.rb
@@ -6,7 +6,7 @@ cask 'zxpinstaller' do
   url "https://github.com/CreativeDo/ZXPInstaller/releases/download/#{version}/ZXPInstaller.dmg"
   appcast 'https://github.com/CreativeDo/ZXPInstaller/releases.atom'
   name 'ZXPInstaller'
-  homepage 'http://zxpinstaller.com/'
+  homepage 'https://zxpinstaller.com/'
 
   app 'ZXPInstaller.app'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

There are some `audit` caveats, though none seem to be caused by this PR:
```
==> Downloading https://static.frdic.com/pkg/eudicmac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'eudic'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
audit for eudic: failed
 - download not possible: Checksum for Cask 'eudic' does not match.

Expected: e9e461948bc33c49c0ced452efb24354b9c30eb7541207205e3ca710c5154382
Actual:   e5cc30c71a746b7d56d53ec82370ea4d11f0e5707b312d6ab39b3cc32d9f7b6d

To retry an incomplete download, remove the file above.
Error: audit failed for casks: eudic

==> Downloading https://downloads.sourceforge.net/jin/jin/jin-2.14.1/jin-2.14.1-macosx-lion.dmg
==> Downloading from https://netix.dl.sourceforge.net/project/jin/jin/jin-2.14.1/jin-2.14.1-macosx-lion.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'jin'.
audit for jin: failed
 - The URL https://downloads.sourceforge.net/jin/jin/jin-2.14.1/jin-2.14.1-macosx-lion.dmg is not reachable
Error: audit failed for casks: jin

audit for lunastudio: passed
==> Downloading http://mirror.koingosw.com/products/macpilot/download/macpilot.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'macpilot'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
audit for macpilot: failed
 - download not possible: Checksum for Cask 'macpilot' does not match.

Expected: aafe33934fb1a5a10c2e7e230b0bdd03865de604ba62dec599ef10920f57f578
Actual:   3915f98f7e9fc2c485b95a85157f0f4e4ef3b06e2870be9fc5922137b675ac48

To retry an incomplete download, remove the file above.
Error: audit failed for casks: macpilot

==> Downloading https://www.xeora.org/Tools/CLI/xeora-cli_v1.0.17506_macos.tgz
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'xeora-cli'.
audit for xeora-cli: failed
 - exception while auditing xeora-cli: invalid byte sequence in UTF-8
Error: audit failed for casks: xeora-cli
```
