### PR TITLE
Update listen1 to 2.1.2

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '2.1.1'
-  sha256 '1771953761544116a466cab6cb9250497b0d2f2d23f294e8ec78f330db668564'
+  version '2.1.2'
+  sha256 '1f793b424df56651b731328439d9df4caafb95d7aa4aee984b023ed2cef69c2b'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.