### PR TITLE
Update wechatwebdevtools to 1.02.1901170

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1812271'
-  sha256 '55cf3dc63fdf58574c0aa5ef9c05d8073794279666b0826b478e82229a532d20'
+  version '1.02.1901170'
+  sha256 '5706973c003b3dca3ac3109a0b4c4f62b4340e284db3a54c01211af13f7619c1'
 
-  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.0.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
+  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.2.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'
   name '微信web开发者工具'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.