### PR TITLE
Bug in list_payload_in_pkg prints “{}” instead of payload path

### DIFF
--- a/developer/bin/list_payload_in_pkg
+++ b/developer/bin/list_payload_in_pkg
@@ -114,6 +114,13 @@ no guarantee that the output is exact.
 If a given file is already installed, it will be followed by
 a plus symbol '(+)' in the output.
 
+Note that Apple's xargs utility has a limitation of processing
+up to 255 bytes. Therefore long payload paths might be printed
+as '{}' instead. To overcome this limitation, please consider
+installing the GNU xargs utility instead using:
+
+brew install findutils
+
 See CONTRIBUTING.md and 'man pkgutil' for more information.
 
 "


### PR DESCRIPTION
__SYMPTOMS:__
While writing the uninstaller for `apple-hewlett-packard-printer-drivers.rb` in the `homebrew-cask-drivers` repo, I found that the `list_payload_in_pkg` tool occasionally prints `{}` instead of the payload path.

An example: 
```
$ list_payload_in_pkg /Volumes/HewlettPackard\ Printer\ Drivers/HewlettPackardPrinterDrivers.pkg
```
prints the following (compressed) output:
```
<snip>
/Library/Printers/hp/Utilities/HPPU Plugins/ProductImprovementStudy.hptask/Contents/Helpers/HP Product Research Manager.app/Contents/Library/LoginItems
/Library/Printers/hp/Utilities/HPPU Plugins/ProductImprovementStudy.hptask/Contents/Helpers/HP Product Research Manager.app/Contents/Library/LoginItems/HP Product Research.app
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
{}
/Library/Printers/hp/Utilities/HPPU Plugins/ProductImprovementStudy.hptask/Contents/Helpers/HP Product Research Manager.app/Contents/MacOS
/Library/Printers/hp/Utilities/HPPU Plugins/ProductImprovementStudy.hptask/Contents/Helpers/HP Product Research Manager.app/Contents/MacOS/HP Product Research Manager
<snip>
```

Printing of `{}` occured multiple times for this `pkg` and not only in this snippet. In this case, the path to an `app` bundle was not printed, which is desired when writing the uninstaller of a cask. 

__ROOT CAUSE:__
Executing the `list_payload_in_pkg` tool without the `mark_up_sources ()` function printed the expected payload paths instead of `{}` (without the conditional ` (+)`).

Further debug led to the conclusion that Apple’s `xargs` utility caused the bug. The following is taken from `man xargs`:
```
-I replstr
        Execute utility for each input line, replacing one or more occurrences of
        replstr in up to replacements (or 5 if no -R flag is specified) arguments to
        utility with the entire line of input.  The resulting arguments, after
        replacement is done, will not be allowed to grow beyond 255 bytes; this is
        implemented by concatenating as much of the argument containing replstr as
        possible, to the constructed arguments to utility, up to 255 bytes.  The 255
        byte limit does not apply to arguments to utility which do not contain
        replstr, and furthermore, no replacement will be done on utility itself.
        Implies -x.
```
A limitation is mentioned here of `255 bytes` and this seems to be the root cause of the problem.
This limitation is not present in the `GNU xargs` utility and after installing it everything worked as expected.

__PROPOSAL:__
The  `list_payload_in_pkg` tool already prefers `gxargs` over `xargs`. However, the user should be made aware of this without digging through the source code. This pull request informs the user of the limitation and suggests to install the `GNU xargs` utility.
