### PR TITLE
Update polar-bookshelf to 1.13.5

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.13.4'
-  sha256 'dda35ecedf0aa23ea845b06b20dcfad9d8cc270b1a4bb4d5d292a36a894d2935'
+  version '1.13.5'
+  sha256 'e96d3917cd8c382859dc2033609646a8e015ec0b55c2b36b9daf86fb3df71a6d'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.