### PR TITLE
Add conflicts_with field to sublime-merge cask

### DIFF
--- a/Casks/sublime-merge.rb
+++ b/Casks/sublime-merge.rb
@@ -9,6 +9,7 @@ cask 'sublime-merge' do
   homepage 'https://www.sublimemerge.com/'
 
   auto_updates true
+  conflicts_with cask: 'sublime-merge-dev'
 
   app 'Sublime Merge.app'
   binary "#{appdir}/Sublime Merge.app/Contents/SharedSupport/bin/smerge"


### PR DESCRIPTION
Add conflicts_with field to sublime-merge cask according to https://github.com/Homebrew/homebrew-cask-versions/pull/7190

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name ~~and version~~.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).