### PR TITLE
Update photo-supreme-single-user to 4.3.2,1901

### DIFF
--- a/Casks/photo-supreme-single-user.rb
+++ b/Casks/photo-supreme-single-user.rb
@@ -1,6 +1,6 @@
 cask 'photo-supreme-single-user' do
-  version '4.3.2,1878'
-  sha256 'e245c40e270bf0e252cfaffc96c6b8a999b7c82f0cfb43c3b748fc485006a98a'
+  version '4.3.2,1901'
+  sha256 '888aaf3e163264d23b04c029acdef1f0ada3058ac96045c8c3fc4a2ceba1c68a'
 
   url "https://trial.idimager.com/PhotoSupreme_V#{version.major}.pkg"
   name 'Photo Supreme Single User'

--- a/Casks/photo-supreme-single-user.rb
+++ b/Casks/photo-supreme-single-user.rb
@@ -1,12 +1,12 @@
 cask 'photo-supreme-single-user' do
-  version '4.3.2,1901'
-  sha256 '888aaf3e163264d23b04c029acdef1f0ada3058ac96045c8c3fc4a2ceba1c68a'
+  version '4'
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://trial.idimager.com/PhotoSupreme_V#{version.major}.pkg"
+  url "https://trial.idimager.com/PhotoSupreme_V#{version}.pkg"
   name 'Photo Supreme Single User'
   homepage 'https://www.idimager.com/home'
 
-  pkg "PhotoSupreme_V#{version.major}.pkg"
+  pkg "PhotoSupreme_V#{version}.pkg"
 
   uninstall pkgutil: 'com.idimager.idimagersu'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.