### PR TITLE
Update rightfont from 5.5.0 to 5.5.1

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,6 +1,6 @@
 cask 'rightfont' do
-  version '5.5.0'
-  sha256 'd4b4f86f11afce774668797882eac415aba61eea8aa9716e36e22e6f6efc8ed5'
+  version '5.5.1'
+  sha256 'c19ac377c09c477d96ec37a583e44b7ba826cc5eff59e44be40ad9c8c4e55a1f'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
   appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.