### PR TITLE
busycontacts 1.3.2: add auto_updates flag

### DIFF
--- a/Casks/busycontacts.rb
+++ b/Casks/busycontacts.rb
@@ -7,6 +7,8 @@ cask 'busycontacts' do
   name 'BusyContacts'
   homepage 'https://www.busymac.com/busycontacts/index.html'
 
+  auto_updates true
+
   pkg 'BusyContacts Installer.pkg'
 
   uninstall pkgutil: 'com.busymac.busycontacts.pkg',


### PR DESCRIPTION
BusyContacts (like BusyCal) has an in-app auto-update mechanism.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).