### PR TITLE
Update timely to 0.6.1

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,6 +1,6 @@
 cask 'timely' do
-  version '0.6.0'
-  sha256 '07b960a77f008abaa2ac6fb73546be5de51e60913f0bbd38482ccf9d9b94ab06'
+  version '0.6.1'
+  sha256 'd6226090847503ca79b6e871854464bc105ff28243df08795876e4f3d85bf43b'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.