### PR TITLE
Update fastonosql to 1.26.0

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '1.25.1'
-  sha256 'bbbfdfb580839c43d9cb646714726fce1e8ca2d91f15dfc02479c5b573541dc9'
+  version '1.26.0'
+  sha256 '771893c53c1a523daf9cc70f378075b49b854a5ced1cbc7d926a1cf9247dda17'
 
   url "https://fastonosql.com/downloads_pro/macosx/fastonosql_pro-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.