### PR TITLE
Update pokertracker from 4.15.8 to 4.15.11

### DIFF
--- a/Casks/pokertracker.rb
+++ b/Casks/pokertracker.rb
@@ -1,6 +1,6 @@
 cask 'pokertracker' do
-  version '4.15.8'
-  sha256 '5b4c46c48c693b87221d08efe61acfd54b22b5d4d0419328331e48738055c756'
+  version '4.15.11'
+  sha256 '5ef4a68869a6be1be2780d3e167101e86739a6a0b82450acaea93a0ea7acedca'
 
   # s3-us1.ptrackupdate.com was verified as official when first introduced to the cask
   url "https://s3-us1.ptrackupdate.com/releases/PT-Install-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.