### PR TITLE
Update musixmatch to 0.21.13

### DIFF
--- a/Casks/musixmatch.rb
+++ b/Casks/musixmatch.rb
@@ -1,8 +1,8 @@
 cask 'musixmatch' do
-  version :latest
-  sha256 :no_check
+  version '0.21.13'
+  sha256 'b5c65f63a9c2a7cc52938ec202c489b116255995c5625382f4b5ed45ef20e77f'
 
-  url 'https://download-app.musixmatch.com/download/osx'
+  url "https://download-app.musixmatch.com/download/Musixmatch-#{version}.dmg"
   name 'Musixmatch'
   homepage 'https://www.musixmatch.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.