### PR TITLE
Update pphelper from 2.3.7 to 2.4.0

### DIFF
--- a/Casks/pphelper.rb
+++ b/Casks/pphelper.rb
@@ -1,6 +1,6 @@
 cask 'pphelper' do
-  version '2.3.7'
-  sha256 '214366e0679c2df2bd5db78cf289eba9a099a4582b3f7c9882b29ac34eee24cd'
+  version '2.4.0'
+  sha256 '2bcade81898c8c1d41c2877d906b94bd889178204c53cd85655d7219d30e55c6'
 
   url 'https://ghost.25pp.com/soft/pp_mac.dmg'
   appcast 'https://liveupdate.25pp.com/macpc/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.