### PR TITLE
Update altair-graphql-client to 1.9.9

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '1.9.8'
-  sha256 '31b39f2a6d5c786b0f0f8667edf216b49645fa1e510597dc94d2eeed52ad2728'
+  version '1.9.9'
+  sha256 '635f3f902cf653cf9572db4a90dd6f4813fc6890c7e9578debc49b5439bc336e'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.