### PR TITLE
Update netron to 2.8.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.8.2'
-  sha256 'dcab72f0eb182ad7b5a7d1abcfc1df64b030b5a5ec1ae6fcf331cb8270764b54'
+  version '2.8.3'
+  sha256 '3ecba2a4243e30c87948baabffbb7a7979becbb3575bfdb4e456931ddf924fd3'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.