### PR TITLE
Update aether to 2.0.0-dev.9,1902131456.97bf3870

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -1,6 +1,6 @@
 cask 'aether' do
-  version '2.0.0-dev.6,1811231746.7e1936d8'
-  sha256 'db8c1d499b04225ea10fd1869f996dd8cf83befe0bcc60b5ee8022af6a7fd77c'
+  version '2.0.0-dev.9,1902131456.97bf3870'
+  sha256 '3bb23fb85c25c7e61f540aa5bff709852f2278252369ec68f825294c19f8e8f2'
 
   url "https://static.getaether.net/Releases/Aether-#{version.before_comma}/#{version.after_comma}/mac/Aether-#{version.before_comma}%2B#{version.after_comma}.dmg"
   appcast 'https://getaether.net/dlstarted/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.