### PR TITLE
Update rawtherapee from 5.5 to 5.6

### DIFF
--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,6 +1,6 @@
 cask 'rawtherapee' do
-  version '5.5'
-  sha256 '2ca1635ab86decb46285a16f21e334e2949ebbf27ffc09567d83be7d36a4ec86'
+  version '5.6'
+  sha256 '274861597061e3febb204a8cd844bbadb20cdd925738f91d35fff382c6cec9f2'
 
   url "https://rawtherapee.com/releases_head/mac/RawTherapee_OSX_10.9_64_#{version}.zip"
   appcast 'https://github.com/Beep6581/RawTherapee/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.