### PR TITLE
Update virtualhostx from 8.7.5,80_54 to 8.7.7,80_56

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.7.5,80_54'
-  sha256 'b73be99d8cde5aaab0d1ce7f592e6a9bd9265ad5697de77eb975dcbd8060ab8d'
+  version '8.7.7,80_56'
+  sha256 'f4e4c8293000d581b051fce5ca6dd31365fce76a5ebe3b6b3f293ef9da59371a'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.