### PR TITLE
Update netron to 2.7.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.7.4'
-  sha256 '5dcbf4115784e0105aa770bea67871fe5b96d9a3a9932ca5b60cd1a0b5ea9488'
+  version '2.7.5'
+  sha256 '529102407f7028e3ea28abd8b358b452ecbf1186d0e6c099b4ee2c8fd97d0601'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.