### PR TITLE
Update there to 1.7.9

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,9 +1,9 @@
 cask 'there' do
-  version '1.7.1'
-  sha256 'b1c81425612a62315e1bde0ed94c9f3178bbfe23553f84f8cf95b219d523d934'
+  version '1.7.9'
+  sha256 'a6099f096df8de7ca3c76c80c48df44c44873393c7ca3847e5570b24fb7661c3'
 
-  # github.com/therepm/there-desktop was verified as official when first introduced to the cask
-  url "https://github.com/therepm/there-desktop/releases/download/v#{version}/there-desktop-#{version}-mac.zip"
+  # github.com/therehq/there-desktop was verified as official when first introduced to the cask
+  url "https://github.com/therehq/there-desktop/releases/download/v#{version}/There-#{version}-mac.zip"
   appcast 'https://github.com/therepm/there-desktop/releases.atom'
   name 'There'
   homepage 'https://there.pm/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.