### PR TITLE
Update ableton-live-suite to 10.0.6

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite' do
-  version '10.0.5'
-  sha256 'f46fb7f402f1c5e5407e0f5cd8c893d6bc0ece172d4847ebdef23a72dc78ac05'
+  version '10.0.6'
+  sha256 '356c1934def95b230bb94393deb486e5fc8565b2ba8259317bb51936a4bac043'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.