### PR TITLE
Update altair-graphql-client from 2.1.4 to 2.1.5

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.1.4'
-  sha256 '0422e29a423aad71e00a760c066ab22e91f4257e6136eff11855abc77cd9cec3'
+  version '2.1.5'
+  sha256 'c0170d08e48c8716b972bdd11c34e11758a02bba77850e887213d0ce116fee93'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.