### PR TITLE
Update airtame to 3.3.2

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -3,7 +3,7 @@ cask 'airtame' do
   sha256 '9ec8223a8998cf9756e1252f6831cc6357f8856813ddef08a788bddbd7594ceb'
 
   url "https://downloads-cdn.airtame.com/application/ga/osx_x64/releases/airtame-application-#{version}.dmg"
-  appcast 'http://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'
+  appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'
   name 'Airtame'
   homepage 'https://airtame.com/'
 

--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -3,6 +3,7 @@ cask 'airtame' do
   sha256 '9ec8223a8998cf9756e1252f6831cc6357f8856813ddef08a788bddbd7594ceb'
 
   url "https://downloads-cdn.airtame.com/application/ga/osx_x64/releases/airtame-application-#{version}.dmg"
+  appcast 'http://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'
   name 'Airtame'
   homepage 'https://airtame.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.