### PR TITLE
Update cutter from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.8.0'
-  sha256 '0000ad30b41b7cb46f2f1cb7f0afefc7ee4f3a419a27d4b929993bcfd0426353'
+  version '1.8.1'
+  sha256 'c07ec9f1900cd54199a7aa51e640361229d86a9de11ab47b26bf99a76431c03a'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.