### PR TITLE
Update qbserve to 1.81 (6802)

### DIFF
--- a/Casks/qbserve.rb
+++ b/Casks/qbserve.rb
@@ -1,6 +1,6 @@
 cask 'qbserve' do
   version '1.81'
-  sha256 '4d9146fc9c4996509de858c1ee5a42a462d411c48accfdf1eb1079cf2e9797d8'
+  sha256 'd0ba56a2a0dcafca31e4a0cfaa382b1857e0d4bdde9c274f11c38502c526872e'
 
   url "https://qotoqot.com/qbserve/app/Qbserve-#{version}.zip"
   appcast 'https://qotoqot.com/qbserve/app/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

-----

The version number is the same, but looks like the build number has changed from `6800` (in appcast) to `6802` (from about dialog in the app) so I think the checksum change is valid.