### PR TITLE
Update activedock from 226,1554215707 to 228,1554727044

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '226,1554215707'
-  sha256 'be3514c68460c93be91edfb83f5aa2365b3db314d4a97a8b42393df5fd81cb98'
+  version '228,1554727044'
+  sha256 'e1c0c3d7bed0add6096772f08675902089ef0b2c6a118780cd3e4a7bbd17ac64'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.