### PR TITLE
Update omniplan to 3.11.2

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,6 +1,6 @@
 cask 'omniplan' do
-  version '3.11.1'
-  sha256 '1410c1d23ad2108c0fab73e6ffc6604d0529fa36fb05daf2d8494305dfa2fcfc'
+  version '3.11.2'
+  sha256 '5b896b08c912942bc61f87f8558c78df2e9351f49af9c6c3e4c83cfed4c8d0d5'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniPlan#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.