### PR TITLE
Update ibackup-viewer from 4.1250 to 4.1260

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1250'
-  sha256 'a3bcdc0adcc0e20659db124959d815721d7df8484af8d581b0e5e92fabca4101'
+  version '4.1260'
+  sha256 'b5ae65fb885ca3a998248aea25f5e837b4c908cfd0e3d35e7cc48b01858e3490'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.