### PR TITLE
Update mailbutler to 2.2.6-10654

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2.2.4-10462'
-  sha256 'dd36bee857a9a0db885af997e447a2d4204e44121766c364f9ad958515ac28ed'
+  version '2.2.6-10654'
+  sha256 '0bb38da4a375c9ff70defa7f14cd41c9b2694bc11c8aff1b7f433ad73b0342a0'
 
   # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mailbutler-data.s3.amazonaws.com/downloads/Mailbutler_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.