### PR TITLE
Update fsnotes to 2.9.2

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.9.1'
-  sha256 '81f1cc78f1bc791748d170309f0c182da175db715992590224477a5890965ed1'
+  version '2.9.2'
+  sha256 'c57419d6e199ed2d4b1772637628dc9ea81a8997612fd6845966c3b65dfb8dac'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.