### PR TITLE
Update termius to 4.1.2

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,5 +1,5 @@
 cask 'termius' do
-  version '4.0.2'
+  version '4.1.2'
   sha256 'cc8799cb107b2d807d0604ec6d6d699b53b164cda8228bda18d0a1179d734de2'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.