### PR TITLE
Update unity to 2018.3.5f1,76b3e37670a4

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2018.3.4f1,1d952368ca3a'
-  sha256 '278d2d0296b4e57828a94a7137806b7008d8e2891a88b0969e06e92781e43954'
+  version '2018.3.5f1,76b3e37670a4'
+  sha256 'd99d36167ee596bc8696b1bd906167cc323512fbae0f5222b1fe1f88120b5fd3'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.