### PR TITLE
Update bookmacster to 2.9.7

### DIFF
--- a/Casks/bookmacster.rb
+++ b/Casks/bookmacster.rb
@@ -1,6 +1,6 @@
 cask 'bookmacster' do
-  version '2.9.6'
-  sha256 'f446d55b8e364024f8e88285b49edf3eedc04c0878a63baa16271332ab558bcc'
+  version '2.9.7'
+  sha256 '56ef20442c6ed572c107f5f1f3924d2a213b9931cbee13d70a3e752fa05256af'
 
   url 'https://sheepsystems.com/bookmacster/BookMacster.zip'
   appcast 'https://sheepsystems.com/bookmacster/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.