### PR TITLE
Update lrtimelapse to 5.2

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,6 +1,6 @@
 cask 'lrtimelapse' do
-  version '5.1.1'
-  sha256 '5cf186b7ae3a645fb1dfcefc91bad3c099e14b54b2b1d4818b67ed3cce110391'
+  version '5.2'
+  sha256 '2c94d67e83db40a9e960dd03bec6c0a7fbdacd5ce9d5333270c3a489d0c932e9'
 
   url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/"
   name 'LRTimelapse'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.