### PR TITLE
Update touchosc-bridge to 1.4.0.1

### DIFF
--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -3,6 +3,7 @@ cask 'touchosc-bridge' do
   sha256 '7911ad9284aafb1ddd337af333d445de7ae57df5ca9b134bdf6881139a8795f4'
 
   url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-osx.zip"
+  appcast 'https://hexler.net/software/touchosc'
   name 'TouchOSC Bridge'
   homepage 'https://hexler.net/software/touchosc'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.