### PR TITLE
Update qownnotes to 19.3.1,b4181-105520

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.3.0,b4175-073722'
-  sha256 '38119855f80fb09636d0ae5d1a412767d3ed2838361239b4d7ea487a8803f17e'
+  version '19.3.1,b4181-105520'
+  sha256 '93f74e327f59ddd26f2dbd3dbd32a3037aa62f286cb05d3a1bdb628f00b26936'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.