### PR TITLE
Update ocenaudio from 3.6.0.1 to 3.6.1

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,6 +1,6 @@
 cask 'ocenaudio' do
-  version '3.6.0.1'
-  sha256 'cd173c3fff41e65b162a594d0f99d6f4d287f0ca5cd61d0a11318cb3591ae85b'
+  version '3.6.1'
+  sha256 '075c79480ddef77da947ca220b14311d1833b9699480040af4c5e6f234d6eb2b'
 
   url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.