### PR TITLE
Update standard-notes to 3.0.2

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
-  version '3.0.1'
-  sha256 'a12418877504b7a5eaf1319c7add8dbf65aae040927729f5918c10a095089f6f'
+  version '3.0.2'
+  sha256 'ddd04bc893b1f6c7ac54020de66b9e68ea897879ec2877b0a28685533653689f'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.