### PR TITLE
Update itch formula to use itch-setup v1.17.0

### DIFF
--- a/Casks/itch.rb
+++ b/Casks/itch.rb
@@ -5,11 +5,8 @@ cask 'itch' do
   # broth.itch.ovh was verified as official when first introduced to the cask
   url "https://broth.itch.ovh/itch-setup/darwin-amd64/#{version}/archive/default"
   appcast 'https://github.com/itchio/itch/releases.atom'
-  name 'itch-setup'
-  name 'the itch.io app installer'
+  name 'itch.io'
   homepage 'https://itch.io/app'
-
-  container type: :zip
 
   installer script: 'itch-setup'
 

--- a/Casks/itch.rb
+++ b/Casks/itch.rb
@@ -1,20 +1,17 @@
 cask 'itch' do
-  version '25.4.0'
-  sha256 'b88dc10ceb69ece6ecab17340e6c4abc6e89e8eb20c7b030207eca5d0c2d8f17'
+  version '1.17.0'
+  sha256 '9053778cbae81ce09129364e0b3ec7f2b9abdd9705334011398d2d66d553c31c'
 
-  # nuts.itch.zone was verified as official when first introduced to the cask
-  url 'https://nuts.itch.zone/download/osx'
+  # broth.itch.ovh was verified as official when first introduced to the cask
+  url "https://broth.itch.ovh/itch-setup/darwin-amd64/#{version}/archive/default"
   appcast 'https://github.com/itchio/itch/releases.atom'
-  name 'itch'
+  name 'itch-setup'
+  name 'the itch.io app installer'
   homepage 'https://itch.io/app'
 
-  container nested: 'Install itch.dmg'
+  container type: :zip
 
-  installer script: 'Install itch.app/Contents/MacOS/itch-setup'
-
-  preflight do
-    set_permissions "#{staged_path}/Install itch.app", '0777'
-  end
+  installer script: 'itch-setup'
 
   uninstall delete: [
                       '~/Applications/itch.app',


### PR DESCRIPTION
Multiple issues with the previous version of the formula:
- the version in the formula (25.4.0) was the version of the installed application, not the version of the installer that the formula downloads (1.17.0), and wasn't used in the URL making it a bit meaningless
- the url used (https://nuts.itch.zone/download/osx) can serve content that will change over time. https://broth.itch.ovh has been [suggested to me](https://twitter.com/fasterthanlime/status/1107367222010351622) by @fasterthanlime, and should be stable.
- the shasum doesn't match the downloaded content
- the formula was downloading a dmg then extracting the installer, while the installer is available naked thus would be a better choice

## PR checklist
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
