### PR TITLE
Upgrade manuskript to 0.9.0

### DIFF
--- a/Casks/manuskript.rb
+++ b/Casks/manuskript.rb
@@ -1,6 +1,6 @@
 cask 'manuskript' do
-  version '0.8.0'
-  sha256 'cd48f796945188c89e34b6e789bfcad7753a55ccd99a64fc5f0c92aaaebba0a9'
+  version '0.9.0'
+  sha256 'aef7bfa96524d2905a983722bb80ad8f1e057b8cf4c3a0aac03bdd22894c7ef8'
 
   # github.com/olivierkes/manuskript was verified as official when first introduced to the cask
   url "https://github.com/olivierkes/manuskript/releases/download/#{version.major_minor_patch}/manuskript-#{version}-osx.zip"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Was not able to run brew cask style since that seems to be broken on my install. No changes affecting style are in the commit, though.

