### PR TITLE
Update qownnotes to 18.12.0,b3955-170606

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.11.6,b3950-152109'
-  sha256 '92252430bfb18776af16f32ae8161d1ad9a50f36955680da320bfcee22ac8ad3'
+  version '18.12.1,b3962-171755'
+  sha256 'd9d495591ccc6813235b678cc50ba885143989b531fa4ccefdb1a1907f44b508'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.