### PR TITLE
Update timing from 2018.4.4 to 2018.4.5

### DIFF
--- a/Casks/timing.rb
+++ b/Casks/timing.rb
@@ -1,5 +1,5 @@
 cask 'timing' do
-  version '2018.4.4'
+  version '2018.4.5'
   sha256 '24b30768c103d350914b16af193837539f4e1034c4cb036feefbff1a57502476'
 
   url 'https://timingapp.com/download/Timing.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.