### PR TITLE
Update wechatwebdevtools to 1.02.1811290

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1810250'
-  sha256 '1ceaedc36d070e788e3ceaa8d2b0047f876f559154d5c4f869c65e52920ece43'
+  version '1.02.1811290'
+  sha256 'd429969c90f5e2b9180df11834dd43141a31fead0b44024042f17ec21bf14190'
 
-  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
+  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/bb9c1558bb234f98b0a5558bcb629fa8/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'
   name '微信web开发者工具'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.