### PR TITLE
update to flash-npapi32.0.0.142

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '32.0.0.114'
-  sha256 '96016eb1f2952c194d3f1c334137d48879b0cb1437e6c5525b0fd39274e8d4db'
+  version '32.0.0.142'
+  sha256 '305b452c0dcf36b9ddc526804e25d7a0913250769b57150ee69062fdc99ccc80'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Update flash-npapi to ver.32.0.0.142 for https://github.com/Homebrew/homebrew-cask/issues/58832

