### PR TITLE
Update unity-webgl-support-for-editor to 2018.3.6f1,a220877bc173

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.3.5f1,76b3e37670a4'
-  sha256 'a2f481ee7396dd1835aa097a93044134052766f4b338427628380b76807acd77'
+  version '2018.3.6f1,a220877bc173'
+  sha256 'a33eb535b06fa4ce149ec018e538286ba678c9b20f053fc344c132bb9b4fcc41'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.