### PR TITLE
Update profilecreator to 0.2.4-beta.9

### DIFF
--- a/Casks/profilecreator.rb
+++ b/Casks/profilecreator.rb
@@ -1,6 +1,6 @@
 cask 'profilecreator' do
-  version '0.2.3-beta.8'
-  sha256 '8a0b9a0b219d5b4047c0e1ce8c4af25e1286060e743ed3dcd51154aaf709b9ec'
+  version '0.2.4-beta.9'
+  sha256 '9771e17d54df6510b00f06e17f87b8d381894eb7f6dd082bf870819950200976'
 
   url "https://github.com/erikberglund/ProfileCreator/releases/download/v#{version}/ProfileCreator_v#{version}.dmg"
   appcast 'https://github.com/erikberglund/ProfileCreator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.