### PR TITLE
Update focuswriter to 1.7.1

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,6 +1,6 @@
 cask 'focuswriter' do
-  version '1.6.14'
-  sha256 '6593d2b28ff6e221009f43026a7da208045d2bee1176369847f018e6755f4582'
+  version '1.7.1'
+  sha256 '2f1763e2bc7ef3363c8006eb3081cb34358be98ae0567bbe007ea8e94579cd61'
 
   url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   name 'FocusWriter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.