### PR TITLE
Update subsurface from 4.8.5 to 4.8.6

### DIFF
--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,6 +1,6 @@
 cask 'subsurface' do
-  version '4.8.5'
-  sha256 '39606c3122d6b3e885214d3212fee296adafd098c26489c5f34c7ca8a900e078'
+  version '4.8.6'
+  sha256 'f9d2c8cd2dd8205a24cc29e87a674e1160b02a4cfc4669e33ae5e7475917c3eb'
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   name 'Subsurface'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.