### PR TITLE
Update plex-media-server from 1.15.3.876-ad6e39743 to 1.15.4.993-bb4a2cb6c

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.15.3.876-ad6e39743'
-  sha256 '48663e381d8154227e98d627839fe7dc6aa0ae593156fe2c1a92fa9965acc24b'
+  version '1.15.4.993-bb4a2cb6c'
+  sha256 '3ee9075a071b8a496269161db25c2ac09fa16a0a48cb7c77b95ec98966723373'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.dmg"
   appcast 'https://plex.tv/api/downloads/1.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.