### PR TITLE
Update station to 1.37.2

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.37.1'
-  sha256 '691111e3211b2811a0c23136b79b432d81621f1727a7367017959115b91e9d04'
+  version '1.37.2'
+  sha256 '7b70ee89a73269fe5c829da8adf85d247f91614d8f11a1cee0c375d45fa79d00'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.