### PR TITLE
Update araxis-merge to 2019.5137

### DIFF
--- a/Casks/araxis-merge.rb
+++ b/Casks/araxis-merge.rb
@@ -8,8 +8,8 @@ cask 'araxis-merge' do
     sha256 'abba11a92e1f50d913356d31123bed5bb08838ce39c4659206fd24c32432c4b3'
     url "https://www.araxis.com/download/Merge#{version}-OSX10.10.dmg"
   else
-    version '2018.5008'
-    sha256 'db47fa9e0d90313a3eb0239248e2cb23489d3ca695ebe9a1299e188efd4a4bb2'
+    version '2019.5137'
+    sha256 'e3be039c7e6c8a42c172b8d18cfdad0d98fe05b1a74d1e6801d323752c0438b2'
     url "https://www.araxis.com/download/Merge#{version}-macOS.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.