### PR TITLE
Update spotify-notifications to 0.6.0

### DIFF
--- a/Casks/spotify-notifications.rb
+++ b/Casks/spotify-notifications.rb
@@ -2,7 +2,7 @@ cask 'spotify-notifications' do
   version '0.6.0'
   sha256 '136f676a4580a561ca08edf13a79a5cea5878f276ff6a38e3f2bb96aeca61031'
 
-  url "https://downloads.spotify-notifications.citruspi.io/#{version}-release.zip"
+  url "http://downloads.spotify-notifications.citruspi.io/#{version}-release.zip"
   appcast 'https://github.com/citruspi/Spotify-Notifications/releases.atom'
   name 'Spotify Notifications'
   homepage 'https://spotify-notifications.citruspi.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.