### PR TITLE
Upgrade x-lite to 5.5.0_97576

### DIFF
--- a/Casks/x-lite.rb
+++ b/Casks/x-lite.rb
@@ -1,6 +1,6 @@
 cask 'x-lite' do
-  version '5.4.0_94385'
-  sha256 '9a84965af675ac5ff3aa84002b8bf27b298b990c2bd36e4a13d938ec2f4503f7'
+  version '5.5.0_97576'
+  sha256 '85a0b7e48a12bb6d4aecf48b0180f9fd2a5f491bd6170bbf5d8350cdbc56e582'
 
   # counterpath.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://counterpath.s3.amazonaws.com/downloads/X-Lite_#{version}.dmg"


### PR DESCRIPTION
```bash
brew cask upgrade x-lite
```
```
Updating Homebrew...
==> Upgrading 1 outdated package:
x-lite 5.4.0_94385 -> 5.5.0_97576
==> Satisfying dependencies
==> Downloading https://counterpath.s3.amazonaws.com/downloads/X-Lite_5.5.0_97576.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'x-lite'.
==> Starting upgrade for Cask x-lite
==> Backing App 'X-Lite.app' up to '/usr/local/Caskroom/x-lite/5.4.0_94385/X-Lite.app'.
==> Removing App '/Applications/X-Lite.app'.
hdiutil attach -plist -nobrowse -readonly -noidme -mountrandom /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/d20190222-81682-r64mnz /Users/gableroux/Library/Caches/Homebrew/downloads/f4f19cf716f599c0cf00d9cf477ff9ec1cfb1280ac185b462f531eae3a3638ff--X-Lite_5.5.0_97576.dmg
mkbom -s -i /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/20190222-81682-j6lc8o.list -- /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/20190222-81682-1y51t8l.bom
ditto --bom /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/20190222-81682-1y51t8l.bom -- /private/var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/d20190222-81682-r64mnz/dmg.4foChY /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/d20190222-81682-1x1fnk3
diskutil eject /private/var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/d20190222-81682-r64mnz/dmg.4foChY
cp -pR /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/d20190222-81682-1x1fnk3/X-Lite.app/. /usr/local/Caskroom/x-lite/5.5.0_97576/X-Lite.app
chmod -Rf +w /var/folders/44/1h74hkj534j6b5cwsbkcsm200000gn/T/d20190222-81682-1x1fnk3
==> Moving App 'X-Lite.app' to '/Applications/X-Lite.app'.
==> Purging files for version 5.4.0_94385 of Cask x-lite
🍺  x-lite was successfully upgraded!
```