### PR TITLE
Update dash-dash from 0.13.2.0 to 0.13.3.0

### DIFF
--- a/Casks/dash-dash.rb
+++ b/Casks/dash-dash.rb
@@ -1,6 +1,6 @@
 cask 'dash-dash' do
-  version '0.13.2.0'
-  sha256 'f63cf2628036a0bdd6012fe883cc7cbb035ca948c9628c1b11a20d9fb7236f6a'
+  version '0.13.3.0'
+  sha256 'bd6265e3665a274c9d557146a915d9b07433a87352f01068f5c8821dfacb49df'
 
   # github.com/dashpay/dash was verified as official when first introduced to the cask
   url "https://github.com/dashpay/dash/releases/download/v#{version}/dashcore-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.