### PR TITLE
Update 115browser to 8.6.5.31

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,6 +1,6 @@
 cask '115browser' do
-  version '8.6.4.5'
-  sha256 '48c226ef862080e88993c9ff6a913a7922822f2ba15423bdce3923b66cf305a0'
+  version '8.6.5.31'
+  sha256 '8af0ce66b49eda99ff5bec26477cb8d44628caa186ea5c54c1146d1e2b1849ed'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'

--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -5,7 +5,7 @@ cask '115browser' do
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
   name '115Browser'
   name '115浏览器'
-  homepage 'https://pc.115.com/'
+  homepage 'http://pc.115.com/'
 
   depends_on macos: '>= :mountain_lion'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.