### PR TITLE
Update zeplin to 2.3.1,638

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.2.6,616'
-  sha256 'f3bdcca3aaccc77137f423e331d332de706937318b4b25b2852c1ad4ebe47688'
+  version '2.3.1,638'
+  sha256 'ae66af629474f879a748385c5f63d5783e759f3259726819a683365130b4c732'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.