### PR TITLE
Update exifrenamer to 2.3.1

### DIFF
--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -1,6 +1,6 @@
 cask 'exifrenamer' do
-  version '2.3.0'
-  sha256 'fa59123950316809ccf555be08d85e75af350f91a40ab1038d0716549b92b851'
+  version '2.3.1'
+  sha256 'c3bec0c2743f7aede074802824ee04f1851d727bdf495bf19c08a25d3cfd8e66'
 
   url 'https://www.qdev.de/downloads/files/ExifRenamer.dmg'
   appcast 'https://www.qdev.de/versions/ExifRenamer.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.