### PR TITLE
Update airflow to 2.3.15

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,6 +1,6 @@
 cask 'airflow' do
-  version '2.3.12'
-  sha256 'bfcd3f0e11afc35adc1910324adc28289769127c41ae32032d75449bcde0b844'
+  version '2.3.15'
+  sha256 'b9152b2173dcc0e18550717b57922104e08e5146254a4f6bfc32e40e5ea08231'
 
   # amazonaws.com/Airflow was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.