### PR TITLE
Update launchpad-manager-yosemite to 1.0.8

### DIFF
--- a/Casks/launchpad-manager-yosemite.rb
+++ b/Casks/launchpad-manager-yosemite.rb
@@ -7,8 +7,8 @@ cask 'launchpad-manager-yosemite' do
 
     app 'Launchpad Manager.app'
   else
-    version '1.0.7'
-    sha256 'd5bb7840076af9c2c77f875b8accf0934572777c3a9bdd06dccf3dd1ccc06aeb'
+    version '1.0.8'
+    sha256 '571c4c5b760e608984d47aa8398e5c1666533158fa65d1afae18ce7f3844a877'
 
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
     appcast 'http://launchpadmanager.com/appyos/sparkle.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.