### PR TITLE
Update audirvana from 3.5.5 to 3.5.6

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.5'
-  sha256 '33e42486b8bcd5746dcada3e20a48c272006719bf4a0a85b4d021426e057e6d1'
+  version '3.5.6'
+  sha256 'a63f5d9137d98f7592c1ca5c36edcfbefba631dea0dc38668bbada17476269df'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
