### PR TITLE
Update wifi-explorer to 2.5.3

### DIFF
--- a/Casks/wifi-explorer.rb
+++ b/Casks/wifi-explorer.rb
@@ -1,6 +1,6 @@
 cask 'wifi-explorer' do
-  version '2.5.2'
-  sha256 'e83e0c9286beabb01190c67b79ad9cba0c482d1c5d5e721476cc3082928cc927'
+  version '2.5.3'
+  sha256 '7b69f00af8a8bc2d7f960e5039a34149cf738bfb36620f8a19f07038ba9c0c1d'
 
   url 'https://www.adriangranados.com/apps/wifiexplorer-download'
   appcast 'https://www.adriangranados.com/appcasts/wifiexplorercast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.