### PR TITLE
Update electron-cash from 4.0.0 to 4.0.1

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.0'
-  sha256 '05bcf29862c7a0f13e931fac56244cb38fb2a75825cea6194f307cb8eab1e8e7'
+  version '4.0.1'
+  sha256 '92ad4a65d2d5bafccd9ea0541ac1abbd3c245a0fb7ba8a1d22f69c21843fd6bf'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/fyookball/electrum/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.