### PR TITLE
Update unity-linux-support-for-editor to 2018.3.4f1

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,9 +1,9 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.3.1f1,bb579dc42f1d'
-  sha256 '5283a40df4e797aa401569ea54a316f7e058ecb15ccda07a746b011e2290eed2'
+  version '2018.3.4f1,1d952368ca3a'
+  sha256 '553c0349d341b6c71eab617af0d0cbc18180c1e6b88c052e6fd8bc70832ee6bc'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
-  appcast 'https://unity3d.com/get-unity/download/archive'
+  appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity Linux Build Support'
   homepage 'https://unity3d.com/unity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
