### PR TITLE
Update adoptopenjdk from 12.33 to 12.0.1,12

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,14 +1,14 @@
 cask 'adoptopenjdk' do
-  version '12.33'
-  sha256 '985036459d4ef0867a3fe83b0bf87877d8e66a121c7b9c145bb97bd921aaf3f1'
+  version '12.0.1,12'
+  sha256 'dcb2ab681247298eda018df24166ba01674127083fb02892acf087e6181d8c56'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.major}+#{version.minor}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.major}_#{version.minor}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
   appcast "https://github.com/adoptopenjdk/openjdk#{version.major}-binaries/releases.atom"
   name 'AdoptOpenJDK Java Development Kit'
   homepage 'https://adoptopenjdk.net/'
 
-  artifact "jdk-#{version.major}+#{version.minor}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.major}.jdk"
+  artifact "jdk-#{version.before_comma}+#{version.after_comma}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
 
   uninstall rmdir: '/Library/Java/JavaVirtualMachines'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.