### PR TITLE
Update duet from 2.0.6.0 to 2.0.6.1

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,6 +1,6 @@
 cask 'duet' do
-  version '2.0.6.0'
-  sha256 'f557d5244bde384ac6f1eb685342ec87b9a81e966a9478ccc8262666226c5f8d'
+  version '2.0.6.1'
+  sha256 '2a575acabd99e8656777207f8401421fc7856f8fa6c8f3219eb0555361373867'
 
   # duet.nyc3.cdn.digitaloceanspaces.com/Mac was verified as official when first introduced to the cask
   url "https://duet.nyc3.cdn.digitaloceanspaces.com/Mac/#{version.major_minor.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.