### PR TITLE
Update armortext to 0.20.84

### DIFF
--- a/Casks/armortext.rb
+++ b/Casks/armortext.rb
@@ -1,9 +1,10 @@
 cask 'armortext' do
-  version '0.19.32'
-  sha256 'c7211c0ce0b999f35e2a8f6b0e4a7b87dfec08b44a6e58cc6f6fd2e5fc7c291a'
+  version '0.20.84'
+  sha256 'b878f9bc0557b7be753f3975d90e6d3ddb63674ee2cec411a4f4f6ff8298e43b'
 
   # armortext.co was verified as official when first introduced to the cask
   url "https://downloads.armortext.co/desktop/release/#{version}/ArmorText-#{version}-mac64.dmg"
+  appcast 'https://armortext.com/download/'
   name 'Armor Text'
   homepage 'https://armortext.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.