### PR TITLE
Update workflowy to 1.2.1

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.1.16'
-  sha256 'efcf8f9133d0257de1df88d3ff489c5ea6b6624eb674c62be1aabe73222231e8'
+  version '1.2.1'
+  sha256 'c9760a1a5aebd774d1ed11a3a0c0a37d23ff7b357bd800ad206fec5825d84dc0'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.