### PR TITLE
Update turtl to 0.7.2.3

### DIFF
--- a/Casks/turtl.rb
+++ b/Casks/turtl.rb
@@ -1,6 +1,6 @@
 cask 'turtl' do
-  version '0.7.1'
-  sha256 '9d920609ab69196ffd246a8f48d008cad4d4e1cf9a6a178962bf4c556c862832'
+  version '0.7.2.3'
+  sha256 '092c200a89d88521a7679ae1c7cefdbbfedc3a7263763a51ec7def9a9d3a34ee'
 
   # github.com/turtl/desktop was verified as official when first introduced to the cask
   url "https://github.com/turtl/desktop/releases/download/v#{version}/turtl-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.