### PR TITLE
Update qiyimedia from 5.4.10 to 5.8.18

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '5.4.10'
-  sha256 '6132c2644c35be55bd8c45416404986712c8ec8d03a98a4d9805fced8dd8c3d2'
+  version '5.8.18'
+  sha256 '952d3bc738837b57a636c33a54711ee81e84ebc7acbe8ac3e26e7ba03f22394f'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://app.iqiyi.com/mac/player/index.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.