### PR TITLE
Update poi to 10.2.2

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,6 +1,6 @@
 cask 'poi' do
-  version '10.2.0'
-  sha256 '619d116d2714cdd973a8adb4c9e8185c77880ac23b4f3e75522f8f567efbf183'
+  version '10.2.2'
+  sha256 'f6ba6d5da7f0ea072ba9f456d917f05ccdc815b16b945bdaa9056a029eecb9a5'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.