### PR TITLE
Update dynamic-dark-mode to 1.1.4

### DIFF
--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -9,5 +9,5 @@ cask 'dynamic-dark-mode' do
 
   depends_on macos: '>= :mojave'
 
-  app 'Dynamic Dark Mode.pkg'
+  pkg 'Dynamic_Dark_Mode-#{version}.pkg'
 end

--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -10,4 +10,6 @@ cask 'dynamic-dark-mode' do
   depends_on macos: '>= :mojave'
 
   pkg "Dynamic_Dark_Mode-#{version}.pkg"
+
+  uninstall pkgutil: 'io.github.apollozhu.Dynamic.pkg'
 end

--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -9,5 +9,5 @@ cask 'dynamic-dark-mode' do
 
   depends_on macos: '>= :mojave'
 
-  app 'Dynamic Dark Mode.app'
+  app 'Dynamic Dark Mode.pkg'
 end

--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -1,8 +1,8 @@
 cask 'dynamic-dark-mode' do
-  version '1.1.3'
-  sha256 'a2363c8038a8babf30186c06674749a09de998dcb644030ecb68894847469b4e'
+  version '1.1.4'
+  sha256 '3101ef4222843c41a48122abef1f5e97501a67d8664c20a61a9397abeee1bdca'
 
-  url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.zip"
+  url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.pkg"
   appcast 'https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases.atom'
   name 'Dynamic Dark Mode'
   homepage 'https://github.com/ApolloZhu/Dynamic-Dark-Mode'

--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -9,5 +9,5 @@ cask 'dynamic-dark-mode' do
 
   depends_on macos: '>= :mojave'
 
-  pkg 'Dynamic_Dark_Mode-#{version}.pkg'
+  pkg "Dynamic_Dark_Mode-#{version}.pkg"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.