### PR TITLE
Update bathyscaphe to 310-v1085

### DIFF
--- a/Casks/bathyscaphe.rb
+++ b/Casks/bathyscaphe.rb
@@ -1,6 +1,6 @@
 cask 'bathyscaphe' do
-  version '310-v1084'
-  sha256 '076418e017e78cb01037fa43eb2f68e1514a14538b82b9de5d70d2e1ad5b0d9a'
+  version '310-v1085'
+  sha256 'b1cb3a273477a6d4003640fbbfa9e93c563b0d88f3adb8a5d26cdffe284173b6'
 
   # bitbucket.org/bathyscaphe/public/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/bathyscaphe/public/downloads/BathyScaphe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.