### PR TITLE
Update mongodb-compass to 1.16.3

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.16.1'
-  sha256 'a3f62b0f516bfb21ca5f695a9962ed499d2045691d4f974befca0e0298d95bc7'
+  version '1.16.3'
+  sha256 '6854ada489b76fa9ffa197dbb9c949ca260bd5b5b083ec48e8c14300f2915a59'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.