### PR TITLE
Update ganache to 1.3.1

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,6 +1,6 @@
 cask 'ganache' do
-  version '1.3.0'
-  sha256 '31d3d1282c688ae33542f78a8398650021e6280b9aa75935db051907146ab0d0'
+  version '1.3.1'
+  sha256 'f3d0d1b6bb51c568a90e0b1b12deb3fbce693d098e00a40f72cb7f57737942cc'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.