### PR TITLE
Upgrade smcfancontrol to 2.6.1

### DIFF
--- a/Casks/smcfancontrol.rb
+++ b/Casks/smcfancontrol.rb
@@ -1,6 +1,6 @@
 cask 'smcfancontrol' do
-  version '2.6'
-  sha256 '7662058e618537eb466307e3b12e540b857e61392646a5b09df51bec9ad6da38'
+  version '2.6.1'
+  sha256 'ed6dcee1cff9cff3def1b9d98c7bb868b12b9e26205f81915a95187e0d4ed826'
 
   url "https://www.eidac.de/smcfancontrol/smcfancontrol_#{version.dots_to_underscores}.zip"
   appcast 'https://www.eidac.de/smcfancontrol/smcfancontrol.xml'


### PR DESCRIPTION
This version should support the 2018 15" MacBook Pro (MacBookPro15,1).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
