### PR TITLE
Add -lax argument to list_ids_in_pkg script

### DIFF
--- a/developer/bin/list_ids_in_pkg
+++ b/developer/bin/list_ids_in_pkg
@@ -15,6 +15,8 @@ shopt -s nocasematch  # case-insensitive regular expressions
 ### global variables
 ###
 
+opt_lax=''
+opt_pkg=''
 pkgdir=''
 
 # prefer GNU xargs
@@ -50,22 +52,76 @@ mark_up_sources () {
       'printf "{}"; /usr/sbin/pkgutil --pkg-info "{}" >/dev/null 2>&1 && printf " (+)"; printf "\n"'
 }
 
+process_args () {
+    local arg
+    if [[ "$#" -eq 0 ]]; then
+        die "ERROR: A file argument is required"
+    else
+        opt_pkg="${!#}"   # last arg
+    fi
+    for arg in "$@"; do
+        if [[ $arg =~ ^-+h(elp)?$ ]]; then
+            printf "list_ids_in_pkg [ -lax ] <file.pkg>
+
+  Given a package file, extract a list of candidate Package IDs
+  which may be useful in a Cask uninstall stanza, eg
+
+      uninstall pkgutil: 'package.id.goes.here'
+
+  The given package file need not be installed.
+
+  The output of this script should be overly inclusive -- not
+  every candidate package id in the output will be needed at
+  uninstall time.
+
+  Package IDs designated by Apple or common development frameworks
+  will be excluded from the output. This can be turned off with
+  the -lax argument.
+
+  If a package id is already installed, it will be followed by
+  a plus symbol '(+)' in the output. This can be verified via
+  the command
+
+      /usr/sbin/pkgutil --pkg-info 'package.id.goes.here'
+
+  Arguments
+
+     -lax   Turn off filtering of Apple or common development
+            framework package IDs from the output.
+
+  See CONTRIBUTING.md and 'man pkgutil' for more information.
+
+"
+            exit
+        elif [[ $arg =~ ^-+lax$ ]]; then
+            opt_lax='true'
+        elif [[ "$arg" = "$opt_pkg" ]]; then
+            true
+        else
+            die "ERROR: Unknown argument '$arg'"
+        fi
+    done
+    if [[ -h "$opt_pkg" ]]; then
+        opt_pkg="$(/usr/bin/readlink "$opt_pkg")"
+    fi
+    if ! [[ -e "$opt_pkg" ]]; then
+        die "ERROR: No such pkg file: '$opt_pkg'"
+    fi
+}
+
 ###
 ### main
 ###
 
 _list_ids_in_pkg () {
 
-    if [[ -d "$1" ]]; then
-        pkgdir="$1"
-        if [[ -h "$pkgdir" ]]; then
-            pkgdir="$(/usr/bin/readlink "$pkgdir")"
-        fi
+    if [[ -d "$opt_pkg" ]]; then
+        pkgdir="$opt_pkg"
     else
         local tmpdir="$(/usr/bin/mktemp -d -t list_ids_in_pkg)"
         trap "/bin/rm -rf -- '$tmpdir'" EXIT
         pkgdir="$tmpdir/unpack"
-        /usr/sbin/pkgutil --expand "$1" "$tmpdir/unpack" "$pkgdir"
+        /usr/sbin/pkgutil --expand "$opt_pkg" "$tmpdir/unpack" "$pkgdir"
     fi
 
     {
@@ -74,42 +130,14 @@ _list_ids_in_pkg () {
       bundle_id_source_2;
     } |                     \
     merge_sources |         \
-    clean_sources |         \
+    ( [[ ! "$opt_lax" ]] && clean_sources || cat ) | \
     mark_up_sources
 
 }
 
-# process args
-if [[ $1 =~ ^-+h(elp)?$ || -z "$1" ]]; then
-    printf "list_ids_in_pkg <file.pkg>
-
-Given a package file, extract a list of candidate Package IDs
-which may be useful in a Cask uninstall stanza, eg
-
-    uninstall pkgutil: 'package.id.goes.here'
-
-The given package file need not be installed.
-
-The output of this script should be overly inclusive -- not
-every candidate package id in the output will be needed at
-uninstall time.
-
-Package IDs designated by Apple or common development frameworks
-will be excluded from the output.
-
-If a package id is already installed, it will be followed by
-a plus symbol '(+)' in the output. This can be verified via
-the command
-
-    /usr/sbin/pkgutil --pkg-info 'package.id.goes.here'
-
-See CONTRIBUTING.md and 'man pkgutil' for more information.
-
-"
-    exit
-fi
+process_args "${@}"
 
 # dispatch main
-_list_ids_in_pkg "${@}"
+_list_ids_in_pkg
 
 #

--- a/developer/bin/list_ids_in_pkg
+++ b/developer/bin/list_ids_in_pkg
@@ -61,37 +61,38 @@ process_args () {
     fi
     for arg in "$@"; do
         if [[ $arg =~ ^-+h(elp)?$ ]]; then
-            printf "list_ids_in_pkg [ -lax ] <file.pkg>
+            printf "
+                list_ids_in_pkg [ -lax ] <file.pkg>
 
-  Given a package file, extract a list of candidate Package IDs
-  which may be useful in a Cask uninstall stanza, eg
+                Given a package file, extract a list of candidate Package IDs
+                which may be useful in a Cask uninstall stanza, eg
 
-      uninstall pkgutil: 'package.id.goes.here'
+                    uninstall pkgutil: 'package.id.goes.here'
 
-  The given package file need not be installed.
+                The given package file need not be installed.
 
-  The output of this script should be overly inclusive -- not
-  every candidate package id in the output will be needed at
-  uninstall time.
+                The output of this script should be overly inclusive -- not
+                every candidate package id in the output will be needed at
+                uninstall time.
 
-  Package IDs designated by Apple or common development frameworks
-  will be excluded from the output. This can be turned off with
-  the -lax argument.
+                Package IDs designated by Apple or common development frameworks
+                will be excluded from the output. This can be turned off with
+                the -lax argument.
 
-  If a package id is already installed, it will be followed by
-  a plus symbol '(+)' in the output. This can be verified via
-  the command
+                If a package id is already installed, it will be followed by
+                a plus symbol '(+)' in the output. This can be verified via
+                the command
 
-      /usr/sbin/pkgutil --pkg-info 'package.id.goes.here'
+                    /usr/sbin/pkgutil --pkg-info 'package.id.goes.here'
 
-  Arguments
+                Arguments
 
-     -lax   Turn off filtering of Apple or common development
-            framework package IDs from the output.
+                   -lax   Turn off filtering of Apple or common development
+                          framework package IDs from the output.
 
-  See CONTRIBUTING.md and 'man pkgutil' for more information.
+                See CONTRIBUTING.md and 'man pkgutil' for more information.
 
-"
+            " | sed -E 's/^ {16}//'
             exit
         elif [[ $arg =~ ^-+lax$ ]]; then
             opt_lax='true'


### PR DESCRIPTION
**Symptoms:**
While writing `uninstall` stanza's for `pkg`s from Apple, the `pkg` ID(s) are filtered out using `egrep`.
This requires manual expansion of the `pkg` and digging through `bom` files for the ID(s).

For example:
```
$ ./list_ids_in_pkg /Volumes/Brother\ Printer\ Drivers/BrotherPrinterDrivers.pkg
``` 
returns no `pkg` IDs at all, while two are present.

**Proposal:**
The `list_ids_in_pkg` script already does the digging through the expanded `pkg`, but applies a filter afterwards. This pull-request simply adds an argument (`-lax`) to turn the filtering of Apple and Sparkle IDs off (similarly to the `list_apps_in_pkg` script).
It also shares the same structure now as the `list_apps_in_pkg` script with stricter checking on the arguments provided to the script.

Using the updated script, the previous command returns the two expected IDs:
```
$ ./list_ids_in_pkg -lax /Volumes/Brother\ Printer\ Drivers/BrotherPrinterDrivers.pkg
com.apple.pkg.BrotherPrinterDrivers
com.apple.pkg.BrotherPrinterDriversPreInstall
```

At the same time, it does not change the already existing behaviour of the script:
```
$ ./list_ids_in_pkg ~/Downloads/WebDriver-378.05.05.25f13.pkg
com.nvidia.nvprefpane
com.nvidia.web-driver
```
```
$ ./list_ids_in_pkg -lax ~/Downloads/WebDriver-378.05.05.25f13.pkg
com.nvidia.nvprefpane
com.nvidia.web-driver
```