### PR TITLE
Update sync-my-l2p from 2.4.0 to 2.4.1

### DIFF
--- a/Casks/sync-my-l2p.rb
+++ b/Casks/sync-my-l2p.rb
@@ -1,6 +1,6 @@
 cask 'sync-my-l2p' do
-  version '2.4.0'
-  sha256 '175459183db212c63b168a64a399a275c7d5957abb463336f18364b3ab4744ee'
+  version '2.4.1'
+  sha256 '481af4bd5be7bb8940fe3c9bd435f5b509acefa45cba347892893664a702265b'
 
   # github.com/RobertKrajewski/Sync-my-L2P was verified as official when first introduced to the cask
   url "https://github.com/RobertKrajewski/Sync-my-L2P/releases/download/v#{version}/SyncMyL2P-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.