### PR TITLE
Update ibackup-viewer from 4.1240 to 4.1250

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1240'
-  sha256 '970c02ff5cf13f1fa660e0f770b8342b416bf99c79be55545e8b236970196662'
+  version '4.1250'
+  sha256 'a3bcdc0adcc0e20659db124959d815721d7df8484af8d581b0e5e92fabca4101'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.