### PR TITLE
Update vmware-horizon-client 4.10.0-11013656,CART19FQ4 depends_on

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -6,5 +6,7 @@ cask 'vmware-horizon-client' do
   name 'VMware Horizon Client'
   homepage 'https://www.vmware.com/'
 
+  depends_on macos: '>= :sierra'
+
   app 'VMware Horizon Client.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
The [release notes](https://docs.vmware.com/en/VMware-Horizon-Client-for-Mac/4.10/rn/horizon-client-mac-410-release-notes.html) state that this version of the client is dropping support for El Capitan.