### PR TITLE
Update vscodium to 1.30.2

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.30.1'
-  sha256 'f906549d94d153516d46423e08579ea3df0899130a2bde9d1c62fbd0b327eef0'
+  version '1.30.2'
+  sha256 'fa01b440a02e58040b04227e11d51acb4bc5da6cf94e3cb1043268e9c416be8e'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCode-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.