### PR TITLE
Update go2shell to 2.5

### DIFF
--- a/Casks/go2shell.rb
+++ b/Casks/go2shell.rb
@@ -1,6 +1,6 @@
 cask 'go2shell' do
-  version '2.3'
-  sha256 '8cdfbe43a9e0a6728cb2bc5f74bdf0c4087e6d033b829acb68cb5ceaddda44a3'
+  version '2.5'
+  sha256 '815222856b39a60af60fa07b75d478ce5f3c6a037a76bab989f7f2f7fbbaba06'
 
   url 'https://zipzapmac.com/download/Go2Shell'
   appcast 'http://appcast.zipzapmac.com/go2shell.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.