### PR TITLE
Update turtl to 0.7.2.5

### DIFF
--- a/Casks/turtl.rb
+++ b/Casks/turtl.rb
@@ -1,6 +1,6 @@
 cask 'turtl' do
-  version '0.7.2.3'
-  sha256 '092c200a89d88521a7679ae1c7cefdbbfedc3a7263763a51ec7def9a9d3a34ee'
+  version '0.7.2.5'
+  sha256 '266ad5026910431e1dd16c77b558c8503b178409ed486a98423491fc050b7b19'
 
   # github.com/turtl/desktop was verified as official when first introduced to the cask
   url "https://github.com/turtl/desktop/releases/download/v#{version}/turtl-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.