### PR TITLE
Update react-native-debugger (0.9.1)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,6 +1,6 @@
 cask 'react-native-debugger' do
-  version '0.8.3'
-  sha256 'e4e62f9bd5528eef94ac8d6725f0ceffe4373f8c3e1c861ba09d7999d9a639b7'
+  version '0.9.1'
+  sha256 'af9f7177ca494573ab3cd5e8aa127ec0af079bdafe0b66acfb582cfc653fc142'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
