### PR TITLE
Update app-tamer to 2.4.2

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,6 +1,6 @@
 cask 'app-tamer' do
-  version '2.4.1'
-  sha256 '3a576245e86b1a42d2249c45855f70507ad0e9277b8ed47ad27612203efa2d86'
+  version '2.4.2'
+  sha256 'be81f3c8d553de827a81ffb3e94697635d1783416339142e458771d65ce00175'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.