### PR TITLE
Update tuxera-ntfs to 2018

### DIFF
--- a/Casks/tuxera-ntfs.rb
+++ b/Casks/tuxera-ntfs.rb
@@ -3,6 +3,7 @@ cask 'tuxera-ntfs' do
   sha256 '73b8c1e7a19ae2f98aeb4f72d8d5f7ea2a81f07b2f2a49a5106ea0581756d9ac'
 
   url "https://download.tuxera.com/mac/tuxerantfs_#{version}.dmg"
+  appcast 'https://www.tuxera.com/products/tuxera-ntfs-for-mac/download/'
   name 'Tuxera NTFS'
   homepage 'https://www.tuxera.com/products/tuxera-ntfs-for-mac/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.