### PR TITLE
Update MuseScore to 3.0.2

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -2,7 +2,6 @@ cask 'musescore' do
   version '3.0.2.20666'
   sha256 '4f31564d3795fe265d229bcebb33999dd41a198be2fca0c6275033019714576a'
 
-  # ftp.osuosl.org/pub/musescore was verified as official when first introduced to the cask
   # 3.0.1 is the last on ftp.osuosl.org/pub/musescore
   # 3.0.2 is available at https://download.musescore.com/releases/MuseScore-3.0.2 (you cannot browse the parent dir). 
   url "https://download.musescore.com/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version.major_minor_patch}.dmg"

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -2,6 +2,7 @@ cask 'musescore' do
   version '3.0.2.20666'
   sha256 '4f31564d3795fe265d229bcebb33999dd41a198be2fca0c6275033019714576a'
 
+  # musescore.com was verified as official when first introduced to the cask
   url "https://download.musescore.com/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version.major_minor_patch}.dmg"
   appcast "https://sparkle.musescore.org/stable/#{version.major}/macos/appcast.xml"
   name 'MuseScore'

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -2,8 +2,6 @@ cask 'musescore' do
   version '3.0.2.20666'
   sha256 '4f31564d3795fe265d229bcebb33999dd41a198be2fca0c6275033019714576a'
 
-  # 3.0.1 is the last on ftp.osuosl.org/pub/musescore
-  # 3.0.2 is available at https://download.musescore.com/releases/MuseScore-3.0.2 (you cannot browse the parent dir). 
   url "https://download.musescore.com/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version.major_minor_patch}.dmg"
   appcast "https://sparkle.musescore.org/stable/#{version.major}/macos/appcast.xml"
   name 'MuseScore'

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,9 +1,11 @@
 cask 'musescore' do
-  version '3.0.1.20439'
-  sha256 '79baa85be701e3fa6e4ec662f3afa673d364203998ee78eefa67e12378f77015'
+  version '3.0.2.20666'
+  sha256 '4f31564d3795fe265d229bcebb33999dd41a198be2fca0c6275033019714576a'
 
   # ftp.osuosl.org/pub/musescore was verified as official when first introduced to the cask
-  url "https://ftp.osuosl.org/pub/musescore/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version.major_minor_patch}.dmg"
+  # 3.0.1 is the last on ftp.osuosl.org/pub/musescore
+  # 3.0.2 is available at https://download.musescore.com/releases/MuseScore-3.0.2 (you cannot browse the parent dir). 
+  url "https://download.musescore.com/releases/MuseScore-#{version.major_minor_patch}/MuseScore-#{version.major_minor_patch}.dmg"
   appcast "https://sparkle.musescore.org/stable/#{version.major}/macos/appcast.xml"
   name 'MuseScore'
   homepage 'https://musescore.org/'


### PR DESCRIPTION
    # 3.0.1 is the last on ftp.osuosl.org/pub/musescore
    # 3.0.2 is available at https://download.musescore.com/releases/MuseScore-3.0.2 (you cannot browse the parent dir).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
