### PR TITLE
Update waterfox to 56.2.6

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.2.4'
-  sha256 '540b7ff80aa31494a32f1df07b694e4399cfe92d11ffb0f74cde85739af37a89'
+  version '56.2.6'
+  sha256 '8d6beb321c36f1cfbcb1afd2247357bb9cab51bc5c55350cc79a2f01659501b0'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.