### PR TITLE
Update radiant-player to 1.12.0

### DIFF
--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -1,6 +1,6 @@
 cask 'radiant-player' do
-  version '1.11.7'
-  sha256 'ef22d4b3fb28e3baec64a9b9cbbace38344ec66d23c8fa782097f8a406a8960c'
+  version '1.12.0'
+  sha256 '1a05de910d7fc0defcf010c7e0bbbb1eb32afc35a6eaa9397a5df57c6a5fc663'
 
   # github.com/radiant-player/radiant-player-mac was verified as official when first introduced to the cask
   url "https://github.com/radiant-player/radiant-player-mac/releases/download/v#{version}/radiant-player-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.