### PR TITLE
Update sqleditor to 3.5.1

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,6 +1,6 @@
 cask 'sqleditor' do
-  version '3.3.12'
-  sha256 'bba8e8a622ba8940c35cbd54eb4211afda82cfef3e1e799310e55ac6ad3e4ec0'
+  version '3.5.1'
+  sha256 'ba2efe9dabe1283683de293455ea7a72343b40728627af14400e2d9c60bd0448'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.