### PR TITLE
Update subsmarine from 1.2.4 to 1.3

### DIFF
--- a/Casks/subsmarine.rb
+++ b/Casks/subsmarine.rb
@@ -1,9 +1,9 @@
 cask 'subsmarine' do
-  version '1.2.4'
-  sha256 '7afbad7d12a9e3ea4ff414dc7351cd9d8ae612063e1b5cf0d48b28d04f401c9d'
+  version '1.3'
+  sha256 '17be7a606995cdb9dbfe083720b056160855b52cfedb7371e707b5d596926ff3'
 
   # amazonaws.com/cwcbucket/subsmarine was verified as official when first introduced to the cask
-  url "https://s3-us-west-2.amazonaws.com/cwcbucket/subsmarine/subsmarine.#{version}.zip"
+  url "https://s3-us-west-2.amazonaws.com/cwcbucket/subsmarine/subsmarine.app.#{version}.zip"
   appcast 'https://www.cocoawithchurros.com/shine/appcast.php?id=7'
   name 'SubsMarine'
   homepage 'https://www.cocoawithchurros.com/subsmarine.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.