### PR TITLE
Update timing to 2018.4.1

### DIFF
--- a/Casks/timing.rb
+++ b/Casks/timing.rb
@@ -1,6 +1,6 @@
 cask 'timing' do
-  version '2018.4'
-  sha256 '2bbd41ec5985fc766a85c49edeabccd5206f77662d7bbc94765b75c4ca21f8cf'
+  version '2018.4.1'
+  sha256 'cd23947cc9f6fc277ef54124ecae12bd398aaafb315d3f49b101c5eae7195c67'
 
   url 'https://timingapp.com/download/Timing.app.zip'
   appcast 'https://timingapp.com/updates/timing2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.