### PR TITLE
Update djv to 1.2.5

### DIFF
--- a/Casks/djv.rb
+++ b/Casks/djv.rb
@@ -1,12 +1,12 @@
 cask 'djv' do
-  version '1.1.0'
-  sha256 'b922fc5d94e57d436779aa912d3f07746f541124149d5f4d8198d4ef0e2e8fd5'
+  version '1.2.5'
+  sha256 '29c148722d7a6e5a0e37b26faf07e876988ce4d6a74b7c89e174f9738930786c'
 
   # downloads.sourceforge.net/djv was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/djv/djv-stable/#{version}/djv-#{version}-OSX-64.dmg"
+  url "https://downloads.sourceforge.net/djv/djv-stable/#{version}/DJV-#{version}-Darwin.dmg"
   appcast 'https://sourceforge.net/projects/djv/rss?path=/djv-stable'
   name 'DJV Imaging'
   homepage 'https://djv.sourceforge.io/'
 
-  app "djv-#{version}-OSX-64.app"
+  app 'DJV.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.