### PR TITLE
Update roboform to 8.5.4

### DIFF
--- a/Casks/roboform.rb
+++ b/Casks/roboform.rb
@@ -1,6 +1,6 @@
 cask 'roboform' do
-  version '8.5.3'
-  sha256 'fb0b58943eb6efec7dbd6f69db2d9d2af41be0e7979336b57f0341fa7ae6cc73'
+  version '8.5.4'
+  sha256 '0f82db22cbaf8b78c7fb81265741411cbb47f644b78fc5e4459b9e2eef404b57'
 
   url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg"
   appcast 'https://www.roboform.com/news-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.