### PR TITLE
Update electron to 3.0.12

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '3.0.11'
-  sha256 '95c774bbe3d082ed60f8156837254d016c67d75fdc7f0b8c813b2fb066db9994'
+  version '3.0.12'
+  sha256 '3f6cf55b0ee7f5e3a9d7f5dc0e12015f28df2c55da46c8a4d0f1d12bd125d6f7'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.