### PR TITLE
Update audio-hijack from 3.5.6 to 3.5.7

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -1,6 +1,6 @@
 cask 'audio-hijack' do
-  version '3.5.6'
-  sha256 '9c6868d98c4ef364aea9622fae8fef6792b897e48b269a93e6aae0492283e738'
+  version '3.5.7'
+  sha256 '12bbfb98c7973aca3956f1ed0018ea43e2da3926ad12363dbec9711bfc87a0fb'
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   appcast 'https://www.rogueamoeba.com/audiohijack/releasenotes.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.