### PR TITLE
Update navicat-for-sqlite from 12.1.16 to 12.1.18

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.16'
-  sha256 'a7c809e8c00b1f10f66c89f99d1772c79739048345ba4f98611e29f20faec81b'
+  version '12.1.18'
+  sha256 '52ff5827e6fa32882beaa45fbbd6f031919f9739a3fb30c0bb733066e53b1fa0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.