### PR TITLE
fluor and istumbler: Fix issues raised by `brew cask style`

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -8,7 +8,7 @@ cask 'fluor' do
   name 'Fluor'
   homepage 'https://fluorapp.net/'
 
-  depends_on macos: '>= :sierra'  
+  depends_on macos: '>= :sierra'
 
   app 'Fluor.app'
 end

--- a/Casks/istumbler.rb
+++ b/Casks/istumbler.rb
@@ -2,13 +2,12 @@ cask 'istumbler' do
   if MacOS.version <= :mavericks
     version '100'
     sha256 '71f6a6b0e255a853664ed4900835a42f2d23dcb05de35acfb3ac2ec1c5fb2edc'
-    url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   else
     version '103.43'
     sha256 '35796f9a119814527f98b85a0b8fbe0352895c3d8f21e9fd5af2cceb6d0277cb'
-    url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   end
 
+  url "https://istumbler.net/downloads/istumbler-#{version}.dmg"
   appcast 'https://istumbler.net/feeds/appcast.rss'
   name 'iStumbler'
   homepage 'https://istumbler.net/'


### PR DESCRIPTION
After making all changes to the casks:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).