### PR TITLE
Update thunder from 3.3.2.3940 to 3.3.2.3944

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '3.3.2.3940'
-  sha256 '6787a3e6ff04efe7d201c34ad511f571783ea08e9c173649658d739f2692f777'
+  version '3.3.2.3944'
+  sha256 '359ca0b366f504978f8a38e54a94826ba369141275144b69b6fc13c2977c319c'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "http://down.sandai.net/mac/thunder_#{version}.dmg"

--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -7,7 +7,7 @@ cask 'thunder' do
   appcast 'http://static-xl9-ssl.xunlei.com/json/mac_download_url.json'
   name 'Thunder'
   name '迅雷'
-  homepage 'https://mac.xunlei.com'
+  homepage 'https://mac.xunlei.com/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -7,7 +7,7 @@ cask 'thunder' do
   appcast 'http://static-xl9-ssl.xunlei.com/json/mac_download_url.json'
   name 'Thunder'
   name '迅雷'
-  homepage 'http://mac.xunlei.com/'
+  homepage 'https://mac.xunlei.com'
 
   depends_on macos: '>= :yosemite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.