### PR TITLE
Update lehreroffice to 2018.17.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,5 +1,5 @@
 cask 'lehreroffice' do
-  version '2018.17'
+  version '2018.17.0'
   sha256 'fb7b9b006e02c4ab32cb6a271825f3308e4e16737de66dda1e9917b295f6f175'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.