### PR TITLE
Update quip to 5.4.33

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.4.24'
-  sha256 '9cdaabd92eb2ae8a071cebff9dd916847b74595387722abb3e79c25077ca1330'
+  version '5.4.33'
+  sha256 '27d073d47d2d47b9496b6437649ae5cbccd0368d13f7d96c695ca436fc098574'
 
   # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.