### PR TITLE
Update polar-bookshelf from 1.16.2 to 1.17.2

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.16.2'
-  sha256 '6237b9eda6d3cc5c97910e3b232e0e7641d9feba959ff22b2afd15f91bd1685d'
+  version '1.17.2'
+  sha256 'a0711c082fac856c7464b16e99640f90fdc19e728ab80f8ff3aab1355a4183a5'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.