### PR TITLE
Update cacher from 2.7.0 to 2.7.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.7.0'
-  sha256 '13bcaac2035dc16018376affdf638eabe9676bc650d177bbfb4e4933679da5d0'
+  version '2.7.1'
+  sha256 'a1a18841646c591edc2fc3206d4c289194174234af95caad4b1f91d4feede0dc'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.