### PR TITLE
Update raw-photo-processor from 1875Beta to 1876Beta

### DIFF
--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -1,6 +1,6 @@
 cask 'raw-photo-processor' do
-  version '1875Beta'
-  sha256 'cdc7d2798915fa49e776c03083fd0fe578a10ee1cb14dc918aa6db4f460105c9'
+  version '1876Beta'
+  sha256 '458d9912db08ba1d874bed49242a51e2d01f32220ecc07cc7449fd5352e8bf3d'
 
   url "https://www.raw-photo-processor.com/RPP/RPP64_#{version}.zip"
   appcast 'https://www.raw-photo-processor.com/rpp_updates_64.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.