### PR TITLE
Update helio from 1.7.6 to 2.0

### DIFF
--- a/Casks/helio.rb
+++ b/Casks/helio.rb
@@ -1,8 +1,9 @@
 cask 'helio' do
-  version '1.7.6'
-  sha256 '7f0499eb9266e65f3535795c20b18b82bf926a9966f757ea1a5854d861e8cfa6'
+  version '2.0'
+  sha256 'd84f3f2b7aae4d93b78392bf452b36c821c4237e13c5430effb26d23495928d2'
 
   url "https://ci.helio.fm/helio-#{version}.dmg"
+  appcast 'https://github.com/helio-fm/helio-workstation/releases.atom'
   name 'Helio'
   homepage 'https://helio.fm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.