### PR TITLE
Update nteract from 0.12.3 to 0.13.0

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask 'nteract' do
-  version '0.12.3'
-  sha256 '07e3dc243f11fb9bb7d87e2e518684dce59f1a66bcd5a6c2a7c5e4bfa4aa75d7'
+  version '0.13.0'
+  sha256 '80bbc59afb68f99d39097331f8ff8bbb719f14e753d8ac4abcf95f4d3f504f36'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.