### PR TITLE
Update postbox to 6.1.10

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.9'
-  sha256 '04ea68a5dc8554092b7ec5e7385afa1b086e776f7eabb60f2163c87e317fe9f7'
+  version '6.1.10'
+  sha256 '4e8e30c466cb4a58eb7fb9a5dd231f785f12538d24bb0024d9ed65ed39e04bac'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.