### PR TITLE
Update dcp-o-matic-batch-converter to 2.12.20

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.12.19'
-  sha256 'b808e63750f7e07780592f6ec181ed97bd43aea35e5468f03638fb7f789b9e4f'
+  version '2.12.20'
+  sha256 'be0343519b17523334b847bfe8ea68982f87d3bc8036ae57c0602dad0a00f36b'
 
   url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.