### PR TITLE
Update vorta from 0.6.16 to 0.6.17

### DIFF
--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -1,6 +1,6 @@
 cask 'vorta' do
-  version '0.6.16'
-  sha256 '77acac11b61fcb35dfb6ac7a9e3c76bfd0626805f60d20c2a8c02dc0c395f728'
+  version '0.6.17'
+  sha256 '9903ef2563ca8b17492d0a40f114424b9c353f5000fa6e3ab44afbba22979b82'
 
   url "https://github.com/borgbase/vorta/releases/download/v#{version}/vorta-#{version}.dmg"
   appcast 'https://github.com/borgbase/vorta/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.