### PR TITLE
Update polar-bookshelf from 1.17.5 to 1.18.1

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.17.5'
-  sha256 '85625c597e5030d3705ea6f31afeb28cfc06cc03e703aeebee39e668fb1abcb2'
+  version '1.18.1'
+  sha256 '30fccf5296be411ad12d4e7ef2b18a81c344b694f6111b18adabf8f1e70df44a'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.