### PR TITLE
Update kvirc from 4.2.0 to 5.0.0

### DIFF
--- a/Casks/kvirc.rb
+++ b/Casks/kvirc.rb
@@ -1,10 +1,11 @@
 cask 'kvirc' do
-  version '4.2.0'
-  sha256 'bb450b5abc2012cfc6c3f2cce3c8b13239acad4553cdd73d48f8d47dd8cf61c2'
+  version '5.0.0'
+  sha256 'd0793ab8a14de5388bc36f99945191120ec3349ab3f2c24f76f4dd11ab9b4874'
 
-  url "https://ftp.kvirc.de/pub/kvirc/#{version}/binary/osx/KVIrc-#{version}-Equilibrium.dmg"
+  url "ftp://ftp.kvirc.net/pub/kvirc/#{version}/binary/macosx/KVIrc-#{version}.dmg"
+  appcast 'https://github.com/kvirc/KVIrc/releases.atom'
   name 'KVIrc'
-  homepage 'https://www.kvirc.de/'
+  homepage 'https://www.kvirc.net/'
 
   app 'KVIrc.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.