### PR TITLE
Update comparemerge to 2.10y

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,6 +1,6 @@
 cask 'comparemerge' do
-  version '2.09y'
-  sha256 '5be37fca9fba28c38ab392ef33e80321617c6bfac541cfaaaa6a7406eb1d6a87'
+  version '2.10y'
+  sha256 'fa25244eba6609956fb2bbaff363f5829c453b99db08d89b3601e026f6a3c406'
 
   url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.