### PR TITLE
Update virtualhostx to 8.4.2,80_43

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,10 +1,10 @@
 cask 'virtualhostx' do
-  version '8.3.4,80_40'
-  sha256 '27d1a3de664d3aeb85f4dd7938712a4c2ab23d1ab181f40e980b65d641d248f7'
+  version '8.4.2,80_43'
+  sha256 '748707d5cc1a9af464292c139c9c7e519d0ed501d1aa1a9263d9d329c5a5c8a5'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"
-  appcast 'https://shine.clickontyler.com/appcast.php?id=33'
+  appcast 'https://shine.clickontyler.com/appcast.php?id=38'
   name 'VirtualHostX'
   homepage 'https://clickontyler.com/virtualhostx/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.