### PR TITLE
Update qgroundcontrol to 3.5.0

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,6 +1,6 @@
 cask 'qgroundcontrol' do
-  version '3.4.4'
-  sha256 '2926371d4385d0bd66917c95b4ce62d91969350fcf943ff16367da412c06c380'
+  version '3.5.0'
+  sha256 '0c6eb7316e895bef1b56981156ce154f6809fcd1094b8ba163ab9024612ea56d'
 
   # github.com/mavlink/qgroundcontrol was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.