### PR TITLE
Update cuppa from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/cuppa.rb
+++ b/Casks/cuppa.rb
@@ -1,6 +1,6 @@
 cask 'cuppa' do
-  version '1.8.1'
-  sha256 '1355d94fb6648b056011beb120f6cd72803e0530c9286efbd46883eaa357253d'
+  version '1.8.2'
+  sha256 'cf1ce3129044cf588e83f8030aef4c30a01859d82265a3e938501e8e2f1ca44c'
 
   url "https://www.nathanatos.com/software/downloads/Cuppa-#{version}.zip"
   appcast 'https://www.nathanatos.com/software/cuppa.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.