### PR TITLE
Update tankix from visual3-38920 to visual1-39890

### DIFF
--- a/Casks/tankix.rb
+++ b/Casks/tankix.rb
@@ -1,6 +1,6 @@
 cask 'tankix' do
-  version 'visual3-38920'
-  sha256 'ab566101842943c9709a9c670e9adb88d292d191b906a5227b25878ce21974f5'
+  version 'visual1-39890'
+  sha256 'c540ac2b6d044cecc3b622d0cc13e03bd7e560cea8ee72a967f3006eafcef8ec'
 
   url "https://static.tankix.com/app/StandaloneOSXIntel64/#{version}/TankiX.dmg"
   appcast 'https://tankix.com/en/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.