### PR TITLE
Update cctalk to 7.3.13.6

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -3,7 +3,7 @@ cask 'cctalk' do
   sha256 'dc9843fb069aa56a2dfa55a4283bb0f7a160cf26348e3f3df6a5f28d607a2e5c'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "http://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
+  url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
   appcast 'https://cc.hjfile.cn/mac/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask 'cctalk' do
-  version '7.3.4,722'
-  sha256 '2b45ee3bf2fee72dc3d00f260697b3998fa34cc6bc9865bd2ca297dd1b446e8c'
+  version '7.3.13.6'
+  sha256 'dc9843fb069aa56a2dfa55a4283bb0f7a160cf26348e3f3df6a5f28d607a2e5c'
 
-  # n1other.hjfile.cn was verified as official when first introduced to the cask
-  url "https://n1other.hjfile.cn/wx/CCtalk/#{version.after_comma}/CCtalk_#{version.before_comma}-#{version.after_comma}.dmg"
+  # cc.hjfile.cn was verified as official when first introduced to the cask
+  url "http://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
   appcast 'https://cc.hjfile.cn/mac/update/info.xml'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.