### PR TITLE
Update glyphs to 2.5.2,1189

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
   version '2.5.2,1189'
-  sha256 '78e08330d8b642d6d8d92d058d5a8d3fee27b3c3dcb68b13d75eab507be36f62'
+  sha256 'c9a4c2abec8e9ea26ef70f980a6deff2ccb5b65a9ff6089b550bd8adbe01f16e'
 
   url "https://updates.glyphsapp.com/Glyphs-#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"

--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
   version '2.5.2,1189'
-  sha256 'c9a4c2abec8e9ea26ef70f980a6deff2ccb5b65a9ff6089b550bd8adbe01f16e'
+  sha256 '3188f1c3740341a804aa9372e04326826c84043b0ed082c0b05706cdeba1b3ed'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"

--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.5.2-1172'
-  sha256 'b5de72dc750aeb54cb22c2fb3f5666352e79a5b3bee6c29dfd6c5b6228e503c7'
+  version '2.5.2,1189'
+  sha256 '78e08330d8b642d6d8d92d058d5a8d3fee27b3c3dcb68b13d75eab507be36f62'
 
   url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"

--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -2,7 +2,7 @@ cask 'glyphs' do
   version '2.5.2,1189'
   sha256 '78e08330d8b642d6d8d92d058d5a8d3fee27b3c3dcb68b13d75eab507be36f62'
 
-  url "https://updates.glyphsapp.com/Glyphs#{version}.zip"
+  url "https://updates.glyphsapp.com/Glyphs-#{version}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'

--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -2,7 +2,7 @@ cask 'glyphs' do
   version '2.5.2,1189'
   sha256 'c9a4c2abec8e9ea26ef70f980a6deff2ccb5b65a9ff6089b550bd8adbe01f16e'
 
-  url "https://updates.glyphsapp.com/Glyphs-#{version}.zip"
+  url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"
   name 'Glyphs'
   homepage 'https://glyphsapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.