### PR TITLE
Update melodics from 2.0.2717 to 2.0.2727

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2717'
-  sha256 '665120fa24cfcd7834d0f94d864d43620fe810233970a29d86eefe0b4e90486a'
+  version '2.0.2727'
+  sha256 '7470733bc137f38ca73db0ed754a005ff7d17ac0510cc42c841c0f6c0dba2fa9'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.