### PR TITLE
Update sublime-merge to 1106

### DIFF
--- a/Casks/sublime-merge.rb
+++ b/Casks/sublime-merge.rb
@@ -1,6 +1,6 @@
 cask 'sublime-merge' do
-  version '1104'
-  sha256 'b55694b7fa5a5b223abb75eab40d66e802751a95b63e37abfee9487acf24a1bb'
+  version '1106'
+  sha256 '2a3a2e4e778b5a5b01681e39fea19d1e213de05e57552727531a4adbca52c757'
 
   # download.sublimetext.com was verified as official when first introduced to the cask
   url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.