### PR TITLE
Update daylite to 6.5.11

### DIFF
--- a/Casks/daylite.rb
+++ b/Casks/daylite.rb
@@ -5,8 +5,8 @@ cask 'daylite' do
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.dmg"
     pkg 'Install Daylite & Mail Assistant.pkg'
   else
-    version '6.6.3.1'
-    sha256 '923cf349c5fb5003c32fc02f1a0d3064d715689dd08010dce93e9cf0189377df'
+    version '6.6.3.2'
+    sha256 'fc49b73a961dc4814fcc6dec7179a41d0eccfaa849dcbabb3ea400fe6588f5eb'
     url "https://download.marketcircle.com/daylite/daylitedma#{version.no_dots}.pkg"
     pkg "daylitedma#{version.no_dots}.pkg"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.