### PR TITLE
Update cool-retro-term to 1.1.1

### DIFF
--- a/Casks/cool-retro-term.rb
+++ b/Casks/cool-retro-term.rb
@@ -1,8 +1,8 @@
 cask 'cool-retro-term' do
-  version '1.0.1'
-  sha256 '1cddb173251290388cee2d24fc668585da03d3cb1f30123efd70c0500ba74b5a'
+  version '1.1.1'
+  sha256 '267732bc3b5b9fea0abeabfe5c7f54c055b5035dcaf834a0382a0e46e2000d90'
 
-  url "https://github.com/Swordfish90/cool-retro-term/releases/download/#{version}/cool-retro-term.dmg"
+  url "https://github.com/Swordfish90/cool-retro-term/releases/download/#{version}/Cool-Retro-Term-#{version}.dmg"
   appcast 'https://github.com/Swordfish90/cool-retro-term/releases.atom'
   name 'cool-retro-term'
   homepage 'https://github.com/Swordfish90/cool-retro-term'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.