### PR TITLE
Update envkey from 1.4.4 to 1.4.5

### DIFF
--- a/Casks/envkey.rb
+++ b/Casks/envkey.rb
@@ -1,6 +1,6 @@
 cask 'envkey' do
-  version '1.4.4'
-  sha256 '84607ca8fe544c918c16da9bf96ba50c3d62e112d4755879ddf76601a583b9a1'
+  version '1.4.5'
+  sha256 '014e77b1c3939832be97e40499ea4443e741321be330eacabb151990fdc3ef0e'
 
   # github.com/envkey/envkey-app was verified as official when first introduced to the cask
   url "https://github.com/envkey/envkey-app/releases/download/darwin-x64-prod-v#{version}/EnvKey-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.