### PR TITLE
Update postbox to 6.1.11

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.10'
-  sha256 '4e8e30c466cb4a58eb7fb9a5dd231f785f12538d24bb0024d9ed65ed39e04bac'
+  version '6.1.11'
+  sha256 'c7f3596d09d142efacbbcb5167793994bea501be9315b649e5986dbe642532af'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.