### PR TITLE
Adding comment to verify stale url for welly.rb.

### DIFF
--- a/Casks/welly.rb
+++ b/Casks/welly.rb
@@ -2,6 +2,7 @@ cask 'welly' do
   version '2.7'
   sha256 'cb24a26432d8927b1159a1865602c3f30b5190f628167c954e4d6cc723cfcb0f'
 
+  # storage.googleapis.com was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/welly/Welly.v#{version}.fix.zip"
   appcast 'https://csie.io/welly/update.xml'
   name 'Welly'

--- a/Casks/welly.rb
+++ b/Casks/welly.rb
@@ -3,7 +3,7 @@ cask 'welly' do
   sha256 'cb24a26432d8927b1159a1865602c3f30b5190f628167c954e4d6cc723cfcb0f'
 
   # storage.googleapis.com was verified as official when first introduced to the cask
-  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/welly/Welly.v#{version}.fix.zip"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v#{version.major}/code.google.com/welly/Welly.v#{version}.fix.zip"
   appcast 'https://csie.io/welly/update.xml'
   name 'Welly'
   homepage 'https://code.google.com/archive/p/welly'


### PR DESCRIPTION
Added comment to appease Rubocop reporting `code.google.com` should be used instead of 'storage.googleapis.com`. This is for `welly.rb` at `2.7`.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
