### PR TITLE
Update wavebox to 4.7.2

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.7.1'
-  sha256 'ea6e49a7d6df5350dd615302cc20d432a7c6ed7a25054c4e0d384c0a77b3418a'
+  version '4.7.2'
+  sha256 '8d441237424fcb831aeb45a08092120867236c22a3f0eac8d6d337aca54e043a'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.