### PR TITLE
Update packetsender to 6.0.19

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,9 +1,9 @@
 cask 'packetsender' do
-  version '5.8.6'
-  sha256 '3dc8514d9bf0dd4957fab5f852b76d9b56703090d7a724c7f765db67c1c458fb'
+  version '6.0.19'
+  sha256 'def6cc2a43c22506f0dbe53690e198bbb47abad862b5b0954b5a6822381cbc56'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
-  url "https://github.com/dannagle/PacketSender/releases/download/v5.8.5/PacketSender_v#{version}.dmg"
+  url "https://github.com/dannagle/PacketSender/releases/download/v#{version}/PacketSender_v#{version}.dmg"
   appcast 'https://github.com/dannagle/PacketSender/releases.atom'
   name 'Packet Sender'
   homepage 'https://packetsender.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.