### PR TITLE
Update mucommander to 0.9.3,2

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,6 +1,6 @@
 cask 'mucommander' do
-  version '0.9.3,1'
-  sha256 '4bdc52fef2b9bc940320ea7c9fca9c8784bdfa0fdcda0ecb9c8b455f289e1f09'
+  version '0.9.3,2'
+  sha256 '2c5a16c5fff6d32763e901b32310a4e4e5e3cfc647b668e111a13197ed4be81c'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version.before_comma}-#{version.after_comma}/mucommander-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.