### PR TITLE
Update musescore to 3.0.0

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,13 +1,13 @@
 cask 'musescore' do
-  version '2.3.2'
-  sha256 '67eb15707c2aff816dce25f1b91c7381184fa3a4bd731c76a3c963bfb110a4fa'
+  version '3.0.0'
+  sha256 '02d327851ec4e0cfaf7ba90b89269a07c5de1383f918d52a78df6220d6c58a05'
 
   # ftp.osuosl.org/pub/musescore was verified as official when first introduced to the cask
   url "https://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version}.dmg"
   name 'MuseScore'
   homepage 'https://musescore.org/'
 
-  depends_on macos: '>= :lion'
+  depends_on macos: '>= :sierra'
 
   app "MuseScore #{version.major}.app"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.