### PR TITLE
Update managenameext 1.6.6 - sha256

### DIFF
--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -1,6 +1,6 @@
 cask 'managenameext' do
   version '1.6.6'
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 '77868a31f6e2e4e4c56922155ce19dbbe0748858ba32f871132d5b1511a3db3c'
 
   url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
   appcast 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html'

--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -1,6 +1,6 @@
 cask 'managenameext' do
   version '1.6.6'
-  sha256 'edd09e9fcdd197727f3db310aaa768f6b086a9e55fb15a101cec894402fdb44a'
+  sha256 :no_check
 
   url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
   appcast 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html'

--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -1,6 +1,6 @@
 cask 'managenameext' do
   version '1.6.6'
-  sha256 :no_check
+  sha256 :no_check # required as upstream package is updated in-place
 
   url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
   appcast 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html'


### PR DESCRIPTION
This PR addresses the findings reported by @suschizu here: https://github.com/Homebrew/homebrew-cask/pull/55199#issuecomment-443353008

After verifying with Pacifist that the downloaded `.zip` was indeed not signed; I updated the formula accordingly.

![screen shot 2018-11-30 at 2 23 44 pm 1](https://user-images.githubusercontent.com/17261190/49318622-19415900-f4ae-11e8-9770-d2c0ecda89d2.png)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).