### PR TITLE
Update axe-edit-iii from 1.01.03 to 1.01.04

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.01.03'
-  sha256 'a171a0bbb3304142cba1cd3c6c1cbb0433ec95ee4b38006f176a5c63ad21b6a5'
+  version '1.01.04'
+  sha256 '3c4246ee3b0eb47a671ec5c404a03766a6ec48e45251f83638e17ffa19a9d3fe'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.