### PR TITLE
Update evernote to 7.7_457389

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -12,8 +12,8 @@ cask 'evernote' do
     version '7.2.3_456885'
     sha256 'eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97'
   else
-    version '7.6_457297'
-    sha256 '94282640888fdb6b9b1e4ef5e8b0f19a41f231b8bbbf3e94a9a9a31a6b95815a'
+    version '7.7_457389'
+    sha256 '0a37dfbd6f32a4c251b382cb577baff9382a87dc361a5c10ac4a2f75e0e77c18'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.