### PR TITLE
Update wavebox to 4.5.9

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.5.8'
-  sha256 'a9bbb9a87f09b7f27fde9c4ced8f6a37286a872626ac92a268af973aa6687c48'
+  version '4.5.9'
+  sha256 '53b9ab42059d0de893568dade028162ca98bc2846814e52419ccf99b7e1545b0'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.