### PR TITLE
Update acronis-true-image to 2019

### DIFF
--- a/Casks/acronis-true-image.rb
+++ b/Casks/acronis-true-image.rb
@@ -3,7 +3,7 @@ cask 'acronis-true-image' do
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dl.acronis.com/u/AcronisTrueImage#{version}.dmg"
-  appcast 'https://dl.acronis.com/u/liveupdate/%7B2CE2087A-349A-4F8A-9919-6AF8B53D8F99%7D/appcast.xml'
+  appcast 'https://www.acronis.com/en-us/support/updates/index.html'
   name 'Acronis True Image'
   homepage 'https://www.acronis.com/personal/computer-backup/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.