### PR TITLE
Update manager to 19.1.29

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.28'
-  sha256 'f8595ac1734a989a47de4228882fb0458706eec9cd50399bf822efbe53fddcb1'
+  version '19.1.29'
+  sha256 'dd1dd10ad680edd92eae8efa0a656e271865418ef8960598496a9c5908568eff'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.