### PR TITLE
Update latexit to 2.13.0

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,6 +1,6 @@
 cask 'latexit' do
-  version '2.12.0'
-  sha256 '6d0fabea227d9c8447bd43c5c22589960c739aacac19168fd443c5d73a8a0fd6'
+  version '2.13.0'
+  sha256 'cedea4041f0fa5a9319af7829ea321e83f607c85c439f070b2466f804fd39464'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.