### PR TITLE
Update ezip to 1.5.5

### DIFF
--- a/Casks/ezip.rb
+++ b/Casks/ezip.rb
@@ -1,6 +1,6 @@
 cask 'ezip' do
-  version '1.5.3'
-  sha256 'c8eda0ccb0d21dbc91d7f6b1be2ba33dd2aac91926e28ccd7f043fd6e19495a8'
+  version '1.5.5'
+  sha256 'c62c6fe55adfe6254a496686b039c0c48d3d3c7bd7dc7839264ddfe0f7933f71'
 
   url "https://cdn.awehunt.com/ezip/release/eZip_V#{version}.dmg"
   appcast 'https://ezip.awehunt.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.