### PR TITLE
Update paintbrush from 2.2.1 to 2.3.0

### DIFF
--- a/Casks/paintbrush.rb
+++ b/Casks/paintbrush.rb
@@ -1,6 +1,6 @@
 cask 'paintbrush' do
-  version '2.2.1'
-  sha256 '96ee40ce8052ffdb687a187e74f22bcce2ab40430d8b4c2f4b1d2637b3ad21a3'
+  version '2.3.0'
+  sha256 'ace47b0ae40c8a1c85d5b4019559c63484eccde83cbfa4a99190428b607c8ad7'
 
   # downloads.sourceforge.net/paintbrush was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/paintbrush/Paintbrush%202.x/Paintbrush%20#{version}/Paintbrush-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.