### PR TITLE
Update vmware-remote-console to 10.0.4-11818843

### DIFF
--- a/Casks/vmware-remote-console.rb
+++ b/Casks/vmware-remote-console.rb
@@ -1,6 +1,6 @@
 cask 'vmware-remote-console' do
-  version '10.0.3-9300449'
-  sha256 'de55eb32d7dcd8207ecca864902f77f7000e6a89a751ce24046873a15e14b1a7'
+  version '10.0.4-11818843'
+  sha256 '4a7b4f272721fc0f456ee0ceed0d516cd1c640622b34fa3de64fe3bae1e91b78'
 
   url "https://softwareupdate.vmware.com/cds/vmw-desktop/vmrc/#{version.hyphens_to_slashes}/macos/com.vmware.vmrc.zip.tar"
   appcast 'https://softwareupdate.vmware.com/cds/vmw-desktop/vmrc-macos.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.