### PR TITLE
Update preference-manager to 4.4.3.0

### DIFF
--- a/Casks/preference-manager.rb
+++ b/Casks/preference-manager.rb
@@ -1,6 +1,6 @@
 cask 'preference-manager' do
-  version '4.4.2.0'
-  sha256 'b39ece3b79d5d72987abf0aa79b8d5fcb996dfd29dff6016f37c3529fd3ecefd'
+  version '4.4.3.0'
+  sha256 '4920d80e09bf5e492a930896068352c4f08b3764ce723b7c13000e8b1d04ae15'
 
   url "https://www.digitalrebellion.com/download/prefman?version=#{version.no_dots}"
   appcast 'https://www.digitalrebellion.com/rss/appcasts/pref_man.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.