### PR TITLE
Update cacher from 2.6.8 to 2.6.9

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.6.8'
-  sha256 'a697699bff4ff1ae65d0b6170cd6165a6881b59f29de48e99dfee2d533ee52d4'
+  version '2.6.9'
+  sha256 '22cfe2c87270019686e54697ed07410d15a2637b7276d60c132a04dcb7e4533c'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.