### PR TITLE
Attempt to enable Azure Pipelines as a CI provider

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ jobs:
         export HOMEBREW_COLOR=1
         export HOMEBREW_DEVELOPER=1
         export HOMEBREW_NO_AUTO_UPDATE=1
+        export HOMEBREW_AZURE_REPOSITORY_URI="$(Build.Repository.Uri)"
+        export HOMEBREW_AZURE_PULLREQUESTNUMBER ="$(System.PullRequest.PullRequestNumber)"
         export HOMEBREW_AZURE_TARGETBRANCH="$(System.PullRequest.TargetBranch)"
         export HOMEBREW_AZURE_SOURCEVERSION="$(Build.SourceVersion)"
         # Using brew update-reset and restricting directories is quicker/more robust than brew update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ jobs:
         export HOMEBREW_NO_AUTO_UPDATE=1
         # Using brew update-reset and restricting directories is quicker/more robust than brew update
         brew update-reset "$(brew --repository)"
+        # TEMPORARY: Overwrite brewcask-ci.rb with my version since the changes are not merged yet
+        cp -f "$(Build.SourcesDirectory)/cmd/brewcask-ci.rb" "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/cmd/"
         # Mirror the repo as a tap.
         TAP_DIR="$(brew --repository)/Library/Taps/$(Build.Repository.Name)"
         mkdir -p "${TAP_DIR}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,22 @@
+jobs:
+- job: macOS
+  pool:
+    vmImage: macOS-10.13
+  steps:
+    - bash: |
+        # Force strict error checking.
+        set -o errexit
+        set -o pipefail
+        # set env
+        export HOMEBREW_COLOR=1
+        export HOMEBREW_DEVELOPER=1
+        export HOMEBREW_NO_AUTO_UPDATE=1
+        # Using brew update-reset and restricting directories is quicker/more robust than brew update
+        brew update-reset "$(brew --repository)"
+        # Mirror the repo as a tap.
+        TAP_DIR="$(brew --repository)/Library/Taps/$(Build.Repository.Name)"
+        mkdir -p "${TAP_DIR}"
+        rsync --archive --compress --delete "$(Build.SourcesDirectory)/" "${TAP_DIR}/"
+        cd "${TAP_DIR}"
+        brew cask ci
+      displayName: Run brew cask ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,7 @@ jobs:
         export HOMEBREW_COLOR=1
         export HOMEBREW_DEVELOPER=1
         export HOMEBREW_NO_AUTO_UPDATE=1
-        export HOMEBREW_AZURE_REPOSITORY_URI="$(Build.Repository.Uri)"
-        export HOMEBREW_AZURE_PULLREQUESTNUMBER="$(System.PullRequest.PullRequestNumber)"
-        export HOMEBREW_AZURE_TARGETBRANCH="$(System.PullRequest.TargetBranch)"
-        export HOMEBREW_AZURE_SOURCEVERSION="$(Build.SourceVersion)"
+        export HOMEBREW_NO_ENV_FILTERING=1
         # Using brew update-reset and restricting directories is quicker/more robust than brew update
         brew update-reset "$(brew --repository)"
         # TEMPORARY: Overwrite brewcask-ci.rb with my version since the changes are not merged yet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ jobs:
         export HOMEBREW_COLOR=1
         export HOMEBREW_DEVELOPER=1
         export HOMEBREW_NO_AUTO_UPDATE=1
+        export HOMEBREW_AZURE_TARGETBRANCH="$(System.PullRequest.TargetBranch)"
+        export HOMEBREW_AZURE_SOURCEVERSION="$(Build.SourceVersion)"
         # Using brew update-reset and restricting directories is quicker/more robust than brew update
         brew update-reset "$(brew --repository)"
         # TEMPORARY: Overwrite brewcask-ci.rb with my version since the changes are not merged yet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ jobs:
         # Force strict error checking.
         set -o errexit
         set -o pipefail
+        set -o nounset
         # set env
         export HOMEBREW_COLOR=1
         export HOMEBREW_DEVELOPER=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ jobs:
         cp -f "$(Build.SourcesDirectory)/cmd/brewcask-ci.rb" "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/cmd/"
         # Mirror the repo as a tap.
         TAP_DIR="$(brew --repository)/Library/Taps/$(Build.Repository.Name)"
