### PR TITLE
Revert "Update prusa-slic3r to 1.42.0-alpha7,201903011807"

### DIFF
--- a/Casks/prusa-slic3r.rb
+++ b/Casks/prusa-slic3r.rb
@@ -1,6 +1,6 @@
 cask 'prusa-slic3r' do
-  version '1.42.0-alpha7,201903011807'
-  sha256 '2e786059c796067150ee7a4922e9b844a2ae9d89c74ce8714afefdef0c7e75e3'
+  version '1.41.3,201902131031'
+  sha256 '449ff5da4dd0bddfd5ba13b57f70fa3e844a16085b11ba400a45a953fd4245bc'
 
   # github.com/prusa3d/Slic3r was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/Slic3r/releases/download/version_#{version.before_comma}/Slic3rPE-#{version.before_comma}+full-#{version.after_comma}.dmg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#59763
this was a mistake - although this release is marked as "latest release", 1.42 is an alpha branch - the stable branch is 1.41 - the developer even writes "Note that this is unrelated to the developement of version 1.42.0."  sorry for that! 
https://github.com/prusa3d/Slic3r/releases
