### PR TITLE
Update qxmledit from 0.9.12 to 0.9.13

### DIFF
--- a/Casks/qxmledit.rb
+++ b/Casks/qxmledit.rb
@@ -1,6 +1,6 @@
 cask 'qxmledit' do
-  version '0.9.12'
-  sha256 'fd61bcb8f2b5569bcde54aa528cc39da93e53b49b9bd2f127de6f5ab4ec44c6f'
+  version '0.9.13'
+  sha256 '93001a20000f8fc8ce354eac7ccc2cb3270b94eb5f24383a30157111d4456200'
 
   # downloads.sourceforge.net/qxmledit was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qxmledit/QXmlEdit-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.