### PR TITLE
Update garagebuy from 3.2 to 3.3

### DIFF
--- a/Casks/garagebuy.rb
+++ b/Casks/garagebuy.rb
@@ -1,6 +1,6 @@
 cask 'garagebuy' do
-  version '3.2'
-  sha256 'b54c2b2e11f9a449fa3211c6db98c6f26f2418b88c89cb0272c9014c6f5c23ea'
+  version '3.3'
+  sha256 '57409fe84cc308fd78fe01101939bd517641e57454bf757a07b47950ce5fdcca'
 
   # iwascoding.de was verified as official when first introduced to the cask
   url "https://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.