### PR TITLE
Update inboxer from 1.2.1 to 1.3.2

### DIFF
--- a/Casks/inboxer.rb
+++ b/Casks/inboxer.rb
@@ -1,6 +1,6 @@
 cask 'inboxer' do
-  version '1.2.1'
-  sha256 '1a57278556e8d65b6b0f0330f0d64c8308c8bc7028fce592c51f969726ea29b3'
+  version '1.3.2'
+  sha256 'a6e66175b53656ccf2965aae0e8f880a9470ffafeae1b0b72e78b170dd08daf8'
 
   # github.com/denysdovhan/inboxer was verified as official when first introduced to the cask
   url "https://github.com/denysdovhan/inboxer/releases/download/v#{version}/Inboxer-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.