### PR TITLE
Update trash-it from 7.0.1 to 7.5

### DIFF
--- a/Casks/trash-it.rb
+++ b/Casks/trash-it.rb
@@ -1,6 +1,6 @@
 cask 'trash-it' do
-  version '7.0.1'
-  sha256 'aaffb0ab43a163178b9b6d230eef9ed5ee096461163ee001cd2c98e6ede43bc5'
+  version '7.5'
+  sha256 'b401adff30cd1110bfef7b14110aa097c8c1053c0ed92ab95506e2829cacd52c'
 
   url 'https://nonamescriptware.com/wp-content/uploads/Trashit.zip'
   appcast 'https://nonamescriptware.com/downloads/'

--- a/Casks/trash-it.rb
+++ b/Casks/trash-it.rb
@@ -7,5 +7,5 @@ cask 'trash-it' do
   name 'Trash It!'
   homepage 'https://nonamescriptware.com/'
 
-  app "Trash It! #{version}/Drag app to Desktop/Trash It! #{version}.app"
+  app "Trash It! #{version}/Trash It!.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.