### PR TITLE
Update stay to 1.2.8

### DIFF
--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -1,6 +1,6 @@
 cask 'stay' do
-  version '1.2.7'
-  sha256 '332d7046630e0ed9367e635081f1eaadbecfb52e655448edc7f173d3c72c1ce5'
+  version '1.2.8'
+  sha256 '754b02b07af6da1383f59751448cab76d18b1ffc9c7dca8047f7fccc37650076'
 
   url "https://cordlessdog.com/stay/versions/Stay%20#{version}.dmg"
   appcast 'https://cordlessdog.com/stay/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.