### PR TITLE
Update nvidia-geforce-now from 2.0.5.49 to 2.0.6.86

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,8 +1,8 @@
 cask 'nvidia-geforce-now' do
   version '2.0.6.86'
-  sha256 'd3e122fbf966f0926d609936e262c134f252c420d49cf00df3265b6ca68fa40a'
+  sha256 '2aa9c198646f2c32c8d12eb4bc12970613349120895e3673d3d62a7982140474'
 
-  url 'https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg'
+  url 'https://ota-downloads.nvidia.com/ota/GeForceNOW-release_E943AA.dmg'
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'
   name 'NVIDIA GeForce NOW'
   homepage 'https://www.nvidia.com/en-us/geforce/products/geforce-now/'

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,5 +1,5 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.5.49'
+  version '2.0.6.86'
   sha256 'd3e122fbf966f0926d609936e262c134f252c420d49cf00df3265b6ca68fa40a'
 
   url 'https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.