### PR TITLE
Update cryptobridge to 0.16.4

### DIFF
--- a/Casks/cryptobridge.rb
+++ b/Casks/cryptobridge.rb
@@ -1,6 +1,6 @@
 cask 'cryptobridge' do
-  version '0.16.1'
-  sha256 '80bcf27ccb1c1135fff93db0a37b299e8d5a815de6d189294bccce912b8eda44'
+  version '0.16.4'
+  sha256 'e9e92e8f1e841eb09cb5e791d7cde7b7c4d4ea7b6631fdd443a04617a6cc1736'
 
   url "https://github.com/CryptoBridge/cryptobridge-ui/releases/download/v#{version}/CryptoBridge-#{version}.dmg"
   appcast 'https://github.com/CryptoBridge/cryptobridge-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.