### PR TITLE
Update lehreroffice from 2019.6.0 to 2019.7.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.6.0'
-  sha256 '62c1bd85e3af06ecfa6704a16adb0e53177e2752f366cc4cd79efd962a72562c'
+  version '2019.7.0'
+  sha256 '9c322ac42a89831dba2c5e48f1da24443ef2552ce69c955e9987e47f3c7958e3'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.