### PR TITLE
Update wavebox from 4.9.1 to 4.9.2

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.9.1'
-  sha256 'f4cbd65ef9166dc6365134dea527e76938ca0cd709140869106c7b17a90106ce'
+  version '4.9.2'
+  sha256 'bf5f22f9937501d923dbede67e7e7b3b263006418f88412d9d8ffe019449317d'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.