### PR TITLE
Update devhub to 0.45.0

### DIFF
--- a/Casks/devhub.rb
+++ b/Casks/devhub.rb
@@ -1,6 +1,6 @@
 cask 'devhub' do
-  version '0.44.0'
-  sha256 'eecdc44b964221522046a465cdaf9b96ee113720b453dea1f36b0d0bf1f36c01'
+  version '0.45.0'
+  sha256 'f370f0caf0d3d8a9cfd00880adf4d5ae88cdebd63f0442b6ae4f2a33353c4766'
 
   url "https://github.com/devhubapp/devhub/releases/download/v#{version}/DevHub-#{version}.dmg"
   appcast 'https://github.com/devhubapp/devhub/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.