### PR TITLE
Update keeweb to 1.7.4

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.7.3'
-  sha256 '4d0a5143ddba3c909f2f896df3e3a9c33db78541bc055544d2bad2d9dfbf77ef'
+  version '1.7.4'
+  sha256 '2eb4e252400f6727ca1c61c816f6cf970c574fec727374992ebfc31904f93c8a'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.