### PR TITLE
Fix Formula for fish-app 3.0.2

### DIFF
--- a/Casks/fish-app.rb
+++ b/Casks/fish-app.rb
@@ -1,9 +1,9 @@
 cask 'fish-app' do
   version '3.0.2'
-  sha256 'cd842d08b06d888978f2e7da2b856e386a86e8180d2137da322045964f9badc5'
+  sha256 'a643f571b26e2e586aa43c9bb13391248600d4f9c2c9519371cb9664aabb4233'
 
   # github.com/fish-shell/fish-shell was verified as official when first introduced to the cask
-  url "https://github.com/fish-shell/fish-shell/releases/download/#{version}/fish-#{version}.app.zip"
+  url "https://github.com/fish-shell/fish-shell/releases/download/#{version}/fish.app.zip"
   appcast 'https://fishshell.com/release_notes.html'
   name 'Fish App'
   homepage 'https://fishshell.com/'


### PR DESCRIPTION
This commit fixes fish-shell/fish-shell#5703.

The command 

```sh
brew cask style --fix fish-app
```

failed with the following error message on my computer:

```
Traceback (most recent call last):
	2: from /Users/rene/.rbenv/versions/2.6.1/bin/rubocop:23:in `<main>'
	1: from /Users/rene/.rbenv/versions/2.6.1/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'
/Users/rene/.rbenv/versions/2.6.1/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': can't find gem rubocop (>= 0.a) with executable rubocop (Gem::GemNotFoundException)
```

. Unfortunately installing `rubocop` via

```sh
gem install rubocop
```

did not fix the problem.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download fish-app` is error-free.
- [ ] `brew cask style --fix fish-app` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
