### PR TITLE
Update cmake to 3.13.1

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.13.0'
-  sha256 '88f52fbfcbf536b6f08ed66a803493e751bfc99c3906bf6128e5e097a87f6f5b'
+  version '3.13.1'
+  sha256 '74fc23823bcb22da7ed6d4fbb0642c3387acab74a608286cb5c323dcc21d9b7a'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.