### PR TITLE
Update retroarch-cg to 1.7.6

### DIFF
--- a/Casks/retroarch-cg.rb
+++ b/Casks/retroarch-cg.rb
@@ -1,6 +1,6 @@
 cask 'retroarch-cg' do
-  version '1.7.5'
-  sha256 '1ff99354183c6177c5366391686f75a591da43c332e8d32c071caccb7321f822'
+  version '1.7.6'
+  sha256 '6cf4e640b56ea197d5c19f6f857936596ba7ea207a822a8c26d7e78e4b1d5e07'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch_CG.dmg"
   name 'RetroArch CG'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.