### PR TITLE
Update kite to 0.20190228.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190227.0'
-  sha256 '561aaf55458ebaf52e72f966f175f2f32805e42a4714b41b88f4f152eb4d6b7e'
+  version '0.20190228.0'
+  sha256 '3ca5cd563245ff7762457d065e7bb4539ee3e0556ce08499dfe1bf2b02686548'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.