### PR TITLE
Update default-folder-x to 5.3.3

### DIFF
--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -1,6 +1,6 @@
 cask 'default-folder-x' do
-  version '5.3.2'
-  sha256 '96049e6cfdde60189fbbc6ef1add3579aa48f5a32f7058fcc5cfab97e99280e8'
+  version '5.3.3'
+  sha256 '1d8dfffcf272bc155db2d2da235a5fb05d1c682302f8da3ca6fccd2022766339'
 
   url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?DX5'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.