### PR TITLE
istat-menus: New download URL

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -2,7 +2,7 @@ cask 'istat-menus' do
   version '6.31'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://file.bjango.com/istatmenus#{version.major}/istatmenus#{version}.zip"
+  url "https://files.bjango.com/istatmenus#{version.major}/istatmenus#{version}.zip"
   name 'iStats Menus'
   homepage 'https://bjango.com/mac/istatmenus/'
 


### PR DESCRIPTION
```cask reinstall istat-menus --force
==> Satisfying dependencies
==> Downloading https://file.bjango.com/istatmenus6/istatmenus6.31.zip

curl: (6) Could not resolve host: file.bjango.com
Error: Download failed on Cask 'istat-menus' with message: Download failed: https://file.bjango.com/istatmenus6/istatmenus6.31.zip
```
Going to their [home page](https://bjango.com/mac/istatmenus/) and clicking "Download", it appears they've changed the URL from "file" to "files".
<hr/>
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).