### PR TITLE
Update dcp-o-matic-batch-converter from 2.12.20 to 2.14.0

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.12.20'
-  sha256 'be0343519b17523334b847bfe8ea68982f87d3bc8036ae57c0602dad0a00f36b'
+  version '2.14.0'
+  sha256 'f0fc931f453c4be014fbb944c7629b032bf37a07e4256fbe75b9f46ff79cc7cd'
 
   url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.