### PR TITLE
Update airy from 3.6,200 to 3.7,205

### DIFF
--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -1,6 +1,6 @@
 cask 'airy' do
-  version '3.6,200'
-  sha256 '0cc3c34b6e7b1fa567ca5d2d0968fbb56aada7b9a5d81d2e61bba8fcf169d1f6'
+  version '3.7,205'
+  sha256 '60d6306b52a94a40150856ebb26e134f264dea85528e12053c4215a16dcf4e09'
 
   url 'https://cdn.eltima.com/download/airy.dmg'
   appcast 'https://cdn.eltima.com/download/airy-update/airy.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.