### PR TITLE
Update coteditor to 3.7.0

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -6,8 +6,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.6.12'
-    sha256 '51ee770cf6c62b0e1a4e20948355c15c23529cabde6b6f6fc5489148a6bf263d'
+    version '3.7.0'
+    sha256 'dcf7a7cdd04f59644c1490fa84a6941c4e9257097507519c2757ac38a8a2054c'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.