### PR TITLE
Update pdfpenpro from 1023.3,1553249972 to 1024.1,1554587687

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1023.3,1553249972'
-  sha256 'ecf226ec36760173a81103a93c72b437a88180d613e5ae8b6ca648b1e2c26157'
+  version '1024.1,1554587687'
+  sha256 '813673068eb5f3d9d8ce53c0f49d00a64f1b26f9b7f4627562b3ddea4160b38f'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.