### PR TITLE
Update iridium to 2018.11-1

### DIFF
--- a/Casks/iridium.rb
+++ b/Casks/iridium.rb
@@ -1,8 +1,8 @@
 cask 'iridium' do
-  version '2018.04.66.0,2018.4-0'
-  sha256 '337b75f59306995d76dc85b155cd693a5411da9e7172b2101d799fa54fff27b7'
+  version '2018.11-1'
+  sha256 'd39b798d9819d0192611ffd9a89fdc67306a05a34e9838ae02fbc4b67953483e'
 
-  url "https://downloads.iridiumbrowser.de/macos/#{version.after_comma}/iridium_browser_#{version.before_comma}_macos_x64.dmg"
+  url "https://downloads.iridiumbrowser.de/macos/#{version}/iridium-browser_#{version}_macos_x64.dmg"
   appcast 'https://downloads.iridiumbrowser.de/macos/'
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.