### PR TITLE
Update wine-stable to 3.0.4

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -1,6 +1,6 @@
 cask 'wine-stable' do
-  version '3.0.3'
-  sha256 'f0dc85a61de75defcc5e7d0091b55ca3178abd71a5d45152228fe77575377490'
+  version '3.0.4'
+  sha256 'a13c4755d837439a0861472885eea0956b39a5eafaf0be674784764691da19ff'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-stable-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.