### PR TITLE
Update flipper from 0.18.0 to 0.19.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.18.0'
-  sha256 '7a0f98b4c837545890c726c9f5ca4c4f1a93ffd9dd4d63191a2b683198bd190e'
+  version '0.19.0'
+  sha256 '39f3c428e7cb082d8e8cf0c959895e74b06cbb5d70f916234c6c9042a43bd06a'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.