### PR TITLE
Update permute to 3.1.1,2090

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,8 +1,8 @@
 cask 'permute' do
-  version '3.0.9,2075'
-  sha256 '37d069a67ff02c07a4aea8055498b467bd7f63b4a54af24982efde47ec4be269'
+  version '3.1.1,2090'
+  sha256 '7a9facd6316930999f4f196080703c736bcf609a79d6cb02f4de914ceaec7f96'
 
-  url "https://trial.charliemonroe.net/permute/Permute_#{version.major}_#{version.after_comma}.zip"
+  url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"
   name 'Permute'
   homepage 'https://software.charliemonroe.net/permute.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.