### PR TITLE
Update macupdater to 1.4.4

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.4.3'
-  sha256 '6eeca8dd9875780979affea035d6852e6984945b7896d539827a6aed9463c3a5'
+  version '1.4.4'
+  sha256 '65bfee1fddefb509046c7a001c4ac2ad45c0d84b4d827a25df341985510c100f'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.