### PR TITLE
Update geogebra to 6.0.529.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.526.0'
-  sha256 '2c187a9c22d38dfbf7630b0eda2935049054891950232fd4e4888373f5668b0a'
+  version '6.0.529.0'
+  sha256 '3acabda73fffcbe4349f6d4384bc3ba709750aec80063b378fb5bcd89bd9922b'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.