### PR TITLE
Update deezer to 4.2.5

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,8 +1,9 @@
 cask 'deezer' do
-  version '4.2.4'
-  sha256 '27f03eb67708c6cf4cbe4d73aefe8dcfc4f15ed3b91cdb63bab04ec9d7054e55'
+  version '4.2.5'
+  sha256 '018da811f6fb932cee8c7af4c89577a51bad93b6e3f5d69311965d02a151c820'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
+  appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'
   name 'Deezer'
   homepage 'https://www.deezer.com/download'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.