### PR TITLE
Update skyfonts to 5.9.5.3

### DIFF
--- a/Casks/skyfonts.rb
+++ b/Casks/skyfonts.rb
@@ -1,6 +1,6 @@
 cask 'skyfonts' do
-  version '5.9.5.0'
-  sha256 '1abbcde9e8df3154490ac78950992fe9461cfd1911d28217701f5ff1c5225088'
+  version '5.9.5.3'
+  sha256 '0c15c517e377f824099c3ea9ce7cd4d1cfcde2686e472592a9f71b66dc15cf88'
 
   url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
   appcast 'https://api.skyfonts.com/api/SkyFontsAppCast?osid=3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.