### PR TITLE
Update serviio to 1.10.1

### DIFF
--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -1,6 +1,6 @@
 cask 'serviio' do
-  version '1.9.2'
-  sha256 'de9a2918ae15b7bdd3042a5007a621bd111dcc552e6b580b74d7c1293fad26ed'
+  version '1.10.1'
+  sha256 '2ffb1263780c7df628fe1e56986fe1a4f23e105d6c3c9ead73303cb9c3f9f704'
 
   url "http://download.serviio.org/releases/serviio-#{version}-osx.tar.gz"
   name 'Serviio'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.