### PR TITLE
Update brook from 20181212 to 20190401

### DIFF
--- a/Casks/brook.rb
+++ b/Casks/brook.rb
@@ -1,6 +1,6 @@
 cask 'brook' do
-  version '20181212'
-  sha256 '02eab8ae283016be76fea11d90ee4fbba4ed9586fa99964fbe9e01acaee9a25d'
+  version '20190401'
+  sha256 '382aa8e252e95dcef0619f4de63af08484768511e0ae2986929bfb1b3561a5ee'
 
   url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.dmg"
   appcast 'https://github.com/txthinking/brook/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.