### PR TITLE
Update vernier-graphical-analysis to 4.7.1-1118

### DIFF
--- a/Casks/vernier-graphical-analysis.rb
+++ b/Casks/vernier-graphical-analysis.rb
@@ -4,6 +4,7 @@ cask 'vernier-graphical-analysis' do
 
   # graphicalanalysis.com was verified as official when first introduced to the cask
   url "https://software-releases.graphicalanalysis.com/ga/mac/release/Vernier-Graphical-Analysis-#{version}.dmg"
+  appcast 'https://www.vernier.com/products/software/graphical-analysis/'
   name 'Vernier Graphical Analysis'
   homepage 'https://www.vernier.com/products/software/graphical-analysis/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.