### PR TITLE
Updated java to 12

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,12 +1,12 @@
 cask 'java' do
-  version '11.0.2,9'
-  sha256 'f365750d4be6111be8a62feda24e265d97536712bc51783162982b8ad96a70ee'
+  version '12'
+  sha256 '52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a'
 
-  url "https://download.java.net/java/GA/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
+  url "https://download.java.net/java/GA/jdk#{version}/GPL/openjdk-#{version}_osx-x64_bin.tar.gz"
   name 'OpenJDK Java Development Kit'
   homepage 'https://jdk.java.net/'
 
-  artifact "jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk"
+  artifact "jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/openjdk-#{version}.jdk"
 
   uninstall rmdir: '/Library/Java/JavaVirtualMachines'
 end

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,12 +1,12 @@
 cask 'java' do
-  version '12'
+  version '12,33'
   sha256 '52164a04db4d3fdfe128cfc7b868bc4dae52d969f03d53ae9d4239fe783e1a3a'
 
-  url "https://download.java.net/java/GA/jdk#{version}/GPL/openjdk-#{version}_osx-x64_bin.tar.gz"
+  url "https://download.java.net/java/GA/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Java Development Kit'
   homepage 'https://jdk.java.net/'
 
-  artifact "jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/openjdk-#{version}.jdk"
+  artifact "jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk"
 
   uninstall rmdir: '/Library/Java/JavaVirtualMachines'
 end


### PR DESCRIPTION
Artifact https://download.java.net/java/GA/jdk12/33/GPL/openjdk-12_osx-x64_bin.tar.gz
SHA256 https://download.java.net/java/GA/jdk12/GPL/openjdk-12_osx-x64_bin.tar.gz.sha256
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
