### PR TITLE
Update signal to 1.23.1

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.22.0'
-  sha256 '777496e4b23f1d088383dfc9694deb646313a2020bd5cd17ab93f68be31d5317'
+  version '1.23.1'
+  sha256 'baf2a609e78c0314c3bbc509c8d7ea8878425ca34e3f43856cda3fe3d911dc1e'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.