### PR TITLE
Update datagrip from 2019.1.1,191.7141.8 to 2019.1.2,191.7141.30

### DIFF
--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -1,6 +1,6 @@
 cask 'datagrip' do
-  version '2019.1.1,191.7141.8'
-  sha256 'c6fb1a314019eb3203f5868379a88d9cb1b5ebab9bf3d063ec64ff9e08888080'
+  version '2019.1.2,191.7141.30'
+  sha256 '217b6d81f898387e762ff353bd4d54f471b018a280640126ec5ceb3424f0fb8d'
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version.before_comma}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.