### PR TITLE
Update glyphs to 2.6.1,1200

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.1,1197'
-  sha256 '8ddfadadcc6fa195202abd3030be0d585406861a0f1756732f07fd148a6331f6'
+  version '2.6.1,1200'
+  sha256 'b6e684667439c16d89f79318ba4880880732cf8acaa8d81c3e7ff160d5dbad9f'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.