### PR TITLE
Update glyphs to 2.6.1,1195

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.1,1193'
-  sha256 '6e97eea3b5d5025060c420aaa251289f564702cbbd5bbc2cebd06e34fe9c998b'
+  version '2.6.1,1195'
+  sha256 'fa3f2e377d9cf215933168e2081068f5b6324408c529da5aadb82db8eebfd243'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.