### PR TITLE
Update runjs from 1.4.0 to 1.5.0

### DIFF
--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -1,6 +1,6 @@
 cask 'runjs' do
-  version '1.4.0'
-  sha256 'f1d921566740edd3ffe4725b00fd57ac1155479d307d07466cf77c751fe83cf2'
+  version '1.5.0'
+  sha256 'a4cf402ec5cd0bd4d64bf2ad3833069b0d069123162beeb54be587e791b94b0e'
 
   # github.com/lukehaas/runjs was verified as official when first introduced to the cask
   url "https://github.com/lukehaas/runjs/releases/download/v#{version}/RunJS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.