### PR TITLE
Update android-messages to 0.9.0

### DIFF
--- a/Casks/android-messages.rb
+++ b/Casks/android-messages.rb
@@ -1,6 +1,6 @@
 cask 'android-messages' do
-  version '0.8.0'
-  sha256 '980cbcc0e2960ab9c3af3c7eeefb8dd5b933a84983586778b8107c18ea7aaaae'
+  version '0.9.0'
+  sha256 '777521de43f83a9cad0ced32242087a593b65fd59ae1bc9e435331cdeffc1e6e'
 
   url "https://github.com/chrisknepper/android-messages-desktop/releases/download/v#{version}/android-messages-desktop-#{version}.dmg"
   appcast 'https://github.com/chrisknepper/android-messages-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.