### PR TITLE
Update wechatwebdevtools to 1.02.1902010

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -3,6 +3,7 @@ cask 'wechatwebdevtools' do
   sha256 '71bbdc0325f52a9cff976f008413642505e9156f36e022d26894b78a776a100f'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.2.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://servicewechat.com/wxa-dev-logic/download_redirect%3Ftype=darwin%26from=mpwiki'
   name 'wechat web devtools'
   name '微信web开发者工具'
   homepage 'https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.