### PR TITLE
Update sublime-merge to 1103

### DIFF
--- a/Casks/sublime-merge.rb
+++ b/Casks/sublime-merge.rb
@@ -1,9 +1,10 @@
 cask 'sublime-merge' do
-  version '1104'
-  sha256 'b55694b7fa5a5b223abb75eab40d66e802751a95b63e37abfee9487acf24a1bb'
+  version '1103'
+  sha256 '5508dd4a797d2d869c6bac2219cd0ce542b39bcdd3ad0908449c9acae5b9489c'
 
   # download.sublimetext.com was verified as official when first introduced to the cask
   url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip"
+  appcast 'https://www.sublimemerge.com/updates/stable_update_check'
   name 'Sublime Merge'
   homepage 'https://www.sublimemerge.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.