### PR TITLE
Update astropad to 3.0

### DIFF
--- a/Casks/astropad.rb
+++ b/Casks/astropad.rb
@@ -1,6 +1,6 @@
 cask 'astropad' do
-  version '2.6.0'
-  sha256 'ded088104963b6d4f7119c9b90e9e8aa30932804e3f3381dfc48ae887958978a'
+  version '3.0'
+  sha256 '85cc66d0682c628aa1bceef4cbc3d0828bc33e2d676b529f9434dd9c7d9d63bf'
 
   url "https://astropad.com/downloads/Astropad-#{version}.zip"
   appcast 'https://astropad.com/downloads/sparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.