### PR TITLE
Revert "Update sublime-merge to 1106"

### DIFF
--- a/Casks/sublime-merge.rb
+++ b/Casks/sublime-merge.rb
@@ -1,6 +1,6 @@
 cask 'sublime-merge' do
-  version '1106'
-  sha256 '2a3a2e4e778b5a5b01681e39fea19d1e213de05e57552727531a4adbca52c757'
+  version '1104'
+  sha256 'b55694b7fa5a5b223abb75eab40d66e802751a95b63e37abfee9487acf24a1bb'
 
   # download.sublimetext.com was verified as official when first introduced to the cask
   url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#59929
sorry @ran-dall - this is a dev-build - 1104 too: 
https://www.sublimemerge.com/dev
can we revert this to 1103? 