### PR TITLE
Update marvin to 1.38.0

### DIFF
--- a/Casks/marvin.rb
+++ b/Casks/marvin.rb
@@ -1,6 +1,6 @@
 cask 'marvin' do
-  version '1.37.4'
-  sha256 'fce9293100fceacabc700e74cac4c6627074f796acf9b716962f16c0ac4b7ff6'
+  version '1.38.0'
+  sha256 '9f15a4faca0b4e01a99a44e26bbbb4db94c6a30da05cd5d8dcdf956781741be8'
 
   # s3.amazonaws.com/amazingmarvin was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/amazingmarvin/Marvin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.