### PR TITLE
Update permute to 3.1.3,2098

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.1.1,2090'
-  sha256 '7a9facd6316930999f4f196080703c736bcf609a79d6cb02f4de914ceaec7f96'
+  version '3.1.3,2098'
+  sha256 '592685e98b120d5a0abe88f836974d7bc4fddfdc5ee5fd981f46cd6c2b9960f8'
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.