### PR TITLE
Update katalon-studio from 6.1.1 to 6.1.2

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '6.1.1'
-  sha256 '8f3e33d32ca20014f232287cb45e4a09ab44a3077dbc7912b25d57b5b5688c48'
+  version '6.1.2'
+  sha256 'df651b9e044c7ecd6d6f4dc68a41869b126f1ee3b80412a096e4805bf205415d'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.