### PR TITLE
Update netron from 3.0.1 to 3.0.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.0.1'
-  sha256 '25131521dbf5f5427eaa970c96243a88c300d3945cf011766f77558024a8bcae'
+  version '3.0.2'
+  sha256 '7a04dfe49193719fd2190ec5a6d5302f9cf671074dfc323ab6ff0c2476f58b26'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.