### PR TITLE
Update cmake to 3.13.2

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.13.1'
-  sha256 '74fc23823bcb22da7ed6d4fbb0642c3387acab74a608286cb5c323dcc21d9b7a'
+  version '3.13.2'
+  sha256 'abcd60d7cdf87a3ccd1c43b2f47b78058b2aa56dec99600702b659f921b0d069'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.