### PR TITLE
Update pulse-sms from 3.3.1 to 3.4.2

### DIFF
--- a/Casks/pulse-sms.rb
+++ b/Casks/pulse-sms.rb
@@ -1,6 +1,6 @@
 cask 'pulse-sms' do
-  version '3.3.1'
-  sha256 'cbe492f2b3020d41e646e05696567e479136e75d5e7402b7b052cf6916924823'
+  version '3.4.2'
+  sha256 '6ade8a3d866b47f219a3369efe192331e177ee1748149c5a5e987e16e7f65639'
 
   # github.com/klinker-apps/messenger-desktop was verified as official when first introduced to the cask
   url "https://github.com/klinker-apps/messenger-desktop/releases/download/v#{version}/pulse-sms-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.