### PR TITLE
Update proxyman to 1.3.3

### DIFF
--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -1,6 +1,6 @@
 cask 'proxyman' do
-  version '1.3.2'
-  sha256 'f38e0fcc9b587a157d942df05b1593ec880100483f6c0e5699df19a54971925b'
+  version '1.3.3'
+  sha256 '6e2635c214f94bd0726734ea4ac1dd19743e0d94651ae16041bdbf641b33acb5'
 
   # github.com/ProxymanApp/Proxyman was verified as official when first introduced to the cask
   url "https://github.com/ProxymanApp/Proxyman/releases/download/#{version}/Proxyman_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.