### PR TITLE
Update joplin to 1.0.132

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.127'
-  sha256 '9bca34daac44808203a0bea288b0e1234d19250e792b2056f8f8ca31a39663d8'
+  version '1.0.132'
+  sha256 '5dd062c67dd7d2b9940f9c5dbd0b3fa7f16d176d260da2bd1204c1e1f5d7ffa4'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.