### PR TITLE
Update sauce-connect to 4.5.2

### DIFF
--- a/Casks/sauce-connect.rb
+++ b/Casks/sauce-connect.rb
@@ -1,6 +1,6 @@
 cask 'sauce-connect' do
-  version '4.5.1'
-  sha256 '920ae7bd5657bccdcd27bb596593588654a2820486043e9a12c9062700697e66'
+  version '4.5.2'
+  sha256 'ec8bbd276cdfec084fd5dc10fcb66eab27c1cf66ef8e848f52f505abd9008d21'
 
   url "https://saucelabs.com/downloads/sc-#{version}-osx.zip"
   name 'Sauce Connect'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I wasn't able to run `style` because I got this error:

```
$ brew cask style --fix sauce-connect
==> Installing or updating 'rubocop' gem
Error: Unable to resolve dependency: user requested 'did_you_mean (= 1.0.0)'
```

For what it's worth, earlier today I had run `sudo gem install -n/usr/local/bin rubocop` to fix an issue with my editor's RuboCop linter.