### PR TITLE
Update ghostlab from 3.2.0 to 3.3.0

### DIFF
--- a/Casks/ghostlab.rb
+++ b/Casks/ghostlab.rb
@@ -1,6 +1,6 @@
 cask 'ghostlab' do
-  version '3.2.0'
-  sha256 '5f9b9b521256bb4514945b2c669c6dc60837f909a4187c071d0602a7bb4f155e'
+  version '3.3.0'
+  sha256 '61e8085ac52520a9a7502eac760564cb239692fbd3c46fba787834fd501137bc'
 
   url "https://awesome.vanamco.com/Ghostlab#{version.major}/downloads/Ghostlab#{version.major}.dmg"
   appcast 'https://awesome.vanamco.com/Ghostlab3/update/ghostlab3-cast.xml?vco=trkd'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.