### PR TITLE
Update armory to 0.96.5

### DIFF
--- a/Casks/armory.rb
+++ b/Casks/armory.rb
@@ -1,6 +1,6 @@
 cask 'armory' do
-  version '0.96.4'
-  sha256 'dd7f778d4bcbe819336286312e826e822c9ca3c405e1b2cf6f2a7e0c75526d96'
+  version '0.96.5'
+  sha256 '53d0286e54bad62309f3a79a33118f2d1f369be36f9a08b07e61d04aa39f6516'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/goatpig/BitcoinArmory/releases/download/v#{version}/armory_#{version}_osx.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.