### PR TITLE
Update mountain-duck to 2.7.1.9840

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,6 +1,6 @@
 cask 'mountain-duck' do
-  version '2.7.0.9820'
-  sha256 '85fa11b17a6c421a2eab0833ff298188ee845b2b70caa2464ab8c0dd7b53fe44'
+  version '2.7.1.9840'
+  sha256 'fac3937d56ca3c093b24fc94958b162dc18205322a8624d0f2258007e3735b48'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.