### PR TITLE
Update torguard from 3.93.1 to 3.93.2

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,6 +1,6 @@
 cask 'torguard' do
-  version '3.93.1'
-  sha256 '4174bb919d757999a9423db688bcc77b95225d65219c5baeebefe609f3759450'
+  version '3.93.2'
+  sha256 '6cf08d3cd58eefde8e861597458433ecf45cea4090e912a2b91aa4749aea2b45'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.