### PR TITLE
Update framer-x to 29021,1552566907

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '28904,1551352889'
-  sha256 'bcba707f1b3839c5f3c19291abf7abb892165ce58036d9c0d6ce1dfd08d1a64c'
+  version '29021,1552566907'
+  sha256 'e04fa0c0cb1a13ea7e5a6d985a420ea0774a550fcc6e98ebff1febd12fde4d76'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.