### PR TITLE
Update joplin to 1.0.125

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.120'
-  sha256 '3d960235f5d4df4970d99f19c05110a809a2a51e69391a2fb5d662fa00bc7def'
+  version '1.0.125'
+  sha256 '4ed3c0e48739120f93953e7550dedbcd185b37170328c3fa5b6e4caf9c33068f'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.