### PR TITLE
Add LeoCAD v18.02 to Homebrew Cask

### DIFF
--- a/Casks/leocad.rb
+++ b/Casks/leocad.rb
@@ -1,0 +1,11 @@
+cask 'leocad' do
+  version '18.02'
+  sha256 'b4522d1af5f2dac3cfd3ae0dc654ed4a5cb95fff2ea7d85ba3331cf9132fedfa'
+
+  url 'https://github.com/leozide/leocad/releases/download/v18.02/LeoCAD-macOS-18.02.dmg'
+  appcast 'https://github.com/leozide/leocad/releases.atom'
+  name 'LeoCAD'
+  homepage 'https://github.com/leozide/leocad'
+
+  app 'LeoCAD.app'
+end

--- a/Casks/leocad.rb
+++ b/Casks/leocad.rb
@@ -2,7 +2,7 @@ cask 'leocad' do
   version '18.02'
   sha256 'b4522d1af5f2dac3cfd3ae0dc654ed4a5cb95fff2ea7d85ba3331cf9132fedfa'
 
-  url 'https://github.com/leozide/leocad/releases/download/v18.02/LeoCAD-macOS-18.02.dmg'
+  url "https://github.com/leozide/leocad/releases/download/v#{version}/LeoCAD-macOS-#{version}.dmg"
   appcast 'https://github.com/leozide/leocad/releases.atom'
   name 'LeoCAD'
   homepage 'https://github.com/leozide/leocad'


### PR DESCRIPTION
LeoCAD is a 3D modelling CAD-like tool for designing structures from Lego blocks. This is the initial release of support for LeoCAD in Homebrew Cask, allowing users to install/uninstall LeoCAD using Homebrew.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
