### PR TITLE
Update insync to 1.5.7.37371

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '1.5.6.37369'
-  sha256 'e08d10e63e941a4185359a4a9949aabd6e7b80c04d79e2e178add7f52da9306b'
+  version '1.5.7.37371'
+  sha256 'b98a6d37a6301805e43c04767e90d662a82b636480a2cccd055c42c027b73b01'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   name 'Insync'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.