### PR TITLE
Update nosqlbooster-for-mongodb to 5.1.4

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.1.2'
-  sha256 'cff4e6eccaa3346e20cd6d211d157d0c681d3713112ddb1ad917d3ad1a6e3f9d'
+  version '5.1.4'
+  sha256 '95087dd9248ff95c555d2b8271e36e2219195d9fe83e6f7f3ece30036a1d2d88'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   name 'NoSQLBooster for MongoDB'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.