### PR TITLE
Update aircall to 1.7.2

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,8 +1,9 @@
 cask 'aircall' do
   version '1.7.2'
-  sha256 'd9aa91805d75139ce9d1d7dd3b26a324be723faefec9930830364a17710441f0'
+  sha256 '25af5980165ab52d9765f5b65b7e76f5b4a2f0c42627ea0aa5538c0933a8b499'
 
-  url "https://electron.aircall.io/download/version/#{version}/osx_64?filetype=dmg&channel=stable"
+  # s3-us-west-1.amazonaws.com/aircall-electron-releases was verified as official when first introduced to the cask
+  url "https://s3-us-west-1.amazonaws.com/aircall-electron-releases/production/Aircall-#{version}-mac.zip"
   appcast 'https://electron.aircall.io/update/osx/1.1.0'
   name 'Aircall'
   homepage 'https://aircall.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.