### PR TITLE
Update default-folder-x to 5.3.5

### DIFF
--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -1,6 +1,6 @@
 cask 'default-folder-x' do
-  version '5.3.4'
-  sha256 'ff61ed0758a67875e8510f161861110cc328fe9ad1cf24c385da2e9a073e3d82'
+  version '5.3.5'
+  sha256 '514afdb151681db8e9ee4332f8023ec6b05eed3e050b15229b1bf8741c5fc980'
 
   url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?DX5'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.