### PR TITLE
Update ganttproject to 2.8.10,r2363

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,6 +1,6 @@
 cask 'ganttproject' do
-  version '2.8.9,r2335'
-  sha256 '9991d419cf30d8c85ce828102f71e07885530b4a7fae3ad9e0c0ae764ea7f237'
+  version '2.8.10,r2363'
+  sha256 '7dbe2f3fe6ece186d781111fe91f77950a271c87ef3a0a6345d65541281e908d'
 
   # github.com/bardsoftware/ganttproject was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.