### PR TITLE
Revert "Delete mtmr.rb"

### DIFF
--- a/Casks/mtmr.rb
+++ b/Casks/mtmr.rb
@@ -1,0 +1,16 @@
+cask 'mtmr' do
+  version '0.18.5'
+  sha256 'd5bb6ff746fbd0322dd4bcf51cf1c7b1f625eff4fbbb23009822fdfb3db53d7c'
+
+  url "https://github.com/Toxblh/MTMR/releases/download/v#{version}/MTMR.#{version}.dmg"
+  appcast 'https://github.com/Toxblh/MTMR/releases.atom'
+  name 'My TouchBar. My rules'
+  homepage 'https://github.com/Toxblh/MTMR'
+
+  auto_updates true
+  depends_on macos: '>= :sierra'
+
+  app 'MTMR.app'
+
+  zap trash: '~/Library/Application Support/MTMR'
+end

--- a/Casks/mtmr.rb
+++ b/Casks/mtmr.rb
@@ -1,6 +1,6 @@
 cask 'mtmr' do
   version '0.19'
-  sha256 'd5bb6ff746fbd0322dd4bcf51cf1c7b1f625eff4fbbb23009822fdfb3db53d7c'
+  sha256 '1a43c3c127526f615834fc0b1b1f75a3352e3a55597da504a1b20c6dd80f57f8'
 
   url "https://mtmr.app/MTMR%20#{version}.dmg"
   appcast 'https://mtmr.app/appcast.xml'

--- a/Casks/mtmr.rb
+++ b/Casks/mtmr.rb
@@ -1,11 +1,11 @@
 cask 'mtmr' do
-  version '0.18.5'
+  version '0.19'
   sha256 'd5bb6ff746fbd0322dd4bcf51cf1c7b1f625eff4fbbb23009822fdfb3db53d7c'
 
-  url "https://github.com/Toxblh/MTMR/releases/download/v#{version}/MTMR.#{version}.dmg"
-  appcast 'https://github.com/Toxblh/MTMR/releases.atom'
+  url "https://mtmr.app/MTMR%20#{version}.dmg"
+  appcast 'https://mtmr.app/appcast.xml'
   name 'My TouchBar. My rules'
-  homepage 'https://github.com/Toxblh/MTMR'
+  homepage 'https://forum.mtmr.app/'
 
   auto_updates true
   depends_on macos: '>= :sierra'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#55295
Version still is public. But use auto-update not from github for version up one