### PR TITLE
Update cura-lulzbot to 3.6.3, add caveat for upgrades

### DIFF
--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -1,6 +1,6 @@
 cask 'cura-lulzbot' do
-  version '3.2.32'
-  sha256 '1587d3d9f2e6215b3d6751becf9e600a187b2c3d892ece2eab9a4f35ef3b5348'
+  version '3.6.3'
+  sha256 'a9cb397b738fac372ac709e85e1b07db91e8c7242b6b8b4209bc495b7a1a5e97'
 
   url "https://download.lulzbot.com/Software/cura-lulzbot/mac/cura-lulzbot_#{version}.dmg"
   name 'Cura LulzBot Edition'
@@ -14,4 +14,20 @@ cask 'cura-lulzbot' do
                '~/Library/Preferences/org.pythonmac.unspecified.cura-lulzbot.cura-lulzbot',
                '~/Library/Saved Application State/org.pythonmac.unspecified.cura-lulzbot.savedState',
              ]
+
+  # Caveat is included per the "Upgrading? Clean your Cache!" section, here:
+  # https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-macos
+  caveats <<-CAVEAT
+  If you are upgrading from a previous version of Cura Lulzbot Edition,
+  Lulzbot reccommends that you clear your cache.
+
+  The commands below will delete the older slicing profiles and 3D printer settings
+  from previous versions of Cura LulzBot Edition. Back up the files and folders
+  listed below first if any customizations have been made.
+
+  Open Terminal, and run the following command:
+
+     rm -rf ~/Library/Application\ Support/cura-lulzbot
+
+  CAVEAT
 end

--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -14,20 +14,4 @@ cask 'cura-lulzbot' do
                '~/Library/Preferences/org.pythonmac.unspecified.cura-lulzbot.cura-lulzbot',
                '~/Library/Saved Application State/org.pythonmac.unspecified.cura-lulzbot.savedState',
              ]
-
-  # Caveat is included per the "Upgrading? Clean your Cache!" section, here:
-  # https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-macos
-  caveats <<-CAVEAT
-  If you are upgrading from a previous version of Cura Lulzbot Edition,
-  Lulzbot reccommends that you clear your cache.
-
-  The commands below will delete the older slicing profiles and 3D printer settings
-  from previous versions of Cura LulzBot Edition. Back up the files and folders
-  listed below first if any customizations have been made.
-
-  Open Terminal, and run the following command:
-
-     rm -rf ~/Library/Application\ Support/cura-lulzbot
-
-  CAVEAT
 end


### PR DESCRIPTION
I'm not sure if adding a Caveat is appropriate for what I'm trying to convey, or if we should assume that the user is aware of this "gotcha" in Cura. If there is an alternate means of messaging, or if we should leave this burden on the user, I'm happy to make a change or remove this part of the PR. 

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
