### PR TITLE
Update tableau-public from 2019.1.0 to 2019.1.2

### DIFF
--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,6 +1,6 @@
 cask 'tableau-public' do
-  version '2019.1.0'
-  sha256 '702a2548a3da20197a6a0ab98a07e53ef7652846f81e475f8347b6cda20bf095'
+  version '2019.1.2'
+  sha256 '2bd2e56d6b57ed57aec7afeb8a58f47e7dc61f2cb80c9999469b515b5994b623'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.