### PR TITLE
Update downie from 3.6.5,1978 to 3.6.6,1981

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.6.5,1978'
-  sha256 'f389d32f3ab6247c8a46b19596f2d2df05e5d5a0407b721462614a7c6671314b'
+  version '3.6.6,1981'
+  sha256 'a3dc29664d706b521b6ccc3a018588e7cd01981aa53a01d91dba60712f33aea1'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.