### PR TITLE
Update kate to 18.12.0-345

### DIFF
--- a/Casks/kate.rb
+++ b/Casks/kate.rb
@@ -1,6 +1,6 @@
 cask 'kate' do
-  version '18.12.0-342'
-  sha256 'ae14ced199997a399148647abcbd9b12be8dec22a342a7f146006fb3970aec3d'
+  version '18.12.0-345'
+  sha256 '2c3ddb31f03c42b8bf85baae26e74db8b5743279a72b3078da6c557ac5514f93'
 
   # binary-factory.kde.org/view/MacOS/job/Kate_Release_macos was verified as official when first introduced to the cask
   url "https://binary-factory.kde.org/view/MacOS/job/Kate_Release_macos/lastSuccessfulBuild/artifact/kate-#{version}-macos-64-clang.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.