### PR TITLE
Add gpg-suite-no-mail 2018.5

### DIFF
--- a/Casks/gpg-suite-no-mail.rb
+++ b/Casks/gpg-suite-no-mail.rb
@@ -1,0 +1,151 @@
+cask 'gpg-suite-no-mail' do
+  version '2018.5'
+  sha256 'c66ecf48ccf709f704f02097cf9d68ba97b0efba24f7a0b7b46adfd1133cb86a'
+
+  url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
+  appcast 'https://gpgtools.org/releases/gka/appcast.xml'
+  name 'GPG Suite (without GPG Mail)'
+  homepage 'https://gpgtools.org/'
+
+  auto_updates true
+  conflicts_with cask: [
+                         'gpg-suite',
+                         'gpg-suite-nightly',
+                         'gpg-suite-pinentry',
+                       ]
+  depends_on macos: '>= :sierra'
+
+  pkg 'Install.pkg',
+      choices: [
+                 {
+                   'choiceIdentifier' => 'installer_choice_1', # preinstall.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_2', # Libmacgpg_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_3', # LibmacgpgXPC_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_4', # GPGMail_14_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_5', # GPGMail_13_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_6', # GPGMail_12_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_7', # GPGMailLoader_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_8', # GPGServices_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_9', # GPGKeychain_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_10', # GPGPreferences_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_11', # MacGPG2.1_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_12', # Updater_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_13', # pinentry_Core.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_14', # version.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_15', # key.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'installer_choice_16', # CheckPrivateKey.pkg
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+               ]
+
+  uninstall_postflight do
+    ['gpg', 'gpg2', 'gpg-agent'].map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
+      File.rm(exec) if File.exist?(exec) && File.readlink(exec).include?('MacGPG2')
+    end
+  end
+
+  uninstall script:    {
+                         executable: "#{staged_path}/Uninstall.app/Contents/Resources/GPG Suite Uninstaller.app/Contents/Resources/uninstall.sh",
+                         sudo:       true,
+                       },
+            pkgutil:   'org.gpgtools.*',
+            quit:      [
+                         'org.gpgtools.gpgkeychainaccess',
+                         'org.gpgtools.gpgkeychain',
+                         'org.gpgtools.gpgservices',
+                         # TODO: add "killall -kill gpg-agent"
+                       ],
+            launchctl: [
+                         'org.gpgtools.Libmacgpg.xpc',
+                         'org.gpgtools.macgpg2.fix',
+                         'org.gpgtools.macgpg2.shutdown-gpg-agent',
+                         'org.gpgtools.macgpg2.updater',
+                         'org.gpgtools.macgpg2.gpg-agent',
+                         'org.gpgtools.updater',
+                       ],
+            delete:    [
+                         '/Library/Services/GPGServices.service',
+                         '/usr/local/MacGPG2',
+                         '/private/etc/paths.d/MacGPG2',
+                         '/private/etc/manpaths.d/MacGPG2',
+                         '/private/tmp/gpg-agent',
+                         '/Library/PreferencePanes/GPGPreferences.prefPane',
+                         '/Library/Application Support/GPGTools',
+                         '/Library/Frameworks/Libmacgpg.framework',
+                       ]
+
+  zap trash: [
+               '~/Library/Services/GPGServices.service',
+               '~/Library/PreferencePanes/GPGPreferences.prefPane',
+               '~/Library/LaunchAgents/org.gpgtools.*',
+               '~/Library/Frameworks/Libmacgpg.framework',
+               '~/Library/Caches/org.gpgtools.gpg*',
+               '~/Library/Application Support/GPGTools',
+               '~/Library/Preferences/org.gpgtools.*',
+             ]
+
+  caveats do
+    files_in_usr_local
+  end
+end


### PR DESCRIPTION
Add a free variant of gpg-suite 2018.5 cask without GPG Mail.

Main reason is recent move to paid model for GPG Mail. With this cask user can install free version of GPG Suite. This is also useful for developers, who only need core gpg functionality.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256