### PR TITLE
Update coteditor from 3.7.2 to 3.7.3

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -6,8 +6,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.7.2'
-    sha256 '6fc0aae8ab7788cff9fdd5dc42a78ee82885ec9b030319320cea9abd21458c06'
+    version '3.7.3'
+    sha256 '1f0ba5c7ed3d731c60b6f8f0e838189ce92c2beedad07d26b2bebd10265c8d8a'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.