### PR TITLE
Update irccloud from 0.9.0 to 0.10.0

### DIFF
--- a/Casks/irccloud.rb
+++ b/Casks/irccloud.rb
@@ -1,6 +1,6 @@
 cask 'irccloud' do
-  version '0.9.0'
-  sha256 '82135f8c706511ebb2a24b54f2e901c9acd45c88361a3678e212aaf9fcf8e18e'
+  version '0.10.0'
+  sha256 '31bc9f2aa35c2d0835183cfa19d10bf6681527e8367d76323f4831fb706b1897'
 
   url "https://github.com/irccloud/irccloud-desktop/releases/download/v#{version}/IRCCloud-#{version}.dmg"
   appcast 'https://github.com/irccloud/irccloud-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.