### PR TITLE
Update blockstack from 0.35.4 to 0.36.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.35.4'
-  sha256 '64fa4fecbd892e3fd1a527d31f5663243614033025bf53b47a0628c85ffd4538'
+  version '0.36.0'
+  sha256 'e6410a28afe8f22fed292775793e83938c947bce4d8d39d65bed940920a376c4'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.