### PR TITLE
docs: Remove references to macOS versions below tiger

### DIFF
--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -50,7 +50,7 @@ if MacOS.version <= :mavericks     # symbolic name
 if MacOS.version <= '10.9'         # version string
 ```
 
-The available symbols for macOS versions are: `:cheetah`, `:puma`, `:jaguar`, `:panther`, `:tiger`, `:leopard`, `:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, `:yosemite`, `:el_capitan`, `:sierra`, `:high_sierra`, and `:mojave`. The corresponding numeric version strings should be given as major releases containing a single dot.
+The available symbols for macOS versions are: `:tiger`, `:leopard`, `:snow_leopard`, `:lion`, `:mountain_lion`, `:mavericks`, `:yosemite`, `:el_capitan`, `:sierra`, `:high_sierra`, and `:mojave`. The corresponding numeric version strings should be given as major releases containing a single dot.
 
 ### Always Fall Through to the Newest Case
 

--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -33,10 +33,6 @@ The available values for macOS releases are:
 
 | symbol             | corresponding string
 | -------------------|----------------------
-| `:cheetah`         | `'10.0'`
-| `:puma`            | `'10.1'`
-| `:jaguar`          | `'10.2'`
-| `:panther`         | `'10.3'`
 | `:tiger`           | `'10.4'`
 | `:leopard`         | `'10.5'`
 | `:snow_leopard`    | `'10.6'`


### PR DESCRIPTION
Per https://github.com/Homebrew/brew/blob/master/Library/Homebrew/os/mac/version.rb nothing below tiger (10.4) is supported)

Unchanged in #23920 after #23852