### PR TITLE
Update ultimate to 3.0.11.104

### DIFF
--- a/Casks/ultimate.rb
+++ b/Casks/ultimate.rb
@@ -1,6 +1,6 @@
 cask 'ultimate' do
-  version '3.0.10.1225'
-  sha256 'dbca4a6b70590990c9c06df9d1555cb3ab0e4f00306cf7dc5ac1a8e113828bbb'
+  version '3.0.11.104'
+  sha256 '724f6c39120b0c7a663d52b750ec973e43924b19ea5498fb1201ef84c43b145f'
 
   url 'https://download.epubor.com/epubor_ultimate.zip'
   appcast 'https://www.epubor.com/ultimate.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.