### PR TITLE
update to sencha 6.7.0.63

### DIFF
--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -1,6 +1,6 @@
 cask 'sencha' do
-  version '6.7.0.37'
-  sha256 '1965691742306653212696556774c8cfc702aa821898b433840a5b96ded6d5ea'
+  version '6.7.0.63'
+  sha256 '3e888afb613223a7584376fc63c68f06eb6010a996eca82ee7a2e0d78b6658f3'
 
   url "https://cdn.sencha.com/cmd/#{version}/jre/SenchaCmd-#{version}-osx.app.zip"
   name 'Sencha Cmd'


### PR DESCRIPTION
update to most recent build version as it is required to build most recent ExtJS 6.7.0.210

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).