### PR TITLE
Update freeplane to 1.7.6

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,6 +1,6 @@
 cask 'freeplane' do
-  version '1.7.5-hotfix1'
-  sha256 '3095b390a2ffd0d8a9466d18e983f90a8e603c44839da5394ac96d99f4a91102'
+  version '1.7.6'
+  sha256 '151758558d7d0887375b68b8f3bb0995c1540ac75c1a26e8787348c68f92ab04'
 
   # downloads.sourceforge.net/freeplane was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app_jre-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.