### PR TITLE
Update downie from 3.6.9,1995 to 3.7,2000

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.6.9,1995'
-  sha256 '747ca1379aa1c94a9aacae13d1f65745e18a7edc9848bf292731cc6b82e031f2'
+  version '3.7,2000'
+  sha256 '26bf246e6bf554f255cc2b616c146c3bb108b37f39778ba6014c740417d693bc'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.