### PR TITLE
updating url and filename for corretto preview2-8u192

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,14 +1,14 @@
 cask 'corretto' do
   version '8,8u192'
-  sha256 '5836ca06194bee33a476bd9412ef810a8e8a98eb0202553567933b70f3aa17e4'
+  sha256 '50ba40b0d5e004c8b4720916a4f40660472bd8ad22f90b88eec87fb98b2455aa'
 
-  # d3pxv6yz143wms.cloudfront.net/corretto was verified as official when first introduced to the cask
-  url "https://d3pxv6yz143wms.cloudfront.net/corretto-jdk-#{version.after_comma}-macosx-x64.pkg"
+  # d3pxv6yz143wms.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d3pxv6yz143wms.cloudfront.net/amazon-corretto-preview2-#{version.after_comma}-macosx-x64.pkg"
   appcast 'https://docs.aws.amazon.com/en_us/corretto/latest/corretto-8-ug/corretto-8-ug.rss'
   name 'Amazon Corretto'
   homepage 'https://aws.amazon.com/corretto/'
 
-  pkg "corretto-jdk-#{version.after_comma}-macosx-x64.pkg"
+  pkg "amazon-corretto-preview2-#{version.after_comma}-macosx-x64.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.before_comma}"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

It looks like this is a "preview" version, but I don't see any alternatives so I'm guessing that this the only option.
