### PR TITLE
Update videostream to 0.3.5

### DIFF
--- a/Casks/videostream.rb
+++ b/Casks/videostream.rb
@@ -1,6 +1,6 @@
 cask 'videostream' do
-  version '0.3.4'
-  sha256 'e67f26983fcddabec09b6bf922d396078af008966b7841f3619c9cb5a9b26b40'
+  version '0.3.5'
+  sha256 '7391c05f0214bf248f0a296aa84f94b943a45ad7dc685a214ea4129ebe5026b0'
 
   url 'https://cdn.getvideostream.com/videostream-native-updates/macOS/Videostream.pkg'
   appcast 'https://s3.amazonaws.com/videostream-cdn/videostream-native-updates/macOS/manifest.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.