### PR TITLE
Update whatroute to 2.2.1

### DIFF
--- a/Casks/whatroute.rb
+++ b/Casks/whatroute.rb
@@ -1,6 +1,6 @@
 cask 'whatroute' do
-  version '2.2.0'
-  sha256 '96989c5398dc9d46950fadb34e06bb4f93a739cf5e0dafe1ca1a369cf03cfde9'
+  version '2.2.1'
+  sha256 '11067888af1cdc72d6aed04edcf380745b172a1da408b49c07ea4571f65bb284'
 
   url "https://downloads.whatroute.net/software/whatroute-#{version}.zip"
   appcast "https://www.whatroute.net/whatroute#{version.major}appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.