### PR TITLE
Update reactotron to 2.6.1

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,6 +1,6 @@
 cask 'reactotron' do
-  version '2.6.0'
-  sha256 '180e5a064f52a1eed060055d859f87d9dbaffaeb9d0c56cb8ecb8953a1379b36'
+  version '2.6.1'
+  sha256 'a0e57fc25f4ec1ba7e4da7690185eceffb713cc19c2a7c5e80aef27066906cf5'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron-#{version}-mac.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.