### PR TITLE
Update worksnaps-client to 1.1.20180604-2

### DIFF
--- a/Casks/worksnaps-client.rb
+++ b/Casks/worksnaps-client.rb
@@ -4,6 +4,7 @@ cask 'worksnaps-client' do
 
   # worksnaps-download.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://worksnaps-download.s3.amazonaws.com/WSClient-mac-10.9-#{version}.dmg"
+  appcast 'https://www.worksnaps.net/www/download.shtml'
   name 'Worksnaps Client'
   homepage 'https://www.worksnaps.net/www/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.