### PR TITLE
Update capture-one to 12.0.2

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -2,7 +2,7 @@ cask 'capture-one' do
   version '12.0.2'
   sha256 'f474f86a69502eb25ab25d9fde62bc1f0058f06f95867fd4e0e1049e90d76b9b'
 
-  url "http://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
+  url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'
   homepage 'https://www.phaseone.com/en/Capture-One.aspx'
 

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '12.0.1'
-  sha256 '84a7f38e3285edf6f3b723122c3612f3bbcc5554f1feb9aacde65d2964d76288'
+  version '12.0.2'
+  sha256 'f474f86a69502eb25ab25d9fde62bc1f0058f06f95867fd4e0e1049e90d76b9b'
 
   url "http://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.