### PR TITLE
Update glyphs to 2.6.1,1215

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.1,1200'
-  sha256 'b6e684667439c16d89f79318ba4880880732cf8acaa8d81c3e7ff160d5dbad9f'
+  version '2.6.1,1215'
+  sha256 'eb3dd43e1ff991502b64be665d28bf7464596423dc9fc4bdd862cbe516bd2b09'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.