### PR TITLE
Update superproductivity to 2.0.7

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '1.999.1000'
-  sha256 '4545ca2b2d994e71e2c14ca16dfb989b2df31a078295a5291d480732d864761c'
+  version '2.0.7'
+  sha256 'eec60b1223d14b7f491c465f58493a5164f437c2dbce50f2b27594dc8c2f3c6b'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.