### PR TITLE
Update endicia to 2.19.1,763

### DIFF
--- a/Casks/endicia.rb
+++ b/Casks/endicia.rb
@@ -1,6 +1,6 @@
 cask 'endicia' do
-  version '2.19,757'
-  sha256 '12513f18b1aabce6ba9c5014b05b1aed5a2ea5be8d4f8e012cb34c3d65077f17'
+  version '2.19.1,763'
+  sha256 '28c3ecf697f98381a268d42ad2952a5b943bfced4af417cf337790e8afc194df'
 
   url "https://download.endiciaformac.com/EndiciaForMac#{version.before_comma.no_dots}v#{version.after_comma}.dmg"
   appcast 'https://s3.amazonaws.com/endiciaformac/EndiciaForMacSparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.