### PR TITLE
Update onlyoffice to 5.2.1

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,6 +1,6 @@
 cask 'onlyoffice' do
-  version '5.2'
-  sha256 '66c60ebf5c478845eea37df68d15a1b903c16fc34ebffec4d533aed3ebde266e'
+  version '5.2.1'
+  sha256 'e6586f3385fad1574b35a0bc2f5fd4fc7efc2a7348eda1c6ebcd129b24fd139f'
 
   url "https://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'https://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.