### PR TITLE
Update eclipse-ide to 4.11.0,2019-03:R

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.10.0,2018-12:R'
-  sha256 'c0bea89eac5789cb0101ba02c4b69fdc5b7672fa4561b9a2fbd551525dea1c8c'
+  version '4.11.0,2019-03:R'
+  sha256 '1b2aa90766c3e7e2fcb8aefcdf7e877e87b4b5b398fb41b7aef0f701e72a170c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.