### PR TITLE
Update Miniconda3 to 4.5.11 from tag 'latest' and fix caveats

### DIFF
--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -24,11 +24,5 @@ cask 'miniconda' do
 
   caveats do
     files_in_usr_local
-
-    <<~EOS
-      To enable the 'conda' command for the current user, run
-
-        $ echo ". #{HOMEBREW_PREFIX}/miniconda3/etc/profile.d/conda.sh" >> ~/.bash_profile
-    EOS
   end
 end

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -1,17 +1,17 @@
 cask 'miniconda' do
-  version :latest
-  sha256 :no_check
+  version '4.5.11'
+  sha256 'eb87312ae5b8cd33d6c9fe66a454dc46fbb4d5fd133683a4a483546b9c05ea6e'
 
-  # repo.continuum.io/miniconda was verified as official when first introduced to the cask
-  url 'https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh'
+  # repo.anaconda.com/miniconda was verified as official when first introduced to the cask
+  url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.sh"
   name 'Continuum Analytics Miniconda'
-  homepage 'https://www.anaconda.com/what-is-anaconda/'
+  homepage 'https://conda.io/miniconda.html'
 
   depends_on macos: '>= :lion'
   container type: :naked
 
   installer script: {
-                      executable: 'Miniconda3-latest-MacOSX-x86_64.sh',
+                      executable: "Miniconda3-#{version}-MacOSX-x86_64.sh",
                       args:       ['-b', '-p', "#{HOMEBREW_PREFIX}/miniconda3"],
                       sudo:       true,
                     }
@@ -23,7 +23,32 @@ cask 'miniconda' do
   uninstall delete: "#{HOMEBREW_PREFIX}/miniconda3"
 
   caveats do
-    path_environment_variable "#{HOMEBREW_PREFIX}/miniconda3/bin"
     files_in_usr_local
+
+    <<~EOS
+      If your shell is Bash or a Bourne variant, enable conda for the current user with
+
+        $ echo ". #{HOMEBREW_PREFIX}/miniconda3/etc/profile.d/conda.sh" >> ~/.bash_profile
+
+      or, for all users, enable conda with
+
+        $ sudo ln -s #{HOMEBREW_PREFIX}/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
+      The options above will permanently enable the 'conda' command, but they do NOT
+      put conda's base (root) environment on PATH.  To do so, run
+
+        $ conda activate
+
+      in your terminal, or to put the base environment on PATH permanently, run
+
+        $ echo "conda activate" >> ~/.bash_profile
+
+      Previous to conda 4.4, the recommended way to activate conda was to modify PATH in
+      your ~/.bash_profile file.  You should manually remove the line that looks like
+
+        export PATH="#{HOMEBREW_PREFIX}/miniconda3/bin:$PATH"
+
+      ^^^ The above line should NO LONGER be in your ~/.bash_profile file! ^^^
+    EOS
   end
 end

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -26,29 +26,9 @@ cask 'miniconda' do
     files_in_usr_local
 
     <<~EOS
-      If your shell is Bash or a Bourne variant, enable conda for the current user with
+      To enable the 'conda' command for the current user, run
 
         $ echo ". #{HOMEBREW_PREFIX}/miniconda3/etc/profile.d/conda.sh" >> ~/.bash_profile
-
-      or, for all users, enable conda with
-
-        $ sudo ln -s #{HOMEBREW_PREFIX}/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh
-
-      The options above will permanently enable the 'conda' command, but they do NOT
-      put conda's base (root) environment on PATH.  To do so, run
-
-        $ conda activate
-
-      in your terminal, or to put the base environment on PATH permanently, run
-
-        $ echo "conda activate" >> ~/.bash_profile
-
-      Previous to conda 4.4, the recommended way to activate conda was to modify PATH in
-      your ~/.bash_profile file.  You should manually remove the line that looks like
-
-        export PATH="#{HOMEBREW_PREFIX}/miniconda3/bin:$PATH"
-
-      ^^^ The above line should NO LONGER be in your ~/.bash_profile file! ^^^
     EOS
   end
 end


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

- The latest Miniconda version is 4.5.11, and Homepage is moved to [here](https://conda.io/miniconda.html), download url's domain is moved from continuum.io to anaconda.com on Homepage.
- Since conda 4.4 (the latest version is 4.5.11), it is not recommanded to modify PATH, so the caveats are fixed accordingly.