### PR TITLE
Update navicat-for-mysql to 12.1.16

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.15'
-  sha256 '31dcaa5fab7c3c110f922c3d052e035e2ed782b140709b8bace6b2ada46246ce'
+  version '12.1.16'
+  sha256 'c2d41ae46d33390e6454a60f5236d20e4fba8520bfcfcedc0541a18ddab68492'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.