### PR TITLE
Update gotofile from 1.3.3 to 1.5

### DIFF
--- a/Casks/gotofile.rb
+++ b/Casks/gotofile.rb
@@ -1,8 +1,8 @@
 cask 'gotofile' do
-  version '1.3.3'
-  sha256 '3eb0f1887517b1dca97a1ffc4818c5a16c98c9323174db71fa07521fe105fedd'
+  version '1.5'
+  sha256 '971e3d1455a6e4ce3d8cde524a31279c85805c61f612a806d59decff3cba82f9'
 
-  url "http://www.soma-zone.com/download/files/GoToFile_#{version}.tbz"
+  url "http://www.soma-zone.com/download/files/GoToFile-#{version}.tar.bz2"
   appcast 'https://somazonecom.ipage.com/soma-zone.com/GoToFile/a/appcast_update.xml'
   name 'GoToFile'
   homepage 'http://www.soma-zone.com/GoToFile/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.