### PR TITLE
Update fontlab to 6.1.3.7002

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,5 +1,5 @@
 cask 'fontlab' do
-  version '6.1.2.6927'
+  version '6.1.3.7002'
   sha256 'ab5079a206cb1ddda0f39889ea10ccf6bf53b5ffd5bacceabb6ace99074db2b8'
 
   url 'https://download.fontlab.com/fontlab-vi/upd-mac.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.