### PR TITLE
Update seashore to 2.3.3

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.3.2'
-  sha256 '412cfbf7c74133d1d5bcf9d118caaf84350fedb5a8cf5ff4a89c98daa3f1ae37'
+  version '2.3.3'
+  sha256 '846a3d1d762c7e02da5a890539fb5c42a3560020bdb9ba66267b69ec498172a1'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.