### PR TITLE
Update managenameext to 1.6.6

### DIFF
--- a/Casks/managenameext.rb
+++ b/Casks/managenameext.rb
@@ -1,6 +1,6 @@
 cask 'managenameext' do
   version '1.6.6'
-  sha256 '77868a31f6e2e4e4c56922155ce19dbbe0748858ba32f871132d5b1511a3db3c'
+  sha256 '0abe150d686719a290bc3687c2b1d33141e06c7e98fc4c971c7304258a43071b'
 
   url 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_c.zip'
   appcast 'http://throb.pagesperso-orange.fr/prg/Xojo/ManageNameExt_AffV.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.