### PR TITLE
Update dotnet-sdk to 2.2.100

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk' do
-  version '2.1.500'
-  sha256 '897de45f5764c3efb9a35d225eb668d355f24c34920a26a1310115658fee3283'
+  version '2.2.100'
+  sha256 '3b40cb7c96d982319b8fd0b5d45f97ddbe857e547582ef8a1f1ab636ca2eb030' # DevSkim: ignore DS173237
 
-  url "https://download.visualstudio.microsoft.com/download/pr/59a7b78f-4e86-473b-b230-c84d15505cec/766e3e5f35e7bb9677dd785071c5fbf7/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/29457b8f-6262-4c4b-8a54-eef308346842/3c7ec575796a2ef0e826a07ca4d13084/dotnet-sdk-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'


### PR DESCRIPTION
Updates dotnet-sdk to 2.2.100

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).