### PR TITLE
Update keeweb to 1.7.7

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.7.4'
-  sha256 '2eb4e252400f6727ca1c61c816f6cf970c574fec727374992ebfc31904f93c8a'
+  version '1.7.5'
+  sha256 'bb956db8e8ffa2a8da879672b4f756b02bf64092d108eb0343cf9153248c2bf1'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"

--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.7.5'
-  sha256 'bb956db8e8ffa2a8da879672b4f756b02bf64092d108eb0343cf9153248c2bf1'
+  version '1.7.7'
+  sha256 '2df509746d20e8bbb4dc8d77ee713e70899d1ecdf644950bdb3a684dd79064f8'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.