### PR TITLE
Update opera to 58.0.3135.118

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '58.0.3135.117'
-  sha256 '3943e078878d3cb748c1832ce8ca2317919bbff8cac3b9602930c76e9fadfbcc'
+  version '58.0.3135.118'
+  sha256 '6715b521d55f05a1bcb9e35a51a36037641f297a5a16f30a75c73093d5966779'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.