### PR TITLE
Update arkclient to 2.1.0

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,11 +1,11 @@
-cask 'arkclient' do
+cask 'ark-desktop-wallet' do
   version '2.1.0'
   sha256 '58fe5c8c7683a83ea0857f294e00502fee81204eaf5471d8b040209c06de0291'
 
   # github.com/ArkEcosystem/ark-desktop was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/ark-desktop/releases/download/#{version}/Ark.Desktop.Wallet-#{version}.dmg"
   appcast 'https://github.com/ArkEcosystem/ark-desktop/releases.atom'
-  name 'Ark Client'
+  name 'Ark Desktop Wallet'
   homepage 'https://ark.io/'
 
   app 'Ark Desktop Wallet.app'

--- a/Casks/arkclient.rb
+++ b/Casks/arkclient.rb
@@ -8,5 +8,5 @@ cask 'arkclient' do
   name 'Ark Client'
   homepage 'https://ark.io/'
 
-  app 'ArkClient.app'
+  app 'Ark Desktop Wallet.app'
 end

--- a/Casks/arkclient.rb
+++ b/Casks/arkclient.rb
@@ -1,9 +1,9 @@
 cask 'arkclient' do
-  version '1.6.1'
-  sha256 'b4a6ac066981c05cf6ebec389bea8b2d0610ea4e283870b6b469a67f95b76e37'
+  version '2.1.0'
+  sha256 '58fe5c8c7683a83ea0857f294e00502fee81204eaf5471d8b040209c06de0291'
 
   # github.com/ArkEcosystem/ark-desktop was verified as official when first introduced to the cask
-  url "https://github.com/ArkEcosystem/ark-desktop/releases/download/#{version}/ArkClient-MacOS-#{version}.dmg"
+  url "https://github.com/ArkEcosystem/ark-desktop/releases/download/#{version}/Ark.Desktop.Wallet-#{version}.dmg"
   appcast 'https://github.com/ArkEcosystem/ark-desktop/releases.atom'
   name 'Ark Client'
   homepage 'https://ark.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.