### PR TITLE
Update wordpresscom to 4.0.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '3.9.0'
-  sha256 '46bbe0d67c1440ea46063b4f1345592cdef235128ae537be1363309f5a47657b'
+  version '4.0.0'
+  sha256 'c55992a869274a1f6d7509f27c15000d3b8842d10584a214570a90c83024f93d'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.