### PR TITLE
Update tagspaces to 3.0.5

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask 'tagspaces' do
-  version '3.0.1'
-  sha256 'e736ef1137c72d226eeead5190c35a32ad6272d7f07fa2fcc4633fdb4815f207'
+  version '3.0.5'
+  sha256 'd1b53b094701cba12543d0cae19b377d7a7f6736079739f76aaa8e0121baedf8'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.