### PR TITLE
Update cacher from 2.8.0 to 2.8.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.8.0'
-  sha256 '143597356ae75b378a1b0e943ec199130cf8b44ea4443757241a1157cb458183'
+  version '2.8.1'
+  sha256 'a9fad4e563cafd26373f0f8959fa1f5f3b39a2f89717590e5b064f372b0ead4c'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.