### PR TITLE
Update airtable to 1.3.2

### DIFF
--- a/Casks/airtable.rb
+++ b/Casks/airtable.rb
@@ -3,6 +3,7 @@ cask 'airtable' do
   sha256 '839466d30355952114a63a409e4e98796285a0be71b81458bd259ace1ba273c8'
 
   url "https://static.airtable.com/download/macos/Airtable-#{version}.dmg"
+  appcast 'https://airtable.com/mac'
   name 'Airtable'
   homepage 'https://airtable.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.