### PR TITLE
Update amazon-chime from 4.17.6448 to 4.20.6584

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,6 +1,6 @@
 cask 'amazon-chime' do
-  version '4.17.6448'
-  sha256 'cbe9a3171c00d76de416815d92933d3a75fd5f2ff335a1a7ed06bb7f87760140'
+  version '4.20.6584'
+  sha256 'ce6cd25a1aa4ff42ae66f4427c0bf08962f347e686480526094a2a03d6532566'
 
   url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.