### PR TITLE
Update polar-bookshelf from 1.15.2 to 1.16.0

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.15.2'
-  sha256 'fd7dae67940817d058d561cdacfec3bb3ca46e2f33bfe0e7f2c256fe1405bc51'
+  version '1.16.0'
+  sha256 'd0bbc89a38f8d2af3d45e72c6848dd9e1da9608b6b99c05d306e0b0d39e00f5a'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.