### PR TITLE
Update namechanger 3.4.2 zap trash

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -10,4 +10,10 @@ cask 'namechanger' do
   auto_updates true
 
   app 'NameChanger.app'
+
+  zap trash: [
+               '~/Library/Application Support/NameChanger',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.mrrsoftware.namechanger.sfl*',
+               '~/Library/Preferences/com.mrrsoftware.NameChanger.plist',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.