### PR TITLE
Update get-iplayer-automator to 1.14.3.b20190121001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,6 +1,6 @@
 cask 'get-iplayer-automator' do
-  version '1.14.1.b20190102001'
-  sha256 '90d756c8f09fac89b33872a648fcef603a5d0e3c3d2718c482c1e50811db6905'
+  version '1.14.3.b20190121001'
+  sha256 'a43012955b3ea677b61cd53d9831855a90e4da2c2079d6db7510fe9b33d5a411'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.