### PR TITLE
Update opera to 58.0.3135.127

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '58.0.3135.118'
-  sha256 '6715b521d55f05a1bcb9e35a51a36037641f297a5a16f30a75c73093d5966779'
+  version '58.0.3135.127'
+  sha256 'd909e3b9e4489223a86c3946290510abfa5a00caa7d301a32b501e98145d5583'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name 'Opera'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.