### PR TITLE
Update preform to 2.19.1,745

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '2.18.0,653'
-  sha256 '220df6332d51307fc66a95cefe7a30017358ca19feddac37216035e3db03d1e9'
+  version '2.19.1,745'
+  sha256 '449b8727e206393d6b3845ec9cb2977f642de4626a29f8ec3a44e95a2d5872fa'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.