### PR TITLE
Update abstract from 78.0.0 to 78.0.2

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '78.0.0'
-  sha256 'c4750ed24acb0f92cb05a6e5f98969ce8202f712cb502cf94188295910c5987e'
+  version '78.0.2'
+  sha256 '5627a3d169fe50d2c1c1b9db86174f4a580e24855e26f870590eae9066cf4b4d'
 
   url "https://downloads.goabstract.com/Abstract-#{version}.dmg"
   appcast 'https://www.goabstract.com/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.