### PR TITLE
Update glyphs from 2.6.1,1225 to 2.6.1,1226

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.1,1225'
-  sha256 'f9238085456e706b17298128e35ffff4140fbbcc6a7dc5b90c710ee32758b08c'
+  version '2.6.1,1226'
+  sha256 '588d0f2af912d6c9a86f6c558f6b85be8666ebc922b434f8afefe5c3f5c94b03'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.