### PR TITLE
Update netron to 2.7.7

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.7.6'
-  sha256 'c9554c694298dd8da7116496ee7f14dd614ece0851ac5d04c5f0f57d6c6044a0'
+  version '2.7.7'
+  sha256 'dc3cbe5694c1da958e7f7a12a4616400bca89ba93eb1d376df0ffb581f84eb2c'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.