### PR TITLE
Update keeweb to 1.7.2

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.7.0'
-  sha256 'c6c3a43bfa326fd6a6d9aceb7958039b0bc074f8ae57989e6725560de58dd322'
+  version '1.7.2'
+  sha256 '8271ee82d929150abfc311f3df2e602e6708bc5cabdb5a3030149e99f92919b3'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.