### PR TITLE
Update paintcode to 3.4.4

### DIFF
--- a/Casks/paintcode.rb
+++ b/Casks/paintcode.rb
@@ -1,6 +1,6 @@
 cask 'paintcode' do
-  version '3.4.3'
-  sha256 '78bbfdb06879176befe8ab5c46310ba9663b0644db02dd7ce068b44bf88921cd'
+  version '3.4.4'
+  sha256 'dfa01032a4fec701fbf0ac9a3593d3413249e83712817f2384168a9f39eb77d4'
 
   # pixelcut.com/paintcode was verified as official when first introduced to the cask
   url "https://www.pixelcut.com/paintcode#{version.major}/paintcode.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.