### PR TITLE
Update cryptomator to 1.4.3

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.4.1'
-  sha256 'f28cbf35a1dc50a10a40cf190cdadb727db8d4981ce17b80866aeb7d664198b5'
+  version '1.4.3'
+  sha256 '72c2ae3a63ce74f400f0eb97c2f19709e8feb62bef419d497b2ed9a65b03b16a'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.