### PR TITLE
Update munki to 3.5.2.3637

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,6 +1,6 @@
 cask 'munki' do
-  version '3.5.1.3622'
-  sha256 '5f4013c36ed04ec4d9191423b915a7629a0125378e8d7c1bc32043b8dc941fd3'
+  version '3.5.2.3637'
+  sha256 '8f0b7d8878dd9b26f5d1e90f09147f7c5b8797a323256802226915811d99f1cf'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.