### PR TITLE
Update astropad-studio from 3.0.1 to 3.1

### DIFF
--- a/Casks/astropad-studio.rb
+++ b/Casks/astropad-studio.rb
@@ -1,6 +1,6 @@
 cask 'astropad-studio' do
-  version '3.0.1'
-  sha256 'ff49790ab2cd57e32e9e3ae3f0db64ff636c11a1ce41cb7407c41390634fea97'
+  version '3.1'
+  sha256 'c8bb192e60f54f8fee090aa94a206f51813bed969c123538f429a2215f65e143'
 
   url "https://astropad.com/downloads/AstropadStudio-#{version}.zip"
   appcast 'https://astropad.com/downloads/studio-sparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.