### PR TITLE
Update ghost-browser from 2.1.0.5 to 2.1.0.6

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.0.5'
-  sha256 '863c3940593a15a70eec3c028b01e4da37ae3cb1e33f7c7ddf6de5ff5985b5f8'
+  version '2.1.0.6'
+  sha256 '17c24adf295b3d1fb2270af874eccd0ea0f9e093ffaf35f7b851aff2bed759b0'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.