### PR TITLE
Update chromium to 638094

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '637735'
-  sha256 'df65972b1b61da82b757149923a95b78303c877e2bf4a144be4f0be0736cba0f'
+  version '638094'
+  sha256 '1a0f9f19cf4e89ea7a6111d50a58556113d2b713ce5c3626b13837c1a1332608'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.