### PR TITLE
Update unity-ios-support-for-editor from 2018.3.9f1,947e1ea5aa8d to 2018.3.11f1,5063218e4ab8

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2018.3.9f1,947e1ea5aa8d'
-  sha256 '96cc483f8139270b97f0dcaed5f5ee24de63bd518a584641cf04d4ca279a60a9'
+  version '2018.3.11f1,5063218e4ab8'
+  sha256 '3fc4ee64d0984249e4a291bbb264a26d91145fbd05e9159060f5e1b8107cd8f2'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.