### PR TITLE
Update a-better-finder-rename to 10.40

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,6 +1,6 @@
 cask 'a-better-finder-rename' do
-  version '10.35'
-  sha256 :no_check # required as upstream randomly uses two different downloads for a/b testing
+  version '10.40'
+  sha256 'a86d4c933206700412e11dc7da303f5edf34624ae90d99e191a55116d54991d1'
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"

--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,6 +1,6 @@
 cask 'a-better-finder-rename' do
   version '10.40'
-  sha256 'a86d4c933206700412e11dc7da303f5edf34624ae90d99e191a55116d54991d1'
+  sha256 :no_check # required as upstream randomly uses two different downloads for a/b testing
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.