### PR TITLE
Update vox-preferences-pane to 1.5.14

### DIFF
--- a/Casks/vox-preferences-pane.rb
+++ b/Casks/vox-preferences-pane.rb
@@ -1,6 +1,6 @@
 cask 'vox-preferences-pane' do
-  version '1.3.8'
-  sha256 '27f3ca138f5360efa795cabd3961998acf52ad534257bd0655222409ef9d4498'
+  version '1.5.14'
+  sha256 '26da53a8c6f4a14a75dc1f4f5d5dc202fbf7d23a4541d0a9ff8ea4f452168ea8'
 
   # devmate.com/com.coppertino.VoxPrefs was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coppertino.VoxPrefs/VoxPrefs.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.