### PR TITLE
Update mimolive to 4.7.1-26979

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,6 +1,6 @@
 cask 'mimolive' do
-  version '4.7-26965'
-  sha256 '615afed0b160a7ccae5bd59bb0b94577100960109bcdb952d145612f796b6352'
+  version '4.7.1-26979'
+  sha256 '8ada458d875dbaa608794032d5fabc04d1293003211a9f74181f567d6bfef674'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://sparkle.boinx.com/appcast.lasso?appName=mimoLive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.