### PR TITLE
Update ultimate to 3.0.10.1206

### DIFF
--- a/Casks/ultimate.rb
+++ b/Casks/ultimate.rb
@@ -1,6 +1,6 @@
 cask 'ultimate' do
-  version '3.0.10.1025'
-  sha256 '99b9490e4a32b61a11def5ead4be95e70f94c8c0515fbb8a2c472f372092b909'
+  version '3.0.10.1206'
+  sha256 'bef0596043714a7f08483fd29bd28e4433ea51de643a71071941a1950d9bbe0f'
 
   url 'https://download.epubor.com/epubor_ultimate.zip'
   appcast 'https://www.epubor.com/ultimate.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.