### PR TITLE
Update darktable to 2.6.2

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask 'darktable' do
-  version '2.6.1'
-  sha256 'dec8ebd36b9747a84ffad119ca1fa92a197297dc7d54e9a03035da99a76f66e8'
+  version '2.6.2'
+  sha256 '8cd945744e56a85c35f982a96be42332a57dc383ec228fcc1d21eb57c068f27c'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
