### PR TITLE
Update fsnotes to 2.9.1

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.9.0'
-  sha256 '2ed55098c0f265a8b18221225d8e30f3feab80bff1fa183208b3e40dbab902c7'
+  version '2.9.1'
+  sha256 '81f1cc78f1bc791748d170309f0c182da175db715992590224477a5890965ed1'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.