### PR TITLE
Update fedora-media-writer from 4.1.1 to 4.1.3

### DIFF
--- a/Casks/fedora-media-writer.rb
+++ b/Casks/fedora-media-writer.rb
@@ -1,6 +1,6 @@
 cask 'fedora-media-writer' do
-  version '4.1.1'
-  sha256 'aefc333e274145b620f29b281068159999e90dba3eb9cd854a3acfb15381e306'
+  version '4.1.3'
+  sha256 'b3d437defb0cfbad0be50127f692b3c6592aada6fe4f5e4447514fe703e5428f'
 
   # github.com/MartinBriza/MediaWriter was verified as official when first introduced to the cask
   url "https://github.com/MartinBriza/MediaWriter/releases/download/#{version}/FedoraMediaWriter-osx-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.