### PR TITLE
Update editready to 2.5

### DIFF
--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -1,6 +1,6 @@
 cask 'editready' do
-  version '2.1.6'
-  sha256 'f3b16ff2519d9bb789835a7eaab532c7c11cec9bc5d4afcd412db6a9e20e9876'
+  version '2.5'
+  sha256 '1ad43c6a58ded6e18daccbd1af364fce22f6e1e4468dcd303d57a509f0955459'
 
   url "https://www.divergentmedia.com/fileRepository/EditReady%20#{version}.dmg"
   appcast 'https://www.divergentmedia.com/autoupdater/editready/2_x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.