### PR TITLE
Disallow Karabiner on Sierra and later

### DIFF
--- a/Casks/karabiner.rb
+++ b/Casks/karabiner.rb
@@ -8,6 +8,7 @@ cask 'karabiner' do
   homepage 'https://pqrs.org/osx/karabiner/'
 
   auto_updates true
+  depends_on macos: '<= :el_capitan'
 
   pkg 'Karabiner.sparkle_guided.pkg'
   binary '/Applications/Karabiner.app/Contents/Library/bin/karabiner'


### PR DESCRIPTION
`karabiner` has been superseded by `karabiner-elements` on macOS Sierra
and later. Lets prevent accidental installation of the old package on
such systems.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.