### PR TITLE
Update melodics to 2.0.2679

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2677'
-  sha256 '926241af674f116aeecaa2f298185006ec99e0c5951f7a6b37b4f1b842bd26f1'
+  version '2.0.2679'
+  sha256 '1cb9d301a5be1db43e653ca8640c69622f324f925da27a7d8453b88d5cd33310'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.