### PR TITLE
Update origin to 10.5.30.15625

### DIFF
--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -1,14 +1,19 @@
 cask 'origin' do
   version '10.5.30.15625'
-  sha256 'd679a1635957edcc677b4f00f9a6d3fb236b1af8d401306999085b3e1c8cfeab'
+  sha256 '146fb7a73e16267b8cdc51f055fcda876fb0026cbb4bb0250cbc86248b1713e7'
 
   # origin-a.akamaihd.net was verified as official when first introduced to the cask
-  url 'https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/Origin.dmg'
-  appcast 'https://api1.origin.com/autopatch/2/upgradeFrom/10.5.24.5022/en_US/PROD?platform=MAC&osVersion=10.13.0'
+  url "https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/OriginUpdate_#{version.dots_to_underscores}.zip"
+  appcast "https://api1.origin.com/autopatch/2/upgradeFrom/#{version}/en_US/PROD?platform=MAC&osVersion=10.14.0"
   name 'Origin'
   homepage 'https://www.origin.com/'
 
   app 'Origin.app'
+
+  preflight do
+    # There is no enclosing .app folder, just the 'Contents' of the app in the appcast download
+    FileUtils.mv(staged_path.children, staged_path.join('Origin.app').tap(&:mkpath))
+  end
 
   zap trash: [
                '~/Library/Application Support/Origin',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.