### PR TITLE
Update prey from 1.8.2 to 1.8.3

### DIFF
--- a/Casks/prey.rb
+++ b/Casks/prey.rb
@@ -1,6 +1,6 @@
 cask 'prey' do
-  version '1.8.2'
-  sha256 'd2abe790da0df675901f6e438484b36431a0992bee7a7607bb5f3f54e3aa13f8'
+  version '1.8.3'
+  sha256 '112c1b38d5415fc86076783885c791eaa02dbce3051e8a7ba5c10bae8b980164'
 
   url "https://downloads.preyproject.com/prey-client-releases/node-client/#{version}/prey-mac-#{version}-x64.pkg"
   appcast 'https://github.com/prey/prey-node-client/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.