### PR TITLE
Update touchswitcher to 1.8.1,738

### DIFF
--- a/Casks/touchswitcher.rb
+++ b/Casks/touchswitcher.rb
@@ -1,9 +1,9 @@
 cask 'touchswitcher' do
-  version '1.0.1,100'
-  sha256 'f7bc7cdf143e0b803c97846bac154fbd20305bc9be3289e43f9604968df839fc'
+  version '1.8.1,738'
+  sha256 '6b1185a16d9d4950d9324c57906df844f959df3ffd308bcaba6dae49ae4ff1c5'
 
-  url 'https://hazeover.com/touchswitcher/TouchSwitcher.zip'
-  appcast 'https://hazeover.com/touchswitcher/updates.xml'
+  url 'https://hazeover.com/HazeOver.dmg'
+  appcast 'https://hazeover.com/updates.xml'
   name 'TouchSwitcher'
   homepage 'https://hazeover.com/touchswitcher.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.