### PR TITLE
Update transmission-remote-gui to 5.16.0

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,6 +1,6 @@
 cask 'transmission-remote-gui' do
-  version '5.15.4'
-  sha256 '8147234915703ab3a7fe4bb224891052fcf8856b0b1793efeabb0210107e27f1'
+  version '5.16.0'
+  sha256 'e90fcb970186890d5a92d99cf37a7f24952a488bd9fa779098731c424bcdbb5c'
 
   url "https://github.com/transmission-remote-gui/transgui/releases/download/v#{version}/transgui-#{version}.dmg"
   appcast 'https://github.com/transmission-remote-gui/transgui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.