### PR TITLE
Update hands-off to 4.1.0

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '4.0.3'
-  sha256 '3126763e43254e79038df33db55342e1ddb6eea69ac3c37cfeabd20a804b3f2b'
+  version '4.1.0'
+  sha256 'aadb288f73fd927628320bf9231f2efbea5c4ff15116dd619250c05ecbe8748b'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.