### PR TITLE
Update reflector-teacher from 3.1.1 to 3.2.0

### DIFF
--- a/Casks/reflector-teacher.rb
+++ b/Casks/reflector-teacher.rb
@@ -5,7 +5,7 @@ cask 'reflector-teacher' do
   url "https://download.airsquirrels.com/ReflectorTeacher/Mac/ReflectorTeacher-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/ReflectorTeacher/Mac/ReflectorTeacher.xml'
   name 'Reflector Teacher'
-  homepage 'http://www.airsquirrels.com/reflector/teacher'
+  homepage 'https://www.airsquirrels.com/reflector/teacher'
 
   app 'Reflector Teacher.app'
 end

--- a/Casks/reflector-teacher.rb
+++ b/Casks/reflector-teacher.rb
@@ -1,6 +1,6 @@
 cask 'reflector-teacher' do
-  version '3.1.1'
-  sha256 '5db3c9144d2d7f9b8487fda12d6c9d81ad6e87c516baadc33eb28d598d051b9d'
+  version '3.2.0'
+  sha256 '5a52c9f34545526729432c2f8ae46e013242ee05eb307d78874fc93988a935b5'
 
   url "https://download.airsquirrels.com/ReflectorTeacher/Mac/ReflectorTeacher-#{version}.dmg"
   appcast 'https://updates.airsquirrels.com/ReflectorTeacher/Mac/ReflectorTeacher.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.