### PR TITLE
Update universal-media-server to 7.7.1

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,6 +1,6 @@
 cask 'universal-media-server' do
-  version '7.7.0'
-  sha256 '52cb5264863304c890142ef9bfaff5ed5188694921fb33778fec03c09aa172dd'
+  version '7.7.1'
+  sha256 '28c7e112f3d86fac1677cef62438550d8caaa1f725b3a6657b742b2d206167a7'
 
   # sourceforge.net/unimediaserver was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/unimediaserver/Official%20Releases/OS%20X/UMS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.