### PR TITLE
Update electron to 4.0.5

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '4.0.4'
-  sha256 '95c0840053037a2ed2f18c0cdc32564f75c3bc262cd246b9a63e547e5781cb06'
+  version '4.0.5'
+  sha256 'ced8c7742b0a9415974e7774bb4222a7757613b82ab5676df315d0fd59f28e8c'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.