### PR TITLE
Update lunar to 2.3.0

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.2.2'
-  sha256 '67b4ceae5d2806755047658c2e3e56d64ba199eee6efc62a8ffde143911ddb88'
+  version '2.3.0'
+  sha256 '86de6cf6485c5a0de56d5f99f8bfeba470e14a5267a5bb8535bfb01e6d4a5acd'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.