### PR TITLE
Update rstudio appcast stanza

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -4,7 +4,7 @@ cask 'rstudio' do
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/RStudio-#{version}.dmg"
-  appcast 'https://www.rstudio.com/products/rstudio/release-notes/'
+  appcast 'https://www.rstudio.org/links/check_for_update?version=1.0.0&os=mac'
   name 'RStudio'
   homepage 'https://www.rstudio.com/'
 


### PR DESCRIPTION
sorry, we keep having trouble with the appcast check on this one. i've submitted a PR to change the stanza previously, because the HTML website was 750KB but actually it seems the new one is even bigger, 850KB.

this is now the URL of the actual 'check for updates' function in-use by the app itself and should be really tiny ;)