### PR TITLE
Update postbox from 6.1.13 to 6.1.14

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.13'
-  sha256 '85bb8e8b3992eaee7195d23a243c438971c53eaf668128cff4ff311b5aa3bb2a'
+  version '6.1.14'
+  sha256 '2170605e622ebe6304656c6b06e3311be33a9f6e956329a936293c8d72945915'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.