### PR TITLE
Update tikzit to 2.1.1

### DIFF
--- a/Casks/tikzit.rb
+++ b/Casks/tikzit.rb
@@ -1,12 +1,14 @@
 cask 'tikzit' do
-  version '2.1'
-  sha256 '3b5ec458e6e50d5689124afc35a0cfc08d672ac7bc508037dfaccff082a8820e'
+  version '2.1.1'
+  sha256 '49a00c97e3c4fa48b62e04012b5b91daf998d2677daab1e5c51caaf164791a9f'
 
   # github.com/tikzit/tikzit was verified as official when first introduced to the cask
   url "https://github.com/tikzit/tikzit/releases/download/v#{version}/tikzit-osx.dmg"
   appcast 'https://github.com/tikzit/tikzit/releases.atom'
   name 'TikZiT'
   homepage 'https://tikzit.github.io/'
+
+  depends_on macos: '>= :sierra'
 
   app 'TikZiT.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.