### PR TITLE
Update megasync to 4.0.1.0

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -1,5 +1,5 @@
 cask 'megasync' do
-  version '4.0.0.0'
+  version '4.0.1.0'
   sha256 '7e58892995d7f9a7ba7365c476ce5c804a8d4557cbd840052b6be73ded7c473a'
 
   url 'https://mega.nz/MEGAsyncSetup.dmg'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

PR #57615 has changed sha256sum but not changed version... With a repackaged dmg, the version has bumped to 4.0.1, and github release changes one day later.