### PR TITLE
Update omegat to 3.6.0_11

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,6 +1,6 @@
 cask 'omegat' do
-  version '3.6.0_10'
-  sha256 '050402aa527aa599c855c95aeb5df8efd193227a2e1ea8b6082ffb091b18fd36'
+  version '3.6.0_11'
+  sha256 'c685471966ad22c8564a923e2e8c9cd99cc6d6b87d723cfd00f3486f49990db9'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}%20update%204/OmegaT_#{version}_Mac_Signed.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.