### PR TITLE
Update reactotron to 2.6.2

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,6 +1,6 @@
 cask 'reactotron' do
-  version '2.6.1'
-  sha256 'a0e57fc25f4ec1ba7e4da7690185eceffb713cc19c2a7c5e80aef27066906cf5'
+  version '2.6.2'
+  sha256 '6cb55b80df8a6309f50c1e1729368bd6f5e911a3f4b3d85e45b5083fba65aec8'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron-#{version}-mac.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.