### PR TITLE
Update feeder from 3.6.2 to 3.6.4

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,6 +1,6 @@
 cask 'feeder' do
-  version '3.6.2'
-  sha256 '1e9952d59cdb18ebe9ca38df290e6f176499df82841d5b5be8f3ad0502edf96a'
+  version '3.6.4'
+  sha256 '6b82440fcfd70c7d77e7dfbefe8bb68d876c0bda858e791fcaf64c216ba9f0ee'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.