### PR TITLE
Update mycrypto from 1.6.1 to 1.6.3

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.6.1'
-  sha256 'e71a9ccda3543206f3e462a6736ade65a896d32fca09ea580e73c030f2e3bc9f'
+  version '1.6.3'
+  sha256 '5fbcd49ab605d47a347c442ca029a421261e9f31a760e5237aa405598551965f'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.