### PR TITLE
Update whalebird from 2.7.0 to 2.7.1

### DIFF
--- a/Casks/whalebird.rb
+++ b/Casks/whalebird.rb
@@ -1,6 +1,6 @@
 cask 'whalebird' do
-  version '2.7.0'
-  sha256 'd98a2cc0aabe320641a13c85c9fb169ea17d53bd76d863c28533db94db6915de'
+  version '2.7.1'
+  sha256 'dcbc96881903f58c19f9b14040d1fe3025e911d68e8cf77d7e7c52109e6e35d7'
 
   # github.com/h3poteto/whalebird-desktop was verified as official when first introduced to the cask
   url "https://github.com/h3poteto/whalebird-desktop/releases/download/#{version}/Whalebird-#{version}-darwin-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.