### PR TITLE
Update cryptomator from 1.4.7 to 1.4.8

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,6 +1,6 @@
 cask 'cryptomator' do
-  version '1.4.7'
-  sha256 'c226030b77d1f0a623ddb77562725d15339a0214e9b80af4ef19acf62d7ae3c3'
+  version '1.4.8'
+  sha256 '007d2fc9eab2e0aaf6d7116cf54a43eafe4ac5be7c6bb06272e887c22dc06f2c'
 
   # dl.bintray.com/cryptomator/cryptomator was verified as official when first introduced to the cask
   url "https://dl.bintray.com/cryptomator/cryptomator/#{version}/Cryptomator-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.