### PR TITLE
Update blue-jeans to 2.11.1.17

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.11.0.405'
-  sha256 '200b14601ce11b28f4b4e84a542a1c87ae08af974566c2572c00b2891d6a047d'
+  version '2.11.1.17'
+  sha256 '83e2b49f878f22ae06692afca5f16e0390821f1749ee5f080b8b01f78bd7dba7'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   appcast 'https://www.bluejeans.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.