### PR TITLE
Update eclipse-platform to 4.11.0,2019-03:R

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.10,201812060815'
-  sha256 '8bee330659ae3464a8ae74dbc0d5221421af1380d207ceed9d6afe52337da80f'
+  version '4.11.0,2019-03:R'
+  sha256 '62123c4c2295da22f65d1cabac6ff15d3380dc0a8630ea35fe602609a73bfbb0'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.11.0,201903070500'
-  sha256 '11e0bbcf4c1776f18be91bd6c6008f9fb2040a8fe0734f692adacd530bee1a75'
+  version '4.11,201903070500'
+  sha256 'b841c5878def4c191f566925b2655838c6103541e74e09095a94ac6a550445d0'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
   version '4.11.0,201903070500'
-  sha256 '62123c4c2295da22f65d1cabac6ff15d3380dc0a8630ea35fe602609a73bfbb0'
+  sha256 '11e0bbcf4c1776f18be91bd6c6008f9fb2040a8fe0734f692adacd530bee1a75'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-platform' do
-  version '4.11.0,2019-03:R'
+  version '4.11.0,201903070500'
   sha256 '62123c4c2295da22f65d1cabac6ff15d3380dc0a8630ea35fe602609a73bfbb0'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.