### PR TITLE
Add depends_on High Sierra to Mediainfo 19.04

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -7,6 +7,8 @@ cask 'mediainfo' do
   name 'MediaInfo'
   homepage 'https://mediaarea.net/en/MediaInfo'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'MediaInfo.app'
 
   zap trash: [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
The DMG contains an APFS structure which isn't able to be opened on Sierra and earlier. Since Travis checks on High Sierra, it doesn't detect this issue.