### PR TITLE
Update fsnotes to 2.9.5

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '2.9.4'
-  sha256 'ddd9a6d3cf6b5c9d748547a90fd5c880f6ad0ac9f58f281b08cb253c04fef01f'
+  version '2.9.5'
+  sha256 '26544c7ce6cb93b25faa3a9a75296f1c6438c365b2a8b8f0c95007a6fe9c8948'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.