### PR TITLE
Update icanhazshortcut from 1.0.1 to 1.1.0

### DIFF
--- a/Casks/icanhazshortcut.rb
+++ b/Casks/icanhazshortcut.rb
@@ -1,6 +1,6 @@
 cask 'icanhazshortcut' do
-  version '1.0.1'
-  sha256 'db7e48fb1b28964cf32180860f79586c84479073dfb1f30968866147088e40bd'
+  version '1.1.0'
+  sha256 'f82fce672409edf3147c60df383ae7e293eadd96a224054194af5d98f042673c'
 
   url "https://github.com/deseven/icanhazshortcut/releases/download/#{version}/ichs.dmg"
   appcast 'https://github.com/deseven/icanhazshortcut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.