### PR TITLE
Update cardhop from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/cardhop.rb
+++ b/Casks/cardhop.rb
@@ -1,6 +1,6 @@
 cask 'cardhop' do
-  version '1.2.2'
-  sha256 'f88551fe66c5ec5dc0eb2a86ef710defa1f3ecd80165cddf8ea8bd478871e210'
+  version '1.2.3'
+  sha256 '567326282b7881d0c4964e5f5824d3ce1499291213c80eed8edcb165a420729b'
 
   url "http://cdn.flexibits.com/Cardhop_#{version}.zip"
   appcast 'https://flexibits.com/cardhop/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.