### PR TITLE
Update lingon-x to 6.6

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,6 +1,6 @@
 cask 'lingon-x' do
-  version '6.5.8'
-  sha256 '524e7576f3554ffccdbd392f5b75e16d88cac4a8051f21ce291f2b63710beb28'
+  version '6.6'
+  sha256 '2e7255700d80e42792286d3c77f0bb12c59957ca4a4ef10f061036f8d87ca437'
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"
   appcast "https://www.peterborgapps.com/updates/lingonx#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.