### PR TITLE
Update kite from 0.20190326.0 to 0.20190402.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190326.0'
-  sha256 '8877f8a9093da225cadf7452758d9fec692495fe201a77b8fbcd6a4e5a2b4a92'
+  version '0.20190402.1'
+  sha256 'd94c47ceefe06d560fb14c885abee9d6669785fea8f4b30af3846cdaa3a79bd9'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.