### PR TITLE
Update qownnotes from 19.3.4,b4197-130925 to 19.4.1,b4204-160433

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.3.4,b4197-130925'
-  sha256 '2958771e0a83e7e9c47cccb2eca683d53bdf76f476a82d6708b6cebc42a71e35'
+  version '19.4.1,b4204-160433'
+  sha256 '8148979cf81b0281b39189cd3b7d61325580b6b8ad774d948d92ce6cd5b8e674'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.