### PR TITLE
Update zoho-mail to 1.0.12

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,8 +1,9 @@
 cask 'zoho-mail' do
-  version '1.0.11'
-  sha256 '02738c978d43974e49c7bd794a6ffc51ed51862cd04472016ba558f21bffa4de'
+  version '1.0.12'
+  sha256 '47e98f1ec76cf9ed8cd397464068824bf6b9ac0c88adf83bc7ef1c4ccd149d4f'
 
   url "https://www.zoho.com/mail/desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"
+  appcast 'https://www.zoho.com/mail/desktop/artifacts.json'
   name 'Zoho Mail'
   homepage 'https://www.zoho.com/mail/desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.