### PR TITLE
Update nosqlbooster-for-mongodb to 5.1.0

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.0.3'
-  sha256 'a9a033a835912802dbc957e4a13ace31b7e5e8c0f827fd05befb87fc20521e38'
+  version '5.1.0'
+  sha256 '226133e1acf9c7fc5c09bf3978f9b0642d0a5382a2af35a22c2df2524cf7271f'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   name 'NoSQLBooster for MongoDB'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.