### PR TITLE
Update nvivo to 12.3.0.3508

### DIFF
--- a/Casks/nvivo.rb
+++ b/Casks/nvivo.rb
@@ -1,6 +1,6 @@
 cask 'nvivo' do
-  version '12.1.0.3068'
-  sha256 'd0d61187f387e2a7ae6bac523673137bd2ef91624067cbe9d0355d5de2a622d7'
+  version '12.3.0.3508'
+  sha256 '46156e0065cd6c5a7cdf141b3b2ab27be41e3ef0a02361867a80090af1befc3d'
 
   url "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/#{version}/NVivo%20#{version.major}.dmg"
   appcast "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.