### PR TITLE
Update rightfont to 5.3.2

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,6 +1,6 @@
 cask 'rightfont' do
-  version '5.2.4'
-  sha256 '57b955fc1ef48284a8ac654f73cb3bb08c1ae4fec265792a508896f64c012e9f'
+  version '5.3.2'
+  sha256 '15c166686c43e266f35df322a9d26750f5b2dff31b32b2054525118d9785fe01'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
   appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.