### PR TITLE
Update pagico to 8.16.2363

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '8.16.2362'
-  sha256 'c762e05e173198b56b654819c2c9f764a6d8ab63dbac3fc01e9bbc8c984f9213'
+  version '8.16.2363'
+  sha256 'd6435c88dfe891c79362d45b3a5969fa2485763ff884c47c28e43259e50d7d3a'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast 'https://www.pagico.com/api/pagico8.mac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.