### PR TITLE
Update cacher to 2.6.4

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.6.3'
-  sha256 '99db7193e8a8e846286507fadfef16df4234f714e3bd72b5d2d4d3658cbdd0dc'
+  version '2.6.4'
+  sha256 '8e04c2a980668f22cd58fc1692c2c167eb7c2d6f875b50c0eb22e5149539735f'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.