### PR TITLE
Update lima from 1.4.6 to 1.4.8

### DIFF
--- a/Casks/lima.rb
+++ b/Casks/lima.rb
@@ -1,6 +1,6 @@
 cask 'lima' do
-  version '1.4.6'
-  sha256 '38a5929b1cf1d503f79cc5738f546f5cd97ffcb6f54e5c9993de39501cc33a61'
+  version '1.4.8'
+  sha256 '213da0b6405ad720884822965466b992a3ef5e762005ee8fdf7640708ea9601a'
 
   url "https://update.api.meetlima.com/downloads/osx/dist/Lima_#{version}.dmg"
   appcast 'https://update.api.meetlima.com/osx?channel=MASTER'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.