### PR TITLE
Update electorrent to 2.6.0

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,6 +1,6 @@
 cask 'electorrent' do
-  version '2.5.2'
-  sha256 'e7d08a0c4723986e974bcd1bc9e11468f0f916a7b589465bfdf6cbe10809e00f'
+  version '2.6.0'
+  sha256 '8a14aa558d0eec409835be48bcff35f249448f41630b9383222536acd2ce8eeb'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.