### PR TITLE
Update bluos-controller to 3.4.4,2018.12

### DIFF
--- a/Casks/bluos-controller.rb
+++ b/Casks/bluos-controller.rb
@@ -1,6 +1,6 @@
 cask 'bluos-controller' do
-  version '3.4.0,2018.10'
-  sha256 'fde5bffb8b9a8e683008b2639db0359ef4857e30fcd35ae96c5dedf2047f559b'
+  version '3.4.4,2018.12'
+  sha256 '4a497717d1aff4dcab06cc5705ce6db47c21ff01f8437445dba1755138797244'
 
   url "https://www.bluesound.com/wp-content/uploads/#{version.after_comma.dots_to_slashes}/BluOS-Controller-#{version.before_comma}.dmg"
   name 'BluOS Controller'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.