### PR TITLE
Update fsnotes to 2.5.3

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.5.2'
-  sha256 '4ff7bdb710e94c79eeed41ea35e508a65b77e54d24aa407bd103c0cd54c8bd4e'
+  version '2.5.3'
+  sha256 'fd3a484e9af02010b7e6d5aa7d867dce83e1ea10858e7f19ebca3462fba8d416'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.