### PR TITLE
Update fastonosql from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '2.2.0'
-  sha256 '40f133e3cdefe87fca485ec2e557a8374b3ac7b0d1945d5556b1d247d1ac7b6a'
+  version '2.2.1'
+  sha256 'fab3beeadfc6d40bffdc0667ca4a1d4e1671bc3ff4dade8626d1bbd21abd9390'
 
   url "https://fastonosql.com/downloads_pro/macosx/fastonosql_pro-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.