### PR TITLE
Update netron from 3.0.1 to 3.0.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.0.1'
-  sha256 '25131521dbf5f5427eaa970c96243a88c300d3945cf011766f77558024a8bcae'
+  version '3.0.3'
+  sha256 '5bca67393e3e1ab6daaba899e2bb2a94cf937191f6355ca2c110912e57d3ca24'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.