### PR TITLE
Update arq-cloud-backup to 1.2.8

### DIFF
--- a/Casks/arq-cloud-backup.rb
+++ b/Casks/arq-cloud-backup.rb
@@ -1,6 +1,6 @@
 cask 'arq-cloud-backup' do
-  version '1.2.7'
-  sha256 '16f3ce2059faaee04085bcc3ab4b7f0d75484e4ca978c45151354e9493993608'
+  version '1.2.8'
+  sha256 'ee8cd6b7160e9d382ac1f51f035bdd7e043fc8cc69b8f2de20a8d8df5980b331'
 
   url 'https://www.arqbackup.com/download/arqcloudbackup/ArqCloudBackup.dmg'
   appcast 'https://www.arqbackup.com/download/arqcloudbackup/arqcloudbackup_release_notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.