### PR TITLE
Update winds to 3.1.4

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,9 +1,9 @@
 cask 'winds' do
-  version '2.1.174'
-  sha256 '53a316dc6a229b290eadc088376925d88f59777f73c8d153f74b282c8a41d906'
+  version '3.1.4'
+  sha256 'ebb116a2a3b7396eff1edfce7d69da31ea6f6d66efc04a98f6c260319eda2ba8'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/winds-#{version.major}.0-releases/releases/Winds-#{version}.dmg"
+  url 'https://s3.amazonaws.com/winds-2.0-releases/releases/Winds-3.1.4.dmg'
   appcast "https://s3.amazonaws.com/winds-#{version.major}.0-releases/latest.html"
   name 'Winds'
   homepage 'https://getstream.io/winds/'

--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -3,8 +3,8 @@ cask 'winds' do
   sha256 'ebb116a2a3b7396eff1edfce7d69da31ea6f6d66efc04a98f6c260319eda2ba8'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/winds-2.0-releases/releases/Winds-3.1.4.dmg'
-  appcast "https://s3.amazonaws.com/winds-#{version.major}.0-releases/latest.html"
+  url "https://s3.amazonaws.com/winds-2.0-releases/releases/Winds-#{version}.dmg"
+  appcast 'https://github.com/GetStream/Winds/releases.atom'
   name 'Winds'
   homepage 'https://getstream.io/winds/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.