### PR TITLE
Update lehreroffice-zusatz to 2019.2.2

### DIFF
--- a/Casks/lehreroffice-zusatz.rb
+++ b/Casks/lehreroffice-zusatz.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice-zusatz' do
-  version '2019.2.0'
-  sha256 '49a021d79f9236c403a677107aa20e21c3ff771619b99da1824773386cc830d5'
+  version '2019.2.2'
+  sha256 '6ab2702ef58df7d6d872ef3d10d79f1bd1c05676449785624eff03cb3a60f407'
 
   url 'https://www.lehreroffice.ch/lo/dateien/zusatz/lo_zusatz_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Zusatz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.