### PR TITLE
Update remembear from 1.2.6 to 1.4.0

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,9 +1,9 @@
 cask 'remembear' do
-  version '1.2.6'
-  sha256 'b4d287a13c91a301f68d4fe600396e05ca7b0cad91aa74a69e320ed719fd6041'
+  version '1.4.0'
+  sha256 '1d0ea7018567b85b98ef332ea47d9c8cffc5fbbb8772986f3a058474813f6456'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.zip"
+  url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.dmg"
   appcast 'https://s3.amazonaws.com/remembear/app/release/downloads/macOS/appcast.xml'
   name 'RememBear'
   homepage 'https://www.remembear.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.