### PR TITLE
Update second-life-viewer from 6.1.1.525446 to 6.2.0.526190

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.1.1.525446'
-  sha256 '520e718ed194b7eea322e1e4926eda2aca5a93df878cfd53c5672f98da0dd35f'
+  version '6.2.0.526190'
+  sha256 '38c7e22c85ebdde900ea0bf849464a317910d950f5a76960922f49571854c9f6'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.