### PR TITLE
Update lilypond to 2.18.2-1

### DIFF
--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -1,6 +1,6 @@
 cask 'lilypond' do
-  version '2.19.82-1'
-  sha256 '558ffac7ba7543b39f2f87ed4a4141a29951d44772893c9af89a89ed33f16176'
+  version '2.18.2-1'
+  sha256 '0009bf234db6a598e30940ae9a5cef50ffe939992c9bf0c7959ecd9c0d179c80'
 
   url "http://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   appcast 'http://lilypond.org/macos-x.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.