### PR TITLE
Update thedesk to 18.0.3

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -4,7 +4,7 @@ cask 'thedesk' do
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/m#{version}/TheDesk-darwin-x64.zip"
-  appcast 'https://thedesk.top/'
+  appcast 'https://github.com/cutls/TheDesk/releases.atom'
   name 'TheDesk'
   homepage 'https://thedesk.top/'
 

--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,8 +1,9 @@
 cask 'thedesk' do
-  version '18.0.2'
-  sha256 'bb176ecf2b18a5bdc80cca5395e8c884c9a875409e4016d9668e279f25ef81b1'
+  version '18.0.3'
+  sha256 '240aca571b2ce4cad659eb9e38e7439a01cb5c7970b72e854fe183fd4f2e86a7'
 
-  url 'https://dl.thedesk.top/TheDesk-darwin-x64.zip'
+  # github.com/cutls/TheDesk was verified as official when first introduced to the cask
+  url "https://github.com/cutls/TheDesk/releases/download/m#{version}/TheDesk-darwin-x64.zip"
   appcast 'https://thedesk.top/'
   name 'TheDesk'
   homepage 'https://thedesk.top/'


### PR DESCRIPTION
Change download url to GitHub Release.

---
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
