### PR TITLE
Update fotomagico to 5.6.4-22863

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,6 +1,6 @@
 cask 'fotomagico' do
-  version '5.6.3-22849'
-  sha256 '2bb5e222f7b955103fee342921a0474f12c509597f5517423c29bf1cb785dc8e'
+  version '5.6.4-22863'
+  sha256 '8a81aba04669d52ef5c502d3e2d1a1680b622222d22d01cb0f7b81ed6a634159'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://sparkle.boinx.com/appcast.lasso?appName=FotoMagico%205'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.