### PR TITLE
Update vitalsource-bookshelf to 8.1.0.123

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,9 +1,9 @@
 cask 'vitalsource-bookshelf' do
-  version '8.0'
-  sha256 '954a6152a74ca9b86b70c1a30ead067a706721b6b833dfb7e5d49569e68b9086'
+  version '8.1.0.123'
+  sha256 '84d8b5267e1958e6616c71d38e9cc8827ecb631b5dcd6a9ea6cea26c22366b1d'
 
-  # downloads.vitalbook.com/vsti/bookshelf was verified as official when first introduced to the cask
-  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version}/MAC/Bookshelf/VitalSource-Bookshelf.dmg"
+  # rink.hockeyapp.net/api/2/apps/ was verified as official when first introduced to the cask
+  url 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2/app_versions/131?format=zip&avtoken=1c7f6e35a15e65024402ca279014534329cbbc31&download_origin=hockeyapp'
   appcast 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2'
   name 'VitalSource Bookshelf'
   homepage 'https://www.vitalsource.com/bookshelf-features'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.