### PR TITLE
Update freac 1.1-alpha-20181201a zap trash

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -9,4 +9,10 @@ cask 'freac' do
   homepage 'https://www.freac.org/'
 
   app 'freac.app'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.freac.freac.sfl*',
+               '~/Library/Preferences/org.freac.freac.plist',
+               '~/Library/Saved Application State/org.freac.freac.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.