### PR TITLE
Update yinxiangbiji from 9.0.2_457849 to 9.0.4_457911

### DIFF
--- a/Casks/yinxiangbiji.rb
+++ b/Casks/yinxiangbiji.rb
@@ -1,6 +1,6 @@
 cask 'yinxiangbiji' do
-  version '9.0.2_457849'
-  sha256 '6c72293b2ad3dff55c1f7a7a03c2130e25a4ad1202075246aff27ec475a2708b'
+  version '9.0.4_457911'
+  sha256 'af71a01294dbc408f5eb272c0a32f592212c2c85789611ecf7295411ef492491'
 
   url "https://cdn.yinxiang.com/mac-smd/public/YinxiangBiji_RELEASE_#{version}.dmg"
   appcast 'https://update.yinxiang.com/public/ENMacSMD/EvernoteMacUpdate.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.