### PR TITLE
Update psi-plus from 1.4.592-macOS10.12 to 1.4.628-macOS10.12

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.592-macOS10.12'
-  sha256 '4c21592fa26a55bfbdc2b1da146ba1d347d56b8801ad44eeac2b412848093643'
+  version '1.4.628-macOS10.12'
+  sha256 '4098bc3aa08c23e3f5dc0fa82786ed021f69a10067073d31e7561ffdcb3577e1'
 
   # downloads.sourceforge.net/psiplus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.