### PR TITLE
Update devonthink-pro to 2.11.2

### DIFF
--- a/Casks/devonthink-pro.rb
+++ b/Casks/devonthink-pro.rb
@@ -1,6 +1,6 @@
 cask 'devonthink-pro' do
-  version '2.11.1'
-  sha256 'ef25a37620fc42218a4c7a86a4d44cb418877f1bdc5ebfb73d17aa0745c40f4b'
+  version '2.11.2'
+  sha256 '49e171a1efcd4cad47f36a858a6920f332e761eb8fb2b307da8e168975c4e3ae'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.