### PR TITLE
Update wechatwebdevtools to 1.02.1812180

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1811290'
-  sha256 'd429969c90f5e2b9180df11834dd43141a31fead0b44024042f17ec21bf14190'
+  version '1.02.1812180'
+  sha256 '85472ef3258f95c822c0981ee4c82c34175abdab01406b4ab514b767d464b163'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/bb9c1558bb234f98b0a5558bcb629fa8/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.