### PR TITLE
Update runjs to 1.2.4

### DIFF
--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -1,6 +1,6 @@
 cask 'runjs' do
-  version '1.2.3'
-  sha256 '01b5411ea59c9a9439f95f84b528975b33e7b7fdb7604b57524e600a97fb4359'
+  version '1.2.4'
+  sha256 'da06399640c505ea334d561b4049ecf81993d8885f380baad9112ffda7ce1423'
 
   # github.com/lukehaas/runjs was verified as official when first introduced to the cask
   url "https://github.com/lukehaas/runjs/releases/download/v#{version}/RunJS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.