### PR TITLE
Update fontforge from 2019.03.17.1d421d1 to 2019.04.13.7f6f1d0

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,6 +1,6 @@
 cask 'fontforge' do
-  version '2019.03.17.1d421d1'
-  sha256 '1b9a04a478e81501f1dda46e0c4ecccf7c586b5cc617e6c7dffdd06e9e63b102'
+  version '2019.04.13.7f6f1d0'
+  sha256 '365e4d406ee524e8bdb5646754cf1ebcb94ad68866a1bdc6870a17c4a14e1a46'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
   url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.