### PR TITLE
Update unity-download-assistant to 2018.3.9f1,947e1ea5aa8d

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2018.3.1f1,bb579dc42f1d'
-  sha256 '68499e0fde64cfd0a9434ff23ae2d1e2fe04be9f98071f1edd5bc1745d427c56'
+  version '2018.3.9f1,947e1ea5aa8d'
+  sha256 'a2b1459d941204d4d75e9887215c2020344f7c1f9a12dd349b2a164957e58ea3'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.