### PR TITLE
Update drafts to 5.6.3.4

### DIFF
--- a/Casks/drafts.rb
+++ b/Casks/drafts.rb
@@ -1,6 +1,6 @@
 cask 'drafts' do
-  version '5.6.3.1'
-  sha256 'de314d3c5af5efe2ef9ef3ac37d9ed4d454526805aba0de0da020851c271a91f'
+  version '5.6.3.4'
+  sha256 'd06d95e30dcc2308a9f62b5043d1de0dd8506ef75c9e290ec4d31b37d036b2d4'
 
   # s3-us-west-2.amazonaws.com/downloads.agiletortoise.com was verified as official when first introduced to the cask
   url 'https://s3-us-west-2.amazonaws.com/downloads.agiletortoise.com/Drafts.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.