### PR TITLE
Update decrediton to 1.4.0

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,6 +1,6 @@
 cask 'decrediton' do
-  version '1.3.1'
-  sha256 '3aad8659b9713a9e787450ed3bdfe8f5f73cb31bb57bc35eb97bb72877d3ef8a'
+  version '1.4.0'
+  sha256 '990cb6b61999be5d1100581cc84bb95f4e9e5be8a5330c5e6c8940c34fe78b19'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.