### PR TITLE
Update eclipse-platform to 4.10,201812060815

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.9,201809060745'
-  sha256 '22028f455a9745165c48f4d92045560f8995a5fbd9037d533939dace9b6e1ead'
+  version '4.10,201812060815'
+  sha256 '8bee330659ae3464a8ae74dbc0d5221421af1380d207ceed9d6afe52337da80f'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.