### PR TITLE
Update holavpn from 1.0.21 to 1.0.22

### DIFF
--- a/Casks/holavpn.rb
+++ b/Casks/holavpn.rb
@@ -1,6 +1,6 @@
 cask 'holavpn' do
-  version '1.0.21'
-  sha256 '0994b474954add4cb822c4a7cee3b859a0b780f3e4729ec4352e237819d56a22'
+  version '1.0.22'
+  sha256 'fa164d67dfcde01476e598593737197b1fc26af1c1de9f778dc4fe606a5e3eb2'
 
   url "https://cdn4.hola.org/static/HolaVPN-#{version}.dmg"
   appcast 'https://hola.org/macos_vpn_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.