### PR TITLE
Update understand to 5.1.981

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.980'
-  sha256 '1d18a771575bd8ef10e578657ffccca562f1e080cd446bd06d0f1a428163dd65'
+  version '5.1.981'
+  sha256 '5b72bba4814aa56e0f18f9730b47f70bd56c3da2e4e619bc20560499c231dbea'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.