### PR TITLE
Update darktable to 2.6.0

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask 'darktable' do
-  version '2.4.4'
-  sha256 '9324562c98a52346fa77314103a5874eb89bd576cdbc21fc19cb5d8dfaba307a'
+  version '2.6.0'
+  sha256 '47d6f1d9ae64394663ffd804692d6b6d6722b312712e938f103cb43f58625c42'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.