### PR TITLE
Update unity-standard-assets to 2018.1.9f2

### DIFF
--- a/Casks/unity-standard-assets.rb
+++ b/Casks/unity-standard-assets.rb
@@ -1,6 +1,9 @@
 cask 'unity-standard-assets' do
-  version '2018.1.7f1,4cb482063d12'
-  sha256 'a9762467ca1fb32bab7c1b12baee306662fc29e84d1d26bc551102e508e331ed'
+  # Please update other unity-related pacakges as well
+  # versions information can be found here
+  # https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json
+  version '2018.1.9f2,a6cc294b73ee'
+  sha256 '39a4af2c1933597c3599f7f90563749bdb1286b8a149355618fe56a606aa0b1c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacStandardAssetsInstaller/StandardAssets-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'

--- a/Casks/unity-standard-assets.rb
+++ b/Casks/unity-standard-assets.rb
@@ -1,12 +1,9 @@
 cask 'unity-standard-assets' do
-  # Please update other unity-related pacakges as well
-  # versions information can be found here
-  # https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json
   version '2018.1.9f2,a6cc294b73ee'
   sha256 '39a4af2c1933597c3599f7f90563749bdb1286b8a149355618fe56a606aa0b1c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacStandardAssetsInstaller/StandardAssets-#{version.before_comma}.pkg"
-  appcast 'https://unity3d.com/get-unity/download/archive'
+  appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity Standard Assets'
   homepage 'https://unity3d.com/unity'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
