### PR TITLE
Update macpass to 0.7.5

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -1,6 +1,6 @@
 cask 'macpass' do
-  version '0.7.4'
-  sha256 'd8fc5a988f984cdf31032fc571b5f7383f3f670be6977d25121e26c73a23c5de'
+  version '0.7.5'
+  sha256 'fc1de9be1b3faa6d9b1e5b227d2ef53133168313594101c94a3cb0179777ee71'
 
   # github.com/MacPass/MacPass was verified as official when first introduced to the cask
   url "https://github.com/MacPass/MacPass/releases/download/#{version}/MacPass-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.