### PR TITLE
Update irccloud to 0.9.0

### DIFF
--- a/Casks/irccloud.rb
+++ b/Casks/irccloud.rb
@@ -1,6 +1,6 @@
 cask 'irccloud' do
-  version '0.8.0'
-  sha256 '452238fa03271adaa1e1fc6df45b1ba55ba94b0bd2888824a568193c94d95bc2'
+  version '0.9.0'
+  sha256 '82135f8c706511ebb2a24b54f2e901c9acd45c88361a3678e212aaf9fcf8e18e'
 
   url "https://github.com/irccloud/irccloud-desktop/releases/download/v#{version}/IRCCloud-#{version}.dmg"
   appcast 'https://github.com/irccloud/irccloud-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.