### PR TITLE
Update hexels to 3.1.5

### DIFF
--- a/Casks/hexels.rb
+++ b/Casks/hexels.rb
@@ -1,6 +1,6 @@
 cask 'hexels' do
-  version '3.1.4'
-  sha256 'b2e180a6b6d2606055ca0868d3e4af9228b87e34af3f5e340a2d9b4178925c7a'
+  version '3.1.5'
+  sha256 '65ae3d445036588100ef82fb077a72ca7b2afd4752ca7d1e1b43a28ea1da8023'
 
   # s3.amazonaws.com/mset/download/release was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/mset/download/release/hexels_install_#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.