### PR TITLE
Update turbo-boost-switcher to 2.8.0

### DIFF
--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -1,6 +1,6 @@
 cask 'turbo-boost-switcher' do
-  version '2.7.1'
-  sha256 'bee6b86d2813c76fe65cac57cf76966b2f613c6fd48fb5418a01e0d1dbb89b64'
+  version '2.8.0'
+  sha256 '4b943962906236ac793ee140897a66415921d3934a1b5ec37ffe0a38a9c9cab3'
 
   # s3.amazonaws.com/turbo-boost-switcher was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/turbo-boost-switcher/Turbo+Boost+Switcher_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.