### PR TITLE
Update microblog from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/microblog.rb
+++ b/Casks/microblog.rb
@@ -1,6 +1,6 @@
 cask 'microblog' do
-  version '1.8.1'
-  sha256 '97aff0dbb348f1d56dc88019cf1eb8e82a7e4a129de584ce7a1ebadfa749d9e8'
+  version '1.8.2'
+  sha256 '92a3683160f3f1f19e5c35ef7d2071421c8bc54fcd9f695c2f1e542e51f4648b'
 
   # s3.amazonaws.com/micro.blog was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/micro.blog/mac/Micro.blog_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.