### PR TITLE
Update kate to 18.12.0-317

### DIFF
--- a/Casks/kate.rb
+++ b/Casks/kate.rb
@@ -1,6 +1,6 @@
 cask 'kate' do
-  version '18.08.3-311'
-  sha256 'd72f897a93c5e83cfd9ba7487bc669f0b93ffaecf4aea5b589fc5a18363c937b'
+  version '18.12.0-317'
+  sha256 '32e2fbf185382ae58d2c138fd5f1438c8f57ffe56da01ffaa45e84d35a3e0499'
 
   # binary-factory.kde.org/view/MacOS/job/Kate_Release_macos was verified as official when first introduced to the cask
   url "https://binary-factory.kde.org/view/MacOS/job/Kate_Release_macos/lastSuccessfulBuild/artifact/kate-#{version}-macos-64-clang.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.