### PR TITLE
Update terminus to 1.0.65

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.1'
-  sha256 'f59d12c713ffc7979175298f1e36d0eb21c2d2a537e8ff95f849d031478034c5'
+  version '1.0.65'
+  sha256 '52eb9c724e2f1523f19920286e187007c5657a256fc7a1586ed326629174b83f'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.