### PR TITLE
Update dcp-o-matic-player to 2.12.18

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.12.13'
-  sha256 '09ce5062d6737ff56e0cc5957a21170af9bd2b437b124b5c898bca1b23eef27d'
+  version '2.12.18'
+  sha256 'efbf129d9a6141d1f858f2d6d2c7d1d6c9e73a7ff4b0385c752866ff074ebf24'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.