### PR TITLE
Update psychopy to 3.0.6

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '3.0.5'
-  sha256 'accc758562dccbdd69099fa4dbb8f58c82e1b1a87826daec3929bccfe46573d4'
+  version '3.0.6'
+  sha256 'e3f04f4fbd866693fa596fc1713324df34a71ef4afe0d2f32482e8250939c994'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.