### PR TITLE
Update wire to 3.7.2930

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,6 +1,6 @@
 cask 'wire' do
-  version '3.6.2923'
-  sha256 'd485c5cea48d44c2584c452dea2e471a3a0742c357cdae8d89f45c65163ca081'
+  version '3.7.2930'
+  sha256 '9be14a67b38640bed584db3962eaf6074c48474f89bca08174313e5c8ad838e4'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
   url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.