### PR TITLE
Update sloth from 2.7 to 2.8

### DIFF
--- a/Casks/sloth.rb
+++ b/Casks/sloth.rb
@@ -1,6 +1,6 @@
 cask 'sloth' do
-  version '2.7'
-  sha256 'fdcbfd025bd50910e62c63f6464ddf40d90b75caed1a4a95654a49cc1b0f2ef1'
+  version '2.8'
+  sha256 'b260203343f955eaae3e3765b0b702713866b980321b6ebcbc7c04a33c5bc073'
 
   url "https://sveinbjorn.org/files/software/sloth/sloth-#{version}.zip"
   appcast 'https://sveinbjorn.org/files/appcasts/SlothAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.