### PR TITLE
Update adoptopenjdk from 11.0.2,9 to 12,33

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,14 +1,14 @@
 cask 'adoptopenjdk' do
-  version '12,33'
+  version '12.33'
   sha256 '985036459d4ef0867a3fe83b0bf87877d8e66a121c7b9c145bb97bd921aaf3f1'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}+#{version.after_comma}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.major}+#{version.minor}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.major}_#{version.minor}.tar.gz"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.major}-binaries/releases.atom"
   name 'AdoptOpenJDK Java Development Kit'
   homepage 'https://adoptopenjdk.net/'
 
-  artifact "jdk-#{version.before_comma}+#{version.after_comma}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+  artifact "jdk-#{version.major}+#{version.minor}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.major}.jdk"
   
   uninstall rmdir: '/Library/Java/JavaVirtualMachines'
 

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -10,7 +10,7 @@ cask 'adoptopenjdk' do
 
   artifact "jdk-#{version.before_comma}+#{version.after_comma}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
   
-  uninstall pkgutil: "net.adoptopenjdk.#{version.before_comma}.jdk"
+  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
 
   caveats <<~EOS
     More versions are available in the AdoptOpenJDK tap:

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -3,7 +3,7 @@ cask 'adoptopenjdk' do
   sha256 '3b974189c4eb74aa43a365676905f6534faf599075e3910fa6ec3b8ffb101cbf'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}+#{version.after_comma.before_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.before_colon}#{version.after_colon}.pkg"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}+#{version.after_comma}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
   appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
   name 'AdoptOpenJDK Java Development Kit'
   homepage 'https://adoptopenjdk.net/'

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -10,9 +10,7 @@ cask 'adoptopenjdk' do
 
   pkg "OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.before_colon}#{version.after_colon}.pkg"
 
-  uninstall pkgutil: [
-                       "net.adoptopenjdk.#{version.before_comma}.jdk",
-                     ]
+  uninstall pkgutil: "net.adoptopenjdk.#{version.before_comma}.jdk"
 
   caveats <<~EOS
     More versions are available in the AdoptOpenJDK tap:

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,6 +1,6 @@
 cask 'adoptopenjdk' do
   version '12,33'
-  sha256 '3b974189c4eb74aa43a365676905f6534faf599075e3910fa6ec3b8ffb101cbf'
+  sha256 '985036459d4ef0867a3fe83b0bf87877d8e66a121c7b9c145bb97bd921aaf3f1'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}+#{version.after_comma}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -9,7 +9,7 @@ cask 'adoptopenjdk' do
   homepage 'https://adoptopenjdk.net/'
 
   artifact "jdk-#{version.major}+#{version.minor}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.major}.jdk"
-  
+
   uninstall rmdir: '/Library/Java/JavaVirtualMachines'
 
   caveats <<~EOS

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,16 +1,18 @@
 cask 'adoptopenjdk' do
-  version '11.0.2,9'
-  sha256 'fffd4ed283e5cd443760a8ec8af215c8ca4d33ec5050c24c1277ba64b5b5e81a'
+  version '12,33'
+  sha256 '3b974189c4eb74aa43a365676905f6534faf599075e3910fa6ec3b8ffb101cbf'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK11U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
-  appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}+#{version.after_comma.before_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.before_colon}#{version.after_colon}.pkg"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
   name 'AdoptOpenJDK Java Development Kit'
   homepage 'https://adoptopenjdk.net/'
 
-  artifact "jdk-#{version.before_comma}+#{version.after_comma}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+  pkg "OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.before_colon}#{version.after_colon}.pkg"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall pkgutil: [
+                       "net.adoptopenjdk.#{version.before_comma}.jdk",
+                     ]
 
   caveats <<~EOS
     More versions are available in the AdoptOpenJDK tap:

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -8,8 +8,8 @@ cask 'adoptopenjdk' do
   name 'AdoptOpenJDK Java Development Kit'
   homepage 'https://adoptopenjdk.net/'
 
-  pkg "OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.before_colon}#{version.after_colon}.pkg"
-
+  artifact "jdk-#{version.before_comma}+#{version.after_comma}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+  
   uninstall pkgutil: "net.adoptopenjdk.#{version.before_comma}.jdk"
 
   caveats <<~EOS


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.