### PR TITLE
Update plex-media-server to 1.15.1.791-8bec0f76c

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,8 +1,8 @@
 cask 'plex-media-server' do
-  version '1.14.1.5488-cc260c476'
-  sha256 '394f3fb06d1e9fcd91a8f4d23281d12a4b329c5c883d7fd8b1b7fc46ad37f67c'
+  version '1.15.1.791-8bec0f76c'
+  sha256 'fbea318c198ea6f85283ac7749346dee9581c338f2135d6e7cf36ef8b7feba45'
 
-  url "https://downloads.plex.tv/plex-media-server/#{version}/PlexMediaServer-#{version}-OSX.zip"
+  url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.dmg"
   appcast 'https://plex.tv/api/downloads/1.json'
   name 'Plex Media Server'
   homepage 'https://www.plex.tv/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.