### PR TITLE
Update freefilesync to 10.8

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
-  version '10.7'
-  sha256 '135a3034e7e49fc28cd865f0c8a4bf4ad0fc49509e05de21d4423c478011302b'
+  version '10.8'
+  sha256 '23d7ed08e029fb7c4d3bee9685c473652536d75739365cc73b30bb15fc091fc1'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '10.8'
-  sha256 '23d7ed08e029fb7c4d3bee9685c473652536d75739365cc73b30bb15fc091fc1'
+  sha256 '38a3a50444deaf560358161deb52c5e6287771a0f9501b06fba7994c164e82cd'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '10.8'
-  sha256 '38a3a50444deaf560358161deb52c5e6287771a0f9501b06fba7994c164e82cd'
+  sha256 '23d7ed08e029fb7c4d3bee9685c473652536d75739365cc73b30bb15fc091fc1'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -4,7 +4,7 @@ cask 'freefilesync' do
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake,
-      referer: 'https://freefilesync.org/download.php'
+      referer:    'https://freefilesync.org/download.php'
   name 'FreeFileSync'
   homepage 'https://www.freefilesync.org/'
 

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,6 +1,6 @@
 cask 'freefilesync' do
   version '10.8'
-  sha256 '38a3a50444deaf560358161deb52c5e6287771a0f9501b06fba7994c164e82cd'
+  sha256 '23d7ed08e029fb7c4d3bee9685c473652536d75739365cc73b30bb15fc091fc1'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake,

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -3,7 +3,7 @@ cask 'freefilesync' do
   sha256 '38a3a50444deaf560358161deb52c5e6287771a0f9501b06fba7994c164e82cd'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
-      user_agent: :fake
+      referer: 'https://freefilesync.org/download.php'
   name 'FreeFileSync'
   homepage 'https://www.freefilesync.org/'
 

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -3,6 +3,7 @@ cask 'freefilesync' do
   sha256 '38a3a50444deaf560358161deb52c5e6287771a0f9501b06fba7994c164e82cd'
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
+      user_agent: :fake,
       referer: 'https://freefilesync.org/download.php'
   name 'FreeFileSync'
   homepage 'https://www.freefilesync.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.