### PR TITLE
Update swinsian from 2.1.11 to 2.1.12

### DIFF
--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,6 +1,6 @@
 cask 'swinsian' do
-  version '2.1.11'
-  sha256 '9d7029e50ae8bcb1faf5ab52546134efaa8cc2799fecf9e2c4900dfe23e2cbf2'
+  version '2.1.12'
+  sha256 'b828f9ab2b154c9680c2786148473805a50495e1eec74768cf4b3a803f9a5dbb'
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.