### PR TITLE
Update hachidori from 3.1.6 to 3.1.7

### DIFF
--- a/Casks/hachidori.rb
+++ b/Casks/hachidori.rb
@@ -1,6 +1,6 @@
 cask 'hachidori' do
-  version '3.1.6'
-  sha256 '7c9e9147417d07b5c237b16c79e99989332976202f4d069f5ff9cf8ad0618f40'
+  version '3.1.7'
+  sha256 'a775f49de9b6da9f1d5a2f04f900c76b4935cc11a2069517084511e694b416e0'
 
   # github.com/Atelier-Shiori/hachidori was verified as official when first introduced to the cask
   url "https://github.com/Atelier-Shiori/hachidori/releases/download/#{version}/hachidori-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.