### PR TITLE
Update rubitrack-pro from 5.2.2 to 5.2.3

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,6 +1,6 @@
 cask 'rubitrack-pro' do
-  version '5.2.2'
-  sha256 'da98016bc0e89a592cbe37fdd9396b3040d17cbc3c9c5f0a297548a35f733d0f'
+  version '5.2.3'
+  sha256 '1fba18c814d35b9475239b3092a2cecfeffb9022fd1df1addce0b1277306d33a'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.