### PR TITLE
Update fastonosql to 1.25.0

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,8 +1,8 @@
 cask 'fastonosql' do
-  version '1.24.1'
-  sha256 'f8235b768525c352ce813799e75ba664faab653160a526bdef688e98fd77ef37'
+  version '1.25.0'
+  sha256 'e61e25c9bdd0b25c4824db327677fa403d8cf1df3be7518014d3b91efa1d4253'
 
-  url "https://www.fastonosql.com/downloads/macosx/fastonosql-#{version}-x86_64.dmg"
+  url "https://fastonosql.com/downloads_pro/macosx/fastonosql_pro-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'
   name 'FastoNoSQL'
   homepage 'https://www.fastonosql.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.