### PR TITLE
Update subutaip2p to 8.1.0

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -1,6 +1,6 @@
 cask 'subutaip2p' do
-  version '8.0.1'
-  sha256 '39a1810c94668e6063ae8048df08120703e0590271905dc653aeaa84226615ad'
+  version '8.1.0'
+  sha256 'b185aa3b623472fd4bd9710acb5280068933c4b070b8d5eede089738296561ff'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://bazaar.subutai.io/rest/v1/cdn/raw?name=subutai-p2p.pkg&latest&download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.