### PR TITLE
Update skype to 8.34.0.78

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,9 +1,10 @@
 cask 'skype' do
-  version '8.36.0.52'
-  sha256 '14805c571946c46be1d3caa04ef83c07399103415cd9f98b814f2947a3f9dafd'
+  version '8.34.0.78'
+  sha256 '814b60d85381d4a6332944cdf5f67f0e067b01843821989e685e53b49e6edf80'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
+  appcast 'https://get.skype.com/s4l-update?version=8.30.0.0&os=mac&ring=production&app=s4l'
   name 'Skype'
   homepage 'https://www.skype.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.