### PR TITLE
Update 115browser to 8.6.5.41

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -3,6 +3,7 @@ cask '115browser' do
   sha256 'd3fa571827326a0cf08ae32fc0782142502f3dc9a9b85419624137a1a9488ff6'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
+  appcast 'http://pc.115.com/#mac'
   name '115Browser'
   name '115浏览器'
   homepage 'http://pc.115.com/'

--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -3,10 +3,10 @@ cask '115browser' do
   sha256 'd3fa571827326a0cf08ae32fc0782142502f3dc9a9b85419624137a1a9488ff6'
 
   url "https://down.115.com/client/mac/115br_v#{version}.dmg"
-  appcast 'http://pc.115.com/#mac'
+  appcast 'https://pc.115.com/#mac'
   name '115Browser'
   name '115浏览器'
-  homepage 'http://pc.115.com/'
+  homepage 'https://pc.115.com/'
 
   app '115Browser.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.