### PR TITLE
Update inkdrop to 3.24.0

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,6 +1,6 @@
 cask 'inkdrop' do
-  version '3.23.2'
-  sha256 'd669516456acb20bd70d6bb5e651e373b8aeed1d023f65c9850a1da358934cc1'
+  version '3.24.0'
+  sha256 'fa32d5f7fb8f0ae63568ff139415f1e6be08b51001281d9216cd7bb537d33558'
 
   # d3ip0rje8grhnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-Mac.zip"

--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.2.7'
-  sha256 'c4bfe91b03052518bd4aa782403b9e05dae8b9b1d6a43dd262c8d7d3c3e11e85'
+  version '1.3.0'
+  sha256 '5abf31f1fef97854fb3543be3d0ef731495d9fab251600a0a1637c903043c75d'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"

--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.3.0'
-  sha256 '5abf31f1fef97854fb3543be3d0ef731495d9fab251600a0a1637c903043c75d'
+  version '1.2.7'
+  sha256 'c4bfe91b03052518bd4aa782403b9e05dae8b9b1d6a43dd262c8d7d3c3e11e85'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.