### PR TITLE
Update cave to 18.1.1-6

### DIFF
--- a/Casks/cave.rb
+++ b/Casks/cave.rb
@@ -1,6 +1,6 @@
 cask 'cave' do
-  version '18.1.1-5'
-  sha256 '9a4da52bfd05e1c83db101cb3def1df3922a58aed21429b6ccdd669d10a37afc'
+  version '18.1.1-6'
+  sha256 'ef04149537e3eac6abaf3b1c1ffaca532aec292f880ea3d6fe6d577b8e9c0367'
 
   url 'https://www.unidata.ucar.edu/downloads/awips2/awips-cave.dmg'
   appcast 'https://github.com/Unidata/awips2/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.