### PR TITLE
Update db-browser-for-sqlite to 3.11.1

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'db-browser-for-sqlite' do
-  version '3.11.0'
-  sha256 '80d66a492ca3ed1f544d3dfea940c222059e9763280491a1d4cac8fb701e5720'
+  version '3.11.1'
+  sha256 'bd4a74540a63a262fc49b816e8fc71fd816e81b215c31572d96b169d980a573e'
 
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.