### PR TITLE
meld: switch to shim script

### DIFF
--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -9,7 +9,16 @@ cask 'meld' do
   homepage 'https://yousseb.github.io/meld/'
 
   app 'Meld.app'
-  binary "#{appdir}/Meld.app/Contents/MacOS/Meld", target: 'meld'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/meld.wrapper.sh"
+  binary shimscript, target: 'meld'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/Meld.app/Contents/MacOS/Meld' "$@"
+    EOS
+  end
 
   zap trash: '~/Library/Preferences/org.gnome.meld.plist'
 end


### PR DESCRIPTION
fixes #57154
(py2app linking issue where it can't find the python runtime)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The commit message includes name but not version because it is not a version update.

Additionally, if **adding a new cask**:   _not a new cask_
