### PR TITLE
Update dyn-updater to 5.4.8

### DIFF
--- a/Casks/dyn-updater.rb
+++ b/Casks/dyn-updater.rb
@@ -1,6 +1,6 @@
 cask 'dyn-updater' do
-  version '5.4.7'
-  sha256 '68c20b49921c1bd5db8256a6aba9b04890a9116d77fc18c6cead5a6e47ad6e15'
+  version '5.4.8'
+  sha256 'be4b02a43ca968df9715975930480cea599fc5ecb3e34798f38139ff209dd1ee'
 
   url "http://cdn.dyn.com/dynupdater/DynUpdater-#{version}.zip"
   appcast 'http://cdn.dyn.com/dynupdater/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.