### PR TITLE
Update talon from 98-0.0.8.38 to 99-0.0.8.39

### DIFF
--- a/Casks/talon.rb
+++ b/Casks/talon.rb
@@ -1,6 +1,6 @@
 cask 'talon' do
-  version '98-0.0.8.38'
-  sha256 '45de05c79f7119785cf01535521e2872ed0c409018a32453804db90c6e707368'
+  version '99-0.0.8.39'
+  sha256 'ee95ab2a16a501c4d7be375eb9ad97b14627708733e51a6326133a8cda24f067'
 
   url "https://talonvoice.com/update/nmi5s3faoq6NzROd2dbCRg/Talon-#{version}.dmg"
   appcast 'https://talonvoice.com/update/nmi5s3faoq6NzROd2dbCRg/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.