### PR TITLE
Reverting Wireshark to stable version 2.6.5

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,6 +1,6 @@
 cask 'wireshark' do
-  version '2.9.0'
-  sha256 '34bb5eb91a6bd1026a52ed59ab7ec26c24400f3c5cb012797ee501b24690000f'
+  version '2.6.5'
+  sha256 'b4e2cb6c9ddb0f700ef8eaba9f19248f92069a27622620646f46640e294c678f'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.wireshark.org/download/osx/'


### PR DESCRIPTION
The pull request for Wireshark 2.9.0 (https://github.com/Homebrew/homebrew-cask/pull/56628) is for the _development_ version of Wireshark. A separate cask for development version should be added instead. 

Reverting back to stable version 2.6.5. 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

`brew cask style --fix wireshark` reported offense: 

> current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
> /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -r ./siteconf20181225-57217-1fwr8ab.rb extconf.rb
> creating Makefile
> 
> current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
> make "DESTDIR=" clean
> 
> current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
> make "DESTDIR="
> make: *** No rule to make target `/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/include/ruby-2.3.0/universal-darwin18/ruby/config.h', needed by `adj_matrix.o'.  Stop.
> 
> make failed, exit code 2