### PR TITLE
Update picgo from 2.0.4 to 2.1.1

### DIFF
--- a/Casks/picgo.rb
+++ b/Casks/picgo.rb
@@ -1,6 +1,6 @@
 cask 'picgo' do
-  version '2.0.4'
-  sha256 '9fd2e86a60072a582a1185b6bd27aba4c0ca71265ac08ea71dbf28f3daf56a79'
+  version '2.1.1'
+  sha256 '0aaec3b31a89e3832d9b939a10e7c0e1817dbcafca3a44dfea35f16f5ac96deb'
 
   url "https://github.com/Molunerfinn/PicGo/releases/download/v#{version}/PicGo-#{version}-mac.zip"
   appcast 'https://github.com/Molunerfinn/PicGo/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.