### PR TITLE
Update slite to 1.0.19

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,9 +1,10 @@
 cask 'slite' do
-  version '1.0.17'
-  sha256 'db0f53b3718dc8e832f14e02cc3fa480dd7d48698abec4508609bdb063e7c933'
+  version '1.0.19'
+  sha256 'ceaab1c064e43f770f9cf3822fa19a363dc44309abfc9caba9f669fb3b02ec65'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"
+  appcast 'https://www.corecode.io/cgi-bin/check_urls/check_url_redirect.cgi?url=https://slite.com/api/desktop/download%3Fplatform=mac'
   name 'Slite'
   homepage 'https://slite.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.