### PR TITLE
Update splice to 3.4.1

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,6 +1,6 @@
 cask 'splice' do
-  version '3.3.13'
-  sha256 'fc74a3df4eb3f13aaebef60f2fc58c5067e4f2a93a808d2c8467e79d3c63a1c5'
+  version '3.4.1'
+  sha256 'c136c2a0921956a6d15f0435b9b9754d5231e15f77835c3b269195f65c81aca8'
 
   # splicedesktop.s3-us-west-1.amazonaws.com was verified as official when first introduced to the cask
   url 'https://splicedesktop.s3-us-west-1.amazonaws.com/darwin/stable/Splice.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.