### PR TITLE
Update mimolive to 4.5.1-26768

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,6 +1,6 @@
 cask 'mimolive' do
-  version '4.4.1-26514'
-  sha256 '4d7ff866e6c1044d99cedd61d72792d6d2af672635ec6fc91f242741906bf4b0'
+  version '4.5.1-26768'
+  sha256 '38a25ff5bf5178ba37f251ff9efb32da61cd38ea4c4411b80fc7c56ab6b1d35e'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://sparkle.boinx.com/appcast.lasso?appName=mimoLive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.