### PR TITLE
Update postbox to 6.1.12

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.11'
-  sha256 'c7f3596d09d142efacbbcb5167793994bea501be9315b649e5986dbe642532af'
+  version '6.1.12'
+  sha256 '583a6e6e7e619c75d4a61ec61e5c5e1c7a39f280fa5767be24eceb737bb6e94d'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.