### PR TITLE
Update libreoffice-language-pack to 6.2.1

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,558 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '6.2.0'
+  version '6.2.1'
 
   language 'af' do
-    sha256 '437f327cdee9878ae0689389f6f52f0a5d58533fa43881ae7a117685267d6f54'
+    sha256 '3f4bfbf25a65ac31385425312d8be43dee52ca07436ba3b5d3eca0258ae64a5f'
     'af'
   end
 
   language 'am' do
-    sha256 '2789fab7dd5bd0d48d8d246662303efe98ffc5ce2dd6e738bff7f088bcaf9ca5'
+    sha256 'c5391310a5b4da2080f5f23639ce128269d1fc7ab1de9a9eb86fa36e11ce93d9'
     'am'
   end
 
   language 'ar' do
-    sha256 'b50d77587ac2dbff0226172da243091cfbf5c9fe68c94780aa40b640ce49c57e'
+    sha256 '520919c4c43124d69671cfcbb71ad5bbf7f17d035704ee2e4a2cc4af9f098447'
     'ar'
   end
 
   language 'as' do
-    sha256 'face66495ebd564417f8c510d12b4814c36f7eb526f4e68d7e206bab800f3b23'
+    sha256 '265b5c5430309c131b4fa0d439099056e0e47232a524d6347d81a074a3cac06f'
     'as'
   end
 
   language 'ast' do
-    sha256 '88a3614c67988729a3ee73616a5bc6a88a2bc33072a5ae9d0fbe60b35aaef037'
+    sha256 '7e5c594c793c2fb1d52213d2cd2374669aa466af99c17ca8df11adb9c16c633c'
     'ast'
   end
 
   language 'be' do
-    sha256 'cba9f51f932dc4fc447c6def151b76e48d29cc9dad1362a6cdc8df1e3112dcea'
+    sha256 'b441345bcf1db32b554633eb63cb203dfdc6b51d3fa8e345b37fca253f012729'
     'be'
   end
 
   language 'bg' do
-    sha256 '4a6c56b3b4681737f308ae207d37d6053ac5f6d90f454552505abbd244de1768'
+    sha256 '20bc03226a60399e7cbba4840706fa9fa28461325d7467948bbc3beb7690cb8b'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 'ab94380ff16b06d5184225d81846bb62435edfe5ada715d3597c5355c4ef13b9'
+    sha256 'b5e669d2c793f83aae630e9259a4c633a96d1245e610fe44fe9ef3a4f25fa45d'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 'f4c7c8c786d8b9892745288416b0ee9af8850f3ad286d91da752e3ed60a36dc5'
+    sha256 '948e841c211064887495d983b986ce62e130423b44f5f20a5c3b32336300b2d0'
     'bn'
   end
 
   language 'bo' do
-    sha256 'fdd5f47028d5412b9a4e9e9fb76ef160375b0a04f0a825c6c5fa7ccf050588a1'
+    sha256 'a90e672aaac17692e4047295de3dfa5ff187ddb70ab6538ca2a1850d2bdf9d19'
     'bo'
   end
 
   language 'br' do
-    sha256 'aee1585de72faed79fef951ba0ab636d76623cdb8ff59489dfa7ac12be9237ae'
+    sha256 '87397f0ab13bc9b48c4815d83768bd18e9e72bc3842430115a568c2fecad10cc'
     'br'
   end
 
   language 'brx' do
-    sha256 'fc6e117708c1714db54ab29d502b1cb6efbba72010bcd5941979716527d34da6'
+    sha256 '02407199213be7794594275a6534bcb5f246502b2a9484401178df760cefd40d'
     'brx'
   end
 
   language 'bs' do
-    sha256 '2322185be066ffa04e85febc02e685069ad287a03f47b3acad075190a800188e'
+    sha256 '892cd8a333739fa9b3938d8bd08f8f699acec24a643665846066fe6dace43dc2'
     'bs'
   end
 
   language 'ca' do
-    sha256 'd892723e85d2417b2f212286e69e6c485449d9e7d6874c3d1ede48bde74fd0f2'
+    sha256 '09516bc9ff48b313f278e04c7def8e35cf0eb4584723ab1116de6cb010be215a'
     'ca'
   end
 
   language 'cs' do
