### PR TITLE
Update bitshares to 2.0.181212

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,6 +1,6 @@
 cask 'bitshares' do
-  version '2.0.181129'
-  sha256 '4c2d59227829d65e27d3b59bd4bd0f56c9a0f8bd90e01bc2cbae7f9a91db4da9'
+  version '2.0.181212'
+  sha256 '08251bca6df17bf4082557f939bc484f50a48ad28384421f26e9777ccc3540ea'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.