### PR TITLE
Update aerial from 1.4.6 to 1.4.8

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.4.6'
-  sha256 '806d56846d65b5ea26bfc3d1ef98f5e66b9fcde7672e09fc22e04121cab3bb24'
+  version '1.4.8'
+  sha256 '8fc34709a49211a85264f73546bf8ec29dc1c1b4efd06e20af0d04eed2988f77'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.