### PR TITLE
Update bisq to 0.9.1

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '0.9.0'
-  sha256 '4a344c9759889a364b60ca35b8b577284548bb0f866d70bafd29bf452251bc3e'
+  version '0.9.1'
+  sha256 'ac026089ace53a9b07023a3d5f2757e76b0e0215a6f341955c30047e7f20b211'
 
   # github.com/bisq-network/bisq-desktop was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq-desktop/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
- [x] `brew cask audit --download bisq` is error-free.
- [x] `brew cask style --fix bisq` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for a stable version.
