### PR TITLE
Update musixmatch to 0.21.21

### DIFF
--- a/Casks/musixmatch.rb
+++ b/Casks/musixmatch.rb
@@ -1,6 +1,6 @@
 cask 'musixmatch' do
-  version '0.21.20'
-  sha256 '87e706b648cac5ad10340178838e20dc6d5a539ad26c3319df8ce289667dd75d'
+  version '0.21.21'
+  sha256 '6c72699837737c25a5c32bf424764a0b005ddcbf10777c8556f757a13862f256'
 
   url "https://download-app.musixmatch.com/download/Musixmatch-#{version}.dmg"
   name 'Musixmatch'

--- a/Casks/musixmatch.rb
+++ b/Casks/musixmatch.rb
@@ -1,6 +1,6 @@
 cask 'musixmatch' do
-  version '0.21.13'
-  sha256 'b5c65f63a9c2a7cc52938ec202c489b116255995c5625382f4b5ed45ef20e77f'
+  version '0.21.20'
+  sha256 '87e706b648cac5ad10340178838e20dc6d5a539ad26c3319df8ce289667dd75d'
 
   url "https://download-app.musixmatch.com/download/Musixmatch-#{version}.dmg"
   name 'Musixmatch'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.