### PR TITLE
quip 5.4.47

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,9 +1,9 @@
 cask 'quip' do
-  version '5.4.33'
-  sha256 '27d073d47d2d47b9496b6437649ae5cbccd0368d13f7d96c695ca436fc098574'
+  version '5.4.47'
+  sha256 '74a8a1ddbd8d022e348742aa9b006ea26a0a2412e726c662c6c7ac8d8c6acfd9'
 
-  # d2i1pl9gz4hwa7.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2i1pl9gz4hwa7.cloudfront.net/macosx_#{version}.dmg"
+  # quip-clients.com was verified as official when first introduced to the cask
+  url "https://quip-clients.com/macosx_#{version}.dmg"
   appcast 'https://api.quip.com/-/sparkle-feed?manual=0'
   name 'Quip'
   homepage 'https://quip.com/'


### PR DESCRIPTION
Quip is also no longer served from Cloudfront (see <https://salesforce.quip.com/download>).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256