### PR TITLE
Update fastonosql to 1.25.1

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.25.0'
-  sha256 'e61e25c9bdd0b25c4824db327677fa403d8cf1df3be7518014d3b91efa1d4253'
+  version '1.25.1'
+  sha256 'bbbfdfb580839c43d9cb646714726fce1e8ca2d91f15dfc02479c5b573541dc9'
 
   url "https://fastonosql.com/downloads_pro/macosx/fastonosql_pro-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.