### PR TITLE
Update grisbi from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/grisbi.rb
+++ b/Casks/grisbi.rb
@@ -1,6 +1,6 @@
 cask 'grisbi' do
-  version '1.2.1'
-  sha256 '37c43a5356b8de4d995c386170a3ccc24a1d5f7184f5d2e709a3e31523db18e0'
+  version '1.2.2'
+  sha256 '4dbd636df2579dfb11b5ea316753fcecaa8dc7d83e57a2552e845d6593c10f24'
 
   # sourceforge.net/grisbi was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/grisbi/grisbi%20stable/#{version.major_minor}.x/Grisbi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.