### PR TITLE
Update local-by-flywheel 3.0.4 SHA256

### DIFF
--- a/Casks/local-by-flywheel.rb
+++ b/Casks/local-by-flywheel.rb
@@ -1,6 +1,6 @@
 cask 'local-by-flywheel' do
   version '3.0.4'
-  sha256 '77b58d1ced72cdfd06399fb1955b9cf36040761e0c92ffdb438bec1e5dffc93e'
+  sha256 '42401cf26f40be2f50f83e63dbff6d0d7fc65712d26044848020a38b13f3f3d5'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-by-flywheel-#{version.dots_to_hyphens}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download local-by-flywheel` is error-free.
- [ ] `brew cask style --fix local-by-flywheel` reports no offenses. _(Skipped, I fought with installing Nokogiri for 30 minutes and thew in the towel considering the change was so simple.)_
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
