### PR TITLE
Update balenaetcher from 1.5.15 to 1.5.18

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.15'
-  sha256 '2b1b08dd9016bbc839e16b29985fff4e02b9fe0820ddd55c7ae56328b3580863'
+  version '1.5.18'
+  sha256 'c6bb758e36048ab5d598b461a9aa6a0279ad02759024cedfa0e2df4100c2c231'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.