### PR TITLE
Update kitty to 0.13.1

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,6 +1,6 @@
 cask 'kitty' do
-  version '0.13.0'
-  sha256 '8fd9797a7bbdb4eacffcbff2508563cbb6f8b4410cb04a02ae635c31f090009c'
+  version '0.13.1'
+  sha256 '63389f5f6bd72e21b558313076d88f0e7a39991805daaac166ff062898f54599'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.