### PR TITLE
Update exodus to 19.1.18

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.1.5'
-  sha256 '730d63c4e767a33c3171bec57784f8130c9fe7dc323f524db76de5a5de17bc35'
+  version '19.1.18'
+  sha256 '1d84ee1b7e556fce726236d21a277767ab2917760cbbcaa25d378615b610ea69'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.