### PR TITLE
Update torrent-file-editor to 0.3.13

### DIFF
--- a/Casks/torrent-file-editor.rb
+++ b/Casks/torrent-file-editor.rb
@@ -1,6 +1,6 @@
 cask 'torrent-file-editor' do
-  version '0.3.10'
-  sha256 'd6e6e7e9481a6ba79c1fadc5f7cb4891400d6e15777a2100df2df4a07b2077af'
+  version '0.3.13'
+  sha256 'b8136b13a3a3106164f443a4a8dcc69870f460d17af011f5e321b78f6f7c261f'
 
   url "https://downloads.sourceforge.net/torrent-file-editor/v#{version}/torrent-file-editor-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/torrent-file-editor/rss'
@@ -10,6 +10,7 @@ cask 'torrent-file-editor' do
   app 'Torrent File Editor.app'
 
   zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.sourceforge.torrent-file-editor.sfl*',
                '~/Library/Caches/net.sourceforge.torrent-file-editor',
                '~/Library/Cookies/net.sourceforge.torrent-file-editor.binarycookies',
                '~/Library/Preferences/net.sourceforge.torrent-file-editor.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.