### PR TITLE
ao new version update

### DIFF
--- a/Casks/ao.rb
+++ b/Casks/ao.rb
@@ -1,11 +1,11 @@
 cask 'ao' do
-  version '5.6.0'
-  sha256 'eebdf605afd5bc9e7f0246d9317f578b3b82be99e49a78bb0e990e9e0fb3c37e'
+  version '6.1.0'
+  sha256 :no_check
 
-  url "https://github.com/klauscfhq/ao/releases/download/v#{version}/ao-macos-#{version}.dmg"
-  appcast 'https://github.com/klauscfhq/ao/releases.atom'
+  url "https://github.com/klaussinani/ao/releases/download/v#{version}/Ao-#{version}.dmg"
+  appcast 'https://github.com/klaussinani/ao/releases.atom'
   name 'Ao'
-  homepage 'https://github.com/klauscfhq/ao'
+  homepage 'https://github.com/klaussinani/ao'
 
   app 'Ao.app'
 end


### PR DESCRIPTION
ao got upgrade to 6.1.0

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for 6.1.0
