### PR TITLE
squirrel: update to version 0.11.0

### DIFF
--- a/Casks/squirrel.rb
+++ b/Casks/squirrel.rb
@@ -1,6 +1,6 @@
 cask 'squirrel' do
-  version '0.10.0'
-  sha256 '9eb07603a078cadd5475797432e578f366d0fa49f878b7f2f6b32336bfa5a258'
+  version '0.11.0'
+  sha256 '78f8294483d52f3f75831d6c5b669a7b39e743ce94b2c5b6d1c50406b80667b8'
 
   # dl.bintray.com/rime/squirrel was verified as official when first introduced to the cask
   url "https://dl.bintray.com/rime/squirrel/Squirrel-#{version}.zip"

--- a/Casks/squirrel.rb
+++ b/Casks/squirrel.rb
@@ -4,8 +4,11 @@ cask 'squirrel' do
 
   # dl.bintray.com/rime/squirrel was verified as official when first introduced to the cask
   url "https://dl.bintray.com/rime/squirrel/Squirrel-#{version}.zip"
+  appcast 'https://rime.github.io/release/squirrel/appcast.xml'
   name 'Squirrel'
-  homepage 'https://rime.im/download/'
+  homepage 'https://rime.im/'
+
+  auto_updates true
 
   pkg 'Squirrel.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download squirrel` is error-free.
- [ ] `brew cask style --fix squirrel` reports no offenses. // not done; `bundle install` couldn't download gems in my network  
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
