### PR TITLE
Update wire to 3.5.2910

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -8,7 +8,7 @@ cask 'wire' do
   name 'Wire'
   homepage 'https://wire.com/'
 
-  pkg "Wire.pkg"
+  pkg 'Wire.pkg'
 
   uninstall pkgutil: 'com.wearezeta.zclient.mac',
             signal:  [

--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,9 +1,9 @@
 cask 'wire' do
-  version '3.3.2862'
-  sha256 '3fc9fc33990bd5be55364a1328c71c9f817ad9cb59814171fa9475523796a672'
+  version '3.5.2910'
+  sha256 '0106500ac52e5f4fc85299d91dae399e2e8dd366b4637207f4673136e009a20b'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
-  url "https://github.com/wireapp/wire-desktop/releases/download/release%2F#{version}/wire-#{version}.pkg"
+  url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"
   appcast 'https://github.com/wireapp/wire-desktop/releases.atom'
   name 'Wire'
   homepage 'https://wire.com/'

--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -8,7 +8,7 @@ cask 'wire' do
   name 'Wire'
   homepage 'https://wire.com/'
 
-  pkg "wire-#{version}.pkg"
+  pkg "Wire.pkg"
 
   uninstall pkgutil: 'com.wearezeta.zclient.mac',
             signal:  [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.