### PR TITLE
Revert "Update postman to 7.0.4"

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -1,10 +1,10 @@
 cask 'postman' do
-  version '7.0.4'
-  sha256 '781841a49e11757ab4d1fbe0db627e323e3d5c32aa09ec53db001e3430bf8738'
+  version '6.7.4'
+  sha256 'f0ac7764e70eb8e9fd27efb82f69ba8e41b9cb7a3767e1db887b439dff09a029'
 
   # dl.pstmn.io/download/version was verified as official when first introduced to the cask
   url "https://dl.pstmn.io/download/version/#{version}/osx64"
-  appcast 'https://dl.pstmn.io/update/status?channel=stable&currentVersion=6.7.4&arch=64&platform=osx&syncEnabled=true&teamPlan='
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.pstmn.io/download/latest/osx'
   name 'Postman'
   homepage 'https://www.getpostman.com/'
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#59815

7.0.4 ist not yet a stable Version. According to https://www.getpostman.com/downloads/release-notes the stable version ist still 6.7.4