### PR TITLE
Update workflowy to 1.2.3

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.2.2'
-  sha256 '43605a109c07d1ee075e712ec836b7c3d609c4d593afaf1d57f753f8b2047470'
+  version '1.2.3'
+  sha256 '5e0098feac4943de9e9d46f300857889385e5dc9e25d0a775853cff1f39f8063'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.