### PR TITLE
Update edex-ui from 2.1.0 to 2.2.1

### DIFF
--- a/Casks/edex-ui.rb
+++ b/Casks/edex-ui.rb
@@ -1,6 +1,6 @@
 cask 'edex-ui' do
-  version '2.1.0'
-  sha256 '41b737b90cf8fb45f083f506151cdc1ae2bfa224dc37f8ea17e1b11c8780e77a'
+  version '2.2.1'
+  sha256 '5ac85a8d3a866520a170842b3baed6673b930101c5acf62f2a173aaa741f4319'
 
   url "https://github.com/GitSquared/edex-ui/releases/download/v#{version}/eDEX-UI.MacOS.Image.dmg"
   appcast 'https://github.com/GitSquared/edex-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.