### PR TITLE
Update keeweb from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.8.0'
-  sha256 'bf09941f7e362e660466524e34e0724c16a856f9797edeeabdacd60ec4816632'
+  version '1.8.1'
+  sha256 '00f31171796c95a2f3459cca5188f328d581282a4cab7a3ddb94308f130f4fa7'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.