### PR TITLE
New cask "ghidra", version 9.0_PUBLIC_20190228

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -6,7 +6,7 @@ cask 'ghidra' do
   name 'Ghidra'
   homepage 'https://www.ghidra-sre.org/'
 
-  binary "ghidra_#{version.major_minor}/ghidraRun"
+  binary "ghidra_#{version.major_minor_patch}/ghidraRun"
 
   zap trash: '~/.ghidra'
 

--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,0 +1,20 @@
+cask 'ghidra' do
+  version '9.0_PUBLIC_20190228'
+  sha256 '3b65d29024b9decdbb1148b12fe87bcb7f3a6a56ff38475f5dc9dd1cfc7fd6b2'
+
+  url "https://www.ghidra-sre.org/ghidra_#{version}.zip"
+  name 'Ghidra'
+  homepage 'https://www.ghidra-sre.org/'
+
+  depends_on cask: 'java'
+
+  binary "ghidra_#{version.major_minor}/ghidraRun"
+
+  zap trash: [
+               '~/.ghidra',
+             ]
+
+  caveats do
+    depends_on_java '11+'
+  end
+end

--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,5 +1,5 @@
 cask 'ghidra' do
-  version '9.0_PUBLIC_20190228'
+  version '9.0.1_PUBLIC_20190325'
   sha256 '3b65d29024b9decdbb1148b12fe87bcb7f3a6a56ff38475f5dc9dd1cfc7fd6b2'
 
   url "https://www.ghidra-sre.org/ghidra_#{version}.zip"

--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,6 +1,6 @@
 cask 'ghidra' do
   version '9.0.1_PUBLIC_20190325'
-  sha256 '3b65d29024b9decdbb1148b12fe87bcb7f3a6a56ff38475f5dc9dd1cfc7fd6b2'
+  sha256 '58ffa488e6dc57e2c023670c1dfac0469bdb6f4e7da98f70610d9f561b65c774'
 
   url "https://www.ghidra-sre.org/ghidra_#{version}.zip"
   name 'Ghidra'

--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -6,13 +6,9 @@ cask 'ghidra' do
   name 'Ghidra'
   homepage 'https://www.ghidra-sre.org/'
 
-  depends_on cask: 'java'
-
   binary "ghidra_#{version.major_minor}/ghidraRun"
 
-  zap trash: [
-               '~/.ghidra',
-             ]
+  zap trash: '~/.ghidra'
 
   caveats do
     depends_on_java '11+'


### PR DESCRIPTION
This is a cask for installing Ghidra from https://www.ghidra-sre.org/.
Ghidra is a new reverse-engineering/decompilation tool, which the NSA
is in the process of open-sourcing.  Since the source is not yet
available, caution is advised due to the source of the software.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
