### PR TITLE
Update unity-webgl-support-for-editor from 2018.3.7f1,9e14d22a41bb to 2018.3.11f1,5063218e4ab8

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.3.7f1,9e14d22a41bb'
-  sha256 '87463cc65bb63389ea5ee29c30411ff1d532cee142c4a40394800c94d1f9f5e8'
+  version '2018.3.11f1,5063218e4ab8'
+  sha256 '9a6ae1b7436ef2c5f6cc6c62230f3e8ee904474c332cf62c3de35e86d2994bf6'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.