### PR TITLE
Update taskpaper to 3.8.4

### DIFF
--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,6 +1,6 @@
 cask 'taskpaper' do
-  version '3.8.3'
-  sha256 'bff89f3bd830c9c7672b0cca322832adb4930f4c9069cdb62bca09458a4fa40f'
+  version '3.8.4'
+  sha256 'aa4812c21d41a32ccdb729de409dbf079dbcaa8230f4182b6433a004dd09b676'
 
   url "https://www.taskpaper.com/assets/app/TaskPaper-#{version}.dmg"
   appcast 'https://www.taskpaper.com/assets/app/TaskPaper.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.