### PR TITLE
Update wechatwebdevtools to 1.02.1901230

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1901170'
-  sha256 '5706973c003b3dca3ac3109a0b4c4f62b4340e284db3a54c01211af13f7619c1'
+  version '1.02.1901230'
+  sha256 '5018888c070a47bfc2fd85586c1c5905ac77f63a8c862f21befbc8b8dec9ab7a'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.2.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   name 'wechat web devtools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.