### PR TITLE
Update showyedge from 3.2.0 to 3.3.0

### DIFF
--- a/Casks/showyedge.rb
+++ b/Casks/showyedge.rb
@@ -1,6 +1,6 @@
 cask 'showyedge' do
-  version '3.2.0'
-  sha256 '6f75e950dc401794f89be596b9467547c570e8e7c9c499335b269218f645f6f1'
+  version '3.3.0'
+  sha256 '65a6b4fad53bf9dd283406f1ea7b5309639c08b7ed436777524bbf16ed248305'
 
   url "https://pqrs.org/osx/ShowyEdge/files/ShowyEdge-#{version}.dmg"
   appcast 'https://pqrs.org/osx/ShowyEdge/files/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.