### PR TITLE
Update cctalk from 7.3.17.9 to 7.5.0.3

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,6 +1,6 @@
 cask 'cctalk' do
-  version '7.3.17.9'
-  sha256 'c27871b1fef20343255188b0e551d64f476153a9ade96b7d8165d9622181b4f8'
+  version '7.5.0.3'
+  sha256 '377515a077cc05960f7e92e2e3307fff9f4afe4c68276d546b67e7153e4618f2'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
   url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.