### PR TITLE
Update bitwarden to 1.12.0

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,9 +1,9 @@
 cask 'bitwarden' do
-  version '1.11.2'
-  sha256 '2dd09312c5ed1f80e8a8d4d12219df1e3016eef1dcb662c1da95da17da0ea1f4'
+  version '1.12.0'
+  sha256 'a2de9dfd54199d246ac4dc15445b7be858f35cf208be2bff31782067e73005b8'
 
   # github.com/bitwarden/desktop was verified as official when first introduced to the cask
-  url "https://github.com/bitwarden/desktop/releases/download/v#{version}/bitwarden-#{version}-mac.zip"
+  url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-mac.zip"
   appcast 'https://github.com/bitwarden/desktop/releases.atom'
   name 'Bitwarden'
   homepage 'https://bitwarden.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.