### PR TITLE
Update brave-browser to 0.58.18

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.58.16'
-  sha256 '1f1ccdb51a1a4b4b759ed2f7efc8437eb7f6ee4f2615ddcce22e2627a9e2ba3a'
+  version '0.58.18'
+  sha256 '46e42abc70153d465292883de820e21967c5b16f842cc6817c9dcfc5ee307ab8'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.