### PR TITLE
Update volt to 0.52

### DIFF
--- a/Casks/volt.rb
+++ b/Casks/volt.rb
@@ -1,9 +1,9 @@
 cask 'volt' do
-  version '0.47'
-  sha256 'e765b86d614472112a0a39b7ae06ae70f06107367d2944d27238970553c6a234'
+  version '0.52'
+  sha256 '9db2f02168a606bd84b44a36571ad00244a1634483820141292da37b6f29aac8'
 
   # github.com/voltapp/volt was verified as official when first introduced to the cask
-  url "https://github.com/voltapp/volt/releases/download/#{version}/volt_mac.zip"
+  url "https://github.com/voltapp/volt/releases/download/#{version}/Volt.dmg"
   appcast 'https://github.com/voltapp/volt/releases.atom'
   name 'Volt'
   homepage 'https://volt.ws/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.