### PR TITLE
Update pdf-squeezer to 3.9.3

### DIFF
--- a/Casks/pdf-squeezer.rb
+++ b/Casks/pdf-squeezer.rb
@@ -1,6 +1,6 @@
 cask 'pdf-squeezer' do
-  version '3.9.1'
-  sha256 '032d292505c9b106ed9198e74dc4795049a1e83b16c0e45312f5051ff626e7df'
+  version '3.9.3'
+  sha256 '4053fdd9a250810f335c3a0e82a392a5934d3517a7d9e9d01f474ca226d882e1'
 
   url 'https://witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
   appcast 'https://witt-software.com/downloads/pdfsqueezer/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.