### PR TITLE
Update cutter to 1.7.4 and depends_on

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,12 +1,14 @@
 cask 'cutter' do
-  version '1.7.3'
-  sha256 'efc42b2a72f7f57ff66ee91d609a0fb1cc3b7ddeee64376344b81b919338f234'
+  version '1.7.4'
+  sha256 'b78e9e0236254a8fbeba6932ba1aebad23de738ec0b8a686c6c349abe706c698'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"
   appcast 'https://github.com/radareorg/cutter/releases.atom'
   name 'Cutter'
   homepage 'https://radare.org/cutter/'
+
+  depends_on macos: '>= :sierra'
 
   app 'Cutter.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.