### PR TITLE
Update private-internet-access to 1.0.1-02349

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,8 +1,8 @@
 cask 'private-internet-access' do
-  version '82'
-  sha256 'e849df3ef9c7114b3b163ad5a3183ee9f55f37dc89089c2f4ca92c16cd758f5d'
+  version '1.0.1-02349'
+  sha256 '59c3a8ad7661cb86c2b9b3f0b9d2994031493cc30fbe454d970d1c8edfb74926'
 
-  url "https://installers.privateinternetaccess.com/download/pia-v#{version}-installer-mac.dmg"
+  url "https://installers.privateinternetaccess.com/download/pia-macos-#{version}.zip"
   name 'Private Internet Access'
   homepage 'https://www.privateinternetaccess.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.