### PR TITLE
Update ringcentral to 10.3.5

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '10.3.2'
-  sha256 '2cb11a5f8be4c68f8969918a5e24f96d4895870d030e3bf80ae291967fdd646f'
+  version '10.3.5'
+  sha256 'c69a4cfb44f844b6020558daafe1151037e15c35bf072ded8dfe1575c771ac71'
 
   url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=http://downloads.ringcentral.com/sp/RingCentralForMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.