### PR TITLE
Update scribus to 1.4.8

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,6 +1,6 @@
 cask 'scribus' do
-  version '1.4.7'
-  sha256 'fc5fb1f34abd177586f3d9791801c4a166cd818f3c985960b95f1092dad8a9d4'
+  version '1.4.8'
+  sha256 '9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5'
 
   # sourceforge.net/scribus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.