### PR TITLE
Update electron to 3.0.11

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '3.0.10'
-  sha256 '302d8fc4fe9bc5d84dd96534139e4f1a3989d0ab6aac0c91351c57576e79e0a9'
+  version '3.0.11'
+  sha256 '95c774bbe3d082ed60f8156837254d016c67d75fdc7f0b8c813b2fb066db9994'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.