### PR TITLE
Update subler to 1.5.12

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask 'subler' do
-  version '1.5.11'
-  sha256 '821b28e84ce69a941c967528b89d1d1345c8bc6b55e52e0b50dd1cd282e4dea3'
+  version '1.5.12'
+  sha256 'de6a3a98195ac6c1fe51fc67c63ed9fd575edb8f3d03291b4ee06f75955c3888'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.