### PR TITLE
Update macspice to 3.1.21

### DIFF
--- a/Casks/macspice.rb
+++ b/Casks/macspice.rb
@@ -1,6 +1,6 @@
 cask 'macspice' do
   version '3.1.21'
-  sha256 '17ac2d9dca93c6da5caa4894abf42a8a4c04aae65aa36855ac842f42f204c2b2'
+  sha256 'cee7530d0f442d9c9d27063efd1c9c009edef82c9a5c4c39df9cf364b285d129'
 
   url "https://www.macspice.com/mirror/binaries/v#{version}/MacSpice3f5.dmg"
   appcast 'https://www.macspice.com/AppCast-v2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.