### PR TITLE
Update xronomorph to 1.5.1

### DIFF
--- a/Casks/xronomorph.rb
+++ b/Casks/xronomorph.rb
@@ -3,6 +3,7 @@ cask 'xronomorph' do
   sha256 '99a1c4fb47b2da9eeaa5fc3a65d7534c0799f7cac0b9a3086273c993a481b85b'
 
   url "https://www.dynamictonality.com/dl/XronoMorph_#{version}_macOS.zip"
+  appcast 'https://www.dynamictonality.com/xronomorph.htm'
   name 'XronoMorph'
   homepage 'https://www.dynamictonality.com/xronomorph.htm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.