### PR TITLE
Update flash-player-debugger to 32.0.0.114

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger' do
-  version '32.0.0.101'
-  sha256 '61c5b79123aa4f33af8b565fc785d2dd17fd88d7a77100fe5d753544a94c9bdf'
+  version '32.0.0.114'
+  sha256 'e0fe31fa3d9a24dd1f939c0586e598960a79e4f694b19edb269d414284de919d'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,6 +1,6 @@
 cask 'flash-player' do
-  version '32.0.0.101'
-  sha256 '1cc35e03dbd9f31349b23cb38fb7684a7a4d4ec5791953d997643d13431a8642'
+  version '32.0.0.114'
+  sha256 'c709358cee5387f77e3823436b2dbb214101207eb89d9ccf368a07e04408d410'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.