### PR TITLE
Update onyx from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -17,8 +17,8 @@ cask 'onyx' do
     version '3.4.9'
     sha256 '60e4f56fb2e5457aca1aa1d2a9be95502a310b0de75112e91b7c89bf4a2be829'
   else
-    version '3.6.0'
-    sha256 '87ced55c6cbcc70a02025fef11a1f185dea2199719f35781108803c3e807b431'
+    version '3.6.1'
+    sha256 '02a9438dfee2622b5900a6fdc5b001b8fefeb1d45acbac9ab341749d61b9d4e5'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/OnyX.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.