### PR TITLE
Update navicat-for-sql-server to 12.1.15

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.12'
-  sha256 '6c1d240d87435778e9032697f37243e6dea7dc07ff5b4b15b4e05e3002afea36'
+  version '12.1.15'
+  sha256 'c8b2de0729e236f11d261f2e3dfb356098ca32fedb87f1767ae44f7e4270d310'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.