### PR TITLE
Update opera to 58.0.3135.68

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '58.0.3135.65'
-  sha256 '6ca52dc8d3a004ef0226e13cd6628f05b936f9696ac9ae5ffc32b68d861e074c'
+  version '58.0.3135.68'
+  sha256 '9809135d9d0a142c6a58f24220b8639401817765d48829594ed3b23cbb6bbc65'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.