### PR TITLE
Update protege to 5.5.0-beta-9

### DIFF
--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -1,6 +1,6 @@
 cask 'protege' do
-  version '5.5.0-beta-8'
-  sha256 'cd69ed7599e896e7796e5686ef416afed6bdfb42e8d679dbe5bb4efa08f748f7'
+  version '5.5.0-beta-9'
+  sha256 'caba39e1c84a02a3160c288a9ccb08537ade57f65c73c0b07dae1d7ade4f2f58'
 
   # github.com/protegeproject/protege-distribution was verified as official when first introduced to the cask
   url "https://github.com/protegeproject/protege-distribution/releases/download/v#{version}/Protege-#{version}-os-x.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.