### PR TITLE
Update postico to 1.5.5

### DIFF
--- a/Casks/postico.rb
+++ b/Casks/postico.rb
@@ -1,6 +1,6 @@
 cask 'postico' do
-  version '1.5.4'
-  sha256 'cc6bd9eff4164b8c5cd773f7cd665965f28824d3249b7ef9033eddfc66f34ae8'
+  version '1.5.5'
+  sha256 'fef095a82af427829a57930e762bf1319252f9222e8d200fb4276af87c775d33'
 
   # amazonaws.com/eggerapps-downloads was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/eggerapps-downloads/postico-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.