### PR TITLE
Update subler from 1.5.13 to 1.5.14

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask 'subler' do
-  version '1.5.13'
-  sha256 '879a3ce9f237062e17e3f0bb4b287f16c8b1d03794f35589f4193c9cb7d9dbb6'
+  version '1.5.14'
+  sha256 'dcbb79add43b936b5323e4ec28f444e906e30ed038d0b30a8d1e6fa99b6ac8f1'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.