### PR TITLE
Update screenflick to 2.7.40

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,6 +1,6 @@
 cask 'screenflick' do
-  version '2.7.38'
-  sha256 'a14fec78920a1992d836460235baed164592e112d4c1f9d742383779d3ab1962'
+  version '2.7.40'
+  sha256 '4fcf5747b4b67196478a85bd6cc8a6d1798f8b3e6d189ebbeba3c86716cd9988'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.