### PR TITLE
Update pagico to 8.17.2382

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '8.17.2379'
-  sha256 'b0639118bf30129e9d11277ac596bc2f50c5192ff05c9a2b78ba849ae8a87678'
+  version '8.17.2382'
+  sha256 '2902e07bf12da5d4b48cceaa8a2992aa3a8364e19499d4a09a9124cf2cb92566'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast 'https://www.pagico.com/api/pagico8.mac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.