### PR TITLE
Update towerim-tower to 0.6.5

### DIFF
--- a/Casks/towerim-tower.rb
+++ b/Casks/towerim-tower.rb
@@ -1,9 +1,10 @@
 cask 'towerim-tower' do
-  version '0.6.4'
-  sha256 'b776b2d71ce0b2ccdc6093979b80239adc387177765381276ffc160a7ebbe863'
+  version '0.6.5'
+  sha256 'd4a03befbfb2edc4d218f9c3d90a8c58c823db3ffcadb63d8d7566b1f3cbe7db'
 
   # towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac was verified as official when first introduced to the cask
   url "https://towerfiles.oss-cn-hangzhou.aliyuncs.com/electron/mac/Tower-#{version}.dmg"
+  appcast 'https://tower.im/downloads'
   name 'Tower'
   homepage 'https://tower.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.