### PR TITLE
Update understand to 5.1.978

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.977'
-  sha256 '116f3a3a2fe04a22e88a08678a0d6c2391ea2406a99e8f3f456fb2c5390c38cd'
+  version '5.1.978'
+  sha256 'b0064c3016cd3209bc006b9341f454c382eb17a2c3446ebd3fc68531fd821762'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.