### PR TITLE
Update firefox to 66.0

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '65.0.2'
+  version '66.0'
 
   language 'cs' do
-    sha256 '42d016a1d27c762ca246d557d03a47dc7656df32b58f41ae71bd829eb583a334'
+    sha256 '9afffdebfa7d4359a7a2dc6af2233f7c8ae9b549ffdadad9e0291aac020ad9e2'
     'cs'
   end
 
   language 'de' do
-    sha256 '8f700d7e067e49b6d9f26135978936a78fd0b34abd38123f02b8661200079653'
+    sha256 '690c4f755b1857bcac2317608637f08447b1df4c58f6c4d71a78b35954b75357'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'c52f725fb7575bec6f62f290cae84499aaf020fd41b484ad35a3ef3714946fb3'
+    sha256 '62e0bc1c5183bcc12b4bb44c4e82a99012e9d8d7e1f571da0bfc4675e3c1d2ce'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '8eeb1fdc8bea3465dc4a9914957185fdf15fd092ddf57694b7f3476d72d42826'
+    sha256 '64e15f0e2a977ea9e1d3a14c674ebf84ee6234f896e719d6c57aeecd8785fa78'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '60c4fa0007b9681087daec2b9869c857deae51576fb546e202848b88f0a65a86'
+    sha256 '7ddb36cb97644a23921171b65bc0bbd12ca9e29ca105dd646deed3fe4ff5cef4'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '340b7834614ea52fa42112f7041bdb45dd41d7658c06e73d11fdf3676ff6b2f9'
+    sha256 '97c7d52e9a59a705fb209d1a0a545fdfc8c10eabb68a1a533fd856c9d0eaccf7'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 'e21e655ca498cea6b98b9152058eada58b6a4aafa8c4fd6fde750a589ab4ec36'
+    sha256 '17e49bb35bb6ae2a25fd81d6a4cba7a72202bb5077aad642c55bd67fd0b7eac5'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'c844a935f972f781ae5a973fe7b32770ab4368c92b0b76ae390b1b74131aad98'
+    sha256 '8e59aa6e65177e19153698c1fd86cb93623b27d031ce17508171fd1d22fd5aad'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '26ebfd4d9d837971c10a98d3657d13c0b7f40ea6fc4ad24d9b188f6e7c9f8fde'
+    sha256 'd4cba19aac14d08afcf6709676b933bb50123bf7b3c5147c0f048376f763fd1d'
     'fi'
   end
 
   language 'fr' do
-    sha256 'a662b48d76d45afa331176701b5025741dd856c4ebddca5c35c8b0492cc37c6d'
+    sha256 '26046825f7666b73152fda65af56cd47d36ee914f76a3ac358d64552aabf7243'
     'fr'
   end
 
   language 'gl' do
-    sha256 '7217228fbde222bc9c02435b0866ba56c1b1f4ba59acac6d0cc4e1305af03eca'
+    sha256 'f08ad9010238b55d3423829083c6d73d6f2e964db96ea223bd8a41318e9bfa5b'
     'gl'
   end
 
   language 'in' do
-    sha256 '6fd6ffdafcbab4c8f066724bcd7258e7d11fdfe433b253213307513bd29aafce'
+    sha256 '1f194954709b5e4ca8c5bcdb15a35613f2b06f0ff900a0856c6edb1585ead4e0'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '28e1851b14a6f35320df0805bb83beb5d0fbdb1c9882d248c8681f0851e0faa7'
+    sha256 '9026124774e4f7950b4d093b4f2a4b7d05ec4f8a1e021294268523ac99527e8b'
     'it'
   end
 
   language 'ja' do
-    sha256 'ea59bce5cbfbbfa4e870aa5d4e0bc408401134659353ea14b7c1580200e6e351'
+    sha256 'a5c4ebc9dde2b0f1a04f87c99c296c0c7d5003f8cfb305c6e94fce17c5815253'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '3eddc98764ae051f3238923f054373dc75d13205ae5829b13e7aa89832b9a8ec'
+    sha256 '9c084947d388a9a5ee53f15b221602b805e9154eb4631e7f49852d3593362540'
     'ko'
   end
 
   language 'nl' do
-    sha256 'd95191565e10ffd894782c64c0be9beff77c6d451acfdeef5a0f635f56f61b41'
+    sha256 'ae737763371269762c4c417f84f8c3c5a8df536ab08b8a8a8d18ef4d68374baa'
     'nl'
   end
 
   language 'pl' do
-    sha256 'c8490dda204fe0e7b578cfe94a3d61f8c5c326d955c1c42b851710c7fa34bf49'
+    sha256 '5f2ec9136e2d81589f65f53531fc23364be77c51ee3e09db39a5fc947f138272'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '9b9a098758afac2fbabfef6d3180011a641991baf628223600c08ac6f161e888'
+    sha256 '86ddcae1f38896ed25633982f32122336de516a5b521b2be0e04605edd4ee07c'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'e9b39a7fbea99ee1209db0045e6d3e981d75f35f473063238940bf5f999a5090'
+    sha256 '3d719fa1768764a5634ee8a10afcd9f596b5657cf1b303f0b153d252968673e3'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'b4de7dcd4a8a22df1394a31100e43cfb4a022bdffac8808602018a0f4eb4b55e'
+    sha256 '51bc0fdb36b5fdc512e4adf095a9f8020dfe916a07baafeb6a03e41b53553887'
     'ru'
   end
 
   language 'tr' do
-    sha256 'e84e25eab6e9921ee018bf345e4074dca5b4c3e293020bd0c8ceed851edf6c1a'
+    sha256 '8a998b6268bfe1b87799096b029d3377caaeeba13795fbc15a79ec0af55d74f9'
     'tr'
   end
 
   language 'uk' do
-    sha256 '20560c3c99400242e7653ec5657932b01c9aaf691280cdc8bd9560e89dfb17f3'
+    sha256 '2723b1bd9895a12e8684be625f484989b468d236d3e8913dde9ef57a849a0f22'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '0c4228c4c6e5ca878033604de1af593fafc71e0e666a321dd32a820e18c9fa76'
+    sha256 'c7424a80ae30bc324974e48299e19809ba8fff41ecba653a391756d900c04090'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'b1989d5d696ad5f4df88a6c2f92486d536d210495f3ec81a590f90a600cf7305'
+    sha256 '00ac90de0e6d8aa6127ec5e108b06663607c8c6fc2d6e2d50748d1887d8572fa'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
