### PR TITLE
Update neteasemusic to 2.0.0_722

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -4,7 +4,7 @@ cask 'neteasemusic' do
 
   # d1.music.126.net was verified as official when first introduced to the cask
   url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://music.163.com/api/osx/download/latest'
+  appcast 'https://music.163.com/api/mac/appcast.xml'
   name 'NetEase cloud music'
   name '网易云音乐'
   homepage 'https://music.163.com/'

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,10 +1,10 @@
 cask 'neteasemusic' do
-  version '2.0.0_700'
-  sha256 '7c63a7c9759f9ee38db5889fed22e1afebbea8225b5a6d6ad9fece961f2d746d'
+  version '2.0.0_722'
+  sha256 '805ddb48ee261718ce59b2a493707aef421df263da1dc2955627e6db9954bf27'
 
   # d1.music.126.net was verified as official when first introduced to the cask
   url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg"
-  appcast 'https://music.163.com/api/mac/appcast.xml'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://music.163.com/api/osx/download/latest'
   name 'NetEase cloud music'
   name '网易云音乐'
   homepage 'https://music.163.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.