### PR TITLE
Update media-center to 24.00.72

### DIFF
--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -1,6 +1,6 @@
 cask 'media-center' do
-  version '24.00.69'
-  sha256 '71bdd4a45c2d88f88fa2be776ab1a4fdb8eb16ac28c11483a5b0ec3c28e6b4e9'
+  version '24.00.72'
+  sha256 '7b017f4cf6a4c5541aece3add1578b439e62f604c79294a10c5947f4d40f060b'
 
   url "https://files.jriver.com/mediacenter/channels/v#{version.major}/stable/MediaCenter#{version.no_dots}.dmg"
   name 'JRiver Media Center'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.