### PR TITLE
Update hobo from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/hobo.rb
+++ b/Casks/hobo.rb
@@ -1,6 +1,6 @@
 cask 'hobo' do
-  version '1.5.0'
-  sha256 '0ae35adac210912f656914fca24b90a006b6ca86c188dc66453cd45c2bc8574b'
+  version '1.5.1'
+  sha256 '55ed3af75ace097863e4cf90dcf80209497af4e8ea67b81cb40d5bff9efd5f3b'
 
   # downloads-clickonideas.netdna-ssl.com/hobo was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/hobo/hobo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.