### PR TITLE
Update trilium-notes from 0.30.5 to 0.30.6

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.30.5'
-  sha256 'ddc9bf355925ca679466913af4574277f5b334b67a639a1f9ed8b8055e17aa1a'
+  version '0.30.6'
+  sha256 'be868cf7e1e2b11cd9a01588d5d168d0e6f33d589d41b0e24b6e3f8855529156'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.