### PR TITLE
Update outline-manager to 1.2.1

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.1.9'
-  sha256 '4d5f4e5e2265f0601483957f4ab3d26e69f508adcf6f61f230bad0174b649629'
+  version '1.2.1'
+  sha256 '32a21a79847468ae4907da6490e13e8e742234586c5dd8d95bf813e9e30e5cac'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.