### PR TITLE
Update diskcatalogmaker from 7.4.11 to 7.4.12

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.4.11'
-  sha256 '099a86dfc8631b8ff94e71fbb67808c4d86bd6ded09d19fb0ff4023967548b0b'
+  version '7.4.12'
+  sha256 '16e96429e255f216250a83649ba3b10f107a1845d129d61fe8c76b376481d1f9'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://fujiwara.sakura.ne.jp/info/appcast/DiskCatalogMaker.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.