### PR TITLE
Add mutify 1.1.1

### DIFF
--- a/Casks/mutify.rb
+++ b/Casks/mutify.rb
@@ -1,0 +1,17 @@
+cask 'mutify' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://storage.mutify.app/data/Mutify.dmg'
+  name 'Mutify'
+  homepage 'https://mutify.app/'
+
+  app 'Mutify.app'
+
+  zap trash: [
+               '~/Library/Application Support/MutifyAgent',
+               '~/Library/Cookies/com.pixel-point.MutifyAgent.binarycookies',
+               '~/Library/Preferences/com.pixel-point.Mutify.plist',
+               '~/Library/Preferences/com.pixel-point.MutifyAgent.plist',
+             ]
+end

--- a/Casks/mutify.rb
+++ b/Casks/mutify.rb
@@ -7,6 +7,8 @@ cask 'mutify' do
   name 'Mutify'
   homepage 'https://mutify.app/'
 
+  auto_updates true
+
   app 'Mutify.app'
 
   zap trash: [

--- a/Casks/mutify.rb
+++ b/Casks/mutify.rb
@@ -1,8 +1,9 @@
 cask 'mutify' do
-  version :latest
-  sha256 :no_check
+  version '1.1.1'
+  sha256 '1ac19cef9d59cd1162ddfbd97c7bbe882159c763458b0fc5ce19690f433b673c'
 
   url 'https://storage.mutify.app/data/Mutify.dmg'
+  appcast 'https://storage.mutify.app/data/appcast.xml'
   name 'Mutify'
   homepage 'https://mutify.app/'
 

--- a/Casks/mutify.rb
+++ b/Casks/mutify.rb
@@ -8,6 +8,7 @@ cask 'mutify' do
   homepage 'https://mutify.app/'
 
   auto_updates true
+  depends_on macos: '>= :sierra'
 
   app 'Mutify.app'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. 
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
<hr>

[Mutify](https://mutify.app/) is the trialware successor to open-source [Mute Me](https://github.com/pixel-point/mute-me) (which already has a cask). Pixel Point have said they will keep Mute Me available indefinitely, however, I highly doubt it will be receiving anymore updates. Has something like this come up before, and how should it be handled if so?

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
