### PR TITLE
Update gns3 to 2.1.15

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.14'
-  sha256 '3a0a1b8f586d4e0bcfe63fc5f801b597ea2a389f5502f5e5ed28b6eb50d784f7'
+  version '2.1.15'
+  sha256 '8b95eb1f5fa0155e5f40adff548292a6714b77562830a00a203c8e6cde60823c'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.