### PR TITLE
Update rocket-chat to 2.14.7

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask 'rocket-chat' do
-  version '2.14.6'
-  sha256 'f71cfa91a652ba83e67211078c766ba2ac0e12ac65d5d00d7980c3331b3ffaf9'
+  version '2.14.7'
+  sha256 '8bfbd004e0afd02954868d856dec189c08df23ac327aabfb8507a4d830107a11'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.