### PR TITLE
Revert "Update touchdesigner from 099.2018.28070 to 099.2019.13330"

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2019.13330'
-  sha256 '12cf7858b4e6094e5c9ce3c272facec5e1b65bac1e2caf44278095be5b374aa0'
+  version '099.2018.28070'
+  sha256 '88366226083c9041c123ddf4b53d4d42d3bc0bfa19b15169c55c95f13e9f7607'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#62434
this is an experimental release - see: https://www.derivative.ca/099/Downloads/experimental.asp
the latest stable release is posted here: https://www.derivative.ca/099/Downloads/ 