### PR TITLE
Update tribler to 7.2.0

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,9 +1,9 @@
 cask 'tribler' do
-  version '7.1.5'
-  sha256 '81f4cd57cd23736e9705da022adcf4582f84ec6e6b594a58a7543be310502c01'
+  version '7.2.0'
+  sha256 '6f65237a55c48313107675e9a570a3e73522a6d3a6adcf4bce8fbaad743c78ab'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
-  url "https://github.com/Tribler/tribler/releases/download/V#{version}/Tribler-#{version}.dmg"
+  url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
   appcast 'https://github.com/Tribler/tribler/releases.atom'
   name 'Tribler'
   homepage 'https://www.tribler.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.