### PR TITLE
Update qcad from 3.21.3 to 3.22.0

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,14 +1,15 @@
 cask 'qcad' do
-  version '3.21.3'
+  version '3.22.0'
 
-  if MacOS.version <= :mavericks
+  if MacOS.version <= :high_sierra
     sha256 '9155a11b10991dbeb5bac5a15b810354d0462f13bee8317e4327765d83582466'
-    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.9-10.13.dmg"
+    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 'dbc0dff4d7106c686a7f3b9d1ed80de2e82bb64e7901b8fd7d42018d2e6a39cc'
-    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-osx-10.10-10.13.dmg"
+    sha256 'c14c3b030b729e4e09abecfa85c077fcadbd2c3856fed26fe2d3c0413f11acd6'
+    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14.dmg"
   end
 
+  appcast 'https://www.qcad.org/en/download'
   name 'QCAD'
   homepage 'https://www.qcad.org/'
 

--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -2,7 +2,7 @@ cask 'qcad' do
   version '3.22.0'
 
   if MacOS.version <= :high_sierra
-    sha256 '9155a11b10991dbeb5bac5a15b810354d0462f13bee8317e4327765d83582466'
+    sha256 'a05bd044702f3e1f582e4b527a4d520ac433ad6231fd3161f3c85ccf3574db17'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
     sha256 'c14c3b030b729e4e09abecfa85c077fcadbd2c3856fed26fe2d3c0413f11acd6'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.