### PR TITLE
Update typora to 0.9.9.20.3

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.20.1'
-  sha256 'cca40dbe3f369b92c050e2b56cca9f926bbbcac1b2717acb2ca8851a686bc972'
+  version '0.9.9.20.3'
+  sha256 '2bb17aaf38e18e56894d596b545c7c656086c42bcd31e02ee58d9e1cdfb01d9a'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.