### PR TITLE
Update imazing-mini from 2.7.1,9566:1538240027 to 2.8.1,9825:1542056055

### DIFF
--- a/Casks/imazing-mini.rb
+++ b/Casks/imazing-mini.rb
@@ -1,6 +1,6 @@
 cask 'imazing-mini' do
-  version '2.7.1,9566:1538240027'
-  sha256 'd6c51a77da7a9dc3a9a37ec832f6609ed8e8a0938b8474ff9ec259cfa02981ae'
+  version '2.8.1,9825:1542056055'
+  sha256 'f6bd3704edbc9f9e4cd2497952155771bd50285ae9a3b99f7adb0f5210572a8b'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac.Mini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac.Mini/#{version.after_comma.before_colon}/#{version.after_colon}/iMazingMini2forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.