### PR TITLE
Update volt to 0.66

### DIFF
--- a/Casks/volt.rb
+++ b/Casks/volt.rb
@@ -1,6 +1,6 @@
 cask 'volt' do
-  version '0.64'
-  sha256 '49edf3bea13932974e517b595fcd9707693a9e845b6394c03a121ef383013b7c'
+  version '0.66'
+  sha256 'ef53e49bc0c91ebbfe378cbefdc0e960a727566155a92222ad5d43bcc5a1341e'
 
   # github.com/voltapp/volt was verified as official when first introduced to the cask
   url "https://github.com/voltapp/volt/releases/download/#{version}/Volt.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.