### PR TITLE
Update riot to 1.0.8 and to new download URL

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,9 +1,9 @@
 cask 'riot' do
-  version '1.0.7'
-  sha256 '53d8743ba3f68bcf312ca442a32e39bbba73123e4d1f5bb254c1d9d2e8eeb9b9'
+  version '1.0.8'
+  sha256 '91d7bebdc753ded82ee92bbc9ed7d6ba3a544360ea305565ed3d0e680404b779'
 
-  url "https://riot.im/download/desktop/install/macos/Riot-#{version}.dmg"
-  appcast 'https://riot.im/desktop.html'
+  url "https://packages.riot.im/desktop/install/macos/Riot-#{version}.dmg"
+  appcast 'https://riot.im/download/desktop/'
   name 'Riot'
   homepage 'https://about.riot.im/'
 
@@ -11,6 +11,9 @@ cask 'riot' do
 
   zap trash: [
                '~/Library/Application Support/Riot',
+               '~/Library/Caches/im.riot.app',
+               '~/Library/Caches/im.riot.app.ShipIt',
+               '~/Library/Logs/Riot',
                '~/Library/Preferences/im.riot.app.helper.plist',
                '~/Library/Preferences/im.riot.app.plist',
                '~/Library/Saved Application State/im.riot.app.savedState',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.