### PR TITLE
Update wechatwork from 2.8.2.2028 to 2.8.2.2030

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.2.2028'
-  sha256 '46040636932d4adac9b9064e858722baf7791f20ab01c0310181939af56aa03b'
+  version '2.8.2.2030'
+  sha256 'f22719af6efe08cc1ac6bb09c6d910bf81affb0af2a67a7ad6d1a33400c495f2'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.