### PR TITLE
Update diskcatalogmaker to 7.4.9

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.4.8'
-  sha256 'd09070dc0b80e956c3c712065253be04b2451aaa4541a8262a0a1483bcd3d558'
+  version '7.4.9'
+  sha256 'fac5e4c4eb4933ede7849fbb069977ee311af7c394c12e3cac3d05066a20fac2'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://fujiwara.sakura.ne.jp/info/appcast/DiskCatalogMaker.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.