### PR TITLE
zoomus: fix ownership of Application Support

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -11,6 +11,10 @@ cask 'zoomus' do
 
   pkg 'zoomusInstaller.pkg'
 
+  postflight do
+    set_ownership '~/Library/Application Support/zoom.us'
+  end
+
   uninstall delete: '/Applications/zoom.us.app',
             quit:   'us.zoom.ZoomOpener',
             signal: [


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Fixes https://github.com/Homebrew/homebrew-cask/issues/57966.