### PR TITLE
Upgrade LoginputMac to v2.1.3

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,14 +1,16 @@
 cask 'loginputmac' do
-  version '1.20,3776'
-  sha256 'c171a34b51304b8d230073035b9901b3b274b2a656f73dd723892c6e38414ab1'
+  version '2.1.3'
+  sha256 '9e28b16cac9a071474c138ae597ba73e109b81bb2d072ce6cea46b760285aa57'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
-  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.after_comma}.app.zip"
-  appcast 'https://im.logcg.com/appcast.xml'
+  url 'https://loginput-mac2.content-delivery.top/loginputmac2_latest.pkg'
+  appcast 'https://im.logcg.com/appcast2.xml'
   name 'LoginputMac'
-  homepage 'https://im.logcg.com/loginputmac'
+  homepage 'https://im.logcg.com/loginputmac2'
 
   auto_updates true
 
-  app 'LogInputMac.app'
+  pkg 'loginputmac2_latest.pkg'
+
+  uninstall pkgutil: 'com.logcg.pkg.LoginputMac2'
 end

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -11,6 +11,6 @@ cask 'loginputmac' do
   auto_updates true
 
   pkg "loginputmac#{version.major}_latest.pkg"
-  
+
   uninstall pkgutil: "com.logcg.pkg.LoginputMac#{version.major}"
 end

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -3,7 +3,7 @@ cask 'loginputmac' do
   sha256 '9e28b16cac9a071474c138ae597ba73e109b81bb2d072ce6cea46b760285aa57'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
-  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.after_comma}.app.zip"
+  url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"
   appcast "https://im.logcg.com/appcast#{version}.xml"
   name 'LoginputMac'
   homepage "https://im.logcg.com/loginputmac#{version.major}"

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,16 +1,16 @@
 cask 'loginputmac' do
-  version '2.1.3'
+  version '2.1.3,8771'
   sha256 '9e28b16cac9a071474c138ae597ba73e109b81bb2d072ce6cea46b760285aa57'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
-  url 'https://loginput-mac2.content-delivery.top/loginputmac2_latest.pkg'
-  appcast 'https://im.logcg.com/appcast2.xml'
+  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.major}.app#{version.after_comma}.zip#
+  appcast "https://im.logcg.com/appcast#{version}.xml"
   name 'LoginputMac'
-  homepage 'https://im.logcg.com/loginputmac2'
+  homepage "https://im.logcg.com/loginputmac#{version.major}"
 
   auto_updates true
 
-  pkg 'loginputmac2_latest.pkg'
+  pkg "loginputmac#{version.major}_latest.pkg"
 
-  uninstall pkgutil: 'com.logcg.pkg.LoginputMac2'
+  uninstall pkgutil: 'com.logcg.pkg.LoginputMac.*'
 end

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,14 +1,16 @@
 cask 'loginputmac' do
-  version '2.1.3,8771'
-  sha256 'eec691c8725a6b19911d63191c04f49ed014bb1cb988b9319589d4d1052f11d7'
+  version '2.1.3'
+  sha256 '9e28b16cac9a071474c138ae597ba73e109b81bb2d072ce6cea46b760285aa57'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
-  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.major}.app#{version.after_comma}.zip"
+  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.after_comma}.app.zip"
   appcast "https://im.logcg.com/appcast#{version}.xml"
   name 'LoginputMac'
   homepage "https://im.logcg.com/loginputmac#{version.major}"
 
   auto_updates true
 
-  app 'LogInputMac2.app'
+  pkg "loginputmac#{version.major}_latest.pkg"
+  
+  uninstall pkgutil: "com.logcg.pkg.LoginputMac#{version.major}"
 end

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
   version '2.1.3,8771'
-  sha256 '9e28b16cac9a071474c138ae597ba73e109b81bb2d072ce6cea46b760285aa57'
+  sha256 'eec691c8725a6b19911d63191c04f49ed014bb1cb988b9319589d4d1052f11d7'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.major}.app#{version.after_comma}.zip"

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -4,7 +4,7 @@ cask 'loginputmac' do
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"
-  appcast "https://im.logcg.com/appcast#{version}.xml"
+  appcast "https://im.logcg.com/appcast#{version.major}.xml"
   name 'LoginputMac'
   homepage "https://im.logcg.com/loginputmac#{version.major}"
 

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -10,7 +10,5 @@ cask 'loginputmac' do
 
   auto_updates true
 
-  pkg "loginputmac#{version.major}_latest.pkg"
-
-  uninstall pkgutil: 'com.logcg.pkg.LoginputMac.*'
+  app 'LogInputMac2.app'
 end

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -3,7 +3,7 @@ cask 'loginputmac' do
   sha256 '9e28b16cac9a071474c138ae597ba73e109b81bb2d072ce6cea46b760285aa57'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
-  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.major}.app#{version.after_comma}.zip#
+  url "https://loginput-mac2.content-delivery.top/LogInputMac#{version.major}.app#{version.after_comma}.zip"
   appcast "https://im.logcg.com/appcast#{version}.xml"
   name 'LoginputMac'
   homepage "https://im.logcg.com/loginputmac#{version.major}"


### PR DESCRIPTION
The developer has offered a new set of URLs and pkg for installation.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
