### PR TITLE
Update unity-vuforia-ar-support-for-editor to 2018.3.7f1,9e14d22a41bb

### DIFF
--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-vuforia-ar-support-for-editor' do
-  version '2018.3.6f1,a220877bc173'
-  sha256 '772adfa3631bd4011d33ee64b927905c0d1db9025d16a30152ad19381d460ee5'
+  version '2018.3.7f1,9e14d22a41bb'
+  sha256 'f0c8aea2cd8490c88d45e56de1433363ee57cab8e0082c08b3899b4acff23f00'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.