### PR TITLE
Update electron-fiddle to 0.4.2

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.4.1'
-  sha256 '0cbca2c942118e0a4cbb128551948f32e34881096376b242e8657270e5abb615'
+  version '0.4.2'
+  sha256 '9e51744d4612a2fcde059b741514ab0551724dd19e676de8321f6471d3f27262'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/electron-fiddle-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.