### PR TITLE
Update gns3 to 2.1.12

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.11'
-  sha256 '18af99447ef1537113b9bc29e46e474429766f46fd8d811165716cbedc9bad4f'
+  version '2.1.12'
+  sha256 '68b367895f5c87ee670644a70b1645465d33a38acb8d2f86cdc539d548b5aaa6'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.