### PR TITLE
Update macx-dvd-ripper-pro to 6.2.0,20190116

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,5 +1,5 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.2.0,20190111'
+  version '6.2.0,20190116'
   sha256 '7c9943d44362b95610159761d496ecc0936a732a2fb21604b7d783e3ec50a949'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.