### PR TITLE
Update receipts to 1.9.5-271

### DIFF
--- a/Casks/receipts.rb
+++ b/Casks/receipts.rb
@@ -1,6 +1,6 @@
 cask 'receipts' do
-  version '1.9.4-267'
-  sha256 'fbb2fbafb8159e4f6711ac6db2958d1ccfe04667b46fe5c0ac5f0bd40ccf5f6b'
+  version '1.9.5-271'
+  sha256 'e369becf9df321adb42d6476f020a9196f04d4cb5bdad90d339a71c01db72a05'
 
   url "https://www.receipts-app.com/update/download/Receipts-#{version}.zip"
   appcast 'https://www.receipts-app.com/updater.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.