### PR TITLE
Update nosqlbooster-for-mongodb from 5.1.5 to 5.1.6

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.1.5'
-  sha256 '612ef2ea9097e15213cf8d094d3bd9ac26e3f1557199339abd6b532526053a88'
+  version '5.1.6'
+  sha256 '5d7bd62e12ad8f79d2f12dae117a1488a968432355d5dace1333faae39085aba'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   name 'NoSQLBooster for MongoDB'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.