### PR TITLE
Update fotomagico from 5.6.4-22863 to 5.6.6-22897

### DIFF
--- a/Casks/fotomagico.rb
+++ b/Casks/fotomagico.rb
@@ -1,6 +1,6 @@
 cask 'fotomagico' do
-  version '5.6.4-22863'
-  sha256 '8a81aba04669d52ef5c502d3e2d1a1680b622222d22d01cb0f7b81ed6a634159'
+  version '5.6.6-22897'
+  sha256 'd26c22e85919352ba4bb730704f57a59124f54d55255661a73581eeb19937ff2'
 
   url "https://cdn.boinx.com/software/fotomagico/Boinx_FotoMagico_#{version.major}_#{version}.app.zip"
   appcast 'https://sparkle.boinx.com/appcast.lasso?appName=FotoMagico%205'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.