### PR TITLE
Update dbschema to 8.1.3

### DIFF
--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -3,7 +3,7 @@ cask 'dbschema' do
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.dbschema.com/download/DbSchema_macos_#{version.dots_to_underscores}.tgz"
-  appcast 'https://www.dbschema.com/dbschema-change-log.html'
+  appcast 'https://www.dbschema.com/changelog.txt'
   name 'DbSchema'
   homepage 'https://www.dbschema.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.