### PR TITLE
Update virtualhostx to 8.6.0,80_48

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.5.2,80_46'
-  sha256 '861bb2f37c0b39ccf6c8ef97ed0e449d8d245f6670cd72da007f402ef392a129'
+  version '8.6.0,80_48'
+  sha256 '03959dd9f83d8b96e3705dddeb5afe78ec0ab9bc417f10f0f1f5d6dda52d19c4'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.