### PR TITLE
Update aircall from 2.0.4 to 2.1.1

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,6 +1,6 @@
 cask 'aircall' do
-  version '2.0.4'
-  sha256 'db90541db4ad176bfc93f96cd3be6fc9c57c78618fc75f095fe8e0c405d8b834'
+  version '2.1.1'
+  sha256 '49b8d2f421460eca75c7319d6ee3167dabcf866de348eada2bbd3babfb904da5'
 
   # s3-us-west-1.amazonaws.com/aircall-electron-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/aircall-electron-releases/production/Aircall-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.