### PR TITLE
Update runjs to 1.3.1

### DIFF
--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -1,6 +1,6 @@
 cask 'runjs' do
-  version '1.3.0'
-  sha256 '4a8d72795afbe3ba2781ffcf3c575922f0ec146080d747f6bc496a93974652b3'
+  version '1.3.1'
+  sha256 'e88d91e0e9e4a2dd9056b614cebffefb3f1becf5cea79affa79b58aa662a4990'
 
   # github.com/lukehaas/runjs was verified as official when first introduced to the cask
   url "https://github.com/lukehaas/runjs/releases/download/v#{version}/RunJS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.