### PR TITLE
Update phon from 3.0.4 to 3.0.5

### DIFF
--- a/Casks/phon.rb
+++ b/Casks/phon.rb
@@ -1,6 +1,6 @@
 cask 'phon' do
-  version '3.0.4'
-  sha256 '772924a473f26585ff39fac21f25cbf99c5fa117950be54d55796102d9fff4ba'
+  version '3.0.5'
+  sha256 '8c1464be96df1423d8fd2f50da2249776c9cdb0ef5937755d8774b3480e8533d'
 
   # github.com/phon-ca/phon was verified as official when first introduced to the cask
   url "https://github.com/phon-ca/phon/releases/download/#{version}/Phon_macos_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.