### PR TITLE
Update ticktick from 2.9.02,89 to 3.0.00,92

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '2.9.02,89'
-  sha256 '3536e3a8070ab44e8632d1ae085f950567490cead848c45dd4eccad8043242dd'
+  version '3.0.00,92'
+  sha256 '6a96b3691a7e3841d55d7affeabe584bf13fff0a73dc44b6bbb5644be2aca93c'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.