### PR TITLE
Update datovka to 4.12.0

### DIFF
--- a/Casks/datovka.rb
+++ b/Casks/datovka.rb
@@ -1,6 +1,6 @@
 cask 'datovka' do
-  version '4.11.1'
-  sha256 '568337b3555a079b4cd62f19b48a771da42777789fcaada5ba0878f0a0cc69ba'
+  version '4.12.0'
+  sha256 '9ed4473b4e7c0c999e537723bde27b8ae43fedd65b96f30d16e3b01bed82b6e4'
 
   # secure.nic.cz/files/datove_schranky was verified as official when first introduced to the cask
   url "https://secure.nic.cz/files/datove_schranky/#{version}/datovka-#{version}-64bit-osx10.7.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.