### PR TITLE
Remove Tiger references.

### DIFF
--- a/Casks/appcleaner.rb
+++ b/Casks/appcleaner.rb
@@ -16,7 +16,7 @@ cask 'appcleaner' do
   homepage 'https://freemacsoft.net/appcleaner/'
 
   auto_updates true
-  depends_on macos: '>= :tiger'
+  depends_on macos: '>= :leopard'
 
   app 'AppCleaner.app'
 

--- a/Casks/bitpim.rb
+++ b/Casks/bitpim.rb
@@ -8,7 +8,7 @@ cask 'bitpim' do
   name 'BitPim'
   homepage 'http://www.bitpim.org/'
 
-  depends_on macos: '>= :tiger'
+  depends_on macos: '>= :leopard'
 
   app 'BitPim.app'
 

--- a/Casks/debt-quencher.rb
+++ b/Casks/debt-quencher.rb
@@ -8,7 +8,7 @@ cask 'debt-quencher' do
   name 'Debt Quencher'
   homepage 'http://nothirst.com/debtquencher/'
 
-  depends_on macos: '>= :tiger'
+  depends_on macos: '>= :leopard'
 
   app 'Debt Quencher.app'
 end

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -7,7 +7,7 @@ cask 'deltawalker' do
   name 'DeltaWalker'
   homepage 'https://www.deltawalker.com/'
 
-  depends_on macos: '>= :tiger'
+  depends_on macos: '>= :leopard'
 
   app 'DeltaWalker.app'
 

--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -13,7 +13,7 @@ cask 'pacifist' do
   homepage 'https://www.charlessoft.com/'
 
   auto_updates true
-  depends_on macos: '>= :tiger'
+  depends_on macos: '>= :leopard'
 
   app 'Pacifist.app'
 end

--- a/Casks/scroll-reverser.rb
+++ b/Casks/scroll-reverser.rb
@@ -12,7 +12,7 @@ cask 'scroll-reverser' do
   name 'Scroll Reverser'
   homepage 'https://pilotmoon.com/scrollreverser/'
 
-  depends_on macos: '>= :tiger'
+  depends_on macos: '>= :leopard'
 
   app 'Scroll Reverser.app'
 

--- a/doc/cask_language_reference/readme.md
+++ b/doc/cask_language_reference/readme.md
@@ -57,7 +57,7 @@ The available symbols for macOS versions are: `:tiger`, `:leopard`, `:snow_leopa
 Conditionals should be constructed so that the default is the newest OS version. When using an `if` statement, test for older versions, and then let the `else` statement hold the latest and greatest. This makes it more likely that the Cask will work without alteration when a new OS is released. Example (from [coconutbattery.rb](https://github.com/Homebrew/homebrew-cask/blob/2c801af44be29fff7f3cb2996455fce5dd95d1cc/Casks/coconutbattery.rb)):
 
 ```ruby
-if MacOS.version <= :tiger
+if MacOS.version <= :leopard
   # ...
 elsif MacOS.version <= :snow_leopard
   # ...

--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -33,7 +33,6 @@ The available values for macOS releases are:
 
 | symbol             | corresponding string
 | -------------------|----------------------
-| `:tiger`           | `'10.4'`
 | `:leopard`         | `'10.5'`
 | `:snow_leopard`    | `'10.6'`
 | `:lion`            | `'10.7'`


### PR DESCRIPTION
Homebrew/brew has never supported these and the symbols have been removed in https://github.com/Homebrew/brew/pull/5477.