### PR TITLE
Update droplr to 5.6.1,233

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version '5.6.0,232'
-  sha256 '243f69ad61fc5a2656b142df666704f8f1b5455a0f4cad1ddb506731cf4a4189'
+  version '5.6.1,233'
+  sha256 '6a1fc57a572a5422f51ba79cc04b39c4315bd1428ee007e3ae7862f2a5484953'
 
   url "https://files.droplr.com/apps/mac/Droplr+#{version.after_comma}.zip"
   appcast 'https://droplr.com/appcast/appcast-sandbox.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.