### PR TITLE
Update telegram to 4.7.1-147606

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
   version '4.7.1-147606'
-  sha256 'd8803d4544745f5282b7e5b093820c5112db96efa39a9674528ec20523518e41'
+  sha256 '4dbb50401a78fcb621f417da717586fcae910af70b1dd9e8018525ec468714f7'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.