### PR TITLE
Update ripcord to 0.3.9

### DIFF
--- a/Casks/ripcord.rb
+++ b/Casks/ripcord.rb
@@ -1,6 +1,6 @@
 cask 'ripcord' do
-  version '0.3.8'
-  sha256 '56c1a0bb370edbf7d51e01732d1032a34383fa20a8233ce5ccf4235f4716e41a'
+  version '0.3.9'
+  sha256 '89c1353e19c26ec33f285397f5835a4153ccbe1ca8ace8e58e8f1c4255db36b9'
 
   url "https://cancel.fm/dl/Ripcord_Mac_#{version}.zip"
   appcast 'https://cancel.fm/ripcord/updates/v1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.