### PR TITLE
Update cryptobridge to 0.16.5

### DIFF
--- a/Casks/cryptobridge.rb
+++ b/Casks/cryptobridge.rb
@@ -1,6 +1,6 @@
 cask 'cryptobridge' do
-  version '0.16.4'
-  sha256 'e9e92e8f1e841eb09cb5e791d7cde7b7c4d4ea7b6631fdd443a04617a6cc1736'
+  version '0.16.5'
+  sha256 '25996b6c4728ceaf1b789da691e2e35b5e2dd385241aa6af7568fe77ff104524'
 
   url "https://github.com/CryptoBridge/cryptobridge-ui/releases/download/v#{version}/CryptoBridge-#{version}.dmg"
   appcast 'https://github.com/CryptoBridge/cryptobridge-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.