### PR TITLE
Update beamdog-client to 2.1.10

### DIFF
--- a/Casks/beamdog-client.rb
+++ b/Casks/beamdog-client.rb
@@ -1,6 +1,6 @@
 cask 'beamdog-client' do
-  version '2.1.9'
-  sha256 'b3ee780be9c3e1d5eefb75c890531eca69d57a24b4b776a81e2cf3f2ecc4515a'
+  version '2.1.10'
+  sha256 '25ddbe6635057148e87b9e4d82d6751a635e0b34b72c87f3ab06001177e233fb'
 
   url "http://client.beamdog.com/download/#{version}/osx_64/Beamdog%20Client-#{version}.dmg"
   name 'Beamdog Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.