### PR TITLE
Update cryptomator to 1.4.5

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.4.4'
-  sha256 '6f3956a6c6c24461dd58e1823e1e9d9555930e73230f395be5d7e414f7553fc5'
+  version '1.4.5'
+  sha256 'a961bbb06af06f903eaf76a37f28c94ad7234ed6bcbdaba9e0309d63f5ffa46f'
 
   # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
   url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.