### PR TITLE
Update seashore to 2.4.0

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.3.4'
-  sha256 '7b9d0bf312e146b8067a6a5c99beabeb23d332bf13f247fd4caa6521401918fb'
+  version '2.4.0'
+  sha256 '10a76f0a5a31c0f828503919805b8878b392a30c96bfd88f35fb4a86c834554c'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.