### PR TITLE
Update jamf-migrator to 3.2.0

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '3.1.2'
-  sha256 'b4e79a941a631a1ee5a1bd99d30c438ad369b4a16e11d0d439e7200d95e816bb'
+  version '3.2.0'
+  sha256 '79c976152dad678969e678d56e83b7a397a7f7910425db7e25fbccb7bfdc0569'
 
   url 'https://github.com/jamfprofessionalservices/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamfprofessionalservices/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.