### PR TITLE
Update hwsensors to 6.26.1440

### DIFF
--- a/Casks/hwsensors.rb
+++ b/Casks/hwsensors.rb
@@ -7,8 +7,6 @@ cask 'hwsensors' do
   name 'HWSensors'
   homepage 'https://github.com/kozlek/HWSensors/'
 
-  auto_updates true
-
   pkg "HWSensors.#{version}.pkg"
 
   uninstall login_item: 'HWMonitor',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes #55908.