### PR TITLE
Update osculator to 3.3.0-15-ge07478ab,7ab922ce-a33a-48b3-8e8f-070d064ec1db

### DIFF
--- a/Casks/osculator.rb
+++ b/Casks/osculator.rb
@@ -1,6 +1,6 @@
 cask 'osculator' do
-  version '3.2.2,84f792ed-e991-4279-9738-7bf0b2d3a029'
-  sha256 '1fa1407b1bd19e05429ac74a3161bc7ec795798cc8ca6f8112b743855bc4ba2b'
+  version '3.3.0-15-ge07478ab,7ab922ce-a33a-48b3-8e8f-070d064ec1db'
+  sha256 '387b57aa64dcc7d21c525c862b28ea22063213de80d53111a855b3163040a65c'
 
   # distribution.wildora.net was verified as official when first introduced to the cask
   url "https://distribution.wildora.net/products/osculator-v#{version.major}/revisions/#{version.after_comma}/osculator-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.