### PR TITLE
Update sip to 1.1.5

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -1,9 +1,9 @@
 cask 'sip' do
-  version '1.1.4'
+  version '1.1.5'
   sha256 'd6719ec395da812dc1e2cd349da8d6ca37cc13db11063b01312595b2081ab05d'
 
   url 'https://sipapp.io/download/sip.dmg'
-  appcast 'https://sipapp.io/sparkle/sip.xml'
+  appcast 'https://sipapp.io/updates/v1/sip.xml'
   name 'Sip'
   homepage 'https://sipapp.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.