### PR TITLE
Update qownnotes to 19.1.1,b4050-193850

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.1.0,b4034-122701'
-  sha256 '4cc6fa29fcba90e678290f088586e82b2a909cf1bc0c5fae2845572760f6468e'
+  version '19.1.1,b4050-193850'
+  sha256 'ad003eb6526c64e836616b43f82e585d4cd4ad45ea4c3981bdfc73cb913b816a'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.