### PR TITLE
Update ringcentral to 10.3.2

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,8 +1,9 @@
 cask 'ringcentral' do
-  version :latest
-  sha256 :no_check
+  version '10.3.2'
+  sha256 '2cb11a5f8be4c68f8969918a5e24f96d4895870d030e3bf80ae291967fdd646f'
 
   url 'https://downloads.ringcentral.com/sp/RingCentralForMac'
+  appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=http://downloads.ringcentral.com/sp/RingCentralForMac'
   name 'RingCentral for Mac'
   homepage 'https://www.ringcentral.com/office/features/desktop-apps/overview.html'
 

--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -2,7 +2,7 @@ cask 'ringcentral' do
   version '10.3.2'
   sha256 '2cb11a5f8be4c68f8969918a5e24f96d4895870d030e3bf80ae291967fdd646f'
 
-  url 'https://downloads.ringcentral.com/sp/RingCentralForMac'
+  url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=http://downloads.ringcentral.com/sp/RingCentralForMac'
   name 'RingCentral for Mac'
   homepage 'https://www.ringcentral.com/office/features/desktop-apps/overview.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.