### PR TITLE
Update wxwork to 2.7.0.1069

### DIFF
--- a/Casks/wxwork.rb
+++ b/Casks/wxwork.rb
@@ -1,6 +1,6 @@
 cask 'wxwork' do
-  version '2.6.1.1076'
-  sha256 'cd7bb29a55e7ae1f51bd14185ee8beaf8ce6225b9a3bf8508ec40fbb39651ccb'
+  version '2.7.0.1069'
+  sha256 'd2bca45b17aedb25388acc7cc15065ceae66f9a63b0e856bc9285e31ca8fc960'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   name 'Wechat Enterprise Version'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.