### PR TITLE
Update wechatwork to 2.7.5.2089

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,8 +1,9 @@
 cask 'wechatwork' do
-  version '2.7.0.1070'
-  sha256 '5ab535fc19afe9404e9f9c4fb4025378b764146273a43b327ae698eb70ac10c1'
+  version '2.7.5.2089'
+  sha256 'c34c78a73b585a583d8ed049f22c5d67c2aad97368f3d8fb022dda5cd59112ef'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'
   name 'WeChat Work'
   name '企业微信'
   homepage 'https://work.weixin.qq.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.