### PR TITLE
Update bluos-controller to 3.4.5,2019.02

### DIFF
--- a/Casks/bluos-controller.rb
+++ b/Casks/bluos-controller.rb
@@ -1,6 +1,6 @@
 cask 'bluos-controller' do
-  version '3.4.4,2018.12'
-  sha256 '4a497717d1aff4dcab06cc5705ce6db47c21ff01f8437445dba1755138797244'
+  version '3.4.5,2019.02'
+  sha256 '45ee4032712104b559e62636c3dc3952cbcfbc33e75207bbaa873177e5c28079'
 
   url "https://www.bluesound.com/wp-content/uploads/#{version.after_comma.dots_to_slashes}/BluOS-Controller-#{version.before_comma}.dmg"
   name 'BluOS Controller'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.