### PR TITLE
Update polar-bookshelf from 1.15.0 to 1.15.2

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.15.0'
-  sha256 '4144b3c4f59df98eb11de9f97b73f3c358dc9de228450b65f01ab7a306602659'
+  version '1.15.2'
+  sha256 'fd7dae67940817d058d561cdacfec3bb3ca46e2f33bfe0e7f2c256fe1405bc51'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.