### PR TITLE
Update marvin from 1.39.0 to 1.39.1

### DIFF
--- a/Casks/marvin.rb
+++ b/Casks/marvin.rb
@@ -1,6 +1,6 @@
 cask 'marvin' do
-  version '1.39.0'
-  sha256 '6b2116204fcd2777c032445b985ea359b9b15687fbbad61fea900498aa38e30c'
+  version '1.39.1'
+  sha256 '4fb6c60bc9a0d329fb844f3f86610fd2a5e2a70cede010249cde18c5cd450dd8'
 
   # s3.amazonaws.com/amazingmarvin was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/amazingmarvin/Marvin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.