### PR TITLE
Update ipe to 7.2.11

### DIFF
--- a/Casks/ipe.rb
+++ b/Casks/ipe.rb
@@ -1,6 +1,6 @@
 cask 'ipe' do
-  version '7.2.10'
-  sha256 '250ed3ec9a20f630c1cdb53a1ea5650ef80b7eeac903691eb1b8db5b34be9148'
+  version '7.2.11'
+  sha256 '4d163c2c29f8a47f737205e9a2fbf41c9423c857a2168447fa776588d3b642ec'
 
   # bintray.com/otfried was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.