### PR TITLE
Update gpsdump from 0.49 to 0.50

### DIFF
--- a/Casks/gpsdump.rb
+++ b/Casks/gpsdump.rb
@@ -1,6 +1,6 @@
 cask 'gpsdump' do
-  version '0.49'
-  sha256 '79fba744497f6739ed8db5f0b49f145b7ea0f0f8ab6fa21bdb0478b77924e831'
+  version '0.50'
+  sha256 '410a95350d28e2806be5e8c7f7697a66685ddc55045af540876f24656ccecba7'
 
   url "http://www.gpsdump.no/GpsDumpMac#{version.no_dots}.zip"
   appcast 'http://www.gpsdump.no/body_mac.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.