### PR TITLE
Update mycrypto to 1.6.1

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.6.0'
-  sha256 '1ae4fca2cfd0297d18af66ffa6f76a07e9ca09590e06c7b159741b0f0f2551a7'
+  version '1.6.1'
+  sha256 'e71a9ccda3543206f3e462a6736ade65a896d32fca09ea580e73c030f2e3bc9f'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.