### PR TITLE
Updating Traverse to 0.10.1

### DIFF
--- a/Casks/traverse.rb
+++ b/Casks/traverse.rb
@@ -1,10 +1,10 @@
 cask 'traverse' do
-  version '0.9.1'
-  sha256 '2c5570ad3879d2784fa776edf8f2e2bf3a7bd0e2514478dbf8b67b488b2e8e4a'
+  version '0.10.1'
+  sha256 '1758e8f13ea8036e818678f2163aeb45bd995ac52b2276879d6a2ae3c70c6b22'
 
-  # traverseapp.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
-  url "https://traverseapp.nyc3.digitaloceanspaces.com/builds/Traverse-#{version}-mac.zip"
-  appcast 'https://traverse.site/release-notes'
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/jasonraimondi/traverse/releases/download/v#{version}/Traverse-#{version}-mac.zip"
+  appcast 'https://github.com/jasonraimondi/traverse/releases'
   name 'Traverse'
   homepage 'https://traverse.site/'
 

--- a/Casks/traverse.rb
+++ b/Casks/traverse.rb
@@ -4,7 +4,7 @@ cask 'traverse' do
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/jasonraimondi/traverse/releases/download/v#{version}/Traverse-#{version}-mac.zip"
-  appcast 'https://github.com/jasonraimondi/traverse/releases'
+  appcast 'https://github.com/jasonraimondi/traverse/releases.atom'
   name 'Traverse'
   homepage 'https://traverse.site/'
 

--- a/Casks/traverse.rb
+++ b/Casks/traverse.rb
@@ -2,7 +2,7 @@ cask 'traverse' do
   version '0.10.1'
   sha256 '1758e8f13ea8036e818678f2163aeb45bd995ac52b2276879d6a2ae3c70c6b22'
 
-  # github.com was verified as official when first introduced to the cask
+  # github.com/jasonraimondi/traverse was verified as official when first introduced to the cask
   url "https://github.com/jasonraimondi/traverse/releases/download/v#{version}/Traverse-#{version}-mac.zip"
   appcast 'https://github.com/jasonraimondi/traverse/releases.atom'
   name 'Traverse'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
```
/u/l/H/L/T/H/h/Casks ❯❯❯ brew cask audit --download traverse                                                            ✘ 1
==> Downloading github.com/jasonraimondi/traverse/releases/download/v0.10.0/Traverse-0.10.0-mac.zip
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/147122812/f0aef200-0f78-11e9-898a-9325cb
######################################################################## 100.0%
^[[A==> Verifying SHA-256 checksum for Cask 'traverse'.
audit for traverse: passed
```
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
```
/u/l/H/L/T/H/h/Casks ❯❯❯ brew cask style traverse
1 file inspected, no offenses detected
```
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
