### PR TITLE
Update geogebra to 6.0.513.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.512.0'
-  sha256 'c7fedefde34cabf342ff2a9742a1453c40e077fd1343558175fc0972ba2a7e75'
+  version '6.0.513.0'
+  sha256 'ea5216cc87c56a9f92e447c43e583a143ab77c907b06987bc3f164699ed5c102'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   name 'GeoGebra'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.