### PR TITLE
Update melodics to 2.0.2717

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2714'
-  sha256 '18ca95e79cc57c46c00924972e01f06fe641448cd7589c510ac7ca0dd6b3adfc'
+  version '2.0.2717'
+  sha256 '665120fa24cfcd7834d0f94d864d43620fe810233970a29d86eefe0b4e90486a'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.