### PR TITLE
Update tunnelblick to 3.7.8,5180

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick' do
-  version '3.7.7,5150'
-  sha256 'afab743ca603810b5724e7d25848b67fc5dee6fc66f496b297916a4d185a8b53'
+  version '3.7.8,5180'
+  sha256 '0918551e80b3f861eb075cae790f3834a81a163a2793d2414064a1451bda3370'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.