### PR TITLE
Update dendroscope to 3.5.10

### DIFF
--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -4,7 +4,7 @@ cask 'dendroscope' do
 
   # ab.inf.uni-tuebingen.de/data/software/dendroscope3 was verified as official when first introduced to the cask
   url "http://ab.inf.uni-tuebingen.de/data/software/dendroscope3/download/Dendroscope_macos_#{version.dots_to_underscores}.dmg"
-  appcast 'http://dendroscope.org/'
+  appcast 'https://ab.inf.uni-tuebingen.de/data/software/dendroscope3/download/release_notes.txt'
   name 'Dendroscope'
   homepage 'http://dendroscope.org/'
 

--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -3,7 +3,7 @@ cask 'dendroscope' do
   sha256 '6fcf8a60e481f6880bf05966013cea02ebb512c0dbc0505d4c7759c129e7ce2c'
 
   # ab.inf.uni-tuebingen.de/data/software/dendroscope3 was verified as official when first introduced to the cask
-  url "http://ab.inf.uni-tuebingen.de/data/software/dendroscope3/download/Dendroscope_macos_#{version.dots_to_underscores}.dmg"
+  url "https://ab.inf.uni-tuebingen.de/data/software/dendroscope3/download/Dendroscope_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://ab.inf.uni-tuebingen.de/data/software/dendroscope3/download/release_notes.txt'
   name 'Dendroscope'
   homepage 'http://dendroscope.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.