### PR TITLE
Update mycrypto to 1.5.0

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.4.2'
-  sha256 'bc7aa35e3701d3a3e1ead7cf32bc20766a752d59986f8ee9ec1444281f288f26'
+  version '1.5.0'
+  sha256 'a4d17409c8dc73a7692ae7016eda371131a7bd67f28ce2e70ea2fd7f2cc30536'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.