### PR TITLE
Update iconjar to 1.13.1,30275:1548623927

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,6 +1,6 @@
 cask 'iconjar' do
-  version '1.12.0,28757:1540151114'
-  sha256 'd8007b473500f584790a9523312be1a8e7a203578911b44a40e3ef83e32b1cd9'
+  version '1.13.1,30275:1548623927'
+  sha256 '41544937969f8cb70640b4226b1a67b4c5ae2c4cc7100fbbc734596f09dcab95'
 
   # dl.devmate.com/com.iconjar.iconjar was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.iconjar.iconjar/#{version.after_comma.before_colon}/#{version.after_colon}/Iconjar-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.