### PR TITLE
Update gtkwave to 3.3.98

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,6 +1,6 @@
 cask 'gtkwave' do
-  version '3.3.97'
-  sha256 '154000345d45427b9def7e858968af685510ab05c11e26f6523666affc513db4'
+  version '3.3.98'
+  sha256 '933863c4f6e0fa1d1f77efadbfaf24b7ceedee0e1e2dd00fbbd3af1429cbf406'
 
   # downloads.sourceforge.net/gtkwave was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.