### PR TITLE
Update telegram to 4.7-146563

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -3,7 +3,7 @@ cask 'telegram' do
   sha256 '3f7c1b5b75a9b563f3a3fab218cc34057253d21d2265569c0f03a10a086830af'
 
   url "https://macos.telegram.org/updates/Telegram-#{version}.app.zip"
-  appcast 'https://macos.telegram.org/updates/versions.xml'
+  appcast 'https://osx.telegram.org/updates/versions.xml'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -2,7 +2,7 @@ cask 'telegram' do
   version '4.7.1-146931'
   sha256 '3f7c1b5b75a9b563f3a3fab218cc34057253d21d2265569c0f03a10a086830af'
 
-  url "https://macos.telegram.org/updates/Telegram-#{version}.app.zip"
+  url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,9 +1,9 @@
 cask 'telegram' do
   version '4.7.1-146931'
-  sha256 '89f426625a061042bb3ea7962059383da939e273d5a87c0e6149cb71ddef718b'
+  sha256 '3f7c1b5b75a9b563f3a3fab218cc34057253d21d2265569c0f03a10a086830af'
 
-  url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
-  appcast 'https://osx.telegram.org/updates/versions.xml'
+  url "https://macos.telegram.org/updates/Telegram-#{version}.app.zip"
+  appcast 'https://macos.telegram.org/updates/versions.xml'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,8 +1,8 @@
 cask 'telegram' do
-  version '4.7.1-146931'
-  sha256 '3f7c1b5b75a9b563f3a3fab218cc34057253d21d2265569c0f03a10a086830af'
+  version '4.6.1'
+  sha256 'd19ef3966bd940b5796135900288d2c221b85c8c17e8936fe0028ff5c3567516'
 
-  url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
+  url 'https://osx.telegram.org/updates/TelegramMac.dmg'
   appcast 'https://osx.telegram.org/updates/versions.xml'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,8 +1,8 @@
 cask 'telegram' do
-  version '4.6.1'
-  sha256 'd19ef3966bd940b5796135900288d2c221b85c8c17e8936fe0028ff5c3567516'
+  version '4.7-146563'
+  sha256 'ba8569ac097efd6e38121ad797ef232c0a9656e004144f393ed3b010ad4ca8bd'
 
-  url 'https://osx.telegram.org/updates/TelegramMac.dmg'
+  url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
### This fixes https://github.com/Homebrew/homebrew-cask/issues/55630 👍

<hr>

**The links `https://osx.telegram.org/updates/Telegram-4.7.1-146931.app.zip` no longer works.** 👎

**4.7-146563 is the version that is appcast.** 👌

<hr>

[VirusTotal Verification](https://www.virustotal.com/#/file/ba8569ac097efd6e38121ad797ef232c0a9656e004144f393ed3b010ad4ca8bd/detection)

![screen shot 2018-12-02 at 8 57 34 pm](https://user-images.githubusercontent.com/17261190/49353880-f319e580-f674-11e8-942b-b84d253de09e.png)

<hr>

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.