### PR TITLE
Bump Arduino IDE to v.1.8.8

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -1,6 +1,6 @@
 cask 'arduino' do
-  version '1.8.7'
-  sha256 'bc5fae3e0b54f000d335d93f2e6da66fc8549def015e3b136d34a10e171c1501'
+  version '1.8.8'
+  sha256 'b1628a0ca7ee5c8d75ee98cfee3d29f61c03d180894ff12636abe3d30ef67258'
 
   url "https://downloads.arduino.cc/arduino-#{version}-macosx.zip"
   appcast 'https://www.arduino.cc/en/Main/ReleaseNotes'


### PR DESCRIPTION
This commit bumps the Arduino IDE to v.1.8.8

Release notes: https://www.arduino.cc/en/Main/ReleaseNotes
Official download URL: https://www.arduino.cc/en/Main/Software

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).