### PR TITLE
Update hype from 3.6.7 to 3.6.8

### DIFF
--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -1,6 +1,6 @@
 cask 'hype' do
-  version '3.6.7'
-  sha256 'bf7c50c3586db09eeb957900a156b4e0c14a53b5a92fdb6471a7a952649cc324'
+  version '3.6.8'
+  sha256 '0f82b4b9b453eaeb834ec64d277a79c8ac74e938a44d6c6c4efec3ed7ff2623f'
 
   url 'https://tumult.com/hype/download/Hype.zip'
   appcast 'https://tumult.com/hype/appcast_hype2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.