### PR TITLE
xquartz.rb: remove postflight

### DIFF
--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -12,16 +12,6 @@ cask 'xquartz' do
 
   pkg 'XQuartz.pkg'
 
-  postflight do
-    Pathname.new(File.expand_path('~')).join('Library', 'Logs').mkpath
-
-    # Set default path to X11 to avoid the need of manual setup
-    system_command '/usr/bin/defaults', args: ['write', 'com.apple.applescript', 'ApplicationMap', '-dict-add', 'X11', 'file://localhost/Applications/Utilities/XQuartz.app/']
-
-    # Load & start XServer to avoid the need of relogin
-    system_command '/bin/launchctl', args: ['load', '/Library/LaunchAgents/org.macosforge.xquartz.startx.plist']
-  end
-
   uninstall quit:      'org.macosforge.xquartz.X11',
             launchctl: [
                          'org.macosforge.xquartz.startx',


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/62674.

I can reproduce the `Could not write domain com.apple.applescript` error. Until someone has a workaround, the only solution is to remove it and have users setup what they need manually, if it’s still required.