### PR TITLE
Update clip-studio-paint from 1.8.8 to 1.9.0

### DIFF
--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -1,6 +1,6 @@
 cask 'clip-studio-paint' do
-  version '1.8.8'
-  sha256 '19ee1780cbace9932870aef0db7c3f77f6b50b1697d01e75532ba2a8893c2cf0'
+  version '1.9.0'
+  sha256 'c005010ca84d0aa88503aa9a81a89cc3ebe6f762533a713dceacd769391f5669'
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
   name 'CLIP STUDIO PAINT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.