### PR TITLE
Update polar-bookshelf to 1.8.0

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.7.0'
-  sha256 'f4365799b9ddf011284544d23d65aa515a983f696baf832f96413cfdadac857f'
+  version '1.8.0'
+  sha256 'b848996b0bab11b9dd1be5e00351b9ab1eefcca99b2e2365b8f4007a4692beb0'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.