### PR TITLE
Update mu-editor to 1.0.2

### DIFF
--- a/Casks/mu-editor.rb
+++ b/Casks/mu-editor.rb
@@ -1,6 +1,6 @@
 cask 'mu-editor' do
   version '1.0.2'
-  sha256 'd0be1d6268cff60f65947280f1d0f2b05b28e67c07ee4c7dd3773a195a3d2f71'
+  sha256 '70087d6f81f641829b8c457a67bc84cf4437a4fb7dec89fafdda03e26d89af88'
 
   # github.com/mu-editor/mu was verified as official when first introduced to the cask
   url "https://github.com/mu-editor/mu/releases/download/#{version}/mu-editor_#{version}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.