### PR TITLE
Update macdive from 2.10.9 to 2.10.10

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,6 +1,6 @@
 cask 'macdive' do
-  version '2.10.9'
-  sha256 'a4429ed0d4fdcffe9bf9bf34c2a2e0541786c4e692e88c0d2aa7e7c23f60f820'
+  version '2.10.10'
+  sha256 '6e7f8cfa541828ccb3458f6eb3bec21421ae10d7c7e9181e020532c58c33a942'
 
   url "https://www.mac-dive.com/downloads/MacDive_#{version}.dmg"
   appcast 'https://www.mac-dive.com/shimmer/?appcast&appName=MacDive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.