### PR TITLE
Update waterfox from 56.2.8 to 56.2.9

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.2.8'
-  sha256 '292e2d6b969798df94be27a1aa35b769fe7870b39d496dd97f0d4ce296065c8a'
+  version '56.2.9'
+  sha256 '9cad039a395cc42edaf889f30426fbae07a259cf239afd8eb3d69a443dc1e982'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.