### PR TITLE
Update vagrant-manager to 2.7.0

### DIFF
--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -1,9 +1,9 @@
 cask 'vagrant-manager' do
-  version '2.6.0'
-  sha256 'ed9ad3f1b6a97e82c959812b0779036946903630627914b02684d53ad71b1052'
+  version '2.7.0'
+  sha256 'e2bc635e7e0f2ddca1fde8279a775f3ca8615144dff71a2b0b0f4d3b0f640936'
 
   # github.com/lanayotech/vagrant-manager was verified as official when first introduced to the cask
-  url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
+  url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/Vagrant.Manager-#{version}.dmg"
   appcast 'https://github.com/lanayotech/vagrant-manager/releases.atom'
   name 'Vagrant Manager'
   homepage 'http://vagrantmanager.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.