### PR TITLE
Update smartsvn to 11.0.1

### DIFF
--- a/Casks/smartsvn.rb
+++ b/Casks/smartsvn.rb
@@ -1,6 +1,6 @@
 cask 'smartsvn' do
-  version '11.0.0'
-  sha256 'f330c30be85dd5df101c2414f8c9f003f7305c786fbaabd3bafa5d506f78e329'
+  version '11.0.1'
+  sha256 '8327315545c7be2f43599a9bb5ca4b55bd183936535410d7f0b90e937112674b'
 
   url "https://www.smartsvn.com/downloads/smartsvn/smartsvn-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.smartsvn.com/documents/smartsvn/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.