-    sha256 '72373e695b64fe4d92a3a8b4fddd7436180b1c3fb751cc9ad4dfecb0e83344a8'
+    sha256 'bd157060acd5101fa416e1b08bca66b852a58b83f7a7153b13eb132976feb021'
     'cs'
   end
 
   language 'cy' do
-    sha256 '33b63adb76ac561c7455d1da8908899fddc2a39057926e69401d73d0f53bf276'
+    sha256 '25e208a5d1e967524d21384e9c4529cfa0526addc0d5b0267ea0485f232878cd'
     'cy'
   end
 
   language 'da' do
-    sha256 '6175da72deac842d4d297ae307eef34a1f2da631871f01d4745a8b1b76cb1df4'
+    sha256 '2de5d4a8a58527a6836031e61895071dcbe635db74fb1fae3ae72db03818ad3f'
     'da'
   end
 
   language 'de' do
-    sha256 '01ea05c41f69d86f65da43eac4e90daff7f14f78c84a8fb66ddb611e5c9a344a'
+    sha256 'cb54cbb0ad279924d961dfc8a8d83acee98c4f8f0d67710bebc2cf4265b5f649'
     'de'
   end
 
   language 'dgo' do
-    sha256 'de1ed06266ca1a2ce9f06a980f63287518d59b026c7371e75cdae1cb25c9c8af'
+    sha256 '8bebb22e308ffab44abb4f13f1e24c7e8db4c8530cdddad85afd4db9e0902aef'
     'dgo'
   end
 
   language 'dz' do
-    sha256 'cc4fb46d6f6f900d0dff782b5ccfdcc32481141bb4c27be86574b7364cfb4411'
+    sha256 '70d326d5a74c34a12811af23a1a256782ce6a5583f628431383f5fae13db09e2'
     'dz'
   end
 
   language 'el' do
-    sha256 '8c8f536b2292b9df5dd663187715e442161b1bfa06acc2347199dd78c06daa14'
+    sha256 'bc295d3192dba10a24ae41fef6bcb90528465c44fa65c598e3d25fa89b2320a2'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 'f4a0a0ce6296e96f8102181c885f525bfb2bb996c4a33147e79da26f9f8991ea'
+    sha256 '47d472a983818744facfac43f72afd8d8ea9be6256e8ae8659cdcfe080ed5e09'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 '8eeab29e07d552b6cef5adee4ebf804568abc92fafffa2aa2cfac7b0ee4cc333'
+    sha256 '020f3d2b82c19bdf3188f9c10984ccb9aa48774bac5b10e33c87cc7bf68a18af'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '61ec43c5a83298f8f52c0470c27ec5a3c72635fb32837bbdbef96161b79d9db6'
+    sha256 '01d44106592781cf58094e4db5663ff362e216912ed843c6982929206407288b'
     'eo'
   end
 
   language 'es' do
-    sha256 'fde47bf790414b70951783238fb69cf8dcfad8eb4c7e8f132578d758fc98920d'
+    sha256 'add042ebef3db3bc105f5e2d730120ba5e0a4a1f41285ba290c84c0b73a2196b'
     'es'
   end
 
   language 'et' do
-    sha256 '7fb721618c2ee43bd3e83a4562ebeebedf3ef3754ad2b639eb8446919a0115c7'
+    sha256 'a83b5e24d5aca2c299e3240137fd6218c0a94c98b0167ab2d849f0c138e5a465'
     'et'
   end
 
   language 'eu' do
-    sha256 '0386b6ae6ec96d60afeb4d910266f6c6308f0c6022d1a52d21ca0c4cd9f5eae9'
+    sha256 'dc0d10d7ca0519de8b538d68946fe6db095c980c4f5fa8f10080d5d78fde87e0'
     'eu'
   end
 
   language 'fa' do
-    sha256 '19ee3b3720bd42f048f18d88fcecb27e441302a9899f11c680afa2d7486fa596'
+    sha256 'e74c514e68d5249e018616c1f2d0c6d6474fad9af742b186061e8c759378b0a2'
     'fa'
   end
 
   language 'fi' do
