### PR TITLE
Update farrago from 1.2.3 to 1.2.4

### DIFF
--- a/Casks/farrago.rb
+++ b/Casks/farrago.rb
@@ -1,9 +1,9 @@
 cask 'farrago' do
-  version '1.2.3'
-  sha256 '7d929251eb1cf83445bad19424a325687223f797d6e6fb73c13b5bf22a8bcf23'
+  version '1.2.4'
+  sha256 '2a10dd26d4d727e371d5edf682568b2b35c309639380fc84797e34f760ba2ed7'
 
   url 'https://rogueamoeba.com/farrago/download/Farrago.zip'
-  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Farrago'
+  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.farrago&system=10140'
   name 'Farrago'
   homepage 'https://rogueamoeba.com/farrago/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.