### PR TITLE
Update audirvana to 3.5.1

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5'
-  sha256 'df54107959fc6a7f8eb64ed1866add7cf78f2a2527fff8de9ec89767b3a7b9b9'
+  version '3.5.1'
+  sha256 '0ef2efe5c295ceb286ef3daec26fcc0b304a285604109b0e4831f4531d042c9e'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
