### PR TITLE
Update kite from 0.20190424.0 to 0.20190425.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190424.0'
-  sha256 'aeaee150a1febc9dccef4d7a8fa2b04eab37266d29a251549eabbc6d361c8ef7'
+  version '0.20190425.0'
+  sha256 '222513eb4d499fa346b86d39d7e32cb3f5f7f62d92c41d0a19d6792b6e484c4e'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.