### PR TITLE
Update wickrme to 5.2.4

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '4.64.8'
-  sha256 'ab6fcdefac88630183784af03035c37dd67b3638f7031a16cffbf7a6b293eabe'
+  version '5.2.4'
+  sha256 '79ba4b6b1cd093647c152884725c3c513ebc314fd8e56e3756d18e6f3d44980b'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.