### PR TITLE
Update netron to 2.7.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.7.5'
-  sha256 '529102407f7028e3ea28abd8b358b452ecbf1186d0e6c099b4ee2c8fd97d0601'
+  version '2.7.6'
+  sha256 'c9554c694298dd8da7116496ee7f14dd614ece0851ac5d04c5f0f57d6c6044a0'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.