### PR TITLE
Update kaku from 1.9.0 to 2.0.2

### DIFF
--- a/Casks/kaku.rb
+++ b/Casks/kaku.rb
@@ -1,6 +1,6 @@
 cask 'kaku' do
-  version '1.9.0'
-  sha256 '3c5edd62a85a244140e73d728879dec93c0073b104fe59726579ebbb97e82546'
+  version '2.0.2'
+  sha256 'ba89cd59a49b7c21d7ccde09044e2fed7e2deeb617798ac45281f83130e313ca'
 
   # github.com/EragonJ/Kaku was verified as official when first introduced to the cask
   url "https://github.com/EragonJ/Kaku/releases/download/#{version}/Kaku-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.