### PR TITLE
Update electron to 3.0.13

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '3.0.12'
-  sha256 '3f6cf55b0ee7f5e3a9d7f5dc0e12015f28df2c55da46c8a4d0f1d12bd125d6f7'
+  version '3.0.13'
+  sha256 '59db83385203b053042317d74378d5f0610cf6e48008f4d2d8b3445f43ab8d86'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.