### PR TITLE
Add gtkwave 3.3.98 binary and zap

### DIFF
--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -11,7 +11,7 @@ cask 'gtkwave' do
   depends_on x11: true
 
   app 'gtkwave.app'
-  binary "#{appdir}/Contents/Resources/bin/gtkwave_bin_launcher.sh", target: 'gtkwave'
+  binary "#{appdir}/gtkwave.app/Contents/Resources/bin/gtkwave_bin_launcher.sh", target: 'gtkwave'
 
   zap trash: [
                '~/Library/Application Support/CrashReporter/gtkwave-bin_*.plist',

--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -11,7 +11,7 @@ cask 'gtkwave' do
   depends_on x11: true
 
   app 'gtkwave.app'
-  binary "#{appdir}/gtkwave.app/Contents/Resources/bin/gtkwave"
+  binary "#{appdir}/Contents/Resources/bin/gtkwave_bin_launcher.sh", target: 'gtkwave'
 
   zap trash: [
                '~/Library/Application Support/CrashReporter/gtkwave-bin_*.plist',

--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -1,6 +1,6 @@
 cask 'gtkwave' do
-  version '3.3.97'
-  sha256 '154000345d45427b9def7e858968af685510ab05c11e26f6523666affc513db4'
+  version '3.3.98'
+  sha256 '933863c4f6e0fa1d1f77efadbfaf24b7ceedee0e1e2dd00fbbd3af1429cbf406'
 
   # downloads.sourceforge.net/gtkwave was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gtkwave/gtkwave-#{version}-osx-app/gtkwave.zip"
@@ -8,5 +8,14 @@ cask 'gtkwave' do
   name 'GTKWave'
   homepage 'https://gtkwave.sourceforge.io/'
 
+  depends_on x11: true
+
   app 'gtkwave.app'
+  binary "#{appdir}/gtkwave.app/Contents/Resources/bin/gtkwave"
+
+  zap trash: [
+               '~/Library/Application Support/CrashReporter/gtkwave-bin_*.plist',
+               '~/Library/Preferences/com.geda.gtkwave.plist',
+               '~/Library/Saved Application State/com.geda.gtkwave.savedState',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

