### PR TITLE
Update vrep to 3.6.0

### DIFF
--- a/Casks/vrep.rb
+++ b/Casks/vrep.rb
@@ -1,6 +1,6 @@
 cask 'vrep' do
   version '3.6.0'
-  sha256 '5eb511deb3c0f0b305b64f6731fe53dc69e4e48fb9f516d8c980b3e31951bb5b'
+  sha256 '6d028ec84112fc85518c6a5298d70c651eadc9267d300f10502ea593817f8f78'
 
   url "http://coppeliarobotics.com/files/V-REP_PRO_EDU_V#{version.dots_to_underscores}_Mac.zip"
   appcast 'http://www.coppeliarobotics.com/helpFiles/en/versionInfo.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.