### PR TITLE
Update triumph to 2.6.10

### DIFF
--- a/Casks/triumph.rb
+++ b/Casks/triumph.rb
@@ -1,6 +1,6 @@
 cask 'triumph' do
-  version '2.6.9'
-  sha256 '60c2aabd73bcb1939c15292cb43b33786b810477bc04f3bfe16e882857789dbc'
+  version '2.6.10'
+  sha256 '8729916d32386d6b656d8612262aedbc11fc3b08dc9fbbb051633ff1fc662f97'
 
   url 'https://triumph.aurchitect.com/downloads/Triumph.zip'
   appcast 'https://triumph.aurchitect.com/sufeed.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.