### PR TITLE
Add cuteNTR Cask

### DIFF
--- a/Casks/cutentr.rb
+++ b/Casks/cutentr.rb
@@ -2,7 +2,8 @@ cask 'cutentr' do
   version '0.3.2'
   sha256 '4a418c7e7a8baad9c64b6ec9730421b9a5411e1c8e2183d610fc9a3e6e634e8c'
 
-  url 'https://github.com/EBLeifEricson/cuteNTR-OSX/releases/download/0.3.2/cuteNTR-0.3.2.dmg'
+  url "https://github.com/EBLeifEricson/cuteNTR-OSX/releases/download/#{version}/cuteNTR-#{version}.dmg"
+  appcast 'https://github.com/EBLeifEricson/cuteNTR-OSX/releases.atom'
   name 'cuteNTR'
   homepage 'https://github.com/EBLeifEricson/cuteNTR-OSX'
 

--- a/Casks/cutentr.rb
+++ b/Casks/cutentr.rb
@@ -1,0 +1,10 @@
+cask 'cutentr' do
+  version '0.3.2'
+  sha256 '4a418c7e7a8baad9c64b6ec9730421b9a5411e1c8e2183d610fc9a3e6e634e8c'
+
+  url 'https://github.com/EBLeifEricson/cuteNTR-OSX/releases/download/0.3.2/cuteNTR-0.3.2.dmg'
+  name 'cuteNTR'
+  homepage 'https://github.com/EBLeifEricson/cuteNTR-OSX'
+
+  app 'cuteNTR.app'
+end


### PR DESCRIPTION
This pull request adds a Cask for the NTR Streaming Client cuteNTR. It's a fork for macOS. The cask works as expected and if the app is eligible for inclusion can be merged without an issue. I use this tool to get a video feed from my Nintendo 3DS on my Mac, it'd be cool to have it included as a cask 😄 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
