### PR TITLE
Update backuploupe to 2.14.5

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,6 +1,6 @@
 cask 'backuploupe' do
-  version '2.14.4'
-  sha256 'ed6b717f6b39f3ee456570b53b11634b3d8fa0e61a5394482359a11349b6c18c'
+  version '2.14.5'
+  sha256 '34d5cef368fa5d931a6510bd579bbd1be47f0fd1c2a735d76c59625a4e4cfcac'
 
   url "http://www.soma-zone.com/download/files/BackupLoupe-#{version}.tar.bz2"
   appcast 'http://www.soma-zone.com/BackupLoupe/a/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.