### PR TITLE
Update command-tab-plus to 1.83,309:1547123484

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.71,301:1537276303'
-  sha256 '9ce1e0408ca910a18fb077c20519729fd84aeee259312927907679688d8c8ceb'
+  version '1.83,309:1547123484'
+  sha256 '6d663ab07ff915a0ab38ad4e57e8d426a2558bb8bff28f78fb8555b9a90e4e13'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.