### PR TITLE
Update screenflick to 2.7.41

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,6 +1,6 @@
 cask 'screenflick' do
-  version '2.7.40'
-  sha256 '4fcf5747b4b67196478a85bd6cc8a6d1798f8b3e6d189ebbeba3c86716cd9988'
+  version '2.7.41'
+  sha256 '2973d0ba0a5799867d53564d6ce5151aa74fe2ba6c33096f98a675f4e62eb1eb'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.