### PR TITLE
Update nagbar to 1.3.6

### DIFF
--- a/Casks/nagbar.rb
+++ b/Casks/nagbar.rb
@@ -1,6 +1,6 @@
 cask 'nagbar' do
-  version '1.3.5'
-  sha256 '28848bc054584923d25fe34b073ecbfcd615f345c720e23b3f753f16ec8b9acc'
+  version '1.3.6'
+  sha256 '31efe0ff0428dc1d45e04c8e4954dc25fd7f4f7839bb1adc763b626f44efc17d'
 
   # github.com/volendavidov/NagBar was verified as official when first introduced to the cask
   url "https://github.com/volendavidov/NagBar/releases/download/#{version}/NagBar.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.