### PR TITLE
Update kite to 0.20190314.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190313.0'
-  sha256 '9a1bc85bdc776b36fd39f59d8d9b4e5e2bc41b4800747690c74094532113061d'
+  version '0.20190314.0'
+  sha256 '3e308b0f0e0d7b93028a8791dee5145f7a194a53c5df5bc795261f7b0058b8eb'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.