### PR TITLE
Update jamf-migrator to 3.1.0

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '3.0.0'
-  sha256 '27919f9976f5e48aee429210953133f238eae5247176f031228c939d974ddc61'
+  version '3.1.0'
+  sha256 '08ab008555ba5fb50e9b64a253a3064978d1bbc2bd9713e3f3b4719eeb0523c5'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.