### PR TITLE
Update exactscan to 18.12.24

### DIFF
--- a/Casks/exactscan.rb
+++ b/Casks/exactscan.rb
@@ -1,6 +1,6 @@
 cask 'exactscan' do
-  version '18.11.19'
-  sha256 'bed6d6adc41275b83085a054ca280dd5c8bdd3e636a9a586b6987cc0ced37fad'
+  version '18.12.24'
+  sha256 '490ebcf48b34b17eadfeb688e6a1fceaef2b87384a1fce9e91b3356591e2d69f'
 
   # dl.exactcode.com was verified as official when first introduced to the cask
   url "https://dl.exactcode.com/exactscan/ExactScan-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.