### PR TITLE
Update rcloneosx to 1.8.1

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask 'rcloneosx' do
-  version '1.7.5'
-  sha256 '6f39343cf1ce4328daa3b52ffa298bb2c1ec0e6b43c1fdb8f6b3a494e8deea56'
+  version '1.8.1'
+  sha256 'f0792030aee807cf274a0a757176a407cfcf5d13619a71528dda868e3ff1a6d2'
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/RcloneOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.