### PR TITLE
flash-player-debugger-npapi 32.0.0.171

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-npapi' do
-  version '32.0.0.156'
-  sha256 '83d7509a420142b0e426981714416a806af66c05145598ed9d5ffe60ac5613e0'
+  version '32.0.0.171'
+  sha256 '9d396354b1e7b9bdfaca2a2fc85d6903612efd1fa2fc624b11993edcd243ba60'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
