### PR TITLE
Add MenuMeters (emcrisostomo fork) version 1.9.7

### DIFF
--- a/Casks/menumeters-emcrisostomo-fork.rb
+++ b/Casks/menumeters-emcrisostomo-fork.rb
@@ -5,7 +5,7 @@ cask 'menumeters-emcrisostomo-fork' do
   # github.com/emcrisostomo/MenuMeters/releases/download/1.9.7%2Bemc/MenuMeters-1.9.7+emc.dmg was verified as official when first introduced to the cask
   url 'https://github.com/emcrisostomo/MenuMeters/releases/download/1.9.7%2Bemc/MenuMeters-1.9.7+emc.dmg'
   appcast 'https://github.com/emcrisostomo/MenuMeters/releases'
-  name 'Menumeters (emcrisostomo fork)'
+  name 'MenuMeters (emcrisostomo fork)'
   homepage 'https://emcrisostomo.github.io/MenuMeters/'
 
   pkg 'MenuMeters.pkg'

--- a/Casks/menumeters-emcrisostomo-fork.rb
+++ b/Casks/menumeters-emcrisostomo-fork.rb
@@ -1,14 +1,14 @@
 cask 'menumeters-emcrisostomo-fork' do
-    version '1.9.7+emc'
-    sha256 '9d4fa909eee01939be5a851502e3f77bbf990af3e228fbeb14a4af7d8fde5862'
-  
-    url 'https://github.com/emcrisostomo/MenuMeters/releases/download/1.9.7%2Bemc/MenuMeters-1.9.7+emc.dmg'
-    appcast 'https://github.com/emcrisostomo/MenuMeters/releases'
-    name 'Menumeters (emcrisostomo fork)'
-    homepage 'https://emcrisostomo.github.io/MenuMeters/'
-  
-    pkg 'MenuMeters.pkg'
-  
-    uninstall pkgutil: 'com.yujitach.MenuMeters'
+  version '1.9.7+emc'
+  sha256 '9d4fa909eee01939be5a851502e3f77bbf990af3e228fbeb14a4af7d8fde5862'
 
-  end
+  # github.com/emcrisostomo/MenuMeters/releases/download/1.9.7%2Bemc/MenuMeters-1.9.7+emc.dmg was verified as official when first introduced to the cask
+  url 'https://github.com/emcrisostomo/MenuMeters/releases/download/1.9.7%2Bemc/MenuMeters-1.9.7+emc.dmg'
+  appcast 'https://github.com/emcrisostomo/MenuMeters/releases'
+  name 'Menumeters (emcrisostomo fork)'
+  homepage 'https://emcrisostomo.github.io/MenuMeters/'
+
+  pkg 'MenuMeters.pkg'
+
+  uninstall pkgutil: 'com.yujitach.MenuMeters'
+end

--- a/Casks/menumeters-emcrisostomo-fork.rb
+++ b/Casks/menumeters-emcrisostomo-fork.rb
@@ -1,0 +1,14 @@
+cask 'menumeters-emcrisostomo-fork' do
+    version '1.9.7+emc'
+    sha256 '9d4fa909eee01939be5a851502e3f77bbf990af3e228fbeb14a4af7d8fde5862'
+  
+    url 'https://github.com/emcrisostomo/MenuMeters/releases/download/1.9.7%2Bemc/MenuMeters-1.9.7+emc.dmg'
+    appcast 'https://github.com/emcrisostomo/MenuMeters/releases'
+    name 'Menumeters (emcrisostomo fork)'
+    homepage 'https://emcrisostomo.github.io/MenuMeters/'
+  
+    pkg 'MenuMeters.pkg'
+  
+    uninstall pkgutil: 'com.yujitach.MenuMeters'
+
+  end


### PR DESCRIPTION
Created new cask for installing the MenuMeters fork (menumeters-emcrisostomo-fork - version 1.9.7) for macOS by emcrisostomo. Tested on macOS Mojave 10.14.2.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
