### PR TITLE
Update subutaip2p to 8.3.1

### DIFF
--- a/Casks/subutaip2p.rb
+++ b/Casks/subutaip2p.rb
@@ -1,6 +1,6 @@
 cask 'subutaip2p' do
-  version '8.3.0'
-  sha256 '18081d46b8157160241691c331c1fa8f4e734670ae3c14575e72910b6caf5365'
+  version '8.3.1'
+  sha256 '54988ea144a31d17b6b5e690a1cc40777a123282563293c17bc49b37029276c2'
 
   # cdn.subutai.io:8338/kurjun/rest/raw was verified as official when first introduced to the cask
   url 'https://bazaar.subutai.io/rest/v1/cdn/raw?name=subutai-p2p.pkg&latest&download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.