### PR TITLE
Update evernote from 7.9_457563 to 7.9.1_457700

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -9,8 +9,8 @@ cask 'evernote' do
     version '7.2.3_456885'
     sha256 'eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97'
   else
-    version '7.9_457563'
-    sha256 'e2edd95224da502d0511b4056863d00125c6f8760375505832dc39facd095dbc'
+    version '7.9.1_457700'
+    sha256 '18b68e74306d335ed1ab00a10824de8af2c6f51ba3db9aeb105cfb258c5e1235'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.