### PR TITLE
Revert "Update dashlane to 6.1909.0.18331"

### DIFF
--- a/Casks/dashlane.rb
+++ b/Casks/dashlane.rb
@@ -1,6 +1,6 @@
 cask 'dashlane' do
-  version '6.1909.0.18331'
-  sha256 'f08349332fdc90c535d257108c6e5ce2095fcca85bf49255115b639da247355a'
+  version '6.1907.0.17860'
+  sha256 '9d335e0447d43b8222ef0e0cdd8d4c0be9c53a142db8a0c9aea1c43198824c5c'
 
   url "https://cdn5.dashlane.com/proxy/d3mfqat9ni8wb5/releases/#{version.major_minor_patch}/#{version}/release/Dashlane.dmg"
   appcast 'https://ws1.dashlane.com/5/binaries/query?target=archive&format=xml&currentSoftwareVersion=6.0.0&platform=server_osx&os=OS_X_10_14_1'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#59625
I can't find this version anywhere on the website - the downloaded version is still 6.1907.0.17860
also the app cast contains Version 6.1907.0