### PR TITLE
Update deezer to 4.3.4

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.2.5'
-  sha256 '018da811f6fb932cee8c7af4c89577a51bad93b6e3f5d69311965d02a151c820'
+  version '4.3.4'
+  sha256 '61e099bb5c10ce7a13284f94ef93488fea5f5d8728bb08408c9c9c49f4a252df'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.