### PR TITLE
Update pomodone to 1.5.1527

### DIFF
--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -1,6 +1,6 @@
 cask 'pomodone' do
-  version '1.5.1523'
-  sha256 '729d7aa3b392e605d1dae46aec789d28d7f1af51197182e022900cfd46278ff5'
+  version '1.5.1527'
+  sha256 '66a1f74b77b4d71227e6bfab953ccd5b90b70720965460de1b62c22de59124c7'
 
   url "https://app.pomodoneapp.com/installers/PomoDoneApp-#{version}.dmg"
   appcast 'https://pomodoneapp.com/download-pomodone-app.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.