### PR TITLE
Update permute from 3.1.9,2119 to 3.2,2125

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.1.9,2119'
-  sha256 'e30d97d9a04a96a60046db129559131cda2977ea8da937a60534085b7f527123'
+  version '3.2,2125'
+  sha256 'a974945745da39b9241a5840bddbfeeb1d897812e3c11b89887c6ed3832f7df7'
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.