### PR TITLE
Update beaker-browser to 0.8.6

### DIFF
--- a/Casks/beaker-browser.rb
+++ b/Casks/beaker-browser.rb
@@ -1,6 +1,6 @@
 cask 'beaker-browser' do
-  version '0.8.5'
-  sha256 '0c08bab0834d394ce6894373f481e245c25049e7572112953258a734397d68d8'
+  version '0.8.6'
+  sha256 '7b9e06cf0e83882579c442383d419d7581164d52bda51e06a7d3c2045f359ef4'
 
   # github.com/beakerbrowser/beaker was verified as official when first introduced to the cask
   url "https://github.com/beakerbrowser/beaker/releases/download/#{version}/beaker-browser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.