### PR TITLE
Update bisq to 0.9.5

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '0.9.4'
-  sha256 '42d9c777464f40538f88d5efe4ffcf915126f4b1cd308772491c731be4b146b6'
+  version '0.9.5'
+  sha256 '5ece20924db7a6d979861067d991b811da02d3f367e0c4f60c5576179a4e59d2'
 
   # github.com/bisq-network/bisq-desktop was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq-desktop/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.