### PR TITLE
Update pokertracker to 4.15.8

### DIFF
--- a/Casks/pokertracker.rb
+++ b/Casks/pokertracker.rb
@@ -1,6 +1,6 @@
 cask 'pokertracker' do
-  version '4.15.6'
-  sha256 'fb8e4b30446ecda0f6ff5f1674fe47062810fb0621b77ab398459247bd28e88e'
+  version '4.15.8'
+  sha256 '5b4c46c48c693b87221d08efe61acfd54b22b5d4d0419328331e48738055c756'
 
   # s3-us1.ptrackupdate.com was verified as official when first introduced to the cask
   url "https://s3-us1.ptrackupdate.com/releases/PT-Install-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.