### PR TITLE
Update sublime-text from 3.200 to 3.202

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text' do
-  version '3.200'
-  sha256 '1c2a1eb25b938cbba7af8996c6bdff2c2ae0b97861db19e8a083f733596ff2f9'
+  version '3.202'
+  sha256 'ab7cb35bbb7e58569adf265f991da6cc8601e9f2470a174814bec1f10207302d'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.