### PR TITLE
Update flirc from 3.20.4 to 3.22.2

### DIFF
--- a/Casks/flirc.rb
+++ b/Casks/flirc.rb
@@ -1,6 +1,6 @@
 cask 'flirc' do
-  version '3.20.4'
-  sha256 '471f5ac1c7f238e233b6562ecbce93606baba14ed05bd113234fe213a3063fb6'
+  version '3.22.2'
+  sha256 '691aeed9020a4eeb937b4ec39c0abb1a649e8cf969b53c9b5621ef882e3af1f4'
 
   url 'https://flirc.tv/software/release/gui/mac/Flirc.dmg'
   appcast 'https://flirc.tv/software/release/gui/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.