### PR TITLE
Update wingide to 6.1.5-1

### DIFF
--- a/Casks/wingide.rb
+++ b/Casks/wingide.rb
@@ -3,6 +3,7 @@ cask 'wingide' do
   sha256 '755d9a50e4ac2f70c7cc8ba763adfa510805a9cd51876781a0e72587129df3fb'
 
   url "https://wingware.com/pub/wingide/#{version.sub(%r{-\d+}, '')}/wingide-#{version}.dmg"
+  appcast 'https://www.wingware.com/downloads/wing-pro'
   name 'WingIDE'
   homepage 'https://www.wingware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.