### PR TITLE
Update qlab to 4.4.1

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,6 +1,6 @@
 cask 'qlab' do
-  version '4.3.3'
-  sha256 'de5f892c85565174176c24b4c4dd98da8caeee471b83ad771562559f037305ae'
+  version '4.4.1'
+  sha256 '52fb818786e263b221e6079c1ff97121911647df97a249bd9f6860e92b156684'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.