### PR TITLE
Update fontexplorer-x-pro from 6.0.5 to 6.0.6

### DIFF
--- a/Casks/fontexplorer-x-pro.rb
+++ b/Casks/fontexplorer-x-pro.rb
@@ -1,6 +1,6 @@
 cask 'fontexplorer-x-pro' do
-  version '6.0.5'
-  sha256 '69e8e419166a01fa84b550268b3f8c3769374c771735aeb6bef78db91891b0bb'
+  version '6.0.6'
+  sha256 '47e860c5974b33694a14b7f681d620ed58ad57729098029532f68b1fca7f07fe'
 
   url "https://fast.fontexplorerx.com/FontExplorerXPro#{version.no_dots}.dmg"
   name 'FontExplorer X Pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.