### PR TITLE
Update chronos from 3.0.1 to 3.1.0

### DIFF
--- a/Casks/chronos.rb
+++ b/Casks/chronos.rb
@@ -1,6 +1,6 @@
 cask 'chronos' do
-  version '3.0.1'
-  sha256 '198b30184ac23ca025cf8da8b14dd98f39285cc565073303d6fccb3ffc4fd5c9'
+  version '3.1.0'
+  sha256 '0d39f2aca0d967c40595804c4b51cd07e81b325fb5bdbaa4a081de8153d2d70b'
 
   url "https://github.com/web-pal/chronos-timetracker/releases/download/v#{version}/Chronos-#{version}-mac.zip"
   appcast 'https://github.com/web-pal/chronos-timetracker/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.