### PR TITLE
syncplay 1.6.3: add legacy version

### DIFF
--- a/Casks/syncplay.rb
+++ b/Casks/syncplay.rb
@@ -1,14 +1,18 @@
 cask 'syncplay' do
   version '1.6.3'
-  sha256 '27cc76a66a2a1c79d2e46ad6568ed8678b83f00d80a3ec7db5527774f2223caf'
+
+  if MacOS.version <= :el_capitan
+    url "https://github.com/Syncplay/syncplay/releases/download/v#{version}/Syncplay_#{version}_macOS_legacy.dmg"
+    sha256 'e81737848d3d03716daa813e6a47431f14f88db694a4ac5e341ea52103b4dea6'
+  else
+    url "https://github.com/Syncplay/syncplay/releases/download/v#{version}/Syncplay_#{version}.dmg"
+    sha256 '27cc76a66a2a1c79d2e46ad6568ed8678b83f00d80a3ec7db5527774f2223caf'
+  end
 
   # github.com/Syncplay/syncplay was verified as official when first introduced to the cask
-  url "https://github.com/Syncplay/syncplay/releases/download/v#{version}/Syncplay_#{version}.dmg"
   appcast 'https://github.com/Syncplay/syncplay/releases.atom'
   name 'Syncplay'
   homepage 'https://syncplay.pl/'
-
-  depends_on macos: '>= :sierra'
 
   app 'Syncplay.app'
 
@@ -20,5 +24,6 @@ cask 'syncplay' do
                '~/Library/Preferences/com.syncplay.MainWindow.plist',
                '~/Library/Preferences/pl.syncplay.Syncplay.plist',
                '~/Library/Preferences/com.syncplay.PlayerList.plist',
+               '~/Library/Application Support/org.videolan.vlc/lua/intf/syncplay.lua',
              ]
 end


### PR DESCRIPTION
I saw you correctly limited Syncplay compatibility to Sierra and onwards, but we also have a legacy release that supports from 10.6.8 to El Capitan. This update to the cask includes this release for people on older systems.

**NOTE:** we do not update the legacy version as often as the regular release so, in time, the version numbers will certainly differ. I wanted to have two version stanzas in this cask, but `brew cask style` complained that, at this moment, the two version number are equal. Please keep this in mind when you will update the version number of the regular release. 

Thanks for supporting Syncplay on homebrew-cask! 

-------------------------------------------------

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).