### PR TITLE
Update melodics to 2.0.2646

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2573'
-  sha256 'a0e4d64618ed3edf5e5f14f69ce8852d3d727c1ccee3e068848d8b86294de807'
+  version '2.0.2646'
+  sha256 'c7fe078132de2ba313e40397f2ef3cc5ab6ff6cd44276da2fc0f47154f398239'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.