### PR TITLE
Update tagspaces from 3.1.1 to 3.1.4

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask 'tagspaces' do
-  version '3.1.1'
-  sha256 'e4dd3622fa3b860594086dfb3743e4d3f93ce8e3196cea2ed5d39bc46ad8a0e5'
+  version '3.1.4'
+  sha256 '563cdddaf9e48f3cafa60a245cb3ef332f15f9d90d1f58de0dbb9cba0d8fd73d'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.