### PR TITLE
Update imageoptim to 1.8.7

### DIFF
--- a/Casks/imageoptim.rb
+++ b/Casks/imageoptim.rb
@@ -1,6 +1,6 @@
 cask 'imageoptim' do
-  version '1.8.6'
-  sha256 'c7239f4142c515c2e481cd0e8f74af7107f59ea5bd622025637f197236df981b'
+  version '1.8.7'
+  sha256 '94654a8f3166ccb0aebd5f863f44d8be609c996936812f3d30c4b5d495e3df06'
 
   url "https://imageoptim.com/ImageOptim#{version}.tar.bz2"
   appcast 'https://imageoptim.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.