### PR TITLE
Update reaper to 5.97.0

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,6 +1,6 @@
 cask 'reaper' do
-  version '5.96.500'
-  sha256 'e901cecd6615cdf827a271b15ca2c373ca6f32cf5237e04e8df655657112e512'
+  version '5.97.0'
+  sha256 '9d4d249ab7a1b8480c81225d4d6b391effa7fc7333a4f9cda31d72900ba25b66'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.