### PR TITLE
Update igv from 2.5.0 to 2.5.1

### DIFF
--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -1,6 +1,6 @@
 cask 'igv' do
-  version '2.5.0'
-  sha256 '6700e22a4768896c607134565f312fa9097ca77bbae84acaa24875e053e0dde9'
+  version '2.5.1'
+  sha256 '4dc1f676174f1125c3b643d2dc57473b816adc88e4f798e3710a1e7884518157'
 
   url "https://data.broadinstitute.org/igv/projects/downloads/#{version.major_minor}/IGV_#{version}.app.zip"
   name 'Integrative Genomics Viewer (IGV)'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.