### PR TITLE
Update horos to 3.3.5

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -6,8 +6,8 @@ cask 'horos' do
     version '2.0.2'
     sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
   else
-    version '3.3.4'
-    sha256 '03052b55fdc882270d6fc86a7edc622ef82f71a9a809af157897f748b4d11928'
+    version '3.3.5'
+    sha256 'e99716ee2939fc16cbe06fd04dfc6945fa0dbbf713c9db9bd53189d473ff9544'
   end
 
   url "https://horosproject.org/horos-content/Horos#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.