### PR TITLE
Update mu-editor to 1.0.2

### DIFF
--- a/Casks/mu-editor.rb
+++ b/Casks/mu-editor.rb
@@ -1,9 +1,9 @@
 cask 'mu-editor' do
-  version '1.0.0'
-  sha256 '1140ad93023bbaa858d2c48e4c32e9ccaf16b3d2aa77dfe31c1d852a1e9da191'
+  version '1.0.2'
+  sha256 'd0be1d6268cff60f65947280f1d0f2b05b28e67c07ee4c7dd3773a195a3d2f71'
 
   # github.com/mu-editor/mu was verified as official when first introduced to the cask
-  url "https://github.com/mu-editor/mu/releases/download/v#{version}/mu-editor_#{version.major_minor}_osx.dmg"
+  url "https://github.com/mu-editor/mu/releases/download/#{version}/mu-editor_#{version}_osx.dmg"
   appcast 'https://github.com/mu-editor/mu/releases.atom'
   name 'Mu'
   homepage 'https://codewith.mu/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.