### PR TITLE
Update workbench to 1.0.4 and mark as auto_updates

### DIFF
--- a/Casks/workbench.rb
+++ b/Casks/workbench.rb
@@ -1,12 +1,13 @@
 cask 'workbench' do
-  version '1.0.3'
-  sha256 '2747f6e5df03ddcf335c2cdde6e5d8318f989ff6090fa29b9ace78146697cfa4'
+  version '1.0.4'
+  sha256 'e892a06910b8bbc7163900e30c5832e21762dc1328140f4175a491d8366c6b76'
 
   url "https://github.com/mxcl/Workbench/releases/download/#{version}/Workbench-#{version}.zip"
   appcast 'https://github.com/mxcl/Workbench/releases.atom'
   name 'Workbench'
   homepage 'https://github.com/mxcl/Workbench'
 
+  auto_updates true
   depends_on macos: '>= :sierra'
 
   app 'Workbench.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.