### PR TITLE
Update mycrypto to 1.5.5

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.5.4'
-  sha256 '9a97672470ef3fffc12540a77010812724c2b0b281aa5ef39b3bc9c73a7c7843'
+  version '1.5.5'
+  sha256 'e45bcf6fc82e6376eb6f2bab98eef0e94548deca5b97d9848bb9cefe0806e34b'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.