### PR TITLE
Update geotag to 4.4.3

### DIFF
--- a/Casks/geotag.rb
+++ b/Casks/geotag.rb
@@ -1,6 +1,6 @@
 cask 'geotag' do
-  version '4.4.2'
-  sha256 'f2a6716dc1698033611d2ba675fd0df334a669d9d71f867146f8eefa4e484fe2'
+  version '4.4.3'
+  sha256 'df2ada19189a768109279542a6dd6007ac2f0f5856080cdaeefd2c08ee228398'
 
   url "https://www.snafu.org/GeoTag/GeoTag-#{version}.dmg"
   appcast 'https://www.snafu.org/GeoTag/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.