### PR TITLE
Update blockstack to 0.35.3

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.35.2'
-  sha256 'bc66cc1be9ff68a739f21e6915ac34c06f06f3c6e796f514c38c5c3c68bce08e'
+  version '0.35.3'
+  sha256 'f95a23ac371d9071c57ee45cfede922d5191a54df011d0e9d5ca41babdbd0494'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.