### PR TITLE
Update qt-creator to 4.8.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.7.2'
-  sha256 '2b262bb733a2794d69451d9de101223fff22e685fc74b29e07c7d84ce5d1d361'
+  version '4.8.0'
+  sha256 'dbbcefe1233cb29f0d20565273b6e5262e60190bcddcc55ed5be97ff57284b7a'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.