### PR TITLE
Update cncjs from 1.9.19 to 1.9.20

### DIFF
--- a/Casks/cncjs.rb
+++ b/Casks/cncjs.rb
@@ -1,6 +1,6 @@
 cask 'cncjs' do
-  version '1.9.19'
-  sha256 '4a6f4a5c688a2440b4bb86b1c75e112a6e2d3c9c01353e47bd6b3fa015c3e8ff'
+  version '1.9.20'
+  sha256 'f66d17573d4f99587dca48c12d24f35b79047c0e9a5fa0b3762f55ffe1dc9160'
 
   # github.com/cncjs/cncjs was verified as official when first introduced to the cask
   url "https://github.com/cncjs/cncjs/releases/download/v#{version}/cncjs-app-#{version}-mac-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.