### PR TITLE
Update electorrent to 2.5.2

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,6 +1,6 @@
 cask 'electorrent' do
-  version '2.5.1'
-  sha256 '0aad8a012c3bffb0e1ecf1a339206b36e84de15dcb7f36ca7a33ce649fd45efb'
+  version '2.5.2'
+  sha256 'e7d08a0c4723986e974bcd1bc9e11468f0f916a7b589465bfdf6cbe10809e00f'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.