### PR TITLE
Update vimr from 0.27.2-323 to 0.27.3-325

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,9 +1,9 @@
 cask 'vimr' do
-  version '0.27.2-323'
-  sha256 '1134d3d2cbf843b0ab6bc8ec6980b30389c2a85a0c2c6dddd08cc14131e544fa'
+  version '0.27.3-325'
+  sha256 '007073570040e59be66d44f73ca15a6e6ae1a5d100d1705a1ea8c467c3ad967c'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
-  url "https://github.com/qvacua/vimr/releases/download/v#{version}/Users.hat.Downloads.VimR-v#{version}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom'
   name 'VimR'
   homepage 'http://vimr.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.