### PR TITLE
Update chronos to 2.8.6

### DIFF
--- a/Casks/chronos.rb
+++ b/Casks/chronos.rb
@@ -1,6 +1,6 @@
 cask 'chronos' do
-  version '2.7.3'
-  sha256 'ea58c022e457dcc9f57c58f913560db54a1d5845c4d0646e3d82bad8ee901a9f'
+  version '2.8.6'
+  sha256 '20bb6e8aeda84c61f4af5c6136d96458502587496455a838b3631b1de8ec36ed'
 
   url "https://github.com/web-pal/chronos-timetracker/releases/download/v#{version}/Chronos-#{version}-mac.zip"
   appcast 'https://github.com/web-pal/chronos-timetracker/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.