### PR TITLE
Update beaker-browser to 0.8.4

### DIFF
--- a/Casks/beaker-browser.rb
+++ b/Casks/beaker-browser.rb
@@ -1,6 +1,6 @@
 cask 'beaker-browser' do
-  version '0.8.3'
-  sha256 'f06f07b361873f5562c87f50a8ca3ae93e168e0ebb3b96db6362ba68e98d9d07'
+  version '0.8.4'
+  sha256 '3b32a6062f6b29bef6680b7a9bc20e1f163b7d9f9203eebd3605f5c5919b1001'
 
   # github.com/beakerbrowser/beaker was verified as official when first introduced to the cask
   url "https://github.com/beakerbrowser/beaker/releases/download/#{version}/beaker-browser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.