### PR TITLE
Update melodics from 2.0.2746 to 2.0.2749

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2746'
-  sha256 '858b721ed687922a2998d583def423a664871363bce36648ce35ab08e7d183ff'
+  version '2.0.2749'
+  sha256 'e8a79fa8d76e412922be77d6a9f35541a0ca195576e4ed88aa77e1c0ffeaf6e0'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://api.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.