### PR TITLE
Update wavebox to 4.7.0

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.6.0'
-  sha256 '6d2d90875f7bf7f36bbb898111a4a8c5f74ed4cba402ea5a2c3afce9a0e9fc80'
+  version '4.7.0'
+  sha256 '53414cf4704aa4208ed8cc674d58e57fc203f5f1567251567525e4d3e8630630'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.