### PR TITLE
Update suitcase-fusion from 9,20.0.2 to 9,20.0.3

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,6 +1,6 @@
 cask 'suitcase-fusion' do
-  version '9,20.0.2'
-  sha256 'b93b513a022f1017bcf04a0343670c24ec566cb782d5646829b67081c85e23d5'
+  version '9,20.0.3'
+  sha256 '795993e13124419cd5d06b36ed99f7c8d5fc378be07801f4838621c9b9d5e56b'
 
   url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
   appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.