### PR TITLE
Update clip-studio-paint to 1.8.4

### DIFF
--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -1,6 +1,6 @@
 cask 'clip-studio-paint' do
-  version '1.8.2'
-  sha256 '55069bfd6ece3bacde37db2eef4fe37c013e0d6f3aed026e3894ed197fa392a2'
+  version '1.8.4'
+  sha256 '479077089a55167fee74c7ed7401427d094e83848c07a9a8adf4188cee128177'
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
   name 'CLIP STUDIO PAINT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.