### PR TITLE
Update istat-menus to 6.31

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -2,7 +2,7 @@ cask 'istat-menus' do
   version '6.31'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://file.bjango.com/istatmenus#{version.major}/istatmenus#{version}.zip"
+  url "https://files.bjango.com/istatmenus#{version.major}/istatmenus#{version}.zip"
   name 'iStats Menus'
   homepage 'https://bjango.com/mac/istatmenus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.