### PR TITLE
Update ripcord from 0.4.0 to 0.4.1

### DIFF
--- a/Casks/ripcord.rb
+++ b/Casks/ripcord.rb
@@ -1,6 +1,6 @@
 cask 'ripcord' do
-  version '0.4.0'
-  sha256 '1289df56e3d2331cb40ea735b59bcc17e5bd66364a105dc14cb266f5bbb46c3e'
+  version '0.4.1'
+  sha256 '2adf1b1a5c99ece69e1a09d9235f6a41b0a63c9f42fcd4455da1b497fa319bf4'
 
   url "https://cancel.fm/dl/Ripcord_Mac_#{version}.zip"
   appcast 'https://cancel.fm/ripcord/updates/v1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.