### PR TITLE
Update deezer to 4.2.4

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.2.2'
-  sha256 '334ae7d5c31aa136d5eeafef0156f6ab40852374f70cbd02e28ba1ef10e3e12d'
+  version '4.2.4'
+  sha256 '27f03eb67708c6cf4cbe4d73aefe8dcfc4f15ed3b91cdb63bab04ec9d7054e55'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   name 'Deezer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.