### PR TITLE
Update displaycal to 3.7.1.4, change to pkg

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -13,17 +13,7 @@ cask 'displaycal' do
 
   pkg "DisplayCAL-#{version}.pkg"
 
-  uninstall pkgutil: [
-                       'net.displaycal.DisplayCAL-3DLUT-maker',
-                       'net.displaycal.DisplayCAL-curve-viewer',
-                       'net.displaycal.DisplayCAL-profile-info',
-                       'net.displaycal.DisplayCAL-scripting-client',
-                       'net.displaycal.DisplayCAL-synthprofile',
-                       'net.displaycal.DisplayCAL-testchart-editor',
-                       'net.displaycal.DisplayCAL-VRML-to-X3D-converter',
-                       'net.displaycal.DisplayCAL',
-                       'net.displaycal.pkg.DisplayCAL',
-                     ]
+  uninstall pkgutil: 'net.displaycal.*.DisplayCAL.*'
 
   zap trash: [
                '~/Library/Application Support/dispcalGUI',

--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,21 +1,29 @@
 cask 'displaycal' do
-  version '3.7.1.3'
-  sha256 'b3d59176563be76b9b31a489abb5449811453d2c41dffa4035259b7eb2e12c64'
+  version '3.7.1.4'
+  sha256 'be10135b6e90536740a6ecddcb6537aa62dfa255ed0e02e1b7cbffac039ef273'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.dmg"
+  url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.pkg"
   appcast 'https://sourceforge.net/projects/dispcalgui/rss?path=/release'
   name 'DisplayCAL'
   homepage 'https://displaycal.net/'
 
+  auto_updates true
   depends_on formula: 'argyll-cms'
 
   suite 'DisplayCAL'
+  pkg "DisplayCAL-#{version}.pkg"
 
-  preflight do
-    # There is no sub-folder in the DMG; the root *is* the folder
-    FileUtils.mv(staged_path.children, staged_path.join('DisplayCAL').tap(&:mkpath))
-  end
+  uninstall pkgutil: [
+                       'net.displaycal.DisplayCAL-3DLUT-maker',
+                       'net.displaycal.DisplayCAL-curve-viewer',
+                       'net.displaycal.DisplayCAL-profile-info',
+                       'net.displaycal.DisplayCAL-scripting-client',
+                       'net.displaycal.DisplayCAL-synthprofile',
+                       'net.displaycal.DisplayCAL-testchart-editor',
+                       'net.displaycal.DisplayCAL-VRML-to-X3D-converter',
+                       'net.displaycal.DisplayCAL',
+                     ]
 
   zap trash: [
                '~/Library/Application Support/dispcalGUI',

--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -22,6 +22,7 @@ cask 'displaycal' do
                        'net.displaycal.DisplayCAL-testchart-editor',
                        'net.displaycal.DisplayCAL-VRML-to-X3D-converter',
                        'net.displaycal.DisplayCAL',
+                       'net.displaycal.pkg.DisplayCAL',
                      ]
 
   zap trash: [

--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -11,7 +11,6 @@ cask 'displaycal' do
   auto_updates true
   depends_on formula: 'argyll-cms'
 
-  suite 'DisplayCAL'
   pkg "DisplayCAL-#{version}.pkg"
 
   uninstall pkgutil: [


### PR DESCRIPTION
Closes #58117.

NOTE: Since I do not use this app myself, I was not able to come up with a solution for the symlinked folders that @compuguy mentioned. If some maintainer could help me with that, it would be appreciated.

Moreover, I added several `uninstall pkgutil` IDs, following the `PackageInfo` XML. Please let me know if this is appropriate, or if we should only attempt to remove the "parent" `DisplayCAL` ID.  

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).