### PR TITLE
Update workflowy to 1.2.4

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.2.3'
-  sha256 '5e0098feac4943de9e9d46f300857889385e5dc9e25d0a775853cff1f39f8063'
+  version '1.2.4'
+  sha256 '6a5e0cd4a253f7a3ce9c2da339a973a0485a4ecee3147883766219d21c4995d8'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.