### PR TITLE
Update jalbum from 18.0.3 to 18.1

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,8 +1,8 @@
 cask 'jalbum' do
-  version '18.0.3'
-  sha256 '84547e6ea152b8ae90b92bfc757a117e47694688c43199aaab311a85041ee9dc'
+  version '18.1'
+  sha256 '0734fe553566abab4dd9c2b79a75f9c53830b5dcafb60dcc8635a6def11de9ae'
 
-  url "https://download.jalbum.net/download/#{version.major}/MacOSX/jAlbum.dmg"
+  url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous'
   name 'jAlbum'
   homepage 'https://jalbum.net/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.