### PR TITLE
Update lehreroffice-zusatz to 2019.1.0

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice-zusatz' do
-  version '2018.17.1'
-  sha256 '57bd12c220c8f7a46611fc5c8e2caa4eb999cc00476b27c6458b01d2c5976a64'
+  version '2019.1.0'
+  sha256 '54a72f96396a4e741b908c26d97b5f4b0962a5e28ab1dc518bb1cf5c4fae2a0f'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.