### PR TITLE
Update postbox to 6.1.7

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.6'
-  sha256 '896ef7e6a869a4d3dcbf936356481fefa6fc3cc314eadead7485c1724952f9dc'
+  version '6.1.7'
+  sha256 'f6f58e0dfb2c2c93daa93ae2c5c3df29969ef429292d14a03e7d368488a26342'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.