### PR TITLE
Update intel-haxm from 7.3.2 to 7.4.1

### DIFF
--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -1,6 +1,6 @@
 cask 'intel-haxm' do
-  version '7.3.2'
-  sha256 '48c87dc4c2e026a367ac5e444308ee486f5ea7d5672f87a12670a53edca7a74e'
+  version '7.4.1'
+  sha256 '613c2ee9725af7febdb1b0adef0f8f487aa610f0fa4b75d89dad267145cd2293'
 
   # github.com/intel/haxm was verified as official when first introduced to the cask
   url "https://github.com/intel/haxm/releases/download/v#{version}/haxm-macosx_v#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.