### PR TITLE
Update sha256 for hachidori 3.1.4

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,6 +1,6 @@
 cask 'hachidori' do
   version '3.1.4'
-  sha256 '4cc864e58ae300305e9cb5ccfb297a580762bb8b1560960022432779afacd75c'
+  sha256 'e75162ad97f88ef156f72014496deffa4ecb569e619b2d9035a58ce1eb8bebf4'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.