### PR TITLE
Update trailrunner to 3.8.3221,201

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -6,7 +6,7 @@ cask 'trailrunner' do
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610'
   name 'TrailRunner'
-  homepage 'https://www.trailrunnerx.com'
+  homepage 'https://www.trailrunnerx.com/'
 
   app 'TrailRunner.app'
 end

--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,6 +1,6 @@
 cask 'trailrunner' do
-  version '3.8.3216,200'
-  sha256 '000f947ce72c8289bdaa5ac7ece965118fd3dd5c3457f24063fa3de6841013c4'
+  version '3.8.3221,201'
+  sha256 '6c699cbce77a26eef24e4ca59cc77978e58c766ca20537270bae9f7f7dd26c0e'
 
   # rink.hockeyapp.net was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"

--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -6,7 +6,7 @@ cask 'trailrunner' do
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610'
   name 'TrailRunner'
-  homepage 'http://www.trailrunnerx.com/'
+  homepage 'https://www.trailrunnerx.com'
 
   app 'TrailRunner.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.