### PR TITLE
Create intelliscape-caffeine cask for forked version of Caffeine.app

### DIFF
--- a/Casks/caffeine.rb
+++ b/Casks/caffeine.rb
@@ -1,12 +1,11 @@
 cask 'caffeine' do
-  version '1.1.2'
-  sha256 '365367f8b3314ffabc1d821f996943755ebc4f90f5ca1433f3123ddb62e1835e'
+  version '1.1.1'
+  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
 
-  # cl.ly/2d0e01d909e4 was verified as official when first introduced to the cask
-  url 'https://cl.ly/2d0e01d909e4/download/Caffeine.dmg'
-  appcast 'https://intelliscapesolutions.com/apps/caffeine/releasenotes'
+  url "http://lightheadsw.com/files/releases/com.lightheadsw.Caffeine/Caffeine#{version}.zip"
+  appcast 'http://lightheadsw.com/caffeine/'
   name 'Caffeine'
-  homepage 'https://intelliscapesolutions.com/apps/caffeine'
+  homepage 'http://lightheadsw.com/caffeine/'
 
   app 'Caffeine.app'
 

--- a/Casks/caffeine.rb
+++ b/Casks/caffeine.rb
@@ -1,11 +1,12 @@
 cask 'caffeine' do
-  version '1.1.1'
-  sha256 '9203c30951f9aab41ac294bbeb1dcef7bed401ff0b353dcb34d68af32ea51853'
+  version '1.1.2'
+  sha256 '365367f8b3314ffabc1d821f996943755ebc4f90f5ca1433f3123ddb62e1835e'
 
-  url "http://lightheadsw.com/files/releases/com.lightheadsw.Caffeine/Caffeine#{version}.zip"
-  appcast 'http://lightheadsw.com/caffeine/'
+  # cl.ly/2d0e01d909e4 was verified as official when first introduced to the cask
+  url 'https://cl.ly/2d0e01d909e4/download/Caffeine.dmg'
+  appcast 'https://intelliscapesolutions.com/apps/caffeine/releasenotes'
   name 'Caffeine'
-  homepage 'http://lightheadsw.com/caffeine/'
+  homepage 'https://intelliscapesolutions.com/apps/caffeine'
 
   app 'Caffeine.app'
 

--- a/Casks/intelliscape-caffeine.rb
+++ b/Casks/intelliscape-caffeine.rb
@@ -1,0 +1,19 @@
+cask 'intelliscape-caffeine' do
+  version '1.1.2'
+  sha256 '365367f8b3314ffabc1d821f996943755ebc4f90f5ca1433f3123ddb62e1835e'
+
+  # cl.ly/2d0e01d909e4 was verified as official when first introduced to the cask
+  url 'https://cl.ly/2d0e01d909e4/download/Caffeine.dmg'
+  appcast 'https://intelliscapesolutions.com/apps/caffeine/releasenotes'
+  name 'Caffeine'
+  homepage 'https://intelliscapesolutions.com/apps/caffeine'
+
+  conflicts_with cask: 'caffeine'
+
+  app 'Caffeine.app'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.lightheadsw.caffeine.sfl*',
+               '~/Library/Preferences/com.lightheadsw.Caffeine.plist',
+             ]
+end


### PR DESCRIPTION
Create a cask for the forked version of Caffeine.app that works with Mojave's new security settings.

https://apple.stackexchange.com/a/343899/215110
https://intelliscapesolutions.com/apps/caffeine

See #57068 for the original, incorrect submission.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
