### PR TITLE
Update mattermost to 4.2.1

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
-  version '4.2.0'
-  sha256 '04643630aa9801cb12252960118f65a5c742100f5bcef51d9db4461ab076584c'
+  version '4.2.1'
+  sha256 '980e2c2b174ed594ba2c16aa1122dc096e1c1bd3eaeba6d25cb2ca8fa4faac72'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
   appcast 'https://github.com/mattermost/desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.