### PR TITLE
Update navicat-for-mysql from 12.1.16 to 12.1.18

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.16'
-  sha256 'c2d41ae46d33390e6454a60f5236d20e4fba8520bfcfcedc0541a18ddab68492'
+  version '12.1.18'
+  sha256 'a7f657ffd62c7e480c9b8e4a1e63bff5e63074a7968b526c685ff3e1bf58c4e9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.