### PR TITLE
Update volt to 0.63

### DIFF
--- a/Casks/volt.rb
+++ b/Casks/volt.rb
@@ -1,6 +1,6 @@
 cask 'volt' do
-  version '0.62'
-  sha256 '37c9f320f836058da4fbc1998dce1f16e0d09566fafac87ae345d92dce1b5a1f'
+  version '0.63'
+  sha256 '3bdb05e446b9f2748b099070b334b4497379b710636918312b4c399d5bc5d367'
 
   # github.com/voltapp/volt was verified as official when first introduced to the cask
   url "https://github.com/voltapp/volt/releases/download/#{version}/Volt.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.