### PR TITLE
Update manager to 19.1.25

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.23'
-  sha256 'abe386a558afbe98acb6d008c650ef5ae74a44b0aa2902af3be0414a5d2bde03'
+  version '19.1.25'
+  sha256 'f8c556e8afd378657ec6548676b6b4a55771049a9c18ae9d400b6c50ce2b1e8e'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.