### PR TITLE
Update second-life-viewer from 6.1.0.524670 to 6.1_1.525446

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.1.0.524670'
-  sha256 '35892ed3f8f152f428125216ea5b185c6d8512d415d49262ea42f1ec25551d8d'
+  version '6.1_1.525446'
+  sha256 '520e718ed194b7eea322e1e4926eda2aca5a93df878cfd53c5672f98da0dd35f'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.