### PR TITLE
Update chromium to 637365

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '636579'
-  sha256 '5dca9cdd99650e6d4cd89b381864e36c3c274ab0081f32d74d9d64d0c3c822b3'
+  version '637365'
+  sha256 'c6823b717d63a37d28e26e0aecb8a14180685045e6920eb35f1fd0c7bdce7c13'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.