### PR TITLE
Update cacher to 2.5.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.4.4'
-  sha256 '6facdab92aa400abfe06888f1e306e7ea2165cea7d186ca9656a2babbfa340cc'
+  version '2.5.1'
+  sha256 'e7db7c9101e4572a94756b477eab8cd066594e2fdfce6adfdd7ccdb45eeb7c0c'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.