### PR TITLE
Update copyclip to 2.9.9

### DIFF
--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -3,7 +3,7 @@ cask 'copyclip' do
   sha256 'da6401eabc681c47bd555ee91ab83c154e7cf0b41bb9ea445774aad7264a73ac'
 
   # rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379/app_versions/28?format=zip&avtoken=874c0ee4ba01a1c228c864a70e1b32dcaeab6185&download_origin=hockeyapp'
+  url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379'
   name 'CopyClip'
   homepage 'https://fiplab.com/apps/copyclip-for-mac'

--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -1,9 +1,9 @@
 cask 'copyclip' do
-  version '2.9.6'
-  sha256 '83c66ef6967991e27b9356c19fc6df52f0fabad4f4d22869dbff8dfb0bc61450'
+  version '2.9.9'
+  sha256 'da6401eabc681c47bd555ee91ab83c154e7cf0b41bb9ea445774aad7264a73ac'
 
   # rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379?format=zip'
+  url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379/app_versions/28?format=zip&avtoken=874c0ee4ba01a1c228c864a70e1b32dcaeab6185&download_origin=hockeyapp'
   appcast 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379'
   name 'CopyClip'
   homepage 'https://fiplab.com/apps/copyclip-for-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.