### PR TITLE
Update rsyncosx to 5.7.3

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,6 +1,6 @@
 cask 'rsyncosx' do
-  version '5.7.1'
-  sha256 'f2043afa65f934eed3979c3948576c80e8a00edafd6ef6819370173c8d043c04'
+  version '5.7.3'
+  sha256 'c3263e79f51ee03a80dd3c98ce1097efeb3dbd6de1728fbe5f849605431820f8'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.