### PR TITLE
Update mollyguard to 1.0.3,188

### DIFF
--- a/Casks/mollyguard.rb
+++ b/Casks/mollyguard.rb
@@ -1,9 +1,9 @@
 cask 'mollyguard' do
-  version '1.0.0'
-  sha256 '1db2745811987d4dbb94aa586b91199eff3b5d715b684ab93c789231c0ca4f13'
+  version '1.0.3,188'
+  sha256 '0e9cd6ba7c94d6a36b03293fe9dda3e94bf9e88b1750f253a67bbd3e469d1ed7'
 
-  # dl.dropboxusercontent.com/s/e2l2dk2qz1u93cb was verified as official when first introduced to the cask
-  url 'https://dl.dropboxusercontent.com/s/e2l2dk2qz1u93cb/MollyGuard.dmg'
+  # dl.dropboxusercontent.com/s/j9kx9ufk74wtpm9 was verified as official when first introduced to the cask
+  url 'https://dl.dropboxusercontent.com/s/j9kx9ufk74wtpm9/MollyGuard.zip?dl=1'
   appcast 'https://dl.dropboxusercontent.com/s/sno9l4q8ncogz27/MGUpdate.xml'
   name 'MollyGuard'
   homepage 'http://mollyguard.infinitemonkeytheory.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.