### PR TITLE
Update archi to 4.3.1

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,8 +1,8 @@
 cask 'archi' do
-  version '4.3'
-  sha256 'd3985e4ebb93ada39a24f232a68b27e95eb8cf3cccb1562de2c9a606ca1bd88f'
+  version '4.3.1'
+  sha256 'ab82f4d7b9c14cf7259cbe9c06f698bc31e2ef11864769cf6d21e0b0c86368c6'
 
-  url "https://www.archimatetool.com/downloads/root#{version.no_dots}/Archi-Mac-#{version}.zip",
+  url "https://www.archimatetool.com/downloads/#{version}/Archi-Mac-#{version}.zip",
       referer: 'https://www.archimatetool.com/download/'
   appcast 'https://github.com/archimatetool/archi/releases.atom'
   name 'Archi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.