### PR TITLE
Update journey from 2.10.2 to 2.10.3

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,6 +1,6 @@
 cask 'journey' do
-  version '2.10.2'
-  sha256 'dd4355c2787d366ba690b9a6c247e163ee9058b9fa5bd3a7faf4ce7c6ef62653'
+  version '2.10.3'
+  sha256 'de396bd02dfd17390d876392d6fea6904d6318c0d34c809333a7b1123a001ac2'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
   url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.