### PR TITLE
Update touchosc-editor to 1.8.5

### DIFF
--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -3,6 +3,7 @@ cask 'touchosc-editor' do
   sha256 '0873ee00f6e7e135d3dc704fd2f072e29e02b5a6d863851370e81c657a788643'
 
   url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
+  appcast 'https://hexler.net/software/touchosc'
   name 'TouchOSC Editor'
   homepage 'https://hexler.net/software/touchosc'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.