### PR TITLE
Update squeak to 5.2-18228

### DIFF
--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -1,6 +1,6 @@
 cask 'squeak' do
-  version '5.2-18225'
-  sha256 '377d9c1354fbf20485f82acd3771c46c3f7235285ba8d231beaff9c81f03a539'
+  version '5.2-18228'
+  sha256 '7bd3de9beedcce792db32f1253f9243a299909368bad6f1ac21dd128f11b289d'
 
   url "https://files.squeak.org/#{version.major_minor}/Squeak#{version}-64bit/Squeak#{version}-64bit-All-in-One.zip"
   name 'Squeak'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.