### PR TITLE
Update ibackup-viewer from 4.1230 to 4.1240

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1230'
-  sha256 '662a93a4c1d4d92ec05f3235112d6f1b7576bbc04906441a3e1de8862aafea64'
+  version '4.1240'
+  sha256 '970c02ff5cf13f1fa660e0f770b8342b416bf99c79be55545e8b236970196662'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.