### PR TITLE
Update command-tab-plus to 1.88,318:1550245110

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.83,309:1547123484'
-  sha256 '6d663ab07ff915a0ab38ad4e57e8d426a2558bb8bff28f78fb8555b9a90e4e13'
+  version '1.88,318:1550245110'
+  sha256 '0e4106abda9fc700b466a8904a5901c7fcf8d9f4c0019e7242a4d4255e3f44da'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.