### PR TITLE
Update thedesk from 18.1.2 to 18.2.0

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.1.2'
-  sha256 'c43d137d2a7ad1d000e200d5a91e525fde396b137677e261b952a5e9ef7c8f4e'
+  version '18.2.0'
+  sha256 '0825725c99ef67b46fc586ac67b784b338051881c1a9964742a7d801eccfb474'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/m#{version}/TheDesk-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.