### PR TITLE
Update workflowy to 1.1.15

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,12 +1,14 @@
 cask 'workflowy' do
-  version '1.1.14'
-  sha256 'b1fd9328840916a507a3577807575242b98e7ff8ee0d5a5fbca1237e7952dd13'
+  version '1.1.15'
+  sha256 'b2e1090b3092edf813ebcc376cde4d316137da779b5b51bd1dbc4ae7e6eae4b1'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"
   appcast 'https://github.com/workflowy/desktop/releases.atom'
   name 'WorkFlowy'
   homepage 'https://workflowy.com/downloads/mac/'
+
+  auto_updates true
 
   app 'WorkFlowy.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.