### PR TITLE
Update r from 3.5.3 to 3.6.0

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,6 +1,6 @@
 cask 'r' do
-  version '3.5.3'
-  sha256 '2f17ad05bac502769f392f778291c407c9933e90bd86815daa2c9cc7661f5158'
+  version '3.6.0'
+  sha256 '51e58a2766e091a85776ab8e44598e4fdd99b066b25b439777f3d4089803a5f1'
 
   url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   appcast 'https://cloud.r-project.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.