### PR TITLE
Added auto_updates true to casks miniconda 4.5.12-MacOSX-x86_64 and a…

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,12 +1,12 @@
 cask 'anaconda' do
   version '2018.12'
   sha256 '4ccd3944d994fd47e5701c341725a63e984f8c042bf4dc19c9dfc7c135e7d8e4'
-  auto_updates true
 
   url "https://repo.anaconda.com/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"
   name 'Continuum Analytics Anaconda'
   homepage 'https://www.anaconda.com/'
 
+  auto_updates true
   container type: :naked
 
   installer script: {

--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,6 +1,7 @@
 cask 'anaconda' do
   version '2018.12'
   sha256 '4ccd3944d994fd47e5701c341725a63e984f8c042bf4dc19c9dfc7c135e7d8e4'
+  auto_updates true
 
   url "https://repo.anaconda.com/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"
   name 'Continuum Analytics Anaconda'

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -1,13 +1,13 @@
 cask 'miniconda' do
   version '4.5.12'
   sha256 '8ebb463ddf46dd003616b2f6b678403a708e2c54dcc58e212bd35e257761912c'
-  auto_updates true
 
   # repo.anaconda.com/miniconda was verified as official when first introduced to the cask
   url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.sh"
   name 'Continuum Analytics Miniconda'
   homepage 'https://conda.io/miniconda.html'
 
+  auto_updates true
   container type: :naked
 
   installer script: {

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -1,6 +1,7 @@
 cask 'miniconda' do
   version '4.5.12'
   sha256 '8ebb463ddf46dd003616b2f6b678403a708e2c54dcc58e212bd35e257761912c'
+  auto_updates true
 
   # repo.anaconda.com/miniconda was verified as official when first introduced to the cask
   url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.sh"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
  - Apparently my ruby installation seems to have a problem. But that's outside the scope of this PR.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
