### PR TITLE
Update dynamite from 3.2.6 to 3.2.7

### DIFF
--- a/Casks/dynamite.rb
+++ b/Casks/dynamite.rb
@@ -1,6 +1,6 @@
 cask 'dynamite' do
-  version '3.2.6'
-  sha256 '8aceec8920ba0ca0fe143b646aa42539640eee941050f0b01ce0e89772e66bd6'
+  version '3.2.7'
+  sha256 '36a119ae316cf3bad8e3f9f211a1e76502c253b26eb2390e16d626990986ae53'
 
   url "https://mediaatelier.com/DynaMite3/DynaMite_#{version}.zip"
   appcast 'https://mediaatelier.com/DynaMite3/feed.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.