### PR TITLE
Update dotnet to 2.2.2

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -2,7 +2,7 @@ cask 'dotnet' do
   version '2.2.2'
   sha256 '263cd8ea9c4579908ba6fb6b4c5f54170a533304ebce4074cc1df6bd0af3250a'
 
-  url 'https://download.visualstudio.microsoft.com/download/pr/eb9047cf-9d6f-472a-940e-05f018cdb29e/62c457d7f2ead9eccc099978f038c1f8/dotnet-runtime-2.2.2-osx-x64.pkg'
+  url "https://download.visualstudio.microsoft.com/download/pr/eb9047cf-9d6f-472a-940e-05f018cdb29e/62c457d7f2ead9eccc099978f038c1f8/dotnet-runtime-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.Net Core Runtime'
   homepage 'https://www.microsoft.com/net/core#macos'

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,8 +1,8 @@
 cask 'dotnet' do
-  version '2.2.1'
-  sha256 '10d1893ef62861f3e1491f35b05a7f0279fad34b6f97c35a172c04b34987448e' # DevSkim: ignore DS173237
+  version '2.2.2'
+  sha256 '263cd8ea9c4579908ba6fb6b4c5f54170a533304ebce4074cc1df6bd0af3250a'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/80a93bfc-dd53-474b-94f4-1dea02dec70c/eab2c0d078899ad0d8f8a15bf84a7f63/dotnet-runtime-#{version}-osx-x64.pkg"
+  url 'https://download.visualstudio.microsoft.com/download/pr/eb9047cf-9d6f-472a-940e-05f018cdb29e/62c457d7f2ead9eccc099978f038c1f8/dotnet-runtime-2.2.2-osx-x64.pkg'
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.Net Core Runtime'
   homepage 'https://www.microsoft.com/net/core#macos'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.