### PR TITLE
Update ao to 6.8.0

### DIFF
--- a/Casks/ao.rb
+++ b/Casks/ao.rb
@@ -1,6 +1,6 @@
 cask 'ao' do
-  version '6.7.0'
-  sha256 '718b147b2274c24ea972a33ce6675290607a755ea4956c484d8716ca57a56eac'
+  version '6.8.0'
+  sha256 'b403a0cef2bf747876f0283b6484d5a3ac4603c8c8d4da63faa02194f9a1e3db'
 
   url "https://github.com/klaussinani/ao/releases/download/v#{version}/Ao-#{version}.dmg"
   appcast 'https://github.com/klaussinani/ao/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.