### PR TITLE
Update tiled to 1.2.3

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,6 +1,6 @@
 cask 'tiled' do
-  version '1.2.2'
-  sha256 '1b9f5e33b4b3e95bca7df6761c9c92944d03bab684056de7be5032d5b50251e3'
+  version '1.2.3'
+  sha256 '07fbfd3a035117763745eb42bca6f6255deb7abfcc3dc47ea60d15e3a4ec1aa1'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/Tiled-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.