### PR TITLE
Update manager to 18.11.54

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.11.50'
-  sha256 '8dedc4dc55f90abdf0418159860599668012d41fd6d87d5f9a2eab82367813a3'
+  version '18.11.54'
+  sha256 'ee202e868a0fb4424de0252fddbec6ddc7a598ff583185835e131daa282ea138'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.