### PR TITLE
Update lingon-x to 6.5.3

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,6 +1,6 @@
 cask 'lingon-x' do
-  version '6.5.2'
-  sha256 '724735cf8a1afaa2f3b88f5ce618a0514ca382430d54cdcd0c06fdd1ac1d520d'
+  version '6.5.3'
+  sha256 '3e467c58756a538601fb352b48db2856be2bb8b4a556d092d66eff275e7f64ea'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.