### PR TITLE
Update goodsync from 10.9.26.81,648 to 10.9.26.82,649

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask 'goodsync' do
-  version '10.9.26.81,648'
-  sha256 '4a07a8a39b6dcb2c1d027603d2b4781c8b609da1c46996322dc088ffa942ae65'
+  version '10.9.26.82,649'
+  sha256 '6ffcb05e29bcea3ad43cd8b686052bb6e5bad08d49f1a544192eea4dfc9e1937'
 
   # rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef/app_versions/#{version.after_comma}?format=zip&avtoken=6b1e930b304f74f53ebe6e776a505fa3bfbe6e6d&download_origin=hockeyapp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.