### PR TITLE
Update vysor from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/vysor.rb
+++ b/Casks/vysor.rb
@@ -1,5 +1,5 @@
 cask 'vysor' do
-  version '2.1.1'
+  version '2.1.2'
   sha256 '40f86a4781585f2aeb5a7ffbf8efaf6d1a52b960b2afbf973c719d0ea65da36d'
 
   # github.com/koush/vysor.io was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.