### PR TITLE
Update yate from 4.6 to 4.6.1

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '4.6'
-  sha256 'f76bd58c9f85e763b5f45885a206ae022843676f53c1b41fb3258cf9550e058b'
+  version '4.6.1'
+  sha256 '268b3cd4ae5ef4584cc7348e2a2c331ad30a119e7742b6631dd19ea55f09356e'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.