### PR TITLE
Update hachidori to 3.0.9

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,6 +1,6 @@
 cask 'hachidori' do
-  version '3.0.7'
-  sha256 'fc357e10d52ea0737263155e31eea9e87b31c9a8f437a049f1dcd6b75ea13765'
+  version '3.0.9'
+  sha256 '6ba2810efdaac15f4d1da84f19cb9de3a9a67dd41911671f619a39a5c76b8a3d'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.