### PR TITLE
Update iconizer to 2.6.1

### DIFF
--- a/Casks/iconizer.rb
+++ b/Casks/iconizer.rb
@@ -1,6 +1,6 @@
 cask 'iconizer' do
-  version '2.6.0'
-  sha256 '3a385847f43a2b7fc2edcf4e45e241a635c4488568c318143811032fb29e9396'
+  version '2.6.1'
+  sha256 '46e6a7a0cd08b2ead59133a13da11ef5f99b0e5f6710f78d9cce8f12d9d43059'
 
   # github.com/raphaelhanneken/iconizer was verified as official when first introduced to the cask
   url "https://github.com/raphaelhanneken/iconizer/releases/download/#{version}/Iconizer.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.