### PR TITLE
Update unity-vuforia-ar-support-for-editor to 2018.3.6f1,a220877bc173

### DIFF
--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-vuforia-ar-support-for-editor' do
-  version '2018.3.5f1,76b3e37670a4'
-  sha256 'f4d798eb912a41f8d920989b2c59052f3ed97da3b074b0da3bdc8a89f812fda0'
+  version '2018.3.6f1,a220877bc173'
+  sha256 '772adfa3631bd4011d33ee64b927905c0d1db9025d16a30152ad19381d460ee5'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.