### PR TITLE
Update vimr to 0.25.0-297

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,6 +1,6 @@
 cask 'vimr' do
-  version '0.24.0-282'
-  sha256 '5cec39cfbca639a00e9b6b4995dce4ce0b3312a5e5c29b5777fb8713f4718a64'
+  version '0.25.0-297'
+  sha256 'f7cc1ef7e62a832f4bc55431825c9c1297d4d265064c149a95d3706cfbae547f'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.