### PR TITLE
Update fsnotes to 2.5.5

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.5.3'
-  sha256 '49593440162dd6e29e255711369ead96e44bea887d0a65bf906502f88306ee42'
+  version '2.5.5'
+  sha256 '48d794a31de66e8d9f8e820071d9d4365b4a609402b60603aecc47f4e78b844c'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.