### PR TITLE
Update icons8 to 5.6.7

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -1,7 +1,7 @@
 cask 'icons8' do
   # note: "8" is not a version number, but an intrinsic part of the product name
-  version '5.6.5'
-  sha256 '1775c821b5d90d52540da4cb52b4618b4732d11509c84feaf3978f3be78753dc'
+  version '5.6.7'
+  sha256 '6f351bb8d32cf3758652b280c7b684d9481d453b719749d6bd1d5c6719e0967f'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
   appcast 'https://desktop.icons8.com/updates/mac/icons8_cast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.