### PR TITLE
update liteide to 35.3

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,9 +1,9 @@
 cask 'liteide' do
-  version '35.2'
-  sha256 'e563158c95aa2c316f00ecaf4a599313c27311b73230a8df9afbf11f1e37a4dd'
+  version '35.3'
+  sha256 'e95356434468157b67bf956bf94e05307d439c163c5de81bacd1308a567f61bb'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
-  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.9.5-1.zip"
+  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.9.5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom'
   name 'LiteIDE'
   homepage 'http://liteide.org/'


### PR DESCRIPTION
update liteide to 35.3

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
