### PR TITLE
Update sbrowserq to 3.5

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,9 +1,9 @@
 cask 'gemini' do
-  version '2.312,1539778530'
-  sha256 '6897195c7da4f57f2972a6f42386979cd8ea908364daadc8122f700e370bcd7e'
+  version '2.5.4,317:1545152224'
+  sha256 '8af15c907b64b3ac6e35b7443d19c2bf5d83f41c49677ea698b29d8fc0a524d5'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.minor}/#{version.after_comma}/Gemini#{version.major}-#{version.minor}.zip"
+  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_comma.before_colon}/#{version.after_colon}/Gemini#{version.major}-#{version.after_comma.before_colon}.zip"
   appcast "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml"
   name 'Gemini'
   homepage 'https://macpaw.com/gemini'

--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -2,9 +2,9 @@ cask 'sbrowserq' do
   version '3.5'
   sha256 'd62efea257215b019421f13b947e4dcb161fb35e1694454b140dc70c5f0fef99'
 
-  url "http://park.geocities.jp/sbrowser_q/SbrowserQ_V#{version}_mac.dmg"
+  url "https://www.sbrowser-q.com//SbrowserQ_V#{version}_mac.dmg"
   name 'SbrowserQ'
-  homepage 'http://park.geocities.jp/sbrowser_q/'
+  homepage 'https://www.sbrowser-q.com/'
 
   app 'SbrowserQ.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.