### PR TITLE
Update altair-graphql-client to 2.1.2

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.1.1'
-  sha256 '227e9ec4c140b2f086e976ac48dc80a7cebf076144c97fd959892a223bc1d2b8'
+  version '2.1.2'
+  sha256 '28d7237a9595db776d57fac2ac7a8572bcd6aa0dfe1160f44a6a92b27da9005b'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.