### PR TITLE
Update mailspring to 1.5.6

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,6 +1,6 @@
 cask 'mailspring' do
-  version '1.5.5'
-  sha256 '3a2749d00699a1db1f8e641b44ff8306fd745a3ea2bb5480026420590f940707'
+  version '1.5.6'
+  sha256 '76ba71bfa962be3c34f4d68a4a63fe237a3903f3c36cf50262442fb64b10df5c'
 
   # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
   url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.