### PR TITLE
Update otp-auth to 1.0.1,455

### DIFF
--- a/Casks/otp-auth.rb
+++ b/Casks/otp-auth.rb
@@ -1,6 +1,6 @@
 cask 'otp-auth' do
-  version '1.0.0,346'
-  sha256 '493343bb68124fda13905cd588eeac99a447ec3c8dc2da6b09d79a396a22a220'
+  version '1.0.1,455'
+  sha256 'bb0fc94a4bf3f1b400f72e176a9de9f5366fd08e513c5b2870fa094d91610916'
 
   url "https://cooperrs.de/downloads/OTPAuth#{version.after_comma}.dmg"
   name 'OTP Auth'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.