### PR TITLE
Request to update Seashore to different upstream source

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,18 +1,12 @@
 cask 'seashore' do
-  version '0.5.1'
-  sha256 '96463a3642f162a20b160d8df273e9b27a5fdbf9708bee6ebf6a6c8528047765'
+  version '0.6.5'
+  sha256 'c283e9225a6d0740812029772a55f0033db4e19f5ee0e81735114c9cf1017dee'
 
   # downloads.sourceforge.net/seashore was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/seashore/seashore%20binaries/Seashore%20#{version}/Seashore.zip"
-  appcast 'https://sourceforge.net/projects/seashore/rss?path=/seashore%20binaries'
+  url 'https://github.com/robaho/seashore/releases/download/v0.6.5/seashore-bin-0.6.5.dmg'
+  appcast 'https://github.com/robaho/seashore/releases'
   name 'Seashore'
-  homepage 'https://seashore.sourceforge.io/'
-
-  depends_on macos: '<= :el_capitan'
+  homepage 'https://github.com/robaho/seashore'
 
   app 'Seashore.app'
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -4,8 +4,8 @@ cask 'seashore' do
 
   # The following is a fork of the original Seashore (hosted on SourceForge) based on the original source code
   # A fork was included in place of the original project since the original project is unmaintained
-  url 'https://github.com/robaho/seashore/releases/download/v0.6.5/seashore-bin-0.6.5.dmg'
-  appcast 'https://github.com/robaho/seashore/releases'
+  url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
+  appcast 'https://github.com/robaho/seashore/releases.atom'
   name 'Seashore'
   homepage 'https://github.com/robaho/seashore'
 

--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -2,7 +2,8 @@ cask 'seashore' do
   version '0.6.5'
   sha256 'c283e9225a6d0740812029772a55f0033db4e19f5ee0e81735114c9cf1017dee'
 
-  # downloads.sourceforge.net/seashore was verified as official when first introduced to the cask
+  # The following is a fork of the original Seashore (hosted on SourceForge) based on the original source code
+  # A fork was included in place of the original project since the original project is unmaintained
   url 'https://github.com/robaho/seashore/releases/download/v0.6.5/seashore-bin-0.6.5.dmg'
   appcast 'https://github.com/robaho/seashore/releases'
   name 'Seashore'


### PR DESCRIPTION
Seashore is a neat little pixel image editor I like using since I don't like Preview.app's image manipulation functionality. Currently the Cask version is based on the original Sourceforge hosted source. Unfortunately, this version has been abandoned since September 2010 and doesn't run on OS X 10.11 or higher.

Therefore I propose replacing the Cask version to [a fork](https://github.com/robaho/seashore) of the project under the original name. This version has some minor bugfixes and most especially has been updated to work on all macOS versions up to now, including 10.14. The author state that he only maintains bug and build fixes for now. The utility is handy enough in its current form - especially since most Homebrew users can actually *run* this version, that I think this is an improvement.

Since it's relevant now - especially when changing upstream sources - I've checked the repository and the changes to the original seem to be all bugfixes and no cryptominers or other malware. Little Snitch reports no network connections, as you would expect from open source utility software.

Be aware I've checked the box below that this is a stable version - it's marked as such by the fork's author. However, this fork is based on the code of the last original *preview* version of Seashore like the previous Cask formula was.

After making all changes to the cask:

☑️ `brew cask audit --download {{cask_file}}` is error-free.
☑️ `brew cask style --fix {{cask_file}}` reports no offenses.
☑️ The commit message includes the cask’s name and version.
☑️ The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

☑️ Named the cask according to the [token reference].
☑️ `brew cask install {{cask_file}}` worked successfully.
☑️ `brew cask uninstall {{cask_file}}` worked successfully.
☑️ Checked there are no [open pull requests] for the same cask.
☑️ Checked the cask was not [already refused].
☑️ Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
