### PR TITLE
Update zoc to 7.23.1

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.23.0'
-  sha256 '02ed86454c596e3963305a46951a6386629f0f29341584b36a44f5a975387878'
+  version '7.23.1'
+  sha256 'f33c273fb789ecea66d99bd3da063fec83cc9c05281410b77582d44d2383145f'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.