### PR TITLE
Update pdf-squeezer from 3.10 to 3.10.1

### DIFF
--- a/Casks/pdf-squeezer.rb
+++ b/Casks/pdf-squeezer.rb
@@ -1,6 +1,6 @@
 cask 'pdf-squeezer' do
-  version '3.10'
-  sha256 '747498decdff62152ac24a27bf14b12172487f6bdf32618eeb467f1e2ae8e271'
+  version '3.10.1'
+  sha256 '3c6c825e802051da2b48208beb42c71ab348cc3cea102f8e8fe4c850e4ef6032'
 
   url 'https://witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
   appcast 'https://witt-software.com/downloads/pdfsqueezer/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.