### PR TITLE
Add Boxy Suite Latest

### DIFF
--- a/Casks/boxy-suite.rb
+++ b/Casks/boxy-suite.rb
@@ -2,7 +2,6 @@ cask 'boxy-suite' do
   version :latest
   sha256 :no_check
 
-  # Check curl -Lv https://accounts.boxysuite.com/redirect/download_suite output to verify:
   # boxyteam-static.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://boxyteam-static.s3.amazonaws.com/release/Boxy%20Suite.dmg'
   name 'Boxy Suite'

--- a/Casks/boxy-suite.rb
+++ b/Casks/boxy-suite.rb
@@ -1,0 +1,14 @@
+cask 'boxy-suite' do
+  version :latest
+  sha256 :no_check
+
+  # Check curl -Lv https://accounts.boxysuite.com/redirect/download_suite output to verify:
+  # boxyteam-static.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://boxyteam-static.s3.amazonaws.com/release/Boxy%20Suite.dmg'
+  name 'Boxy Suite'
+  homepage 'https://www.boxysuite.com/'
+
+  app 'Boxy Dashboard.app'
+  app 'Boxy for Gmail.app'
+  app 'Boxy for Calendar.app'
+end


### PR DESCRIPTION
Adds the three Boxy suite applications:
- Boxy for Gmail.app
- Boxy for Calendar.app
- Boxy Dashboard.app

These are curated and tweaked single-site browsers for some of the Google productivity suite.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
   The three apps are known collectively as "Boxy Suite", thus the cask is not named "boxy-for-gmail" or "boxy-for_calendar" etc.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
