### PR TITLE
Update macmediakeyforwarder to 2.3

### DIFF
--- a/Casks/macmediakeyforwarder.rb
+++ b/Casks/macmediakeyforwarder.rb
@@ -1,6 +1,6 @@
 cask 'macmediakeyforwarder' do
-  version '2.2'
-  sha256 'e9b2644ee4e7ebcbe2f1240143997a4c1f3c1c274125f1260da716a4ac3b78e2'
+  version '2.3'
+  sha256 'ce50a9b41928421a2fc56ae28fdd6c5c42757d69bd900bc0419a1599decb1d55'
 
   url "http://milgra.com/downloads/mmkf/MacMediaKeyForwarder#{version}.zip"
   name 'Mac Media Key Forwarder'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.