### PR TITLE
Update clashx to 1.8.4

### DIFF
--- a/Casks/clashx.rb
+++ b/Casks/clashx.rb
@@ -1,6 +1,6 @@
 cask 'clashx' do
-  version '1.8.2'
-  sha256 'e8a87106f3c95a79f911beed11edd5ca0be18e38f54a78426392eb6d219940f0'
+  version '1.8.4'
+  sha256 '4e3bddb644eacc953954c09aec7e3b84e55b80dc3bdd97a6c0752638505a1e29'
 
   url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   appcast 'https://github.com/yichengchen/clashX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.