### PR TITLE
Update qt-creator from 4.8.2 to 4.9.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.8.2'
-  sha256 '02e05c2e21eccfda6bbcc82f5338e75bc3fe073e6f89c2b723c142b205fc0506'
+  version '4.9.0'
+  sha256 '11e897c807826d153a159dd0f84e7fda2bf559a44e66a17cb2550ed27dbb0279'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qtcreator/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.