### PR TITLE
Update framer-x from 29021,1552566907 to 29322,1553614664

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '29021,1552566907'
-  sha256 'e04fa0c0cb1a13ea7e5a6d985a420ea0774a550fcc6e98ebff1febd12fde4d76'
+  version '29322,1553614664'
+  sha256 'ac591eb5c6c93602941095a9dc0af8e6e442e4b9407f6cfbb5411b05f69816c0'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.