### PR TITLE
Update unity-android-support-for-editor to 2018.3.6f1,a220877bc173

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2018.3.5f1,76b3e37670a4'
-  sha256 '9567a466c6c67b705522e812ba1075936532569eb4e0205a0293b57d5d3e2af1'
+  version '2018.3.6f1,a220877bc173'
+  sha256 '581864ad8fdba2b5d3bb6b00da9abf85fbee674969702e8e0691ac1d22530db4'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.