### PR TITLE
Update mailspring from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,6 +1,6 @@
 cask 'mailspring' do
-  version '1.6.0'
-  sha256 'a16c0de36a3d480506c7034380608d075f88af2c8ba10250f1ec89c3d2e53bc6'
+  version '1.6.1'
+  sha256 'a6ab898bbb966705a760e8ebb1960eab55fa5ae3ef7282a5332ab76576f33bc9'
 
   # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
   url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.