### PR TITLE
Update framer-x to 26657,1546958151

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '26388,1544707956'
-  sha256 '23f7a250c518fe921fafc31964b54df37ccc6ab1e903f23822464b3a6efee797'
+  version '26657,1546958151'
+  sha256 '47b55ac753973eb25b05f267371dcb2c2f491d17d990393f6b885b89a954a4ef'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.