### PR TITLE
Update lehreroffice-zusatz to 2019.1.1

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice-zusatz' do
-  version '2019.1.0'
-  sha256 '54a72f96396a4e741b908c26d97b5f4b0962a5e28ab1dc518bb1cf5c4fae2a0f'
+  version '2019.1.1'
+  sha256 'a95c1c8daf89043ff8d001aa9c244554ffdab598f763a6491bc03991daca6872'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.