### PR TITLE
Update ticktick to 2.9.01,88

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.9.00,87'
-  sha256 'b9546c747a57000fd2a2173a31357afb4b4b146a2df6bc9aedc86604e7f4476e'
+  version '2.9.01,88'
+  sha256 'c8e62cde27f9c5a164b288c61cbc5284f8b4594b41378ed721f81626c086389b'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.