### PR TITLE
Update seashore to 2.1.9

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.1.8'
-  sha256 '9b0531d900603f7476397e1cdca2cbb278d3cb6181021a15d2212d3703b6328a'
+  version '2.1.9'
+  sha256 '9d8e2ed821845763a6fdb08aecda025de3bc2a660047130b0d25876d4014d542'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.