### PR TITLE
Add Cube.app v4.4

### DIFF
--- a/Casks/cube.rb
+++ b/Casks/cube.rb
@@ -1,0 +1,15 @@
+cask 'cube' do
+  version '4.4'
+  sha256 '20698456ed2c19bf0bfb5a9e4ea74a761248e86a741c15d6f525ec8c5e20897c'
+
+  # apps.fz-juelich.de/scalasca/releases/cube was verified as official when first introduced to the cask
+  url 'https://apps.fz-juelich.de/scalasca/releases/cube/4.4/dist/Cube-Compressed.dmg'
+  appcast 'https://scalasca.org/software/cube-4.x/download.html'
+  name 'Scalasca Cube GUI'
+  name 'Scalasca Cube'
+  name 'CubeGUI'
+  name 'Cube'
+  homepage 'https://scalasca.org/software/cube-4.x/download.html'
+
+  app 'Cube.app'
+end

--- a/Casks/cube.rb
+++ b/Casks/cube.rb
@@ -6,7 +6,7 @@ cask 'cube' do
   url "https://apps.fz-juelich.de/scalasca/releases/cube/#{version.major}/dist/Cube-Compressed.dmg"
   appcast "https://scalasca.org/software/cube-#{version.major}.x/download.html"
   name 'Scalasca Cube GUI'
-  homepage "https://scalasca.org/software/cube-#{vesion.major}.x/download.html"
+  homepage "https://scalasca.org/software/cube-#{version.major}.x/download.html"
 
   app 'Cube.app'
 end

--- a/Casks/cube.rb
+++ b/Casks/cube.rb
@@ -3,13 +3,10 @@ cask 'cube' do
   sha256 '20698456ed2c19bf0bfb5a9e4ea74a761248e86a741c15d6f525ec8c5e20897c'
 
   # apps.fz-juelich.de/scalasca/releases/cube was verified as official when first introduced to the cask
-  url 'https://apps.fz-juelich.de/scalasca/releases/cube/4.4/dist/Cube-Compressed.dmg'
-  appcast 'https://scalasca.org/software/cube-4.x/download.html'
+  url "https://apps.fz-juelich.de/scalasca/releases/cube/#{version.major}/dist/Cube-Compressed.dmg"
+  appcast "https://scalasca.org/software/cube-#{version.major}.x/download.html"
   name 'Scalasca Cube GUI'
-  name 'Scalasca Cube'
-  name 'CubeGUI'
-  name 'Cube'
-  homepage 'https://scalasca.org/software/cube-4.x/download.html'
+  homepage "https://scalasca.org/software/cube-#{vesion.major}.x/download.html"
 
   app 'Cube.app'
 end

--- a/Casks/cube.rb
+++ b/Casks/cube.rb
@@ -3,7 +3,7 @@ cask 'cube' do
   sha256 '20698456ed2c19bf0bfb5a9e4ea74a761248e86a741c15d6f525ec8c5e20897c'
 
   # apps.fz-juelich.de/scalasca/releases/cube was verified as official when first introduced to the cask
-  url "https://apps.fz-juelich.de/scalasca/releases/cube/#{version.major}/dist/Cube-Compressed.dmg"
+  url "https://apps.fz-juelich.de/scalasca/releases/cube/#{version}/dist/Cube-Compressed.dmg"
   appcast "https://scalasca.org/software/cube-#{version.major}.x/download.html"
   name 'Scalasca Cube GUI'
   homepage "https://scalasca.org/software/cube-#{version.major}.x/download.html"


### PR DESCRIPTION
 - Cube.app provides the Cube GUI performance report explorer for Scalasca and
   Score-P
 - N.B.: The homepage does __*NOT*__ rener correctly when visiting the https
   url (with chrome at least)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
  - N.B.: I added https versions of the URL to the appcast and homepage, however, that page does not render correctly when using https.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
