### PR TITLE
Update acorn to 6.3.2

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,6 +1,6 @@
 cask 'acorn' do
-  version '6.3.1'
-  sha256 '8bd173dd9e403205d08f7b5f92db51d9aacc0206f56c5bf3da108f97d761f457'
+  version '6.3.2'
+  sha256 '54a50ea516da3f64c01d2d5a5d462977c14202e43ae286186901fb65c5ed42f0'
 
   url 'https://flyingmeat.com/download/Acorn.zip'
   appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.