### PR TITLE
Update timing from 2018.4.5 to 2018.4.6

### DIFF
--- a/Casks/timing.rb
+++ b/Casks/timing.rb
@@ -1,6 +1,6 @@
 cask 'timing' do
-  version '2018.4.5'
-  sha256 '24b30768c103d350914b16af193837539f4e1034c4cb036feefbff1a57502476'
+  version '2018.4.6'
+  sha256 '07b363028ef3a066bad45e2441bc2efde0b051af806b479bc1ef3c05975ad789'
 
   url 'https://timingapp.com/download/Timing.app.zip'
   appcast 'https://timingapp.com/updates/timing2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.