### PR TITLE
Update blue-jeans from 2.12.0.418 to 2.12.0.423

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.12.0.418'
-  sha256 'ace42c28c2e91e5753fa5c9f1dcf04e331ce44831e22bb4948a17458cc1d2b05'
+  version '2.12.0.423'
+  sha256 'b553140bbd8b04df915b8b2cef0d12c152943889e3f8221b4024ba3bf4bfc84d'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   appcast 'https://www.bluejeans.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.