### PR TITLE
Update rotato to 62.1552052042

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '59.1551366700'
-  sha256 'f71b344efb8cb75e0a0300aea4c53daea4a97c6f1f9c870f3a48dda992ab0705'
+  version '62.1552052042'
+  sha256 '29447c02bb1a0f887b2d5b39fb6578cea295b7f846253de0a832d1f40c5269b4'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.