### PR TITLE
Update permute to 3.0.9,2075

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.0.8,2070'
-  sha256 'e78cf100cd0f1012052bc887e0cfa04ecc57c0d50b74806d3d48d1e31e4c5022'
+  version '3.0.9,2075'
+  sha256 '37d069a67ff02c07a4aea8055498b467bd7f63b4a54af24982efde47ec4be269'
 
   url "https://trial.charliemonroe.net/permute/Permute_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.