### PR TITLE
Update cask to reflect changes in multipass 0.6.0

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,13 +1,13 @@
 cask 'multipass' do
-  version '0.5'
-  sha256 'b9cdf4bdb65fcebd4cdff510f3a559d2c86d591749bd3d4ea1ec0dd495a42590'
+  version '0.6.0'
+  sha256 '8883682aecea31efd4afa2838d692a89aceda50d72810405dfbd2747d0e62715'
 
-  url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-v#{version}-full-Darwin.pkg"
+  url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast 'https://github.com/CanonicalLtd/multipass/releases.atom'
   name 'Multipass'
   homepage 'https://github.com/CanonicalLtd/multipass/'
 
-  pkg "multipass-v#{version}-full-Darwin.pkg"
+  pkg "multipass-#{version}+mac-Darwin.pkg"
 
   uninstall launchctl: 'com.canonical.multipassd',
             pkgutil:   'com.canonical.multipass.*',

--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -7,7 +7,7 @@ cask 'multipass' do
   name 'Multipass'
   homepage 'https://github.com/CanonicalLtd/multipass/'
 
-  pkg "multipass-#{version}+mac-Darwin.pkg"
+  pkg "multipass-#{version} mac-Darwin.pkg"
 
   uninstall launchctl: 'com.canonical.multipassd',
             pkgutil:   'com.canonical.multipass.*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).