### PR TITLE
Update lehreroffice from 2019.5.0 to 2019.5.1

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.5.0'
-  sha256 'f84024e2a22c33951e3fcca5f1609b28f5d4bc877a25ef2ff5d0ffa70d86e287'
+  version '2019.5.1'
+  sha256 'c8bc6a367067f7d6d4fc6b31d88779864d57e80200e6446c822193b6e44e1954'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.