### PR TITLE
Update mathtype from 7.8.0 to 7.4.2

### DIFF
--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,5 +1,5 @@
 cask 'mathtype' do
-  version '7.8.0'
+  version '7.4.2'
   sha256 'd2b2bfcd37f212edd1d7241d11ecc345cafe6adffcc2fc7a0e1565afb2759e89'
 
   url 'https://store.wiris.com/en/products/downloads/mathtype/installer/mac/en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.