### PR TITLE
Update traverse to 0.10.4

### DIFF
--- a/Casks/traverse.rb
+++ b/Casks/traverse.rb
@@ -1,6 +1,6 @@
 cask 'traverse' do
-  version '0.10.3'
-  sha256 '3eb627d5ad5cd930d499b8e46149780e686130e75874c88c502723773d03c805'
+  version '0.10.4'
+  sha256 '86fee743c97bf36e5fd96c799cb33b94cb00e82733397d6518685e14f0bd4eeb'
 
   # github.com/jasonraimondi/traverse was verified as official when first introduced to the cask
   url "https://github.com/jasonraimondi/traverse/releases/download/v#{version}/Traverse-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.