### PR TITLE
Update mailbutler to 2,1405-10837

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,9 +1,9 @@
 cask 'mailbutler' do
-  version '2.2.7-10748'
-  sha256 '5392628de8f7ab72234bf1547f2a43c19dad4634af996d85acd14eec6979b730'
+  version '2,1405-10837'
+  sha256 '0210927c43b279eb253ba31fe502773352db313c94ff2942700f0ae693145bb6'
 
   # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://mailbutler-data.s3.amazonaws.com/downloads/Mailbutler_#{version}.zip"
+  url "https://downloads.mailbutler.io/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"
   name 'MailButler'
   homepage 'https://www.mailbutler.io/'

--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -2,7 +2,6 @@ cask 'mailbutler' do
   version '2,1405-10837'
   sha256 '0210927c43b279eb253ba31fe502773352db313c94ff2942700f0ae693145bb6'
 
-  # mailbutler-data.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://downloads.mailbutler.io/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"
   name 'MailButler'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.