### PR TITLE
Update savoir-faire-linux-ring to 201812181300

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,11 +1,11 @@
-cask 'savoir-faire-linux-ring' do
+cask 'jami' do
   version '20181219.1734'
   sha256 '795d49b2c5c71826a53422f12c0e92efe83f9dab3dfa9d634fded7da270d8c75'
 
   url "https://dl.ring.cx/mac_osx/ring-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
-  name 'Savoir-faire LINUX Ring'
   name 'Jami'
+  name 'Savoir-faire Linux Ring'
   homepage 'https://ring.cx/'
 
   auto_updates true

--- a/Casks/savoir-faire-linux-ring.rb
+++ b/Casks/savoir-faire-linux-ring.rb
@@ -1,14 +1,14 @@
 cask 'savoir-faire-linux-ring' do
-  version '201812181300'
-  sha256 '4730fe08a824a3263899af96013dda3ff813c4bfe5a4167f35a70a8072bfc77f'
+  version '20181219.1734'
+  sha256 '795d49b2c5c71826a53422f12c0e92efe83f9dab3dfa9d634fded7da270d8c75'
 
-  url "https://dl.ring.cx/mac_osx/jami-#{version}.dmg"
+  url "https://dl.ring.cx/mac_osx/ring-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
   name 'Savoir-faire LINUX Ring'
-  name 'Ring'
+  name 'Jami'
   homepage 'https://ring.cx/'
 
   auto_updates true
 
-  app 'Ring.app'
+  app 'Jami.app'
 end

--- a/Casks/savoir-faire-linux-ring.rb
+++ b/Casks/savoir-faire-linux-ring.rb
@@ -1,8 +1,8 @@
 cask 'savoir-faire-linux-ring' do
-  version '201810011851'
-  sha256 '1252d701bb93fdd5850ca82ce0df2c3c11bb1c3ae7a67af723002dc2dd3ba186'
+  version '201812181300'
+  sha256 '4730fe08a824a3263899af96013dda3ff813c4bfe5a4167f35a70a8072bfc77f'
 
-  url "https://dl.ring.cx/mac_osx/ring-#{version}.dmg"
+  url "https://dl.ring.cx/mac_osx/jami-#{version}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
   name 'Savoir-faire LINUX Ring'
   name 'Ring'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.