### PR TITLE
Update nosleep from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/nosleep.rb
+++ b/Casks/nosleep.rb
@@ -1,9 +1,9 @@
 cask 'nosleep' do
-  version '1.5.0'
-  sha256 '5e280d6268a26f292dd6ad308e5cafc9a2396861a43e53a01744ac78db987e2d'
+  version '1.5.1'
+  sha256 '2dd5293c41a16a35deeaf903cc9f10092721b8869b69ef263231a73a4202cb5a'
 
   # github.com/integralpro/nosleep was verified as official when first introduced to the cask
-  url "https://github.com/integralpro/nosleep/releases/download/#{version.major_minor}/NoSleep-#{version}.dmg"
+  url "https://github.com/integralpro/nosleep/releases/download/#{version}/NoSleep-#{version}.dmg"
   appcast 'https://github.com/integralpro/nosleep/releases.atom'
   name 'NoSleep'
   homepage 'https://integralpro.github.io/nosleep/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.