### PR TITLE
Update unity-vuforia-ar-support-for-editor from 2018.3.9f1,947e1ea5aa8d to 2018.3.11f1,5063218e4ab8

### DIFF
--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-vuforia-ar-support-for-editor' do
-  version '2018.3.9f1,947e1ea5aa8d'
-  sha256 '1c786aff87f2d3ef1f8cfcf374a5dc1a3e083da5aa49cf9ae93e3b0008197671'
+  version '2018.3.11f1,5063218e4ab8'
+  sha256 '29341c21cd08c049dabe6627d8d3531ee123d8ab9c0b0e95a48a38f098b1e50e'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.