### PR TITLE
Update monal from 2.3b19 to 2.4b1

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
-  version '2.3b19'
-  sha256 '12b16696d6dc931e998a482563f9ee0d03d3a42f170b6a951d9c888fe6587f33'
+  version '2.4b1'
+  sha256 '87676da93e04ad7b12c943c44e932ebb643f852aac88f5a228c44b4d9956d91a'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.