### PR TITLE
Downgrade FDR4 to v4.2.3

### DIFF
--- a/Casks/fdr.rb
+++ b/Casks/fdr.rb
@@ -1,8 +1,8 @@
 cask 'fdr' do
-  version '4.2.3'
+  version '4.2.3,3789'
   sha256 'c9a30591cd0f28cab68de59691c2ebe717134daa38eaac5803b19d0c086f123c'
 
-  url 'https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-3789-mac-x86_64.zip'
+  url "https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-#{version.after_comma}-mac-x86_64.zip"
   appcast 'https://www.cs.ox.ac.uk/projects/fdr/manual/changes.html'
   name 'FDR'
   homepage 'https://www.cs.ox.ac.uk/projects/fdr/'

--- a/Casks/fdr.rb
+++ b/Casks/fdr.rb
@@ -1,8 +1,8 @@
 cask 'fdr' do
-  version '4.2.4'
-  sha256 '127b0b4b4e7e571f4e910452cf393fdcca642575710d4ad9b30577ba8cb1be81'
+  version '4.2.3'
+  sha256 'c9a30591cd0f28cab68de59691c2ebe717134daa38eaac5803b19d0c086f123c'
 
-  url 'https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-3800-mac-x86_64.zip'
+  url 'https://www.cs.ox.ac.uk/projects/fdr/downloads/fdr-3789-mac-x86_64.zip'
   appcast 'https://www.cs.ox.ac.uk/projects/fdr/manual/changes.html'
   name 'FDR'
   homepage 'https://www.cs.ox.ac.uk/projects/fdr/'


### PR DESCRIPTION
The latest version, v4.2.4, has known issues that prevent the user from
being able to debug failed assertions. The owners advised to use v4.2.3
until its fixed.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
