### PR TITLE
Update pulse-sms to 3.2.1

### DIFF
--- a/Casks/pulse-sms.rb
+++ b/Casks/pulse-sms.rb
@@ -1,6 +1,6 @@
 cask 'pulse-sms' do
-  version '3.1.4'
-  sha256 '99c37cc87d6e367937147d5b7acee2f84edfa51c4f1aec924ba6726e0c5986d6'
+  version '3.2.1'
+  sha256 '0c531b4d1b12c1b8b4593df822077beba52d407f228652bbb37ae84360961e72'
 
   # github.com/klinker-apps/messenger-desktop was verified as official when first introduced to the cask
   url "https://github.com/klinker-apps/messenger-desktop/releases/download/v#{version}/pulse-sms-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.