### PR TITLE
Update lando to 3.0.0-rc.12

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.0-rc.11'
-  sha256 '909b19d999ae01ed2d2a95ed6667b3b3058e89db8a67b76248518224684f0361'
+  version '3.0.0-rc.12'
+  sha256 '8f2cf3b097d03b800025047cf4986da9f3a1e4046431997b30afbc134e406273'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.