### PR TITLE
Update melodics to 2.0.2714

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2694'
-  sha256 'aa787fe804204e0deec2ff2f43dba62fd0ef5f22aa0c28c1dd1bdf89764d901c'
+  version '2.0.2714'
+  sha256 '18ca95e79cc57c46c00924972e01f06fe641448cd7589c510ac7ca0dd6b3adfc'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.