### PR TITLE
Update chromedriver to 73.0.3683.20

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,6 +1,6 @@
 cask 'chromedriver' do
-  version '2.46'
-  sha256 '2aa256d17e4b2cc21f888b0e1b9ed211b925bf40f371d369fa0b9fbecf4bc52d'
+  version '73.0.3683.20'
+  sha256 'ef6eaa713b6f550edc9d7c5b0a0e234bc07d0976774ef2055f470abaa322c6dd'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.