### PR TITLE
Update tableau-prep to 2019.1.2

### DIFF
--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -9,7 +9,7 @@ cask 'tableau-prep' do
 
   depends_on macos: '>= :el_capitan'
 
-  pkg 'Tableau Prep Builder.pkg
+  pkg 'Tableau Prep Builder.pkg'
 
   uninstall pkgutil: [
                        'com.amazon.redshiftodbc',

--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -1,6 +1,6 @@
 cask 'tableau-prep' do
-  version '2019.1.1'
-  sha256 '392db25721e22d93e8489ab07b6a6107b8c66db5eee0cf97e844601717c50d47'
+  version '2019.1.2'
+  sha256 '964039fc8016b7a7ce33e12bf2ec5c7082dc44f944a5ff9053ea33bc91a0deb6'
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}.dmg"
   name 'Tableau Prep'

--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -3,13 +3,13 @@ cask 'tableau-prep' do
   sha256 '964039fc8016b7a7ce33e12bf2ec5c7082dc44f944a5ff9053ea33bc91a0deb6'
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}.dmg"
-  appcast 'http://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/prep/mac'
+  appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/prep/mac'
   name 'Tableau Prep'
   homepage 'https://www.tableau.com/support/releases/prep'
 
   depends_on macos: '>= :el_capitan'
 
-  pkg 'Tableau Prep.pkg'
+  pkg 'Tableau Prep Builder.pkg'
 
   uninstall pkgutil: [
                        'com.amazon.redshiftodbc',

--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -1,6 +1,6 @@
 cask 'tableau-prep' do
   version '2019.1.2'
-  sha256 '964039fc8016b7a7ce33e12bf2ec5c7082dc44f944a5ff9053ea33bc91a0deb6'
+  sha256 'a28317be77a6ef781a5734e0cb9c9af9205bda7e8148c1dbf5c62c6f0d8f9aea'
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}.dmg"
   appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/prep/mac'

--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -9,7 +9,7 @@ cask 'tableau-prep' do
 
   depends_on macos: '>= :el_capitan'
 
-  pkg 'Tableau Prep Builder.pkg'
+  pkg 'Tableau Prep Builder.pkg
 
   uninstall pkgutil: [
                        'com.amazon.redshiftodbc',

--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -3,6 +3,7 @@ cask 'tableau-prep' do
   sha256 '964039fc8016b7a7ce33e12bf2ec5c7082dc44f944a5ff9053ea33bc91a0deb6'
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}.dmg"
+  appcast 'http://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/prep/mac'
   name 'Tableau Prep'
   homepage 'https://www.tableau.com/support/releases/prep'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.