### PR TITLE
Update jamf-migrator to 3.1.2

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '3.1.0'
-  sha256 '08ab008555ba5fb50e9b64a253a3064978d1bbc2bd9713e3f3b4719eeb0523c5'
+  version '3.1.2'
+  sha256 'b4e79a941a631a1ee5a1bd99d30c438ad369b4a16e11d0d439e7200d95e816bb'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.