### PR TITLE
Update fsnotes to 2.8.2

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.7.5'
-  sha256 '47c1e6ab6675bc7abc056f063296530742755e0674aa1b94d570eb2a5d7023c3'
+  version '2.8.2'
+  sha256 'c685e5ba01f04dbc47debae580e1f36918f197647128618425dbe7a994a4f89a'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.