### PR TITLE
Update cave from 18.1.1-6 to 18.1.1.7

### DIFF
--- a/Casks/cave.rb
+++ b/Casks/cave.rb
@@ -1,6 +1,6 @@
 cask 'cave' do
-  version '18.1.1-6'
-  sha256 'ef04149537e3eac6abaf3b1c1ffaca532aec292f880ea3d6fe6d577b8e9c0367'
+  version '18.1.1.7'
+  sha256 '91ba9c2421fcdc849a5a694ff483c1c466404514174f1b61a45339a7252eba87'
 
   url 'https://www.unidata.ucar.edu/downloads/awips2/awips-cave.dmg'
   appcast 'https://github.com/Unidata/awips2/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.