### PR TITLE
Revert "Update wechat from 2.3.23.17_1548069461 to 2.3.24.17_1553586184"

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,6 +1,6 @@
 cask 'wechat' do
-  version '2.3.24.17_1553586184'
-  sha256 '23bc1b7b49d90d9d1802ac0259201c51543050a2afd2ee63173c2b0e170417f0'
+  version '2.3.23.17_1548069461'
+  sha256 '64aa3cea43988c672a36bc31f1788e9454761d97c6da0a27ad1ceafb03613c96'
 
   url "https://dldir1.qq.com/weixin/mac/WeChat_#{version}.dmg"
   appcast 'https://dldir1.qq.com/weixin/mac/mac-release.xml'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#60925

where did you find this update? I think this is still a beta version because: 
website download is v 2.3.23.17 (https://mac.weixin.qq.com/)
feed also shows 2.3.23.17 as actual version (https://dldir1.qq.com/weixin/mac/mac-release.xml)