### PR TITLE
Update clover-configurator to 5.4.1.1

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.4.0.0'
-  sha256 '98b4a322102780ce6a58b89bfb8c236caf1add3cda4e7511611f21d31ca079b4'
+  version '5.4.1.1'
+  sha256 'a466c8950984791acc88568e09d90a4281bec7342667482e948eb69a9a2c2685'
 
   url 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/builds-data/CCG.zip'
   appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.