### PR TITLE
Update syrinscape to 1.3.7-20180730

### DIFF
--- a/Casks/syrinscape.rb
+++ b/Casks/syrinscape.rb
@@ -2,7 +2,7 @@ cask 'syrinscape' do
   version '1.3.7-20180730'
   sha256 'e5f49aae95968689400c72e03156790f8d49b49585979a230de573044fbbcb05'
 
-  url "https://syrinscape.com/get-download/syrinscape-mac-#{version}.dmg"
+  url "https://syrinscape.com/get-download/syrinscape-mac-#{version}?type=mac&version=#{version}"
   name 'Syrinscape Fantasy Player'
   homepage 'https://syrinscape.com/'
 

--- a/Casks/syrinscape.rb
+++ b/Casks/syrinscape.rb
@@ -1,6 +1,6 @@
 cask 'syrinscape' do
   version '1.3.7-20180730'
-  sha256 '9f7f441a05578bcfdfd67173c1c9928b60d2d6e2004699ac02e9e182a7df107f'
+  sha256 '5c3d784ea12f8137809b88c945f6aa8ac5d5bfe2fb8e1539853259c2c2a0400f'
 
   url "https://syrinscape.com/get-download/syrinscape-mac-#{version}.dmg"
   name 'Syrinscape Fantasy Player'

--- a/Casks/syrinscape.rb
+++ b/Casks/syrinscape.rb
@@ -1,6 +1,6 @@
 cask 'syrinscape' do
   version '1.3.7-20180730'
-  sha256 '5c3d784ea12f8137809b88c945f6aa8ac5d5bfe2fb8e1539853259c2c2a0400f'
+  sha256 'e5f49aae95968689400c72e03156790f8d49b49585979a230de573044fbbcb05'
 
   url "https://syrinscape.com/get-download/syrinscape-mac-#{version}.dmg"
   name 'Syrinscape Fantasy Player'

--- a/Casks/syrinscape.rb
+++ b/Casks/syrinscape.rb
@@ -1,6 +1,6 @@
 cask 'syrinscape' do
   version '1.3.7-20180730'
-  sha256 'e5f49aae95968689400c72e03156790f8d49b49585979a230de573044fbbcb05'
+  sha256 'cff21438b856171fa8f1b7f7fea670535366060338af4483dde41dfb4cc6982e'
 
   url "https://syrinscape.com/get-download/syrinscape-mac-#{version}?type=mac&version=#{version}"
   name 'Syrinscape Fantasy Player'

--- a/Casks/syrinscape.rb
+++ b/Casks/syrinscape.rb
@@ -1,9 +1,8 @@
 cask 'syrinscape' do
-  version '1.3.3-20160816'
-  sha256 'a4fbceeb78564e6648311cde5add027e26f814c7e2a5e36ebd3d8656781682c3'
+  version '1.3.7-20180730'
+  sha256 '9f7f441a05578bcfdfd67173c1c9928b60d2d6e2004699ac02e9e182a7df107f'
 
-  # syrinscape-us.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://syrinscape-us.s3.amazonaws.com/files/syrinscape-mac-#{version}.dmg"
+  url "https://syrinscape.com/get-download/syrinscape-mac-#{version}.dmg"
   name 'Syrinscape Fantasy Player'
   homepage 'https://syrinscape.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.