### PR TITLE
Update fontlab to 6.1.2.6927

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,8 +1,9 @@
 cask 'fontlab' do
-  version :latest
-  sha256 :no_check
+  version '6.1.2.6927'
+  sha256 'ab5079a206cb1ddda0f39889ea10ccf6bf53b5ffd5bacceabb6ace99074db2b8'
 
-  url 'https://download.fontlab.com/fontlab-vi/get-mac.php'
+  url 'https://download.fontlab.com/fontlab-vi/upd-mac.php'
+  appcast 'https://download.fontlab.com/fontlab-vi/appcast-mac.xml'
   name 'Fontlab'
   homepage 'https://www.fontlab.com/font-editor/fontlab-vi'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.