### PR TITLE
Update aerial from 1.4.8 to 1.4.9

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.4.8'
-  sha256 '8fc34709a49211a85264f73546bf8ec29dc1c1b4efd06e20af0d04eed2988f77'
+  version '1.4.9'
+  sha256 '407445e740d397960d27f51fcf14dfc4085e87e2073388e8aec5d27398d22562'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.