### PR TITLE
Add Block Keeper.app v2.1.0

### DIFF
--- a/Casks/block-keeper.rb
+++ b/Casks/block-keeper.rb
@@ -1,0 +1,12 @@
+cask 'block-keeper' do
+  version '2.1.0'
+  sha256 '6db2a4b67190b8d950f894c1c30157433e81e938dd0e4f350fefb323c1bf66bc'
+
+  # github.com/DallasMcNeil/Block-Keeper was verified as official when first introduced to the cask
+  url "https://github.com/DallasMcNeil/Block-Keeper/releases/download/v#{version}/Block-Keeper.dmg"
+  appcast 'https://github.com/DallasMcNeil/Block-Keeper/releases.atom'
+  name 'Block Keeper'
+  homepage 'https://dallasmcneil.com/projects/blockkeeper/'
+
+  app 'Block Keeper.app'
+end


### PR DESCRIPTION
Adds Block Keeper, an app for tracking speedcubing times

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
