### PR TITLE
Update autopano-giga to 4.4.2

### DIFF
--- a/Casks/autopano-giga.rb
+++ b/Casks/autopano-giga.rb
@@ -1,5 +1,5 @@
 cask 'autopano-giga' do
-  version '4.4.2.400,2018-09-10''
+  version '4.4.2.400,2018-09-10'
   sha256 '0d5808f3904dae5937411ba7efdb275eaef2dea957c89b869c6c637aa29b824a'
 
   url "https://cdn-download.kolor.com/apg/#{version.before_comma}_#{version.after_comma}/AutopanoGiga_Mac_#{version.major_minor_patch.no_dots}_#{version.after_comma}.dmg"

--- a/Casks/autopano-giga.rb
+++ b/Casks/autopano-giga.rb
@@ -1,8 +1,9 @@
 cask 'autopano-giga' do
-  version '4.4.2.400,2018-09-10'
+  version '4.4.2'
   sha256 '0d5808f3904dae5937411ba7efdb275eaef2dea957c89b869c6c637aa29b824a'
 
-  url "https://cdn-download.kolor.com/apg/#{version.before_comma}_#{version.after_comma}/AutopanoGiga_Mac_#{version.major_minor_patch.no_dots}_#{version.after_comma}.dmg"
+  url 'http://download.kolor.com/apg/stable/mac'
+  appcast "https://www.corecode.io/cgi-bin/check_urls/check_url_filename.cgi?url=#{url}"
   name 'Autopano Giga'
   homepage 'https://www.kolor.com/autopano/'
 

--- a/Casks/autopano-giga.rb
+++ b/Casks/autopano-giga.rb
@@ -2,7 +2,7 @@ cask 'autopano-giga' do
   version '4.4.2'
   sha256 '0d5808f3904dae5937411ba7efdb275eaef2dea957c89b869c6c637aa29b824a'
 
-  url 'http://download.kolor.com/apg/stable/mac'
+  url 'https://download.kolor.com/apg/stable/mac'
   appcast "https://www.corecode.io/cgi-bin/check_urls/check_url_filename.cgi?url=#{url}"
   name 'Autopano Giga'
   homepage 'https://www.kolor.com/autopano/'

--- a/Casks/autopano-giga.rb
+++ b/Casks/autopano-giga.rb
@@ -1,9 +1,9 @@
 cask 'autopano-giga' do
-  version '4.4.2'
+  version '4.4.2.400,2018-09-10''
   sha256 '0d5808f3904dae5937411ba7efdb275eaef2dea957c89b869c6c637aa29b824a'
 
-  url 'https://download.kolor.com/apg/stable/mac'
-  appcast "https://www.corecode.io/cgi-bin/check_urls/check_url_filename.cgi?url=#{url}"
+  url "https://cdn-download.kolor.com/apg/#{version.before_comma}_#{version.after_comma}/AutopanoGiga_Mac_#{version.major_minor_patch.no_dots}_#{version.after_comma}.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://download.kolor.com/apg/stable/mac'
   name 'Autopano Giga'
   homepage 'https://www.kolor.com/autopano/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.