### PR TITLE
Update ableton-live-standard to 10.0.6

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard' do
-  version '10.0.5'
-  sha256 'e76280986699c40148632e7a9d9a0fb7596d0cf57f41f7f62e6ef09e219c153f'
+  version '10.0.6'
+  sha256 'ba566192b56e74a9b455b307727413e6f2449626c1e83978dac3e18f6040180b'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.