### PR TITLE
Update subler to 1.5.10

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask 'subler' do
-  version '1.5.9'
-  sha256 '7b7f3a266aee35dad7f38c56d2820cc2536728a00e92bbace4fbc22f212e1939'
+  version '1.5.10'
+  sha256 '4bf6c2663768b81efcbe9533c8fac938aa704a7a8e50dd8ac394721b3bf88772'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.