### PR TITLE
Update big-mean-folder-machine from 2.37 to 2.39

### DIFF
--- a/Casks/big-mean-folder-machine.rb
+++ b/Casks/big-mean-folder-machine.rb
@@ -1,6 +1,6 @@
 cask 'big-mean-folder-machine' do
-  version '2.37'
-  sha256 '8410146f1378ef33244dd2fa816fcc7a6c211d2f3b567526805fd43f0ffd4d59'
+  version '2.39'
+  sha256 '9625293528edf4b32f62bbbd21dac956acf0a1902523e63153f6be01063f75fc'
 
   url 'http://www.publicspace.net/download/BMFM.dmg'
   appcast "http://www.publicspace.net/app/bmfm#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.