### PR TITLE
Update marvel to 8.2.4

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.1.9'
-  sha256 '9db6eadd599fe601326274728fca5224bde49bb2ea271e79d2a703ce51c833ed'
+  version '8.2.4'
+  sha256 'd6305dda6649b6ac81657bba2620af23b6e63426ce82db023adc00f02a004a92'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.