### PR TITLE
Update omnifocus from 3.2.1 to 3.3

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -16,8 +16,8 @@ cask 'omnifocus' do
     sha256 '8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0'
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
   else
-    version '3.2.1'
-    sha256 '372433dea4971c59e369e5d50e07a6155d213df8f49d2d74bc1d905d2223eec6'
+    version '3.3'
+    sha256 '206435e2e514cdbfe0a51f6175522493d387f4705d0d0176aab5bf3e762454a1'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniFocus-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.