### PR TITLE
Update understand to 5.1.974

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.0.973'
-  sha256 '1b26a02bbc3a383fca449cf16ad8b6447b92543ad3ef4b580810ef6618b2987a'
+  version '5.1.974'
+  sha256 'fee0ff0696b441dcd19fc823a92f3ebb6b6f612e7bbacb38b3af0dc73351660a'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   name 'SciTools Understand'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.