### PR TITLE
Update manager to 19.1.36

### DIFF
--- a/Casks/manager.rb
+++ b/Casks/manager.rb
@@ -1,6 +1,6 @@
 cask 'manager' do
-  version '19.1.34'
-  sha256 '5330d8347f03ded08d0d044f39af772567234534a3b71b3d76a3973e2bf3efd0'
+  version '19.1.36'
+  sha256 'b2e5997ce248dd2c3f9bc96ba4c0d015c5fd87e4af55ad381011a5e58cf52046'
 
   # d2ap5zrlkavzl7.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2ap5zrlkavzl7.cloudfront.net/#{version}/Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.