### PR TITLE
Update tribler to 7.1.3

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,6 +1,6 @@
 cask 'tribler' do
-  version '7.1.2'
-  sha256 'eb0d12302b29dc5a3dedcb74222dc38ea5c226badb0f08ef0976b35fc7d5f795'
+  version '7.1.3'
+  sha256 '49d0cbfc96e28f71fe413097ac834c8fbe581c46a89d6b677176bb7ab63b355d'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.