### PR TITLE
Update phpstorm to 2018.3.4,183.5429.47

### DIFF
--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -1,6 +1,6 @@
 cask 'phpstorm' do
-  version '2018.3.3,183.5153.36'
-  sha256 'ceb7c730632eae6c76dc3fcf577c8d08dbbd790ebd334694814370ecdc32fe78'
+  version '2018.3.4,183.5429.47'
+  sha256 '71626736b46a692e118919c68edc1fcf2326ee1ff5ed8772ddcbe16b36f99b36'
 
   url "https://download.jetbrains.com/webide/PhpStorm-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.