### PR TITLE
Update gisto to 1.10.18

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.17'
-  sha256 '8c95961fab98b6c7f70e70971597b6ad461884beeea17ea44d03896e797cac2a'
+  version '1.10.18'
+  sha256 'b09aef8ece164d564fe30f64e1e638cac17b2853d04b281dcb3a97ebd1f51d96'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.