### PR TITLE
Update propresenter from 6.3.9_b16229 to 6.4_b16245

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,6 +1,6 @@
 cask 'propresenter' do
-  version '6.3.9_b16229'
-  sha256 '3b9976af8fb89e66bd523411254e6b78785ead3100f3c859d7c3baeaef94e1ef'
+  version '6.4_b16245'
+  sha256 '0cc28e38f8c6f70ce15e56742e08bd51831f79e3e57669f5a477a0d33180faca'
 
   url "https://www.renewedvision.com/downloads/ProPresenter#{version.major}_#{version}.dmg"
   appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.