### PR TITLE
Update kodelife from 0.7.10.83 to 0.8.0.88

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,6 +1,6 @@
 cask 'kodelife' do
-  version '0.7.10.83'
-  sha256 'fa08921609c413cdd38153cb2012a14c28dbf43381237f63c4d45a936ce8f47e'
+  version '0.8.0.88'
+  sha256 '05b36deb59b7dc28445060ff00e41ea14a2370e4ca8239abee261ede0c6ad8aa'
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-macos.zip"
   appcast 'https://hexler.net/pub/kodelife/appcast.hex'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.