### PR TITLE
Update app-tamer from 2.4.2 to 2.4.4

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,6 +1,6 @@
 cask 'app-tamer' do
-  version '2.4.2'
-  sha256 'be81f3c8d553de827a81ffb3e94697635d1783416339142e458771d65ce00175'
+  version '2.4.4'
+  sha256 'd92737991c06e746dfe0ddc0cfc5f81b14ffeb91b5fc3fdca03c49de96aec639'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.