### PR TITLE
Add font-cica for v4.1.1

### DIFF
--- a/Casks/font-cica.rb
+++ b/Casks/font-cica.rb
@@ -1,0 +1,14 @@
+cask 'font-cica' do
+  version '4.1.1'
+  sha256 '884733b723cc6896786c2e2c6e1778cc928fd6e1baac03169d18d553959067a2'
+
+  url "https://github.com/miiton/Cica/releases/download/v#{version}/Cica-v#{version}.zip"
+  appcast 'https://github.com/miiton/Cica/releases.atom'
+  name 'Cica'
+  homepage 'https://github.com/miiton/Cica'
+
+  font 'Cica-Bold.ttf'
+  font 'Cica-BoldItalic.ttf'
+  font 'Cica-Regular.ttf'
+  font 'Cica-RegularItalic.ttf'
+end


### PR DESCRIPTION
Since the issue of this license has already been resolved, I re-registered and updated.
[Remove font\-cica by unasuke · Pull Request \#1719 · Homebrew/homebrew\-cask\-fonts](https://github.com/Homebrew/homebrew-cask-fonts/pull/1719)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
