### PR TITLE
Update scythebill to 14.4.0

### DIFF
--- a/Casks/scythebill.rb
+++ b/Casks/scythebill.rb
@@ -1,6 +1,6 @@
 cask 'scythebill' do
-  version '14.0.2'
-  sha256 'bd9a4232932fe5e477e2c0b475798c1c1eeb83ddd95604d00cc22affdef0a540'
+  version '14.4.0'
+  sha256 '2c5ff7e3a001865752996c95349b5cb490c1dffb0c5f379fd6dbbe0b57a34a24'
 
   # storage.googleapis.com/scythebill-releases was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/scythebill-releases/Scythebill-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.