### PR TITLE
Update iridient-developer to 3.3.3

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.3.2'
-  sha256 '03c4095d726adff4bb1d67282ade462a234aee8c7ee1e28afb80d169034e2b2a'
+  version '3.3.3'
+  sha256 'fd1737ce307cb8269c6fd4eeb77d663a7e4e9dd0fde1ff439e8fd4b2c6a7f1cd'
 
   url "https://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'https://www.iridientdigital.com/products/rawdeveloper_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.