### PR TITLE
Update tikzit to 2.1.2

### DIFF
--- a/Casks/tikzit.rb
+++ b/Casks/tikzit.rb
@@ -1,6 +1,6 @@
 cask 'tikzit' do
-  version '2.1.1'
-  sha256 '49a00c97e3c4fa48b62e04012b5b91daf998d2677daab1e5c51caaf164791a9f'
+  version '2.1.2'
+  sha256 '75b079085a686a7254abb381294f7d04c0a8ac12c0aca0cc5562b79103bc3819'
 
   # github.com/tikzit/tikzit was verified as official when first introduced to the cask
   url "https://github.com/tikzit/tikzit/releases/download/v#{version}/tikzit-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.