### PR TITLE
Update unity from 2018.3.11f1,5063218e4ab8 to 2018.3.12f1,8afd630d1f5b

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2018.3.11f1,5063218e4ab8'
-  sha256 'c1275061c2e2025c4971d71aa9492246e465482ac686b26dc1cfc56eb6ae67d4'
+  version '2018.3.12f1,8afd630d1f5b'
+  sha256 'ba3dd3bddfab49fc5bf7d06ee7e2586f7914a2b5a6e197e4be1d1268183a1c13'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.