### PR TITLE
Update tribler to 7.1.5

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,9 +1,9 @@
 cask 'tribler' do
-  version '7.1.3'
-  sha256 '49d0cbfc96e28f71fe413097ac834c8fbe581c46a89d6b677176bb7ab63b355d'
+  version '7.1.5'
+  sha256 '81f4cd57cd23736e9705da022adcf4582f84ec6e6b594a58a7543be310502c01'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
-  url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
+  url "https://github.com/Tribler/tribler/releases/download/V#{version}/Tribler-#{version}.dmg"
   appcast 'https://github.com/Tribler/tribler/releases.atom'
   name 'Tribler'
   homepage 'https://www.tribler.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.