### PR TITLE
Revert "Update sublime-text from 3.200 to 3.202 (#61080)"

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text' do
-  version '3.202'
-  sha256 'ab7cb35bbb7e58569adf265f991da6cc8601e9f2470a174814bec1f10207302d'
+  version '3.200'
+  sha256 '1c2a1eb25b938cbba7af8996c6bdff2c2ae0b97861db19e8a083f733596ff2f9'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml"


### PR DESCRIPTION
This reverts commit 1ac25352b89bc589f94e990550c96e4ed5aea882.

Version 3.202 is a development build and is instead maintained as the
sublime-text-dev package in the homebrew-cask repository.

Version 3.200 is the latest stable release as can be seen on the changelogs
for the stable and development builds here:

Stable: https://www.sublimetext.com/3
Development: https://www.sublimetext.com/3dev