### PR TITLE
Update papers to 3.4.20,579

### DIFF
--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -1,6 +1,6 @@
 cask 'papers' do
-  version '3.4.19,573'
-  sha256 '2462f23d4db30f8fcd82273687eea79de030ccd622e695b33b38a9d8f3fb0be7'
+  version '3.4.20,579'
+  sha256 '48882e7852cd60ee42356e16fc297bbbe4f49c6a01f8a4a9127cfd10e45ff775'
 
   # appcaster.papersapp.com/apps/mac/production/download was verified as official when first introduced to the cask
   url "https://appcaster.papersapp.com/apps/mac/production/download/#{version.after_comma}/papers_#{version.before_comma.no_dots}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.