### PR TITLE
Update invisionsync to 1.9.1,692

### DIFF
--- a/Casks/invisionsync.rb
+++ b/Casks/invisionsync.rb
@@ -1,6 +1,6 @@
 cask 'invisionsync' do
-  version '1.8.8,689'
-  sha256 '67e27b0221d1f6c597e2d3541b9a2fc11f1d9dfa53fe357ef0de2e1e83b80c38'
+  version '1.9.1,692'
+  sha256 'cb3c89b52a9c64c7996b4c427f73fe0805b6fa9b8dd5f213dc666391838f93ee'
 
   url "https://projects.invisionapp.com/native_app/mac/sparkle/#{version.after_comma}.zip"
   appcast 'https://projects.invisionapp.com/native_app/mac/sparkle/appcast_v2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.