### PR TITLE
Update mycrypto to 1.5.9

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.5.7'
-  sha256 '75d0e6e27a7b7c8671ad51f8607d7bf2d6b2f0bf16919525f50e18ef6c1d163a'
+  version '1.5.9'
+  sha256 '1059b3f032ab51c7b85648203efd92ff561635a26ad0dbe2f46e46b5f5e58714'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.