### PR TITLE
Update jalbum from 18.2 to 18.2.1

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,5 +1,5 @@
 cask 'jalbum' do
-  version '18.2'
+  version '18.2.1'
   sha256 'fb7ad297a51c8418485f13afa4e42b9f6e950828ef86148644bc17a6913a9400'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.