### PR TITLE
Update coyim from 0.3.10 to 0.3.11

### DIFF
--- a/Casks/coyim.rb
+++ b/Casks/coyim.rb
@@ -1,6 +1,6 @@
 cask 'coyim' do
-  version '0.3.10'
-  sha256 '6623eb9f86ae44006a312de23537910558fe5c283e0b603daef24a38d577c325'
+  version '0.3.11'
+  sha256 'ecb0eac42d2871fcb673bd89013490519e48b1afca76076353da3577162d6f5f'
 
   # dl.bintray.com/coyim/coyim-bin was verified as official when first introduced to the cask
   url "https://dl.bintray.com/coyim/coyim-bin/v#{version}/mac-bundle/coyim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.