### PR TITLE
Update softorino-youtube-converter to 2.1.1,1545414679

### DIFF
--- a/Casks/softorino-youtube-converter.rb
+++ b/Casks/softorino-youtube-converter.rb
@@ -1,6 +1,6 @@
 cask 'softorino-youtube-converter' do
-  version '2.0.23,1538666747'
-  sha256 '069ae9b5170763821ca633bf69b597e70d36bbfe468c211799a74912a017acae'
+  version '2.1.1,1545414679'
+  sha256 '79b63ee355a1b70d27d3a218c8169f8a67ae38705f5f5ee515bc4e8d4b0f97e3'
 
   # devmate.com/com.softorino.syc2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.syc2/#{version.before_comma}/#{version.after_comma}/SYC2-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.