### PR TITLE
Update tribler to 7.2.2

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,6 +1,6 @@
 cask 'tribler' do
-  version '7.2.1'
-  sha256 '084ad702cb95f53dc8bb24e42f82dbade3b8b2f3e0c3e1d790944f2579058beb'
+  version '7.2.2'
+  sha256 'd9fc8860950414daa062b3bdb219505f44869adc31096acafb44712cd719dafa'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.