### PR TITLE
Update scopebox to 3.5.6

### DIFF
--- a/Casks/scopebox.rb
+++ b/Casks/scopebox.rb
@@ -1,6 +1,6 @@
 cask 'scopebox' do
-  version '3.5.5'
-  sha256 '6f5b880dc7c4cb16b4407117dd1ddc619020b906aa122a6cf20caaf90da726cf'
+  version '3.5.6'
+  sha256 'bbc41a5761eaf4202f4d53cc48ff0dc4ef136fb783f270f739971b16b6e228cc'
 
   url "https://www.divergentmedia.com/fileRepository/ScopeBox%20#{version}.dmg"
   appcast 'https://www.divergentmedia.com/autoupdater/scopebox/3_1_x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.