### PR TITLE
updated dsha-256 digest for deeper-2.4.0

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -18,7 +18,7 @@ cask 'deeper' do
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   else
     version '2.4.0'
-    sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
+    sha256 '905f72d4880c98559ba8443fc6eaa83152d2d98b2cf13bd9a84fca62bf59b37f'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
