### PR TITLE
Update zoc to 7.22.2

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.22.1'
-  sha256 '49e0aff92b812418704d5fff8b019fd0d6c15c8e9b30961e4864dbb170cf13fe'
+  version '7.22.2'
+  sha256 '830238c526a28e66914b0a08157484efddf3dd035705018d54e6ecc849881a13'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.