### PR TITLE
Update segger-embedded-studio-for-arm from 4.12 to 4.16

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.12'
-  sha256 '77f11cc14bd706adf4f955b3c35c4d93e2c115b283c110d7cd2497a1add629c6'
+  version '4.16'
+  sha256 '348aa89f688a90977fd368be94774cc4347110bd69850fd614f6ebea43d027b9'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   name 'SEGGER Embedded Studio for ARM'
@@ -8,5 +8,5 @@ cask 'segger-embedded-studio-for-arm' do
 
   pkg "Install SEGGER Embedded Studio for ARM #{version}.pkg"
 
-  uninstall pkgutil: "com.rowley.crossworks.arm_segger_studio.#{version}"
+  uninstall pkgutil: "arm_segger_studio.#{version}"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.