### PR TITLE
Update coverload from 1.2.2-503 to 1.2.3-505

### DIFF
--- a/Casks/coverload.rb
+++ b/Casks/coverload.rb
@@ -1,6 +1,6 @@
 cask 'coverload' do
-  version '1.2.2-503'
-  sha256 '0b6167e30478a024bc479fc53237c0e948c81a4c7347dfe6cac77328e546d164'
+  version '1.2.3-505'
+  sha256 'a6028ca94789df6d18f7f296c04413c542e57237d27fac6061a5c43018e48847'
 
   # amazonaws.com/coverloadapp.com was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/coverloadapp.com/Uploads/CoverLoad-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.