### PR TITLE
Update whalebird to 2.6.1

### DIFF
--- a/Casks/whalebird.rb
+++ b/Casks/whalebird.rb
@@ -1,6 +1,6 @@
 cask 'whalebird' do
-  version '2.6.0'
-  sha256 '2db518c3c4871e88c9c4a960cf3116da8e90ee7c0cb12b8cd2af94fa8fe4d577'
+  version '2.6.1'
+  sha256 '810565933a218d55a7d0b0b8bcf7244e55224336e6f6d3e943566ead38761f32'
 
   # github.com/h3poteto/whalebird-desktop was verified as official when first introduced to the cask
   url "https://github.com/h3poteto/whalebird-desktop/releases/download/#{version}/Whalebird-#{version}-darwin-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.