### PR TITLE
Update tableplus to 1.6,194

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '1.5,190'
-  sha256 'adda9bf1225c56b22653144f5e69845117b8d0079b4ddd3cd3361628828ce292'
+  version '1.6,194'
+  sha256 'e622a1bb43a57611bf0f107be88470d7a10ddc6fc78567bae3c1edcaf32590f8'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/tableplus-osx-builds/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.