### PR TITLE
Update lbry to 0.29.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.28.0'
-  sha256 '1c1b36988b47c07ea8fee6db761b40ede6f7721bdb5bb5c62a74da7feb3cdc06'
+  version '0.29.1'
+  sha256 '23078bcb4c007efa927aecc8a00e9138bff1d1e0b533df4268c45a06280299c5'
 
   # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.