### PR TITLE
Update lingon-x to 6.5.7

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,6 +1,6 @@
 cask 'lingon-x' do
-  version '6.5.6'
-  sha256 'c12561c8d1b0f011d0d04f75d77b72e7055476d0cf41727bb7beae7bd8c677b2'
+  version '6.5.7'
+  sha256 '40ebf4d38d2448ee85a47c5b7988c2f3c435afb68aec2a7f9a370fd4153547e1'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.