### PR TITLE
Update context-free to 3.1

### DIFF
--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -1,6 +1,6 @@
 cask 'context-free' do
-  version '3.0.11.3'
-  sha256 '5baae1cf7487ea0902f781f0891d3f7dc2c01071ab9546a1e2523676ea45c0da'
+  version '3.1'
+  sha256 '57e93777b37f14ad697964fd435a638ef17216503011ebf87b861958cd16ccc3'
 
   url "https://www.contextfreeart.org/download/ContextFree#{version}.dmg"
   appcast 'https://github.com/MtnViewJohn/context-free/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.