### PR TITLE
Update texturepacker to 4.12.1

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -1,6 +1,6 @@
 cask 'texturepacker' do
-  version '4.12.0'
-  sha256 '21eb5e9a61cabaddca2ad567731e07e6a39fe1a4038b7a8b98868f6613da3af3'
+  version '4.12.1'
+  sha256 '6eb8f9beb30c793cd720c66f43f38a29844ffd5dc6be3428e5d8ff4b6cb7f690'
 
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/TexturePacker/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.