### PR TITLE
Update virtualhostx from 8.7.1,80_50 to 8.7.5,80_54

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.7.1,80_50'
-  sha256 'fb0419a0771eac306cd1285716184a13d16030696ac1787beedd17c58f360999'
+  version '8.7.5,80_54'
+  sha256 'b73be99d8cde5aaab0d1ce7f592e6a9bd9265ad5697de77eb975dcbd8060ab8d'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.