### PR TITLE
Update cryptomator from 1.4.6 to 1.4.7

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.4.6'
-  sha256 '2529a2e14b5b5b9566ff9f55679513527966ad5e8b56ff88dfba0619217b58a7'
+  version '1.4.7'
+  sha256 'c226030b77d1f0a623ddb77562725d15339a0214e9b80af4ef19acf62d7ae3c3'
 
   # dl.bintray.com/cryptomator/cryptomator was verified as official when first introduced to the cask
   url "https://dl.bintray.com/cryptomator/cryptomator/#{version}/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.