### PR TITLE
Update cacher to 2.6.7

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.6.5'
-  sha256 'f7fb67858abe27d051d6505dedcc64ad61e27eadd6f70c1be8c6e0c2b5b6ab9d'
+  version '2.6.7'
+  sha256 '34b5f6f7671e5f6433715ccbc29417013d20f39b2f42390f0645e65f1f4c3d10'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.