### PR TITLE
Update free-download-manager to 5.1

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -3,6 +3,7 @@ cask 'free-download-manager' do
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dn3.freedownloadmanager.org/#{version.major}/#{version}-latest/fdm.dmg"
+  appcast 'https://www.freedownloadmanager.org/download.htm'
   name 'Free Download Manager'
   homepage 'https://www.freedownloadmanager.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.