### PR TITLE
Update aria2d to 358,1544709925

### DIFF
--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,6 +1,6 @@
 cask 'aria2d' do
-  version '1.2.4,1538136711'
-  sha256 'b13a5ca5897c3b6614e1ff974cf43f6293db91697cdb4bec4eb8b31ab4d1d527'
+  version '358,1544709925'
+  sha256 '428daaed8dc4843c876eff8449e1630d08e679afcdc8bac84209f018d8a6171c'
 
   # dl.devmate.com/com.xjbeta.Aria2D was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.xjbeta.Aria2D/#{version.before_comma}/#{version.after_comma}/Aria2D-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.