### PR TITLE
Update go-server to 18.12.0-8222

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.12.2'
-  sha256 '8faa0b2d9adb16265918884ba4806a1c4601662ae954cbfdc40e08a60e904793'
+  version '1.13.0'
+  sha256 '2b66b04d6ddf85e2fb45db06fe08c05d38e06b6b693612f708981488683a8473'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"

--- a/Casks/go-server.rb
+++ b/Casks/go-server.rb
@@ -1,6 +1,6 @@
 cask 'go-server' do
-  version '18.10.0-7703'
-  sha256 'ec75a894399d0979e56e2de4ddb942071a41c722f46f1ed666a0b108991c24d8'
+  version '18.12.0-8222'
+  sha256 'ef311ae2c2236de6bc77d430109025d27414696833885153083e8c2b30fab67f'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-server-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.