### PR TITLE
Update understand to 5.1.980

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.979'
-  sha256 'b3172e78d4ee459ebd90f34f10713d3a2451e5d0ce542fdc2f2ffc811f843233'
+  version '5.1.980'
+  sha256 '1d18a771575bd8ef10e578657ffccca562f1e080cd446bd06d0f1a428163dd65'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.