### PR TITLE
Update wechatwork from 2.7.8.2009 to 2.8.2.2028

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.7.8.2009'
-  sha256 '855a6b7887fc44522bda222cf7c1acf596002bd6acc4a22b8aa728ee32079c81'
+  version '2.8.2.2028'
+  sha256 '46040636932d4adac9b9064e858722baf7791f20ab01c0310181939af56aa03b'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.