### PR TITLE
Update tropy to 1.4.0

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.3.2'
-  sha256 'f9687c86fdf5954890d97e0384d954b10db06f675da33eba706ef64f61242a8c'
+  version '1.4.0'
+  sha256 'f440af13f7215bdaf4ba927aface680c8d99e8d82d58aa904d16e51a0d52ec8b'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.