### PR TITLE
Update boom-3d from 1.2.5,1551787743 to 1.2.6,1554732029

### DIFF
--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -1,6 +1,6 @@
 cask 'boom-3d' do
-  version '1.2.5,1551787743'
-  sha256 '48352d742a05655ef03707d70a3d0cbc8a9087e910771df96c31de5b88a01323'
+  version '1.2.6,1554732029'
+  sha256 '25d63ddcd0aeb2be085398f55aef7708de3716e9e6f81f730310785ce6b70c42'
 
   # devmate.com/com.globaldelight.Boom3D was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Boom3D/#{version.before_comma}/#{version.after_comma}/Boom3D-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.