### PR TITLE
Update odio to 1.4.0

### DIFF
--- a/Casks/odio.rb
+++ b/Casks/odio.rb
@@ -1,6 +1,6 @@
 cask 'odio' do
-  version '1.3.5'
-  sha256 'cff3add9553cafd699821eefedb106c3fc6674c82ff33d7b8b8ada903d48e1aa'
+  version '1.4.0'
+  sha256 '2f1b584f2ace2fee03f4786b59b29ccb0a0e4099580c4fd1a5817b1ab084636f'
 
   # github.com/odioapp/odio was verified as official when first introduced to the cask
   url "https://github.com/odioapp/odio/releases/download/v#{version}/odio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.