### PR TITLE
Update omniplan to 3.10.4

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,6 +1,6 @@
 cask 'omniplan' do
-  version '3.10.3'
-  sha256 '8d541bacffc4594d5a2994173113e86def1e9ae84128eb4c34b5de489ad8f662'
+  version '3.10.4'
+  sha256 'a30728e72ae970dbf37b2ef9942a6b54267aa3456288dcc1815f20b44667e9e5'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniPlan#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.