### PR TITLE
Update appium from 1.11.0 to 1.10.0

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,6 +1,6 @@
 cask 'appium' do
-  version '1.11.0'
-  sha256 '298c1f87be00ae467bedf57b379eff2819a9bc9bc39761f9da1a5f3ea8226563'
+  version '1.10.0'
+  sha256 '4302162eed289c5533e1cf9c5a13e2513ca766143fd9262c027daccfb9b99ab1'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
   url "https://github.com/appium/appium-desktop/releases/download/v#{version}/Appium-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.