### PR TITLE
Update auryo to 2.3.3

### DIFF
--- a/Casks/auryo.rb
+++ b/Casks/auryo.rb
@@ -1,6 +1,6 @@
 cask 'auryo' do
-  version '2.3.0'
-  sha256 '0f184b44cb0ad363330873525760bfbb34d9204892f856c1eadb37ec9bc468e9'
+  version '2.3.3'
+  sha256 '31b7dc9e086eb54ee88ed8bda223833b0cb81c81481859514bc4635f674cad6d'
 
   # github.com/Superjo149/auryo was verified as official when first introduced to the cask
   url "https://github.com/Superjo149/auryo/releases/download/v#{version}/Auryo-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.