### PR TITLE
Update vscodium from 1.33.0 to 1.33.1

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.33.0'
-  sha256 '05ff92cccfff8ba80708955d451d3093dfd63ce2eeface220aa5b8771c84cf02'
+  version '1.33.1'
+  sha256 '16728204799226611c1c62e089f10a4247333c3512857209efb23f6aeaae8a44'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.