### PR TITLE
Update qgroundcontrol from 3.5.1 to 3.5.2

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,6 +1,6 @@
 cask 'qgroundcontrol' do
-  version '3.5.1'
-  sha256 'c749c16e2813f150fc95cc612cba3b06c73eb7d551bad5600e476f6408f6937f'
+  version '3.5.2'
+  sha256 '40c1a16f20c27e28d181dde3bfb58dfb021cfc4a2c0406d04560895501920982'
 
   # github.com/mavlink/qgroundcontrol was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.