### PR TITLE
Update activedock to 208,1552390975

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '201,1548428976'
-  sha256 '897fae532b34a895e74dd021378867472b7b1c17199a967ed0a3778e4faeb006'
+  version '208,1552390975'
+  sha256 '63ed167955c73d5cf5d7f5518d52ba4881a7c41e18916a354622504badcfe89d'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.