### PR TITLE
Update pext to 0.22

### DIFF
--- a/Casks/pext.rb
+++ b/Casks/pext.rb
@@ -1,6 +1,6 @@
 cask 'pext' do
-  version '0.21'
-  sha256 'e29ca928f407a3c9d03e84a49c81f036176cf535d51f9ff3538f89f679d4dc9b'
+  version '0.22'
+  sha256 'a273a78be94e883fc57050f284486ac2c53a4c06e0b70b304146475f2e162ca1'
 
   # github.com/Pext/Pext was verified as official when first introduced to the cask
   url "https://github.com/Pext/Pext/releases/download/v#{version}/Pext-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.