### PR TITLE
Update unity-webgl-support-for-editor to 2018.3.5f1,76b3e37670a4

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.3.4f1,1d952368ca3a'
-  sha256 '80dbfe72ff850cb9e19e3f2fc8f1f51cf8c8ee1867f73db951869158928ea569'
+  version '2018.3.5f1,76b3e37670a4'
+  sha256 'a2f481ee7396dd1835aa097a93044134052766f4b338427628380b76807acd77'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.