### PR TITLE
Update framer-x to 26388,1544707956

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '24271,1539682151'
-  sha256 'ae1ae101f6509908bfa0b7e5e4cb10ae7c6ba7a8d3f957cedf3c87d4cc157422'
+  version '26388,1544707956'
+  sha256 '23f7a250c518fe921fafc31964b54df37ccc6ab1e903f23822464b3a6efee797'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.