### PR TITLE
Update studio-3t to 2019.1.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2018.6.1'
-  sha256 '6a6550d1240a80961ad4976e69bc54397ba4249617df64fd89ef05a9f6a23249'
+  version '2019.1.0'
+  sha256 'a5ad2439faf84f466bda1f86b366528d90621b9d5fdb16db6f0acd3b3697dfeb'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.