### PR TITLE
Update brisync to 1.2.0

### DIFF
--- a/Casks/brisync.rb
+++ b/Casks/brisync.rb
@@ -7,6 +7,8 @@ cask 'brisync' do
   name 'Brisync'
   homepage 'https://github.com/czarny/Brisync/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Brisync.app'
 
   zap trash: '~/.brisync.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.