### PR TITLE
Update sublime-merge to 1098

### DIFF
--- a/Casks/sublime-merge.rb
+++ b/Casks/sublime-merge.rb
@@ -1,6 +1,6 @@
 cask 'sublime-merge' do
-  version '1097'
-  sha256 '17ae9f9166c0f1e2910e37877ab9d90688b2b950aa632e886ad3810c80e6a75f'
+  version '1098'
+  sha256 '15c33cff3bb8b51c9502e71ceee7fe2ca282b567048af0e45d07d02a551f6f08'
 
   # download.sublimetext.com was verified as official when first introduced to the cask
   url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.