### PR TITLE
Update citrix-workspace to 18.12,15579:1546471587_64a0cbb2d63b64b4bba1394d1d21caec

### DIFF
--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,5 +1,5 @@
 cask 'citrix-workspace' do
-  version '18.12,15579:1545940629_adfa92c83b8b302175ff456856be0e30'
+  version '18.12,15579:1546471587_64a0cbb2d63b64b4bba1394d1d21caec'
   sha256 'b5d6e406402ae4f72ba431e60c3c0a390a6cf483be34fbea44c710a8a0c8e1bc'
 
   url "https://downloads.citrix.com/#{version.after_comma.before_colon}/CitrixWorkspaceApp.dmg?__gda__=#{version.after_colon}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.