### PR TITLE
Update flipper to 0.15.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.14.2'
-  sha256 '3568a95b58e9dcb6643dd715c34d773ee5be5a9a7d9309d9af74f1c0168b247a'
+  version '0.15.0'
+  sha256 '59c889f8e6c61ec7755db553541fd0a7ce4dac23eb805ef0eed597b4706d8d0d'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.