### PR TITLE
Update qownnotes to 19.1.11,b4123-183203

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.1.10,b4114-085430'
-  sha256 '59bfb01d21d26b1dc8dc688b475fe262a8ab2062e5af3b2a8fd85b88463e89af'
+  version '19.1.11,b4123-183203'
+  sha256 '477916ff387b5217f892cd4fd2d0fd25ba29e7e6b3fdad3d68dba218210b1e77'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.