### PR TITLE
Update photo-supreme-single-user to 4.3.2

### DIFF
--- a/Casks/photo-supreme-single-user.rb
+++ b/Casks/photo-supreme-single-user.rb
@@ -1,6 +1,6 @@
 cask 'photo-supreme-single-user' do
   version '4.3.2'
-  sha256 'c77370e4402750db00717c25bda55074d167797c94355c494fc3f83e24620db9'
+  sha256 '68f9180951e0e60f84bf425439bb581a670179888841158ce4fd07c4c74f48c1'
 
   url "https://trial.idimager.com/PhotoSupreme_V#{version.major}.pkg"
   name 'Photo Supreme Single User'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.