### PR TITLE
Update bettertouchtool to 2.686

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -18,8 +18,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.685'
-    sha256 '827315d0f9b8d621b1ff1f122a09b39439fc7b4ed0be5b4f6817962839cd8f93'
+    version '2.686'
+    sha256 '5cfd733e5d100ebeee65228135aae6a3f2731cdcba35bc5a69d17985330aa97f'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.