### PR TITLE
Update touchswitcher from 1.0.1,100 to 1.3.1,100

### DIFF
--- a/Casks/touchswitcher.rb
+++ b/Casks/touchswitcher.rb
@@ -1,5 +1,5 @@
 cask 'touchswitcher' do
-  version '1.0.1,100'
+  version '1.3.1,100'
   sha256 'f7bc7cdf143e0b803c97846bac154fbd20305bc9be3289e43f9604968df839fc'
 
   url 'https://hazeover.com/touchswitcher/TouchSwitcher.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.