### PR TITLE
Update eclipse-java to 4.10.0,2018-12:R

### DIFF
--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-java' do
-  version '4.9.0,2018-09:R'
-  sha256 '0b8f0fda62bdb89a249cda45400c53758a0886f4019042fc9a9d15ddc399fe8e'
+  version '4.10.0,2018-12:R'
+  sha256 '320d65a46789c3f3c1e38401703399ef0404f3d752c15786aa14101fb66c71bf'
 
-  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-macosx-cocoa-x86_64.dmg&r=1"
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.