### PR TITLE
Fix kernel extension caveat for simsim 1.4.1

### DIFF
--- a/Casks/simsim.rb
+++ b/Casks/simsim.rb
@@ -10,8 +10,7 @@ cask 'simsim' do
   app 'SimSim.app'
 
   uninstall quit:       'com.dsmelov.SimSim',
-            login_item: 'SimSim',
-            kext:       'com.dsmelov.SimSim'
+            login_item: 'SimSim'
 
   zap trash: '~/Library/Preferences/com.dsmelov.SimSim.plist'
 end


### PR DESCRIPTION
SimSim does not include any kernel extensions

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
