### PR TITLE
Update daylite to 6.5.5

### DIFF
--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -5,8 +5,8 @@ cask 'daylite' do
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.dmg"
     pkg 'Install Daylite & Mail Assistant.pkg'
   else
-    version '6.6.2'
-    sha256 'c92f73d42c889e172fb917c0782dc744452d1da128b74a888aaa57f2d4be64f6'
+    version '6.6.3.1'
+    sha256 '529477859f49bcca08c0704522338201bc0b64de5d58f650c3011d5e711aa223'
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.pkg"
     pkg "daylitedma#{version.no_dots}.pkg"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.