### PR TITLE
Update screaming-frog-seo-spider to 11.1

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -1,6 +1,6 @@
 cask 'screaming-frog-seo-spider' do
-  version '11.0'
-  sha256 '9512a518b67f1b98b2066016afba63d49cd3699cc68e5832fd3bcae33ab6ceb6'
+  version '11.1'
+  sha256 'b9655712d2791e6085c3bbb67d7ac3096baa3854bfb697582b2c30e27bc933a7'
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.