### PR TITLE
Update dockstation from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/dockstation.rb
+++ b/Casks/dockstation.rb
@@ -1,6 +1,6 @@
 cask 'dockstation' do
-  version '1.5.0'
-  sha256 '3afc653f45e29495db7f9c60a2f533b3a1f715a538c4176d659df6e17486fe20'
+  version '1.5.1'
+  sha256 '3449009fcd2fc8476381d4de62b2086999281ede81f903dfb63715c3383491c7'
 
   # github.com/DockStation/dockstation was verified as official when first introduced to the cask
   url "https://github.com/DockStation/dockstation/releases/download/v#{version}/dockstation-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.