### PR TITLE
Update advancedrestclient from 13.0.5 to 13.0.6

### DIFF
--- a/Casks/advancedrestclient.rb
+++ b/Casks/advancedrestclient.rb
@@ -1,6 +1,6 @@
 cask 'advancedrestclient' do
-  version '13.0.5'
-  sha256 '7dd41b3967a02b4615d778220d9644339f98d38f74a2175480ab3f40c3d7f942'
+  version '13.0.6'
+  sha256 'f5c851323730f0b9301e4e9087ea85074ae308dfebbfcbe70b7c1aba8ebd8364'
 
   # github.com/advanced-rest-client/arc-electron was verified as official when first introduced to the cask
   url "https://github.com/advanced-rest-client/arc-electron/releases/download/v#{version}/arc-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.