-    sha256 '5afb26f921c0435fc1f6d77a2f7ab23430b6c3cf6f2b42657d66032ceddcf5a7'
+    sha256 '1de867276bde42c3f939900466bac04275d754d269441ed640c17f8bfcdd03f0'
     'fi'
   end
 
   language 'fr' do
-    sha256 '7f3a2f8efeaa378cb77a0f5b4cf3c0c327e4a9eb104a81a0c46c5f6bb83c959b'
+    sha256 'd21f6e148016298912d0d0151f46b126771007343829686692dc2ef8d2eeea27'
     'fr'
   end
 
   language 'ga' do
-    sha256 'c77b3a35acedd26858a83ea1e1593a0483caa7c2125547e2ca2fb0d8cdf1425b'
+    sha256 '05f392dc41e59cf2be50511b6cd340c7124c51da1db30dc7c29d949f6fcba497'
     'ga'
   end
 
   language 'gd' do
-    sha256 '01bd654bc7c351ada83808a5abc85878f51a7c483b09887673e3358abf2e4615'
+    sha256 '1898467699754a20a6215dfb712a2ff192e2eb9f86b25603c2eabe8ee320ec43'
     'gd'
   end
 
   language 'gl' do
-    sha256 'f375187c74589ee31ad3027754a09086f47a6c19fcecd587c7cf0ff51b0f67b5'
+    sha256 'de4e0d843d36b7cccf34f7552f973be3fe541a692cee6b07934e0e0bd5b99c60'
     'gl'
   end
 
   language 'gu' do
-    sha256 '9fca12d4577da5ee98cdb30ea6c8748246fd722e2887ba6bd0bca1f0a3173674'
+    sha256 'ace14763d5830ae5d7624d6de8cfbae81360ef87823f3a0b7fb27c1e9c4075d1'
     'gu'
   end
 
   language 'gug' do
-    sha256 '148c724d0f9a0cabdb9a448e160f377e73588094f683341c8aa7319451151dad'
+    sha256 '377829a1361dc8284d3718f4fdf0446031e2731c0735abb16a4c7464de38216a'
     'gug'
   end
 
   language 'he' do
-    sha256 '2d41284052920a322172337b492379f1b3423991b15dba9c35c291457bdd18ed'
+    sha256 'ab5e078c2e15b687f0d344596c9973ddd6858fee73bd86363b29a5dcba8048a9'
     'he'
   end
 
   language 'hi' do
-    sha256 '320bef34fd330fcb85df95a30f2c4df05a0fcbb9c61c8dd647b26221a541787c'
+    sha256 '14f4c2b254209e1d3dc28b750576d69dc70db144a90e41b4dac93ed78f9cb1ea'
     'hi'
   end
 
   language 'hr' do
-    sha256 '7c5ec8c62a5e5c8d688373d9e5fee6d8fd1996bc9669dcd0a3d59466328a1fa7'
+    sha256 '383c509f31be1ec677762184a0385a0dde90de1d97ea8d3fa976c128c61ee803'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '74d1e991f0af47ff3f5c6133d28a8c2cab4e546203e3c484aa236c050ddd1fb2'
+    sha256 'd253c99a032364543775e23d1b279fd971e6cf73e131fd53857c1624e26c3a6e'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '60ab2da4ac07be529e094857391ab2aac7bcc3cded6f0f081fb4990477172bb8'
+    sha256 'a06a395fecc8f016100a11165b4984c22e5d669040875811d8e8f5d562023cdb'
     'hu'
   end
 
   language 'id' do
-    sha256 'a666befae0eba10847fd7d056bbe9d51852ff944cfd4e6859b81c2a4dbd8a8b8'
+    sha256 'ac7e6ecbe1aba1eca0813c6d3c4dbe96b9e6e762c6815a88272cdcd42f93b81e'
     'id'
   end
 
   language 'is' do
