### PR TITLE
Update fontlab from 6.1.4,7043 to 6.1.4,7044

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,6 +1,6 @@
 cask 'fontlab' do
-  version '6.1.4,7043'
-  sha256 '7f1174afa88516459a8ab57a8190c44f1fffb2fc12553efe6fcdf539fef2cbd7'
+  version '6.1.4,7044'
+  sha256 'cc04ff57dbd51915f41e69811254b1fba0bf6900ac04a015b5dd4c7efc3ca588'
 
   url "https://download.fontlab.com/fontlab-vi/downloads/FontLab-VI-Mac-Install-#{version.after_comma}.dmg"
   appcast 'https://download.fontlab.com/fontlab-vi/appcast-mac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.