### PR TITLE
Update bathyscaphe to 310-v1089

### DIFF
--- a/Casks/bathyscaphe.rb
+++ b/Casks/bathyscaphe.rb
@@ -1,6 +1,6 @@
 cask 'bathyscaphe' do
-  version '310-v1085'
-  sha256 'b1cb3a273477a6d4003640fbbfa9e93c563b0d88f3adb8a5d26cdffe284173b6'
+  version '310-v1089'
+  sha256 '32f7758d2898fd8cccd1b506c8d78bbff6733640e392eba67c95a6626377a603'
 
   # bitbucket.org/bathyscaphe/public/downloads was verified as official when first introduced to the cask
   url "https://bitbucket.org/bathyscaphe/public/downloads/BathyScaphe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.