### PR TITLE
Update mi from 3.0.3 to 3.0.3r1

### DIFF
--- a/Casks/mi.rb
+++ b/Casks/mi.rb
@@ -1,6 +1,6 @@
 cask 'mi' do
-  version '3.0.3'
-  sha256 'c8b6d0c8ef7954b45f92544b33fa5605437dec239168ee4ac6f6751c85a87762'
+  version '3.0.3r1'
+  sha256 'dd711bbba83663757076ecd62104ef439682d9006f29daa859ff5e6cfc3ed209'
 
   url "https://www.mimikaki.net/download/mi#{version}.dmg"
   appcast 'https://www.mimikaki.net/download/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.