### PR TITLE
Update camunda-modeler from 2.2.4 to 3.0.1

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '2.2.4'
-  sha256 '9936bd54c0c15f7574fcaa8e58df5e2154831384608efb38c009c3e6e20db219'
+  version '3.0.1'
+  sha256 '7481a4e1b5667e467be6a3c5cdca0bb4f75fc04cd871a9eb0689bc62294d9b97'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-mac.zip"
   appcast 'https://camunda.com/download/modeler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.