-    sha256 'cc5f3efccede6a6d908e260585e9d77029de5c676398acfb7aa9804bf18adfbb'
+    sha256 'fd83f3c67e824d1c2bc382602214e4ace7b23f958db694c4ebdbaf920dff44fc'
     'is'
   end
 
   language 'it' do
-    sha256 '7a51b7a65e2d2d0ee2d4619850513b9ad6ebf06c9c9765b896e82b7ea93e3818'
+    sha256 'f3d353eda70b80448b1c9c2b72a8edd20ee56bd4548abd40655f63c4b2963d80'
     'it'
   end
 
   language 'ja' do
-    sha256 'f3e580328ab2d31499d48c599859077aedc4861437934f242a1754df3a5e4333'
+    sha256 '1b9c2716ce5d8023e984fded31a95d22defc71cd1ad70b2efb64c7f550c99002'
     'ja'
   end
 
   language 'ka' do
-    sha256 '5bd6c4c3046f6e45ccd6e7bfdc81ebb29e4ee322572db34a7620eaaff32eb5ec'
+    sha256 'cd807f888fce437fc4394ac425e6e9195594f1d76aa87bad8f1a0fd59247ba77'
     'ka'
   end
 
   language 'kk' do
-    sha256 'd9c0035b7110b5fe2710f40d8be46f5d9eb79b0a7f21b89dda6f4e39dd38ef3c'
+    sha256 '20598a6f6e1d2307d313050b3c247cf7cf7b158adfb82275c469dabc9d13d3c8'
     'kk'
   end
 
   language 'km' do
-    sha256 'd348aa2c12770d9f3f60704c5ba2b3b8ce157ff07a9fbf3e10daf303680fad18'
+    sha256 '192adee6c96e75519f737242c257daf11b781e3a7925d9545ff9b3f96798e7ee'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '0f8c873e2c2d619e660c78193210135509fec71f2a486df85ec0480cc4d2e8b6'
+    sha256 'c7d11a0d04f28bf52484f3b2374c4ef26f20b3f78257567c0b63b7740fcf33e8'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 '5e5b73983de0269778ee5645dbed31c6ddc3ea9e284df056ed9ef157a03afec6'
+    sha256 '1c2b5050bb6ee12f10fb264784c105fecffb37feb6d57ebc646e927ae3b84c13'
     'kn'
   end
 
   language 'ko' do
-    sha256 '52c0bf3a5d86d8b2a3aefd3b761366fd3e6ab4388ec9a6d9fe2a408e4bbd239a'
+    sha256 '16b907b20ca5338dbcf07adc843a2ac0c5cfccf2e3bdf0c1593b6321d888ce95'
     'ko'
   end
 
   language 'kok' do
-    sha256 '0b59e6a8b6248f033982d781a38aecc004ca6331fbfe4f36e51943c0af2ba6c8'
+    sha256 'cd9034fda07fc9ced8ef938a159331c28786837681298490ca51edaaa696e487'
     'kok'
   end
 
   language 'ks' do
-    sha256 'c209bb8923d872195ce881896d25af0267badb03914d87d2f3e247980f9a01d9'
+    sha256 'e8fa1ff1ed22e2ab836bb87ea322b0821a8b289fe09a5fb0cf77457138bdfb60'
     'ks'
   end
 
   language 'lb' do
-    sha256 'f5bb513a70edb96e240606eb65baf43d36c5b77053f4dcd3e2d5c879c4220aa7'
+    sha256 '87db6d740b1277ff4a84fab05a04fd1b295441c6f8d98b1e7bd280c77d6f0c19'
     'lb'
   end
 
   language 'lo' do
-    sha256 '0c5ccf1187d4f366d50938852783923c8ede36a43ff19f4338355a73709613e6'
+    sha256 '128003e0e442ee5f9e4a1befb549017fd869f6f7fb5d3cbf88c4b7f2477fe9ee'
     'lo'
   end
 
   language 'lt' do
-    sha256 'b0bd4dd800462dc9a4f71033d966253b8f6994533935627618f3e379fa4eb321'
+    sha256 '313c8f5571cd81ebcba1da774743970e40def9c035f6ad21ac11826a9281a873'
     'lt'
   end
 
   language 'lv' do
