### PR TITLE
Update milanote from 1.1.10 to 1.1.11

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.1.10'
-  sha256 '5a8a0a06d80688ef1b3f8b26a48da6ef66828a1a0648b0e1cf56c2da9a8b94a3'
+  version '1.1.11'
+  sha256 'b1df1e24e180e2fa8f3207271cdf8bc7745ea6037ab90f8f94b9edd20d83d7a6'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.