### PR TITLE
chromium.rb: make versioned

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,9 +1,10 @@
 cask 'chromium' do
-  version :latest
-  sha256 :no_check
+  version '636579'
+  sha256 '5dca9cdd99650e6d4cd89b381864e36c3c274ab0081f32d74d9d64d0c3c822b3'
 
-  # download-chromium.appspot.com was verified as official when first introduced to the cask
-  url 'https://download-chromium.appspot.com/dl/Mac?type=snapshots'
+  # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
+  url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
+  appcast 'https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2FLAST_CHANGE?alt=media'
   name 'Chromium'
   homepage 'https://www.chromium.org/Home'
 


### PR DESCRIPTION
Guessing the Chromium crowd (of which there are many — it hovers around 100<sup>th</sup> place in all analytics) will like having this cask versioned, meaning `upgrade` will work.

Let’s see if it doesn’t become too much of a burden to maintain.

Got the download link starting from https://www.chromium.org/getting-involved/download-chromium.