### PR TITLE
Update altair-graphql-client to 2.1.0

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.0.9'
-  sha256 '2da33c8e4ec41839c93512a19b1d75c812a59d99ef24e93246d5722e371f3c35'
+  version '2.1.0'
+  sha256 'cfdc93c8f27c7fe6a0a05480c6503a428b2a2c253d26249b1cd622c6d2cb8fde'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.