### PR TITLE
Update vivaldi from 2.3.1440.61 to 2.4.1488.35

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.3.1440.61'
-  sha256 'e678730c5f8d22a4890b845a037ceedcbafba7f417bbd7f3ee73756e571dd1f2'
+  version '2.4.1488.35'
+  sha256 'd0c54e3ba166b2024f04968fa5a66f40b44d4bb99cc5651d1a6b83522bad2779'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.