### PR TITLE
Update dcp-o-matic-encode-server to 2.12.19

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.12.18'
-  sha256 '7c834e276978ad7d68cfd9bd3133ff16b6a607efc7999240f9f18dffbe94903e'
+  version '2.12.19'
+  sha256 '0c42f4e596f07b35014837001d0fd6c95d415d5cd75576085f19c7cf41abac8a'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.