### PR TITLE
Update textual to 7.1.1,ab24aeff0

### DIFF
--- a/Casks/textual.rb
+++ b/Casks/textual.rb
@@ -1,6 +1,6 @@
 cask 'textual' do
-  version '7.1.0,d1a23b2c8'
-  sha256 '5015b317848de85d63b84db3360515643574b228d98f2dbbbd70e127763825f6'
+  version '7.1.1,ab24aeff0'
+  sha256 '4e25b168c10798085a9876a59d3cd21ebdddcdb1c2c9dea881ba7d9c07169e07'
 
   url "https://cached.codeux.com/textual/downloads/resources/builds/standard-release/Textual-#{version.after_comma}.dmg"
   appcast 'https://textual-updates-backend.codeux.com/sparkle/feeds/v7/feed-one.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.