### PR TITLE
Update anki to 2.1.6

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -1,13 +1,13 @@
 cask 'anki' do
-  version '2.1.5'
-  sha256 'a239f97cb7ea052e8c58083e67c77d53c4610c1b838c6b5e8226caddddd24031'
+  version '2.1.6'
+  sha256 'f03866b906ac57a5e596696c8fc61547fef6d8639995eddbdc83bbef09d633e0'
 
   url "https://apps.ankiweb.net/downloads/current/anki-#{version}-mac.dmg"
   appcast 'https://apps.ankiweb.net/docs/changes.html'
   name 'Anki'
   homepage 'https://apps.ankiweb.net/'
 
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :sierra'
 
   app 'Anki.app'
 end


### PR DESCRIPTION
The requirements for 2.1.6 have changed and it now requires at least macOS 10.12.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.