### PR TITLE
Update touchdesigner from 099.2018.28070 to 099.2019.13330

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2018.28070'
-  sha256 '88366226083c9041c123ddf4b53d4d42d3bc0bfa19b15169c55c95f13e9f7607'
+  version '99.2019.13330'
+  sha256 '135261081607355f7829ceb7662396934a52ecb61e6593acd2c58d06776f7c9f'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,5 +1,5 @@
 cask 'touchdesigner' do
-  version '99.2019.13330'
+  version '099.2019.13330'
   sha256 '135261081607355f7829ceb7662396934a52ecb61e6593acd2c58d06776f7c9f'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
   version '099.2019.13330'
-  sha256 '135261081607355f7829ceb7662396934a52ecb61e6593acd2c58d06776f7c9f'
+  sha256 '12cf7858b4e6094e5c9ce3c272facec5e1b65bac1e2caf44278095be5b374aa0'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.