### PR TITLE
Update wordpresscom to 3.9.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,8 +1,8 @@
 cask 'wordpresscom' do
-  version '3.8.0'
-  sha256 '471be5e96058a8550f045e4419a577a55fc7581d2d62ca14ae25c06bf96290ef'
+  version '3.9.0'
+  sha256 '46bbe0d67c1440ea46063b4f1345592cdef235128ae537be1363309f5a47657b'
 
-  url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=dmg&ref=update&version=#{version}"
+  url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'
   name 'WordPress.com'
   homepage 'https://apps.wordpress.com/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.