### PR TITLE
Update franz to 5.0.0-beta.19

### DIFF
--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -1,6 +1,6 @@
 cask 'franz' do
-  version '5.0.0-beta.18'
-  sha256 'b964a1976948b7af71147659a4651f7576859fb6fdc8020288f44f0351841099'
+  version '5.0.0-beta.19'
+  sha256 '1e8bdf39f4c11668e5f463bda9b92cdf5b93b2cb31602b2c35ff99c3d82b919b'
 
   # github.com/meetfranz/franz was verified as official when first introduced to the cask
   url "https://github.com/meetfranz/franz/releases/download/v#{version}/franz-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.