### PR TITLE
Update tinymediamanager to 2.9.15_69b6104

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -2,8 +2,8 @@ cask 'tinymediamanager' do
   version '2.9.15_69b6104'
   sha256 '7a1aa341d9701b0adc4c7a60d6183aaff1cd4efb10c013de82265020f6fcf84a'
 
-  url "https://release.tinymediamanager.org/dist/tmm_#{version}_mac.zip"
-  appcast 'https://release.tinymediamanager.org/'
+  url "http://release.tinymediamanager.org/dist/tmm_#{version}_mac.zip"
+  appcast 'http://release.tinymediamanager.org/'
   name 'tinyMediaManager'
   homepage 'https://www.tinymediamanager.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.