### PR TITLE
Update psychopy to 3.0.0b13

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,11 +1,11 @@
 cask 'psychopy' do
-  version '1.90.3'
-  sha256 '7e1dfac94c39bd2a8fa5489e5e856b73add5d23a1fd381ce0c60e2478e0f6b55'
+  version '3.0.0b13'
+  sha256 '94656b12e55bbbfa4529ddf36bfac4da3ef7a4ca611b3cd76fa9e23a6eb773e3'
 
-  url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy2_PY3-#{version}-MacOS.dmg"
+  url "https://github.com/psychopy/psychopy/releases/download/3.0.0b13/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'
   name 'PsychoPy'
   homepage 'https://github.com/psychopy/psychopy'
 
-  app 'PsychoPy2_PY3.app'
+  app 'PsychoPy3.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.