### PR TITLE
Update lando to 3.0.0-rc.10

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.0-rc.9'
-  sha256 'b50c7a90bbb8f148dfa76ecb553369662a1c04df1a90328c736851414d10de1a'
+  version '3.0.0-rc.10'
+  sha256 '1aef728272133886684794c27ac224368bd503b5fbc3f01bfd0cde7cd245d37a'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.