### PR TITLE
Update musixmatch to 0.21.26

### DIFF
--- a/Casks/musixmatch.rb
+++ b/Casks/musixmatch.rb
@@ -1,6 +1,6 @@
 cask 'musixmatch' do
-  version '0.21.24'
-  sha256 'd91e3bbfd82beca8a1960efbb88ef6d5601b2a0381cd64a4d274f097da9ba8b9'
+  version '0.21.26'
+  sha256 '8fb83ecede01131fad03c2575cd96f711a33a30531463dcc22a92d77e97d85b5'
 
   url "https://download-app.musixmatch.com/download/Musixmatch-#{version}.dmg"
   appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_filename.cgi?url=http://download-app.musixmatch.com/download/osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.