### PR TITLE
Update polar-bookshelf to 1.13.12

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.13.11'
-  sha256 'f1b8e17d370fa8aac4376dec4a7953f8c8f63d16dff90736565ce73a03f2546e'
+  version '1.13.12'
+  sha256 '54b7f2a4c955f4441173413ea59383b315f5e0c0f5254e2b40191bfc4b36c8ba'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.