### PR TITLE
Update disk-drill to 3.7.932

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,6 +1,6 @@
 cask 'disk-drill' do
-  version '3.7.929'
-  sha256 '876c3ce3bbe70c57f4bc7108ed03db98a18a6b1e56d77a0c309437cc03d54482'
+  version '3.7.932'
+  sha256 '870be28a0ac95d4277f1f30c59c12a68019110c081dc75ab13dffc79623934de'
 
   url "https://www.cleverfiles.com/releases/DiskDrill_#{version}.zip"
   appcast 'https://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.