### PR TITLE
Update powershell.rb for PowerShell Core 6.1.2

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -1,6 +1,6 @@
 cask 'powershell' do
-  version '6.1.1'
-  sha256 'bcaa357fb472b688ecd3fc3472d360c1eb58e43afe9b083d7c8c76c36fded4b9'
+  version '6.1.2'
+  sha256 '23e90dbfd00bf1b4c82dfef0fbdda7aa1b2ce5c544fca0d1cdef657ef7398689'
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
   appcast 'https://github.com/PowerShell/PowerShell/releases.atom'


### PR DESCRIPTION
Update PowerShell Core to 6.1.2

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I have not checked the two brew commands as I have not done this on my Mac and am not familiar with this, however based on file history I am confident this is correct.