### PR TITLE
Update 4k-video-downloader from 4.7.0.2602 to 4.7.1.2712

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.7.0.2602'
-  sha256 '3f42af1c85c347abbfe8f187adca91a4198341f3ba1a8e0bed668e86f98e068b'
+  version '4.7.1.2712'
+  sha256 '787422466b475ef7f63cfc76e8620104232dc59155391ff9f937e97d508a7602'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.