### PR TITLE
Update crypho from latest to 4.1.3

### DIFF
--- a/Casks/crypho.rb
+++ b/Casks/crypho.rb
@@ -1,8 +1,9 @@
 cask 'crypho' do
-  version :latest
-  sha256 :no_check
+  version '4.1.3'
+  sha256 '9cec4de034eeba00f867f05e9d4a678193e6cee6a669685435d6918cb9e6272e'
 
-  url 'https://www.crypho.com/downloads/Crypho.dmg'
+  url "https://www.crypho.com/downloads/desktop/Crypho-#{version}.dmg"
+  appcast 'https://www.crypho.com/download/'
   name 'Crypho'
   homepage 'https://www.crypho.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.