### PR TITLE
Update virtualhostx to 8.5.2,80_46

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.4.2,80_43'
-  sha256 '748707d5cc1a9af464292c139c9c7e519d0ed501d1aa1a9263d9d329c5a5c8a5'
+  version '8.5.2,80_46'
+  sha256 '861bb2f37c0b39ccf6c8ef97ed0e449d8d245f6670cd72da007f402ef392a129'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.