### PR TITLE
Update manager to 19.1.28

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.25'
-  sha256 'f8c556e8afd378657ec6548676b6b4a55771049a9c18ae9d400b6c50ce2b1e8e'
+  version '19.1.28'
+  sha256 'f8595ac1734a989a47de4228882fb0458706eec9cd50399bf822efbe53fddcb1'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.