### PR TITLE
Update connectiq from 3.0.9-2019-2-27-0ad96b4 to 3.0.9-2019-3-25-0df4ba2

### DIFF
--- a/Casks/connectiq.rb
+++ b/Casks/connectiq.rb
@@ -1,6 +1,6 @@
 cask 'connectiq' do
-  version '3.0.9-2019-2-27-0ad96b4'
-  sha256 '25523b4e92ff0689e7d2948e08c126b057b5dfed709ba11d5fe00afaee8737ac'
+  version '3.0.9-2019-3-25-0df4ba2'
+  sha256 'f0f703b20f8cd6522c4c13f720cc8fa31f67d98d9d179aa479dc842c92d12b7a'
 
   url "https://developer.garmin.com/downloads/connect-iq/sdks/connectiq-sdk-mac-#{version}.dmg"
   appcast 'https://developer.garmin.com/connect-iq/sdk/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.