### PR TITLE
Update dabble to 1.0.100

### DIFF
--- a/Casks/dabble.rb
+++ b/Casks/dabble.rb
@@ -1,6 +1,6 @@
 cask 'dabble' do
-  version '1.0.15'
-  sha256 '7db6b85083a33c9da72ec5ed459585de763db5c79b05bdea5b804cc7b22bc27b'
+  version '1.0.100'
+  sha256 'e48f70b7caed4360f63a3d35db17aa6eadacebda52370a163d955499fb0f3480'
 
   url "https://www.dabblewriter.com/releases/mac/downloads/Dabble-#{version}.dmg"
   name 'Dabble'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.