### PR TITLE
Update mudlet to 3.16.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -7,5 +7,7 @@ cask 'mudlet' do
   name 'Mudlet'
   homepage 'https://www.mudlet.org/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Mudlet.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.