### PR TITLE
Update printopia to 3.0.13

### DIFF
--- a/Casks/printopia.rb
+++ b/Casks/printopia.rb
@@ -3,6 +3,7 @@ cask 'printopia' do
   sha256 'cac11d0ba2af9d33c7dcb7ecd42812c3ca4845f7f403c9c9d1b8a015829a90e1'
 
   url "https://www.decisivetactics.com/products/printopia/dl/Printopia_#{version}.zip"
+  appcast 'https://www.decisivetactics.com/api/checkupdate?x-app_id=com.decisivetactics.printopia'
   name 'Printopia'
   homepage 'https://www.decisivetactics.com/products/printopia/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.