### PR TITLE
Update cmake from 3.14.0 to 3.14.1

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.14.0'
-  sha256 '97f34f3ce6657a65c5232bfc1ecea41c8e7bf084d35ce5a43c58f02b97143771'
+  version '3.14.1'
+  sha256 '885ff60ca4b93670380ad0e241ce80b961fe34104b94ec7c43f2d8c3f915540d'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.