### PR TITLE
Update jamovi from 0.9.6.3 to 0.9.6.4

### DIFF
--- a/Casks/jamovi.rb
+++ b/Casks/jamovi.rb
@@ -1,6 +1,6 @@
 cask 'jamovi' do
-  version '0.9.6.3'
-  sha256 '5f8f161e8a82db36ac42f838609caa0cbaf7b9b801a3088d553436b113c0d136'
+  version '0.9.6.4'
+  sha256 '741df258d78eef11d5ed11f4d8a92912426df3570994dc5a321ce6bed1b7526f'
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos.dmg"
   appcast 'https://www.jamovi.org/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.