### PR TITLE
Update splice to 3.3.10

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,6 +1,6 @@
 cask 'splice' do
-  version '3.3.9'
-  sha256 '5af691dcd84e1fb4b23f04216834b5d7c58aca820dcbaaa1bfcd305592619983'
+  version '3.3.10'
+  sha256 'ba5ef1d97f3491e10316be00abfae9d5b00e00588376a141c371b7975e8ec991'
 
   # splicedesktop.s3-us-west-1.amazonaws.com was verified as official when first introduced to the cask
   url 'https://splicedesktop.s3-us-west-1.amazonaws.com/darwin/stable/Splice.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.