### PR TITLE
Update fsnotes to 2.7.2

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.7.1'
-  sha256 'f359295bd7db4e66bf80e1a61ba77dd685eb1373cd062a9629866bf764c66c74'
+  version '2.7.2'
+  sha256 'fcd1b213203f937b886780ebfa36662a2a9fc23598a5d47e390b2e462fb9d5b2'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.