### PR TITLE
Localized PDFelement for China

### DIFF
--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,11 +1,25 @@
 cask 'pdfelement' do
-  version '6.7.12,2991'
-  sha256 'a4fd5421b98d00fb2433c9d64e2f29962d39dadf64e25d98e31325cdab37a711'
+  language 'en', default: true do
+    version '6.7.12,2991'
+    sha256 'a4fd5421b98d00fb2433c9d64e2f29962d39dadf64e25d98e31325cdab37a711'
+    homepage 'https://pdf.wondershare.com/pdf-editor-mac/'
+    url "http://download.wondershare.com/mac-pdfelement#{version.major}_full#{version.after_comma}.dmg"
 
-  url "http://download.wondershare.com/cbs_down/mac-pdfelement#{version.major}_full#{version.after_comma}.dmg"
+    # Renamed for consistency: app name is different in the Finder and in a shell.
+    app "PDFelementStd#{version.major}.app", target: "PDFelement #{version.major}.app"
+    'en-US'
+  end
+
+  language 'zh' do
+    version '6.7.8,4223'
+    sha256 'b4072a62e1a9cd00cca28afa2aa5d89a3788b733b1227c506923b1cc3a1f606c'
+    homepage 'https://pdf.wondershare.cn/pdfelement-mac/'
+    url "http://download.wondershare.com/mac-pdfelement#{version.major}_full#{version.after_comma}.dmg"
+
+    # Renamed for consistency: app name is different in the Finder and in a shell.
+    app "PDFelementStd#{version.major}.app", target: "PDFelement #{version.major}.app"
+    'zh-CN'
+  end
+
   name 'Wondershare PDFelement for Mac'
-  homepage 'https://pdf.wondershare.com/'
-
-  # Renamed for consistency: app name is different in the Finder and in a shell.
-  app "PDFelementStd#{version.major}.app", target: "PDFelement #{version.major}.app"
 end


### PR DESCRIPTION
There is a seperate version of PDFelement for China. License keys sold in China does not work for the international version. I did not include cask's version in the commit message because there is no update to this app.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
