### PR TITLE
Update iridient-developer to 3.3.6

### DIFF
--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -1,6 +1,6 @@
 cask 'iridient-developer' do
-  version '3.3.5'
-  sha256 '6d7002298604c4e547b9ffc053d22c9911c16eeb031bca574535bd76b756ac6a'
+  version '3.3.6'
+  sha256 '3df50633ea449d9848ee7a76de757326e98b532cc4e12b16bdf2385f0591b6ed'
 
   url "https://www.iridientdigital.com/downloads/IridientDeveloper_#{version.no_dots}.dmg"
   appcast 'https://www.iridientdigital.com/products/rawdeveloper_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.