### PR TITLE
Update dungeon-crawl-stone-soup-console to 0.23.0

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-console' do
-  version '0.22.1'
-  sha256 'ab2152518d6f06f14f82b57e508e98947c1a6b3c38a43a4d150be620d1675d27'
+  version '0.23.0'
+  sha256 '49d4e7812438193de33c4c3cc3bc3456692860e4843815c5573e63d21bae4a4e'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-console-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.