### PR TITLE
Update simplenote to 1.5.0

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,8 +1,8 @@
 cask 'simplenote' do
-  version '1.4.1'
-  sha256 '9c9d6972fdb687850b77de7cd82993c1bed1dba1984208e5b9ead0c0604e5deb'
+  version '1.5.0'
+  sha256 '003b3e304d592fa5ba35af5bcc434b8388ba8dfba9337c795c24ef74fe8ddba9'
 
-  url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.zip"
+  url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.dmg"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom'
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'

--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -7,7 +7,7 @@ cask 'simplenote' do
   name 'Simplenote'
   homepage 'https://github.com/Automattic/simplenote-electron'
 
-  app 'mac/Simplenote.app'
+  app 'Simplenote.app'
 
   zap trash: [
                '~/Library/Application Support/Simplenote',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.