### PR TITLE
Update widgetrunner to 1.0.3

### DIFF
--- a/Casks/widgetrunner.rb
+++ b/Casks/widgetrunner.rb
@@ -3,6 +3,7 @@ cask 'widgetrunner' do
   sha256 'dba26a4e3dfd03c0f7718eaab678c781d66d04b36a4cb69b07adb15275fbdcc5'
 
   url "http://db.csail.mit.edu/madden/WidgetRunner/widgetrunner#{version.no_dots}.zip"
+  appcast 'http://db.csail.mit.edu/madden/WidgetRunner/'
   name 'WidgetRunner'
   homepage 'http://db.csail.mit.edu/madden/WidgetRunner/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.