### PR TITLE
Update phocus from 3.4.2 to 3.4.3

### DIFF
--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -1,8 +1,8 @@
 cask 'phocus' do
-  version '3.4.2'
-  sha256 '79ad542b8888b67c51a23222ba04cff75934a7bc109bc947775a2c3b567f94de'
+  version '3.4.3'
+  sha256 '8b2b830d92604002a7406c2bbd8a1ec7eb4941e388d62e1b2a73e03ec9de76d2'
 
-  url "https://cdn.hasselblad.com/phocus/Phocus.#{version}.dmg"
+  url "https://cdn.hasselblad.com/software/Phocus-for-Mac/#{version}/Phocus-#{version}.dmg"
   name 'Hasselblad Phocus'
   homepage 'https://www.hasselblad.com/software/phocus'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.