### PR TITLE
Update aircall to 1.7.2

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,6 +1,6 @@
 cask 'aircall' do
-  version '1.7.1'
-  sha256 'fdca1a399240300d14d5348c422990dc8f77579015384567f4620da2747355c9'
+  version '1.7.2'
+  sha256 'd9aa91805d75139ce9d1d7dd3b26a324be723faefec9930830364a17710441f0'
 
   url "https://electron.aircall.io/download/version/#{version}/osx_64?filetype=dmg&channel=stable"
   appcast 'https://electron.aircall.io/update/osx/1.1.0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.