### PR TITLE
Update coteditor to 3.6.10

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -9,8 +9,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.6.9'
-    sha256 'd58664787804bc22644de2b2bfbe94f17198337377e9496d6f86d453dc131f32'
+    version '3.6.10'
+    sha256 'ca33bbb6ad51ba5a67a173b6a591113b26e5fe5b3e7043e3500b047dad32b9f2'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.