### PR TITLE
Update capto to 1.2.10,1541678419

### DIFF
--- a/Casks/capto.rb
+++ b/Casks/capto.rb
@@ -1,6 +1,6 @@
 cask 'capto' do
-  version '1.2.9,1519212504'
-  sha256 '18594a1f435560cafd40d3b1db3416f0f504becd83cad4db97f716885af2ea27'
+  version '1.2.10,1541678419'
+  sha256 '41a5c554791dd4432e9ede6923e2c40e7d0e2839fc2f970e69648a9c21a1f604'
 
   # dl.devmate.com/com.globaldelight.Capto was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Capto/#{version.before_comma}/#{version.after_comma}/Capto-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.