### PR TITLE
Update unity-linux-support-for-editor to 2018.3.7f1,9e14d22a41bb

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2018.3.6f1,a220877bc173'
-  sha256 '5c632ddfe649d8bbf2ec7ba079a277f1c92fc69c76d3e0dbf4e3f8fec53f910f'
+  version '2018.3.7f1,9e14d22a41bb'
+  sha256 'd87d6e6c8a7d6cb50cc1ecddee0037c3f6ee7996f7d8bcdf07ee063a2a8470bb'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.