### PR TITLE
Update historyhound from 2.0 to 2.0.1

### DIFF
--- a/Casks/historyhound.rb
+++ b/Casks/historyhound.rb
@@ -1,6 +1,6 @@
 cask 'historyhound' do
-  version '2.0'
-  sha256 'eb6be5bbd0b87cfac6cf40b10613c2eb5f5653676641e70b709cf1c6690f8bc8'
+  version '2.0.1'
+  sha256 '51d59cb892008ca85bfea44cc8e9e4cc867068779cc6367cb6ac5365309c4a7c'
 
   url "https://www.stclairsoft.com/download/HistoryHound-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?HH'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.