### PR TITLE
Update openscad to 2019.01-RC3

### DIFF
--- a/Casks/openscad.rb
+++ b/Casks/openscad.rb
@@ -1,6 +1,6 @@
 cask 'openscad' do
-  version '2015.03-3'
-  sha256 '1f2e8e52e04bbb6d3b2c8699d314d1ca28d2fcf68164eca7d0a20e248cee01a7'
+  version '2019.01-RC3'
+  sha256 '3569408dae9073adfd2336cda256deecb74ec0afaffcc5b79ccaa765124fc10e'
 
   url "http://files.openscad.org/OpenSCAD-#{version}.dmg"
   appcast 'http://files.openscad.org/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.