### PR TITLE
Update poll-everywhere to 2.19.1

### DIFF
--- a/Casks/poll-everywhere.rb
+++ b/Casks/poll-everywhere.rb
@@ -1,6 +1,6 @@
 cask 'poll-everywhere' do
-  version '2.17.0'
-  sha256 'fddfe9efe8c9df77529234095ec815e4ea3db8b784460ecd6fc439724bf1b39d'
+  version '2.19.1'
+  sha256 '984f420f7120906a2fa55008337f94e4e058955ef5e897b7d0a432b4c77e5cee'
 
   # amazonaws.com/polleverywhere-app was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/polleverywhere-app/mac-stable/#{version}/pollev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.