### PR TITLE
Update navicat-premium-essentials from 12.1.16 to 12.1.18

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '12.1.16'
-  sha256 'd458203cfd78a06a61caaece7e978918cfd77b780cdfc7a14721f8d007ad3319'
+  version '12.1.18'
+  sha256 '233a823fb8632f3b4d40cd8f129be2cc127c73dd6b8692567744091002078d85'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20Premium%20Essentials&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.