### PR TITLE
Update prepros to 6.3.0

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,9 +1,9 @@
 cask 'prepros' do
-  version '6.2.3'
-  sha256 'deda79eccb33814513569438a222b3682328a3ac074de242b16188034360d6b7'
+  version '6.3.0'
+  sha256 '575ea35fbcbf55a421b44e9812558b88384dffc7345fa94e77e2947c90ae5fff'
 
-  # s3-us-west-2.amazonaws.com/prepros-io-releases was verified as official when first introduced to the cask
-  url "https://s3-us-west-2.amazonaws.com/prepros-io-releases/stable/Prepros-Mac-#{version}.zip"
+  # prepros-6.nyc3.cdn.digitaloceanspaces.com was verified as official when first introduced to the cask
+  url "https://prepros-6.nyc3.cdn.digitaloceanspaces.com/stable/Prepros-Mac-#{version}.zip"
   appcast 'https://prepros.io/changelog'
   name 'Prepros'
   homepage 'https://prepros.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.