### PR TITLE
Update gpodder from 3.10.7 to 3.10.8

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,6 +1,6 @@
 cask 'gpodder' do
-  version '3.10.7'
-  sha256 '515608388004b0295f7afc14ed0f4d6884340feeb3455f3a91a4b61a5c9af2f6'
+  version '3.10.8'
+  sha256 '68487b3693d433b653a043e9c6625721608d1ea6ee785d3f5eb04537ccdbb105'
 
   # github.com/gpodder/gpodder was verified as official when first introduced to the cask
   url "https://github.com/gpodder/gpodder/releases/download/#{version}/macOS-gPodder-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.