### PR TITLE
Fix for error "Cask 'onyx' definition is invalid"

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -27,14 +27,7 @@ cask 'onyx' do
   homepage 'https://www.titanium-software.fr/en/onyx.html'
 
   # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
-  depends_on macos: [
-                      :mavericks,
-                      :yosemite,
-                      :el_capitan,
-                      :sierra,
-                      :high_sierra,
-                      :mojave,
-                    ]
+  depends_on macos: '<= :mojave'
 
   app 'OnyX.app'
 


### PR DESCRIPTION
I had to change this only machine otherwise I was getting the following error upon issuing "brew cask upgrade":

```
"Cask 'onyx' definition is invalid: invalid 'depends_on macos' value: :snow_leopard"
```

I'm using Ruby 2.6.1, maybe this is the source of this issue?! Because the array looked good to me. Don't know really, but the fix worked at least.