### PR TITLE
Update thonny from 3.0.8 to 3.1.2

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,9 +1,9 @@
 cask 'thonny' do
-  version '3.0.8'
-  sha256 'df6f513deb7c649dee731c261374020cfbee3567bfb4e9bb6388cac2543b95fe'
+  version '3.1.2'
+  sha256 '7a71c31d61a769b0725d745ee2509229f8da086701670d48e02a85fa4b70388a'
 
-  # bitbucket.org/plas/thonny/downloads was verified as official when first introduced to the cask
-  url "https://bitbucket.org/plas/thonny/downloads/thonny-#{version}.dmg"
+  # github.com/thonny/thonny/releases/download was verified as official when first introduced to the cask
+  url "https://github.com/thonny/thonny/releases/download/v#{version}/thonny-#{version}.dmg"
   appcast 'https://thonny.org/blog/categories/releases.html'
   name 'Thonny'
   homepage 'https://thonny.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.