### PR TITLE
Update ogdesign-eagle to 1.8.2,build5

### DIFF
--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -1,9 +1,9 @@
 cask 'ogdesign-eagle' do
-  version '1.8.1'
-  sha256 '2ea4de81ef4f6dc5951ab682352595516e43948ea5716d31b646d105397c46f6'
+  version '1.8.2,build5'
+  sha256 '3f93ede904a1b88167f32738bacad65d67eaa852f45c47045d92ac9d362b5814'
 
-  # s3.amazonaws.com/eagleapp/ was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/eagleapp/releases/Eagle-#{version}.dmg"
+  # eagleapp.s3-accelerate.amazonaws.com was verified as official when first introduced to the cask
+  url "https://eagleapp.s3-accelerate.amazonaws.com/releases/Eagle-#{version.before_comma}-#{version.after_comma}.dmg?download"
   name 'Eagle'
   homepage 'https://eagle.cool/macOS'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.