### PR TITLE
Update qfinder-pro to 2.6.1.0104

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,6 +1,6 @@
 cask 'qfinder-pro' do
-  version '2.6.0.0214A'
-  sha256 '545fa6703a1676e3dc6d0d01ec32de1f9a1abdf2299dd4c2c712bf97dc75051e'
+  version '2.6.1.0104'
+  sha256 '375575d39e63744ad44267e0683b3e17cdcc73227922e2473618a63c3c1b70f2'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'https://update.qnap.com/SoftwareRelease.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.