### PR TITLE
Update zotero to 5.0.61

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.60'
-  sha256 '8a62c4e73abeae1bb552c522fd51be31ce6f490d2657a8317faf1255e654c07e'
+  version '5.0.61'
+  sha256 'e66b583b5802802c5207f1ece7a90ec061f10e9c8b98c3cd7dd3c6dfecf1fc12'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.