### PR TITLE
Update unity to 2018.3.8f1,fc0fe30d6d91

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2018.3.7f1,9e14d22a41bb'
-  sha256 'd5ec4df6a8699e812d0f7b7f32881917f3cfb388e128952e502239a0ed3ccab8'
+  version '2018.3.8f1,fc0fe30d6d91'
+  sha256 'ccb90ca90b6a68c936b32195e394205c55760e02c5a1adf4e84946b909a907d3'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.