### PR TITLE
Update reaper from 5.97.300 to 5.97.400

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,6 +1,6 @@
 cask 'reaper' do
-  version '5.97.300'
-  sha256 '1523f9edb7ad3a5ad56ad310e785b49368484dc3e956c0b907919c547869ba1a'
+  version '5.97.400'
+  sha256 'b877fef65a55c20d08c8f9f363af01bd7ca0f628bc82519dfac6f5478c7e0e4d'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.