### PR TITLE
Update augur to 1.8.4

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.6.2'
-  sha256 '171769380a796f270314215d84d3d2349c5885bf5cee8b8dcaadf7a72b0a263e'
+  version '1.8.4'
+  sha256 '890534416a95a4b0ffd58a843e60ebb91bcf4c88d1c9a41cd33a126115f90ac6'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.