### PR TITLE
Update toptracker to 1.5.8.6185

### DIFF
--- a/Casks/toptracker.rb
+++ b/Casks/toptracker.rb
@@ -1,6 +1,6 @@
 cask 'toptracker' do
-  version '1.5.7.6079'
-  sha256 '1f7c116da6b3f6ad1c7584b84daf28329e9fe158dd0251063d9401db7d8bd5d4'
+  version '1.5.8.6185'
+  sha256 '7da3130bc20023780af8a2abc7cfa8b89e90275a6eaa8f61fcdc0b914024b2b0'
 
   # d101nvfmxunqnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d101nvfmxunqnl.cloudfront.net/desktop/builds/mac/toptracker_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.