### PR TITLE
Update teamspeak-client from 3.2.3 to 3.2.5

### DIFF
--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -1,6 +1,6 @@
 cask 'teamspeak-client' do
-  version '3.2.3'
-  sha256 'a689ffbd54b14c1a3edf887731cb6b24676ea6d90249cabd7f6e378e1642dafe'
+  version '3.2.5'
+  sha256 '6b2bd20a0cb16e1b634a32e19768f1c9045726c2db9a02e98ec4f6808f6c7e3f'
 
   # dl.4players.de/ts was verified as official when first introduced to the cask
   url "http://dl.4players.de/ts/releases/#{version}/TeamSpeak#{version.major}-Client-macosx-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.