### PR TITLE
Update diskcatalogmaker to 7.4.10

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.4.9'
-  sha256 'fac5e4c4eb4933ede7849fbb069977ee311af7c394c12e3cac3d05066a20fac2'
+  version '7.4.10'
+  sha256 '4418d3cec2d7f361d57a39363fc9a7a864925e2f756f75989ba9b2ee5f8c989d'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://fujiwara.sakura.ne.jp/info/appcast/DiskCatalogMaker.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.