### PR TITLE
Update pdf-squeezer from 3.10.2 to 3.10.3

### DIFF
--- a/Casks/pdf-squeezer.rb
+++ b/Casks/pdf-squeezer.rb
@@ -1,6 +1,6 @@
 cask 'pdf-squeezer' do
-  version '3.10.2'
-  sha256 '8366ba407b64475015da142f1380706ba6ad50dba64d4ef72e72e885e91342b6'
+  version '3.10.3'
+  sha256 '1bc08bab64ea3d9de61d3048f7007d3aba082fc80384463e409b0047d2371f2a'
 
   url 'https://witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
   appcast 'https://witt-software.com/downloads/pdfsqueezer/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.