### PR TITLE
Update ghost-browser to 2.1.0.4

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.0.3'
-  sha256 'fb84349fe735087bc4a3f72f5d45b69c7c1a99bde68b6d365edaa8e507936b46'
+  version '2.1.0.4'
+  sha256 '992ef683b55d2d2e0f0eef52469b840e8ad6f318a5074137cd425263e669fc11'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.