### PR TITLE
Update kite to 0.20190131.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190127.1'
-  sha256 '818ee6606fb0f6f0f90f73089196e93d542fac2602e2220438f7205bfa6b9bd8'
+  version '0.20190131.0'
+  sha256 '4b33884e77e4e000fb74750f4bec4cc3fbbb501e0d23e9efbc3acfcd53ca0246'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.