### PR TITLE
Update odrive from 6344 to 6507

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,10 +1,11 @@
 cask 'odrive' do
-  version '6344'
-  sha256 'f6af36bfef76b9d6b5d192392f3d807d31f21320e7b80567131d4055c2ba7ab8'
+  version '6507'
+  sha256 'daf952fd6c3b10d2598a49af7cacffb65648437d28f11a5af19d58f180f4f05f'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3huse1s6vwzq6.cloudfront.net/odrivesync.#{version}.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.odrive.com/downloaddesktop?platform=mac'
   name 'odrive'
   homepage 'https://www.odrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.