### PR TITLE
Update extraterm to 0.38.1

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,6 +1,6 @@
 cask 'extraterm' do
-  version '0.37.1'
-  sha256 'ee4d1426569ca7174f75afb293043dc17df871676f62afefeaca04b4feea6849'
+  version '0.38.1'
+  sha256 '2aa1f4b67759e44c2daad68e2c0efd8800ea259ce14833c530333406b1b86e4c'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.