### PR TITLE
Update muruslogsvisualizer from 1.4.3 to 1.4.4

### DIFF
--- a/Casks/muruslogsvisualizer.rb
+++ b/Casks/muruslogsvisualizer.rb
@@ -1,6 +1,6 @@
 cask 'muruslogsvisualizer' do
-  version '1.4.3'
-  sha256 '43d7219580b8e3afd9a0dce3b258e66b19aa759bee023b2bc8b33266a8cd4c20'
+  version '1.4.4'
+  sha256 'fa0629b87cb79c011fa8553a7ba24912d372cd418e26cbff170b8e1c3cf4b65c'
 
   url "https://www.murusfirewall.com/downloads/muruslogsvisualizer-#{version}.zip"
   name 'Murus Logs Visualizer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.