### PR TITLE
Update appium from 1.10.0 to 1.12.0

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,9 +1,9 @@
 cask 'appium' do
-  version '1.10.0'
-  sha256 '4302162eed289c5533e1cf9c5a13e2513ca766143fd9262c027daccfb9b99ab1'
+  version '1.12.0'
+  sha256 '3b6d50fc5202309098cd0387b87b4c69053976770fd51a9371653b6be4353ae0'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
-  url "https://github.com/appium/appium-desktop/releases/download/v#{version}/Appium-#{version}.dmg"
+  url "https://github.com/appium/appium-desktop/releases/download/v#{version}/Appium-mac-#{version}.dmg"
   appcast 'https://github.com/appium/appium-desktop/releases.atom'
   name 'Appium Desktop'
   homepage 'https://appium.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.