### PR TITLE
Update fldigi to 4.1.00,4.3.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,8 +1,8 @@
 cask 'fldigi' do
-  version '4.0.18,4.3.7'
-  sha256 '8c6b317d6825b664df192d87e726b7c7caba4dcf6722d8f362d4565b24622d0d'
+  version '4.1.00,4.3.7'
+  sha256 '32e4da40dc5e4c15681027bec433301f62fd4a08a513cd6501df43152d578632'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_macos.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.