### PR TITLE
Update dosbox-x-app to 0.82.15,20190202110559

### DIFF
--- a/Casks/dosbox-x-app.rb
+++ b/Casks/dosbox-x-app.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x-app' do
-  version '0.82.14,20190101022247'
-  sha256 '13767ab3ae0599a4f166dc7c7a4c076f832f760e9a691eb0c3e5523fdcfdb461'
+  version '0.82.15,20190202110559'
+  sha256 '4e1c55c4e6662eae54f7a6cf76209acdab68de9565e7f8d6c29c0bd36b3e6630'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.