### PR TITLE
Update tableplus to 2.0,200

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,5 +1,5 @@
 cask 'tableplus' do
-  version '1.6,200'
+  version '2.0,200'
   sha256 '5a9d2452a71227a030937f82cedd14a685fdf853f33829215b2f7a9eedf7492e'
 
   # s3.amazonaws.com/tableplus-osx-builds was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.