### PR TITLE
Update katana to 1.4.4

### DIFF
--- a/Casks/katana.rb
+++ b/Casks/katana.rb
@@ -1,6 +1,6 @@
 cask 'katana' do
-  version '1.4.1'
-  sha256 '47712925c772150326e798f809e5037a9426f0629eb0a7d0bb71fea79f3f68d1'
+  version '1.4.4'
+  sha256 '905a578cd5d2fd3ee18e521ef0e1574f19229938181585bee41008b172dc5d1e'
 
   url "https://github.com/bluegill/katana/releases/download/v#{version}/katana-#{version}-mac.zip"
   appcast 'https://github.com/bluegill/katana/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.