-    sha256 'ea6e6f7bf2cbe4b61cdf3fcbd37717e2b09cdd1b6eefc01edc5bc90549cbd2c8'
+    sha256 '3d4725eaef04ef2faf9400e90d6115657a49398391a6e981161f0026a8c70a07'
     'lv'
   end
 
   language 'mai' do
-    sha256 'f1a768362b9b3f66313eb7ceae7cf2b83f6e4a41a6eb0914ae38e8463fb3ebf6'
+    sha256 '92ba84e7ce7f5258eda2a37edd2163276aebda4e909a8d58e4fe8d9563605275'
     'mai'
   end
 
   language 'mk' do
-    sha256 'f27600fd907d37d7a3551928f2d3ca112dae7c4eb15509860feacf08f896d32a'
+    sha256 'f13f9c1210926ae5169ab8e5370e357237450a06637c862417c93c77f0b3341a'
     'mk'
   end
 
   language 'ml' do
-    sha256 '772611b3cd391b59f99508500f281c1707e92a07690364b5255c971448bc4fd0'
+    sha256 '5d957b3d3931d90ff636ce6560251260f39d8b63f3095ab9466a1ccfb4d54270'
     'ml'
   end
 
   language 'mn' do
-    sha256 '8c9fcb665d08921cb558b218fd736c601f0ac9ec851f9b74e9651cb39a951ff9'
+    sha256 '5834cbcaebabcfe81a44332ae1fa011205532d6e03baf44138c12152f2b7889a'
     'mn'
   end
 
   language 'mni' do
-    sha256 '66e2368de4e2c18a942e328372a848554f13d0efaa788802c33f0f896dd46a30'
+    sha256 'd30ab64332db977a6a8a1d6ffbb276a23649ba873cd581da58d5afec03322e46'
     'mni'
   end
 
   language 'mr' do
-    sha256 '2866847194fbf39d7787dbd37311146bb43f06b2e300528f96867838498c67d5'
+    sha256 '6364f6aeb52d2e3d0e3f8f16dc1bfeab73c5190cb8febd61a7f22f22d821903f'
     'mr'
   end
 
   language 'my' do
-    sha256 'd24c96155fac17069562d1d503c59a8898fe65f365b92f55bef39e75cded3438'
+    sha256 'd22db89a43a779b314554c8382de3270a6e9213b4227edc1e6930626254221d1'
     'my'
   end
 
   language 'nb' do
-    sha256 '1e958a53377eca03a29bb2675075b0f7d44027f7d68c4166e33349c47b9a5cea'
+    sha256 'bd3c169011e3cfde0a5b495ac6b8c2ddd21a99a082df3e150eb23b1ec81cce6e'
     'nb'
   end
 
   language 'ne' do
-    sha256 '2810bfd29a3a73709d5ddffbc35945b4fab0edb2ecb449d89435ccdb3aeec637'
+    sha256 '48829d0195e7cecef8a06170246598352578c2271df935835f16cf98fddb0ea0'
     'ne'
   end
 
   language 'nl' do
-    sha256 '8f6327253881c9a5aa092de9d4a006ab6b716d3f2f1d66c176c185f4d5a98543'
+    sha256 'c8e3550e7025de77bd791ab9c8c9353cc14637a832c0b30bda0d82d297152bf9'
     'nl'
   end
 
   language 'nn' do
-    sha256 'eea9d874bce3c2dd70446c0d1d786c696d605b2c1752ff350f76a49541256465'
+    sha256 '091996c6ee43d6fc55d413751ea90a57db8aaf69f133203c003013bd937d0311'
     'nn'
   end
 
   language 'nr' do
-    sha256 '9a51221326445e58ed4dff6882c52b387876fda8f457f689877f1f4b33e25e83'
+    sha256 '0d745ac9469f63964d831c77ae01eb678cfdf0af13c9fadfec2ba9fac39ba3e3'
     'nr'
   end
 
   language 'nso' do
