### PR TITLE
Update graphql-playground to 1.8.7

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,6 +1,6 @@
 cask 'graphql-playground' do
-  version '1.8.6'
-  sha256 '40c4985dea9cfa2660728aa0d730f7f4ac12319890aae6f572fe2e1fa657b285'
+  version '1.8.7'
+  sha256 '91071e9fb0cce6ad6078ffd6a0bd4f23fe086e357fce426766286b713d1ca5ab'
 
   url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prisma/graphql-playground/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.