### PR TITLE
Update molotov to 3.1.0

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '3.0.2'
-  sha256 'e514b867375bf82915862334c9b409ef695056d73d02e2d2709f44a04d42d029'
+  version '3.1.0'
+  sha256 '37f4372515ed4056f34bf50a010410c97cab704e7950330be8051f9c1679c307'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   name 'Molotov'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.