### PR TITLE
Update permute to 3.1.4,2102

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.1.3,2098'
-  sha256 '592685e98b120d5a0abe88f836974d7bc4fddfdc5ee5fd981f46cd6c2b9960f8'
+  version '3.1.4,2102'
+  sha256 '7c602dcc1295366f2ed2c86c97d9ca59ba03e16e42c6539f35fe95dd831f8fb0'
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.