### PR TITLE
Update quickhash from 3.0.3,1770 to 3.0.4,1816

### DIFF
--- a/Casks/quickhash.rb
+++ b/Casks/quickhash.rb
@@ -1,8 +1,9 @@
 cask 'quickhash' do
-  version '3.0.3,1770'
-  sha256 '04486fa4d192ab12b19efb3213f4b2f66713de2ca098183d7acf736a87246f60'
+  version '3.0.4,1816'
+  sha256 'a04252a9803abad388218c27c6387d9783891863d2bd3899ac4804c04cb0914f'
 
-  url "https://quickhash-gui.org/download/quickhash-v#{version.before_comma.dots_to_hyphens}-for-apple-mac-osx/?wpdmdl=#{version.after_comma}"
+  url "https://quickhash-gui.org/download/quickhash-v#{version.before_comma.dots_to_hyphens}-for-apple-osx/?wpdmdl=#{version.after_comma}"
+  appcast 'https://quickhash-gui.org/downloads/'
   name 'Quickhash'
   homepage 'https://quickhash-gui.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.