### PR TITLE
Update graphql-playground to 1.8.10

### DIFF
--- a/Casks/graphql-playground.rb
+++ b/Casks/graphql-playground.rb
@@ -1,6 +1,6 @@
 cask 'graphql-playground' do
-  version '1.8.9'
-  sha256 '479a50d6b8aaf25debfe15da0fd4f5e700af4c19993cc5ba8774e90770106167'
+  version '1.8.10'
+  sha256 '43d54be598ec83dddcaee789e8434c547d0ff1a49ffc2d95fb798996293b7f13'
 
   url "https://github.com/prisma/graphql-playground/releases/download/v#{version}/graphql-playground-electron-#{version}.dmg"
   appcast 'https://github.com/prisma/graphql-playground/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.