### PR TITLE
Update double-commander to 0.9.0-8649

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,6 +1,6 @@
 cask 'double-commander' do
-  version '0.8.4-8272'
-  sha256 'fad2a1e184ca63635fe8ded675d0a9fbbc6cd70576bc921afcd3e975241f1623'
+  version '0.9.0-8649'
+  sha256 '189d2a9fa450a5fce355d1db750c67a646c730c29634c1e0cc66676f3f2552ca'
 
   # downloads.sourceforge.net/doublecmd was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.