### PR TITLE
Update listen1 to 2.0.0

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '1.8.0'
-  sha256 '85f2044ecca3999331e8b96e1b317574dbd13c83c33aab6a9f48e2ec22d6a985'
+  version '2.0.0'
+  sha256 '318adc4fc6da60fc88af73337dc8fb2825297b4926585ec77ac12521bf9f728b'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.