### PR TITLE
Update rider to 2018.3,183.5047.86

### DIFF
--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -1,6 +1,6 @@
 cask 'rider' do
-  version '2018.2.3,182.4231.496'
-  sha256 '83817839fb3e5ef44bfe61f360adadf9e8a1597438589723282eed9fc7199dee'
+  version '2018.3,183.5047.86'
+  sha256 'e1701ff76e1805a0409dd15d47cc48a1d13d6f7b592b046f7c77579e343e1143'
 
   url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=RD&latest=true&type=release'

--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -9,7 +9,7 @@ cask 'rider' do
 
   auto_updates true
 
-  app "Rider #{version.before_comma}.app"
+  app 'Rider.app'
 
   uninstall_postflight do
     ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'rider') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }


### PR DESCRIPTION
Based on https://github.com/Homebrew/homebrew-cask/pull/56303. This also fixes the casks app name. I verified manually, but JetBrains seems to have dropped the version from it's app name.

This is consistent with all the other JetBrains casks.