### PR TITLE
Passafari 0.2

### DIFF
--- a/Casks/passafari.rb
+++ b/Casks/passafari.rb
@@ -1,0 +1,12 @@
+cask 'passafari' do
+  version '0.2'
+  sha256 '9b9b71fd4af2c7519d0b5cbf35920760a07d5368cfeefcff7ef16d3745405470'
+
+  url 'https://github.com/adur1990/Passafari/releases/download/0.2/Passafari.app.zip'
+  name 'Passafari'
+  homepage 'https://github.com/adur1990/Passafari'
+
+  app 'Passafari.app'
+
+  appcast 'https://github.com/adur1990/Passafari/releases.atom'
+end

--- a/Casks/passafari.rb
+++ b/Casks/passafari.rb
@@ -2,11 +2,10 @@ cask 'passafari' do
   version '0.2'
   sha256 '9b9b71fd4af2c7519d0b5cbf35920760a07d5368cfeefcff7ef16d3745405470'
 
-  url 'https://github.com/adur1990/Passafari/releases/download/0.2/Passafari.app.zip'
+  url "https://github.com/adur1990/Passafari/releases/download/#{version}/Passafari.app.zip"
+  appcast 'https://github.com/adur1990/Passafari/releases.atom'
   name 'Passafari'
   homepage 'https://github.com/adur1990/Passafari'
 
   app 'Passafari.app'
-
-  appcast 'https://github.com/adur1990/Passafari/releases.atom'
 end


### PR DESCRIPTION
Passafari is a Safari App Extension for pass, the standard UNIX password manager.
It is (to the best of my knowledge) the first Extension for Safari on macOS.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
  * Could not run style check due to broken `rubocop` gem on [macOS Mojave](https://github.com/tonytonyjan/jaro_winkler/issues/22).
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256