### PR TITLE
Update wey to 0.3.1

### DIFF
--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,6 +1,6 @@
 cask 'wey' do
-  version '0.3.0'
-  sha256 'b0d596aa92b0eb40181fba9201ed7604d1df3b0d6ce62d8e913cd1e99e1dd966'
+  version '0.3.1'
+  sha256 'c0a8fd689fcbeab6a75af034fdf8c41d8c77b7f66c1485a953a38c8ab8e712b1'
 
   url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.