### PR TITLE
Update double-commander from 0.9.1-8664 to 0.9.2-8761

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,6 +1,6 @@
 cask 'double-commander' do
-  version '0.9.1-8664'
-  sha256 '78095b62b3692e571afa3cd481c3eb618243554436ae35e7d0ba3c5388ad6d10'
+  version '0.9.2-8761'
+  sha256 'c84e7496022bc7511fe9b8aa15fba7820f57f5acdd79a821c7f87dbad98ed758'
 
   # downloads.sourceforge.net/doublecmd was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.