### PR TITLE
Update syncovery to 8.15b

### DIFF
--- a/Casks/syncovery.rb
+++ b/Casks/syncovery.rb
@@ -1,6 +1,6 @@
 cask 'syncovery' do
-  version '8.12d'
-  sha256 '695a47031f163d7decdd538f1d2487740f67ec4817df0831fc75362e1ed8e493'
+  version '8.15b'
+  sha256 '8c61dc8045df1893d26476c4e5b1b6ebf1f06131d8c2482a6d81a8788e757c39'
 
   url "https://www.syncovery.com/release/SyncoveryMac#{version}.dmg"
   name 'Syncovery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.