### PR TITLE
Update flume from 2.8.6.2 to 2.8.6.3

### DIFF
--- a/Casks/flume.rb
+++ b/Casks/flume.rb
@@ -1,6 +1,6 @@
 cask 'flume' do
-  version '2.8.6.2'
-  sha256 '4b5867aa21a47a41ef5b23cc47d89f819c01b382dfc035ef17c75fc9c015c32b'
+  version '2.8.6.3'
+  sha256 'dea76634a76b808add5a96fc7710f130eba306544c9c2cf22676bc11489ccdd5'
 
   url "https://flumeapp.com/files/Flume-#{version}.zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/c88c56b02dcd4dd3acceb6d7a24f7122'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.