### PR TITLE
Update profilecreator from 0.2.4-beta.9 to 0.2.5-beta.10

### DIFF
--- a/Casks/profilecreator.rb
+++ b/Casks/profilecreator.rb
@@ -1,6 +1,6 @@
 cask 'profilecreator' do
-  version '0.2.4-beta.9'
-  sha256 '9771e17d54df6510b00f06e17f87b8d381894eb7f6dd082bf870819950200976'
+  version '0.2.5-beta.10'
+  sha256 'b493fe7597ce6df0d95b22420a630dba920459e9fec8f95062cfb961555da640'
 
   url "https://github.com/erikberglund/ProfileCreator/releases/download/v#{version}/ProfileCreator_v#{version}.dmg"
   appcast 'https://github.com/erikberglund/ProfileCreator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.