### PR TITLE
Update macx-dvd-ripper-pro to 6.2.0

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,7 +3,7 @@ cask 'macx-dvd-ripper-pro' do
   sha256 'be833ed61e2da6224216d49eddab58df020e7212ccf3a1ced8b620877a2f051e'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
-  appcast 'http://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'
+  appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'
   name 'MacX DVD Ripper Pro'
   homepage 'https://www.macxdvd.com/mac-dvd-ripper-pro/'
 

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.1.1'
-  sha256 '1a7a4fdfc8d30569e2b45ec299f200808e083735aa5ce1808e0a2692b982b9b7'
+  version '6.2.0'
+  sha256 'be833ed61e2da6224216d49eddab58df020e7212ccf3a1ced8b620877a2f051e'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
   appcast 'http://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.