### PR TITLE
Update deezer from 4.5.1 to 4.5.3

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.5.1'
-  sha256 '6698eee42151d0a1cabc30757096f45e7952aadeeda12e075372c5e48feb932e'
+  version '4.5.3'
+  sha256 'd269a0896d6c587fe18bf49fc8f2f3ad5d3ba95745066af092737af3eaac3246'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.