### PR TITLE
Update navicat-for-mariadb from 12.1.16 to 12.1.18

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.16'
-  sha256 'bc8774c5c1c559f603b4a81c6c60c7d2c32b47eb008f41e07a76112526bfd4da'
+  version '12.1.18'
+  sha256 'a252c67a1c0813c45d69bcd24fab09e45cb86cb46d8bc6fee08048de5689250a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.