### PR TITLE
Update liteide to 35.5

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,6 +1,6 @@
 cask 'liteide' do
-  version '35.4-1'
-  sha256 '7f95ef6c2fcb924fd1d98d16c6223d46b979194b499061db1cf8c5dc0c5cff7c'
+  version '35.5'
+  sha256 '43a6704d6d48702cdfa2b29fe711518e143da2f879f287c408996400bdfc6181'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
   url "https://github.com/visualfc/liteide/releases/download/x#{version.major_minor}/liteidex#{version}.macos-qt5.9.5.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.