### PR TITLE
Update sqlpro-for-sqlite from 1.0.402 to 1.0.454

### DIFF
--- a/Casks/sqlpro-for-sqlite.rb
+++ b/Casks/sqlpro-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-sqlite' do
-  version '1.0.402'
-  sha256 '1138adc1d611d913d9280d1a2e5b51e17078e9f1ef10c7a648c5442ab7494009'
+  version '1.0.454'
+  sha256 '6c5e35e95d585972b7db70f2af5f6826cdbfbe162eb0818819f76309b7cefd07'
 
   # d3fwkemdw8spx3.cloudfront.net/sqlite was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/sqlite/SQLProSQLite.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.