### PR TITLE
Update blitz to 0.9.17

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '0.9.16'
-  sha256 'fbc5a899ca22bbadd2751997d31bf4aa345d1b6e0e9d604dcfdd1ad16621c2ec'
+  version '0.9.17'
+  sha256 '6655bcf3626fe835e0ac30a0f76f34e9b77a39a18ac7a3f0c4eab7a05d3382cf'
 
   url 'https://dl.blitz.gg/download/mac'
   appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.