### PR TITLE
Update splice to 3.4.3

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,6 +1,6 @@
 cask 'splice' do
-  version '3.4.2'
-  sha256 'd55d7a063238eb4e43a084699ded0e2720934e39fafcbc43f74abd6c5df80745'
+  version '3.4.3'
+  sha256 '9e1ee52719b269921eda48fe53e42219c3f94e119b96bf43648ece269069f9d0'
 
   # splicedesktop.s3-us-west-1.amazonaws.com was verified as official when first introduced to the cask
   url 'https://splicedesktop.s3-us-west-1.amazonaws.com/darwin/stable/Splice.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.