### PR TITLE
Update upwork to 5_1_0_647_g0nxmj7uab8q069t

### DIFF
--- a/Casks/intika-firefox.rb
+++ b/Casks/intika-firefox.rb
@@ -1,0 +1,34 @@
+cask 'intika-firefox' do
+  version '2.1,64.0.0'
+  sha256 '7585622fb7ee7b7fa6bc2ad98c473bf1c0862793c9391203897de1b267e7fcfb'
+
+  # github.com/intika/Librefox was verified as official when first introduced to the cask
+  url "https://github.com/intika/Librefox/releases/download/Librefox-v#{version.before_comma}-v#{version.after_comma}/Librefox-#{version.before_comma}-Firefox-Mac-#{version.after_comma}-x64.dmg"
+  appcast 'https://github.com/intika/Librefox/releases.atom'
+  name 'Librefox'
+  homepage 'https://librefox.org/'
+
+  conflicts_with cask: [
+                         'intika-firefox-esr',
+                         'firefox',
+                         'firefox-beta',
+                         'firefox-esr',
+                       ]
+
+  app 'Firefox.app'
+
+  zap trash: [
+               '/Library/Logs/DiagnosticReports/firefox_*',
+               '~/Library/Application Support/Firefox',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*',
+               '~/Library/Caches/Firefox',
+               '~/Library/Caches/Mozilla/updates/Applications/Firefox',
+               '~/Library/Preferences/org.mozilla.firefox.plist',
+             ],
+      rmdir: [
+               '~/Library/Application Support/Mozilla', #  May also contain non-Firefox data
+               '~/Library/Caches/Mozilla/updates/Applications',
+               '~/Library/Caches/Mozilla/updates',
+               '~/Library/Caches/Mozilla',
+             ]
+end

--- a/Casks/intika-firefox.rb
+++ b/Casks/intika-firefox.rb
@@ -25,7 +25,7 @@ cask 'intika-firefox' do
                '~/Library/Preferences/org.mozilla.firefox.plist',
              ],
       rmdir: [
-               '~/Library/Application Support/Mozilla', #  May also contain non-Firefox data
+               '~/Library/Application Support/Mozilla',
                '~/Library/Caches/Mozilla/updates/Applications',
                '~/Library/Caches/Mozilla/updates',
                '~/Library/Caches/Mozilla',

--- a/Casks/intika-firefox.rb
+++ b/Casks/intika-firefox.rb
@@ -2,11 +2,10 @@ cask 'intika-firefox' do
   version '2.1,64.0.0'
   sha256 '7585622fb7ee7b7fa6bc2ad98c473bf1c0862793c9391203897de1b267e7fcfb'
 
-  # github.com/intika/Librefox was verified as official when first introduced to the cask
   url "https://github.com/intika/Librefox/releases/download/Librefox-v#{version.before_comma}-v#{version.after_comma}/Librefox-#{version.before_comma}-Firefox-Mac-#{version.after_comma}-x64.dmg"
   appcast 'https://github.com/intika/Librefox/releases.atom'
   name 'Librefox'
-  homepage 'https://librefox.org/'
+  homepage 'https://github.com/intika/Librefox/'
 
   conflicts_with cask: [
                          'intika-firefox-esr',

--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,6 +1,6 @@
 cask 'upwork' do
-  version '5_1_0_562_f3wgs5ljinabm69t'
-  sha256 'cd73202f2d09b9a16b0ca0e8a701db79af127d76744821cbf98c49d1fa03f85f'
+  version '5_1_0_647_g0nxmj7uab8q069t'
+  sha256 '9119a78f4262c8fe4c6b9f50f768759ade8959495d32f81511c46a3289be998a'
 
   url "https://updates-desktopapp.upwork.com/binaries/v#{version}/Upwork.dmg"
   name 'Upwork'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.