### PR TITLE
Update Motrix to 1.3.8

### DIFF
--- a/Casks/motrix.rb
+++ b/Casks/motrix.rb
@@ -1,6 +1,6 @@
 cask 'motrix' do
-  version '1.3.7'
-  sha256 '4eae68b843f1cec0b76aa2d0fd50447422ba573e6f29fea1f541051383b54027'
+  version '1.3.8'
+  sha256 'c92a21627f36dd7f0c86147e7fb51c47dedc0d81f78f82e2306fa739334e45dd'
 
   # github.com was verified as official when first introduced to the cask
   url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Motrix v1.3.7 found a bug that failed to save preferences, so a new version was released.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
