### PR TITLE
Update cncjs from 1.9.17 to 1.9.18

### DIFF
--- a/Casks/cncjs.rb
+++ b/Casks/cncjs.rb
@@ -1,6 +1,6 @@
 cask 'cncjs' do
-  version '1.9.17'
-  sha256 'd673a171e4ccc953deb2cd4a81328186c0006e32faf35f36cbe2d77c3b7d9779'
+  version '1.9.18'
+  sha256 '6b4fe786e04e2eb46c498efba8d9a320f4401b24b6687ef0fa1b9c2b45d19efb'
 
   # github.com/cncjs/cncjs was verified as official when first introduced to the cask
   url "https://github.com/cncjs/cncjs/releases/download/v#{version}/cncjs-app-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.