### PR TITLE
Update terminus from 1.0.75 to 1.0.77

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.75'
-  sha256 '2607114aa2d31ea5601e6a64d37dfd20dd800aca50a6c1b7f10f023be6705a3f'
+  version '1.0.77'
+  sha256 '430ac310ca01201171fda0167a72c83417e13d4faa05614e9b977abc7273a10b'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.