### PR TITLE
Add intelliscape-caffeine fork of caffeine

### DIFF
--- a/Casks/caffeine.rb
+++ b/Casks/caffeine.rb
@@ -1,11 +1,12 @@
 cask 'caffeine' do
-  version '1.1.1'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.1.2'
+  sha256 '365367f8b3314ffabc1d821f996943755ebc4f90f5ca1433f3123ddb62e1835e'
 
-  url "http://lightheadsw.com/files/releases/com.lightheadsw.Caffeine/Caffeine#{version}.zip"
-  appcast 'http://lightheadsw.com/caffeine/'
+  # cl.ly/2d0e01d909e4 was verified as official when first introduced to the cask
+  url 'https://cl.ly/2d0e01d909e4/download/Caffeine.dmg'
+  appcast 'https://intelliscapesolutions.com/apps/caffeine/releasenotes'
   name 'Caffeine'
-  homepage 'http://lightheadsw.com/caffeine/'
+  homepage 'https://intelliscapesolutions.com/apps/caffeine'
 
   app 'Caffeine.app'
 


### PR DESCRIPTION
Due to changes in Mojave, Caffeine has required an update to work with the Accessibility Security preferences.

The previous maintainer has transferred responsibility to a new author, as mentioned in this Stack Exchange answer: https://apple.stackexchange.com/a/343899/215110

This is my first contribution/modification to a Homebrew .rb file. So I may have left some errors by accident. In particular, I'm concerned about the `appcast` I chose, whether to use an SHA or `:latest` given there isn't a version number in the URL, and the `# ... official ...` comment.

I am happy to make any requested modifications.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).