-    sha256 '3bdf0919102031fcd7b2d69385147a805babceef1243d8b8d67042ea9430160e'
+    sha256 '4e0d9a08fb3c3a2e511f975878982bafe08e691e3a2391b8f75a3cf88efa7af4'
     'nso'
   end
 
   language 'oc' do
-    sha256 '34b5f64e60611633b7a08bdd238eab7d67ad78f823b876cab8cc66fb8de5e769'
+    sha256 '77963143e6de37bddadb6b3555e3fc2e5a0c7779f77a5bef5c89103ce785272e'
     'oc'
   end
 
   language 'om' do
-    sha256 'c3beebc79a0aa5ab73f5663f77ff89553db2cb47f9f583f32914c8cea697630b'
+    sha256 '8db2ef65d9224a007def3cc5282cf410ffcbd29e9decd8359e2ee990e7eb4ef5'
     'om'
   end
 
   language 'or' do
-    sha256 'e4a0bb025dc04d4ea8a053ec86233418ecbcd9952a43e0bdb7504d0af7affa47'
+    sha256 '63c57e690c90921e0820fc4f818d329c4f2a7f7f28e1f5f54fc3dacf5655643e'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '1515be33fc18ffb676572196b0ed8303b82d91c9ec4edfe2040ee4562cc37d58'
+    sha256 'd2c6f9437d55b54be09c9370fb9f64f580a91c8ebdef280065d2dd31b721d9ee'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 'c0af9e58549bf3ad346c852332663178ac257d9af2a0dc41f6a301390172af8a'
+    sha256 'e0ca152b539204f919f2a6be3397964b71460565d955d8c24e80cb0b65c6723c'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'a3e432524a224d1b73628304b9a54bb96e277a760a1746afe33ccd80c94fdcd3'
+    sha256 '55b75c27d38b14c4fe9dcb934c59d1ab4897e8f292e5348cc4680190fdb86cfc'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '2e7e716b0c1e92106907091ee6e7a8bac1d3016bead16cc4225432177ac81e4d'
+    sha256 '260c7d1930433fcc703f1ee2806af20a9426b6416fb1a2014d1691d2bc975fcf'
     'pt'
   end
 
   language 'ro' do
-    sha256 '92d96f917a9c9edf12a0049254790dabf6594e6f8b8ce29a15e838636d882b71'
+    sha256 '158ceb63b71d3e47aa0b07d57f57463bda56b9e9bfb69576ebb1d2e5d3c90f38'
     'ro'
   end
 
   language 'ru' do
-    sha256 '7bfe9e81f521177e8c15648bd7a3794ab13fd1bd26ab09ffca2c751f19790b66'
+    sha256 'd65e4453e13d3cb71812c514de1049a2a668360651f54f341d8c7a3f07d072a8'
     'ru'
   end
 
   language 'rw' do
-    sha256 '93e5386d53e6a7eb48ec764bc426efe56e50452a98ae965f53c0362030ea7cb4'
+    sha256 '33a1625c3bc7823dddc27e1e9094bdde932275ff8d76634e26fa98afd38e5744'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 'ce2aa46a03d3332528ff9a7054849c1151d1574b386aa17731540d0439a176b1'
+    sha256 '4df4230d5458ebb36e6e8184fe3c9155cf93471e46279c0c2a703f812165eb4e'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 'af4ad6945c468df7df3021de86b42c96385d29ac520cb4e2f1e6dd9241fa948d'
+    sha256 '4aca8ace84b0e3eecbff6f2fd026ab5c4bfaff002528d3db65b47375e76bc8d7'
     'sat'
   end
 
   language 'sd' do
-    sha256 'ce336006b99ba7cdc87bacc4b219c260d21acd99b7e811d2d22d731517a9143e'
+    sha256 '40542d83a7b88bd25452b937bcbf041f0da1fe68a5adca2ef87174f863864166'
     'sd'
   end
 
   language 'si' do
-    sha256 'd73ae731c5ae61bfbbfd7ed6684a2c239048c4dbf91c7e0101c80b1eafc4d387'
+    sha256 'fe82c908d5a9b312b512b696a00bc4aae22c6e110588d5de606fe64e10b1e693'
     'si'
   end
 
   language 'sid' do
