### PR TITLE
Update tusk to 0.20.0

### DIFF
--- a/Casks/tusk.rb
+++ b/Casks/tusk.rb
@@ -1,6 +1,6 @@
 cask 'tusk' do
-  version '0.19.0'
-  sha256 '7a7728e998d7a3d3dfef378f2fbddd2b2a92bdc49325183e8aa97e3a0c3b835c'
+  version '0.20.0'
+  sha256 '560956fd89af5f738a1aee2193acb1f59904b2f3f32eb8e65ee0f500aa3e60c2'
 
   # github.com/klaussinani/tusk was verified as official when first introduced to the cask
   url "https://github.com/klaussinani/tusk/releases/download/v#{version}/Tusk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.