### PR TITLE
Update rapidweaver to 8.1.4,20642.1549903837

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,6 +1,6 @@
 cask 'rapidweaver' do
-  version '8.1.3,20613.1548954553'
-  sha256 'd5aec6763cbe930ecb0861d87a7be2459cc164268559e52c937147f24a4e0d2b'
+  version '8.1.4,20642.1549903837'
+  sha256 '73c6da08e198569ff07fb1d0d6e2cbb532d51e10616f7b31a9b890f102eb8d11'
 
   # devmate.com/com.realmacsoftware.rapidweaver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.realmacsoftware.rapidweaver#{version.major}/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver#{version.major}-#{version.after_comma.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.