### PR TITLE
Update manuskript to 0.8.0

### DIFF
--- a/Casks/manuskript.rb
+++ b/Casks/manuskript.rb
@@ -1,6 +1,6 @@
 cask 'manuskript' do
-  version '0.7.0-3'
-  sha256 'f82046d9b41eb4604edd1cf9d3b816a3c54b54f9ac749ddafc9ddefe3714232a'
+  version '0.8.0'
+  sha256 'cd48f796945188c89e34b6e789bfcad7753a55ccd99a64fc5f0c92aaaebba0a9'
 
   # github.com/olivierkes/manuskript was verified as official when first introduced to the cask
   url "https://github.com/olivierkes/manuskript/releases/download/#{version.major_minor_patch}/manuskript-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.