### PR TITLE
Fix link to sqlitebrowser to reflect sqlitebrowser github releases page and hash

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,9 +1,9 @@
 cask 'db-browser-for-sqlite' do
-  version '3.11.1'
+  version '3.11.1v2'
   sha256 'b0ee5b73b9c6305de79640f651ba59edd32c6a94c2245a2bda01ae8091a69b48'
 
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
-  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}v2.dmg"
+  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom'
   name 'SQLite Database Browser'
   homepage 'https://sqlitebrowser.org/'

--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,9 +1,9 @@
 cask 'db-browser-for-sqlite' do
   version '3.11.1'
-  sha256 'bd4a74540a63a262fc49b816e8fc71fd816e81b215c31572d96b169d980a573e'
+  sha256 'b0ee5b73b9c6305de79640f651ba59edd32c6a94c2245a2bda01ae8091a69b48'
 
   # github.com/sqlitebrowser/sqlitebrowser was verified as official when first introduced to the cask
-  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
+  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}v2.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom'
   name 'SQLite Database Browser'
   homepage 'https://sqlitebrowser.org/'


### PR DESCRIPTION
Current version in 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
