### PR TITLE
Add pointer to HOMEBREW_DEVELOPER setting in Contributing doc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ $ git remote add "${github_user}" "https://github.com/${github_user}/homebrew-ca
 
 4: Switch to a new branch (ie. `new-feature`), and work from there: `git checkout -b new-feature`.
 
+5: You will probably also want to set `export HOMEBREW_DEVELOPER=1`.  This variable prevents Homebrew from switching to the `master` branch every time, among other things.
+
 
 ## Adding a Cask
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ $ git remote add "${github_user}" "https://github.com/${github_user}/homebrew-ca
 4: Switch to a new branch (ie. `new-feature`), and work from there: `git checkout -b new-feature`.
 
 5: You will probably also want to set `export HOMEBREW_DEVELOPER=1`.  This variable prevents Homebrew from switching to the `master` branch every time, among other things.
+See also [Testing your new Cask](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#testing-your-new-cask).
 
 
 ## Adding a Cask


### PR DESCRIPTION
I found it counter-intuitive that `brew cask` tried to switch to the Git `master` branch while i was trying to do development on a new Cask.  I think it might be good to include a pointer in the Contributing docs to avoid others having issues similar to mine in #60241.

I'd love to add a link from here to somewhere where the `HOMEBREW_DEVELOPER` variable is explained.  The `man brew` text is very brief and IMHO didn't help me discover my own error:

       HOMEBREW_DEVELOPER
              If set, Homebrew will tweak behaviour to be more relevant for Homebrew developers (active  or  bud-
              ding), e.g. turning warnings into errors.

Comments?