-    sha256 '3fe6c44cc7b24f442bbe9f38af052979589b327f7911d40ece78f05e2ec7f5e0'
+    sha256 'ad8258025de9f61b5725cde921f793b7a58f95f8abc576dcdde317cbf41f3c66'
     'sid'
   end
 
   language 'sk' do
-    sha256 'c677b8a549af474122e15c9de99751b34d2445bdc79a81652969a38f370f6dfe'
+    sha256 '7d5cc0c966199749e8f0886b39e68a7852eedc995a486a59cc84b266708c0cc3'
     'sk'
   end
 
   language 'sl' do
-    sha256 '6d7a1035f372ab38d42d8726181cedb1c012260016e5ee4a4d78b0ebb04254fb'
+    sha256 '9bbd5de5a4774f3596eae3c59c69a311111c967405f1cb77b9e9cf3ae0d980b4'
     'sl'
   end
 
   language 'sq' do
-    sha256 'b2168cbbf9426face275c1190ab375bebe117476b07ee26dd472718a9ce42b59'
+    sha256 'b4b0b4bb78e0bba435179edce226795da8fbde32941bc41d4f363acdaa45e038'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '0ff378e74a312431e2fa02ad0e351e0aa601a84e2207270c063c5f87aa4f8235'
+    sha256 '8ae75706c74c7dd189e41cedb44d2e82c650db4533b81d52e4ea13dce3efa9a1'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 '658ed4048fb34838a73e61c70f7c8d15d79466ba171c1ac7df97a919aceb2180'
+    sha256 'e314210d65d5dba8acdd648604b9b97cd185d6f303dd977b51af8c545d89fd63'
     'sr'
   end
 
   language 'ss' do
-    sha256 '9f41f0e874a1feea2f4f7e7076ce0190db453619cf0d1da832bdb74fb530e7b8'
+    sha256 '151ad53348a66cd85d47f7b9b4a84f2782cd7ccd14e37e5f964f3a002f4932ff'
     'ss'
   end
 
   language 'st' do
-    sha256 'b6f80ac1e862730b39527619108af3cd685d3e017f902dcd12e788ed36b03d38'
+    sha256 '2f0781e48090a56e0905c5c69edd2da1fdc46bfd19244d1f8ce62752613e4f2e'
     'st'
   end
 
   language 'sv' do
-    sha256 'e95a0e61fb9e3dea8e41f9d3836badef05f6705cb445f0bfd7db19fa2f410869'
+    sha256 'a66c024e4d74d46af93f14fa6dd87ae822ccb12d5b7196fb727d75810916ab53'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'ce81d0b32f5f1b2a6e4fa4ef2b0e8b704a14b702521f6fc8b51d001115f5d35e'
+    sha256 '91f91d1540f16b6d68532224c7cf4e6bb9bd3f9cfbe6d48410260f5182375db7'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '28afd02229888c5cd1ef34b2ee7c5174a0d4b29fcbb4929a3cbe42c656fbf496'
+    sha256 '619d423c0d392eac969792aae9ed1d6bc10dbe5b9bf11561ed792058ec3305b8'
     'ta'
   end
 
   language 'te' do
-    sha256 'd5f6b005858a47461f3a7213423b920b421255a0b6ddafaea26a1886b7967632'
+    sha256 '9509c71e8be100b06e63ff8bc0b7bb9a508d4b1aa2827517e85bacd786d01692'
     'te'
   end
 
   language 'tg' do
-    sha256 '97852625523cf1a53ac281054a5c30af31c45964520f9312c3d1ea5937a4171d'
+    sha256 'c4dd97c97f0024a81cbf29ece00c9e89eb2d51c768bd671d1727877b2eca20ab'
     'tg'
   end
 
   language 'th' do
-    sha256 'af3fe353deacbeb00fa9f0efadda92ed3f03a92497e203ef27f81c2773a9dbe5'
+    sha256 '45a5fa420be4439a70ae6e685d37213e694b577225ecdf5acf873e018ab716dc'
     'th'
   end
 
   language 'tn' do
