### PR TITLE
Update exodus from 19.3.29 to 19.3.31

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.3.29'
-  sha256 '9d04e616f632293c2a551724385f12d6ee25864d5f45c7bd73e9e34c9308a57a'
+  version '19.3.31'
+  sha256 'be295402ce35ffab0ec718945daef21f0c537f2f705b1fb00a0bdbbe7b313223'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.