### PR TITLE
Update electron to 4.0.4

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '4.0.3'
-  sha256 'a4bf82663e0b59c4d4f072bf90396278e6bf1100826d712f796143f2a8b708fa'
+  version '4.0.4'
+  sha256 '95c0840053037a2ed2f18c0cdc32564f75c3bc262cd246b9a63e547e5781cb06'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.