### PR TITLE
Update qownnotes to 19.1.3,b4067-192406

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.1.2,b4056-192034'
-  sha256 '6482c142aa68d459bde11fbd53ec5242d2b1c20af46a6d2d46160c7ae29a6586'
+  version '19.1.3,b4067-192406'
+  sha256 '49429583a351ece6621dd804fc2b92b5a14fab60f107e0ce43a92c43893e4cd5'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.