### PR TITLE
Update thedesk from 18.2.1 to 18.2.3

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.2.1'
-  sha256 '53b2175449700988e4b0a9e215672648f2a508b73a991b8401f62fda8c5fb5c8'
+  version '18.2.3'
+  sha256 'ed97a9e0696939ea8bcfb7493eff8d849cbdaca9caf61334a17e01fa1db99007'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/#{version}/TheDesk-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.