### PR TITLE
Update mathtype to 7.3.1

### DIFF
--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,12 +1,13 @@
 cask 'mathtype' do
-  version '6.7'
-  sha256 'f512b322c9b1e16c0f9c523ade1dc7f5e743768a2ac4d7fa37780abfbe05a861'
+  version '7.3.1'
+  sha256 '247c6c1bc0439b0273810a82c0b9930f0bc1dbca3ca30b88eb1da78bfef982d6'
 
-  url "https://www.dessci.com/en/dl/MTM#{version.no_dots}h_EN.pkg"
+  url 'https://store.wiris.com/en/products/downloads/mathtype/installer/mac/en'
+  appcast 'https://docs.wiris.com/en/mathtype/release_notes/start'
   name 'MathType'
-  homepage 'https://www.dessci.com/'
+  homepage 'http://www.wiris.com/en/mathtype'
 
-  installer manual: "MTM#{version.no_dots}h_EN.pkg"
+  installer manual: 'MathType-mac-en.pkg'
 
   uninstall pkgutil: "com.dessci.mathtype#{version.no_dots}Hf.MathType.pkg",
             delete:  "/Applications/MathType #{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.