### PR TITLE
Update kate to 18.12.0-342

### DIFF
--- a/Casks/kate.rb
+++ b/Casks/kate.rb
@@ -1,6 +1,6 @@
 cask 'kate' do
-  version '18.12.0-333'
-  sha256 'ac4a09ad7f4f0fcfe82c7b041b4e1ae2a63f478047529580343c0b9808d6a9cd'
+  version '18.12.0-342'
+  sha256 'ae14ced199997a399148647abcbd9b12be8dec22a342a7f146006fb3970aec3d'
 
   # binary-factory.kde.org/view/MacOS/job/Kate_Release_macos was verified as official when first introduced to the cask
   url "https://binary-factory.kde.org/view/MacOS/job/Kate_Release_macos/lastSuccessfulBuild/artifact/kate-#{version}-macos-64-clang.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.