### PR TITLE
Update master-pdf-editor from 5.3.22 to 5.4.04

### DIFF
--- a/Casks/master-pdf-editor.rb
+++ b/Casks/master-pdf-editor.rb
@@ -1,6 +1,6 @@
 cask 'master-pdf-editor' do
-  version '5.3.22'
-  sha256 '8b36bff13d5a8ef8fafe16962de2c1c271e656a47693ff3de7f13e0f846a33c9'
+  version '5.4.04'
+  sha256 'b3da9d3c9c325af46ffa716a702c96288e1f394f5030be189a232d4c244fa192'
 
   url 'https://code-industry.net/public/MasterPDFEditor.dmg'
   appcast 'https://code-industry.net/get-masterpdfeditor/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.