### PR TITLE
Update couchbase-server-enterprise from 6.0.0 to 6.0.1

### DIFF
--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -3,8 +3,8 @@ cask 'couchbase-server-enterprise' do
     version '4.5.1'
     sha256 'de014c7c134eb97ff00be6b2e6f5d0da84295ce05bbb7bb3a4d3c747a365cd22'
   else
-    version '6.0.0'
-    sha256 '5e0a8e9fb176905b3bab7b72a8474a3fb6be1b36790b1e2eb30de82249d5bbbc'
+    version '6.0.1'
+    sha256 '80f47b4fa43ef7b9a5866e5d8a36d895cd8bc4dc942dfe0c0a4f33819966180a'
   end
 
   url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.