### PR TITLE
Update astroguider to 3.8

### DIFF
--- a/Casks/astroguider.rb
+++ b/Casks/astroguider.rb
@@ -1,8 +1,9 @@
 cask 'astroguider' do
-  version '1.8'
-  sha256 '23a564dad7cfe21ad89f2d34cad80b3771c070fc5048015a44df91765a740b96'
+  version '3.8'
+  sha256 'd1abf1ced034c6ad27c8b254ebc7f65011058e1e768a2ebb808b8366a5d7d483'
 
   url "http://download.cloudmakers.eu/AstroGuider_#{version}.dmg"
+  appcast 'http://www.cloudmakers.eu/astroguider/'
   name 'AstroGuider'
   homepage 'http://www.cloudmakers.eu/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.