### PR TITLE
Update overflow to 3.0.4

### DIFF
--- a/Casks/overflow.rb
+++ b/Casks/overflow.rb
@@ -8,6 +8,8 @@ cask 'overflow' do
   name 'overflow'
   homepage 'https://stuntsoftware.com/overflow/'
 
+  depends_on macos: '>= :high_sierra'
+
   app "Overflow #{version.major}.app"
 
   zap trash: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.