### PR TITLE
Update fish-app to 3.0.2

### DIFF
--- a/Casks/fish-app.rb
+++ b/Casks/fish-app.rb
@@ -1,9 +1,9 @@
 cask 'fish-app' do
-  version '3.0.1'
-  sha256 '104e023ed25f2ca5d4bb565c868bebaf64ef4394b8a518804da83b63bad327ea'
+  version '3.0.2'
+  sha256 'cd842d08b06d888978f2e7da2b856e386a86e8180d2137da322045964f9badc5'
 
   # github.com/fish-shell/fish-shell was verified as official when first introduced to the cask
-  url "https://github.com/fish-shell/fish-shell/releases/download/#{version}/fish.app.zip"
+  url "https://github.com/fish-shell/fish-shell/releases/download/#{version}/fish-#{version}.app.zip"
   appcast 'https://fishshell.com/release_notes.html'
   name 'Fish App'
   homepage 'https://fishshell.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.