### PR TITLE
Update qownnotes to 18.12.9,b4023-122014

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '18.12.6,b4005-123725'
-  sha256 '3914d4fdd6ed2e847837e00abc67e10264adf8c846b8c68072d596e8148dcb75'
+  version '18.12.9,b4023-122014'
+  sha256 '8a37de82c0cc7d48b9f43aa71210a95037c442000fc855c20190fa734147bec4'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.