### PR TITLE
Update command-tab-plus to 1.89,319:1551102820

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.88,318:1550245110'
-  sha256 '0e4106abda9fc700b466a8904a5901c7fcf8d9f4c0019e7242a4d4255e3f44da'
+  version '1.89,319:1551102820'
+  sha256 'f58401c55d8e1af98c7d4fc23dd20ca6221bf255af9676444ed7c15ecacc7948'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.