### PR TITLE
Update qownnotes to 19.2.3,b4148-062533

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.2.2,b4139-073729'
-  sha256 'd7d29fb80e338de4e7c5c8650068f545a9e9e3164672b13cf9df135946c5753a'
+  version '19.2.3,b4148-062533'
+  sha256 '2ca85221a5e96617b85fd7f9e6833fbd19c74da440f352bbca099d9398e67b3f'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.