### PR TITLE
Update eclipse-installer to 4.11.0,2019-03:R

### DIFF
--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-installer' do
-  version '4.10.0,2018-12:R'
-  sha256 '8164fc2ff8b5889324e91b1ba2510945d33730af324b49432a4ca11f25e7a367'
+  version '4.11.0,2019-03:R'
+  sha256 '7f19c21c6e324a1c3d9b5babc01b353a0b41b9ba4e159436a860342eeaaedce4'
 
   url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-inst-mac64.tar.gz&r=1"
   name 'Eclipse Installer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.