### PR TITLE
Update vorta to 0.6.14

### DIFF
--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -1,6 +1,6 @@
 cask 'vorta' do
-  version '0.6.13'
-  sha256 'e1798294d863dde328d0fb312eab311e717bf48205866fafa1ab1a751bbb9f97'
+  version '0.6.14'
+  sha256 'd3e220bc2ad7f7df517357ff1ce7617d821dd6a90fd92ca2e1d66f98dcd3313f'
 
   url "https://github.com/borgbase/vorta/releases/download/v#{version}/vorta-#{version}.dmg"
   appcast 'https://github.com/borgbase/vorta/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.