### PR TITLE
Update ezip from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/ezip.rb
+++ b/Casks/ezip.rb
@@ -1,6 +1,6 @@
 cask 'ezip' do
-  version '1.7.1'
-  sha256 '694f5630e0fc57c225c651d3a9fb6ba35ddad8da586c1b1afbd665c58dc0426c'
+  version '1.7.2'
+  sha256 '555110185f54dcd1dda9186f6baa85d0ea23b99e12f565e7a7a12597e8f407b3'
 
   url "https://cdn.awehunt.com/ezip/release/eZip_V#{version}.dmg"
   appcast 'https://ezip.awehunt.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.