### PR TITLE
Update acorn from 6.3.2 to 6.3.3

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,6 +1,6 @@
 cask 'acorn' do
-  version '6.3.2'
-  sha256 '54a50ea516da3f64c01d2d5a5d462977c14202e43ae286186901fb65c5ed42f0'
+  version '6.3.3'
+  sha256 'b6bc5e49967af165249f1f7ae03c1e0edaa1f21c04ac7ad6ad7e5813a13b0749'
 
   url 'https://flyingmeat.com/download/Acorn.zip'
   appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.