### PR TITLE
Update captin from 1.0.17,93:1539867062 to 1.0.19,95:1551453024

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.17,93:1539867062'
-  sha256 'dd89ab1c7d6c640e6b4b6e1e8cd3db83ca4edf33574bab07ae79ae40c32733d6'
+  version '1.0.19,95:1551453024'
+  sha256 'c950c028e2cdf60e2afe3aaaa204109326d4dcddc834f4ee77342d242b5d81a6'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.