### PR TITLE
Homebrew TablePlus Build 166

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,7 +1,7 @@
 cask 'tableplus' do
   version '1.0,166'
   sha256 '247772a3b33dcdabbd83c8ac4e123e760cbdf32cf72587311021a0ff51c61421'
-  
+
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.dmg"
   appcast 'https://tableplus.io/osx/version.xml'

--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,7 +1,7 @@
 cask 'tableplus' do
-  version '1.0,164'
-  sha256 'a06e10479ce2f3dd649b284f324ce69739a0d70f8a2d1e83bd1f40fc232f6408'
-
+  version '1.0,166'
+  sha256 '247772a3b33dcdabbd83c8ac4e123e760cbdf32cf72587311021a0ff51c61421'
+  
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.dmg"
   appcast 'https://tableplus.io/osx/version.xml'


### PR DESCRIPTION
Update the Homebrew Cask for TablePlus to Build 166

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
