### PR TITLE
Update stremio to 4.4.21

### DIFF
--- a/Casks/stremio.rb
+++ b/Casks/stremio.rb
@@ -1,6 +1,6 @@
 cask 'stremio' do
-  version '4.4.10'
-  sha256 'b0c185d2f161b13d9e1a22c3ec35305c34afa1d69be400cf6c684da0317a8f0e'
+  version '4.4.21'
+  sha256 'a12e85e2e3798ca37ad0c60420d5d3b8b9f1524e0b51010d69cc757c612550d0'
 
   url "https://dl.strem.io/mac/v#{version}/Stremio+#{version}.dmg"
   appcast 'https://www.stremio.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.