### PR TITLE
Update bettertouchtool from 2.764 to 2.800

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.764'
-    sha256 '40ce276a1ee64fe80bea8c843bbff177507694467fc0b7a1945b48006a983824'
+    version '2.800'
+    sha256 '8a487b6594077c00fcf1cc2c78bf6ad72a8e7ce07d4927fe218a6f058396d846'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.