### PR TITLE
Update kode54-cog to 0.08,4d18505da

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,4f828c91b'
-  sha256 'af1ad34a11729506081dd27b513201f903032fe5e3604ff8d5c910601e915c06'
+  version '0.08,4d18505da'
+  sha256 '016c95aab16108158991f82d034f3d13fc517b53e824adeb9aa68913711949d8'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.