### PR TITLE
Update hstracker to 1.5.4

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.5.3'
-  sha256 'ab816511bfa84de56be93f250c264cb2131197e8bd2e0259a71776eb8dbd5ac3'
+  version '1.5.4'
+  sha256 '390eec264b8f5ad429266505015e10d181542b1a329a6a9219dc53b7f313e3a8'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.