### PR TITLE
Update riot to 1.0.5

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,6 +1,6 @@
 cask 'riot' do
-  version '1.0.4'
-  sha256 'fe966836a77c4473b33109fc1fbf6f129989dc4260399081f1fc857b46b97906'
+  version '1.0.5'
+  sha256 'aa599308d5f7537f1a98f2a1fab485500afc43516494656f67fd3ddaa5e01849'
 
   url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://riot.im/desktop.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.