### PR TITLE
Update graphql-playground to 1.8.8

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,6 +1,6 @@
 cask 'graphql-playground' do
-  version '1.8.7'
-  sha256 '91071e9fb0cce6ad6078ffd6a0bd4f23fe086e357fce426766286b713d1ca5ab'
+  version '1.8.8'
+  sha256 '30d803609d6884575c49dd529b420a264696b72ecf84049a77b327bb375541b0'
 
   url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prisma/graphql-playground/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.