### PR TITLE
Updated URL and Version Number in Fing.app v5.3.3

### DIFF
--- a/Casks/fing.rb
+++ b/Casks/fing.rb
@@ -1,13 +1,12 @@
 cask 'fing' do
-  version '3.0,2016-09'
-  sha256 'a8497ce00d58609d8677c6c7850e479420516d94e9f37d681dbdc970359294c6'
+  version '5.3.3-osX'
+  sha256 'c3ba4964fcec0a027893e4f31065f47868b82f226e1da82871d66ed580249cd3'
 
-  # 39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com/wp-content/uploads/#{version.after_comma.hyphens_to_slashes}/overlook-fing-#{version.before_comma}.dmg_.zip"
+  url 'https://www.fing.com/images/uploads/general/CLI_macOSX.zip'
   name 'Fing'
-  homepage 'https://www.fing.io/'
+  homepage 'https://www.fing.com/'
 
-  pkg "overlook-fing-#{version.before_comma}.pkg"
+  pkg "fing-#{version}.pkg"
 
-  uninstall pkgutil: 'com.Overlook.Fing'
+  uninstall pkgutil: 'com.fing.Fing.plist'
 end

--- a/Casks/fing.rb
+++ b/Casks/fing.rb
@@ -1,12 +1,12 @@
 cask 'fing' do
-  version '5.3.3-osX'
+  version '5.3.3'
   sha256 'c3ba4964fcec0a027893e4f31065f47868b82f226e1da82871d66ed580249cd3'
 
   url 'https://www.fing.com/images/uploads/general/CLI_macOSX.zip'
   name 'Fing'
   homepage 'https://www.fing.com/'
 
-  pkg "fing-#{version}.pkg"
+  pkg "fing-#{version}-osX.pkg"
 
   uninstall pkgutil: 'com.fing.Fing.plist'
 end


### PR DESCRIPTION
Fing changed how their URL's are formatted. 

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

