### PR TITLE
Update name-mangler to 3.5

### DIFF
--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -1,6 +1,6 @@
 cask 'name-mangler' do
-  version '3.4.1'
-  sha256 '040b98d0d0da0f4457b6186d9a3854165bf59dad3b45e61f5df6dbee4173c710'
+  version '3.5'
+  sha256 '2f896e219820beade8e0f9bd9cd337cf3a59a35aaf1aabdec5a2a64ca9897943'
 
   url 'https://manytricks.com/download/namemangler'
   appcast 'https://manytricks.com/namemangler/appcast/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.