### PR TITLE
Update macmediakeyforwarder to 2.5

### DIFF
--- a/Casks/macmediakeyforwarder.rb
+++ b/Casks/macmediakeyforwarder.rb
@@ -1,8 +1,9 @@
 cask 'macmediakeyforwarder' do
-  version '2.4'
-  sha256 '8be06b389caba6ccf0132cba566b280b8d670a3146a906ddb6f818afe6a82161'
+  version '2.5'
+  sha256 '4fabc1cde4cb460f68c4801f310fb1f83f7db4b06055e9bac9c597d073c0ffd3'
 
   url "http://milgra.com/downloads/mmkf/MacMediaKeyForwarder#{version}.zip"
+  appcast 'http://milgra.com/downloads/mmkf/'
   name 'Mac Media Key Forwarder'
   homepage 'http://milgra.com/mac-media-key-forwarder.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.