### PR TITLE
Update microsoft-teams from 1.2.00.3961 to 1.2.00.6957

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-teams' do
-  version '1.2.00.3961'
-  sha256 'ca1f0040e2815fc51a04be0caf7c085df10c7d4009ace9808bb680dcf613fd71'
+  version '1.2.00.6957'
+  sha256 'f9802f37da8827f04121c4ea5df5a890dd3d07525a126ec8b2b2ea387f2a6585'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.pkg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.