### PR TITLE
Update hstracker from 1.5.5 to 1.5.6

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.5.5'
-  sha256 '14f0a9f050f856b7fcd9e7b9ab98982748366e6d5cb67b0d7f7046648edd54ee'
+  version '1.5.6'
+  sha256 '3f8c53d951d76448865ef05d11543c6e079eb6a5fb15d71c218b7ebca797a8b7'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.