### PR TITLE
Upgrade Rightfont from v4.10 to v5.2.3

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -3,11 +3,11 @@ cask 'rightfont' do
   sha256 '203a9bb92c6e07e028bdeeab6758a9e05bb0bcd428b2b9c61d9ca8d3ee09e948'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
-  appcast 'https://rightfontapp.com/update/appcast5.xml'
+  appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"
   name 'RightFont'
   homepage 'https://rightfontapp.com/'
 
   depends_on macos: '>= :yosemite'
 
-  app 'RightFont 5.app'
+  app "RightFont #{version.major}.app"
 end

--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,9 +1,9 @@
 cask 'rightfont' do
-  version '4.10'
-  sha256 '9ff22c538b96cc928dca659abc63158be5f8b156c6fdef776392c0cbd6e2ab84'
+  version '5.2.3'
+  sha256 '203a9bb92c6e07e028bdeeab6758a9e05bb0bcd428b2b9c61d9ca8d3ee09e948'
 
-  url "https://rightfontapp.com/downloads/#{version}/rightfont.zip"
-  appcast 'https://rightfontapp.com/update/appcast.xml'
+  url 'https://rightfontapp.com/update/rightfont.zip'
+  appcast 'https://rightfontapp.com/update/appcast5.xml'
   name 'RightFont'
   homepage 'https://rightfontapp.com/'
 

--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -9,5 +9,5 @@ cask 'rightfont' do
 
   depends_on macos: '>= :yosemite'
 
-  app 'RightFont.app'
+  app 'RightFont 5.app'
 end


### PR DESCRIPTION
Upgrade Rightfont from v4.1 to v5.2.3
- new appcast url
- download URL no longer contains version number

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256