### PR TITLE
 p4v 18.3-1719707: Correctly handle spaces in CLI arguments

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -24,7 +24,7 @@ cask 'p4v' do
       #!/bin/bash
       set -euo pipefail
       COMMAND=$(basename "$0")
-      exec "#{appdir}/${COMMAND}.app/Contents/MacOS/${COMMAND}" $@ 2> /dev/null
+      exec "#{appdir}/${COMMAND}.app/Contents/MacOS/${COMMAND}" "$@" 2> /dev/null
     EOS
   end
 


### PR DESCRIPTION
Problem: If you attempt to invoke, e.g. p4merge on a filename with spaces in it, the filename will end up being broken into multiple incorrect fragments when the wrapped app is actually invoked.

Solution: Use quotes, i.e. `"$@"` instead of a bare `$@`

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I'm not clear on the requirements for the cask name and version, or indeed whether cask versions should change when the underlying software doesn't change. This change is just to fix the broken shim, it doesn't change the version of p4v used. Let me know if you need changes.