### PR TITLE
Update salesx to 1.5.1

### DIFF
--- a/Casks/salesx.rb
+++ b/Casks/salesx.rb
@@ -1,6 +1,6 @@
 cask 'salesx' do
-  version '1.5'
-  sha256 'c8e458a038a62f81fb78b912f3a557d6af5d125bd9117a603e4f17eafad09656'
+  version '1.5.1'
+  sha256 '28021a36794163bcefd2eaab09f33c9613b0da5853be1f039a8ff917b4b87311'
 
   # dl.devmate.com/io.seedlab.salesx was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/io.seedlab.salesx/SalesX.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.