### PR TITLE
1password-cli.rb: update the binary sha256sum to match reality

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask '1password-cli' do
   version '0.5.5'
-  sha256 'e4ea329debcf991434d90728fa3cba531bce5449a08883d3530dfeb796fc3a3b'
+  sha256 '5e47ee0f1801d178818056eae9752d332ee69fbd0d96d49b3087a098b49a5db0'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"


### PR DESCRIPTION
This is just correcting a SHA256 checksum which appears to have shifted.

After making all changes to the cask:

- [ X ] `brew cask audit --download {{cask_file}}` is error-free.
- [ X ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ X ] The commit message includes the cask’s name and version.
- [ X ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).