### PR TITLE
Update dhs from 1.4.0 to 1.4.1

### DIFF
--- a/Casks/dhs.rb
+++ b/Casks/dhs.rb
@@ -1,6 +1,6 @@
 cask 'dhs' do
-  version '1.4.0'
-  sha256 '37211f5051413fa866781e6943ad2adb3c68546fcfd3033c0d69a0bbeadc5462'
+  version '1.4.1'
+  sha256 '6d0ce00e0e111059e157bae26d4a913d7cb7c42cee6493b638c2c5019fe987fc'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/DHS_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.