### PR TITLE
Update paraview to 5.6.0

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,6 +1,6 @@
 cask 'paraview' do
   version '5.6.0'
-  sha256 '711ccfe071f32ee60b41b22c42e98193ccc336d89105c3786ac729e6951c4836'
+  sha256 '7e326051fec9b83a3144bae8a0b99cdf00d00d04022a1723a3c97be5a7f33576'
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.8-64bit.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.