### PR TITLE
Update remembear to 1.2.4

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.2.2'
-  sha256 '94c49a796d0f9aef6cf89a84cc9646fa5075614f9f01a8995095de74069be38c'
+  version '1.2.4'
+  sha256 'e2b04f0b402f908e42622475c2ba6590608d8244ccd4eaee53f21d515fec4554'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.