### PR TITLE
Update standard-notes to 3.0.5

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
-  version '3.0.4'
-  sha256 '73b62ab8b3623740a06bae99919c4e40721f94759316c418ff52a15624c1014f'
+  version '3.0.5'
+  sha256 '702d9f856adeea01b3dbb710fa59777615cbfe546a5eca0ac7f973a01c18cb43'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.