### PR TITLE
Update docker to 2.0.0.0-ce-mac81,29211

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -3,8 +3,8 @@ cask 'docker' do
     version '18.06.1-ce-mac73,26764'
     sha256 '3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5'
   else
-    version '2.0.0.0-ce-mac78,28905'
-    sha256 'a452026a1780e17ea2717acf68c56a09bb19a2e46dbc6988e011f889cd28e5b6'
+    version '2.0.0.0-ce-mac81,29211'
+    sha256 '5343fa169b9f7bc6f41f91e5797d148a21d2c0fc1d5c2da80d7d93ed6b3bd1ff'
   end
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.