### PR TITLE
Update unity to 2018.2.18f1,4550892b6062

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2018.2.17f1,88933597c842'
-  sha256 'de6aa1b3d17774c21078f6ad8be3a72dae691a1e4c33654b6fe38fe148ed68de'
+  version '2018.2.18f1,4550892b6062'
+  sha256 'a0e0553710f1031369615604f411db13f882852798f42a2a761b291ff443ebb1'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.