### PR TITLE
Add ResidualVM v3.0.1

### DIFF
--- a/Casks/residualvm.rb
+++ b/Casks/residualvm.rb
@@ -1,0 +1,18 @@
+cask 'residualvm' do
+  version '0.3.1'
+  sha256 '35843fb78390e008318ae416e4875deb3b01257b7efb4ff5882b037a83c49cff'
+
+  url "http://www.residualvm.org/downloads/release/#{version}/residualvm-#{version}-macosx-intel32.dmg"
+  name 'ResidualVM'
+  homepage 'http://www.residualvm.org/'
+
+  depends_on macos: '>= :lion'
+
+  app 'ResidualVM.app'
+
+  zap trash: [
+               '~/Library/Logs/residualvm.log',
+               '~/Library/Preferences/org.residualvm.residualvm.plist',
+               '~/Library/Preferences/ResidualVM Preferences',
+             ]
+end


### PR DESCRIPTION
This is a one-year-later follow-up on https://github.com/Homebrew/homebrew-cask/pull/42536.  
64-bit version has been removed from upstream but 32-bit is correctly installed without libraries conflicts.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
