### PR TITLE
Update pdf-squeezer from 3.9.3 to 3.10

### DIFF
--- a/Casks/pdf-squeezer.rb
+++ b/Casks/pdf-squeezer.rb
@@ -1,6 +1,6 @@
 cask 'pdf-squeezer' do
-  version '3.9.3'
-  sha256 '4053fdd9a250810f335c3a0e82a392a5934d3517a7d9e9d01f474ca226d882e1'
+  version '3.10'
+  sha256 '747498decdff62152ac24a27bf14b12172487f6bdf32618eeb467f1e2ae8e271'
 
   url 'https://witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
   appcast 'https://witt-software.com/downloads/pdfsqueezer/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.