### PR TITLE
Update MEGAsync to 3.7.1

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -1,15 +1,16 @@
 cask 'megasync' do
-  version :latest
-  sha256 :no_check
+  version '3.7.1.0'
+  sha256 'a808259d6f93be450b7e874b28329df6a3dad4526399331c7f5720da539c338e'
 
   url 'https://mega.nz/MEGAsyncSetup.dmg'
+  appcast 'https://github.com/meganz/MEGAsync/releases.atom'
   name 'MEGAsync'
   homepage 'https://mega.nz/'
 
   app 'MEGAsync.app'
 
-  caveats <<~EOS
-    #{token} only works if called from /Applications, so you may need to install it with
-      brew cask install --appdir=/Applications #{token}
-  EOS
+  zap trash: [
+               '~/Library/Caches/mega.mac',
+               '~/Library/Preferences/mega.mac.plist',
+             ]
 end


### PR DESCRIPTION
Edit: One PR for One Cask. This one is for MEGAsync.

--------------------------------

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Add appcast to MEGAsync and MEGAcmd, and change version from `latest` to actual version `3.7.1` and `1.0.0`.

These two apps from mega.nz don't have a versioned download link, but they DO have version and source code are released in github on the schedule. They need version.

btw, [MEGAcmd](https://mega.nz/cmd) is the official CLI app from mega.nz, [megacmd](https://github.com/t3rm1n4l/megacmd) in homebrew-core ([link](https://github.com/Homebrew/homebrew-core/blob/master/Formula/megacmd.rb))is a third party tools based on go-mega, so change the token name of MEGAcmd from megacmd-app to megacmd and change the name of homebrew-core/megacmd to t3rm1n4l-megacmd or megacmd-go is more suitable.
