### PR TITLE
Update navicat-for-sql-server from 12.1.16 to 12.1.18

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.16'
-  sha256 '89487ea52092a3cae5e9d46f94a4d1e0998ef1250bae2c4ef9f8859684d871b7'
+  version '12.1.18'
+  sha256 '0760b3178ba65e9d3ea84b6ebdab83ff30ed028cadd3cf5cc86c452eb5f5d687'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.