### PR TITLE
Update fbreader to 0.9.0

### DIFF
--- a/Casks/fbreader.rb
+++ b/Casks/fbreader.rb
@@ -1,8 +1,8 @@
 cask 'fbreader' do
-  version '0.99.5-alpha'
-  sha256 'c05e23d66942b49533e0eabc9d39e2062c9a11086369c31b417a1937ac5886f9'
+  version '0.9.0'
+  sha256 '1bec249e1a20efb274a365cacd3b8c41ee96a5d92075d991a864823622272572'
 
-  url "https://fbreader.org/files/macos/FBReader%20#{version.gsub('-', '%20')}.dmg"
+  url 'https://fbreader.org/files/macos/FBReaderMacOS.dmg'
   name 'FBReader'
   homepage 'https://fbreader.org/content/macos'
 

--- a/Casks/fbreader.rb
+++ b/Casks/fbreader.rb
@@ -3,8 +3,9 @@ cask 'fbreader' do
   sha256 '1bec249e1a20efb274a365cacd3b8c41ee96a5d92075d991a864823622272572'
 
   url 'https://fbreader.org/files/macos/FBReaderMacOS.dmg'
+  appcast 'https://fbreader.org/macos/'
   name 'FBReader'
-  homepage 'https://fbreader.org/content/macos'
+  homepage 'https://fbreader.org/macos/'
 
   app 'FBReader.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.