### PR TITLE
Update dejalu to 1.0,217

### DIFF
--- a/Casks/dejalu.rb
+++ b/Casks/dejalu.rb
@@ -1,6 +1,6 @@
 cask 'dejalu' do
-  version '1.0,213'
-  sha256 '527901fbaf9782caf5cded4132f856fa3922c5cba67323f4b29a9d32bcdc1c83'
+  version '1.0,217'
+  sha256 'ee1b08c2d6698b1938e0044b21a0cc6746543d2853048234b5eca91169db233b'
 
   url "https://d.dejalu.me/dejalu-eKTEtTljm4/dejalu-#{version.after_comma}/DejaLu-#{version.after_comma}.zip"
   appcast 'https://d.dejalu.me/dejalu-eKTEtTljm4/sparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.