### PR TITLE
Update pdfpenpro to 1023.3,1553249972

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1022.6,1551314274'
-  sha256 '4a1b493a68ee71d5cdc6afee75309494786d6fc0470931b5f2d9c59ed1c86429'
+  version '1023.3,1553249972'
+  sha256 'ecf226ec36760173a81103a93c72b437a88180d613e5ae8b6ca648b1e2c26157'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.