### PR TITLE
Update raw-photo-processor from 1876Beta to 4.8.0,1703

### DIFF
--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -2,7 +2,7 @@ cask 'raw-photo-processor' do
   version '4.8.0,1703'
   sha256 '578b2ad21ba0a6a1704a6b80083be5096aba18a50ea394711cf9c12f8b46a538'
 
-  url 'http://www.raw-photo-processor.com/RPP/RPP64_Upd.zip'
+  url 'https://www.raw-photo-processor.com/RPP/RPP64_Upd.zip'
   appcast 'https://www.raw-photo-processor.com/rpp_updates_64.xml'
   name 'Raw Photo Processor'
   homepage 'https://www.raw-photo-processor.com/RPP/Overview.html'

--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -1,8 +1,8 @@
 cask 'raw-photo-processor' do
-  version '1876Beta'
-  sha256 '458d9912db08ba1d874bed49242a51e2d01f32220ecc07cc7449fd5352e8bf3d'
+  version '4.8.0,1703'
+  sha256 '578b2ad21ba0a6a1704a6b80083be5096aba18a50ea394711cf9c12f8b46a538'
 
-  url "https://www.raw-photo-processor.com/RPP/RPP64_#{version}.zip"
+  url 'http://www.raw-photo-processor.com/RPP/RPP64_Upd.zip'
   appcast 'https://www.raw-photo-processor.com/rpp_updates_64.xml'
   name 'Raw Photo Processor'
   homepage 'https://www.raw-photo-processor.com/RPP/Overview.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.