### PR TITLE
Update gingko from 2.3.5 to 2.4.0

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,6 +1,6 @@
 cask 'gingko' do
-  version '2.3.5'
-  sha256 '40025bf2e7a73239254b965267487247ca0bf51968d9c529bd473d5683947547'
+  version '2.4.0'
+  sha256 'c1fb945a4062c075d1954882b76e133ab45d978ae5ee928f32024f332b526bd2'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/Gingko-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.