### PR TITLE
Add a Java 8 caveat to JOSM

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -8,6 +8,12 @@ cask 'josm' do
 
   app 'JOSM.app'
 
+  zap trash: [
+               '~/Library/Preferences/JOSM',
+               '~/Library/Caches/JOSM',
+               '~/Library/JOSM',
+             ]
+
   caveats do
     depends_on_java '8'
   end

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -7,4 +7,8 @@ cask 'josm' do
   homepage 'https://josm.openstreetmap.de/'
 
   app 'JOSM.app'
+
+  caveats do
+    depends_on_java '8'
+  end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download Casks/josm.rb` is error-free.
- [x] `brew cask style --fix Casks/josm.rb` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This does not change the version of JOSM, so no version mentioned in the commit, happy to change that if it's helpful.

Adds a caveat to highlight the dependency on Java 8, and includes a zap stanza for better cleanup.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
