### PR TITLE
Update bytecoin from 3.4.1 to 3.4.2

### DIFF
--- a/Casks/bytecoin.rb
+++ b/Casks/bytecoin.rb
@@ -1,6 +1,6 @@
 cask 'bytecoin' do
-  version '3.4.1'
-  sha256 'f2fb056f2da6e51a8d3ab0f9b439763c4b030314080dd3f44a78a77302826fe5'
+  version '3.4.2'
+  sha256 '97b1d33bf1e02f6594cbd41b07d2c42c5c326be18d880e0bff99396ef8159a4a'
 
   # github.com/bcndev/bytecoin-gui was verified as official when first introduced to the cask
   url "https://github.com/bcndev/bytecoin-gui/releases/download/v#{version}/bytecoin-desktop-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.