### PR TITLE
Update zeebe-modeler to 0.6.2

### DIFF
--- a/Casks/zeebe-modeler.rb
+++ b/Casks/zeebe-modeler.rb
@@ -1,9 +1,9 @@
 cask 'zeebe-modeler' do
-  version '0.2.0'
-  sha256 '47c5d0e955083505e1e7208c6dc9568134e42f521bc7db16509052288b15cc1b'
+  version '0.6.2'
+  sha256 '04bfe8afd7595825451cc65929705d529afccf0deb85b2f5868bfa27564733ee'
 
   # github.com/zeebe-io/zeebe-modeler was verified as official when first introduced to the cask
-  url "https://github.com/zeebe-io/zeebe-modeler/releases/download/#{version}/zeebe-modeler-#{version}-mac.zip"
+  url "https://github.com/zeebe-io/zeebe-modeler/releases/download/v#{version}/zeebe-modeler-#{version}-mac.zip"
   appcast 'https://github.com/zeebe-io/zeebe-modeler/releases.atom'
   name 'Zeebe Modeler'
   homepage 'https://zeebe.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.