### PR TITLE
Update jcryptool to 0.9.9

### DIFF
--- a/Casks/jcryptool.rb
+++ b/Casks/jcryptool.rb
@@ -3,6 +3,7 @@ cask 'jcryptool' do
   sha256 '6614bbfb2d9b3c6df365cdcff2a6b18c47f006b6fdd6783eb5e4faadabcb18e4'
 
   url "https://www.cryptool.org/jctdownload/Builds/downloads/stable/jcryptool-#{version}-macosx.cocoa.x86_64.tar.gz"
+  appcast 'https://www.cryptool.org/en/jct-downloads/stable'
   name 'JCrypTool'
   homepage 'https://www.cryptool.org/en/jcryptool'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.