### PR TITLE
Update pro-motion-ng from 7.1.8 to 7.2.0

### DIFF
--- a/Casks/pro-motion-ng.rb
+++ b/Casks/pro-motion-ng.rb
@@ -1,6 +1,6 @@
 cask 'pro-motion-ng' do
-  version '7.1.8'
-  sha256 '270dda804ebb11258ee0694ece791848f76686c68d796786f2a04e8530c89fb0'
+  version '7.2.0'
+  sha256 'f7c9a7977153ffc8a3eb837bea86f96bdb8a0264ea4f16472a6a04564b5f9542'
 
   url 'https://www.cosmigo.com/wp-content/uploads/pro-motion-ng-mac-os.zip'
   appcast 'https://www.cosmigo.com/pixel_animation_software/downloads/mac_linux_downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.