### PR TITLE
Update forklift from 3.3.2 to 3.3.3

### DIFF
--- a/Casks/forklift.rb
+++ b/Casks/forklift.rb
@@ -1,6 +1,6 @@
 cask 'forklift' do
-  version '3.3.2'
-  sha256 'c37d3b71ddb813cc49f135df29766cbf57da8fea7a0d47b65bf967e4ec867e86'
+  version '3.3.3'
+  sha256 'b9ed99e7ec22907e9517892b33f5f191425705a06fb185775c1e9f7eb71a7e61'
 
   url "https://download.binarynights.com/ForkLift#{version}.zip"
   appcast "https://updates.binarynights.com/ForkLift#{version.major}/update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.