### PR TITLE
Update ganache to 1.3.0

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,6 +1,6 @@
 cask 'ganache' do
-  version '1.2.3'
-  sha256 '9346adf4f87fd2d4d92ab4f64d98011dfb7e71f84692ed35b1d73f040e86f0bf'
+  version '1.3.0'
+  sha256 '31d3d1282c688ae33542f78a8398650021e6280b9aa75935db051907146ab0d0'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.