### PR TITLE
Update minishift to 1.31.0

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,6 +1,6 @@
 cask 'minishift' do
-  version '1.30.0'
-  sha256 '36b8c262c6d78820258be9e968d88fae9856bf73466d29edb6b261447f883760'
+  version '1.31.0'
+  sha256 'f1a752ebb225d85d813ad7c44e34545d56c53e01aad817f8223a51ee95004f9c'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.