### PR TITLE
Update curio from 12.02.10 to 12022.5

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '12.02.10'
-  sha256 'bda3b8a787b89882d5e8850826bfe1ffad3c0f703b67ae8da10015cc3ec6ce40'
+  version '12022.5'
+  sha256 'b79ca4b7e0c9aaffafc78e8b2768ae679af741da428a449ae499470fb44b9037'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio12MarkdownAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.