### PR TITLE
Update lehreroffice-zusatz to 2018.17.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,5 +1,5 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.17'
+  version '2018.17.0'
   sha256 '32ff6adc04eebcd187a841968df358a409435846d0f97972388b143b9c11b2ee'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.