### PR TITLE
Update station to 1.33.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.31.3'
-  sha256 'a49b53ecce744146e6251792e593aeed034e6fa5ae9c48ace30c756c25d11aeb'
+  version '1.33.0'
+  sha256 '8a362cafcb233e36605d7c0e6e2049ea3b8fe106063de715b4d1ef5563f41bb9'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.