### PR TITLE
Update toptracker to 1.5.7.6079

### DIFF
--- a/Casks/toptracker.rb
+++ b/Casks/toptracker.rb
@@ -4,7 +4,7 @@ cask 'toptracker' do
 
   # d101nvfmxunqnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d101nvfmxunqnl.cloudfront.net/desktop/builds/mac/toptracker_#{version}.dmg"
-  appcast 'https://tracker.toptal.com/tracker/'
+  appcast 'https://tracker-api.toptal.com/desktop/updates/mac'
   name 'TopTracker'
   homepage 'https://tracker.toptal.com/tracker/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.