### PR TITLE
Update kite to 0.20190125.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190109.1'
-  sha256 'ef94248a5d55a3f7ad2e4d82bccae2cbd62606fc8af47d488a45a04ab92a1729'
+  version '0.20190125.1'
+  sha256 'c10a1fa258c2927471ffa114b5d3d73e7503d0f31aff0f89293e36b67053dbe4'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.