### PR TITLE
Update electron-cash from 4.0.1 to 4.0.2

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.1'
-  sha256 '92ad4a65d2d5bafccd9ea0541ac1abbd3c245a0fb7ba8a1d22f69c21843fd6bf'
+  version '4.0.2'
+  sha256 'edce2676a1c57814f99c95dd6a31d2b8778b6129d64559d61103f09daf0f3579'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/fyookball/electrum/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.