### PR TITLE
Update camtasia from 2018.0.8 to 2019.0.0

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,6 +1,6 @@
 cask 'camtasia' do
-  version '2018.0.8'
-  sha256 '774c82d0c13fddb7d53267396154ddfcbd881dc5602fe23daee34cc42b04e309'
+  version '2019.0.0'
+  sha256 '062d5f0c75a6627ea8b284d972dcb1887ca365707ed7a7af0e028a9a7bd57b94'
 
   url 'https://download.techsmith.com/camtasiamac/releases/Camtasia.dmg'
   appcast 'https://support.techsmith.com/hc/en-us/articles/115006624748-Camtasia-Mac-Version-History'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.