### PR TITLE
Update downie to 3.5.8,1934

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.5.7,1931'
-  sha256 '35823e678170713cf2aa1e6e43ec863923517180e0fac2490c84eea8fd589de5'
+  version '3.5.8,1934'
+  sha256 'a7258d51f60f972b4d898026998611d2e8293fd1eb9be1c26733c2487ed34bd1'
 
   url "https://trial.charliemonroe.net/downie/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.