### PR TITLE
Update flux to 39.987

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -1,6 +1,6 @@
 cask 'flux' do
-  version '39.9871'
-  sha256 '122a451943ce68a11d3db3b11c74566cef99ed61ab6767679d96cdd8d57a82c2'
+  version '39.987'
+  sha256 'a94f0adc267700c933dba0ed71b3dd6ef4891499e94bbb6be0903a3dbc0692b2'
 
   url "https://justgetflux.com/mac/Flux#{version}.zip"
   appcast 'https://justgetflux.com/mac/macflux.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.