### PR TITLE
Update patchwork to 3.11.6

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.11.5'
-  sha256 '8e47477aa9e3b920b67bbada35225c2f88acc805efea4e11618ab56ede1a42bf'
+  version '3.11.6'
+  sha256 '6c085e4ba2146e7e379b3bedfb92c6ce81192ab9866ec0235d2efdfe9a724aeb'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.