### PR TITLE
repair touch-bar-simulator@3.0.0

### DIFF
--- a/Casks/touch-bar-simulator.rb
+++ b/Casks/touch-bar-simulator.rb
@@ -5,7 +5,7 @@ cask 'touch-bar-simulator' do
     url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch-Bar-Simulator-#{version}.dmg"
   else
     version '3.0.0'
-    sha256 '4abe55de716ae56a41031cdb1d3b27bf6b1efae18b33b80bb0419669a9a76aa1'
+    sha256 'a32089c9c52be117751e08d82e6e79474d298877754c15c02f78b1efeec88312'
     url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
   end
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I repaired touch-bar-simulator@3.0.0 for https://github.com/Homebrew/homebrew-cask/issues/59994