### PR TITLE
Update ticktick from 3.0.00,92 to 3.0.01,93

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.0.00,92'
-  sha256 '6a96b3691a7e3841d55d7affeabe584bf13fff0a73dc44b6bbb5644be2aca93c'
+  version '3.0.01,93'
+  sha256 '86e6da635af467c4e2bd566ce8227c98e8bcae3509f3a29c7b85b12772423dba'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.