### PR TITLE
Update copyclip to 2.9.91

### DIFF
--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -1,6 +1,6 @@
 cask 'copyclip' do
-  version '2.9.9'
-  sha256 'da6401eabc681c47bd555ee91ab83c154e7cf0b41bb9ea445774aad7264a73ac'
+  version '2.9.91'
+  sha256 '4e086a27c2d78559032431012d7b3d6f195a2ff9e01adbf4170c8b151d5cb51e'
 
   # rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379?format=zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.