### PR TITLE
Update djv from 1.2.5 to 1.2.6

### DIFF
--- a/Casks/djv.rb
+++ b/Casks/djv.rb
@@ -1,6 +1,6 @@
 cask 'djv' do
-  version '1.2.5'
-  sha256 '29c148722d7a6e5a0e37b26faf07e876988ce4d6a74b7c89e174f9738930786c'
+  version '1.2.6'
+  sha256 'de29b756a8d8cc4f88fa4f5f2718680a7b41c937c48658617d796190aefa19cf'
 
   # downloads.sourceforge.net/djv was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/djv/djv-stable/#{version}/DJV-#{version}-Darwin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.