### PR TITLE
Update protege to 5.5.0-beta-7

### DIFF
--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -1,6 +1,6 @@
 cask 'protege' do
-  version '5.5.0-beta-4'
-  sha256 '7ca43f07b6a6bc086e428bfe1e23d0a725177636a32ee41ca6f1b5bb2f36d9a0'
+  version '5.5.0-beta-7'
+  sha256 '7329053402e0d4a72c2e54deeeaef2006b841b8edd3cf092c9262268fb8094f9'
 
   # github.com/protegeproject/protege-distribution was verified as official when first introduced to the cask
   url "https://github.com/protegeproject/protege-distribution/releases/download/v#{version}/Protege-#{version}-os-x.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.