### PR TITLE
Update superproductivity from 2.5.8 to 2.6.0

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.5.8'
-  sha256 '9ab4b1e94799d6d7dac4ebed4969fb485891559270ff8fa773285ac07e368c63'
+  version '2.6.0'
+  sha256 '6410c87672603de253d70925749957555372d53585b59b808d45f71ea809330c'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.