### PR TITLE
Update flipper to 0.14.2

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.14.1'
-  sha256 '48096999eff07f5834d29e7f8837ddd630124f88cd85b8d25d3d5fcf9a94a0de'
+  version '0.14.2'
+  sha256 '3568a95b58e9dcb6643dd715c34d773ee5be5a9a7d9309d9af74f1c0168b247a'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.