### PR TITLE
Update flash-npapi to 32.0.0.156

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '32.0.0.142'
-  sha256 '305b452c0dcf36b9ddc526804e25d7a0913250769b57150ee69062fdc99ccc80'
+  version '32.0.0.156'
+  sha256 '37d236e071f66727cf0b900352faf457c043a2776a1d791df2dc3984ae0172ce'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.