### PR TITLE
Update data-rescue from 5.0.7 to 5.0.8

### DIFF
--- a/Casks/data-rescue.rb
+++ b/Casks/data-rescue.rb
@@ -1,6 +1,6 @@
 cask 'data-rescue' do
-  version '5.0.7'
-  sha256 '2fec60663055ccb708c07f6b8eb1843951e3db1d0abd4c6e0c8425a69890bcfb'
+  version '5.0.8'
+  sha256 '22b298f0ba27ddecf03da11064f716dc8529a0fc20eb649a6dd14b4160e58a98'
 
   url "https://downloads.prosofteng.com/dr/Data_Rescue_#{version}.dmg"
   appcast "https://www.prosofteng.com/resources/dr#{version.major}/dr#{version.major}_updates_mac.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.