### PR TITLE
Update tusk to 0.18.0

### DIFF
--- a/Casks/tusk.rb
+++ b/Casks/tusk.rb
@@ -1,6 +1,6 @@
 cask 'tusk' do
-  version '0.17.0'
-  sha256 '239920d257faf9092b05d0a98b3720abc9164437dd707eedeafb17a8d5dce2ff'
+  version '0.18.0'
+  sha256 '173d94e7d16780996d8dc7e78eb7fff3f19e0fc1e29f7d3866e26d44fdb5fc3c'
 
   # github.com/klaussinani/tusk was verified as official when first introduced to the cask
   url "https://github.com/klaussinani/tusk/releases/download/v#{version}/Tusk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.