### PR TITLE
Update qlab to 4.4.2

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,6 +1,6 @@
 cask 'qlab' do
-  version '4.4.1'
-  sha256 '52fb818786e263b221e6079c1ff97121911647df97a249bd9f6860e92b156684'
+  version '4.4.2'
+  sha256 '4143487cba01560bdb324cba342c42ac4e3571d1a7a698bbd75f0ee7a4752b5e'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.