### PR TITLE
Update piezo from 1.5.11 to 1.5.12

### DIFF
--- a/Casks/piezo.rb
+++ b/Casks/piezo.rb
@@ -1,6 +1,6 @@
 cask 'piezo' do
-  version '1.5.11'
-  sha256 '5854f52282071ace571d3d1a8ec026923489979eaa01aede220c91bf53cedb9e'
+  version '1.5.12'
+  sha256 'a17a0ac554cc0dfaa19a0dc981532968597bd25b4e99262d1b6ff7c9e687d039'
 
   url 'https://rogueamoeba.com/piezo/download/Piezo.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Piezo&system=10114'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.