### PR TITLE
Update quip to 5.4.24

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.4.16'
-  sha256 '4f6f0c351b366cc39af1189d0eb47441242f047c98690db0432cfc85eeb1fa96'
+  version '5.4.24'
+  sha256 '9cdaabd92eb2ae8a071cebff9dd916847b74595387722abb3e79c25077ca1330'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.