### PR TITLE
Update hostbuddy from 2.0.4,20_5 to 2.1.0,20_8

### DIFF
--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,6 +1,6 @@
 cask 'hostbuddy' do
-  version '2.0.4,20_5'
-  sha256 '4b92dc74470538e06c86d327a2259abb087954038df31c0191b6f3abd61d62c2'
+  version '2.1.0,20_8'
+  sha256 '40b364de09259fba8812f53ce841a08a13aa0e6c3e9337db1697ecdf03c920aa'
 
   # downloads-clickonideas.netdna-ssl.com/hostbuddy was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.