### PR TITLE
Update tencent-lemon from 1.1.2 to 1.1.3

### DIFF
--- a/Casks/tencent-lemon.rb
+++ b/Casks/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask 'tencent-lemon' do
-  version '1.1.2'
-  sha256 '539c934d863fa348dded620e82794d61aa6d7bdd14a44a37a782c89ca06fc104'
+  version '1.1.3'
+  sha256 'b2aa08a46f4541bcea6dbc444ed5a3e1d6a80a5dcccb23ea45314ef5e95dcfc1'
 
   # pm.myapp.com/invc/xfspeed/qqpcmgr was verified as official when first introduced to the cask
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/Lemon_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.