### PR TITLE
Update unshaky from 0.4.4 to 0.4.5

### DIFF
--- a/Casks/unshaky.rb
+++ b/Casks/unshaky.rb
@@ -1,6 +1,6 @@
 cask 'unshaky' do
-  version '0.4.4'
-  sha256 'a1210604185037049b0d62a895315da229a86c34c8806c0f310697f9b5d92b5b'
+  version '0.4.5'
+  sha256 'f2b534fddde64193ee6621ec1b33fb73edfc10f86aa5f6fa16c621c824713dae'
 
   url "https://github.com/aahung/Unshaky/releases/download/v#{version}/Unshaky_v#{version}.zip"
   appcast 'https://github.com/aahung/Unshaky/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.