### PR TITLE
Change download URL to oracle.com

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -2,7 +2,7 @@ cask 'java' do
   version '12.0.1,69cfe15208a647278a19ef0990eea691'
   sha256 'cba6f42f82496f62c51fb544e243d440984d442bdc906550a30428d8be6189e5'
 
-  url "https://download.java.net/java/GA/jdk#{version.before_comma}/#{version.after_comma}/#{version.major}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
+  url "https://download.oracle.com/java/GA/jdk#{version.before_comma}/#{version.after_comma}/#{version.major}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Java Development Kit'
   homepage 'https://jdk.java.net/'
 

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -2,8 +2,8 @@ cask 'virtualbox-extension-pack' do
   version '6.0.6'
   sha256 '794f023a186bd217c29c3d30bd1434b6e9de3b242c7bf740d06d10f2d3d981c6'
 
-  url "https://download.virtualbox.org/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
-  appcast 'https://download.virtualbox.org/virtualbox/LATEST.TXT'
+  url "https://download.oracle.com/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
+  appcast 'https://download.oracle.com/virtualbox/LATEST.TXT'
   name 'Oracle VirtualBox Extension Pack'
   homepage 'https://www.virtualbox.org/'
 

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -2,8 +2,8 @@ cask 'virtualbox' do
   version '6.0.6,130049'
   sha256 'e7fea3a51d7be7e00b7d0115e33eb62dc5e4cbd10542fd7b0b83de904666b6bf'
 
-  url "https://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
-  appcast 'https://download.virtualbox.org/virtualbox/LATEST.TXT'
+  url "https://download.oracle.com/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
+  appcast 'https://download.oracle.com/virtualbox/LATEST.TXT'
   name 'Oracle VirtualBox'
   homepage 'https://www.virtualbox.org/'
 


### PR DESCRIPTION
Fix SSL certificate error for download.java.net and download.virtualbox.com. Both are redirecting to download.oracle.com from which belongs the SSL certificate

Probably there are other domains that have the same problem!

Resolves #62503 
