### PR TITLE
Update finereader.rb

### DIFF
--- a/Casks/finereader.rb
+++ b/Casks/finereader.rb
@@ -2,7 +2,7 @@ cask 'finereader' do
   version :latest
   sha256 :no_check
 
-  url 'https://fr7.abbyy.com/mac/fr/ABBYY_FineReader_Pro_ESD.dmg'
+  url 'http://fr7.abbyy.com/mac/fr/ABBYY_FineReader_Pro_ESD.dmg'
   name 'ABBYY FineReader Pro'
   homepage 'https://www.abbyy.com/finereader/pro-for-mac/'
 


### PR DESCRIPTION
certificate is expired, HTTP still works

if we want to avoid HTTP only at all costs, we could switch over to:
http://www.abbyydownloads.com/frmacpro/ABBYYFineReaderPro_1215_25.dmg
but it has a slightly older build and i don't know how stable that URL is