### PR TITLE
Update telegram from 5.1-166400 to 5.1-166466

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '5.1-166400'
-  sha256 '4b56d48a7f29c6023ac1d09f76b5a462277d919c0f82f986e699448840f69314'
+  version '5.1-166466'
+  sha256 'adab4a1df63e1f78863c30af2f282ed1e6292a50197a8f172fe047c15ffa0df9'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.