### PR TITLE
Update routebuddy to 4.2.1

### DIFF
--- a/Casks/routebuddy.rb
+++ b/Casks/routebuddy.rb
@@ -2,8 +2,8 @@ cask 'routebuddy' do
   version '4.2.1'
   sha256 '95d979d775ebfbd5c835150d50c809fdb8f5e29823b54a13deec73b6df21c643'
 
-  # objects-us-west-1.dream.io/routebuddy was verified as official when first introduced to the cask
-  url "https://objects-us-west-1.dream.io/routebuddy/download/apps2/RouteBuddy_#{version}.dmg"
+  # objects-us-east-1.dream.io/routebuddy was verified as official when first introduced to the cask
+  url "https://objects-us-east-1.dream.io/routebuddy/download/apps2/RouteBuddy_#{version}.dmg"
   name 'RouteBuddy'
   homepage 'https://routebuddy.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.