### PR TITLE
Update ghidra from 9.0.1_PUBLIC_20190325 to 9.0.2_PUBLIC_20190403

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,6 +1,6 @@
 cask 'ghidra' do
-  version '9.0.1_PUBLIC_20190325'
-  sha256 '58ffa488e6dc57e2c023670c1dfac0469bdb6f4e7da98f70610d9f561b65c774'
+  version '9.0.2_PUBLIC_20190403'
+  sha256 '10ffd65c266e9f5b631c8ed96786c41ef30e2de939c3c42770573bb3548f8e9f'
 
   url "https://www.ghidra-sre.org/ghidra_#{version}.zip"
   name 'Ghidra'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.