### PR TITLE
Update pdfpen to 1022.6,1551314434

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,6 +1,6 @@
 cask 'pdfpen' do
-  version '1020.14,1539654911'
-  sha256 '9335491b51a5a900868bb206bde03539ab02da688636045a506eb180988fa979'
+  version '1022.6,1551314434'
+  sha256 '164ff02581ba8b94cd244d15cf748cba56af73990a8e66807cbae1a51eba8538'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.