### PR TITLE
Update downie to 3.5.4,1918

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.5.3,1916'
-  sha256 '034aa1200418d8e771a12c142d7ff5f8384de1deceb961877daf439e48df3796'
+  version '3.5.4,1918'
+  sha256 '9773ab2b3278549659d782c6b465f39adf89324a4ede9dbb877cee7e2a5a55f5'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.