### PR TITLE
Fix OpenSesame 3.2.6

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,9 +1,9 @@
 cask 'opensesame' do
   version '3.2.6'
-  sha256 'b77f4cf4ca8ca5919055d93e881927aee1610facc451746315d704633822a711'
+  sha256 '90d07e4013c0f1835dcd944df1ef5ec97669a325713845a30c1da20892c23069'
 
   # github.com/smathot/OpenSesame was verified as official when first introduced to the cask
-  url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
+  url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-2.dmg"
   appcast 'https://github.com/smathot/OpenSesame/releases.atom'
   name 'OpenSesame'
   homepage 'https://osdoc.cogsci.nl/'


### PR DESCRIPTION
The path to the download for OpenSesame 3.2.6 was broken. This has been resolved with this commit.
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
