### PR TITLE
Update softorino-youtube-converter from 2.1.1,1545414679 to 2.1.3,1554224549

### DIFF
--- a/Casks/softorino-youtube-converter.rb
+++ b/Casks/softorino-youtube-converter.rb
@@ -1,6 +1,6 @@
 cask 'softorino-youtube-converter' do
-  version '2.1.1,1545414679'
-  sha256 '79b63ee355a1b70d27d3a218c8169f8a67ae38705f5f5ee515bc4e8d4b0f97e3'
+  version '2.1.3,1554224549'
+  sha256 '65aca509cc52babfd2ee2493552d57e6497d768f689f8f343a8c3ab5a067b8df'
 
   # devmate.com/com.softorino.syc2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.syc2/#{version.before_comma}/#{version.after_comma}/SYC2-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.