### PR TITLE
Update disk-inventory-x to 1.2

### DIFF
--- a/Casks/disk-inventory-x.rb
+++ b/Casks/disk-inventory-x.rb
@@ -1,12 +1,14 @@
 cask 'disk-inventory-x' do
-  version '1.0'
-  sha256 'f61c070a1ec8f29ee78b8a7c84dd4124553098acc87134e2ef05dbaf2a442636'
+  version '1.2'
+  sha256 '05ce4ffcb012545601fd87fef5aa1719f47f2fffbbd3ee7d314ec0bf4a0bdda5'
 
-  url "http://www.derlien.com/diskinventoryx/downloads/dev/DIX#{version}Universal.dmg",
+  url "http://www.derlien.com/diskinventoryx/downloads/Disk%20Inventory%20X%20#{version}.dmg",
       user_agent: :fake
   appcast 'http://www.derlien.com/downloads/index.html'
   name 'Disk Inventory X'
   homepage 'http://www.derlien.com/'
+
+  depends_on macos: '>= :high_sierra'
 
   app 'Disk Inventory X.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.