### PR TITLE
Update apple-events to 1.4

### DIFF
--- a/Casks/apple-events.rb
+++ b/Casks/apple-events.rb
@@ -1,6 +1,6 @@
 cask 'apple-events' do
-  version '1.2'
-  sha256 '47b109cf1aa91e6772b4941654cc8717aab4393f68646129cbd322e40154ab0b'
+  version '1.4'
+  sha256 'a29d998f1b8c297c93934f45294e1798cfcf5a47123fd189f7d10bc5ff479208'
 
   url "https://github.com/insidegui/AppleEvents/releases/download/#{version}/AppleEvents_v#{version}.zip"
   appcast 'https://github.com/insidegui/AppleEvents/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.