### PR TITLE
Update kindle-comic-converter to 5.5.1

### DIFF
--- a/Casks/kindle-comic-converter.rb
+++ b/Casks/kindle-comic-converter.rb
@@ -1,8 +1,9 @@
 cask 'kindle-comic-converter' do
-  version '5.4.5'
-  sha256 '3247dc452edb0702b3e5a4fa138e15132e04af856902f1ce3e3a3fc58ef9ad34'
+  version '5.5.1'
+  sha256 '4fea22c4db0c7953050e0dedfb97007af1dd30470360e39373e1cadcedc5bcce'
 
   url "https://kcc.iosphe.re/OSX/KindleComicConverter_osx_#{version}.dmg"
+  appcast 'https://github.com/ciromattia/kcc/releases.atom'
   name 'Kindle Comic Converter'
   homepage 'https://kcc.iosphe.re/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.