### PR TITLE
Update qownnotes from 19.4.3,b4217-172713 to 19.4.4,b4236-181806

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.4.3,b4217-172713'
-  sha256 '59bd2d3d71cd440a5bccea37f793bfb32f27c5bc14428ef10fedb45c8482c94b'
+  version '19.4.4,b4236-181806'
+  sha256 '1ba112ffda0873f282eee311fce6259f2643fe634e8f3f443812d5da0200c6c8'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.