### PR TITLE
Update iina: homepage, depends_on and zap

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -2,24 +2,27 @@ cask 'iina' do
   version '1.0.0'
   sha256 '1af6892fa41b95dd5c0d42be0cfb2dccd52522f716da0b8951a8e87f8e8d4f91'
 
-  # dl-portal.iina.io was verified as official when first introduced to the cask
   url "https://dl-portal.iina.io/IINA.v#{version}.dmg"
   appcast 'https://www.iina.io/appcast.xml'
   name 'IINA'
-  homepage 'https://lhc70000.github.io/iina/'
+  homepage 'https://iina.io/'
 
   auto_updates true
   conflicts_with cask: 'iina-beta'
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :el_capitan'
 
   app 'IINA.app'
   binary "#{appdir}/IINA.app/Contents/MacOS/iina-cli", target: 'iina'
 
   zap trash: [
+               '~/Library/Application Scripts/com.colliderli.iina.OpenInIINA',
                '~/Library/Application Support/com.colliderli.iina',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.colliderli.iina.sfl*',
+               '~/Library/Application Support/CrashReporter/IINA*.plist',
                '~/Library/Caches/com.colliderli.iina',
+               '~/Library/Containers/com.colliderli.iina.OpenInIINA',
                '~/Library/Cookies/com.colliderli.iina.binarycookies',
+               '~/Library/Logs/com.colliderli.iina',
                '~/Library/Logs/DiagnosticReports/IINA*.crash',
                '~/Library/Preferences/com.colliderli.iina.plist',
                '~/Library/Safari/Extensions/Open in IINA*.safariextz',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/pull/56835