### PR TITLE
Update maintenance from 2.5.0 to 2.5.1

### DIFF
--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -15,8 +15,8 @@ cask 'maintenance' do
     version '2.4.2'
     sha256 '94c7a322d4d796afc5e52534f3564a562240d9c0ec0a60de210e68372fef2137'
   else
-    version '2.5.0'
-    sha256 '9a38e3104647803100e4ab02830ebf23d63e6e672ade5b03db07d32d2d9ffb01'
+    version '2.5.1'
+    sha256 '45d276ca88060de98279e9c7cb39ef10f2d3fb9f41d757f4eb7b567c893347c8'
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/Maintenance.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.