### PR TITLE
Update understand to 5.1.976

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,8 +1,9 @@
 cask 'understand' do
-  version '5.1.974'
-  sha256 'fee0ff0696b441dcd19fc823a92f3ebb6b6f612e7bbacb38b3af0dc73351660a'
+  version '5.1.976'
+  sha256 'f7e692fd191d8ba96cf7a4e26bac80aa348d04e51c7d2470e901d71be333692d'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
+  appcast 'https://scitools.com/build-notes/'
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.