### PR TITLE
Update cncjs from 1.9.18 to 1.9.19

### DIFF
--- a/Casks/cncjs.rb
+++ b/Casks/cncjs.rb
@@ -1,6 +1,6 @@
 cask 'cncjs' do
-  version '1.9.18'
-  sha256 '6b4fe786e04e2eb46c498efba8d9a320f4401b24b6687ef0fa1b9c2b45d19efb'
+  version '1.9.19'
+  sha256 '4a6f4a5c688a2440b4bb86b1c75e112a6e2d3c9c01353e47bd6b3fa015c3e8ff'
 
   # github.com/cncjs/cncjs was verified as official when first introduced to the cask
   url "https://github.com/cncjs/cncjs/releases/download/v#{version}/cncjs-app-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.