### PR TITLE
Update quicken to 5.11.0,511.25626.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.10.1,510.25438.100'
-  sha256 '8e6685692e50b1c9408ebfd6ea3f0be79a1cce1b04502b8a31a461deaa9c4402'
+  version '5.11.0,511.25626.100'
+  sha256 '1d17847896247683bea41e3cfc5369b6f38c2200b7548cc939e0c9476fc59570'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.