### PR TITLE
Update traverse to 0.10.7

### DIFF
--- a/Casks/traverse.rb
+++ b/Casks/traverse.rb
@@ -1,6 +1,6 @@
 cask 'traverse' do
-  version '0.10.6'
-  sha256 'bd4e252c59b2787a9102022bd7710c712a093196f5ba983cb6050500bb867ddc'
+  version '0.10.7'
+  sha256 '2f34be44f24c593b996e2d0935ab230d1c4a546972f0add30e5d0daa4feb7be2'
 
   # github.com/jasonraimondi/traverse was verified as official when first introduced to the cask
   url "https://github.com/jasonraimondi/traverse/releases/download/v#{version}/Traverse-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.