### PR TITLE
Update compositor from 1.7.0 to 1.8.0

### DIFF
--- a/Casks/compositor.rb
+++ b/Casks/compositor.rb
@@ -1,6 +1,6 @@
 cask 'compositor' do
-  version '1.7.0'
-  sha256 '3674cbff94baa2e411cb0e5ba6ed4130a10979dbf68a7876f3866c8fa452a44a'
+  version '1.8.0'
+  sha256 'b75fbdc6c4879b2e64c1c47c38d87fb293dbaed10d1179c7a5ee79d25d2ff2bb'
 
   url "https://compositorapp.com/updates/Compositor_#{version}.zip"
   appcast 'https://compositorapp.com/updates/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.