### PR TITLE
Update macmediakeyforwarder to 2.1

### DIFF
--- a/Casks/macmediakeyforwarder.rb
+++ b/Casks/macmediakeyforwarder.rb
@@ -1,6 +1,6 @@
 cask 'macmediakeyforwarder' do
-  version '2.0'
-  sha256 '3eff3459f07ccecfb0bd1c456bf4d4a281af12550166863599d7230567a8ed31'
+  version '2.1'
+  sha256 'cc9367f440aef6183a1378f5a8e814743a769c8c770b29ed05ba0f00c4084870'
 
   url "http://milgra.com/downloads/mmkf/MacMediaKeyForwarder#{version}.zip"
   name 'Mac Media Key Forwarder'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.