### PR TITLE
Update bookmacster to 2.9.9

### DIFF
--- a/Casks/bookmacster.rb
+++ b/Casks/bookmacster.rb
@@ -1,6 +1,6 @@
 cask 'bookmacster' do
-  version '2.9.8'
-  sha256 '19eadbdb10bc452104b065fd5eb73e37020585720cc531bf3bdc846eed8e04f1'
+  version '2.9.9'
+  sha256 '60a4bb74f69783c669346276536a33180a0c20f30e285c38da8fe67855af0771'
 
   url 'https://sheepsystems.com/bookmacster/BookMacster.zip'
   appcast 'https://sheepsystems.com/bookmacster/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.