### PR TITLE
Remove Updating the SHA256 documentation

### DIFF
--- a/doc/cask_language_reference/stanzas/sha256.md
+++ b/doc/cask_language_reference/stanzas/sha256.md
@@ -15,22 +15,3 @@ The special value `sha256 :no_check` is used to turn off SHA checking whenever c
 `version :latest` requires `sha256 :no_check`, and this pairing is common. However, `sha256 :no_check` does not require `version :latest`.
 
 We use a checksum whenever possible.
-
-## Updating the SHA256
-
-When updating the `sha256` stanza of an existing Cask, the `version` also has to have changed. Otherwise, the new checksum has to be confirmed. This is necessary to help rule out malicious tampering.
-
-The confirmation of the updated `sha256` should ideally be publicly available. Specifically:
-
-- Ask the developer to publicly confirm the new checksum and provide a link to this confirmation in your pull request. As examples, confirmation can be acheived by opening an issue of the project’s GitHub, or asking on the developer’s Twitter. Note that a link to an upstream page with the checksum is never sufficient, as a malicious third-party who could modify the download could also modify checksums on the page.
-
-- If the Cask is an `.app` that is codesigned (in a `.dmg` or `.zip` container) it can be uploaded and verified using [VirusTotal](https://www.virustotal.com/) by looking at the “Details” tab. 
-
-   **If there is no *Signature Info* section, VirusTotal verification is not enough**.
-
-   Maintainers will confirm the VirusTotal submission is legitimate by comparing its `sha256` with the one on the updated cask.
-   
-   Here's an example for [Brave-0.18.36.dmg](https://www.virustotal.com/#/file/0aa0ebfd310a627f4ba50c518bd141764a4b0335d5bc244d3cc8fa1538bfaef0/details):
-   
-    <img src="https://i.imgur.com/Jiyllps.png" width="1080px" alt="VirusTotal codesigning">
-


### PR DESCRIPTION
To be merged after https://github.com/Homebrew/brew/pull/5371.

**Warning**: Merging this means the end of the policy of verifying `sha256`-only changes (discussed in https://github.com/Homebrew/homebrew-cask/issues/48862).