### PR TITLE
Update netnewswire to 5.0d15

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,6 +1,6 @@
 cask 'netnewswire' do
-  version '5.0d14'
-  sha256 '07d28db14b73ae04183bc4db8d941df7cad09e785989d21cb68a3758903c246a'
+  version '5.0d15'
+  sha256 '505c01569ec6c815dc19f066b8a1e4f91e3a35b52cb61696a5bdf515d1a7d285'
 
   url "https://ranchero.com/downloads/NetNewsWire#{version}.zip"
   appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.