### PR TITLE
Update gzdoom to 3.7.2

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '3.7.1'
-  sha256 'a655507f3cbfc470620f1e89986088065afb53e2cb40a39dff4e16c45928f01a'
+  version '3.7.2'
+  sha256 'a8f7d7453e3b5926a0606098fbed3433af39176512298e6f9c654e9a27626477'
 
   url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.