### PR TITLE
Update toptracker to 1.5.9.6399

### DIFF
--- a/Casks/toptracker.rb
+++ b/Casks/toptracker.rb
@@ -1,6 +1,6 @@
 cask 'toptracker' do
-  version '1.5.8.6185'
-  sha256 '7da3130bc20023780af8a2abc7cfa8b89e90275a6eaa8f61fcdc0b914024b2b0'
+  version '1.5.9.6399'
+  sha256 'e150d5463e32db0cc41bb56b982e8e0f4a5a0dda120115ddbe4e4a61471c06d3'
 
   # d101nvfmxunqnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d101nvfmxunqnl.cloudfront.net/desktop/builds/mac/toptracker_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.