### PR TITLE
Update astroguider from 3.8 to 3.9

### DIFF
--- a/Casks/astroguider.rb
+++ b/Casks/astroguider.rb
@@ -1,6 +1,6 @@
 cask 'astroguider' do
-  version '3.8'
-  sha256 'd1abf1ced034c6ad27c8b254ebc7f65011058e1e768a2ebb808b8366a5d7d483'
+  version '3.9'
+  sha256 '57ce3e37fe05cefbb41a236d966917944d6ae4d375a27303858b05301c64629b'
 
   url "http://download.cloudmakers.eu/AstroGuider_#{version}.dmg"
   appcast 'http://www.cloudmakers.eu/astroguider/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.