### PR TITLE
Update eclipse-dsl to 4.10.0,2018-12:R

### DIFF
--- a/Casks/eclipse-dsl.rb
+++ b/Casks/eclipse-dsl.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-dsl' do
-  version '4.9.0,2018-09:R'
-  sha256 '5eb75b9e69e62d6af4d84c0eadf67ecf296efd0fd13adf0209889a96ce13c0c6'
+  version '4.10.0,2018-12:R'
+  sha256 '82958ebf1672c53e939885d1d4bd2135e342cb97e7b1e17f52fba1a03eb8afdc'
 
-  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-dsl-#{version.after_comma.before_colon}-macosx-cocoa-x86_64.dmg&r=1"
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-dsl-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java and DSL Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.