### PR TITLE
Update wingide to 6.1.4-1

### DIFF
--- a/Casks/wingide.rb
+++ b/Casks/wingide.rb
@@ -1,6 +1,6 @@
 cask 'wingide' do
-  version '6.1.2-1'
-  sha256 'c5b6d5fa60ee046eb41f73a305763df5f50838b41a8c7d00a8f1ac9bbf8c8f2c'
+  version '6.1.4-1'
+  sha256 '7fd388da07bf506579bb038b18487c415ce5e5d181e2770ba11a2f5fedb98cad'
 
   url "https://wingware.com/pub/wingide/#{version.sub(%r{-\d+}, '')}/wingide-#{version}.dmg"
   name 'WingIDE'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.