### PR TITLE
Update tinymediamanager to 2.9.15_69b6104

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -1,7 +1,6 @@
 cask 'tinymediamanager' do
-  # NOTE! Update depends_on_java when updating the version.
-  version '2.9.14_096b083'
-  sha256 'd575154fa03d4b4b329cbea09d74c9ed38f60c01950b56342fb17908ad20cf60'
+  version '2.9.15_69b6104'
+  sha256 '7a1aa341d9701b0adc4c7a60d6183aaff1cd4efb10c013de82265020f6fcf84a'
 
   url "https://release.tinymediamanager.org/dist/tmm_#{version}_mac.zip"
   appcast 'https://release.tinymediamanager.org/'
@@ -11,9 +10,6 @@ cask 'tinymediamanager' do
   app 'tinyMediaManager.app'
 
   caveats do
-    # The Java dependency should be relaxed to 8+ on the next release.
-    # Keeping it at 8 for this version only.
-    # See https://github.com/tinyMediaManager/tinyMediaManager/pull/437
-    depends_on_java '8'
+    depends_on_java '8+'
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).