### PR TITLE
Update winds from 3.1.4 to 3.1.11

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '3.1.4'
-  sha256 'ebb116a2a3b7396eff1edfce7d69da31ea6f6d66efc04a98f6c260319eda2ba8'
+  version '3.1.11'
+  sha256 'f99d4c0f1d85697078ab20cc88b11a556d0ecaba51966bf9c213ad194ef474b3'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-2.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.