### PR TITLE
Update copyq to 3.7.2

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -1,6 +1,6 @@
 cask 'copyq' do
-  version '3.7.1'
-  sha256 '44d22c91a57024a3566e1fcf74576cd50f0986d491c8f923bb7824f08ccfdad7'
+  version '3.7.2'
+  sha256 '7285b597062c9f93e854c1a6c32299cdcb64146c36fda3068747efca7eda2a5f'
 
   # github.com/hluk/CopyQ was verified as official when first introduced to the cask
   url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.