### PR TITLE
Update scrivener to 3.1.2,10882

### DIFF
--- a/Casks/scrivener.rb
+++ b/Casks/scrivener.rb
@@ -1,6 +1,6 @@
 cask 'scrivener' do
-  version '3.1.1,9852'
-  sha256 'e97b0b1382bc4ad60b814a5e50d410b8e0e88bcad88e561d3ee7207fd83a4d99'
+  version '3.1.2,10882'
+  sha256 'a4b72a9e273bcaca8e8b9e75a735e6f37c3f801c7d1466b53ecf927b4af2c82a'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://scrivener.s3.amazonaws.com/mac_updates/Scrivener_1012_#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.