### PR TITLE
add qlImageSize.qlgenerator v1.6.0

### DIFF
--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -4,7 +4,7 @@ cask 'qlimagesize' do
 
   url 'https://github.com/L1cardo/qlImageSize/releases/download/1.6.0/qlImageSize.qlgenerator.zip'
   name 'qlImageSize'
-  homepage 'https://github.com/Nyx0uf/qlImageSize'
+  homepage 'https://github.com/L1cardo/qlImageSize'
 
   qlplugin 'qlImageSize.qlgenerator'
 end

--- a/Casks/qlimagesize.rb
+++ b/Casks/qlimagesize.rb
@@ -1,0 +1,10 @@
+cask 'qlimagesize' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/L1cardo/qlImageSize/releases/download/1.6.0/qlImageSize.qlgenerator.zip'
+  name 'qlImageSize'
+  homepage 'https://github.com/Nyx0uf/qlImageSize'
+
+  qlplugin 'qlImageSize.qlgenerator'
+end


### PR DESCRIPTION
Owner no longer provides compiled versions. So the homepage is the origin owner's repo , and the url is my repo, like below

<img width="719" alt="2019-01-09 1 51 37" src="https://user-images.githubusercontent.com/33802186/50880385-35270b80-1419-11e9-9ad8-cec9d6c9a041.png">

I really hope it can be merged , thanks !