### PR TITLE
Update grandperspective to 2.1.2

### DIFF
--- a/Casks/grandperspective.rb
+++ b/Casks/grandperspective.rb
@@ -1,6 +1,6 @@
 cask 'grandperspective' do
-  version '2.1.1'
-  sha256 'ba8153c26fc4d5c1eb60710fd5d13555ed2f3c470a01f4849c2267d39b0ee2e9'
+  version '2.1.2'
+  sha256 'f3a247a3123a904f200e99708ca7ecbc32995a0715b51cb661bdec67bf88a094'
 
   # downloads.sourceforge.net/grandperspectiv was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/grandperspectiv/grandperspective/#{version}/GrandPerspective-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.