### PR TITLE
Update plex-media-player from 2.30.0.965-87662862 to 2.30.1.966-e4e7b964

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.30.0.965-87662862'
-  sha256 '8b9715b0fde2a1314d5ce5b0c960897b2bec604585e5adedb71ab4dc44b5194d'
+  version '2.30.1.966-e4e7b964'
+  sha256 'e97fb141d92324e9679b405497a4fa873dab596fefb254b3f65a58c491daca17'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.