### PR TITLE
Update buttercup to 1.12.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.12.0'
-  sha256 '4d75f6d9575cdcfc1717f70893d883206b9af5a37fd8b3a28aa343df21858d20'
+  version '1.12.2'
+  sha256 '8faa0b2d9adb16265918884ba4806a1c4601662ae954cbfdc40e08a60e904793'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.