### PR TITLE
Update camtasia to 2018.0.9,161

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,6 +1,6 @@
 cask 'camtasia' do
-  version '2018.0.9,159'
-  sha256 '3e142e510478666607f7e1b7e523f7bf685b2c1e8f89a7bb8b5fe8e25c0b91be'
+  version '2018.0.9,161'
+  sha256 '95c81c267ed4b6b9abc4a7a9885ad5f53cc749ca2719fdfb303331bb94048b49'
 
   # rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/5d440dc130030d8a5db2ee6265d8df09/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.