### PR TITLE
Update bisq from 0.9.5 to 0.9.7

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '0.9.5'
-  sha256 '5ece20924db7a6d979861067d991b811da02d3f367e0c4f60c5576179a4e59d2'
+  version '0.9.7'
+  sha256 '2c1b81507bfd647b8355df20ecfdf130d6d45407990cdabb4750c9e4512d7e03'
 
   # github.com/bisq-network/bisq-desktop was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq-desktop/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.