### PR TITLE
Update unity-windows-support-for-editor from 2018.3.12f1,8afd630d1f5b to 2019.1.0f2,292b93d75a2c

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2018.3.12f1,8afd630d1f5b'
-  sha256 '1727c05a62e5c5cc3a131dc378c1ae139e72949d13319d56c52c58fb1c4f3595'
+  version '2019.1.0f2,292b93d75a2c'
+  sha256 '5dbd92424cf36b4d6682a44cdadbc954e723b97930ca2040e144b5705e1754f1'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.