### PR TITLE
Update flixster-video from 2.7.1.638 to 2.7.1.645

### DIFF
--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -3,7 +3,7 @@ cask 'flixster-video' do
   sha256 '545740a435d22e442c5edb1cb43d88859458960419ed2cd16894af0fba84ded9'
 
   # dtmmt9rxsy2no.cloudfront.net was verified as official when first introduced to the cask
-  url 'http://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterVideo.zip'
+  url 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterVideo.zip'
   appcast 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml'
   name 'Flixster Video'
   homepage 'https://www.flixstervideo.com/apps'

--- a/Casks/flixster-video.rb
+++ b/Casks/flixster-video.rb
@@ -1,9 +1,9 @@
 cask 'flixster-video' do
-  version '2.7.1.638'
-  sha256 'eef953f1b4636d158a594728a9bed6ded61f5af1402bd7432cce817e836f1346'
+  version '2.7.1.645'
+  sha256 '545740a435d22e442c5edb1cb43d88859458960419ed2cd16894af0fba84ded9'
 
   # dtmmt9rxsy2no.cloudfront.net was verified as official when first introduced to the cask
-  url 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktop.zip'
+  url 'http://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterVideo.zip'
   appcast 'https://dtmmt9rxsy2no.cloudfront.net/desktop/mac/FlixsterDesktopMacAppcast.xml'
   name 'Flixster Video'
   homepage 'https://www.flixstervideo.com/apps'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.