### PR TITLE
Update gisto to 1.10.28

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.10.27'
-  sha256 'de291bb8ecd5b29f4b6aee3cfedffbe5673c191e143f62c3abb3bc54495c15a7'
+  version '1.10.28'
+  sha256 '62e292a946adc7536e11d4477e5114abada38c4417a2adcc23902c25a1942f0a'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.