### PR TITLE
Update mindforger to 1.49.0

### DIFF
--- a/Casks/mindforger.rb
+++ b/Casks/mindforger.rb
@@ -1,6 +1,6 @@
 cask 'mindforger' do
-  version '1.48.2'
-  sha256 'd412e7f71b04cb5fa6d69effae51a51553a97d54947332d525d0af1470aa2759'
+  version '1.49.0'
+  sha256 '2e5b5cfd55d054fbc67039fe38c683c2b6e3e4e8e52c9f74f246162d7f2c3b46'
 
   # github.com/dvorka/mindforger was verified as official when first introduced to the cask
   url "https://github.com/dvorka/mindforger/releases/download/#{version.major_minor}.0/mindforger-macos10.12-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.