### PR TITLE
Update unity-webgl-support-for-editor to 2018.2.18f1,4550892b6062

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.2.17f1,88933597c842'
-  sha256 '9e7de4c7c431510df3cb6779a091c35befed516a27ed778a067b70c4e31509d9'
+  version '2018.2.18f1,4550892b6062'
+  sha256 '6668ab614d9e0ff1f404bffb4ee5a1cc951e0100a0edfb08edb2d3c228d6ca1f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.