### PR TITLE
Update mycrypto from 1.6.3 to 1.6.4

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.6.3'
-  sha256 '5fbcd49ab605d47a347c442ca029a421261e9f31a760e5237aa405598551965f'
+  version '1.6.4'
+  sha256 '008444591ba9b58a2b190fb25eb41b1c514f2c216b9a83f970140a2280a44c7a'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.