### PR TITLE
Update ishowu-instant to 1.2.11

### DIFF
--- a/Casks/ishowu-instant.rb
+++ b/Casks/ishowu-instant.rb
@@ -1,6 +1,6 @@
 cask 'ishowu-instant' do
-  version '1.2.10'
-  sha256 '87a1eab84ffeb861fb4878b96ef708fe1e2a86bb4012b8fe197f716342d520a2'
+  version '1.2.11'
+  sha256 '7429c2d8a9c7ecdf67b2bb00dc1319836f2114281e6906f9432cb522f2b0765b'
 
   url "https://www.shinywhitebox.com/downloads/instant/iShowU_Instant_#{version}.dmg"
   appcast 'https://www.shinywhitebox.com/store/appcast.php?p=14'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.