### PR TITLE
Update cardhop from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/cardhop.rb
+++ b/Casks/cardhop.rb
@@ -1,6 +1,6 @@
 cask 'cardhop' do
-  version '1.2.1'
-  sha256 '256004b0385b7e90fc545f3710229d47ebb3457305593406b8cf18763d13eafe'
+  version '1.2.2'
+  sha256 'f88551fe66c5ec5dc0eb2a86ef710defa1f3ecd80165cddf8ea8bd478871e210'
 
   url "http://cdn.flexibits.com/Cardhop_#{version}.zip"
   appcast 'https://flexibits.com/cardhop/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.