### PR TITLE
Update balenaetcher from 1.5.28 to 1.5.29

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.28'
-  sha256 '1b000536fa8f3b0b59cbca86aeefa96604990fd8db0e50ea932a903bc0829a1b'
+  version '1.5.29'
+  sha256 '93fe2164595ad68b2e2e9910090707b99d44ef5b1bac9c5f4af0df7884d7f73a'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.