### PR TITLE
Update pock from 0.4.5 to 0.4.6

### DIFF
--- a/Casks/pock.rb
+++ b/Casks/pock.rb
@@ -1,6 +1,6 @@
 cask 'pock' do
-  version '0.4.5'
-  sha256 '324e273727ae373d48912b820449e679db0ce9cbc68cb0eb3c9e705daed99b67'
+  version '0.4.6'
+  sha256 '1f300493668c6b8948d68e92a44d25658721cc8a9a581ccbc75b5f78228f35a3'
 
   url "https://pock.pigigaldi.com/download.php?file=pock_#{version.dots_to_underscores}_eket.zip"
   appcast 'https://github.com/pigigaldi/Pock/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.