### PR TITLE
Update retro-virtual-machine to 1.1.8

### DIFF
--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -3,9 +3,9 @@ cask 'retro-virtual-machine' do
   sha256 '49ea57688d0afbe63cc886606067f400c0e827e60db9c781e2f8c93cc993d139'
 
   url "http://static1.retrovirtualmachine.org/release/Retro%20Virtual%20Machine%20v#{version}.dmg"
-  appcast 'http://www.retrovirtualmachine.org/en/changelog'
+  appcast 'https://www.retrovirtualmachine.org/en/downloads'
   name 'Retro Virtual Machine'
-  homepage 'http://www.retrovirtualmachine.org/'
+  homepage 'https://www.retrovirtualmachine.org/en/'
 
   app 'Retro Virtual Machine.app'
 end

--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -1,6 +1,6 @@
 cask 'retro-virtual-machine' do
-  version '1.1.7'
-  sha256 'a31930bcc63d9dd69e43b84376a11d8d86064b15fc0e47a0acb29c86b964e09f'
+  version '1.1.8'
+  sha256 '49ea57688d0afbe63cc886606067f400c0e827e60db9c781e2f8c93cc993d139'
 
   url "http://static1.retrovirtualmachine.org/release/Retro%20Virtual%20Machine%20v#{version}.dmg"
   appcast 'http://www.retrovirtualmachine.org/en/changelog'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.