### PR TITLE
Update inboxer from 1.3.2 to 1.2.3

### DIFF
--- a/Casks/inboxer.rb
+++ b/Casks/inboxer.rb
@@ -1,6 +1,6 @@
 cask 'inboxer' do
-  version '1.3.2'
-  sha256 'a6e66175b53656ccf2965aae0e8f880a9470ffafeae1b0b72e78b170dd08daf8'
+  version '1.2.3'
+  sha256 '751f4987476668778b060177cd185f8ed2f2a449303938194b67f0c6cad90f9a'
 
   # github.com/denysdovhan/inboxer was verified as official when first introduced to the cask
   url "https://github.com/denysdovhan/inboxer/releases/download/v#{version}/Inboxer-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.