### PR TITLE
Update hipchat to 4.30.2-760

### DIFF
--- a/Casks/hipchat.rb
+++ b/Casks/hipchat.rb
@@ -21,4 +21,8 @@ cask 'hipchat' do
                '~/Library/Saved Application State/com.hipchat.HipChat.savedState',
                '~/Library/chat.hipchat.com',
              ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.