### PR TITLE
Update iterm2 to 3.2.8

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.7'
-  sha256 'ac71ddf4b9378fb87a30c64aa9bde543300728ed5e5ab996f1687f40fd7e2ae1'
+  version '3.2.8'
+  sha256 'e1a659c8041bb765f1a71dcec8d2bd34e598f9c433ecd15c53fdb15fb1db5148'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.