### PR TITLE
Update lehreroffice from 2019.5.1 to 2019.6.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.5.1'
-  sha256 'c8bc6a367067f7d6d4fc6b31d88779864d57e80200e6446c822193b6e44e1954'
+  version '2019.6.0'
+  sha256 '62c1bd85e3af06ecfa6704a16adb0e53177e2752f366cc4cd79efd962a72562c'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.