### PR TITLE
Update windows95 to 2.0.0

### DIFF
--- a/Casks/windows95.rb
+++ b/Casks/windows95.rb
@@ -1,7 +1,7 @@
 cask 'windows95' do
   # note: "95" is not a version number, but an intrinsic part of the product name
-  version '1.4.0'
-  sha256 '64e2d7d447c5841a6a34802d7d394770e2b08f20498ff33d61ace53607087023'
+  version '2.0.0'
+  sha256 '9f2ce72b7ec7a79cb3521bd75722b39f99a4234784dc232667ae682e6104637b'
 
   url "https://github.com/felixrieseberg/windows95/releases/download/v#{version}/windows95-macos-#{version}.zip"
   appcast 'https://github.com/felixrieseberg/windows95/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.