### PR TITLE
Update fontforge to 20190317,2019-03-17-1d421d1

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,9 +1,9 @@
 cask 'fontforge' do
-  version '20190317,2019-03-17-1d421d1'
+  version '2019.03.17.1d421d1'
   sha256 '1b9a04a478e81501f1dda46e0c4ecccf7c586b5cc617e6c7dffdd06e9e63b102'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
-  url "https://github.com/fontforge/fontforge/releases/download/#{version.before_comma}/FontForge-#{version.after_comma}.app.dmg"
+  url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_dashes}.app.dmg"
   appcast 'https://github.com/fontforge/fontforge/releases.atom'
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,9 +1,9 @@
 cask 'fontforge' do
-  version '20170731'
-  sha256 '980c66e00f0f5c7a722eadd8b78a0ef2b20a7ccd952149cbfdfeaae9e66e4d4e'
+  version '20190317,2019-03-17-1d421d1'
+  sha256 '1b9a04a478e81501f1dda46e0c4ecccf7c586b5cc617e6c7dffdd06e9e63b102'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
-  url "https://github.com/fontforge/fontforge/releases/download/#{version}/FontForge-20170730-Mac.dmg"
+  url "https://github.com/fontforge/fontforge/releases/download/#{version.before_comma}/FontForge-#{version.after_comma}.app.dmg"
   appcast 'https://github.com/fontforge/fontforge/releases.atom'
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -3,7 +3,7 @@ cask 'fontforge' do
   sha256 '1b9a04a478e81501f1dda46e0c4ecccf7c586b5cc617e6c7dffdd06e9e63b102'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
-  url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_dashes}.app.dmg"
+  url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"
   appcast 'https://github.com/fontforge/fontforge/releases.atom'
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.