### PR TITLE
Update vimr from 0.27.0-321 to 0.27.1-323

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,9 +1,9 @@
 cask 'vimr' do
-  version '0.27.0-321'
-  sha256 'a9bfe8d67e4888bdb1637ca234760fece5283e0c1ca1c22f28fe545b02555e66'
+  version '0.27.1-322'
+  sha256 '933f1f2bcb486bada4fd8b162a985d421faa104b438d75b1a492e9febe1a8f15'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
-  url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/v#{version}/Users.hat.Downloads.VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom'
   name 'VimR'
   homepage 'http://vimr.org/'

--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,6 +1,6 @@
 cask 'vimr' do
-  version '0.27.1-322'
-  sha256 '933f1f2bcb486bada4fd8b162a985d421faa104b438d75b1a492e9febe1a8f15'
+  version '0.27.2-323'
+  sha256 '1134d3d2cbf843b0ab6bc8ec6980b30389c2a85a0c2c6dddd08cc14131e544fa'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/Users.hat.Downloads.VimR-v#{version}.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
I believe the developer accidentally changed this release's file name. It will probably revert back to the previous naming convention in the next release.