### PR TITLE
Update sigil to 0.9.12

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,6 +1,6 @@
 cask 'sigil' do
-  version '0.9.11'
-  sha256 '67df3947381449445db0e13ea8132103906725f1a5fe220a426c93a4e45811f7'
+  version '0.9.12'
+  sha256 '04948ed2c7563430b7103f43e3cfcc94f62897d0449dd668b8fc9352060d7670'
 
   # github.com/Sigil-Ebook/Sigil was verified as official when first introduced to the cask
   url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.