### PR TITLE
Update wordmark to 3.0.1-beta.19

### DIFF
--- a/Casks/wordmark.rb
+++ b/Casks/wordmark.rb
@@ -1,6 +1,6 @@
 cask 'wordmark' do
-  version '3.0.1-beta.18'
-  sha256 'f19410eed783e9b84d877fc843c52a352c6867e4406830735b3fbfa6e84e78e1'
+  version '3.0.1-beta.19'
+  sha256 'b9849fae63c3236632677a95b2720a156630c29460d448c035e17086c8c7d66e'
 
   # github.com/wordmark/wordmark was verified as official when first introduced to the cask
   url "https://github.com/wordmark/wordmark/releases/download/v#{version}/wordmark-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.