### PR TITLE
Update electrum-ltc to 3.3.3.1

### DIFF
--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -1,6 +1,6 @@
 cask 'electrum-ltc' do
-  version '3.1.3.1'
-  sha256 '93f7a6cc9e512bd644e0bc4242df95ae86009fba2201e1f8aaf92e14a885c458'
+  version '3.3.3.1'
+  sha256 '1cf0144b01fa42e9f1350e5fd4bd5166981b3725ab281d421d7fa7c448510ee2'
 
   url "https://electrum-ltc.org/download/electrum-ltc-#{version}.dmg"
   appcast 'https://electrum-ltc.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.