### PR TITLE
Update dosbox-x from 0.82.16,20190301171645 to 0.82.17,20190405211829

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.16,20190301171645'
-  sha256 'd415500e0e9c4c786cd4664d02ef134fbe73983d74dac3944b10ad8675f087df'
+  version '0.82.17,20190405211829'
+  sha256 '23996d4eef7849db3958f74a72ad2e9a17e6777220d4439431787dd6bdbb38db'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.