### PR TITLE
Update ipfs to 0.7.2

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -1,6 +1,6 @@
 cask 'ipfs' do
-  version '0.7.1'
-  sha256 'c6b8c195475fca6dce68bed22d56942983cf42474e74c9afdb8b4971cde74775'
+  version '0.7.2'
+  sha256 '7eb037d3f6c3a27a4b1ac1657cb0127e141e15d2f4509f0fde1450727e8ad4b6'
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/ipfs-desktop-#{version}.dmg"
   appcast 'https://github.com/ipfs-shipyard/ipfs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.