### PR TITLE
Update rstudio from 1.1.463 to 1.2.1335

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,9 +1,9 @@
 cask 'rstudio' do
-  version '1.1.463'
-  sha256 'c6956721114b160e581e02edfe53bc412f9882bdd907a1967f7cdd7ce007094d'
+  version '1.2.1335'
+  sha256 '9633421e4c8fd8a439fcf54be495c489734b12900c5ffc378fb2fecc6e1bff51'
 
   # rstudio.org was verified as official when first introduced to the cask
-  url "https://download1.rstudio.org/RStudio-#{version}.dmg"
+  url "https://download1.rstudio.org/desktop/macos/RStudio-#{version}.dmg"
   appcast 'https://www.rstudio.org/links/check_for_update?version=1.0.0&os=mac'
   name 'RStudio'
   homepage 'https://www.rstudio.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.