### PR TITLE
Update jalbum from 18.1.2 to 18.1.3

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,6 +1,6 @@
 cask 'jalbum' do
-  version '18.1.2'
-  sha256 '2de2dc3ddec9599e081bba9fe3555306168dded4da6aa42ad16bb9c9e6ea29a9'
+  version '18.1.3'
+  sha256 '70bd744d32554f54b4d0a341c008faf3abc1ff79fa3b4cf6e0e8a8dfc6930f3c'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.