### PR TITLE
Update papyrus from 4.2.0,2018-12 to 4.3.0,2019-03

### DIFF
--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -1,6 +1,6 @@
 cask 'papyrus' do
-  version '4.2.0,2018-12'
-  sha256 '54ccef7276cf2a21f06e6b011b923d02f9f143e99b766f7e079ca33f871e4c98'
+  version '4.3.0,2019-03'
+  sha256 '40330141eabf6d41bd49f3d8f37644b6f095cbf49652eaba28b0c80685dd6e6b'
 
   url "https://www.eclipse.org/downloads/download.php?file=/modeling/mdt/papyrus/rcp/#{version.after_comma}/#{version.before_comma}/papyrus-#{version.after_comma}-#{version.before_comma}-macosx64.tar.gz&r=1"
   name 'Papyrus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.