### PR TITLE
Update nestopia to 1.4.2

### DIFF
--- a/Casks/nestopia.rb
+++ b/Casks/nestopia.rb
@@ -3,6 +3,7 @@ cask 'nestopia' do
   sha256 '59792eaac94350c497c472805c07ed1e1f422a94b4cf2746801b8af71c9ef18f'
 
   url 'https://www.bannister.org/cgi-bin/download.cgi?nestopia'
+  appcast 'http://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.bannister.org/cgi-bin/download.cgi%3Fnestopia'
   name 'Nestopia'
   homepage 'https://www.bannister.org/software/nestopia.htm'
 

--- a/Casks/nestopia.rb
+++ b/Casks/nestopia.rb
@@ -3,7 +3,7 @@ cask 'nestopia' do
   sha256 '59792eaac94350c497c472805c07ed1e1f422a94b4cf2746801b8af71c9ef18f'
 
   url 'https://www.bannister.org/cgi-bin/download.cgi?nestopia'
-  appcast 'http://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.bannister.org/cgi-bin/download.cgi%3Fnestopia'
+  appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.bannister.org/cgi-bin/download.cgi%3Fnestopia'
   name 'Nestopia'
   homepage 'https://www.bannister.org/software/nestopia.htm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.