### PR TITLE
Update netron to 2.6.8

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.6.6'
-  sha256 '832ee2ea0bb350f4743598e167e5303134f521d42fdd5090a00a7bb51c5f96f1'
+  version '2.6.8'
+  sha256 '43ba5131c1cdacfe3261752818e45a9ddfb19dd8494bf156b7bbd14004f0c151'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.