### PR TITLE
Update nvidia-geforce-now from 2.0.4.28 to 2.0.5.41

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.4.28'
-  sha256 'f75a58baf353940c53e053d1c14958d57b7e58d69ce9711da5a99583d10bae96'
+  version '2.0.5.41'
+  sha256 '570a73ae0520a8b219199cd9a3c1b608dcc02722659792b19836aae26d2a0e2a'
 
   url 'https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg'
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.