### PR TITLE
Update rightfont to 5.3.3

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,6 +1,6 @@
 cask 'rightfont' do
-  version '5.3.2'
-  sha256 '15c166686c43e266f35df322a9d26750f5b2dff31b32b2054525118d9785fe01'
+  version '5.3.3'
+  sha256 '4f13f3138d765bd0f4c5bff6a9b3bedd2878d6569a1c210b3bb67a8981f3df47'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
   appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.