### PR TITLE
Update sqlitemanager to 4.8.3

### DIFF
--- a/Casks/sqlitemanager.rb
+++ b/Casks/sqlitemanager.rb
@@ -3,7 +3,7 @@ cask 'sqlitemanager' do
   sha256 '0e0e99490f45e6145efde46ddc32dd1e131248b024824254579dc7985426793e'
 
   url 'https://www.sqlabs.com/download/SQLiteManager.zip'
-  appcast 'https://www.sqlabs.com/news/sqlitemanager/'
+  appcast 'https://www.sqlabs.com/sqlitemanager_version'
   name 'SQLiteManager'
   homepage 'https://www.sqlabs.com/sqlitemanager.php'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.