### PR TITLE
Arq Backup Version 5.14.3

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '5.14.2'
-  sha256 '5429d75cec415a00b84fe7d8730d43bde8cab022b7d420de0c6b53a833ef4e46'
+  version '5.14.3'
+  sha256 '9e6794c5f19d6706b6663c7cfeb799110815f5d38830bd298057fc86936087f6'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arqbackup/arq#{version.major}.xml"


### PR DESCRIPTION
```
December 14, 2018
Added Features
	•	Added support for new AWS regions eu-north-1 (Stockholm) and ap-southeast-3 (Osaka).
Fixed Issues
	•	Fixed a OneDrive OAuth2 issue that caused a "We're unable to complete your request" error when you try to add OneDrive as a destination.
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
