### PR TITLE
Update onionshare.rb to v2.0

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,14 +1,14 @@
 cask 'onionshare' do
-  version '1.3.1'
+  version '2.0,2'
   sha256 '6d748022b28ae0ae105ad595fa5d6428d7ce9e9882bc8808951f9870499519a2'
 
   # github.com/micahflee/onionshare was verified as official when first introduced to the cask
-  url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare-#{version}.pkg"
+  url "https://github.com/micahflee/onionshare/releases/download/v#{version.before_comma}/OnionShare-#{version.after_comma}.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
 
-  pkg "OnionShare-#{version}.pkg"
+  pkg "OnionShare-#{version.after_comma}.pkg"
 
   uninstall pkgutil: 'com.micahflee.onionshare'
 end


### PR DESCRIPTION
In this version they decided to not but the .0 on the file name so needed additional changes.

we could wait for 2.1 where we can revert back to the old version where we don't need to specify filename separately 

I was not able to run the test commands for some reason.