### PR TITLE
Update zotero to 5.0.62

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.61'
-  sha256 'e66b583b5802802c5207f1ece7a90ec061f10e9c8b98c3cd7dd3c6dfecf1fc12'
+  version '5.0.62'
+  sha256 'e8d7fea76050f0a9f4ef917ab73051af065f5bbf64407e832e914c740b6697e1'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.