### PR TITLE
Update red to 0.6.4

### DIFF
--- a/Casks/red.rb
+++ b/Casks/red.rb
@@ -1,6 +1,6 @@
 cask 'red' do
-  version '0.6.3'
-  sha256 '3558eb6c7973443c91361b9d2b5824a4b3229209af0a13a580f46ae0f4043e81'
+  version '0.6.4'
+  sha256 '43bab7be96978b7740879eefd9131dbd51280ed319e96d83f87b2df05ea938c7'
 
   url "https://static.red-lang.org/dl/mac/red-#{version.no_dots}"
   name 'Red Programming Language'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.