### PR TITLE
Update lbry to 0.26.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.25.1'
-  sha256 '5fb92b87d561cfaf0e4a9edf5dfa99f678e27718bfefc145f64c5943f4630146'
+  version '0.26.1'
+  sha256 '832a26cdb0b20eef5bc317cc3fa15c6bcef8c1d1a12aeb7acbccd82b96d085d1'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.