### PR TITLE
Update enpass to 6.0.4,331

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -1,6 +1,6 @@
 cask 'enpass' do
-  version '6.0.3,319'
-  sha256 '1ffa58e6784ea086e89592e13bbf6a4d23419789a2752eb0f23e1a1e37b5dce7'
+  version '6.0.4,331'
+  sha256 '639555edba6e26c44710d70da7fdaa63adc8eeb55801bdc144cd2f092a9b05bd'
 
   url "https://dl.enpass.io/stable/mac/package/#{version.after_comma}/Enpass.pkg"
   appcast 'https://dl.sinew.in/mac/package/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.