### PR TITLE
Update hazel from 4.3.4 to 4.3.5

### DIFF
--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -1,6 +1,6 @@
 cask 'hazel' do
-  version '4.3.4'
-  sha256 '85ebb56ee86224144e8044a638d49cc9e0e79a8b83d76281529e97f4cbe39587'
+  version '4.3.5'
+  sha256 'a96240c700f4954c1c0f51a1cc3ae0d0e29129df0cb26810a1cbdade760f7ae2'
 
   # s3.amazonaws.com/Noodlesoft was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Noodlesoft/Hazel-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.