+        echo "DEBUG: TAP_DIR is ${TAP_DIR}"
         mkdir -p "${TAP_DIR}"
         rsync --archive --compress --delete "$(Build.SourcesDirectory)/" "${TAP_DIR}/"
         cd "${TAP_DIR}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
         export HOMEBREW_DEVELOPER=1
         export HOMEBREW_NO_AUTO_UPDATE=1
         export HOMEBREW_AZURE_REPOSITORY_URI="$(Build.Repository.Uri)"
-        export HOMEBREW_AZURE_PULLREQUESTNUMBER ="$(System.PullRequest.PullRequestNumber)"
+        export HOMEBREW_AZURE_PULLREQUESTNUMBER="$(System.PullRequest.PullRequestNumber)"
         export HOMEBREW_AZURE_TARGETBRANCH="$(System.PullRequest.TargetBranch)"
         export HOMEBREW_AZURE_SOURCEVERSION="$(Build.SourceVersion)"
         # Using brew update-reset and restricting directories is quicker/more robust than brew update

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -25,10 +25,9 @@ module Cask
         current_commit_hash = system_command!(
           "git", args: ["rev-parse", "--short", "HEAD"]
         ).stdout.strip
-        # Use Travis CI Git variables
+
         if ENV.key?("TRAVIS_COMMIT_RANGE")
           @commit_range = ENV["TRAVIS_COMMIT_RANGE"]
-        # Use Azure Pipeline variables
         elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
           start_commit_hash = system_command!(
             "git", args: ["rev-parse", "--short", ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]]

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -26,16 +26,19 @@ module Cask
           "git", args: ["rev-parse", "--short", "HEAD"]
         ).stdout.strip
 
-        if ENV.key?("TRAVIS_COMMIT_RANGE")
-          @commit_range = ENV["TRAVIS_COMMIT_RANGE"]
-        elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
-          start_commit_hash = system_command!(
-            "git", args: ["rev-parse", "--short", ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]]
-          ).stdout.strip
-          @commit_range = "#{start_commit_hash}...#{current_commit_hash}"
-        else
-          @commit_range = "#{current_commit_hash}...#{current_commit_hash}"
-        end
+        @commit_range =
+          if ENV.key?("TRAVIS_COMMIT_RANGE")
+            # Travis CI
+            ENV["TRAVIS_COMMIT_RANGE"]
+          elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
+            # Azure Pipelines
+            start_commit_hash = system_command!(
+              "git", args: ["rev-parse", "--short", ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]]
+            ).stdout.strip
+            "#{start_commit_hash}...#{current_commit_hash}"
+          else
+            "#{current_commit_hash}...#{current_commit_hash}"
+          end
         puts "DEBUG: SYSTEM_PULLREQUEST_TARGETBRANCH is #{ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]}"
         puts "DEBUG: BUILD_SOURCEVERSION is #{ENV["BUILD_SOURCEVERSION"]}"
         puts "DEBUG: @commit_range is #{@commit_range}"

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -27,9 +27,9 @@ module Cask
         ).stdout.strip
 
         pr_url =
-          if ENV.key?("HOMEBREW_AZURE_REPOSITORY_URI") && ENV.key?("HOMEBREW_AZURE_PULLREQUESTNUMBER")
+          if ENV.key?("BUILD_REPOSITORY_URI") && ENV.key?("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
             # Use Azure Pipeline variables for pull request jobs.
-            "#{ENV["HOMEBREW_AZURE_REPOSITORY_URI"]}/pull/#{ENV["HOMEBREW_AZURE_PULLREQUESTNUMBER"]}"
+            "#{ENV["BUILD_REPOSITORY_URI"]}/pull/#{ENV["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"]}"
           else
             nil
           end
@@ -45,18 +45,18 @@ module Cask
               "git", args: ["rev-parse", "--short", "HEAD"]
             ).stdout.strip
             "#{current_commit_hash}...#{pr_commit_hash}"
