### PR TITLE
Update muzie from 1.4.0 to 1.5.1

### DIFF
--- a/Casks/muzie.rb
+++ b/Casks/muzie.rb
@@ -1,6 +1,6 @@
 cask 'muzie' do
-  version '1.4.0'
-  sha256 '727aa99af123e9459646515455f85bf25ede0641098850fe32a72b23adb6a708'
+  version '1.5.1'
+  sha256 '15dfcd74e39d03698ff0a92d94f2053aa83bcf5a88c9afc1dd75c98e8e24befb'
 
   # s3.amazonaws.com/muzie-release was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/muzie-release/Muzie-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.