### PR TITLE
Update wavebox to 4.7.3

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.7.2'
-  sha256 '8d441237424fcb831aeb45a08092120867236c22a3f0eac8d6d337aca54e043a'
+  version '4.7.3'
+  sha256 '4533a5bdd7a37de902fd58d4a6bc324b354fe2fb7ca43ac3f3e44d6ffe259e35'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.