### PR TITLE
Update cryptomator to 1.4.6

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,9 +1,9 @@
 cask 'cryptomator' do
-  version '1.4.5'
-  sha256 'a961bbb06af06f903eaf76a37f28c94ad7234ed6bcbdaba9e0309d63f5ffa46f'
+  version '1.4.6'
+  sha256 '2529a2e14b5b5b9566ff9f55679513527966ad5e8b56ff88dfba0619217b58a7'
 
-  # bintray.com/artifact/download/cryptomator was verified as official when first introduced to the cask
-  url "https://bintray.com/artifact/download/cryptomator/cryptomator/Cryptomator-#{version}.dmg"
+  # dl.bintray.com/cryptomator/cryptomator was verified as official when first introduced to the cask
+  url "https://dl.bintray.com/cryptomator/cryptomator/#{version}/Cryptomator-#{version}.dmg"
   appcast 'https://github.com/cryptomator/cryptomator/releases.atom'
   name 'Cryptomator'
   homepage 'https://cryptomator.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
