### PR TITLE
Update mysqlworkbench to 8.0.15

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -1,6 +1,6 @@
 cask 'mysqlworkbench' do
-  version '8.0.14'
-  sha256 '67c21adbf18a99d50c5afd1d3eb1a8606f2dc7c8a243a1a992af2951c8661eaf'
+  version '8.0.15'
+  sha256 'bc888ed496cd5a654b63dee655117511349b03f1fc10679f4ec158ab1a0475b7'
 
   url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   name 'MySQL Workbench'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.