### PR TITLE
Update navicat-for-sqlite to 12.1.15

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.12'
-  sha256 'd12a2d0c5af4144540d0896bd4fb1c30f70fe28e10c5c7618ff7f15857c5e345'
+  version '12.1.15'
+  sha256 '56a80d8488f65d79f89050308ced54457317e528436afb53a83aa76d865eb1da'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.