### PR TITLE
Update corretto to 8.202.08.2

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,14 +1,14 @@
 cask 'corretto' do
-  version '8,8u192'
-  sha256 '50ba40b0d5e004c8b4720916a4f40660472bd8ad22f90b88eec87fb98b2455aa'
+  version '8,8.202.08.2'
+  sha256 '0b79bbf6e4fa5f5ad75e49a36b52def428e160582476530b20a68837deaf0e58'
 
-  # d3pxv6yz143wms.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d3pxv6yz143wms.cloudfront.net/amazon-corretto-preview2-#{version.after_comma}-macosx-x64.pkg"
+  # d2znqt9b1bc64u.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d2znqt9b1bc64u.cloudfront.net/amazon-corretto-#{version.after_comma}-macosx-x64.pkg"
   appcast 'https://docs.aws.amazon.com/en_us/corretto/latest/corretto-8-ug/corretto-8-ug.rss'
   name 'Amazon Corretto'
   homepage 'https://aws.amazon.com/corretto/'
 
-  pkg "amazon-corretto-preview2-#{version.after_comma}-macosx-x64.pkg"
+  pkg "amazon-corretto-#{version.after_comma}-macosx-x64.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.before_comma}"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Note: the cloudfront subdomain has changed, this can be verified by viewing the Download Link on https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
