### PR TITLE
Update fluor to 2.1.0

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,6 +1,6 @@
 cask 'fluor' do
-  version '2.0.2'
-  sha256 'a1a90ca6b1cb4194f08ba29181331fdfd2786e99ae6d684fcb9e1a0034915753'
+  version '2.1.0'
+  sha256 '92034b630bf5a19eca160054c780a3c1767f21def3c02f28787f79fed5fab757'
 
   # pyrolyse.it was verified as official when first introduced to the cask
   url "https://resources.pyrolyse.it/distrib/Fluor/Fluor%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.