### PR TITLE
Update sage to 8.4,10.13.6

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,21 +1,13 @@
 cask 'sage' do
-  if MacOS.version == :el_capitan
-    version '8.3,10.11.6'
-    sha256 '71bc5b85ffa251a6db38f27feec7eb725a2745ab769b752b55dca34ec8c75417'
-  elsif MacOS.version == :sierra
-    version '8.1,10.12.6'
-    sha256 'bd795369398873ccd26bae7e4ccc67370799d3038bebab911a626f496eba6d33'
-  else
-    version '8.4,10.13.6'
-    sha256 '80c9ee79321afc75dea6342af4dadfad6add2b11f762d56727af153c9880c08c'
-  end
+  version '8.4,10.13.6'
+  sha256 '80c9ee79321afc75dea6342af4dadfad6add2b11f762d56727af153c9880c08c'
 
   # mirrors.mit.edu/sage/osx/intel was verified as official when first introduced to the cask
   url "http://mirrors.mit.edu/sage/osx/intel/sage-#{version.before_comma}-OSX_#{version.after_comma}-x86_64.app.dmg"
   name 'Sage'
   homepage 'https://www.sagemath.org/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :high_sierra'
 
   app "SageMath-#{version.before_comma}.app"
   binary "#{appdir}/SageMath-#{version.before_comma}.app/Contents/Resources/sage/sage"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Versions are inconsistent, older versions being more up-to-date than nwer, and some of them no longer exist on the website on the same URL pattern. Let’s leave it at the latest