### PR TITLE
Update pester from 1.1b23 to 1.1b24

### DIFF
--- a/Casks/pester.rb
+++ b/Casks/pester.rb
@@ -1,6 +1,6 @@
 cask 'pester' do
-  version '1.1b23'
-  sha256 '5df4b28e0ab3511688709cb9af399b15c76494cbad975e917b4308aa5867162e'
+  version '1.1b24'
+  sha256 '1a05282c1de4cde91048bac86a17e39bdf18990be98d43758ce248f67a124e46'
 
   url "https://sabi.net/nriley/software/Pester-#{version}.dmg"
   appcast 'https://sabi.net/nriley/software/Pester/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.