### PR TITLE
Update pluralsight from 1.9.248 to 1.10.253

### DIFF
--- a/Casks/pluralsight.rb
+++ b/Casks/pluralsight.rb
@@ -1,6 +1,6 @@
 cask 'pluralsight' do
-  version '1.9.248'
-  sha256 '687983b46b66385017beab0595b68e7d6d501cc3841e96d36b62d74331954a77'
+  version '1.10.253'
+  sha256 '9ad60630dff81a2a5f9eb054f5e418023d70818a733e989d8d3daa8a232072fd'
 
   url "https://macapp.pluralsight.com/installpluralsight#{version}.dmg"
   appcast 'https://macapp.pluralsight.com/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.