### PR TITLE
Update adobe-dng-converter to 11.2

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -3,8 +3,8 @@ cask 'adobe-dng-converter' do
     version '9.6.1'
     sha256 '087eac5026667e4e6e3c156fd13243c9ea00f6c0238cbbb94d3099ae8772603f'
   else
-    version '11.1'
-    sha256 '24a9d5f570bc6ee2b59e504d0fcfad25f54f35eba34f7b8b51d702b7989eef1f'
+    version '11.2'
+    sha256 'add5f4d40f0bd5963ea2e01c88f05b1c5a8f3c5a1eec519971b75f061fb0fbcb'
   end
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.