### PR TITLE
Update pascom-client to 47.R161_ca0d78b

### DIFF
--- a/Casks/pascom-client.rb
+++ b/Casks/pascom-client.rb
@@ -1,6 +1,6 @@
 cask 'pascom-client' do
-  version '46.R152_f23040b'
-  sha256 'd54b3417289981008c0946a0f3125c3bb0ce3cac057a41116d13d78e1af1b76a'
+  version '47.R161_ca0d78b'
+  sha256 'd33672bb5fefa963604cda66c8d4cdecd5c9adbcb3511a069e7212fd6fe2cc5d'
 
   url "https://download.pascom.net/release-archive/client/stable/pascom%20Client-#{version}.dmg"
   name 'pascom Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.