### PR TITLE
Update banking-4 from 7.0.3,7040 to 7.0.3,7041

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,6 +1,6 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.0.3,7040'
+  version '7.0.3,7041'
   sha256 'f93a5c11abeea99f93c58463296449a09aea6209d1dc7123dca91977d162534a'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.