### PR TITLE
Update terminus to 1.0.67

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.66'
-  sha256 '9ff70e4cb0d6b65da452d306088a1b465065e91150eaf94003f07d1a9a3c92b9'
+  version '1.0.67'
+  sha256 'd600215d7c6d990479b6269b02a7f9d282185f9b9e07048e8d9febacbdcf853e'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.