### PR TITLE
Update sabnzbd to 2.3.8

### DIFF
--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -1,6 +1,6 @@
 cask 'sabnzbd' do
-  version '2.3.7'
-  sha256 'db30fb226e34918dc365f7e660e3442e9979eca16bddc6903eea2796144e5228'
+  version '2.3.8'
+  sha256 '3abe2edd8b38c64ddde526207f70748970b91680a981d69df0640fecfb44f64c'
 
   # github.com/sabnzbd/sabnzbd was verified as official when first introduced to the cask
   url "https://github.com/sabnzbd/sabnzbd/releases/download/#{version}/SABnzbd-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.