### PR TITLE
Update go-agent to 18.12.0-8222

### DIFF
--- a/Casks/go-agent.rb
+++ b/Casks/go-agent.rb
@@ -1,6 +1,6 @@
 cask 'go-agent' do
-  version '18.10.0-7703'
-  sha256 'f1bbcc468033c77197654833f4c08bf5415f0db26b841ab526ee899269f33017'
+  version '18.12.0-8222'
+  sha256 '625dc3822c9c61b537f52b042e68b11ef45c4cd5d5ca02f4159af8a2249c95a6'
 
   # download.gocd.io/binaries was verified as official when first introduced to the cask
   url "https://download.gocd.io/binaries/#{version}/osx/go-agent-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.