### PR TITLE
Update netron to 2.7.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.7.2'
-  sha256 '3213b6089d91b51e26e46794bdd2a3e2f5318dd7715f812e14d6ce584f10cfb6'
+  version '2.7.3'
+  sha256 'e0b373e63867da318be0a291b07f801cc12787b397e3bbcdf6f6317f0dba0a2e'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.