### PR TITLE
Update fork to 1.0.74 url change

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,8 +1,8 @@
 cask 'fork' do
   version '1.0.74'
-  sha256 'e6be1e39261cbfb688e71d7d5ed8668cc04db7e16f0caf400eb8f1b8ab35eefe'
+  sha256 '04b7a06735d34492830d12696cb5145798dee11eb8840a5e7fdf90807e42c5b8'
 
-  url 'https://git-fork.com/update/files/Fork.dmg'
+  url "https://forkapp.ams3.cdn.digitaloceanspaces.com/mac/Fork-#{version}.dmg"
   appcast 'https://git-fork.com/update/feed.xml'
   name 'Fork'
   homepage 'https://git-fork.com/'

--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -2,6 +2,7 @@ cask 'fork' do
   version '1.0.74'
   sha256 '04b7a06735d34492830d12696cb5145798dee11eb8840a5e7fdf90807e42c5b8'
 
+  # forkapp.ams3.cdn.digitaloceanspaces.com/mac was verified as official when first introduced to the cask
   url "https://forkapp.ams3.cdn.digitaloceanspaces.com/mac/Fork-#{version}.dmg"
   appcast 'https://git-fork.com/update/feed.xml'
   name 'Fork'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
#59022 missed the URL change in the appcast, and by downloading that file, you are still getting version `1.0.73.5`. That's why the `sha256` did not change in that commit.