### PR TITLE
Update workcraft to 3.2.2

### DIFF
--- a/Casks/workcraft.rb
+++ b/Casks/workcraft.rb
@@ -1,8 +1,9 @@
 cask 'workcraft' do
-  version '3.2.0'
-  sha256 '36b20f6b6fa188a3de112cbd60d9fdcc0cbedb3d8932fac4a532afe1ed6d31c2'
+  version '3.2.2'
+  sha256 '8a0829d768dbf84402645b1cf3b68b4ca5cd27843ad8619cf68e7dd086efe7c3'
 
   url "https://www.workcraft.org/_media/download/workcraft-v#{version}-osx.tar.gz"
+  appcast 'https://github.com/workcraft/workcraft/releases.atom'
   name 'Workcraft'
   homepage 'https://www.workcraft.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.