### PR TITLE
Update exifrenamer to 2.3.2

### DIFF
--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -1,6 +1,6 @@
 cask 'exifrenamer' do
-  version '2.3.1'
-  sha256 'c3bec0c2743f7aede074802824ee04f1851d727bdf495bf19c08a25d3cfd8e66'
+  version '2.3.2'
+  sha256 '4dc20743a923394226daacdf86f11c273793f5b9dfb9b22289175c155b5782d8'
 
   url 'https://www.qdev.de/downloads/files/ExifRenamer.dmg'
   appcast 'https://www.qdev.de/versions/ExifRenamer.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.