### PR TITLE
Update unshaky from 0.4.5 to 0.4.6

### DIFF
--- a/Casks/unshaky.rb
+++ b/Casks/unshaky.rb
@@ -1,6 +1,6 @@
 cask 'unshaky' do
-  version '0.4.5'
-  sha256 'f2b534fddde64193ee6621ec1b33fb73edfc10f86aa5f6fa16c621c824713dae'
+  version '0.4.6'
+  sha256 'c04ae51ee8cb38e9db75b61a5b0b8592df65855a5765b9f4a688a6bb28eab7f0'
 
   url "https://github.com/aahung/Unshaky/releases/download/v#{version}/Unshaky_v#{version}.zip"
   appcast 'https://github.com/aahung/Unshaky/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.