### PR TITLE
Update lightsoff to 1.0.6

### DIFF
--- a/Casks/lightsoff.rb
+++ b/Casks/lightsoff.rb
@@ -7,5 +7,7 @@ cask 'lightsoff' do
   name 'LightsOff'
   homepage 'https://www.lightsoff-app.com/'
 
+  depends_on macos: '>= :mojave'
+
   app 'LightsOff.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.