### PR TITLE
Update ringcentral from 10.3.5 to 11.0.1

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '10.3.5'
-  sha256 'c69a4cfb44f844b6020558daafe1151037e15c35bf072ded8dfe1575c771ac71'
+  version '11.0.1'
+  sha256 'e24090317a0e3a83b7096f1092fc061077fead343e9445f17a2ca0b040086e2c'
 
   url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://downloads.ringcentral.com/sp/RingCentralForMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.