### PR TITLE
Update joplin from 1.0.142 to 1.0.143

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.142'
-  sha256 '53d93c997bb14bcf3724a0f00e8b85fd8c0d148d8a8fd7e29f301d0431b0f81c'
+  version '1.0.143'
+  sha256 '24ab42af55eb322fa3201b98b43a10782240657fa0871aee4960e73b918fb905'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.