### PR TITLE
Update brave-browser to 0.61.51

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.60.45'
-  sha256 'a9f7b18e5ae497c568910f301acce94a2a0b35f3aef8636edabcf668f8d3a241'
+  version '0.61.51'
+  sha256 'a5420e90db83f8f2cc42acd5d72002c55545351416045315b96b8cc703c20ef3'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.