### PR TITLE
Update dust3d to 1.0.0-beta.14

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-beta.10'
-  sha256 'ff0ebfbe1e22f30e175b3c46fe6eb680c7d31d5867c0207b55898895ac464548'
+  version '1.0.0-beta.14'
+  sha256 '8aab10d40bfd11e73f28bd2c2868460abde22388478c0314bf6e80031400cce6'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.