### PR TITLE
Update amazon-music to 7.1.1,20181218:045644a919

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask 'amazon-music' do
-  version '7.0.3,20181129:044211e983'
-  sha256 '430f10b6b41addca147180eb239a9620fa1073a1e216b41cde8f788258337c92'
+  version '7.1.1,20181218:045644a919'
+  sha256 '3107d83c851fe0090cdb03bfd6be02b6592107eba7105bbdfaaffed824400418'
 
   # ssl-images-amazon.com/images was verified as official when first introduced to the cask
   url "https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/#{version.after_comma.before_colon}/#{version.after_colon}/AmazonMusicInstaller.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.