### PR TITLE
Update drafts to 5.6.1.2

### DIFF
--- a/Casks/drafts.rb
+++ b/Casks/drafts.rb
@@ -1,6 +1,6 @@
 cask 'drafts' do
-  version '5.6.1.1'
-  sha256 '0c83e42005bd533432df167d4ba0d8c20eb264ea354d679eb8f2e40a66fff0a7'
+  version '5.6.1.2'
+  sha256 '1c2731111704e90dc4f473d89eecd4fdf5a7289cf44d2daee54a67031c26f33c'
 
   # s3-us-west-2.amazonaws.com/downloads.agiletortoise.com was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/downloads.agiletortoise.com/Drafts.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.