### PR TITLE
Update rider to 2018.3,183.5047.86

### DIFF
--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -1,6 +1,6 @@
 cask 'rider' do
-  version '2018.2.3,182.4231.496'
-  sha256 '83817839fb3e5ef44bfe61f360adadf9e8a1597438589723282eed9fc7199dee'
+  version '2018.3,183.5047.86'
+  sha256 'e1701ff76e1805a0409dd15d47cc48a1d13d6f7b592b046f7c77579e343e1143'
 
   url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=RD&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.