### PR TITLE
Update rapidweaver to 8.1.7,20674.1553595093

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,6 +1,6 @@
 cask 'rapidweaver' do
-  version '8.1.6,20662.1551112236'
-  sha256 '7af2766bd0fcdc60e88dac1c3a2a7c1e3e2ebaf4f1964d217ebc174e5c349355'
+  version '8.1.7,20674.1553595093'
+  sha256 '7cded50091d2eb32f3c7c9f5fc98c8cca6ba97a02ee6b1e81337f57b4c26cb51'
 
   # devmate.com/com.realmacsoftware.rapidweaver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.realmacsoftware.rapidweaver#{version.major}/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver#{version.major}-#{version.after_comma.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.