### PR TITLE
Update cryptobridge to 0.16.1

### DIFF
--- a/Casks/cryptobridge.rb
+++ b/Casks/cryptobridge.rb
@@ -1,6 +1,6 @@
 cask 'cryptobridge' do
-  version '0.15.6'
-  sha256 'c6f24fb77a71477b5aa5c707fd85594b7a563cacb51e618c96bf3224d5f9ac33'
+  version '0.16.1'
+  sha256 '80bcf27ccb1c1135fff93db0a37b299e8d5a815de6d189294bccce912b8eda44'
 
   url "https://github.com/CryptoBridge/cryptobridge-ui/releases/download/v#{version}/CryptoBridge-#{version}.dmg"
   appcast 'https://github.com/CryptoBridge/cryptobridge-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.