### PR TITLE
Update eclipse-javascript to 4.10.0,2018-12:R

### DIFF
--- a/Casks/eclipse-javascript.rb
+++ b/Casks/eclipse-javascript.rb
@@ -1,8 +1,8 @@
 cask 'eclipse-javascript' do
-  version '4.9.0,2018-09:R'
-  sha256 '5a6644cb046d9bfdeec07f60cd7f61656a9786743d78ade6087701db234dc80c'
+  version '4.10.0,2018-12:R'
+  sha256 '7494bb89966a6a508fbeae52624cb16152851a36b2243dd5e0f43adcdaf849c9'
 
-  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-javascript-#{version.after_comma.before_colon}-macosx-cocoa-x86_64.dmg&r=1"
+  url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-javascript-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for JavaScript and Web Developers'
   homepage 'https://eclipse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.