### PR TITLE
Update icq from 3.0.20260 to 3.0.20390

### DIFF
--- a/Casks/icq.rb
+++ b/Casks/icq.rb
@@ -1,6 +1,6 @@
 cask 'icq' do
-  version '3.0.20260'
-  sha256 '26ff09b3fdc885e71fcf61602f94f0ec2526a7facd761867c9b5674ff1daac99'
+  version '3.0.20390'
+  sha256 '2576a208310ebfa64ebc4e292beb9b8e09c7a815cf89a00c87f13066b8559cba'
 
   # mra.mail.ru/icq_mac3_update was verified as official when first introduced to the cask
   url 'https://mra.mail.ru/icq_mac3_update/icq.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.