### PR TITLE
Update qtum-qt from 0.17.3 to 0.17.4

### DIFF
--- a/Casks/qtum-qt.rb
+++ b/Casks/qtum-qt.rb
@@ -1,6 +1,6 @@
 cask 'qtum-qt' do
-  version '0.17.3'
-  sha256 'cbb8fc885ad327b13e71e4a4357884d1723e0a212557cdd85798d5f74334e01c'
+  version '0.17.4'
+  sha256 '692ff5e3bc211cbdf3a5579199ea798837bd2cf3152e0ea65b3a5ed7ff1f6482'
 
   # github.com/qtumproject/qtum was verified as official when first introduced to the cask
   url "https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v#{version}/qtum-#{version}-osx-unsigned.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.