### PR TITLE
Update owncloud to 2.5.3.11290

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -1,6 +1,6 @@
 cask 'owncloud' do
-  version '2.5.2.11198'
-  sha256 '2b3200adf8168367723d5198f2774d25078fd5b43f5f6c35d0a256b687c50771'
+  version '2.5.3.11290'
+  sha256 '1d2439a47f13315a38fde0ef6df9de46503ef8c2225ef3f8e7d0671b1b695746'
 
   url "https://download.owncloud.com/desktop/stable/ownCloud-#{version}.pkg"
   appcast 'https://github.com/owncloud/client/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.