### PR TITLE
Update vitamin-r from 3.06 to 3.07

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -3,8 +3,8 @@ cask 'vitamin-r' do
     version '2.58'
     sha256 'c6c631430b44359aa022d9ca5ca6e98dbdf7258f2ceae0353f344a035682661e'
   else
-    version '3.06'
-    sha256 '1026b92b1b2126de8e33c6ee745087d9d6eff0b38a07ac98bcd2ec30cc701935'
+    version '3.07'
+    sha256 '2ef284579728b2315c9e3c82648eaa85b2c9b62d42635ba61b20b6aaa31134b2'
   end
 
   url "http://www.publicspace.net/download/signedVitamin#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.