-          elsif ENV.key?("HOMEBREW_AZURE_TARGETBRANCH") && ENV.key?("HOMEBREW_AZURE_SOURCEVERSION")
+          elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
             # Use Azure Pipeline variables for master or branch jobs.
             start_commit_hash = system_command!(
-              "git", args: ["rev-parse", "--short", ENV["HOMEBREW_AZURE_TARGETBRANCH"]]
+              "git", args: ["rev-parse", "--short", ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]]
             ).stdout.strip
             "#{start_commit_hash}...#{current_commit_hash}"
           else
             # Otherwise just use the current hash.
             "#{current_commit_hash}...#{current_commit_hash}"
           end
-        puts "DEBUG: HOMEBREW_AZURE_TARGETBRANCH is #{ENV["HOMEBREW_AZURE_TARGETBRANCH"]}"
-        puts "DEBUG: HOMEBREW_AZURE_SOURCEVERSION is #{ENV["HOMEBREW_AZURE_SOURCEVERSION"]}"
+        puts "DEBUG: SYSTEM_PULLREQUEST_TARGETBRANCH is #{ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]}"
+        puts "DEBUG: BUILD_SOURCEVERSION is #{ENV["BUILD_SOURCEVERSION"]}"
         puts "DEBUG: @commit_range is #{@commit_range}"
 
         ruby_files_in_wrong_directory = modified_ruby_files - (modified_cask_files + modified_command_files)

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -22,6 +22,22 @@ module Cask
           raise CaskError, "This command must be run from inside a tap directory."
         end
 
+        current_commit_hash = system_command!(
+          "git", args: ["rev-parse", "--short", "HEAD"]
+        ).stdout.strip
+        # Use Travis CI Git variables
+        if ENV.key?("TRAVIS_COMMIT_RANGE")
+          @commit_range = @commit_range
+        # Use Azure Pipeline variables
+        elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
+          start_commit_hash = system_command!(
+            "git", args: ["rev-parse", "--short", ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]]
+          ).stdout.strip
+          @commit_range = "#{start_commit_hash}...#{current_commit_hash}"
+        else
+          @commit_range = "#{current_commit_hash}...#{current_commit_hash}"
+        end
+
         ruby_files_in_wrong_directory = modified_ruby_files - (modified_cask_files + modified_command_files)
 
         unless ruby_files_in_wrong_directory.empty?
@@ -41,7 +57,7 @@ module Cask
           overall_success &= step "brew cask audit #{cask.token}", "audit" do
             Auditor.audit(cask, audit_download: true,
                                 check_token_conflicts: added_cask_files.include?(path),
-                                commit_range: ENV["TRAVIS_COMMIT_RANGE"])
+                                commit_range: @commit_range)
           end
 
           overall_success &= step "brew cask style #{cask.token}", "style" do
@@ -144,13 +160,13 @@ module Cask
 
       def modified_files
         @modified_files ||= system_command!(
-          "git", args: ["diff", "--name-only", "--diff-filter=AMR", ENV["TRAVIS_COMMIT_RANGE"]]
+          "git", args: ["diff", "--name-only", "--diff-filter=AMR", @commit_range]
         ).stdout.split("\n").map { |path| Pathname(path) }
       end
 
       def added_files
         @added_files ||= system_command!(
-          "git", args: ["diff", "--name-only", "--diff-filter=A", ENV["TRAVIS_COMMIT_RANGE"]]
+          "git", args: ["diff", "--name-only", "--diff-filter=A", @commit_range]
         ).stdout.split("\n").map { |path| Pathname(path) }
       end
 

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -40,7 +40,7 @@ module Cask
             ENV["TRAVIS_COMMIT_RANGE"]
           elsif pr_url
             # Use PR URL
-            system_command!("brew", "pull", "--clean", pr_url)
+            system_command!("brew", args: ["pull", "--clean", pr_url])
             pr_commit_hash = system_command!(
               "git", args: ["rev-parse", "--short", "HEAD"]
             ).stdout.strip

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -30,17 +30,17 @@ module Cask
           if ENV.key?("TRAVIS_COMMIT_RANGE")
             # Travis CI
             ENV["TRAVIS_COMMIT_RANGE"]
