### PR TITLE
Update selflanguage-self-control to 2017.1

### DIFF
--- a/Casks/selflanguage-self-control.rb
+++ b/Casks/selflanguage-self-control.rb
@@ -1,8 +1,8 @@
 cask 'selflanguage-self-control' do
-  version '4.5.0'
-  sha256 'fa5edc50ec517c06547e8c57246075f1fcd4ad98b5b9c681b9a60e357f4d3f04'
+  version '2017.1'
+  sha256 'd066ae8d8b3b8da79eaaa8743f2238370c36e3fd5e1236bd52b5c71beea8676d'
 
-  url "http://files.selflanguage.org/releases/#{version.sub(%r{\.\d+$}, '')}/Self-#{version}.dmg"
+  url "http://files.selflanguage.org/releases/#{version}/Self-#{version}.dmg"
   name 'Self'
   homepage 'http://www.selflanguage.org/'
 

--- a/Casks/selflanguage-self-control.rb
+++ b/Casks/selflanguage-self-control.rb
@@ -7,9 +7,4 @@ cask 'selflanguage-self-control' do
   homepage 'http://www.selflanguage.org/'
 
   app 'Self Control.app'
-  binary 'Clean.snap', target: '/Users/Shared/Self/Clean.snap'
-
-  caveats <<~EOS
-    A clean snapshot is available in /Users/Shared/Self/Clean.snap
-  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.