### PR TITLE
Update soundsource from 4.0.0 to 4.0.1

### DIFF
--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -1,6 +1,6 @@
 cask 'soundsource' do
-  version '4.0.0'
-  sha256 '7a336135afb6b53f00ce898838281212b935631fd958bfc93facc239c3601889'
+  version '4.0.1'
+  sha256 'c878dd443003fdfec9ed0565e1e5942a1742f98f69c5388582668cbc13ae4d3f'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&version=4008000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.