### PR TITLE
Update sqlpro-studio from 1.0.455 to 1.0.456

### DIFF
--- a/Casks/sqlpro-studio.rb
+++ b/Casks/sqlpro-studio.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-studio' do
-  version '1.0.455'
-  sha256 '6e4f9c61e02028ad268e2f66afe2e60495de9331993c613c33188643225a7c55'
+  version '1.0.456'
+  sha256 '965b13cca3c93144bf19d024841bd38d67712b49b77403ad09be6511f38bb4f6'
 
   # d3fwkemdw8spx3.cloudfront.net/studio was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/studio/SQLProStudio.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.