### PR TITLE
Update geotag-photos-pro to 1.1.0

### DIFF
--- a/Casks/geotag-photos-pro.rb
+++ b/Casks/geotag-photos-pro.rb
@@ -1,6 +1,6 @@
 cask 'geotag-photos-pro' do
-  version '1.0.8'
-  sha256 '3357a079aa065ac214b23cefb1b81b89a42b660573fd63afaf2f96013ddf84d6'
+  version '1.1.0'
+  sha256 '079761e318d21bae71162380a3aebd80de26575defd4c87f991429c820bd8101'
 
   # github.com/tappytaps was verified as official when first introduced to the cask
   url "https://github.com/tappytaps/geotag-desktop-app/releases/download/v#{version}/geotag-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.