### PR TITLE
Update telegram-desktop to 1.6.2

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop' do
-  version '1.6.1'
-  sha256 '3d5a0283bfb41493c0f576d3b02f4d92358f452232ae4b9a52b4769648f3d85d'
+  version '1.6.2'
+  sha256 '4d2370e5fab9babdb17f844af690e9422c68e9f4c4bd7c04660861d7fe4dd980'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.