### PR TITLE
Update iridient-developer to 3.3.4

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.3.3'
-  sha256 'fd1737ce307cb8269c6fd4eeb77d663a7e4e9dd0fde1ff439e8fd4b2c6a7f1cd'
+  version '3.3.4'
+  sha256 'ae7a279be57761dc14f0eb742e48de237241f0080f81ad5f8e61c4965aca9f6c'
 
   url "https://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'https://www.iridientdigital.com/products/rawdeveloper_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.