### PR TITLE
Update krisp to 0.6.8

### DIFF
--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -1,6 +1,6 @@
 cask 'krisp' do
-  version '0.5.7'
-  sha256 '5a43643864c30191dfafd2d17bf941cd049124146562f27be1bafc56421809b4'
+  version '0.6.8'
+  sha256 '3bb1e8f497dd8e1d3e021352765c8f49efd8dfe9b592eee7ed52c122288b497b'
 
   url "https://cdn.krisp.ai/installer/release/krisp_#{version}.pkg"
   name 'Krisp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.