### PR TITLE
Update r-app to 3.5.2

### DIFF
--- a/Casks/r-app.rb
+++ b/Casks/r-app.rb
@@ -1,6 +1,6 @@
 cask 'r-app' do
-  version '3.5.1'
-  sha256 '5f781220ff2f9374a4db114435fa2d22cfebc353ed8d5246a1f1e162eab75a01'
+  version '3.5.2'
+  sha256 '47a829eff7a7a9e6f28e0bc4086ad9654fbe8a65e5273205edf72c2e5bcd5805'
 
   url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   appcast 'https://www.r-project.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.