### PR TITLE
Update openrefine to 3.1

### DIFF
--- a/Casks/openrefine.rb
+++ b/Casks/openrefine.rb
@@ -1,6 +1,6 @@
 cask 'openrefine' do
-  version '3.0'
-  sha256 '3302658a1e2f42047d24658b35cfa6f759400aacc4e9dec74604685516b514d3'
+  version '3.1'
+  sha256 'cd076a7da0664dddbdbf2c56026a127722a8f99915d8b80401f9664cfa020a5c'
 
   # github.com/OpenRefine/OpenRefine was verified as official when first introduced to the cask
   url "https://github.com/OpenRefine/OpenRefine/releases/download/#{version}/openrefine-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.