### PR TITLE
Update neteasemusic to 2.0.0_696

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask 'neteasemusic' do
-  version '2.0.0_690'
-  sha256 '5fb73f29ee1cb377bc64edac5f4f00012e64b2f0bb88674f6bdc07f6c637caff'
+  version '2.0.0_696'
+  sha256 'c6dc7e77f2721cc3de14b336774fd97bfac2dea075f4954d03433cdbe0ca760c'
 
   # d1.music.126.net was verified as official when first introduced to the cask
   url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.