### PR TITLE
Update drivedx to 1.8.2

### DIFF
--- a/Casks/drivedx.rb
+++ b/Casks/drivedx.rb
@@ -1,6 +1,6 @@
 cask 'drivedx' do
-  version '1.8.1'
-  sha256 '700e14fccca7a66fd723f5af67ed1d7f1406fd1ba5675073cb73ab9c3ec6b48e'
+  version '1.8.2'
+  sha256 'a9d0ac0f1fd9098eb6eb64c53fd4077cece81658e27f8a992b4a3966edb8d993'
 
   url "https://binaryfruit.com/download/drivedx/mac/#{version.major}/bin/DriveDx.#{version}.zip"
   appcast "https://binaryfruit.com/download/drivedx/mac/#{version.major}/updates/?appcast&appName=DriveDxMac"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.