### PR TITLE
Update bettertouchtool from 2.762 to 2.763

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.762'
-    sha256 '0323496d83d8a58ed926e0c59d4d77b2f8eccb0d33800ca6cfc61bb2055c89f5'
+    version '2.763'
+    sha256 '0c7411da6c7a963c06fbaf7a0739b3d86b765907a66be2cdc6ed9347a8dd386d'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.