### PR TITLE
Update igv from 2.4.18 to 2.5.0

### DIFF
--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -2,7 +2,7 @@ cask 'igv' do
   version '2.5.0'
   sha256 '6700e22a4768896c607134565f312fa9097ca77bbae84acaa24875e053e0dde9'
 
-  url 'https://data.broadinstitute.org/igv/projects/downloads/2.5/IGV_2.5.0.app.zip'
+  url "https://data.broadinstitute.org/igv/projects/downloads/#{version.major_minor}/IGV_#{version}.app.zip"
   name 'Integrative Genomics Viewer (IGV)'
   homepage 'https://software.broadinstitute.org/software/igv/'
 

--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -7,4 +7,8 @@ cask 'igv' do
   homepage 'https://software.broadinstitute.org/software/igv/'
 
   app "IGV_#{version}.app"
+
+  caveats do
+    depends_on_java '8+'
+  end
 end

--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -1,14 +1,10 @@
 cask 'igv' do
-  version '2.4.18'
-  sha256 '39f6bef037340e02b981e019ad2a3f38d10bed6a9bc663b7510c5ee348b69657'
+  version '2.5.0'
+  sha256 '6700e22a4768896c607134565f312fa9097ca77bbae84acaa24875e053e0dde9'
 
-  url "https://data.broadinstitute.org/igv/projects/downloads/#{version.major_minor}/IGV_#{version}.app.zip"
+  url 'https://data.broadinstitute.org/igv/projects/downloads/2.5/IGV_2.5.0.app.zip'
   name 'Integrative Genomics Viewer (IGV)'
   homepage 'https://software.broadinstitute.org/software/igv/'
 
   app "IGV_#{version}.app"
-
-  caveats do
-    depends_on_java '8'
-  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.