### PR TITLE
Update fastonosql to 1.23.0

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.20.4'
-  sha256 '12da3ae829defbfc5f104404ef56ec81d82c323e7b4c5347672c5cd83be67965'
+  version '1.23.0'
+  sha256 'aed516263d8a830cdfb9b8558d84ab3f52d7a7e89b3613ae50e91cb2912d539e'
 
   url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.