### PR TITLE
Update postico to 1.5.6

### DIFF
--- a/Casks/postico.rb
+++ b/Casks/postico.rb
@@ -1,6 +1,6 @@
 cask 'postico' do
-  version '1.5.5'
-  sha256 'fef095a82af427829a57930e762bf1319252f9222e8d200fb4276af87c775d33'
+  version '1.5.6'
+  sha256 'ea5a88d9b669a490f42ff08f1d2fc6eacbd0e58f5beee4355540bdab99139e31'
 
   # amazonaws.com/eggerapps-downloads was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/eggerapps-downloads/postico-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.