### PR TITLE
Update freecad from 0.17-13541.9948ee4 to 0.18-16110

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,9 +1,9 @@
 cask 'freecad' do
-  version '0.17-13541.9948ee4'
-  sha256 '48623a0dc48c93863ed5bdd76e19008e96c3c2492d3e49041e123b1d582dc383'
+  version '0.18-16110'
+  sha256 '4b5de3237e498041e5fa7164dad4f70723c610e703696469486b9cd2a015a4be'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.split('-')[0]}/FreeCAD_#{version}-OSX-x86_64-Qt5.dmg"
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.split('-')[0]}.1/FreeCAD_#{version}-OSX-x86_64-conda-Qt5-Py3.dmg"
   appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom'
   name 'FreeCAD'
   homepage 'https://www.freecadweb.org/'

--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -3,7 +3,7 @@ cask 'freecad' do
   sha256 '4b5de3237e498041e5fa7164dad4f70723c610e703696469486b9cd2a015a4be'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.split('-')[0]}.1/FreeCAD_#{version}-OSX-x86_64-conda-Qt5-Py3.dmg"
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.major_minor}.1/FreeCAD_#{version}-OSX-x86_64-conda-Qt5-Py3.dmg"
   appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom'
   name 'FreeCAD'
   homepage 'https://www.freecadweb.org/'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


This branch was created using the cask-repair script, but it was unable to actually create the pull request so I am creating it manually.

I was unsure about how to handle the URL field, since FreeCAD used 0.18.1 as their github release number but didn't change the name of the actual generated file, which breaks the existing version url.

It works now and downloads the right file, but it introduces a nonstandard change.