### PR TITLE
Update apk-icon-editor from 2.1.0 to 2.2.0

### DIFF
--- a/Casks/apk-icon-editor.rb
+++ b/Casks/apk-icon-editor.rb
@@ -1,6 +1,6 @@
 cask 'apk-icon-editor' do
-  version '2.1.0'
-  sha256 '2168fa47f0ac5d29cc2d18e48fa70a0bb4cff07397af97bf3b30d31793c69b3f'
+  version '2.2.0'
+  sha256 '11d08b197f303f638e3663f0f14e0a5fb3587e64b07d4691c63d5d18e90460a0'
 
   # github.com/kefir500/apk-icon-editor was verified as official when first introduced to the cask
   url "https://github.com/kefir500/apk-icon-editor/releases/download/v#{version}/apk-icon-editor_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.