### PR TITLE
Update spotify from latest to 1.1.4.197.g92d52c4f

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,6 +1,6 @@
 cask 'spotify' do
-  version :latest
-  sha256 :no_check
+  version '1.1.4.197.g92d52c4f'
+  sha256 '1a24517567bcda501493a7f6db2708c2b1de9e34599d838d03b8ec0bf2145c27'
 
   # scdn.co was verified as official when first introduced to the cask
   url 'https://download.scdn.co/Spotify.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.