### PR TITLE
Update superproductivity to 2.2.2

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.0.7'
-  sha256 'eec60b1223d14b7f491c465f58493a5164f437c2dbce50f2b27594dc8c2f3c6b'
+  version '2.2.2'
+  sha256 '798ce9d3eae3437e073c2b101964b1fd0ec5c40d26caeceab8fc1afc12c4574f'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.