### PR TITLE
Update manager to 18.12.1

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.11.68'
-  sha256 '2199680b45734ff3320af7d47a6c9a9ac9108be7e5496b7b3f8d0a29358df6d1'
+  version '18.12.1'
+  sha256 'ea445d1987724dbac58adaaeaed0cf63e140cd2065a8517fac13977dc28b26cc'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.