### PR TITLE
Update kite from 0.20190418.0 to 0.20190423.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190418.0'
-  sha256 'adb09478aba429791f1e13b99ac4ab4c4f97d36c79e401e53f90fa5441c96cad'
+  version '0.20190423.0'
+  sha256 'c47d58462f6a1cb802f697acaf1856ba31a65ebbc2d164edd7105c0724818296'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.