### PR TITLE
update parsec (latest) URL to use Dual-Stack

### DIFF
--- a/Casks/parsec.rb
+++ b/Casks/parsec.rb
@@ -3,7 +3,7 @@ cask 'parsec' do
   sha256 :no_check
 
   # s3.amazonaws.com/parsec-build was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/parsec-build/package/parsec-macos.pkg'
+  url 'https://s3.dualstack.us-east-1.amazonaws.com/parsec-build/package/parsec-macos.pkg'
   name 'Parsec'
   homepage 'https://parsecgaming.com/'
 

--- a/Casks/parsec.rb
+++ b/Casks/parsec.rb
@@ -2,7 +2,7 @@ cask 'parsec' do
   version :latest
   sha256 :no_check
 
-  # s3.amazonaws.com/parsec-build was verified as official when first introduced to the cask
+  # s3.dualstack.us-east-1.amazonaws.com/parsec-build was verified as official when first introduced to the cask
   url 'https://s3.dualstack.us-east-1.amazonaws.com/parsec-build/package/parsec-macos.pkg'
   name 'Parsec'
   homepage 'https://parsecgaming.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Fix for https://github.com/Homebrew/homebrew-cask/pull/57119