### PR TITLE
Update beatport-pro from 2.4.1_173 to 2.4.3_178

### DIFF
--- a/Casks/beatport-pro.rb
+++ b/Casks/beatport-pro.rb
@@ -1,6 +1,6 @@
 cask 'beatport-pro' do
-  version '2.4.1_173'
-  sha256 'e832d11e0eefcdd03754294eedff449cf48a3af06b4271bfd652d09be1fe7a15'
+  version '2.4.3_178'
+  sha256 '821c791ab9bd01aff5082ed1ce317c25d36385953efbe9eb06fe75dc14980ea2'
 
   url "https://pro.beatport.com/mac/#{version}/beatportpro_#{version}.zip"
   appcast 'https://pro.beatport.com/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.