### PR TITLE
Update geany to 1.34.1

### DIFF
--- a/Casks/geany.rb
+++ b/Casks/geany.rb
@@ -1,6 +1,6 @@
 cask 'geany' do
-  version '1.34'
-  sha256 '15636ba493084d7b8ac3938ec0f5c9649e07759ffe08859761af762c2231f98e'
+  version '1.34.1'
+  sha256 'a00361cef315f8291e05655124bdfb6397e8b9e55613a3e04287727dbd22f029'
 
   url "https://download.geany.org/geany-#{version}_osx.dmg"
   appcast 'https://github.com/geany/geany/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.