### PR TITLE
Update sip to 2.0.3

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -3,8 +3,8 @@ cask 'sip' do
     version '1.1.6'
     sha256 'bb170a54090aab5703388a3e7a22e9cf4e4d98e84f5658893e1e6f9677b9a51e'
   else
-    version '2.0.2'
-    sha256 'd8392735488ef31895e088b6651577c77bfd9f754699cb4da520e006ee73bd46'
+    version '2.0.3'
+    sha256 '86b1eb0f07d2345b49baa84e8b51578bf30a74938f411970fc8d6fef72ffd90b'
   end
 
   url "https://sipapp.io/updates/v#{version.major}/sip-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.