### PR TITLE
Update porting-kit to 2.9.598

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,6 +1,6 @@
 cask 'porting-kit' do
-  version '2.9.596'
-  sha256 'def94c62e0b561e92976f17994754ca2394b0a689107b70b07ac41e86b46a681'
+  version '2.9.598'
+  sha256 'd441f5107e9e40fb21d0dd7cec864a984ec20f3ef16c2cc8c9a3e77ddcdcad02'
 
   url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
   appcast 'http://portingkit.com/kit/updatecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.