### PR TITLE
Update chatty to 0.9.4

### DIFF
--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -1,6 +1,6 @@
 cask 'chatty' do
-  version '0.9.3'
-  sha256 'f99c14bc5914e9c623652f5f834c93c5982724739964f7039218c2d6adeaf8f5'
+  version '0.9.4'
+  sha256 '5172ff7cf7bf37e3c78b9a01f57782152649038d44d5e632695ccd87ca61154f'
 
   # github.com/chatty/chatty was verified as official when first introduced to the cask
   url "https://github.com/chatty/chatty/releases/download/v#{version}/Chatty_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.