### PR TITLE
Update qownnotes to 19.2.4,b4165-055216

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.2.3,b4148-062533'
-  sha256 '2ca85221a5e96617b85fd7f9e6833fbd19c74da440f352bbca099d9398e67b3f'
+  version '19.2.4,b4165-055216'
+  sha256 '2d2466a970676539780fc7bcce665296e62e8410bfbb41dea5fc353f680fe60e'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.