### PR TITLE
Update jumpshare to 2.4.4 -sha256

### DIFF
--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -1,6 +1,6 @@
 cask 'jumpshare' do
   version '2.4.4'
-  sha256 '79d062a1b4d9ae069f7990b73ec7b153d8c4a7700620f60dda1311e05b3d3a56'
+  sha256 '39ed08287ec4a7d0999aa0f096e8fc6687189365e3fa4d99a80ca3538d289174'
 
   # d21hi1or3tbtjm.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d21hi1or3tbtjm.cloudfront.net/desktop/mac/Jumpshare.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.