### PR TITLE
Update mudlet from 3.18.0 to 3.19.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '3.18.0'
-  sha256 '9d48c2447c3f3f0d7523516358cb7e1ad188d30f3c7c6e0d5605551fb7b5d5c7'
+  version '3.19.0'
+  sha256 '9ef29eb72aaa8e0380a6bf61d8399cc79eb91eeb21f30b3ee16d657a7d7d05d1'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.