### PR TITLE
Update zoomus to 4.1.35374.1217

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.1.34801.1116'
-  sha256 '9938a9f0d26cdd2b1e8e251b70dc0488050bbb2b087bc0af3ca18a7800e48f45'
+  version '4.1.35374.1217'
+  sha256 'fa2a3275c915d9514d0fad5aafa050af2b6dcdfc9ae46ff0c8ed1b12e036173a'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   appcast 'https://support.zoom.us/hc/en-us/articles/201361963-New-Updates-for-Mac-OS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.