### PR TITLE
Update the dependency of visual-studio

### DIFF
--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -9,7 +9,7 @@ cask 'visual-studio' do
   homepage 'https://www.visualstudio.com/vs/visual-studio-mac/'
 
   auto_updates true
-  depends_on cask: 'homebrew/cask-versions/mono-mdk'
+  depends_on cask: 'mono-mdk'
 
   app 'Visual Studio.app'
 

--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -9,7 +9,7 @@ cask 'visual-studio' do
   homepage 'https://www.visualstudio.com/vs/visual-studio-mac/'
 
   auto_updates true
-  depends_on cask: 'homebrew/cask-versions/mono-mdk516'
+  depends_on cask: 'homebrew/cask-versions/mono-mdk'
 
   app 'Visual Studio.app'
 


### PR DESCRIPTION
Now that VS 2019 for Mac is out, it required MDK 5.18+, so I updated the dependency in the formula.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
