### PR TITLE
Update cutter to 1.7.3

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.7.2'
-  sha256 '875e06b266427c4e5251e247307f17370bc42cca0933aabdccb9d79b7a73995b'
+  version '1.7.3'
+  sha256 'efc42b2a72f7f57ff66ee91d609a0fb1cc3b7ddeee64376344b81b919338f234'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.