### PR TITLE
Update flightgear to 2018.3.2

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask 'flightgear' do
-  version '2018.3.1'
-  sha256 '586032d07ba119a28c583626e39f0ff7a80dffacc553f5a0e6bd15439ede1b02'
+  version '2018.3.2'
+  sha256 'dc7a40e19f64b80fdf7171be1516fd877dc7934981268ee72dfb974b53849b9a'
 
   # sourceforge.net/flightgear was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.