### PR TITLE
Update dcp-o-matic-kdm-creator to 2.12.20

### DIFF
--- a/Casks/dcp-o-matic-kdm-creator.rb
+++ b/Casks/dcp-o-matic-kdm-creator.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-kdm-creator' do
-  version '2.12.19'
-  sha256 '42bc9843e2306ff171f5a3fcd467b7d63343eb386b7b4cbefc7065c3296be867'
+  version '2.12.20'
+  sha256 'ff5a1b4e0fac6ed5e351d25fc40e1073662c85543c3e0fec29c36d48d330b3bf'
 
   url "https://dcpomatic.com/dl.php?id=osx-kdm&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.