### PR TITLE
Update pd-l2ork to 2.8.1

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,6 +1,6 @@
 cask 'pd-l2ork' do
-  version '2.6.0'
-  sha256 'd5301d0b8ec6d8532e2b7516e712d1b1a0808061317da6fd8d416495f40523b6'
+  version '2.8.1'
+  sha256 '11d4d24820bdc18fe077aa8f300ccdab133d07b94347b66228c27b76d9a60b1d'
 
   # github.com/agraef/purr-data was verified as official when first introduced to the cask
   url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-x86_64-dmg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.