### PR TITLE
Update termius to 4.2.7

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '4.1.2'
-  sha256 'cc8799cb107b2d807d0604ec6d6d699b53b164cda8228bda18d0a1179d734de2'
+  version '4.2.7'
+  sha256 'c643452a817cc3e8407b16ad2ec181ff549ae23ba08dcc3a5560545ae45ecefb'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.