### PR TITLE
Update intellij-idea to 2019.1,191.6183.87

### DIFF
--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -1,8 +1,8 @@
 cask 'intellij-idea' do
-  version '2018.3.6,183.6156.11'
-  sha256 '2ae152de3933cae002b50d13735ec0cf7cbad23918ce3819640a3c7c14079e61'
+  version '2019.1,191.6183.87'
+  sha256 '8369a1ab49b19cafc5cafb473c9271eca1f785960dbd346bde183d1a0993fcdf'
 
-  url "https://download.jetbrains.com/idea/ideaIU-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.before_comma}-jbr11.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release'
   name 'IntelliJ IDEA Ultimate'
   homepage 'https://www.jetbrains.com/idea/'


### PR DESCRIPTION
This change set is upgrading IntelliJ IDEA to version 2019.1 (build 191.6183.87) and switching to the new JetBrains Runtime 11 for IntelliJ IDEA.

Release notes:
https://blog.jetbrains.com/idea/2019/03/intellij-idea-2019-1-is-released-theme-customization-java-12-switch-expressions-debug-inside-docker-containers-and-more/

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).