### PR TITLE
Update ocenaudio from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,12 +1,12 @@
 cask 'ocenaudio' do
-  version '3.6.1'
+  version '3.6.2'
 
   if MacOS.version <= :high_sierra
     sha256 '0c45879b66e3392aacf344d04c3731cca423b27195b85eabab1c33a7d0389297'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 '075c79480ddef77da947ca220b14311d1833b9699480040af4c5e6f234d6eb2b'
+    sha256 'f4d737e4f071655d4c0fe88768c81db21c253bceab8ba835745d13bcc1cccb9b'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,7 +2,7 @@ cask 'ocenaudio' do
   version '3.6.2'
 
   if MacOS.version <= :high_sierra
-    sha256 '0c45879b66e3392aacf344d04c3731cca423b27195b85eabab1c33a7d0389297'
+    sha256 'da3883d9a25b6a6eecb7383250a824ffc7cf591e46eea6d68410a96a285e10a2'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.