### PR TITLE
Update netron to 2.8.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.8.4'
-  sha256 'd8ac83f3027d247361aa08e95f2065cba161d8a0c1260da889aa9c6eaab8fe1c'
+  version '2.8.5'
+  sha256 'b5d3510a7a1a1e5a5f4249bdb5d1dbbc6d7eccfca6ee57ea976bae6554c4e591'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.