### PR TITLE
Update praat from 6.0.49 to 6.0.50

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.0.49'
-  sha256 '1321aeed94a6b376ddd8f5c0201e7ab61bcd2fc93a12cec0ba0f6d9f937997ff'
+  version '6.0.50'
+  sha256 '120a7f25291a370c9e9f21e1561efcd2e563ef3e2b88322154323b65c106b013'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.