### PR TITLE
Update omnidb from 2.12.0 to 2.14.0

### DIFF
--- a/Casks/omnidb.rb
+++ b/Casks/omnidb.rb
@@ -1,8 +1,9 @@
 cask 'omnidb' do
-  version '2.12.0'
-  sha256 '0402685643f8eec6092c193623ee2266fee3c80b85a485a124d88e9c79345270'
+  version '2.14.0'
+  sha256 '16aa91e22cf25b5a0d7f5f3ccb1069ed24c73be14d52d0900f75b01f7da39b96'
 
   url "https://omnidb.org/dist/#{version}/omnidb-app_#{version}-mac.dmg"
+  appcast 'https://github.com/OmniDB/OmniDB/releases.atom'
   name 'OmniDB'
   homepage 'https://omnidb.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.