### PR TITLE
Update udeler to 1.6.3

### DIFF
--- a/Casks/udeler.rb
+++ b/Casks/udeler.rb
@@ -1,6 +1,6 @@
 cask 'udeler' do
-  version '1.6.2'
-  sha256 'd7eb6ca284f753cbb38ab12b260f9a44fc375485c74a6de6af3f681047c19cad'
+  version '1.6.3'
+  sha256 '8cf08ad8c2045b8f5b6fce27b2bfed4169f7a5ac75b4e67c5c2eec7a0b23e24e'
 
   url "https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v#{version}/Udeler-#{version}-mac.zip"
   appcast 'https://github.com/FaisalUmair/udemy-downloader-gui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.