### PR TITLE
Update kullo to 58.0.0

### DIFF
--- a/Casks/kullo.rb
+++ b/Casks/kullo.rb
@@ -1,6 +1,6 @@
 cask 'kullo' do
-  version '57.0.0'
-  sha256 '01603e375246db52ac65a6363a6a285067297a076eb3c358b7fed16d39fcd81d'
+  version '58.0.0'
+  sha256 '8bbe3fad09bc44b3540107b69e421075fc3eba5fc5ea8463cdb61aea2cce19b5'
 
   url "https://www.kullo.net/download/files/osx/Kullo-#{version}.dmg"
   name 'Kullo'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.