### PR TITLE
Update hubstaff to 1.4.4,556fe980

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,5 +1,5 @@
 cask 'hubstaff' do
-  version '1.4.2,8d78ff24'
+  version '1.4.4,556fe980'
   sha256 'b388bede05079f2e0bb9f8804846c010c70b47263c7cd23a893a2f62f135ee99'
 
   url "https://app.hubstaff.com/download/344-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.