### PR TITLE
Update tweet-tray to 1.1.5

### DIFF
--- a/Casks/tweet-tray.rb
+++ b/Casks/tweet-tray.rb
@@ -1,6 +1,6 @@
 cask 'tweet-tray' do
-  version '1.1.3'
-  sha256 '611afd3ee43464de47ac1e4587fdae71f85205cb6d4075fa550c241214ed7298'
+  version '1.1.5'
+  sha256 '55496bbd3253165dd4ec639ffca2626605892e44d59842578dd44cab1073cb04'
 
   url "https://github.com/jonathontoon/tweet-tray/releases/download/v#{version}/tweet-tray-#{version}.dmg"
   appcast 'https://github.com/jonathontoon/tweet-tray/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.