### PR TITLE
Update now to 4.0.11

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,6 +1,6 @@
 cask 'now' do
-  version '4.0.10'
-  sha256 '41ea05a9072b0c923f51bffe03c52c6249630a36baab0d3101e450d628ffe524'
+  version '4.0.11'
+  sha256 '355ddcc791348c6071559a7f82cefc77a2471d2c98c0b178a109cc0b9140a6e2'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/Now-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.