### PR TITLE
Update goodsync to 10.9.25.3,643

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,8 +1,9 @@
 cask 'goodsync' do
-  version '10.9.25.0'
-  sha256 '51d28b8761e754260404cdd039fbe4aad9db14278ef8dacb9137f8f47d177807'
+  version '10.9.25.3,643'
+  sha256 '3e65d45d33f716c9e509bafe261fe42f0ff4ce6f80038bd3ba700220477af9f8'
 
-  url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
+  # rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef/app_versions/#{version.after_comma}?format=zip&avtoken=6b1e930b304f74f53ebe6e776a505fa3bfbe6e6d&download_origin=hockeyapp"
   appcast 'https://rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef'
   name 'GoodSync'
   homepage 'https://www.goodsync.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.