### PR TITLE
Update ff-works.rb to prevent download failure (does not depend on version).

### DIFF
--- a/Casks/ff-works.rb
+++ b/Casks/ff-works.rb
@@ -2,7 +2,7 @@ cask 'ff-works' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.ffworks.net/ffWorks.dmg?forcedownload'
+  url 'https://www.ffworks.net/ffWorks.dmg'
   name 'ff·Works'
   homepage 'https://www.ffworks.net/'
 


### PR DESCRIPTION
The existing version of ff-works.rb fails repeatably as follows:

curl: (56) Unexpected EOF
Error: Download failed on Cask 'ff-works' with message: Download failed: https://www.ffworks.net/ffWorks.dmg?forcedownload

The proposed change prevents this.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
