### PR TITLE
Update mucommander to 0.9.3,3

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -9,8 +9,4 @@ cask 'mucommander' do
   homepage 'https://www.mucommander.com/'
 
   app 'muCommander.app'
-
-  caveats do
-    depends_on_java '8'
-  end
 end

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,6 +1,6 @@
 cask 'mucommander' do
-  version '0.9.3,2'
-  sha256 '2c5a16c5fff6d32763e901b32310a4e4e5e3cfc647b668e111a13197ed4be81c'
+  version '0.9.3,3'
+  sha256 '0d996b2d0351a167c4445cf0a01c857c7b972cd2f809bb6fe580bf8af1994257'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version.before_comma}-#{version.after_comma}/mucommander-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.