### PR TITLE
Update dbschema to 8.0.11

### DIFF
--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -1,5 +1,5 @@
 cask 'dbschema' do
-  version '8.0.10'
+  version '8.0.11'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.dbschema.com/download/DbSchema_macos_#{version.dots_to_underscores}.tgz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.