### PR TITLE
Update freesmug-chromium to 73.0.3683.75

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '72.0.3626.121'
-  sha256 '796d269c9f12d8614875ae7327214e57bd3872ffe203dd1c7ec0f3fbeca1ba85'
+  version '73.0.3683.75'
+  sha256 '6bbe697f08a9f4bfde754e6873f18ff984778d05862a259b2a27c98ebb4d8a98'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.