### PR TITLE
Update manager to 19.1.23

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.22'
-  sha256 '78e321b3d5db043022a87ce584fa535bc1874bbe7b25d65eca9b3e02591c582f'
+  version '19.1.23'
+  sha256 'abe386a558afbe98acb6d008c650ef5ae74a44b0aa2902af3be0414a5d2bde03'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.