### PR TITLE
Update mediaelch from 2.6.1-dev_2019-02-09_14-04_git-master-c1f194a to 2.6.0

### DIFF
--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,9 +1,9 @@
 cask 'mediaelch' do
-  version '2.6.1-dev_2019-02-09_14-04_git-master-c1f194a'
-  sha256 '8412e258e303b4be13ec6890c5e330316054c28b505e3922f0ffcb0e9cc2e208'
+  version '2.6.0'
+  sha256 'c4a44f10f59281a35910e476a450a3811dcd1eb7be666dd0acb4518767fa6bc7'
 
-  # bintray.com/artifact/download/komet/MediaElch was verified as official when first introduced to the cask
-  url "https://bintray.com/artifact/download/komet/MediaElch/MediaElch_macOS_#{version}.dmg"
+  # github.com/Komet/MediaElch was verified as official when first introduced to the cask
+  url "https://github.com/Komet/MediaElch/releases/download/v#{version}/MediaElch_#{version}_macOS.dmg"
   appcast 'https://github.com/Komet/MediaElch/releases.atom'
   name 'MediaElch'
   homepage 'https://www.kvibes.de/en/mediaelch/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.