### PR TITLE
Update wiznote from 2.7.1,2019-03-13 to 2.7.2,2019-03-13

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,5 +1,5 @@
 cask 'wiznote' do
-  version '2.7.1,2019-03-13'
+  version '2.7.2,2019-03-13'
   sha256 '9b7ba3700406297743c9bafa333b5885d342ade338eeae4d355e5985876bcb3b'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.