### PR TITLE
Update hostbuddy from 2.2.0,20_9 to 2.2.3,20_12

### DIFF
--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,6 +1,6 @@
 cask 'hostbuddy' do
-  version '2.2.0,20_9'
-  sha256 'f9a6f4858f7ceddb29f29c63668acb994b1576a45392845e189184f5cddcc6b7'
+  version '2.2.3,20_12'
+  sha256 '13371a8b03df1035043421fb695aae945ca2e751266cfc35f422c51b0c5d8873'
 
   # downloads-clickonideas.netdna-ssl.com/hostbuddy was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.