### PR TITLE
Update psychopy from 3.0.6 to 3.0.7

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '3.0.6'
-  sha256 'e3f04f4fbd866693fa596fc1713324df34a71ef4afe0d2f32482e8250939c994'
+  version '3.0.7'
+  sha256 'e1adf0cfb86f5183dc49f828780b8a1efa140408438eed7f27cdda9301bf0f43'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.