### PR TITLE
Update dcp-o-matic-player to 2.12.13

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.13.68'
-  sha256 '0bb5b4e92fc11c67e818f1ea66b203ee9392be1fe08a310c4166425815e90c8f'
+  version '2.12.13'
+  sha256 '09ce5062d6737ff56e0cc5957a21170af9bd2b437b124b5c898bca1b23eef27d'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.