### PR TITLE
Update rstudio appcast stanza

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -4,7 +4,7 @@ cask 'rstudio' do
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/RStudio-#{version}.dmg"
-  appcast 'https://www.rstudio.com/products/rstudio/download/'
+  appcast 'https://www.rstudio.com/products/rstudio/release-notes/'
   name 'RStudio'
   homepage 'https://www.rstudio.com/'
 


### PR DESCRIPTION
rationale: we are going to start observing html appcasts too. the current one here is 750kb, the new one should be < 50.