### PR TITLE
Update unity-webgl-support-for-editor from 2018.3.12f1,8afd630d1f5b to 2019.1.0f2,292b93d75a2c

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2018.3.12f1,8afd630d1f5b'
-  sha256 '0ede6491e82be4cee7428b907f99d4f2c85bb75eea45a35a0930b38ec31f5d50'
+  version '2019.1.0f2,292b93d75a2c'
+  sha256 '9b9d270ee90e22fd86bdceb753f078a6b06d6a85de06a03c83c500e4f471377f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.