-          elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
+          elsif ENV.key?("HOMEBREW_AZURE_TARGETBRANCH") && ENV.key?("HOMEBREW_AZURE_SOURCEVERSION")
             # Azure Pipelines
             start_commit_hash = system_command!(
-              "git", args: ["rev-parse", "--short", ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]]
+              "git", args: ["rev-parse", "--short", ENV["HOMEBREW_AZURE_TARGETBRANCH"]]
             ).stdout.strip
             "#{start_commit_hash}...#{current_commit_hash}"
           else
             "#{current_commit_hash}...#{current_commit_hash}"
           end
-        puts "DEBUG: SYSTEM_PULLREQUEST_TARGETBRANCH is #{ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]}"
-        puts "DEBUG: BUILD_SOURCEVERSION is #{ENV["BUILD_SOURCEVERSION"]}"
+        puts "DEBUG: HOMEBREW_AZURE_TARGETBRANCH is #{ENV["HOMEBREW_AZURE_TARGETBRANCH"]}"
+        puts "DEBUG: HOMEBREW_AZURE_SOURCEVERSION is #{ENV["HOMEBREW_AZURE_SOURCEVERSION"]}"
         puts "DEBUG: @commit_range is #{@commit_range}"
 
         ruby_files_in_wrong_directory = modified_ruby_files - (modified_cask_files + modified_command_files)

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -37,6 +37,9 @@ module Cask
         else
           @commit_range = "#{current_commit_hash}...#{current_commit_hash}"
         end
+        puts "DEBUG: SYSTEM_PULLREQUEST_TARGETBRANCH is #{ENV["SYSTEM_PULLREQUEST_TARGETBRANCH"]}"
+        puts "DEBUG: BUILD_SOURCEVERSION is #{ENV["BUILD_SOURCEVERSION"]}"
+        puts "DEBUG: @commit_range is #{@commit_range}"
 
         ruby_files_in_wrong_directory = modified_ruby_files - (modified_cask_files + modified_command_files)
 

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -27,7 +27,7 @@ module Cask
         ).stdout.strip
         # Use Travis CI Git variables
         if ENV.key?("TRAVIS_COMMIT_RANGE")
-          @commit_range = @commit_range
+          @commit_range = ENV["TRAVIS_COMMIT_RANGE"]
         # Use Azure Pipeline variables
         elsif ENV.key?("SYSTEM_PULLREQUEST_TARGETBRANCH") && ENV.key?("BUILD_SOURCEVERSION")
           start_commit_hash = system_command!(


### PR DESCRIPTION
I was following #57156 as I look forward to being able to use Azure Pipelines for Cask taps. 
I see that the activity on that PR has died down recently and thought I would give it a try. Apologies to @shikhar-scs if you are still working on it.

Here are the new changes:
- Updated `vmImage` version. 
- `set -o errexit` and `set -o pipefail` added to the bash script per comments from the previous PR. 
- `TAP_DIR` is set and serves as the rsync destination in the bash script. 
- Use `brew update-reset` on `Homebrew/brew` instead of doing `brew update` per suggestion from the previous PR. (Is this enough?)
- Created an Azure build pipeline _for my forked repo_ to test this. 
  - Note that in order to test with the modified `brewcask-ci.rb` in this PR on Azure, the bash script overwrites `Homebrew/homebrew-cask`'s shipping version. 

Here is where I am stuck:
I noticed that `brewcask-ci.rb` needs commit range info to work. On Travis, this info is provided by the `TRAVIS_COMMIT_RANGE` env variable. Since there is no Azure Pipelines equivalent, commit range info needs to be derived. 
I tried to copy [how homebrew-test-bot does it](https://github.com/Homebrew/homebrew-test-bot/blob/5cf61bcb03bb70ca657724a8d8db6571e5a25abb/cmd/brew-test-bot.rb#L413-L419) but it doesn't seem to work with my test PR tommyang/homebrew-cask#1. ~~[Azure Pipelines log](https://dev.azure.com/tommyang/homebrew-cask/_build/results?buildId=144) indicates that `SYSTEM_PULLREQUEST_TARGETBRANCH` and `BUILD_SOURCEVERSION` were not set.~~ Env variables are filtered. 

Not sure how far I can go from here as I am familiar with neither Ruby nor Azure Pipelines. But I thought I should share my findings. 