### PR TITLE
Update beamer from 3.3.3 to 3.3.4

### DIFF
--- a/Casks/beamer.rb
+++ b/Casks/beamer.rb
@@ -1,6 +1,6 @@
 cask 'beamer' do
-  version '3.3.3'
-  sha256 '6fca864df09a49f109cd61dd30135be3d4a421bbb4f378d59f533740b58e0d40'
+  version '3.3.4'
+  sha256 'c8ad45a76063e0c344534e144f0378509f9a401dad279541b96fe1fe393040f3'
 
   url "https://beamer-app.com/resources/downloads/Beamer-#{version}.zip"
   appcast "https://beamer-app.com/beamer#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.