### PR TITLE
Update futuniuniu to 9.2.484_201902141709

### DIFF
--- a/Casks/futuniuniu.rb
+++ b/Casks/futuniuniu.rb
@@ -1,6 +1,6 @@
 cask 'futuniuniu' do
-  version '8.12.462_201812291212'
-  sha256 '2c8983d3bd3903a729abb58a92e0636991d292c4e21a6eb7ab4b3bf0c986f20f'
+  version '9.2.484_201902141709'
+  sha256 'c988ab0dc1ac95d066d9ce047b4660c16c1f8d5cea1dd852f83d45c6dae9169b'
 
   # software-file-1251001049.cosgz.myqcloud.com was verified as official when first introduced to the cask
   url "https://software-file-1251001049.cosgz.myqcloud.com/FTNNForMac_#{version}_std_release_std_officially.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.