### PR TITLE
Update freedom to 2.1

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,6 +1,6 @@
 cask 'freedom' do
-  version '2.0.5'
-  sha256 '0715908df326be50d159afb59a276eeaa515f53e8d712c79bbebbe81705b13df'
+  version '2.1'
+  sha256 'a670097fe80ddf990bc51692248ea3f9da164abe4a19cb2770954d80ec058cff'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.