### PR TITLE
Update zoho-mail from 1.0.13 to 1.0.14

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.0.13'
-  sha256 'cc88a4187405492d5687681b46255cad4b72e02fc6d1116a14a3e74ebf727671'
+  version '1.0.14'
+  sha256 '39b269c727c397adad6a0c6b381aed5a52071ae4833826ff2579446168e29170'
 
   url "https://www.zoho.com/mail/desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"
   appcast 'https://www.zoho.com/mail/desktop/artifacts.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.