### PR TITLE
Update buttercup to 1.14.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
   version '1.14.0'
-  sha256 '025652fe2b7672566c4dfd36bc9dc87b2eb3b6cd1077eac4588cfbeec3509a89'
+  sha256 'e5893a9108a98a1fcadc7c682851b7e9904b20818b6f81cff608515bf5be1de8'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.