### PR TITLE
Update thebrain from 10.0.44.0 to 10.0.48.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,8 +1,9 @@
 cask 'thebrain' do
-  version '10.0.44.0'
-  sha256 'db38aedd419baabb33bb94a76c4ab0a6ab2bd20f8161f12ef8d402d4b5dfd134'
+  version '10.0.48.0'
+  sha256 '8fc3f33fa0ee35655a5bffe3e68272b68cae81bcb2b4cc67fa813b413a058903'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'
   name 'TheBrain'
   homepage 'https://www.thebrain.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.