### PR TITLE
Update fips to 3.3.1

### DIFF
--- a/Casks/fips.rb
+++ b/Casks/fips.rb
@@ -1,6 +1,6 @@
 cask 'fips' do
-  version '3.3.0'
-  sha256 '4bba26c41e48aef7d3cc760626b559c3a174672dd4e9231c41232012119827a8'
+  version '3.3.1'
+  sha256 '630ee2776117876d49d8073bb6715c9a7c7d927bc2745fca6ce5db2ab9c1456e'
 
   # github.com/matwey/fips3 was verified as official when first introduced to the cask
   url "https://github.com/matwey/fips3/releases/download/#{version}/Fips-#{version}-Darwin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.