### PR TITLE
Update google-chrome to 73.0.3683.75

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,6 +1,6 @@
 cask 'google-chrome' do
-  version '72.0.3626.121'
-  sha256 'ba04c1a3567aecf960370b8c241c6b9e546ef79ac4115919373a0d1f07770324'
+  version '73.0.3683.75'
+  sha256 'b8db2aad8a22f28a6204646c3c298555b52784153c27bc4b3edc620f535f5fce'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
   appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.