### PR TITLE
Update sciebo to 2.5.1.2378

### DIFF
--- a/Casks/sciebo.rb
+++ b/Casks/sciebo.rb
@@ -1,6 +1,6 @@
 cask 'sciebo' do
-  version '2.5.1.2376'
-  sha256 '00e167c61aa32801968c36d3bb4dec3399094a9f48828a91988e4273f64d7e84'
+  version '2.5.1.2378'
+  sha256 '38b67469fa672e9a0e1be9b91aa35ad9aafffdf2acff1399582b8c080a2a03da'
 
   url "https://www.sciebo.de/install/sciebo-#{version}.pkg"
   appcast 'https://www.sciebo.de/updateserver/?version=2.3.3.1812&platform=macos&oem=sciebo&sparkle=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.