### PR TITLE
Update curio from 12022.5 to 13000.17

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '12022.5'
-  sha256 'b79ca4b7e0c9aaffafc78e8b2768ae679af741da428a449ae499470fb44b9037'
+  version '13000.17'
+  sha256 '9601606dfc33d001381694a29b4f3a54709e8099c93345c99b9b05726f7b95d5'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio12MarkdownAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.