### PR TITLE
Update eclipse-jee to 4.10.0,2018-12:R

### DIFF
--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-jee' do
   version '4.10.0,2018-12:R'
-  sha256 '0ee8ce4040c19d80fbdaf9daf67fa7ea6c6a36475d0d5a3a46f56de08320a093'
+  sha512 'ece8d1b511b7fb68c6083a69128f109719741df846756bd048227d5c4f71f88d092be0f18266b049fe51aee4600797ece58f6c2346bc96f4b5f6fa664b21cbfe'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java EE Developers'

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-jee' do
-  version '4.9.0,2018-09:R'
-  sha256 '5ca049d86362534815a169224604f44c8c32a162920697f04f2e4f0230450bcf'
+  version '4.10.0,2018-12:R'
+  sha256 '1bf59382e7eae3f1de29db3e4931455e20c34493269b3567f973b85bf44cb2a0'
 
-  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-macosx-cocoa-x86_64.dmg&r=1"
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg"
   name 'Eclipse IDE for Java EE Developers'
   homepage 'https://eclipse.org/'
 

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-jee' do
   version '4.10.0,2018-12:R'
-  sha512 'ece8d1b511b7fb68c6083a69128f109719741df846756bd048227d5c4f71f88d092be0f18266b049fe51aee4600797ece58f6c2346bc96f4b5f6fa664b21cbfe'
+  sha256 '25dc99adab94649b143f77fee7d154f560dd0bb8839805598a6c40526fb542bc'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java EE Developers'

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-jee' do
   version '4.10.0,2018-12:R'
-  sha256 '1bf59382e7eae3f1de29db3e4931455e20c34493269b3567f973b85bf44cb2a0'
+  sha256 '0ee8ce4040c19d80fbdaf9daf67fa7ea6c6a36475d0d5a3a46f56de08320a093'
 
-  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg"
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java EE Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.