### PR TITLE
Update manager to 19.1.18

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.16'
-  sha256 '1246464a4c5a93221cfcf8948347fce93ac0a4d82feee3123b76d7a25b1690fb'
+  version '19.1.18'
+  sha256 'bd62a7acacb8b5956bc5d7d1c2e2a37f24c1435c669dd27a30437ddc6416a41a'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.