### PR TITLE
Update cozy-drive to 3.11.0

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.10.4'
-  sha256 '65bed44bea1802dcbd5a039459bdd1b9dc817b90f9610c0ac02d37df4aa057ba'
+  version '3.11.0'
+  sha256 'c8738655317d4480b4cd2b292ea1c2d64c95cd4185cc1bded0d573e2fdbfb250'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.