### PR TITLE
Update devonthink-pro-office to 2.11.2

### DIFF
--- a/Casks/devonthink-pro-office.rb
+++ b/Casks/devonthink-pro-office.rb
@@ -1,6 +1,6 @@
 cask 'devonthink-pro-office' do
-  version '2.11.1'
-  sha256 '4b92086532bf3996d36073b2f989ca2cc7e95f05db35a7e15fc034413224c6e1'
+  version '2.11.2'
+  sha256 '083ae8094656229c72ddf76278837832ff471ee9c8485351142522c4f9a3d224'
 
   # amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_Pro_Office.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.