### PR TITLE
Update netron to 2.7.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.6.9'
-  sha256 'abb7eecfee72f2ac6658f61e3bf99879918d04fe23764bc6e4a9688d1ff1d378'
+  version '2.7.0'
+  sha256 'cc72f2391db910a3b6f05d87347e3e2f441869e4e60bb61cfb92cf820b25f175'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.