### PR TITLE
Update weka to 3.8.3

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,6 +1,6 @@
 cask 'weka' do
   version '3.8.3'
-  sha256 'f13fdbaa34969722138308afc40951b8c741e51a4ce01823b1a7c9a08a779dab'
+  sha256 '3689a2ef1fbc5de143ca5b751c8b8183351ed4452955bb222a3f6fc5ea9d42c2'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-oracle-jvm.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.