### PR TITLE
Update superduper to 3.2.4,118.e

### DIFF
--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -1,5 +1,5 @@
 cask 'superduper' do
-  version '3.2.4,118'
+  version '3.2.4,118.e'
   sha256 'a6af47ea7df3903ba7195dfb25eb57d4150b02d8a910c0a52ab7297fb588e3e9'
 
   # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.