### PR TITLE
Update luminetmonitor from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/luminetmonitor.rb
+++ b/Casks/luminetmonitor.rb
@@ -1,12 +1,10 @@
 cask 'luminetmonitor' do
-  version '2.2.0'
-  sha256 'e53bfaa2eb7649da9fe6e4a37d8c707f776e2e84b61d77d2e4e4a99849257756'
+  version '2.2.1'
+  sha256 '21ade79c58c310fa84e32c1d613bbb76cc3a92670c20fb8b6501f4290a8381ed'
 
-  url 'http://www.mrte.jp/files/topics/122_ext_03_0.zip'
+  url "http://software.luminex.be/download.php?file=mac/LumiNetMonitor/#{version}LumiNetMonitor.app.7z"
   name 'LumiNet Monitor'
-  homepage 'http://www.mrte.jp/'
-
-  container nested: "LumiNetMonitor#{version.no_dots}_mac/LumiNetMonitor#{version.no_dots}.dmg"
+  homepage 'https://www.luminex.be/'
 
   app 'LumiNetMonitor.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
