### PR TITLE
Update eaglefiler to 1.8.6

### DIFF
--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,6 +1,6 @@
 cask 'eaglefiler' do
-  version '1.8.5'
-  sha256 '26a5e0f4270fa83bd55a3a60c6f64308c23cc2ceb8da4e402da514008e940c31'
+  version '1.8.6'
+  sha256 'bfdbdd9b7ddde9488dca7239ad38ccc37ca81a2121febf93c1b519326c26d860'
 
   url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   appcast 'https://c-command.com/eaglefiler/help/version-history'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.