### PR TITLE
Update lunar to 2.2.0

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.2.1'
-  sha256 '9905de514eead837380110fd9828e36ac6693ca4f9d6fbb94273d4021996e04e'
+  version '2.2.0'
+  sha256 'eec7d26743c27a304d99206380150404a0ab9f07b2c9e610c55dc20be2d6d350'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.