### PR TITLE
Correct visual-studio mono-mdk516 dependence

### DIFF
--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -1,28 +1,28 @@
-cask "visual-studio" do
-  version "7.8.2.1"
-  sha256 "51f1b1d1ed1582d0f4922963e07f5e08a6f1c593165dbe136d18ed73e6247abf"
+cask 'visual-studio' do
+  version '7.8.2.1'
+  sha256 '51f1b1d1ed1582d0f4922963e07f5e08a6f1c593165dbe136d18ed73e6247abf'
 
   # dl.xamarin.com/VsMac was verified as official when first introduced to the cask
   url "https://dl.xamarin.com/VsMac/VisualStudioForMac-#{version}.dmg"
-  appcast "https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-mac-relnotes"
-  name "Visual Studio for Mac"
-  homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
+  appcast 'https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-mac-relnotes'
+  name 'Visual Studio for Mac'
+  homepage 'https://www.visualstudio.com/vs/visual-studio-mac/'
 
   auto_updates true
-  depends_on :cask => "cask-versions/mono-mdk-visual-studio"
+  depends_on cask: 'homebrew/cask-versions/mono-mdk-visual-studio'
 
-  app "Visual Studio.app"
+  app 'Visual Studio.app'
 
-  zap :trash => [
-    "/Applications/Xamarin Workbooks.app",
-    "/Applications/Xamarin Profiler.app",
-    "~/Library/Application Support/VisualStudio",
-    "~/Library/Application Support/CrashReporter/VisualStudio*",
-    "~/Library/Caches/VisualStudio",
-    "~/Library/Logs/VisualStudio",
-    "~/Library/Preferences/Visual*Studio",
-    "~/Library/Preferences/Xamarin",
-    "~/Library/Developer/Xamarin",
-    "~/Library/VisualStudio",
-  ]
+  zap trash: [
+               '/Applications/Xamarin Workbooks.app',
+               '/Applications/Xamarin Profiler.app',
+               '~/Library/Application Support/VisualStudio',
+               '~/Library/Application Support/CrashReporter/VisualStudio*',
+               '~/Library/Caches/VisualStudio',
+               '~/Library/Logs/VisualStudio',
+               '~/Library/Preferences/Visual*Studio',
+               '~/Library/Preferences/Xamarin',
+               '~/Library/Developer/Xamarin',
+               '~/Library/VisualStudio',
+             ]
 end

--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -9,7 +9,7 @@ cask 'visual-studio' do
   homepage 'https://www.visualstudio.com/vs/visual-studio-mac/'
 
   auto_updates true
-  depends_on cask: 'homebrew/cask-versions/mono-mdk-visual-studio'
+  depends_on cask: 'homebrew/cask-versions/mono-mdk516'
 
   app 'Visual Studio.app'
 

--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -1,27 +1,28 @@
-cask 'visual-studio' do
-  version '7.8.2.1'
-  sha256 '51f1b1d1ed1582d0f4922963e07f5e08a6f1c593165dbe136d18ed73e6247abf'
+cask "visual-studio" do
+  version "7.8.2.1"
+  sha256 "51f1b1d1ed1582d0f4922963e07f5e08a6f1c593165dbe136d18ed73e6247abf"
 
   # dl.xamarin.com/VsMac was verified as official when first introduced to the cask
   url "https://dl.xamarin.com/VsMac/VisualStudioForMac-#{version}.dmg"
-  appcast 'https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-mac-relnotes'
-  name 'Visual Studio for Mac'
-  homepage 'https://www.visualstudio.com/vs/visual-studio-mac/'
+  appcast "https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-mac-relnotes"
+  name "Visual Studio for Mac"
+  homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
 
-  depends_on cask: 'mono-mdk'
+  auto_updates true
+  depends_on :cask => "cask-versions/mono-mdk-visual-studio"
 
-  app 'Visual Studio.app'
+  app "Visual Studio.app"
 
-  zap trash: [
-               '/Applications/Xamarin Workbooks.app',
-               '/Applications/Xamarin Profiler.app',
-               '~/Library/Application Support/VisualStudio',
-               '~/Library/Application Support/CrashReporter/VisualStudio*',
-               '~/Library/Caches/VisualStudio',
-               '~/Library/Logs/VisualStudio',
-               '~/Library/Preferences/Visual*Studio',
-               '~/Library/Preferences/Xamarin',
-               '~/Library/Developer/Xamarin',
-               '~/Library/VisualStudio',
-             ]
+  zap :trash => [
+    "/Applications/Xamarin Workbooks.app",
+    "/Applications/Xamarin Profiler.app",
+    "~/Library/Application Support/VisualStudio",
+    "~/Library/Application Support/CrashReporter/VisualStudio*",
+    "~/Library/Caches/VisualStudio",
+    "~/Library/Logs/VisualStudio",
+    "~/Library/Preferences/Visual*Studio",
+    "~/Library/Preferences/Xamarin",
+    "~/Library/Developer/Xamarin",
+    "~/Library/VisualStudio",
+  ]
 end


### PR DESCRIPTION
One of the commits that will close https://github.com/Homebrew/homebrew-cask/issues/60110.

The associated PR is in the `cask-versions` tap: https://github.com/Homebrew/homebrew-cask-versions/pull/7145.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).