### PR TITLE
Update downie to 3.5.3,1916

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.5.2,1914'
-  sha256 '9dd0479baed109f05f80ff61929a2e42d4d1c72ef3cfe40e173fdb2eafa82d42'
+  version '3.5.3,1916'
+  sha256 '034aa1200418d8e771a12c142d7ff5f8384de1deceb961877daf439e48df3796'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.