### PR TITLE
Update gns3 from 2.1.15 to 2.1.16

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.15'
-  sha256 '8b95eb1f5fa0155e5f40adff548292a6714b77562830a00a203c8e6cde60823c'
+  version '2.1.16'
+  sha256 'ce4aa0895223a42c26baf9a8dd13ac6665437c42663a0e3dfc7d6ddb065f0dee'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.