### PR TITLE
Update rotato to 52.1550499356

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '50.1550354063'
-  sha256 '7e44dfb4fd7202b529391771f7d5d5b5c07ae45be5e23ea1f465e621118cff06'
+  version '52.1550499356'
+  sha256 'cf6d850ab941ed396a6eb7d06b7a88c2b1263bc7626137ed7eab47ad6f74fca2'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.