### PR TITLE
Update udeler from 1.6.3 to 1.7.0

### DIFF
--- a/Casks/udeler.rb
+++ b/Casks/udeler.rb
@@ -1,6 +1,6 @@
 cask 'udeler' do
-  version '1.6.3'
-  sha256 '8cf08ad8c2045b8f5b6fce27b2bfed4169f7a5ac75b4e67c5c2eec7a0b23e24e'
+  version '1.7.0'
+  sha256 '191f03ee627b7ef2e731448ace860c882b2eff60b27cdd05a3d95ebe748f28bc'
 
   url "https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v#{version}/Udeler-#{version}-mac.zip"
   appcast 'https://github.com/FaisalUmair/udemy-downloader-gui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.