### PR TITLE
Update chronycontrol from 1.3.1 to 1.3.2

### DIFF
--- a/Casks/chronycontrol.rb
+++ b/Casks/chronycontrol.rb
@@ -1,6 +1,6 @@
 cask 'chronycontrol' do
-  version '1.3.1'
-  sha256 '59b99b55d37d708191c31ce254a9ea02c7e00d4fd200ffb889ae1297b72aaedb'
+  version '1.3.2'
+  sha256 '7bd9b33b71883d10dc3b9c6b06c92c53028f16f98eef302b265db3ecd943f5f1'
 
   url "https://www.whatroute.net/software/chronycontrol-#{version}.zip"
   appcast 'https://www.whatroute.net/chronycontrolappcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.