### PR TITLE
cscreen.rb: removed _to_slahses

### DIFF
--- a/Casks/cscreen.rb
+++ b/Casks/cscreen.rb
@@ -2,9 +2,9 @@ cask 'cscreen' do
   version '2012.09'
   sha256 '522348667b4ac13a3bd63afee5a9b796b97cb06f12f4e9cbb1943dd4c8bb0895'
 
-  url "http://www.pyehouse.com/wp-content/uploads/#{version.major}/#{version.minor}/cscreenIntel.dmg"
+  url "https://www.pyehouse.com/wp-content/uploads/#{version.major}/#{version.minor}/cscreenIntel.dmg"
   name 'cscreen'
-  homepage 'http://www.pyehouse.com/cscreen/'
+  homepage 'https://www.pyehouse.com/cscreen/'
 
   binary 'cscreen'
 end

--- a/Casks/cscreen.rb
+++ b/Casks/cscreen.rb
@@ -2,7 +2,7 @@ cask 'cscreen' do
   version '2012.09'
   sha256 '522348667b4ac13a3bd63afee5a9b796b97cb06f12f4e9cbb1943dd4c8bb0895'
 
-  url "http://www.pyehouse.com/wp-content/uploads/#{version.dots_to_slashes}/cscreenIntel.dmg"
+  url "http://www.pyehouse.com/wp-content/uploads/#{version.major}/#{version.minor}/cscreenIntel.dmg"
   name 'cscreen'
   homepage 'http://www.pyehouse.com/cscreen/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).