### PR TITLE
Added Oracle JDK 8u202 cask

### DIFF
--- a/Casks/oracle-jdk8.rb
+++ b/Casks/oracle-jdk8.rb
@@ -1,0 +1,43 @@
+cask 'oracle-jdk8' do
+  version '8u202,b08:1961070e4c9b4e26a04e7f5a083f551e'
+  sha256 'b41367948cf99ca0b8d1571f116b7e3e322dd1ebdfd4d390e959164d75b97c20'
+
+  url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}-#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}-macosx-x64.dmg",
+      cookies: {
+                 'oraclelicense' => 'accept-securebackup-cookie',
+               }
+  name 'Java 8 Standard Edition Development Kit'
+  homepage 'https://www.oracle.com/technetwork/java/javase/overview/index.html'
+
+  # auto_updates true: JDK does not auto-update
+  depends_on macos: '>= :yosemite'
+
+  pkg "JDK 8 Update 202.pkg"
+
+  postflight do
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/MacOS", '/Library/Java/MacOS'],
+                   sudo: true
+    system_command '/bin/mkdir',
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   sudo: true
+  end
+
+  uninstall pkgutil: "com.oracle.jdk-#{version.before_comma}",
+            delete:  [
+                       "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
+                       '/Library/Java/Home',
+                       '/Library/Java/MacOS',
+                     ],
+            rmdir:   "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk"
+
+  caveats do
+    license 'https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html'
+  end
+end

--- a/Casks/oracle-jdk8.rb
+++ b/Casks/oracle-jdk8.rb
@@ -29,7 +29,7 @@ cask 'oracle-jdk8' do
                    sudo: true
   end
 
-  uninstall pkgutil: "com.oracle.jdk-#{version.before_comma}",
+  uninstall pkgutil: "com.oracle.jdk#{version.before_comma}",
             delete:  [
                        "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
                        '/Library/Java/Home',

--- a/Casks/oracle-jdk8.rb
+++ b/Casks/oracle-jdk8.rb
@@ -12,7 +12,7 @@ cask 'oracle-jdk8' do
   # auto_updates true: JDK does not auto-update
   depends_on macos: '>= :yosemite'
 
-  pkg "JDK 8 Update 202.pkg"
+  pkg 'JDK 8 Update 202.pkg'
 
   postflight do
     system_command '/bin/ln',


### PR DESCRIPTION
Added Oracle JDK 8 (update 202).

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
