### PR TITLE
Update opera to 58.0.3135.90

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '58.0.3135.79'
-  sha256 'f282273a96c9d4e5f0d9f0316d3dec9fa82341809ac1d0041fc9cd8d67cfdfea'
+  version '58.0.3135.90'
+  sha256 'f0f0c1ccfcda63fd4d49979e28d1e167eddf6fc830b43f2998d463ff6dc2c8d7'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.