### PR TITLE
Update navicat-for-oracle to 12.1.16

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '12.1.15'
-  sha256 '0bba3168ea5bcd93a755ad39b10df5d409bece185c8f9d5b639493602a282ec7'
+  version '12.1.16'
+  sha256 'e3cd088790d29e9b8187e6050a5b2a2a499f9d521d81bcf18fad14e4b932fc64'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.