### PR TITLE
Update hugin from 2018.0.0 to 2019.0.0

### DIFF
--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -1,6 +1,6 @@
 cask 'hugin' do
-  version '2018.0.0'
-  sha256 '286812bb95e34c2dd8458d49878c54d919e1c0f37ed042d174e8cf0c651edb3e'
+  version '2019.0.0'
+  sha256 'dced75dab3723631fbe794fa79535c90c05e39f1c6d481763dacb6c898efd61b'
 
   # downloads.sourceforge.net/hugin was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/hugin/Hugin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.