### PR TITLE
Update soapui to 5.5.0

### DIFF
--- a/Casks/soapui.rb
+++ b/Casks/soapui.rb
@@ -1,6 +1,6 @@
 cask 'soapui' do
-  version '5.4.0'
-  sha256 '9528936b416f8b4925c65d72a486108f8bf251cf102ebdcef5146a61a83ca9b5'
+  version '5.5.0'
+  sha256 'ba04466e07dc0b54aecc9323fd1c638024c25eaca20b790fd14e559e2eec668e'
 
   # s3.amazonaws.com/downloads.eviware/soapuios was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.eviware/soapuios/#{version}/SoapUI-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.