### PR TITLE
Update vscodium to 1.31.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,8 +1,8 @@
 cask 'vscodium' do
-  version '1.30.2'
-  sha256 'fa01b440a02e58040b04227e11d51acb4bc5da6cf94e3cb1043268e9c416be8e'
+  version '1.31.0'
+  sha256 'd394b6a7a67a2382bf85d59eb864039b9894f1f6b88bb7dbf8760f611ead4923'
 
-  url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCode-darwin-#{version}.zip"
+  url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'
   name 'VSCodium'
   homepage 'https://github.com/VSCodium/vscodium'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.