### PR TITLE
Update scidavis to 1.25

### DIFF
--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -1,18 +1,14 @@
 cask 'scidavis' do
-  version '1.23'
-  sha256 '5b3925dfdf0b5dcda9d2a9929b5ae8a9f83cb6130389cea2a9248e84e396fdf2'
+  version '1.25'
+  sha256 '8a554f90c390426dc04d104814fc2a109b68a55cf272ee25f82e419cfebafbf5'
 
   # downloads.sourceforge.net/scidavis was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/scidavis/scidavis-#{version}.pkg"
+  url "https://downloads.sourceforge.net/scidavis/scidavis-#{version}-mac-dist.dmg"
   appcast 'https://sourceforge.net/projects/scidavis/rss.xml'
   name 'scidavis'
   homepage 'https://scidavis.sourceforge.io/'
 
   depends_on macos: '>= :yosemite'
 
-  pkg "scidavis-#{version}.pkg"
-
-  uninstall pkgutil: 'SciDAVis'
-
-  zap trash: '~/Library/Saved Application State/net.sourceforge.scidavis.savedState'
+  app 'scidavis.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.