### PR TITLE
Update dust3d to 1.0.0-beta.15

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-beta.14'
-  sha256 '8aab10d40bfd11e73f28bd2c2868460abde22388478c0314bf6e80031400cce6'
+  version '1.0.0-beta.15'
+  sha256 'e52f648747a83abec242a43f97dfb5266cd9a976de3a99060e7a9015b0f98cea'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.