### PR TITLE
Update marginnote to 3.2.5006,1551969214

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,6 +1,6 @@
 cask 'marginnote' do
-  version '3.2.3004,1550966909'
-  sha256 'e1a6310697973fe8bc8372c610bb2b4d1e97d7fd9df500172199244de150b256'
+  version '3.2.5006,1551969214'
+  sha256 '05f8136d7249784ee6bdcdcfed1c4b842215972e34ac5e72896207f274123152'
 
   # dl.devmate.com/QReader.MarginStudyMac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/QReader.MarginStudyMac/#{version.before_comma}/#{version.after_comma}/MarginNote#{version.major}-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.