### PR TITLE
Update 4k-youtube-to-mp3 from 3.4.0.1964 to 3.6.0.2084

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.4.0.1964'
-  sha256 'b61cabb490f2a78ba9a33ebd937702fe715946f69cb954559ce5fe5103b7881a'
+  version '3.6.0.2084'
+  sha256 '4d71ae2794663c0166aa0c1697756df8816b1a332d88aac7cdd990c0d18ba6b2'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.