### PR TITLE
Update data-rescue from 5.0.8 to 5.0.9

### DIFF
--- a/Casks/data-rescue.rb
+++ b/Casks/data-rescue.rb
@@ -1,6 +1,6 @@
 cask 'data-rescue' do
-  version '5.0.8'
-  sha256 '22b298f0ba27ddecf03da11064f716dc8529a0fc20eb649a6dd14b4160e58a98'
+  version '5.0.9'
+  sha256 'eb99d6e6a2b050b1bfe8c40b9c5e14ccc6d72293db742974124d5d51f07ccf01'
 
   url "https://downloads.prosofteng.com/dr/Data_Rescue_#{version}.dmg"
   appcast "https://www.prosofteng.com/resources/dr#{version.major}/dr#{version.major}_updates_mac.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.