### PR TITLE
Update monolingual to 1.8.2

### DIFF
--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -12,8 +12,8 @@ cask 'monolingual' do
     version '1.7.8'
     sha256 '42771c3c4d615a39ab502d7723f3c7d23e6b384b56bbcebcbdd5a04cf2495c41'
   else
-    version '1.8.1'
-    sha256 '6eb36f887eb6dfb93157eb7b3cf9cadf078530c85a0b43f0fb516800957f2987'
+    version '1.8.2'
+    sha256 'd4acf912fa132d7615c88940f5a997505e1880a8d6f9af47f0da427d9e0cd13f'
   end
 
   # github.com/IngmarStein/Monolingual was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.