### PR TITLE
Update manager to 18.11.64

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.11.63'
-  sha256 'b889b42e01f13662c890e0c63ea254acdd0ca195df74695d71e53b6ec886fb6a'
+  version '18.11.64'
+  sha256 'dbe6b8b8534da699387f6fd39082e2085600b2e5751c1fc89c2bdebe35d2b0c5'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.