### PR TITLE
Update unity-linux-support-for-editor to 2018.3.5f1,76b3e37670a4

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.3.4f1,1d952368ca3a'
-  sha256 '553c0349d341b6c71eab617af0d0cbc18180c1e6b88c052e6fd8bc70832ee6bc'
+  version '2018.3.5f1,76b3e37670a4'
+  sha256 '60c2547409f455c0b576231dbf3a2ed67cb6704b39ede81b7906c471641b6743'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.