### PR TITLE
Update netron to 2.9.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '2.9.4'
-  sha256 '5cbae9ac1d88183d3912d46e821e8fff171126730ca7cb839f2dafcf132e8f15'
+  version '2.9.5'
+  sha256 '45cb49d1d1c7917b2824ea66b8ab46dc17f4d1b15ebada615a26bca1b39843bc'
 
   url "https://github.com/lutzroeder/Netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/Netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.