### PR TITLE
Update unity-webgl-support-for-editor to 2018.3.4f1

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,9 +1,9 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.3.1f1,bb579dc42f1d'
-  sha256 'a416f023ae42969fdc566902d07fc6a2a75ec8c44c68b5126e46bf786b454642'
+  version '2018.3.4f1,1d952368ca3a'
+  sha256 '80dbfe72ff850cb9e19e3f2fc8f1f51cf8c8ee1867f73db951869158928ea569'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
-  appcast 'https://unity3d.com/get-unity/download/archive'
+  appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity WebGL Build Support'
   homepage 'https://unity3d.com/unity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
