### PR TITLE
Update trilium-notes to 0.28.3

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.28.2'
-  sha256 'f47e06d676a94997001b860d20dcd8e0ea2f3ba72f8086962424aa939bb8328a'
+  version '0.28.3'
+  sha256 '1aba9af4bdd8a05c45cf67e83038ff0f8cc1a162bae1a0f66de04a4d2c5fc3a2'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.