### PR TITLE
Update opera from 58.0.3135.127 to 60.0.3255.27

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '58.0.3135.127'
-  sha256 'd909e3b9e4489223a86c3946290510abfa5a00caa7d301a32b501e98145d5583'
+  version '60.0.3255.27'
+  sha256 '2fea33251fc975d341c5b96cb9e3d8de064167bd03bdded0f5579540902eabc5'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast 'https://ftp.opera.com/pub/opera/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.