### PR TITLE
Update trilium-notes to 0.30.5

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.30.4'
-  sha256 '8879710a4688dcc3c4fac61a33145d3bbc2d68d5077984706ccf85ed9beb02ba'
+  version '0.30.5'
+  sha256 'ddc9bf355925ca679466913af4574277f5b334b67a639a1f9ed8b8055e17aa1a'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.