### PR TITLE
Update private-internet-access to 1.0.2-02363

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,8 +1,9 @@
 cask 'private-internet-access' do
-  version '1.0.1-02349'
-  sha256 '59c3a8ad7661cb86c2b9b3f0b9d2994031493cc30fbe454d970d1c8edfb74926'
+  version '1.0.2-02363'
+  sha256 '3e9315166502925b9531de6c0a32ffd67491cd7745ab9eb79ef98b5ab917a296'
 
   url "https://installers.privateinternetaccess.com/download/pia-macos-#{version}.zip"
+  appcast 'https://www.privateinternetaccess.com/pages/download'
   name 'Private Internet Access'
   homepage 'https://www.privateinternetaccess.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.