### PR TITLE
updated broken app name and homepage for Google Ads Editor

### DIFF
--- a/Casks/google-ads-editor.rb
+++ b/Casks/google-ads-editor.rb
@@ -1,4 +1,4 @@
-cask 'google-adwords-editor' do
+cask 'google-ads-editor' do
   version :latest
   sha256 :no_check
 

--- a/Casks/google-adwords-editor.rb
+++ b/Casks/google-adwords-editor.rb
@@ -3,8 +3,8 @@ cask 'google-adwords-editor' do
   sha256 :no_check
 
   url 'https://dl.google.com/adwords_editor/Google_AdWords_Editor.dmg'
-  name 'Google AdWords Editor'
-  homepage 'https://adwords.google.com/home/tools/adwords-editor/?zd=1'
+  name 'Google Ads Editor'
+  homepage 'https://ads.google.com/home/tools/ads-editor/'
 
   app 'Google Ads Editor.app'
 end

--- a/Casks/google-adwords-editor.rb
+++ b/Casks/google-adwords-editor.rb
@@ -6,5 +6,5 @@ cask 'google-adwords-editor' do
   name 'Google AdWords Editor'
   homepage 'https://adwords.google.com/home/tools/adwords-editor/?zd=1'
 
-  app 'Google AdWords Editor.app'
+  app 'Google Ads Editor.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

The current cask in `master` is broken.  This PR is an attempt to fix it with minimal changes.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
