### PR TITLE
Update postman to 7.0.4

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,10 +1,10 @@
 cask 'postman' do
-  version '6.7.4'
-  sha256 'f0ac7764e70eb8e9fd27efb82f69ba8e41b9cb7a3767e1db887b439dff09a029'
+  version '7.0.4'
+  sha256 '781841a49e11757ab4d1fbe0db627e323e3d5c32aa09ec53db001e3430bf8738'
 
   # dl.pstmn.io/download/version was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"
-  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.pstmn.io/download/latest/osx'
+  appcast 'https://dl.pstmn.io/update/status?channel=stable&currentVersion=6.7.4&arch=64&platform=osx&syncEnabled=true&teamPlan='
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.