### PR TITLE
Update springtoolsuite to 4.1.1.RELEASE,4.10.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask 'springtoolsuite' do
-  version '4.1.0.RELEASE,4.10.0'
-  sha256 '2de077011e1039c39d63538437d7b67112b695596545b7bb6c2c07c917cd5aa9'
+  version '4.1.1.RELEASE,4.10.0'
+  sha256 '4eeb65ebf287758e2fb601352b94df7d53d8a5eae1c8519ecaf560dda34c3529'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.