### PR TITLE
Update katalon-studio from 6.0.5 to 6.1.1

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,8 +1,9 @@
 cask 'katalon-studio' do
-  version '6.0.5'
-  sha256 'ab31ef0777a590a78ffbecd59b8a915af836098d2bc77b742d69614ce0ecc17a'
+  version '6.1.1'
+  sha256 '8f3e33d32ca20014f232287cb45e4a09ab44a3077dbc7912b25d57b5b5688c48'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
+  appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'
   name 'Katalon Studio'
   homepage 'https://www.katalon.com/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.