### PR TITLE
Update lockrattler from 4.18,2018.12 to 4.19,2019.04

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.18,2018.12'
-  sha256 '185f01ddc8f054b85006867a2513528196c0b4190413cf2b2c88f4f2c1031db2'
+  version '4.19,2019.04'
+  sha256 '4802010dfd82d5699f2002f15d06247e62ebc44498cab4ef25e31d9d652d2df8'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.dots_to_slashes}/lockrattler#{version.before_comma.major}#{version.before_comma.minor}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.