### PR TITLE
Update mimolive to 4.7.2-26993

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,6 +1,6 @@
 cask 'mimolive' do
-  version '4.7.1-26979'
-  sha256 '8ada458d875dbaa608794032d5fabc04d1293003211a9f74181f567d6bfef674'
+  version '4.7.2-26993'
+  sha256 '9905d42f36a4fe4480d155448627a5cba266ce67b8dd3c671a643b40a904d122'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://sparkle.boinx.com/appcast.lasso?appName=mimoLive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.