### PR TITLE
Update gog-galaxy from 1.2.54.27 to 1.2.55.53

### DIFF
--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -1,6 +1,6 @@
 cask 'gog-galaxy' do
-  version '1.2.54.27'
-  sha256 '334afabfa55afa924f867a2b5e87aa980653ee8309c741f66437ffa41f2780f6'
+  version '1.2.55.53'
+  sha256 'e3009a71c14e4ee35202e96ef6b7a1312c2adfc56f35089c5e2297baa5acc792'
 
   url "https://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
   name 'GOG Galaxy Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.