### PR TITLE
Update wiznote from 2.7.2,2019-03-13 to 2.7.2,2019-04-16

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.7.2,2019-03-13'
-  sha256 '9b7ba3700406297743c9bafa333b5885d342ade338eeae4d355e5985876bcb3b'
+  version '2.7.2,2019-04-16'
+  sha256 'c12a79f12287013d9f817674d11c18e054ab82d3c55605db5d39d06267c2f3f9'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://url.wiz.cn/u/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.