### PR TITLE
Update frhelper to 3.8.7,2018-11-28

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,9 +1,10 @@
 cask 'frhelper' do
-  version '2018-11-24'
+  version '3.8.7,2018-11-28'
   sha256 '95c5e5d2ffcb91faf6f7a7259367afacca0bb0e9672a35b408bb6fc52e0ebc8d'
 
   # static.frdic.com was verified as official when first introduced to the cask
-  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version}"
+  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_comma}"
+  appcast 'http://www.francochinois.com/update/frhelper_mac.xml'
   name 'Frhelper'
   name '法语助手'
   homepage 'https://www.eudic.net/v4/fr/app/frhelper'

--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -4,7 +4,7 @@ cask 'frhelper' do
 
   # static.frdic.com was verified as official when first introduced to the cask
   url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_comma}"
-  appcast 'http://www.francochinois.com/update/frhelper_mac.xml'
+  appcast 'https://www.francochinois.com/update/frhelper_mac.xml'
   name 'Frhelper'
   name '法语助手'
   homepage 'https://www.eudic.net/v4/fr/app/frhelper'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.