### PR TITLE
Update electron from 4.1.3 to 4.1.4

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '4.1.3'
-  sha256 '3fa77342666ba08a24b04208d1b6c980de786e0a33d0e470f995be8ab48f4e68'
+  version '4.1.4'
+  sha256 '46754fe6887e669fdb25d472ce09a60effbb53acc7a2a8f09fae87062fcf6f7d'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.