### PR TITLE
Update manager to 18.12.17

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.12.14'
-  sha256 '0389c841a773250fc528e0d9e2cd06a06a570e0a33afef9f76783ace8ddb5a6c'
+  version '18.12.17'
+  sha256 '04f432048add34aa58f783ddd41c2b8d2b732a0c7cb2d336708401e4f6eab56b'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.