### PR TITLE
Update cask for Next browser 1.2.0

### DIFF
--- a/Casks/next.rb
+++ b/Casks/next.rb
@@ -1,11 +1,11 @@
 cask 'next' do
-  version '0.08'
-  sha256 '5d2feef32815f79e776bb7db543bc2e8e7bfd7e5ecdefa4e92c1c0d846b1db8a'
+  version '1.2.0 '
+  sha256 '286e9af278797db6c41bbc9efd5c97e6d249734b4bca5df687ebaa481b35dc7b'
 
-  url "https://github.com/next-browser/next/releases/download/#{version}/Next.dmg"
-  appcast 'https://github.com/next-browser/next/releases.atom'
+  url 'https://next.atlas.engineer/static/release/next-macos-webkit.dmg'
+  appcast 'https://github.com/atlas-engineer/next/releases.atom'
   name 'Next Browser'
-  homepage 'https://github.com/next-browser/next'
+  homepage 'https://next.atlas.engineer/'
 
   app 'Next.app'
 


### PR DESCRIPTION
Next browser appears to have moved from https://github.com/nEXT-browser/ to
https://github.com/atlas-engineer/next

As a result the recipe is currently broken as is. This updates it to at least be
functional.

I determined the version number from
https://github.com/atlas-engineer/next/blob/master/documents/CHANGELOG.org but
it does not appear that they offer a version stamped release dmg file.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Regarding a stable version, I believe this is a stable release because of how the download is provided from their release url but am unsure how to verify.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
