### PR TITLE
Update mudlet to 3.17.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '3.17.0'
-  sha256 'c358d2b03528deadc8ec333dee7e326e6efd5eba175e2c2dd972f844e42ebb66'
+  version '3.17.1'
+  sha256 '63b8bdec97798cea700a36052d4e8a0ed711d19ea33cc6737b0c93662fea9522'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.