### PR TITLE
Update turbo-boost-switcher to 2.8.0

### DIFF
--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -4,6 +4,7 @@ cask 'turbo-boost-switcher' do
 
   # s3.amazonaws.com/turbo-boost-switcher was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/turbo-boost-switcher/Turbo+Boost+Switcher_#{version}.zip"
+  appcast 'https://www.rugarciap.com/turbo-boost-switcher-for-os-x/'
   name 'Turbo Boost Switcher'
   homepage 'https://www.rugarciap.com/turbo-boost-switcher-for-os-x/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.