### PR TITLE
Update Dropshare to Version 5.1 Build 5047

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,21 +1,21 @@
 cask 'dropshare' do
-  version '5,5036'
-  sha256 'c28dd83d2da7107d85953dec8e03a5ddaff837ba34fdc547427144e26358e665'
+  version '5.1,5047'
+  sha256 '7f727b7762f7c8ea6230f70ec748f0df760ea0edb95fefc00045d5235c42384f'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"
   appcast "https://getdropsha.re/sparkle/Dropshare#{version.major}.xml"
   name 'Dropshare'
-  homepage 'https://getdropsha.re/'
+  homepage 'https://dropshare.app/'
 
   app "Dropshare #{version.major}.app"
   binary "#{appdir}/Dropshare #{version.major}.app/Contents/Resources/ds.sh", target: 'ds'
 
   zap trash: [
-               '~/Library/Application Support/Dropshare 4',
-               '~/Library/Caches/net.mkswap.Dropshare4',
-               '~/Library/Cookies/net.mkswap.Dropshare4.binarycookies',
-               '~/Library/Logs/Dropshare 4',
-               '~/Library/Preferences/net.mkswap.Dropshare4.plist',
+               '~/Library/Application Support/Dropshare 5',
+               '~/Library/Caches/net.mkswap.Dropshare5',
+               '~/Library/Cookies/net.mkswap.Dropshare5.binarycookies',
+               '~/Library/Logs/Dropshare 5',
+               '~/Library/Preferences/net.mkswap.Dropshare5.plist',
              ]
 end

--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -12,10 +12,10 @@ cask 'dropshare' do
   binary "#{appdir}/Dropshare #{version.major}.app/Contents/Resources/ds.sh", target: 'ds'
 
   zap trash: [
-               '~/Library/Application Support/Dropshare 5',
-               '~/Library/Caches/net.mkswap.Dropshare5',
+               "~/Library/Application Support/Dropshare #{version.major}",
+               "~/Library/Caches/net.mkswap.Dropshare#{version.major}",
                '~/Library/Cookies/net.mkswap.Dropshare5.binarycookies',
-               '~/Library/Logs/Dropshare 5',
+               "~/Library/Logs/Dropshare #{version.major}",
                '~/Library/Preferences/net.mkswap.Dropshare5.plist',
              ]
 end

--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -14,7 +14,7 @@ cask 'dropshare' do
   zap trash: [
                "~/Library/Application Support/Dropshare #{version.major}",
                "~/Library/Caches/net.mkswap.Dropshare#{version.major}",
-               '~/Library/Cookies/net.mkswap.Dropshare5.binarycookies',
+               "~/Library/Cookies/net.mkswap.Dropshare#{version.major}.binarycookies",
                "~/Library/Logs/Dropshare #{version.major}",
                '~/Library/Preferences/net.mkswap.Dropshare5.plist',
              ]

--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -16,6 +16,6 @@ cask 'dropshare' do
                "~/Library/Caches/net.mkswap.Dropshare#{version.major}",
                "~/Library/Cookies/net.mkswap.Dropshare#{version.major}.binarycookies",
                "~/Library/Logs/Dropshare #{version.major}",
-               '~/Library/Preferences/net.mkswap.Dropshare5.plist',
+               "~/Library/Preferences/net.mkswap.Dropshare#{version.major}.plist",
              ]
 end


### PR DESCRIPTION
- Also fix Dropshare 5 directory paths and files

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).