### PR TITLE
Update timing to 2018.3.4

### DIFF
--- a/Casks/timing.rb
+++ b/Casks/timing.rb
@@ -1,6 +1,6 @@
 cask 'timing' do
-  version '2018.3.2'
-  sha256 'abe3f8a13362704f0079ddb2b5bdca11bfe50340675e9fcaa1b0c506cf0bd146'
+  version '2018.3.4'
+  sha256 '2bbd41ec5985fc766a85c49edeabccd5206f77662d7bbc94765b75c4ca21f8cf'
 
   url 'https://timingapp.com/download/Timing.app.zip'
   appcast 'https://timingapp.com/updates/timing2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.