### PR TITLE
Update listen1 to 2.1.1

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '2.0.0'
-  sha256 '318adc4fc6da60fc88af73337dc8fb2825297b4926585ec77ac12521bf9f728b'
+  version '2.1.1'
+  sha256 '1771953761544116a466cab6cb9250497b0d2f2d23f294e8ec78f330db668564'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.