### PR TITLE
Update manager to 18.12.23

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '18.12.22'
-  sha256 '7102593a7e73a33391853a1ec8dbf56fd962ff11659e15680d91a496d8edf1ee'
+  version '18.12.23'
+  sha256 '6198400f7e6bdb2ef611d8c21aabb830aba70d78cb7ee66da99e3e8bedbbf561'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.