### PR TITLE
Update archipelago from 3.2.1 to 3.2.2

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.2.1'
-  sha256 'a56f40af689c1ca3312c58693e08a4a0fe1c8cb740fc3931281bc08f97cdb683'
+  version '3.2.2'
+  sha256 'a364b7c7db85c46a7db2e6ce253fbbb67860b1fca05fa8a7e822dff12437c241'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.