### PR TITLE
Update keeweb to 1.7.6

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.7.5'
-  sha256 'bb956db8e8ffa2a8da879672b4f756b02bf64092d108eb0343cf9153248c2bf1'
+  version '1.7.6'
+  sha256 '1975f2c0abb4d5d38433688eeb2546550b35edb53fca211e7bed40f54160df3a'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.