### PR TITLE
Update clockify from 2.2.4_59 to 2.2.5_69

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,5 +1,5 @@
 cask 'clockify' do
-  version '2.2.5_69'
+  version '2.2.5.69'
   sha256 '6624c3b25cb8788dd72f46e4532e62266173250981dd61ba201cf9ff1870643f'
 
   url "https://clockify.me/downloads/ClockifyDesktop_#{version.no_dots}.zip"

--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
-  version '2.2.4_59'
-  sha256 'e2e4804a259dc49f15be62017ce519725ee633dd3d6be5511515b1c342addad0'
+  version '2.2.5_69'
+  sha256 '6624c3b25cb8788dd72f46e4532e62266173250981dd61ba201cf9ff1870643f'
 
   url "https://clockify.me/downloads/ClockifyDesktop_#{version.no_dots}.zip"
   name 'Clockify'

--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
   version '2.2.5.69'
-  sha256 '6624c3b25cb8788dd72f46e4532e62266173250981dd61ba201cf9ff1870643f'
+  sha256 'dc35b3a92338ae794825c1018f836c653e88a1613738592fcd09a9260ddd1a0a'
 
   url "https://clockify.me/downloads/ClockifyDesktop_#{version.no_dots}.zip"
   name 'Clockify'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.