### PR TITLE
Update manager to 19.1.26

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.28'
-  sha256 'f8595ac1734a989a47de4228882fb0458706eec9cd50399bf822efbe53fddcb1'
+  version '19.1.26'
+  sha256 'f2b2b82d260de22ec69ae987b17620203a89f2652f29c703c36e3a7811606c63'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.