### PR TITLE
superduper: Add support for mavericks

### DIFF
--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -1,10 +1,37 @@
 cask 'superduper' do
-  version '3.2.4,118'
-  sha256 'a6af47ea7df3903ba7195dfb25eb57d4150b02d8a910c0a52ab7297fb588e3e9'
+  if MacOS.version <= :snow_leopard
+    version '2.7.1'
+    sha256 'e851bdf522bf1ab69bc2baf2af52fac9b7a31199fc9fb1b32ac49551bf6a8f2f'
 
-  # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'
-  appcast 'https://versioncheck.blacey.com/superduper/version.xml?VSN=100'
+    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
+    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
+  elsif MacOS.version <= :lion
+    version '2.8'
+    sha256 '32cd12cda784d7cd995386a96ec17d75900832e338edcda59b250d12251556e5'
+
+    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
+    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
+  elsif MacOS.version <= :mountain_lion
+    version '2.9.2'
+    sha256 '0501dc7215a5059c124deba30e9cc49197abc40a38bf1017b7a05fad43bbed8a'
+
+    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
+    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
+  elsif MacOS.version <= :mavericks
+    version '3.1.1'
+    sha256 '6639cf292fe391cfb1c2283fc3614c462a9859910a4c85e190119548d3c32c31'
+
+    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
+    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
+  else
+    version '3.2.4,118'
+    sha256 'a6af47ea7df3903ba7195dfb25eb57d4150b02d8a910c0a52ab7297fb588e3e9'
+
+    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
+    url 'https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'
+    appcast 'https://versioncheck.blacey.com/superduper/version.xml?VSN=100'
+  end
+
   name 'SuperDuper!'
   homepage 'https://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html'
 

--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -1,5 +1,5 @@
 cask 'superduper' do
-  if MacOS.version == :mavericks
+  if MacOS.version <= :mavericks
     version '3.1.1'
     sha256 '6639cf292fe391cfb1c2283fc3614c462a9859910a4c85e190119548d3c32c31'
 

--- a/Casks/superduper.rb
+++ b/Casks/superduper.rb
@@ -1,23 +1,5 @@
 cask 'superduper' do
-  if MacOS.version <= :snow_leopard
-    version '2.7.1'
-    sha256 'e851bdf522bf1ab69bc2baf2af52fac9b7a31199fc9fb1b32ac49551bf6a8f2f'
-
-    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
-    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
-  elsif MacOS.version <= :lion
-    version '2.8'
-    sha256 '32cd12cda784d7cd995386a96ec17d75900832e338edcda59b250d12251556e5'
-
-    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
-    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
-  elsif MacOS.version <= :mountain_lion
-    version '2.9.2'
-    sha256 '0501dc7215a5059c124deba30e9cc49197abc40a38bf1017b7a05fad43bbed8a'
-
-    # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
-    url "https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!#{version}.dmg"
-  elsif MacOS.version <= :mavericks
+  if MacOS.version == :mavericks
     version '3.1.1'
     sha256 '6639cf292fe391cfb1c2283fc3614c462a9859910a4c85e190119548d3c32c31'
 
@@ -29,9 +11,9 @@ cask 'superduper' do
 
     # amazonaws.com/shirtpocket/SuperDuper was verified as official when first introduced to the cask
     url 'https://s3.amazonaws.com/shirtpocket/SuperDuper/SuperDuper!.dmg'
-    appcast 'https://versioncheck.blacey.com/superduper/version.xml?VSN=100'
   end
 
+  appcast 'https://versioncheck.blacey.com/superduper/version.xml?VSN=100'
   name 'SuperDuper!'
   homepage 'https://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).