### PR TITLE
Update trickster from 2.8 to 3.0

### DIFF
--- a/Casks/trickster.rb
+++ b/Casks/trickster.rb
@@ -1,6 +1,6 @@
 cask 'trickster' do
-  version '2.8'
-  sha256 '4d2e4196e5baf7ace6e7258c867eae7e5310acb1de263c4bc631ae6a95e075b6'
+  version '3.0'
+  sha256 '187c9cfb4519363f342636744a0149ab8fbfd229bfbf3228e8bed34248d79ac4'
 
   url "https://dl.apparentsoft.com/Trickster_#{version}.zip"
   appcast 'https://dl.apparentsoft.com/trickster.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.