### PR TITLE
Update atext from 2.32 to 2.32.1

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,6 +1,6 @@
 cask 'atext' do
-  version '2.32'
-  sha256 'd696e89477719046d01e42ed6c02a0ddb102f7f54615da9c940123a902b50eec'
+  version '2.32.1'
+  sha256 'f20b9b35a1abd165fe02ca470f119efe078c7315430af93e103b89a94c7f10c5'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.