### PR TITLE
Update poll-everywhere from 2.20.0 to 2.20.1

### DIFF
--- a/Casks/poll-everywhere.rb
+++ b/Casks/poll-everywhere.rb
@@ -1,6 +1,6 @@
 cask 'poll-everywhere' do
-  version '2.20.0'
-  sha256 '55a514352ebf18ca48b0a197841a369500b36f8eddcb16bdd196eccf0f8f8b95'
+  version '2.20.1'
+  sha256 '3f01fa415018393afeef6a39a0340a3ef49eaf65630fea4a921426c4c0d308fc'
 
   # amazonaws.com/polleverywhere-app was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/polleverywhere-app/mac-stable/#{version}/pollev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.