### PR TITLE
Update electron from 4.1.1 to 4.1.3

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '4.1.1'
-  sha256 '5b172d5ca70cf9730516fab4c6898fac9dcf161e73b9c68959cceb9f586f40a9'
+  version '4.1.3'
+  sha256 '3fa77342666ba08a24b04208d1b6c980de786e0a33d0e470f995be8ab48f4e68'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.