### PR TITLE
Update gnucash to 3.4-1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask 'gnucash' do
-  version '3.3-1'
-  sha256 'c1d97818e9f34e5113d030b4d9a850a297cb2d2ffb871e7cb9b80d5cf3ff2336'
+  version '3.4-1'
+  sha256 '359d3ecbfc2143fe11901bd0319a60c5b802a8c13206c4da0041e510b7d39d59'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}/Gnucash-Intel-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.