### PR TITLE
Update cycling74-max to 8.0.3_190108

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '8.0.2_181127'
-  sha256 'ddc254ccc3e8cfedc13d165fe68763b2521fd6d680c6804e9cde1b1aa155c23e'
+  version '8.0.3_190108'
+  sha256 '3e500e1cccdaa2319baa5edec26a8b92642a08587abee073595872531d292ea6'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.