### PR TITLE
Update unity-vuforia-ar-support-for-editor to 2018.3.5f1,76b3e37670a4

### DIFF
--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-vuforia-ar-support-for-editor' do
-  version '2018.3.4f1,1d952368ca3a'
-  sha256 '717ff3a1a240ace0ffd730c5e106e805696aee907e472f96d4bda94e88c56e2e'
+  version '2018.3.5f1,76b3e37670a4'
+  sha256 'f4d798eb912a41f8d920989b2c59052f3ed97da3b074b0da3bdc8a89f812fda0'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'

--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -2,7 +2,7 @@ cask 'unity-vuforia-ar-support-for-editor' do
   version '2018.3.5f1,76b3e37670a4'
   sha256 'f4d798eb912a41f8d920989b2c59052f3ed97da3b074b0da3bdc8a89f812fda0'
 
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity Vuforia AR Build Support'
   homepage 'https://unity3d.com/unity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.