### PR TITLE
Update wondershare-video-converter-ultimate from 10.3.3.6,735 to 10.5.0.8,735

### DIFF
--- a/Casks/uniconverter.rb
+++ b/Casks/uniconverter.rb
@@ -1,12 +1,12 @@
-cask 'wondershare-video-converter-ultimate' do
+cask 'uniconverter' do
   version '10.5.0.8,735'
   sha256 'a1aee6704cdfda186a18c62a2de7d22e0003079260bfb05b1d96de5bd864357e'
 
   url "http://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full#{version.after_comma}.dmg"
-  name 'Wondershare Video Converter Ultimate'
+  name 'UniConverter'
   homepage 'https://videoconverter.wondershare.com/'
 
-  app 'Wondershare Video Converter Ultimate.app'
+  app 'UniConverter.app'
 
   zap trash: [
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.wondershare.video-converter-ultimate.sfl*',

--- a/Casks/wondershare-video-converter-ultimate.rb
+++ b/Casks/wondershare-video-converter-ultimate.rb
@@ -1,6 +1,6 @@
 cask 'wondershare-video-converter-ultimate' do
-  version '10.3.3.6,735'
-  sha256 '185b01405409148ad2155eaff0cf545332d23b6c86a76d48ad9a20a46e09b9fc'
+  version '10.5.0.8,735'
+  sha256 'a1aee6704cdfda186a18c62a2de7d22e0003079260bfb05b1d96de5bd864357e'
 
   url "http://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full#{version.after_comma}.dmg"
   name 'Wondershare Video Converter Ultimate'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.