### PR TITLE
Update resolume-avenue from 6.1.2,62140 to 6.1.3,63134

### DIFF
--- a/Casks/resolume-avenue.rb
+++ b/Casks/resolume-avenue.rb
@@ -1,6 +1,6 @@
 cask 'resolume-avenue' do
-  version '6.1.2,62140'
-  sha256 '51a09f16ae19f252c9486134039389fe638208eded7f407cf9cb233086fb3e50'
+  version '6.1.3,63134'
+  sha256 'e82312bc10d274d53bf10024ac36e67590cf13b05345a5beadb7db90f51e74b6'
 
   url "https://resolume.com/download/Resolume_Avenue_#{version.major_minor_patch.dots_to_underscores}_rev_#{version.after_comma}_Installer.dmg"
   appcast 'https://resolume.com/update/avenue_mac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.