### PR TITLE
Update kinsky to 4.4.19

### DIFF
--- a/Casks/kinsky.rb
+++ b/Casks/kinsky.rb
@@ -1,6 +1,6 @@
 cask 'kinsky' do
-  version '4.4.5'
-  sha256 '2f4f04e76863eebe1da3d77e2fbd8eee71d57cdd3950f3bac64e0d569fa104de'
+  version '4.4.19'
+  sha256 '86be0b0c7b50d65a44a1cac24dc47dce55b5a6dceed36e8d66b8842db31574bc'
 
   url "https://oss.linn.co.uk/Releases/Kinsky/Davaar/Kinsky_#{version}_osx.pkg"
   appcast 'https://oss.linn.co.uk/Releases/Kinsky/Davaar/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.