### PR TITLE
Update opencpn from 4.8.8 to 5.0.0,9065270

### DIFF
--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -1,9 +1,8 @@
 cask 'opencpn' do
-  version '4.8.8'
-  sha256 'ef0134e0cbfdf6c4e6ad5e4c08ee3d720506676fb6228d6174db1a4b5505651f'
+  version '5.0.0,9065270'
+  sha256 'ce572043a1e58f9b44cfd7904e1080fc202e2ae6152f357e898db4bc0d555ae1'
 
-  # opencpn.navnux.org was verified as official when first introduced to the cask
-  url "http://opencpn.navnux.org/#{version}/OpenCPN_#{version}.dmg"
+  url "http://download.opencpn.org/#{version.before_comma}/OpenCPN_#{version.before_comma}+#{version.after_comma}.dmg"
   appcast 'https://github.com/OpenCPN/OpenCPN/releases.atom'
   name 'OpenCPN'
   homepage 'https://www.opencpn.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.