### PR TITLE
Update jitouch to latest version of Mojave

### DIFF
--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -3,15 +3,17 @@ cask 'jitouch' do
   sha256 :no_check
 
   if MacOS.version <= :mavericks
-    url 'http://www.jitouch.com/jitouch_mavericks.zip'
+    url 'https://www.jitouch.com/jitouch_mavericks.zip'
   elsif MacOS.version <= :el_capitan
-    url 'http://www.jitouch.com/jitouch_el_capitan.zip'
+    url 'https://www.jitouch.com/jitouch_el_capitan.zip'
+  elsif MacOS.version <= :sierra
+    url 'https://www.jitouch.com/jitouch_sierra.zip'
   else
-    url 'http://www.jitouch.com/jitouch_sierra.zip'
+    url 'https://www.jitouch.com/jitouch_mojave.zip'
   end
 
   name 'jitouch'
-  homepage 'http://www.jitouch.com/'
+  homepage 'https://www.jitouch.com/'
 
   prefpane 'jitouch/Jitouch.prefPane'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
