### PR TITLE
Update postbox from 6.1.12 to 6.1.13

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.12'
-  sha256 '583a6e6e7e619c75d4a61ec61e5c5e1c7a39f280fa5767be24eceb737bb6e94d'
+  version '6.1.13'
+  sha256 '85bb8e8b3992eaee7195d23a243c438971c53eaf668128cff4ff311b5aa3bb2a'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.