-    sha256 'd76046d0cdba1f7e1b69182647e0a20c420c2270ed5c9544bc59b177526347bd'
+    sha256 '4769fbac5faea9df42bcbdccc9048cf171b250e8b92168cee7e95e2f4088d6ee'
     'tn'
   end
 
   language 'tr' do
-    sha256 'b24ed43a3fda140e5b7eaff7982206d211003c1dc4cec7ba9e850ef627bffd25'
+    sha256 '027341614dc0989a29aec86ffd2f46c6cdd0276378a8068a5d038b823a72ace6'
     'tr'
   end
 
   language 'ts' do
-    sha256 'e3e07cd8903351b583cc8b0a05eaab654ebd24ba314c1e9c492f0acabe7a16eb'
+    sha256 'b94acf10abc16b65b9d589739ad5ea95ecc7e25dfa4bf24da06aa30aad806232'
     'ts'
   end
 
   language 'tt' do
-    sha256 'c305fc052b57a82e7acaf6a00747fea986550d5b776af5e76eed32d6536898a8'
+    sha256 'b4197c05092e4c4487331293b5f6b27f528a609371eea289da26dbc85673e833'
     'tt'
   end
 
   language 'ug' do
-    sha256 '4191951b44b21913eabcf96d7293b3adbd90ef49c2953da733483b63538c837d'
+    sha256 'e21e0fcdf8b2fa4b218c3df8c2bb7a01b42542d7457f52a6691104d1253b2e88'
     'ug'
   end
 
   language 'uk' do
-    sha256 '346ad894173ea2b09e58de7ea1217b9b9680a183096fc3503bc8c5d84d926ccf'
+    sha256 '480f0c01683257879d6c2df53f50166f70e0716f3686b311fa504ee71c1db2d9'
     'uk'
   end
 
   language 'uz' do
-    sha256 'e6404f93e2c2010231eba0614f0ae1b68ec9a63963ebe24cb7b9b945721053ac'
+    sha256 'd32dc4b4ddc79f34cd735e0aaa6c46bd74063ee98308a68f670c68daaf4d3cd9'
     'uz'
   end
 
   language 've' do
-    sha256 '4621b26055945760f8377e239f935e7fd3b4c1cb6bba1bfd39a49b40057bba3e'
+    sha256 '5b1812853b0b7f854e39d9d19697a8dbb047417ecf4b8af689945cdfdaede984'
     've'
   end
 
   language 'vec' do
-    sha256 'ec5b18a31a5b850713e8f96e6ebd6729b5e4394e1d149804650ff04b8bf0a474'
+    sha256 '0b45f59328736f6c4bc6295d010fbea76e96b3b9ab613ccff9ee76b7e058575d'
     'vec'
   end
 
   language 'vi' do
-    sha256 'cc446f2162b3983413cef455183f529d2d6e3ccdf8ea562ea9011756ba7fb4d8'
+    sha256 'ca05364b39c33943a0049e3460b03071ea0167afe1b5bd6dbf4336874a994e13'
     'vi'
   end
 
   language 'xh' do
-    sha256 'f0ae31fac9b3776b37a9a557c27fc487e28ab7a7223ce3d6be1ac84590146483'
+    sha256 '80e121c05d051e5f73ac4cb028ccd57506aa99bfe913e11b83bdca4c38277c47'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'e21df39fb3d75c6ddabe0eb8b6606ed94863dff083b0cfadef9d1bccfd7ebc12'
+    sha256 'fac25eaf136cc9212f8752813eab7956fb1b4b43c7e50c5f533106ce5f8e7e74'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 'f8dea7a77199d7f8c98efbaf6a70e8f54a6b44f3cf2e551b5d2f7b5cc3f3ae0f'
+    sha256 '53cf0267fdb3b8424f7541b01a6862dae8153b42fd08e74c8c2b083f9f664281'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 'a411c2aeb9c634d737f38a38b3af578e3d2adf70cf22be1fec949709cd413d53'
+    sha256 '4596ad513b115af37174dc86383c50d9e5d9d48b40e5fb1ba1261ef80e74ee8f'
     'zu'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
