### PR TITLE
Update parallels-client to 16.5.3-20740

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,6 +1,6 @@
 cask 'parallels-client' do
-  version '16.5.2-20585'
-  sha256 '27dc2cb2fc658591cfc689a320a15d99b74164fe3ae9ace2d751df11d1bd32d2'
+  version '16.5.3-20740'
+  sha256 '2019e3de597659e06261f76569f2ac34c94d0bcb93bbe23a7b0e0378d611de76'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
   appcast "https://download.parallels.com/ras/v#{version.major_minor}/RAS%20Client%20for%20Mac%20Changelog.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.