### PR TITLE
Update renamer from 5.2.2 to 5.3.1

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
-  version '5.2.2'
-  sha256 '4390b0af2889cda86f9124a30040e43e8275864ca57a5c5b2d8e4f0fab66e5a2'
+  version '5.3.1'
+  sha256 'b909bbc98bced9f74bcdc59492674f75e49434a6a75686ab67cc81e88c8d28c5'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.