### PR TITLE
Update unity-windows-support-for-editor to 2018.3.4f1

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,9 +1,9 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.3.1f1,bb579dc42f1d'
-  sha256 'e826e4ef546aa2331c0d8688509ba9d9d272bd4f32236227467ecde400e283d1'
+  version '2018.3.4f1,1d952368ca3a'
+  sha256 '8b0be0563a3c17780dd406f5869b63d8cca169e27023079eaa0c23d2764002ab'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
-  appcast 'https://unity3d.com/get-unity/download/archive'
+  appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity Windows (Mono) Build Support'
   homepage 'https://unity3d.com/unity/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
