### PR TITLE
Revert "Update wechatwebdevtools from 1.02.1902010 to 1.02.1903251"

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1903251'
-  sha256 '1b65dfd2dc547180d31f1883458e95ade673197194489d86c73f5c9bed3bd59a'
+  version '1.02.1902010'
+  sha256 '71bbdc0325f52a9cff976f008413642505e9156f36e022d26894b78a776a100f'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.2.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   appcast 'https://developers.weixin.qq.com/miniprogram/dev/devtools/stable.html'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#61885
its an unstable version - I've revered it before - sorry I haven't seen that this update has been in the list … 
https://github.com/Homebrew/homebrew-cask/pull/61795
