### PR TITLE
Update navicat-for-mysql to 12.1.13

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.12'
-  sha256 '1792825d8b5c43e255276f2940d2a302f1b2096be13364de0f9d0b8886fd1a20'
+  version '12.1.13'
+  sha256 '2dbde626225934cf8591e50b27430e5aa651444ad206b735191595ca4f79f8c0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.