### PR TITLE
Update psychopy to 3.0.2

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '3.0.0'
-  sha256 'a7d5c616023b888928816fb3418cfd93a38d005ff9e1e10bdb3d650aedd3773d'
+  version '3.0.2'
+  sha256 '121c5e80a24eb9fcd57f5b8e6b2a4a512a7da866f5b66cea01ca7c434ac77301'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.