### PR TITLE
Update remember-the-milk from 1.1.11 to 1.1.12

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.1.11'
-  sha256 'f263e2c74bb10b2dbedc329bfb953f0aa03948f29661715bb56feb3a1150881c'
+  version '1.1.12'
+  sha256 '984a6765c6ec7352fd8018c1bc01b148c5d033fbe7e46fba22daf26a8d1fc668'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   name 'Remember The Milk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.