### PR TITLE
Update mockplus to 3.4.1.2

### DIFF
--- a/Casks/mockplus.rb
+++ b/Casks/mockplus.rb
@@ -1,6 +1,6 @@
 cask 'mockplus' do
-  version '3.4.1.0'
-  sha256 '9b6e11b380900c7a16895c2f48da13db82a054fb2f78af5f1feafe07fbd3657c'
+  version '3.4.1.2'
+  sha256 '5cb79d9066fb9a148a546b58c3b07909e9b13c971329ed47210e616c08b22ab5'
 
   # s3-us-west-1.amazonaws.com/mockplus-static was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/mockplus-static/software/macos/Mockplus_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.