### PR TITLE
Upgrade VisIt to v2.13.3

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,9 +1,9 @@
 cask 'visit' do
-  version '2.13.2'
-  sha256 'e7e05ec4393f1f1c944b1963ff8f2619383f506a3b05546c91de61082ba4bb21'
+  version '2.13.3'
+  sha256 '984d85a597ecd391ff4fcf05fede6d320ef7eb138ce296aa88b7136b0ea1ea50'
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
-  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}-10.11.dmg"
+  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'


### PR DESCRIPTION
Substitute for #62258. 

Drop the *-10.11.dmg file suffix for *.dmg in url field. Last 2x releases have not offered either the 10.11 or 10.12 versions (only 10.13):

- https://portal.nersc.gov/project/visit/releases/2.13.3/visit_sha256_checksums
Whereas they have all offered the generic .dmg.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
