### PR TITLE
Update mjml from 2.9.0 to 2.11.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,9 +1,9 @@
 cask 'mjml' do
-  version '2.9.0'
-  sha256 '0dfae8495120f5150bdca92f9ce0782f71412d56cdcfffb51fbc48b02c6cc318'
+  version '2.11.0'
+  sha256 'df16f34efa6f145f859e74333d6d37235e04a42e1b7d6cb096807d24551588d9'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
-  url "https://github.com/mjmlio/mjml-app/releases/download/v#{version}/mjml-app-#{version}-mac.zip"
+  url "https://github.com/mjmlio/mjml-app/releases/download/#{version}/mjml-app-#{version}-mac.dmg"
   appcast 'https://github.com/mjmlio/mjml-app/releases.atom'
   name 'MJML'
   homepage 'https://mjmlio.github.io/mjml-app/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.