### PR TITLE
Update apple-juice from 1.7.1 to 1.8.0

### DIFF
--- a/Casks/apple-juice.rb
+++ b/Casks/apple-juice.rb
@@ -1,6 +1,6 @@
 cask 'apple-juice' do
-  version '1.7.1'
-  sha256 'dbad910d134f3a2c6de503d81738d8cf7072a9b6a73c34fad502e59441fafaba'
+  version '1.8.0'
+  sha256 '88284c11a82cd220fccbb99e8321b34202cb5650e28cddf0c876435a1a9a7e8d'
 
   url "https://github.com/raphaelhanneken/apple-juice/releases/download/#{version}/Apple.Juice.dmg"
   appcast 'https://github.com/raphaelhanneken/apple-juice/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.