### PR TITLE
Update chromium to 639865

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '639356'
-  sha256 '2852113fbf2fe5ff5c22007bd35053654d4a4160722fc43ba3fbb4f9ad655592'
+  version '639865'
+  sha256 '6c02e2be1fd68b518010d932a38a6efd5df945d33e6c4bd57b546ab97c5db62e'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.