### PR TITLE
Add Cask for BloomRPC 1.2.0

### DIFF
--- a/Casks/bloomrpc.rb
+++ b/Casks/bloomrpc.rb
@@ -1,0 +1,11 @@
+cask 'bloomrpc' do
+  version '1.2.0'
+  sha256 'a43e32f5a06545711e82e72ba15ab1198fac219c672362712ced06f3ea99a5ab'
+
+  url "https://github.com/uw-labs/bloomrpc/releases/download/v#{version}/BloomRPC-#{version}.dmg"
+  appcast 'https://github.com/uw-labs/bloomrpc/releases.atom'
+  name 'BloomRPC'
+  homepage 'https://github.com/uw-labs/bloomrpc'
+
+  app 'BloomRPC.app'
+end


### PR DESCRIPTION
Created a new Cask for BloomRPC, a gRPC desktop client. Cask points
to the latest version, which is 1.2.0.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
