### PR TITLE
Fixed sha256 for patchwork to 3.11.5

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
   version '3.11.5'
-  sha256 '1e66856dbfee4f5cb1c4b6d69b05a27bc195525e96fa386663572f6375557e70'
+  sha256 '8e47477aa9e3b920b67bbada35225c2f88acc805efea4e11618ab56ede1a42bf'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
