### PR TITLE
Fix docs for case sensitive fs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ For manual updates, you'll need to fork the repository and add your copy as a re
 
 ```bash
 $ github_user='<my-github-username>'
-$ cd "$(brew --repository)"/Library/Taps/Homebrew/homebrew-cask
+$ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
 $ git remote add "${github_user}" "https://github.com/${github_user}/homebrew-cask"
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -196,7 +196,7 @@ Most `brew cask` commands can accept a Cask token as an argument. As described a
 
 `brew cask` also accepts three other forms as arguments:
 
-* A path to a Cask file, _eg_: `/usr/local/Library/Taps/Homebrew/homebrew-cask/Casks/google-chrome.rb`.
+* A path to a Cask file, _eg_: `/usr/local/Library/Taps/homebrew/homebrew-cask/Casks/google-chrome.rb`.
 * A `curl`-retrievable URI to a Cask file, _eg_: `https://raw.githubusercontent.com/Homebrew/homebrew-cask/f25b6babcd398abf48e33af3d887b2d00de1d661/Casks/google-chrome.rb`.
 * A file in the current working directory, _eg_: `my-modfied-google-chrome.rb`. Note that matching Tapped Cask tokens will be preferred over this form when there is a conflict. To force the use of a Cask file in the current directory, specify a pathname with slashes, _eg_: `./google-chrome.rb`.
 

--- a/doc/cask_language_reference/stanzas/uninstall.md
+++ b/doc/cask_language_reference/stanzas/uninstall.md
@@ -50,13 +50,13 @@ This is the most useful uninstall key. `pkgutil:` is often sufficient to complet
 IDs for the most recently-installed packages can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_recent_pkg_ids"
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_recent_pkg_ids"
 ```
 
 `pkgutil:` also accepts a regular expression match against multiple package IDs. The regular expressions are somewhat nonstandard. To test a `pkgutil:` regular expression against currently-installed packages, use the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_pkg_ids_by_regexp" <regular-expression>
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_pkg_ids_by_regexp" <regular-expression>
 ```
 
 ## List Files Associated With a pkg Id
@@ -74,13 +74,13 @@ Listing the associated files can help you assess whether the package included an
 IDs for currently loaded `launchctl` jobs can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_loaded_launchjob_ids"
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_loaded_launchjob_ids"
 ```
 
 IDs for all installed `launchctl` jobs can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_installed_launchjob_ids"
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_installed_launchjob_ids"
 ```
 
 ## uninstall Key quit:
@@ -88,13 +88,13 @@ $ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_i
 Bundle IDs for currently running Applications can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_running_app_ids"
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_running_app_ids"
 ```
 
 Bundle IDs inside an Application bundle on disk can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_ids_in_app" '/path/to/application.app'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_ids_in_app" '/path/to/application.app'
 ```
 
 ## uninstall Key signal:
@@ -130,7 +130,7 @@ Unlike `quit:` directives, Unix signals originate from the current user, not fro
 Login items associated with an Application bundle on disk can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_login_items_for_app" '/path/to/application.app'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_login_items_for_app" '/path/to/application.app'
 ```
 
 Note that you will likely need to have opened the app at least once for any login items to be present.
@@ -140,13 +140,13 @@ Note that you will likely need to have opened the app at least once for any logi
 IDs for currently loaded kernel extensions can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_loaded_kext_ids"
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_loaded_kext_ids"
 ```
 
 IDs inside a kext bundle you have located on disk can be listed using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_id_in_kext" '/path/to/name.kext'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_id_in_kext" '/path/to/name.kext'
 ```
 
 ## uninstall Key script:
@@ -186,19 +186,19 @@ Advanced users may wish to work with a `pkg` file manually, without having the p
 A list of files which may be installed from a `pkg` can be extracted using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_payload_in_pkg" '/path/to/my.pkg'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_payload_in_pkg" '/path/to/my.pkg'
 ```
 
 Candidate application names helpful for determining the name of a Cask may be extracted from a `pkg` file using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_apps_in_pkg" '/path/to/my.pkg'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_apps_in_pkg" '/path/to/my.pkg'
 ```
 
 Candidate package IDs which may be useful in a `pkgutil:` key may be extracted from a `pkg` file using the command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_ids_in_pkg" '/path/to/my.pkg'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_ids_in_pkg" '/path/to/my.pkg'
 ```
 
 A fully manual method for finding bundle ids in a package file follows:

--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -39,7 +39,7 @@ The comment doesn’t mean you should trust the source blindly, but we only appr
 Web browsers may obscure the direct `url` download location for a variety of reasons. Homebrew Cask supplies a script which can read extended file attributes to extract the actual source URL for most files downloaded by a browser on macOS. The script usually emits multiple candidate URLs; you may have to test each of them:
 
 ```bash
-$ $(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/list_url_attributes_on_file <file>
+$ $(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/list_url_attributes_on_file <file>
 ```
 
 ## Subversion URLs

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -65,13 +65,13 @@ The Cask **token** is the mnemonic string people will use to interact with the C
 The easiest way to generate a token for a Cask is to run this command:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/generate_cask_token" '/full/path/to/new/software.app'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/generate_cask_token" '/full/path/to/new/software.app'
 ```
 
 If the software you wish to Cask is not installed, or does not have an associated App bundle, just give the full proper name of the software instead of a pathname:
 
 ```bash
-$ "$(brew --repository)/Library/Taps/Homebrew/homebrew-cask/developer/bin/generate_cask_token" 'Google Chrome'
+$ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/generate_cask_token" 'Google Chrome'
 ```
 
 If the `generate_cask_token` script does not work for you, see [Cask Token Details](#cask-token-details).
@@ -167,7 +167,7 @@ brew cask audit my-new-cask --download
 You should also check stylistic details with `brew cask style`:
 
 ```bash
-$ cd "$(brew --repository)"/Library/Taps/Homebrew/homebrew-cask
+$ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
 $ brew cask style Casks/my-new-cask.rb [--fix]
 ```
 
@@ -242,7 +242,7 @@ for details.
 Hop into your Tap and check to make sure your new Cask is there:
 
 ```bash
-$ cd "$(brew --repository)"/Library/Taps/Homebrew/homebrew-cask
+$ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
 $ git status
 # On branch master
 # Untracked files:
@@ -309,6 +309,6 @@ Congratulations! You are done now, and your Cask should be pulled in or otherwis
 After your Pull Request is submitted, you should get yourself back onto `master`, so that `brew update` will pull down new Casks properly:
 
 ```bash
-cd "$(brew --repository)"/Library/Taps/Homebrew/homebrew-cask
+cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
 git checkout master
 ```


### PR DESCRIPTION
homebrew installs taps from the Homebrew org in `$(brew --prefix)/Library/Taps/homebrew/homebrew-<tap>`, NOT `$(brew --prefix)/Library/Taps/Hombrew/homebrew-<tap>`. (Note the lower-case `h`.)

For people with case-sensitive file systems, copying commands from the documentation results in errors when the tap location is given with a capital `H`.

The PR updates the documentation to use the correct tap location (lower-case `h` in `Taps/homebrew/`).