### PR TITLE
Fly: update to 4.2.2.

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,6 +1,6 @@
 cask 'fly' do
-  version '4.2.1'
-  sha256 'b31665b68f7158a8c4a6fefa97272781e8e28852e0163f47161b3010fd0ae8c0'
+  version '4.2.2'
+  sha256 'b8dacaddea09a58b1594186d3c92fdca3899096fc720fe431b4ca8962bf8a6d9'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
   appcast 'https://github.com/concourse/concourse/releases.atom'


### PR DESCRIPTION
Update Concourse CLI to latest

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
