### PR TITLE
Update webrecorder-player to 1.6.4

### DIFF
--- a/Casks/webrecorder-player.rb
+++ b/Casks/webrecorder-player.rb
@@ -1,6 +1,6 @@
 cask 'webrecorder-player' do
-  version '1.6.3'
-  sha256 '142a2c897246d84e9fa837691b1ab2ec15b3f2cd603aaa7a5f522ee440fa9bce'
+  version '1.6.4'
+  sha256 '11ccbe2040d53c673c38a08f6b13acec3a36c9ad0a18c3a51b86987219533dcc'
 
   url "https://github.com/webrecorder/webrecorder-player/releases/download/v#{version}/webrecorder-player-#{version}.dmg"
   appcast 'https://github.com/webrecorder/webrecorderplayer-electron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.