### PR TITLE
Update hachidori to 3.1

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,6 +1,6 @@
 cask 'hachidori' do
-  version '3.0.9'
-  sha256 '6ba2810efdaac15f4d1da84f19cb9de3a9a67dd41911671f619a39a5c76b8a3d'
+  version '3.1'
+  sha256 '3f1f1dafdfd8098b7733970083ec876a25b7219f39de56b607278c4fa56de85a'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.