### PR TITLE
Update hashbackup to 2186

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,6 +1,6 @@
 cask 'hashbackup' do
-  version '2164'
-  sha256 '5e04c03e23a8e3b5036d118284fcd94a14fbcbda173799b1c3807cba73d5e9f6'
+  version '2186'
+  sha256 '1137b4b3b9aec21fb6a0cc50b2dd5cfcc21d3e245a532e61b3b7f17cb163e582'
 
   url "http://www.hashbackup.com/download/hb-#{version}-mac-64bit.tar.gz"
   name 'hashbackup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.