### PR TITLE
Update google-chrome to 72.0.3626.121

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,6 +1,6 @@
 cask 'google-chrome' do
-  version '72.0.3626.119'
-  sha256 '2286e694661df41b3c13a43d508bc948f2d83eee8a34429c5f892eddc7c6f128'
+  version '72.0.3626.121'
+  sha256 'ba04c1a3567aecf960370b8c241c6b9e546ef79ac4115919373a0d1f07770324'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
   appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.