### PR TITLE
Update smartgit to 18.2.1

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '18.2.0'
-  sha256 '1935e886cb4a18bc1d6925d18daecc0940855b15f24c0010e7d12bb79a8e77e3'
+  version '18.2.1'
+  sha256 '9a6060e1503e6149ad9f4eed0005b7ec187a8e379578fb7579e1578f42ce0473'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.