### PR TITLE
Update focused to 3.2,1825:1544822315

### DIFF
--- a/Casks/focused.rb
+++ b/Casks/focused.rb
@@ -1,6 +1,6 @@
 cask 'focused' do
-  version '3.1,1817:1508267199'
-  sha256 'c59d98631f8d4fcc15682b735ed0dc4e2991c52688168692c2fee5c8f55fb2c5'
+  version '3.2,1825:1544822315'
+  sha256 'e9da7b084243c73f78d2a441f1414b1e6d3a2b31c0391b8e9ae3631efa834f03'
 
   # devmate.com/com.71squared.focused was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.71squared.focused/#{version.after_comma.before_colon}/#{version.after_colon}/Focused-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.