### PR TITLE
Update grandtotal from 5.2.6.1 to 5.2.7

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,6 +1,6 @@
 cask 'grandtotal' do
-  version '5.2.6.1'
-  sha256 '411f5266b83ab3b649e6cd909fc481cc3b793a4364dbf6d2a6349a8c393801f9'
+  version '5.2.7'
+  sha256 'be327403637a2d993aacacd3e4af48728831fba0bcc991c135090e66fc15b2cc'
 
   url "https://mediaatelier.com/GrandTotal#{version.major}/GrandTotal_#{version}.zip"
   appcast "https://mediaatelier.com/GrandTotal#{version.major}/feed.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.