### PR TITLE
Update wechatwork to 2.7.0.1070

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.7.0.1069'
-  sha256 'd2bca45b17aedb25388acc7cc15065ceae66f9a63b0e856bc9285e31ca8fc960'
+  version '2.7.0.1070'
+  sha256 '5ab535fc19afe9404e9f9c4fb4025378b764146273a43b327ae698eb70ac10c1'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   name 'WeChat Work'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.