### PR TITLE
Update flipper to 0.17.1

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.17.0'
-  sha256 '81570109a92a6b90d4d5d2f5a443038b7ff5360fdccc394c676e590092b3bd47'
+  version '0.17.1'
+  sha256 'adde4f8605f0c3e3f026b955dce16a9cf547b5b4b95ad4c81d4f81701cf9c880'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.