### PR TITLE
Update capture-one from 12.0.2 to 12.0.3.28

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '12.0.2'
-  sha256 'f474f86a69502eb25ab25d9fde62bc1f0058f06f95867fd4e0e1049e90d76b9b'
+  version '12.0.3.28'
+  sha256 '36b679822a772e30a5694fdbd2304fe2b2398eaaae6a39aa4f7bec98a2a1bd9a'
 
   url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.