### PR TITLE
Add script to update cask families

### DIFF
--- a/developer/bin/update_cask_family
+++ b/developer/bin/update_cask_family
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+readonly program="$(basename "${0}")"
+readonly families=(flash navicat) # Needs to be in sync with the 'get_' functions
+readonly cask_family="${1}"
+readonly new_version="${2}"
+
+function usage {
+  echo "
+    Submit updates to a family of casks all at once.
+
+    Usage: ${program} <family> <new_version>
+    Available families: ${families[*]}
+  " | sed -E 's/^ {4}//'
+}
+
+function is_in_array {
+  local string="${1}"
+
+  for value in "${@:2}"; do
+    [[ "${string}" == "${value}" ]] && return 0
+  done
+
+  return 1
+}
+
+function get_flash {
+  brew search 'flash' | grep 'flash-[np]'
+}
+
+function get_navicat {
+  brew search 'navicat' | grep 'navicat-[fp]'
+}
+
+if ! command -v 'cask-repair' &>/dev/null; then
+  echo 'You need cask-repair to run this script'
+  exit 1
+fi
+
+if [[ -z "${new_version}" ]] || ! is_in_array "${cask_family}" "${families[@]}"; then
+  usage
+  exit 1
+fi
+
+if [[ "${1}" =~ ^(-h|--help)$ ]]; then
+  usage
+  exit 0
+fi
+
+brew update
+
+for cask in $(get_${cask_family}); do
+  cask_version="$(brew cask _stanza version "${cask}")"
+
+  if [[ "${cask_version}" == "${new_version}" ]]; then
+    echo "${cask} was already updated"
+    continue
+  fi
+
+  cask-repair --cask-version "${new_version}" --blind-submit "${cask}"
+done

--- a/developer/bin/update_cask_family
+++ b/developer/bin/update_cask_family
@@ -10,6 +10,8 @@ function usage {
     Submit updates to a family of casks all at once.
 
     Usage: ${program} <family> <new_version>
+    Example: ${program} flash '32.0.0.142'
+
     Available families: ${families[*]}
   " | sed -E 's/^ {4}//'
 }


### PR DESCRIPTION
Hope I won’t regret adding this to the repo (people running it without checking if someone else has done it before).

There are a few casks that are part of a “family” whose versions are always in sync. Running this script makes it easy to update them all at once.