### PR TITLE
Update dash-dash to 0.13.1.0

### DIFF
--- a/Casks/dash-dash.rb
+++ b/Casks/dash-dash.rb
@@ -1,9 +1,9 @@
 cask 'dash-dash' do
-  version '0.13.0.0'
-  sha256 '6f97f502732e5b63a431d0edb5a9d14e95ff8afb8e7eb94463566a75e7589a70'
+  version '0.13.1.0'
+  sha256 '8b89be3f47a45d86fda1015f07bac4dbfeab72b1636ee6837de467fe1dfe960d'
 
   # github.com/dashpay/dash was verified as official when first introduced to the cask
-  url "https://github.com/dashpay/dash/releases/download/v#{version}/dashcore-#{version}-osx-unsigned.dmg"
+  url "https://github.com/dashpay/dash/releases/download/v#{version}/dashcore-#{version}-osx.dmg"
   appcast 'https://github.com/dashpay/dash/releases.atom'
   name 'Dash'
   homepage 'https://www.dash.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.