### PR TITLE
Update vivaldi to 2.3.1440.48

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.3.1440.41'
-  sha256 '24e607993b4ce864b9f114b10d7fa0ac9137876d8f0c6970c016f5cd85f859f1'
+  version '2.3.1440.48'
+  sha256 'e894cb78f37c2b772882d72b418f87df992d87d279c215e7e9733a95484f764f'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.