### PR TITLE
Update omnifocus from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -16,8 +16,8 @@ cask 'omnifocus' do
     sha256 '8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0'
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
   else
-    version '3.3.1'
-    sha256 '64170d1f287fa0d594b06ba61904012fc8e0687f9f55e61d2e63587ef23e27d3'
+    version '3.3.2'
+    sha256 'a6ac601e6291dcdc3099aa1613fd7aec56fa41438833293a7d4fa6b943c50d7a'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniFocus-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.