### PR TITLE
Update wordcounter to 1.4.1

### DIFF
--- a/Casks/wordcounter.rb
+++ b/Casks/wordcounter.rb
@@ -9,6 +9,6 @@ cask 'wordcounter' do
   homepage 'https://wordcounterapp.com/'
   
   depends_on macos: '>= :sierra'
-
+  
   app 'WordCounter.app'
 end

--- a/Casks/wordcounter.rb
+++ b/Casks/wordcounter.rb
@@ -7,6 +7,8 @@ cask 'wordcounter' do
   appcast "https://update.christiantietze.de/wordcounter/v#{version.major}/beta.xml"
   name 'WordCounter'
   homepage 'https://wordcounterapp.com/'
+  
+  depends_on macos: '>= :sierra'
 
   app 'WordCounter.app'
 end

--- a/Casks/wordcounter.rb
+++ b/Casks/wordcounter.rb
@@ -7,8 +7,8 @@ cask 'wordcounter' do
   appcast "https://update.christiantietze.de/wordcounter/v#{version.major}/beta.xml"
   name 'WordCounter'
   homepage 'https://wordcounterapp.com/'
-  
+
   depends_on macos: '>= :sierra'
-  
+
   app 'WordCounter.app'
 end

--- a/Casks/wordcounter.rb
+++ b/Casks/wordcounter.rb
@@ -1,9 +1,9 @@
 cask 'wordcounter' do
-  version '1.3.5'
-  sha256 '01ef9d7e8edf73d1279e124d6a62bdda4b86c166ccc279de8bac060c386ad3f5'
+  version '1.4.1'
+  sha256 'f4b6a7b0134af96bbbaa7a7a4f0c21d9736b3a3b75f664984d55b2d576d3428b'
 
-  # amazonaws.com/wordcounterapp was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/wordcounterapp/WordCounter-v#{version}.zip"
+  # update.christiantietze.de/wordcounter was verified as official when first introduced to the cask
+  url "https://update.christiantietze.de/wordcounter/v#{version.major}/WordCounter-v#{version}.zip"
   appcast "https://update.christiantietze.de/wordcounter/v#{version.major}/beta.xml"
   name 'WordCounter'
   homepage 'https://wordcounterapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.