### PR TITLE
Add Psi+ 1.4.567-macOS10.12

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -2,7 +2,7 @@ cask 'psi-plus' do
   version '1.4.592-macOS10.12'
   sha256 '4c21592fa26a55bfbdc2b1da146ba1d347d56b8801ad44eeac2b412848093643'
 
-  # sourceforge.net/psiplus was verified as official when first introduced to the cask
+  # downloads.sourceforge.net/psiplus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"
   appcast 'https://sourceforge.net/projects/psiplus/rss'
   name 'Psi+'

--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,0 +1,20 @@
+cask 'psi-plus' do
+  version '1.4.592-macOS10.12'
+  sha256 '4c21592fa26a55bfbdc2b1da146ba1d347d56b8801ad44eeac2b412848093643'
+
+  # sourceforge.net/psiplus was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"
+  appcast 'https://sourceforge.net/projects/psiplus/rss'
+  name 'Psi+'
+  homepage 'https://psi-plus.com/'
+
+  app 'Psi+.app'
+
+  uninstall quit: 'com.psi-plus'
+
+  zap trash: [
+               '~/Library/Saved Application State/com.psi-plus.savedState',
+               '~/Library/Caches/Psi+',
+               '~/Library/Application Support/Psi+',
+             ]
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Please note that `-macOS10.12` is part of version and may be changed any time in the future.

This PR is currently marked as `[Work in Progress]` because SHA-256 checksum for Cask 'psi-plus' is different each time after download from SF and it differs from original file. I have to find out what is wrong with this project on SF. Any comments are welcome!