### PR TITLE
Update pydiosync from 1.2.8 to 2.2.0

### DIFF
--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -8,8 +8,11 @@ cask 'pydiosync' do
 
   pkg 'PydioSync-Setup.pkg'
 
-  uninstall launchctl: 'PydioSync*',
-            pkgutil:   'io.pyd.sync.installer.PydioSync'
+  uninstall pkgutil:   'io.pyd.sync.installer.PydioSync',
+            launchctl: [
+                         'PydioSync',
+                         'PydioSyncUI',
+                       ]
 
   zap trash: [
                '~/Library/Preferences/io.pyd.sync.PydioTray',

--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -8,11 +8,10 @@ cask 'pydiosync' do
 
   pkg 'PydioSync-Setup.pkg'
 
-  uninstall pkgutil: 'io.pyd.sync.installer.PydioSync'
+  uninstall launchctl: 'io.pyd.sync*',
+            pkgutil:   'io.pyd.sync.installer.PydioSync'
 
   zap trash: [
-               'Library/LaunchAgents/io.pyd.sync.launcher.plist',
-               'Library/LaunchAgents/io.pyd.sync.ui.plist',
                '~/Library/Preferences/io.pyd.sync.PydioTray',
                '~/Library/Caches/com.pydio.pydioswiftsync',
                '~/Library/Group Containers/PydioSync.pydio',

--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -8,7 +8,7 @@ cask 'pydiosync' do
 
   pkg 'PydioSync-Setup.pkg'
 
-  uninstall launchctl: 'io.pyd.sync*',
+  uninstall launchctl: 'PydioSync*',
             pkgutil:   'io.pyd.sync.installer.PydioSync'
 
   zap trash: [

--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -1,6 +1,6 @@
 cask 'pydiosync' do
-  version '1.2.8'
-  sha256 'da7ef2a6729b27bb9837d7637da6b7c2288a595b6bec52288b0f123f85e8021e'
+  version '2.2.0'
+  sha256 '02cceaa7de07596543b60b10bfe07c250b0b823c4455989362446699924db6f3'
 
   url "https://download.pydio.com/pub/pydio-sync/release/#{version}/PydioSync-MacOSX-Installer-v#{version}.dmg"
   name 'PydioSync'

--- a/Casks/pydiosync.rb
+++ b/Casks/pydiosync.rb
@@ -10,5 +10,11 @@ cask 'pydiosync' do
 
   uninstall pkgutil: 'io.pyd.sync.installer.PydioSync'
 
-  zap trash: '~/Pydio'
+  zap trash: [
+               'Library/LaunchAgents/io.pyd.sync.launcher.plist',
+               'Library/LaunchAgents/io.pyd.sync.ui.plist',
+               '~/Library/Preferences/io.pyd.sync.PydioTray',
+               '~/Library/Caches/com.pydio.pydioswiftsync',
+               '~/Library/Group Containers/PydioSync.pydio',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.