### PR TITLE
Update wraparound to 2.0b3-2020

### DIFF
--- a/Casks/wraparound.rb
+++ b/Casks/wraparound.rb
@@ -3,6 +3,7 @@ cask 'wraparound' do
   sha256 '6b7626af484bc6070cb822197dbe22014b3a1433ac072caf57d5272ada2437f2'
 
   url "https://www.digicowsoftware.com/downloads/Wraparound#{version}.zip"
+  appcast 'https://www.digicowsoftware.com/detail?_app=Wraparound'
   name 'Wraparound'
   homepage 'https://www.digicowsoftware.com/detail?_app=Wraparound'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.