### PR TITLE
Update android-platform-tools from 28.0.1 to 28.0.2

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,6 +1,6 @@
 cask 'android-platform-tools' do
-  version '28.0.1'
-  sha256 '3bc833ae3f4bd831af03811f2d1be540c2eb2eb9a17de9398b0a06dc5af6fa84'
+  version '28.0.2'
+  sha256 'ee3a6762bead5d77c19d8772f205b846c0170b8cd387f8e6d6932aed60d7814c'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.