### PR TITLE
Update adobe-digital-editions to 4.5.10

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -11,7 +11,7 @@ cask 'adobe-digital-editions' do
 
   uninstall quit:    'com.adobe.adobedigitaleditions.app',
             pkgutil: 'com.adobe.adobedigitaleditions.app',
-            delete:  'Applications/Adobe Digital Editions.app'
+            delete:  '/Applications/Adobe Digital Editions.app'
 
   zap trash: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.adobe.adobedigitaleditions.app.sfl*'
 end

--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -9,7 +9,9 @@ cask 'adobe-digital-editions' do
 
   pkg "Digital Editions #{version.major_minor} Installer.pkg"
 
-  uninstall pkgutil: 'com.adobe.adobedigitaleditions.app'
+  uninstall quit:    'com.adobe.adobedigitaleditions.app',
+            pkgutil: 'com.adobe.adobedigitaleditions.app',
+            delete:  'Applications/Adobe Digital Editions.app'
 
   zap trash: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.adobe.adobedigitaleditions.app.sfl*'
 end

--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,12 +1,13 @@
 cask 'adobe-digital-editions' do
-  version '4.5'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '4.5.10'
+  sha256 '33f784ab50188cc9e5a6c575a739af726cb1deda5970b075851e03b0e9b26d62'
 
-  url "https://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version}_Installer.dmg"
+  url "https://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version.major_minor}_Installer.dmg"
+  appcast 'https://www.adobe.com/solutions/ebook/digital-editions/download.html'
   name 'Adobe Digital Editions'
   homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
 
-  pkg "Digital Editions #{version} Installer.pkg"
+  pkg "Digital Editions #{version.major_minor} Installer.pkg"
 
   uninstall pkgutil: 'com.adobe.adobedigitaleditions.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.