### PR TITLE
Update ibackup-viewer from 4.1260 to 4.1300

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1260'
-  sha256 'b5ae65fb885ca3a998248aea25f5e837b4c908cfd0e3d35e7cc48b01858e3490'
+  version '4.1300'
+  sha256 '8c36604ba646ac75a3d7f2168ffaaf775222f331c40a6f1d3db7155c8719c2f5'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.