### PR TITLE
Update sirimote from 1.2.9 to 1.3.0

### DIFF
--- a/Casks/sirimote.rb
+++ b/Casks/sirimote.rb
@@ -1,6 +1,6 @@
 cask 'sirimote' do
-  version '1.2.9'
-  sha256 'b5e713f7d38f95f6c0608f71ca03bf8fc671c17b212f5c37ed902d059e01c06b'
+  version '1.3.0'
+  sha256 '76b37c23006847d763fde28fcc2ac0499eff4a18ed9dcda8508d4acfc4e25ac3'
 
   url 'https://eternalstorms.at/sirimote/SiriMote.zip'
   appcast 'https://eternalstorms.at/sirimote/updatefeed.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.