### PR TITLE
Fix imazing cask

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,9 +1,9 @@
 cask 'imazing' do
   version '2.9.5,10630:1553604114'
-  sha256 '9af1f56aafcd7abba1dbf4b56b0ec1a0cf4df818608ac9c71f19cb2478649758'
+  sha256 '10840254b71b422ae2338e96fd1d43aea4ae89a5e32f22f7151dc628f100cc56'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"
+  url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/iMazing#{version.major}forMac.dmg"
   appcast "https://updates.devmate.com/com.DigiDNA.iMazing#{version.major}Mac.xml"
   name 'iMazing'
   homepage 'https://imazing.com/'


### PR DESCRIPTION
File download name changed on the server

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name ~~and version~~.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).