### PR TITLE
Update hubstaff to 1.4.4,556fe980

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,8 +1,8 @@
 cask 'hubstaff' do
-  version '1.4.4,556fe980'
+  version '1.4.4,705'
   sha256 '70e030962fa1ac1b376b272e95bc140321198047db2abc24b7c66a3682b63f35'
 
-  url "https://app.hubstaff.com/download/705-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
+  url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'
   name 'Hubstaff'
   homepage 'https://hubstaff.com/'

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,8 +1,8 @@
 cask 'hubstaff' do
   version '1.4.4,556fe980'
-  sha256 'b388bede05079f2e0bb9f8804846c010c70b47263c7cd23a893a2f62f135ee99'
+  sha256 '70e030962fa1ac1b376b272e95bc140321198047db2abc24b7c66a3682b63f35'
 
-  url "https://app.hubstaff.com/download/344-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
+  url "https://app.hubstaff.com/download/705-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'
   name 'Hubstaff'
   homepage 'https://hubstaff.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.