### PR TITLE
Update nvidia-geforce-now to 1.17.2.28

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,8 +1,9 @@
 cask 'nvidia-geforce-now' do
-  version :latest
-  sha256 :no_check
+  version '1.17.2.28'
+  sha256 'ced40a2e079d7f4a16b131640b9c84e4844588f5f1bbe9b0dc779a9e18ed856f'
 
   url 'https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg'
+  appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'
   name 'NVIDIA GeForce NOW'
   homepage 'https://www.nvidia.com/en-us/geforce/products/geforce-now/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.