### PR TITLE
Update seashore to 2.1.4

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.1.3'
-  sha256 'cfca508c78cd95233f3b3fe6d69c458ae963b29a00e8850f62405bea9e555302'
+  version '2.1.4'
+  sha256 '80bc66a1a7afa4e9f37e4d69da7b8d3b4a9ca324674de48cc15998bf47dbdab0'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.