### PR TITLE
Update avidemux to 2.7.2

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,9 +1,9 @@
 cask 'avidemux' do
-  version '2.7.1'
-  sha256 'e45507e8f4fd501061136956527f0a9492c18254547d5dec3c38dce91aea2db6'
+  version '2.7.2'
+  sha256 '0418e55697da2a362fab3f62c8efd3ebf16ba627b40152fd5cf19126f83ff54d'
 
   # sourceforge.net/avidemux was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_HighSierra_64Bits_Qt5.dmg"
+  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Mojave_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.