### PR TITLE
Update pomodone to 1.5.1479

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,6 +1,6 @@
 cask 'pomodone' do
-  version '1.5.1475'
-  sha256 'a612bac61942f3674c700d0531261e92356382dac7a22e283373f6c3b7d7a855'
+  version '1.5.1479'
+  sha256 '053d3bfee09fa7606725314d1a56500e5da5d83450ce64906aed1a5335b8bdd1'
 
   url "https://app.pomodoneapp.com/installers/PomoDoneApp-#{version}.dmg"
   name 'PomoDone'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.