### PR TITLE
Fix java class not found error in textricator (#62500)

### DIFF
--- a/Casks/textricator.rb
+++ b/Casks/textricator.rb
@@ -8,5 +8,14 @@ cask 'textricator' do
   name 'Textricator'
   homepage 'https://textricator.mfj.io/'
 
-  binary "textricator-#{version}/textricator"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/62500)
+  shimscript = "#{staged_path}/textricator.wrapper.sh"
+  binary shimscript, target: 'textricator'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      java -cp "#{staged_path}/textricator-#{version}/lib/*" ${JAVA_OPTS} io.mfj.textricator.cli.TextricatorCli "$@"
+    EOS
+  end
 end


### PR DESCRIPTION
Add shim script to set correct classpath, but otherwise identical
to original textricator bootstrap code. Fixes issue [#62500](https://github.com/Homebrew/homebrew-cask/issues/62500).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

**Note:** The version number was not changed and is not relevant to the fix. Cask name is included in commit message.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
