### PR TITLE
Update lockrattler to 4.18,2018.12

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.17,2018.12'
-  sha256 '725e3c338b9d7389c45f13db29f66bbbe8215d3fef6e974b32c41af2ecd15097'
+  version '4.18,2018.12'
+  sha256 '185f01ddc8f054b85006867a2513528196c0b4190413cf2b2c88f4f2c1031db2'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.