### PR TITLE
fluor: Remove trailing whitespace

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -8,7 +8,7 @@ cask 'fluor' do
   name 'Fluor'
   homepage 'https://fluorapp.net/'
 
-  depends_on macos: '>= :sierra'  
+  depends_on macos: '>= :sierra'
 
   app 'Fluor.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
== /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/fluor.rb ==
C: 11: 33: Trailing whitespace detected.
```