### PR TITLE
Update gitnote to 3.0.4

### DIFF
--- a/Casks/gitnote.rb
+++ b/Casks/gitnote.rb
@@ -1,6 +1,6 @@
 cask 'gitnote' do
-  version '3.0.3'
-  sha256 '28801e8a2981ef3658ed35d748bbf37ffc7662b6307d2b31a606af22fe546cda'
+  version '3.0.4'
+  sha256 '1dc59e97f220c9d39b0f00cfef08a152ff352038ebb63891ec933ffbf27b75b3'
 
   # github.com/zhaopengme/gitnote was verified as official when first introduced to the cask
   url "https://github.com/zhaopengme/gitnote/releases/download/#{version}/GitNote_setup_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.