### PR TITLE
Update screentray to 1.5.0

### DIFF
--- a/Casks/screentray.rb
+++ b/Casks/screentray.rb
@@ -1,6 +1,6 @@
 cask 'screentray' do
-  version '1.1.0'
-  sha256 'c014c85574196fd45550ebe964047d9e385bb405f7631f51814f944aa1a46210'
+  version '1.5.0'
+  sha256 'e2d0fc8ff4fde4299c8c7b1815580c72432dda160eda5696c51c1086f712b10c'
 
   # github.com/DSnopov/screentray-distribution was verified as official when first introduced to the cask
   url "https://github.com/DSnopov/screentray-distribution/releases/download/v#{version}/ScreenTray-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.