### PR TITLE
Update navicat-for-postgresql to 12.1.13

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '12.1.12'
-  sha256 '8d1b821e59d22608b7316bcacd3fcc0fb7989bcb30207781c370f08b37a187d1'
+  version '12.1.13'
+  sha256 '67ba6a8421fd48fc726758ae6b318ddfeb642d5faf598277c791be5807319917'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.