### PR TITLE
Update cacher to 2.3.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.3.0'
-  sha256 '4f0950090dad291ccc33249f7ea6848538c1d1d256c9babc277718d89fc1d064'
+  version '2.3.3'
+  sha256 '63b41f2f479d20b02d03ccddfa21bed23530be74dd7b9677d6d7b30e86753da8'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.