### PR TITLE
Update url for VLC player download

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -2,7 +2,7 @@ cask 'vlc' do
   version '3.0.6'
   sha256 '0c807a2e352fd6fe7e591fe01a7a53794b7d817e1e1eda3f673df06f26db27d5'
 
-  url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
+  url "https://ftp.free.org/mirrors/videolan/vlc/#{version}/macosx/vlc-#{version}.dmg"
   appcast 'https://download.videolan.org/pub/videolan/vlc/'
   name 'VLC media player'
   homepage 'https://www.videolan.org/vlc/'


### PR DESCRIPTION
I couldn't download VLC using cask today so I checked the URL on the official website.

- Site link: https://get.videolan.org/vlc/3.0.6/macosx/vlc-3.0.6.dmg
- Download: https://ftp.free.org/mirrors/videolan/vlc/3.0.6/macosx/vlc-3.0.6.dmg

It's the first time I try to contribute. Can someone help me with making the tests pass?