### PR TITLE
Update leanote from 2.6.1 to 2.6.2

### DIFF
--- a/Casks/leanote.rb
+++ b/Casks/leanote.rb
@@ -1,6 +1,6 @@
 cask 'leanote' do
-  version '2.6.1'
-  sha256 '12595377e6560689c5ca7370fb83be9670cbd335669da35ed3131123936050c2'
+  version '2.6.2'
+  sha256 '2d24602efe3a31b63b6fc82b91f28be0bb6f1939f7c2bb23a7a8455b3ed24a54'
 
   # sourceforge.net/leanote-desktop-app was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/leanote-desktop-app/#{version}/leanote-desktop-mac-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.