### PR TITLE
Update hachidori from 3.1.4 to 3.1.5

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,6 +1,6 @@
 cask 'hachidori' do
-  version '3.1.4'
-  sha256 'e75162ad97f88ef156f72014496deffa4ecb569e619b2d9035a58ce1eb8bebf4'
+  version '3.1.5'
+  sha256 '73d4dd0db905b56d64ab3005eabfac6795692be13a4b4a102323af03c62a3c72'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.