### PR TITLE
Update ipartition to 3.6.2

### DIFF
--- a/Casks/ipartition.rb
+++ b/Casks/ipartition.rb
@@ -4,6 +4,11 @@ cask 'ipartition' do
     sha256 '0b66c44dfb4b8525056b68bfd8f4d56fe4b78fd0e5e4705659bfd242e2722319'
 
     url "https://coriolis-systems.com/downloads/iPartition-#{version}.zip"
+  elsif MacOS.version <= :el_capitan
+    version '3.5.1'
+    sha256 'c3400af48b24ea2f30d6d1f829c761a0542cc04ecbe87755223d95418ddeb40a'
+
+    url "https://coriolis-systems.com/downloads/iPartition-#{version}.dmg"
   else
     version '3.6.2'
     sha256 '46e17302cd7153d6b4c6ef46ba84fa8ee1112b65789a4d244b78b7e6d8c2f6c2'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.