### PR TITLE
Update sonic-visualiser to 3.2,2422

### DIFF
--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -1,6 +1,6 @@
 cask 'sonic-visualiser' do
-  version '3.1.1,2395'
-  sha256 '2b7f09075f00082c28d694f9e1bff9ed04a22bc04b5f0e20e46a7a5f185f149f'
+  version '3.2,2422'
+  sha256 'a168e142dfbff5ee78e3c8246dac4751243f407f0131b426a62bbc61903c4442'
 
   # code.soundsoftware.ac.uk was verified as official when first introduced to the cask
   url "https://code.soundsoftware.ac.uk/attachments/download/#{version.after_comma}/Sonic%20Visualiser-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.