### PR TITLE
Update pyfa to 2.8.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,8 +1,8 @@
 cask 'pyfa' do
-  version '2.7.0,december-1.0'
-  sha256 'f20e0b3071b9e0247b88095f17f7424039050ad9cb246c5af8ea49579effe4ba'
+  version '2.8.0'
+  sha256 'ea18d91f372e0aa73b470b3419ff8dfb00497de0f3756be4025e147689b09884'
 
-  url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version.before_comma}/pyfa-#{version.before_comma}-#{version.after_comma}-mac.zip"
+  url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'
   name 'pyfa'
   homepage 'https://github.com/pyfa-org/Pyfa'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.