### PR TITLE
Update quassel to 0.13.1

### DIFF
--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -1,8 +1,9 @@
 cask 'quassel' do
-  version '0.13.0'
-  sha256 'f4f36f51208503ecc6782649f60ce2f4f0bd81e0b3152aa0818785eb60c5eac5'
+  version '0.13.1'
+  sha256 'bda19cfd004a0b377f1c6a3974fd63f5665d5dc570eac2a24bf7c48d387f24fb'
 
-  url "https://quassel-irc.org/pub/QuasselMono_MacOSX-x86_64_#{version}.dmg"
+  # github.com/quassel/quassel/ was verified as official when first introduced to the cask
+  url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselCore_MacOSX-x86_64_#{version}.dmg"
   appcast 'https://github.com/quassel/quassel/releases.atom'
   name 'Quassel IRC'
   homepage 'https://quassel-irc.org/'

--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -3,7 +3,8 @@ cask 'quassel' do
   sha256 'bda19cfd004a0b377f1c6a3974fd63f5665d5dc570eac2a24bf7c48d387f24fb'
 
   # github.com/quassel/quassel/ was verified as official when first introduced to the cask
-  url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselCore_MacOSX-x86_64_#{version}.dmg"
+  url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselMono_MacOSX-x86_64_#{version}.dmg"
+
   appcast 'https://github.com/quassel/quassel/releases.atom'
   name 'Quassel IRC'
   homepage 'https://quassel-irc.org/'

--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -4,7 +4,6 @@ cask 'quassel' do
 
   # github.com/quassel/quassel/ was verified as official when first introduced to the cask
   url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselMono_MacOSX-x86_64_#{version}.dmg"
-
   appcast 'https://github.com/quassel/quassel/releases.atom'
   name 'Quassel IRC'
   homepage 'https://quassel-irc.org/'

--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -1,6 +1,6 @@
 cask 'quassel' do
   version '0.13.1'
-  sha256 'bda19cfd004a0b377f1c6a3974fd63f5665d5dc570eac2a24bf7c48d387f24fb'
+  sha256 '5a2437dd0fc51a8fa12f2c83472e8294635edea41e55c523535df080c012379e'
 
   # github.com/quassel/quassel/ was verified as official when first introduced to the cask
   url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselMono_MacOSX-x86_64_#{version}.dmg"

--- a/Casks/quassel.rb
+++ b/Casks/quassel.rb
@@ -2,7 +2,7 @@ cask 'quassel' do
   version '0.13.1'
   sha256 '5a2437dd0fc51a8fa12f2c83472e8294635edea41e55c523535df080c012379e'
 
-  # github.com/quassel/quassel/ was verified as official when first introduced to the cask
+  # github.com/quassel/quassel was verified as official when first introduced to the cask
   url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselMono_MacOSX-x86_64_#{version}.dmg"
   appcast 'https://github.com/quassel/quassel/releases.atom'
   name 'Quassel IRC'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.