### PR TITLE
Update audiobook-builder from 2.0.1 to 2.0.2

### DIFF
--- a/Casks/audiobook-builder.rb
+++ b/Casks/audiobook-builder.rb
@@ -1,6 +1,6 @@
 cask 'audiobook-builder' do
-  version '2.0.1'
-  sha256 '5372b3dca0d7bd7fab08614312a5d9b5cceaa21ac387a854596cb2941b65e985'
+  version '2.0.2'
+  sha256 '8d235350b46fd5f06c6eddbb54fec9ca5875a0c664e7a2cf8f4e4d48ff99cd85'
 
   url "https://www.splasm.com/downloads/audiobookbuilder/Audiobook%20Builder%20#{version}.dmg"
   appcast 'https://www.splasm.com/audiobookbuilder/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.