### PR TITLE
Update deeper to 2.3.3

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -17,8 +17,8 @@ cask 'deeper' do
     version '2.3.3'
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   else
-    version '2.3.9'
-    sha256 '76665d9c3bcc6257d087ad565e62e41f2444f05f0175f077d3586dd1aa8f19b7'
+    version '2.4.0'
+    sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.