### PR TITLE
Update jaxx to 2.1.1

### DIFF
--- a/Casks/jaxx-liberty.rb
+++ b/Casks/jaxx-liberty.rb
@@ -1,4 +1,4 @@
-cask 'jaxx' do
+cask 'jaxx-liberty' do
   version '2.1.1'
   sha256 'c2d9ad29629f547766bca8e0c963addda1c9c11786f2c2604fdbe24c0eebbf7d'
 

--- a/Casks/jaxx.rb
+++ b/Casks/jaxx.rb
@@ -1,14 +1,13 @@
 cask 'jaxx' do
-  version '1.3.18'
-  sha256 'cd23115f58cd6779ca1c90507126de279caadb34f8358001e01e167ba35f62a2'
+  version '2.1.1'
+  sha256 'c2d9ad29629f547766bca8e0c963addda1c9c11786f2c2604fdbe24c0eebbf7d'
 
-  # github.com/Jaxx-io/Jaxx was verified as official when first introduced to the cask
-  url "https://github.com/Jaxx-io/Jaxx/releases/download/v#{version}/Jaxx-#{version}.dmg"
-  appcast 'https://github.com/Jaxx-io/Jaxx/releases.atom'
+  url "https://download-liberty.jaxx.io/Jaxx.Liberty-#{version}.dmg"
+  appcast 'https://jaxx.io/downloads.html'
   name 'Jaxx Blockchain Wallet'
   homepage 'https://jaxx.io/'
 
-  app 'Jaxx.app'
+  app 'Jaxx Liberty.app'
 
   zap trash: [
                '~/Library/Application Support/jaxx',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.