### PR TITLE
Update now to 4.0.17

### DIFF
--- a/Casks/now.rb
+++ b/Casks/now.rb
@@ -1,6 +1,6 @@
 cask 'now' do
-  version '4.0.16'
-  sha256 'cabf8faf7493f8a0711ceee1cf0b528b9893ef57db0d5d25fc38a2b4ca503eaa'
+  version '4.0.17'
+  sha256 '462cf8efd05d379800961b147007cf1d45e7b89faab14c26ffd0dce0690412eb'
 
   # github.com/zeit/now-desktop was verified as official when first introduced to the cask
   url "https://github.com/zeit/now-desktop/releases/download/#{version}/Now-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.