### PR TITLE
Update Brooklyn to 2.0.1

### DIFF
--- a/Casks/brooklyn.rb
+++ b/Casks/brooklyn.rb
@@ -1,6 +1,6 @@
 cask 'brooklyn' do
-  version '1.0.0'
-  sha256 '77d8e3235db2464a28ca497d330a1a423a64f199d259173aff0a0b3306c9d351'
+  version '2.0.0'
+  sha256 'fd2dbc0bfdc5d12db202d7e6c7eb0a11e822e669ac1edbf12d205f2d91e9f088'
 
   url "https://github.com/pedrommcarrasco/Brooklyn/releases/download/#{version}/Brooklyn.saver.zip"
   appcast 'https://github.com/pedrommcarrasco/Brooklyn/releases.atom'

--- a/Casks/brooklyn.rb
+++ b/Casks/brooklyn.rb
@@ -1,6 +1,6 @@
 cask 'brooklyn' do
-  version '2.0.0'
-  sha256 'fd2dbc0bfdc5d12db202d7e6c7eb0a11e822e669ac1edbf12d205f2d91e9f088'
+  version '2.0.1'
+  sha256 '6ecde466f8f88c2649dbf3e38c98fd7abb95a7d1828ac4cc8d499f2c7a0cb9ec'
 
   url "https://github.com/pedrommcarrasco/Brooklyn/releases/download/#{version}/Brooklyn.saver.zip"
   appcast 'https://github.com/pedrommcarrasco/Brooklyn/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).