### PR TITLE
Update nimble-commander from 1.2.4,2676 to 1.2.5,2846

### DIFF
--- a/Casks/nimble-commander.rb
+++ b/Casks/nimble-commander.rb
@@ -1,6 +1,6 @@
 cask 'nimble-commander' do
-  version '1.2.4,2676'
-  sha256 '3b1d984b81225e17f2a767d8ceb14306bca21522df7f9c6d7954a932389707d5'
+  version '1.2.5,2846'
+  sha256 'b18240ff5642342ab8eb4f258b3d665e2f5b90e6fd09b0f1c283fae95a9cd490'
 
   url "https://magnumbytes.com/downloads/releases/nimble-commander-#{version.before_comma}(#{version.after_comma}).dmg"
   appcast 'https://magnumbytes.com/downloads/releases/sparkle-nimble-commander.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.