### PR TITLE
Update robofont from 3.1 to 3.2

### DIFF
--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -1,6 +1,6 @@
 cask 'robofont' do
-  version '3.1'
-  sha256 '82e03426bcae68c0712b6733f177c1f5b4376508eee67836be1729dbbc7ca77e'
+  version '3.2'
+  sha256 '75cd586f08d6b17eb74f5a309f0df26ad745ba7ccb6355e1b1e94d7a0d067cfd'
 
   # static.typemytype.com/robofont was verified as official when first introduced to the cask
   url 'https://static.typemytype.com/robofont/RoboFont.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.