### PR TITLE
Update phoenix-slides to 1.4.4

### DIFF
--- a/Casks/phoenix-slides.rb
+++ b/Casks/phoenix-slides.rb
@@ -1,6 +1,6 @@
 cask 'phoenix-slides' do
-  version '1.4.3'
-  sha256 'ef150da77dc578cfdaaf94fd7680d4b09107d3cdf217e71f7065eb02bf5be934'
+  version '1.4.4'
+  sha256 'f27bb747a822e8b39eae81a6fe426692624d209cf7a50b98bdd5331bd451fdb9'
 
   # github.com/gobbledegook/creevey was verified as official when first introduced to the cask
   url "https://github.com/gobbledegook/creevey/releases/download/v#{version}/phoenix-slides-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.