### PR TITLE
Update rightfont to 5.4.0

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,6 +1,6 @@
 cask 'rightfont' do
-  version '5.3.3'
-  sha256 '4f13f3138d765bd0f4c5bff6a9b3bedd2878d6569a1c210b3bb67a8981f3df47'
+  version '5.4.0'
+  sha256 '9e73cd1a67c74dfc9ecee15d06fe6fc958a8c26f714a86c9fbe80241b503359a'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
   appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.