### PR TITLE
add appcast to ipswdownloader to 2.7.0

### DIFF
--- a/Casks/ipswdownloader.rb
+++ b/Casks/ipswdownloader.rb
@@ -3,6 +3,7 @@ cask 'ipswdownloader' do
   sha256 '76f1fbff4496bb836bce3706bd0488880d82c91494fd58a5dfc99a1d51d75989'
 
   url "http://downloads.igrsoft.com/downloads/ipswDownloader/ipswDownloader_#{version.no_dots}.zip"
+  appcast 'http://igrsoft.com/wp-content/iPhone/update.xml'
   name 'ipswDownloader'
   homepage 'https://igrsoft.com/ipswdownloader/'
 

--- a/Casks/ipswdownloader.rb
+++ b/Casks/ipswdownloader.rb
@@ -5,7 +5,7 @@ cask 'ipswdownloader' do
   url "http://downloads.igrsoft.com/downloads/ipswDownloader/ipswDownloader_#{version.no_dots}.zip"
   appcast 'http://igrsoft.com/wp-content/iPhone/update.xml'
   name 'ipswDownloader'
-  homepage 'https://igrsoft.com/ipswdownloader/'
+  homepage 'http://igrsoft.com/ipswdownloader/'
 
   app 'ipswDownloader.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.