### PR TITLE
Update bbc-iplayer-downloads to 2.8.3

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -1,6 +1,6 @@
 cask 'bbc-iplayer-downloads' do
-  version '2.7.4'
-  sha256 '97a8995ca9b8a9423623790e89ed4dd4627bc1385c26ac38039573b8f024e45f'
+  version '2.8.3'
+  sha256 '243bbe651632695e59900cd3c4e1330dfcde3a9c078b81ebf35c2b0a7da64501'
 
   # live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com/releases/darwin-x64/BBCiPlayerDownloads-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.