### PR TITLE
Update talon from 89-0.0.8.29 to 98-0.0.8.38

### DIFF
--- a/Casks/talon.rb
+++ b/Casks/talon.rb
@@ -1,6 +1,6 @@
 cask 'talon' do
-  version '89-0.0.8.29'
-  sha256 '87d49ff38693872394f17dc9413e00de2c82693c6eaf0c44a45c8740c86748b2'
+  version '98-0.0.8.38'
+  sha256 '45de05c79f7119785cf01535521e2872ed0c409018a32453804db90c6e707368'
 
   url "https://talonvoice.com/update/nmi5s3faoq6NzROd2dbCRg/Talon-#{version}.dmg"
   appcast 'https://talonvoice.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.