### PR TITLE
Update flipper to 0.18.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.17.1'
-  sha256 'adde4f8605f0c3e3f026b955dce16a9cf547b5b4b95ad4c81d4f81701cf9c880'
+  version '0.18.0'
+  sha256 '7a0f98b4c837545890c726c9f5ca4c4f1a93ffd9dd4d63191a2b683198bd190e'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.