### PR TITLE
Update nucleo to 2.5.4

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,6 +1,6 @@
 cask 'nucleo' do
-  version '2.5.3'
-  sha256 '6a5634d12710ca4d1fea73262097529460b551eacd2faf3135ec7598a3019298'
+  version '2.5.4'
+  sha256 'a06d37b19fd6bef6d9e32121b1651251619c9341b5f1bed58384a6813e48d0c1'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.