### PR TITLE
Update edex-ui to 2.1.0

### DIFF
--- a/Casks/edex-ui.rb
+++ b/Casks/edex-ui.rb
@@ -1,6 +1,6 @@
 cask 'edex-ui' do
-  version '2.0.1'
-  sha256 'ee4819d7543a2bc1ba60aa8b1252e3a6f0fae2a08580b4cb596c31ca008783c3'
+  version '2.1.0'
+  sha256 '41b737b90cf8fb45f083f506151cdc1ae2bfa224dc37f8ea17e1b11c8780e77a'
 
   url "https://github.com/GitSquared/edex-ui/releases/download/v#{version}/eDEX-UI.MacOS.Image.dmg"
   appcast 'https://github.com/GitSquared/edex-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.