### PR TITLE
Update wordpresscom to 3.8.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '3.7.0'
-  sha256 '0919bf710ba47769dafd89b752c95af419930d2ca04afdedb0864b6d11027f32'
+  version '3.8.0'
+  sha256 '471be5e96058a8550f045e4419a577a55fc7581d2d62ca14ae25c06bf96290ef'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=dmg&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.