### PR TITLE
Update mongodb from 4.0.5-build.1 to 4.0.8-build.1

### DIFF
--- a/Casks/mongodb.rb
+++ b/Casks/mongodb.rb
@@ -1,6 +1,6 @@
 cask 'mongodb' do
-  version '4.0.5-build.1'
-  sha256 '6073c2e97965f12070aee0b6f8f57986e4629a35f59e4a4b2361715d15e02651'
+  version '4.0.8-build.1'
+  sha256 '38d60ce05de52aedf10bf4d686681db28731a7e90b9b88b7047036cd9bd0d67f'
 
   # github.com/gcollazo/mongodbapp was verified as official when first introduced to the cask
   url "https://github.com/gcollazo/mongodbapp/releases/download/#{version}/MongoDB.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.