### PR TITLE
Update advancedrestclient from 13.0.4 to 13.0.5

### DIFF
--- a/Casks/advancedrestclient.rb
+++ b/Casks/advancedrestclient.rb
@@ -1,6 +1,6 @@
 cask 'advancedrestclient' do
-  version '13.0.4'
-  sha256 '061499c9eac8deb9c27b27f68bbaba131ded696487833353b890291e65543f5a'
+  version '13.0.5'
+  sha256 '7dd41b3967a02b4615d778220d9644339f98d38f74a2175480ab3f40c3d7f942'
 
   # github.com/advanced-rest-client/arc-electron was verified as official when first introduced to the cask
   url "https://github.com/advanced-rest-client/arc-electron/releases/download/v#{version}/arc-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.