### PR TITLE
Update zoho-mail-desktop to 1.0.10

### DIFF
--- a/Casks/zoho-mail-desktop.rb
+++ b/Casks/zoho-mail-desktop.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail-desktop' do
-  version '1.0.9'
-  sha256 '73adeda015a4940ac79eb052028bc34c28252e241e1a08ff5f789d955b54e4e6'
+  version '1.0.10'
+  sha256 '9e5a08cd9bbf07e3ca07a7ce43e18764b22a022cdad7c749e6ef9baf3139f32b'
 
   url "https://www.zoho.com/mail/desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"
   name 'zoho-mail-desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.