### PR TITLE
Update splashtop-streamer to 3.3.0.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-streamer' do
-  version '3.2.6.0'
-  sha256 'b69cf91c0c908f5fd69c8ae3a361b261eeed308647de629c1d447f7d49e6eac9'
+  version '3.3.0.0'
+  sha256 '53ad358aa8dc1ce399c267e9c4dcbf909a2909fb3106fe750bd67fd273d8f58e'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -9,7 +9,7 @@ cask 'splashtop-streamer' do
   homepage 'https://www.splashtop.com/downloads'
 
   auto_updates true
-  
+
   pkg 'Splashtop Streamer.pkg'
 
   uninstall quit:      'com.splashtop.Splashtop-Streamer',

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -8,6 +8,8 @@ cask 'splashtop-streamer' do
   name 'Splashtop Streamer'
   homepage 'https://www.splashtop.com/downloads'
 
+  auto_updates true
+  
   pkg 'Splashtop Streamer.pkg'
 
   uninstall quit:      'com.splashtop.Splashtop-Streamer',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.