### PR TITLE
Update kleiner-brauhelfer to version 1.4.4.5

### DIFF
--- a/Casks/brauhelfer.rb
+++ b/Casks/brauhelfer.rb
@@ -1,10 +1,14 @@
 cask 'brauhelfer' do
-  version '1.4.3.2'
-  sha256 '51bfb781be422c42cf80d9bc8716a3ef8612c6df658848eb67cbebc80f80f616'
+  version '1.4.4.5'
+  sha256 '802c915c4b5e74356ab22df5d34748dfa79c3c5490d5abfac6700fb3ef86676f'
 
-  url "http://www.joerum.de/kleiner-brauhelfer/lib/exe/fetch.php?media=download:01_04_03_02:kb_osx_#{version}.dmg"
+  # github.com/realholgi/kleiner-brauhelfer was verified as official when first introduced to the cask
+  url "https://github.com/realholgi/kleiner-brauhelfer/releases/download/v#{version}/kb_macos_v#{version.dots_to_underscores}.zip"
+  appcast 'https://github.com/realholgi/kleiner-brauhelfer/releases.atom'
   name 'Kleiner Brauhelfer'
   homepage 'http://www.joerum.de/kleiner-brauhelfer/doku.php'
 
-  app 'brauhelfer.app'
+  app 'kleiner-brauhelfer.app'
+
+  zap trash: 'brauhelfer.app'
 end

--- a/Casks/kleiner-brauhelfer.rb
+++ b/Casks/kleiner-brauhelfer.rb
@@ -1,4 +1,4 @@
-cask 'brauhelfer' do
+cask 'kleiner-brauhelfer' do
   version '1.4.4.5'
   sha256 '802c915c4b5e74356ab22df5d34748dfa79c3c5490d5abfac6700fb3ef86676f'
 


### PR DESCRIPTION
Update version from 1.4.3.2 to 1.4.4.5. macOS releases are now maintained by Github user @realholgi (in conjunction with the official author), thus the download url changed.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
