### PR TITLE
Update hachidori from 3.1.3 to 3.1.4

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,6 +1,6 @@
 cask 'hachidori' do
-  version '3.1.3'
-  sha256 '169764e2e254c557b408b011747a0740bcb26ebd1603ad3d1551a853a20f8506'
+  version '3.1.4'
+  sha256 '4cc864e58ae300305e9cb5ccfb297a580762bb8b1560960022432779afacd75c'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.