### PR TITLE
Update licecap to 1.29

### DIFF
--- a/Casks/licecap.rb
+++ b/Casks/licecap.rb
@@ -1,6 +1,6 @@
 cask 'licecap' do
-  version '1.28'
-  sha256 '130c8cd34b0048297433df9bce5dbc1b52e0e5b3d798c2cbc5be68773f3adbc6'
+  version '1.29'
+  sha256 '9d12df4946d3247483a1e050279b032320799ee96918f44628b92d862866250f'
 
   url "https://www.cockos.com/licecap/licecap#{version.no_dots}.dmg"
   appcast 'https://www.cockos.com/licecap/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.