### PR TITLE
Update netron to 2.9.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.9.3'
-  sha256 '63668663a4dcadb56b29ee95e05ea88c4d8b0e6de9fcd02e39ddb46f91ce822f'
+  version '2.9.4'
+  sha256 '5cbae9ac1d88183d3912d46e821e8fff171126730ca7cb839f2dafcf132e8f15'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.