### PR TITLE
Update neo4j from 1.1.13 to 1.1.20

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,7 +1,7 @@
 cask 'neo4j' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '1.1.13'
-  sha256 'e14f9332218f4d6e2ff292e3b036bde2f48f5fc63250319abedaa47d68c1c7c2'
+  version '1.1.20'
+  sha256 '800671362cc7684ecc459398e8684de27a5bcf4db0580d2a17165a8fd662aae5'
 
   url "https://neo4j.com/artifact.php?name=neo4j-desktop-offline-#{version}.dmg"
   name 'Neo4j Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.