### PR TITLE
Update obinslab-starter from 1.0.9 to 1.0.10

### DIFF
--- a/Casks/obinslab-starter.rb
+++ b/Casks/obinslab-starter.rb
@@ -1,6 +1,6 @@
 cask 'obinslab-starter' do
-  version '1.0.9'
-  sha256 '5156a8d6e319091fe98f7cfbc136d1cffa981640b85ff1592f7e6292d59e4b36'
+  version '1.0.10'
+  sha256 '5aa810df804d18ae4ecdf3a049596164d2af76f518b83476d943f4e186c8b4e2'
 
   url "http://releases.obins.net/occ/darwin/x64/ObinslabStarter_#{version}_x64.dmg"
   appcast 'http://en.obins.net/obinslab-starter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.