### PR TITLE
Update hyperdock to 1.8

### DIFF
--- a/Casks/hyperdock.rb
+++ b/Casks/hyperdock.rb
@@ -1,6 +1,6 @@
 cask 'hyperdock' do
-  version :latest
-  sha256 :no_check
+  version '1.8'
+  sha256 '2e5aa71b9e2e1e7671275570fcc7ad87e661d9fcb1f8bb5a7ea5ea55d213f15a'
 
   url 'https://bahoom.com/hyperdock/HyperDock.dmg'
   name 'HyperDock'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.