### PR TITLE
Update sonic-visualiser to 3.2.1,2435

### DIFF
--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -1,6 +1,6 @@
 cask 'sonic-visualiser' do
-  version '3.2,2422'
-  sha256 'a168e142dfbff5ee78e3c8246dac4751243f407f0131b426a62bbc61903c4442'
+  version '3.2.1,2435'
+  sha256 'e1d61769ac29db8d9644b2efe23df9f40a182783678ddca1626f0bc39c54acc5'
 
   # code.soundsoftware.ac.uk was verified as official when first introduced to the cask
   url "https://code.soundsoftware.ac.uk/attachments/download/#{version.after_comma}/Sonic%20Visualiser-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.