### PR TITLE
Update manager to 18.11.68

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.11.66'
-  sha256 'a8ea5e3d6e17163c06a4b2c00897887a1ac35f197ecc09388bfdbaedef0d6207'
+  version '18.11.68'
+  sha256 '2199680b45734ff3320af7d47a6c9a9ac9108be7e5496b7b3f8d0a29358df6d1'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.