### PR TITLE
Update snapndrag to 4.3.1

### DIFF
--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -1,6 +1,6 @@
 cask 'snapndrag' do
-  version '4.2.8'
-  sha256 '113664b9616fff224aba6d3cb8006cd302f3089b1a93b6f3b5e9f7d0daf00daa'
+  version '4.3.1'
+  sha256 'e643cd47fbc3ffbe2ef98f22987ad0e8588d090e017717164a7e14fec9a838da'
 
   url "http://yellowmug.com/download/SnapNDrag_#{version}.dmg"
   appcast 'http://yellowmug.com/snapndrag/appcast-1012.xml'

--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -2,10 +2,10 @@ cask 'snapndrag' do
   version '4.3.1'
   sha256 'e643cd47fbc3ffbe2ef98f22987ad0e8588d090e017717164a7e14fec9a838da'
 
-  url "http://yellowmug.com/download/SnapNDrag_#{version}.dmg"
-  appcast 'http://yellowmug.com/snapndrag/appcast-1012.xml'
+  url "https://yellowmug.com/download/SnapNDrag_#{version}.dmg"
+  appcast 'https://yellowmug.com/snapndrag/appcast-1012.xml'
   name 'SnapNDrag'
-  homepage 'http://www.yellowmug.com/snapndrag/'
+  homepage 'https://www.yellowmug.com/snapndrag/'
 
   app 'SnapNDrag.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.