### PR TITLE
Update macupdater from 1.4.5 to 1.4.7

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -3,7 +3,7 @@ cask 'macupdater' do
   sha256 '82793a06ff6aca03ede5233f012cd98c525b0c4e5c8b32283f090dba9b5be1bc'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
-  appcast 'https://macupdater.net/macupdater/macupdater.xml'
+  appcast 'https://www.corecode.io/macupdater/macupdater.xml'
   name 'MacUpdater'
   homepage 'https://www.corecode.io/macupdater/index.html'
 

--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.4.5'
-  sha256 '76ee48d25d86e53db370516f92c0b96ca29b9899b3bda60a3b8023d4158d7ad9'
+  version '1.4.7'
+  sha256 '82793a06ff6aca03ede5233f012cd98c525b0c4e5c8b32283f090dba9b5be1bc'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.zip"
   appcast 'https://macupdater.net/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.