### PR TITLE
Update vimr to 0.26.0-303

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,6 +1,6 @@
 cask 'vimr' do
-  version '0.25.0-297'
-  sha256 'f7cc1ef7e62a832f4bc55431825c9c1297d4d265064c149a95d3706cfbae547f'
+  version '0.26.0-303'
+  sha256 'c153e796b19bc47eb9b9753a70639d7a0d3805e00d01345848f9a46eca980e69'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
@@ -9,6 +9,7 @@ cask 'vimr' do
   homepage 'http://vimr.org/'
 
   auto_updates true
+  depends_on macos: '>= :sierra'
 
   app 'VimR.app'
   binary "#{appdir}/VimR.app/Contents/Resources/vimr"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.