### PR TITLE
Update keka to 1.1.11

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,6 +1,6 @@
 cask 'keka' do
-  version '1.1.10'
-  sha256 '47d2e3be590a72edcdc255a3c9bb9936ef7b69af36ff55b4f15d6c47fd5ba8b1'
+  version '1.1.11'
+  sha256 'c27601750a57469daf0a85e9ca524a6186aed45a2af110b6871ec2f112c4c416'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.