### PR TITLE
Update surge to 3.1.0-807

### DIFF
--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -1,6 +1,6 @@
 cask 'surge' do
-  version '3.0.6-781'
-  sha256 '475ae96cd817bb772fd121b099084b47e9cecd1e3bde0a6a87e75c5d38bbda2b'
+  version '3.1.0-807'
+  sha256 'bada1e297cf5b0748abe81694395c9f52b1592487da78b23ec8c7d94e5b5f1e4'
 
   url "https://www.nssurge.com/mac/v#{version.major}/Surge-#{version}.zip"
   appcast "https://www.nssurge.com/mac/v#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.