### PR TITLE
Update gitnote to 3.0.3

### DIFF
--- a/Casks/gitnote.rb
+++ b/Casks/gitnote.rb
@@ -1,6 +1,6 @@
 cask 'gitnote' do
-  version '3.0.2'
-  sha256 '0af6e346de2bb70af41354356de7cefcb06ce52b6f53c7a327d0eb669f0b4191'
+  version '3.0.3'
+  sha256 '28801e8a2981ef3658ed35d748bbf37ffc7662b6307d2b31a606af22fe546cda'
 
   # github.com/zhaopengme/gitnote was verified as official when first introduced to the cask
   url "https://github.com/zhaopengme/gitnote/releases/download/#{version}/GitNote_setup_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.