### PR TITLE
Update kate to 18.12.1-363

### DIFF
--- a/Casks/kate.rb
+++ b/Casks/kate.rb
@@ -1,6 +1,6 @@
 cask 'kate' do
-  version '18.12.1-357'
-  sha256 '9c40f27caf8eaae75b99d92b071f470ee2cd65900856d1bfa3267cbad2451b6d'
+  version '18.12.1-363'
+  sha256 '814ea82834741a9a754e5da60b2770ed0d2d2bfd3551d6e743677801cfef238a'
 
   # binary-factory.kde.org/view/MacOS/job/Kate_Release_macos was verified as official when first introduced to the cask
   url "https://binary-factory.kde.org/view/MacOS/job/Kate_Release_macos/lastSuccessfulBuild/artifact/kate-#{version}-macos-64-clang.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.