### PR TITLE
Update airmedia to 3.1.12

### DIFF
--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -6,6 +6,8 @@ cask 'airmedia' do
   appcast 'https://www.crestron.com/en-US/Products/Featured-Solutions/Airmedia'
   name 'Crestron AirMedia'
   homepage 'https://www.crestron.com/microsites/airmedia-mobile-wireless-hd-presentations'
+  
+  container nested: "airmedia_osx_#{version}_guest/airmedia_osx_#{version}_guest.dmg"
 
   app 'Crestron AirMedia.app'
 end

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -6,7 +6,7 @@ cask 'airmedia' do
   appcast 'https://www.crestron.com/en-US/Products/Featured-Solutions/Airmedia'
   name 'Crestron AirMedia'
   homepage 'https://www.crestron.com/microsites/airmedia-mobile-wireless-hd-presentations'
-  
+
   container nested: "airmedia_osx_#{version}_guest/airmedia_osx_#{version}_guest.dmg"
 
   app 'Crestron AirMedia.app'

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -1,9 +1,9 @@
 cask 'airmedia' do
-  version '3.1.3'
-  sha256 '7e36017df29860cfc7bf613b1da160cdab80f633fa5f21f6f734eca933a1dda4'
+  version '3.1.12'
+  sha256 '809d193a9f71494734be57b3bebc2912f284acd88f4bc408486ef6fb6951522d'
 
-  # p.widencdn.net/c0b4qy was verified as official when first introduced to the cask
-  url "https://p.widencdn.net/c0b4qy/software_airmedia_macOS_#{version}_guest.dmg"
+  url "https://www.crestron.com/getmedia/751a3c59-a9a8-49b8-ac28-4989da4dc2e1/airmedia_osx_#{version}_guest"
+  appcast 'https://www.crestron.com/en-US/Products/Featured-Solutions/Airmedia'
   name 'Crestron AirMedia'
   homepage 'https://www.crestron.com/microsites/airmedia-mobile-wireless-hd-presentations'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.