### PR TITLE
Update provisionql from 1.5.0 to 1.6.0

### DIFF
--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -1,6 +1,6 @@
 cask 'provisionql' do
-  version '1.5.0'
-  sha256 '01a8cae466cdcc5fc8677a31343bda2c8f0e5ebb6a271890b5f11a7cab52b838'
+  version '1.6.0'
+  sha256 'eb4646ca2f082f15755fb93b2b1ab70d62b439dd657917667a8a921c0fa437d2'
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
   appcast 'https://github.com/ealeksandrov/ProvisionQL/releases.atom'
@@ -8,4 +8,8 @@ cask 'provisionql' do
   homepage 'https://github.com/ealeksandrov/ProvisionQL'
 
   qlplugin 'ProvisionQL.qlgenerator'
+
+  caveats do
+    'To prevent mobileprovision QuickLook override by Xcode - check https://github.com/ealeksandrov/ProvisionQL/issues/20'
+  end
 end

--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -10,6 +10,6 @@ cask 'provisionql' do
   qlplugin 'ProvisionQL.qlgenerator'
 
   caveats do
-    'To prevent mobileprovision QuickLook override by Xcode - check https://github.com/ealeksandrov/ProvisionQL/issues/20'
+    'To prevent mobileprovision QuickLook override by Xcode: https://github.com/ealeksandrov/ProvisionQL/issues/20'
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.