### PR TITLE
Update workflowy from 1.2.6 to 1.2.7

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.2.6'
-  sha256 '4e3152e47883268a9abb53cb0c1933b7a67f26b1ad1263d2c5c6984bf6b78bb4'
+  version '1.2.7'
+  sha256 'a881bde9518607120d878484ece88119be93fe66bdad7e3f821b5db3b7ba2aad'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.