### PR TITLE
Update lando to 3.0.0-rc.5

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.0-rc.1'
-  sha256 '450888a92e0b353dea96975a011b58a7efbb52f3f23edea1a7f3eb673780b041'
+  version '3.0.0-rc.5'
+  sha256 '68108ab6d261edcff38a9c63cd636f2089957cad00ca002bcad6cd56f6337436'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.