### PR TITLE
Update okapi to 0.36

### DIFF
--- a/Casks/okapi.rb
+++ b/Casks/okapi.rb
@@ -1,6 +1,6 @@
 cask 'okapi' do
-  version '0.35'
-  sha256 '94033a291df167172271aab8004974dfd84feb2c9023c0213056c0fe58124250'
+  version '0.36'
+  sha256 '268d64f445998ba9f8e53493fc1a7f5cfdcf40fb331777a80e6f2f20d65f2723'
 
   # bintray.com/okapi was verified as official when first introduced to the cask
   url "https://dl.bintray.com/okapi/Distribution/okapi-apps_cocoa-macosx-x86_64_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.