### PR TITLE
Update telegram to 4.9.9-160300

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '4.9.9-160276'
-  sha256 'bce9b08fc67e2a2488b3dd15c24d99f67f66dab18f40e948df043e6ca5f492aa'
+  version '4.9.9-160300'
+  sha256 '40ca003c29731f336c0e7023667fe1dd0750268e9d76432db5d3f1d9fca7715b'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.