### PR TITLE
Update ao to 6.7.0

### DIFF
--- a/Casks/ao.rb
+++ b/Casks/ao.rb
@@ -1,6 +1,6 @@
 cask 'ao' do
-  version '6.6.0'
-  sha256 'ec46e9ee8eb164722af9815a0b2c3677259c41985b70c275b29e8d323c1b6108'
+  version '6.7.0'
+  sha256 '718b147b2274c24ea972a33ce6675290607a755ea4956c484d8716ca57a56eac'
 
   url "https://github.com/klaussinani/ao/releases/download/v#{version}/Ao-#{version}.dmg"
   appcast 'https://github.com/klaussinani/ao/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.