### PR TITLE
Update poi to 10.1.0

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,6 +1,6 @@
 cask 'poi' do
-  version '10.0.0'
-  sha256 '517742cab4c6ac12b748e39d71acf834ac918f38136a240ccc05212e072666ce'
+  version '10.1.0'
+  sha256 '3f5432cd79458988d54a9a17a54e29d0c1489e7553dc93a53927ea3208802848'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.