### PR TITLE
Update stattransfer to 14

### DIFF
--- a/Casks/stattransfer.rb
+++ b/Casks/stattransfer.rb
@@ -3,6 +3,7 @@ cask 'stattransfer' do
   sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://www.stattransfer.com/downloads/stdemo.dmg'
+  appcast 'https://stattransfer.com/downloads/mac_downloads/'
   name 'Stat/Transfer'
   homepage 'https://stattransfer.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.