### PR TITLE
Update nvidia-geforce-now to 2.0.4.28

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.4.25'
-  sha256 '49b552e1aa8626bbddd1f7993416dd15e535a5f3abbd1d44195fb31aa8076fcf'
+  version '2.0.4.28'
+  sha256 'f75a58baf353940c53e053d1c14958d57b7e58d69ce9711da5a99583d10bae96'
 
   url 'https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg'
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.