### PR TITLE
Update trilium-notes from 0.30.7 to 0.30.8

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.30.7'
-  sha256 '56d75fa70a6a1ae9d55f00a664cca27a10044128178923ddc2e7f8fd94f33f9c'
+  version '0.30.8'
+  sha256 '43c4646ee6a860aa16c0d8dd6c681e32b106bc47d04f907c735507e02b6adf15'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.