### PR TITLE
Update protopie from 3.10.1 to 3.11.0

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '3.10.1'
-  sha256 'bb2130d308f4561cf2fc9f8fc7f9d83960d1af403db408205f5940247331176d'
+  version '3.11.0'
+  sha256 'b599a8c7949ab780fb854307e4bd555627b0572682de34dfaa1847ce0ee94f20'
 
   url "http://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.