### PR TITLE
Update jprofiler from 10.1.5 to 11.0

### DIFF
--- a/Casks/jprofiler.rb
+++ b/Casks/jprofiler.rb
@@ -1,6 +1,6 @@
 cask 'jprofiler' do
-  version '10.1.5'
-  sha256 '2efd82af381240196ac4571070bfa6ed764b1589068b995f12dfb97bc2aeac26'
+  version '11.0'
+  sha256 '51f206fbb9a44ea839558bd0aac2afd34ca0949c3cad9a2f6e7ab16ad9afef0c'
 
   url "https://download-keycdn.ej-technologies.com/jprofiler/jprofiler_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.ej-technologies.com/feeds/jprofiler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.