### PR TITLE
Update zoc to 7.22.5

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.22.4'
-  sha256 '618f6bf25853a03ad57b94b2ba6ff37edcbea23e713dea390ab6cc55302c6ea9'
+  version '7.22.5'
+  sha256 'aaf15a454c86d866b6db21bd13bbbe703f1664c49f7b02c831f93ef95cbc780b'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.