### PR TITLE
Update flipper to 0.17.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.16.2'
-  sha256 'e4920982b3f318c31858959dd7cf3e99428767cc19ba3f7cdbcebbffcaff6cc7'
+  version '0.17.0'
+  sha256 '81570109a92a6b90d4d5d2f5a443038b7ff5360fdccc394c676e590092b3bd47'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.