### PR TITLE
Update plex-media-server to 1.14.0.5470-9d51fdfaa

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.13.9.5456-ecd600442'
-  sha256 '40df2dde105a478861c65b5b99ddb5c0fc4dee93394e8d6be49d4f782c23411d'
+  version '1.14.0.5470-9d51fdfaa'
+  sha256 '91008335abe645f2dd0eaad3468426f1f47105952acfe9d93cc3ba6b4c0d0492'
 
   url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
   appcast 'https://plex.tv/api/downloads/1.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.