### PR TITLE
Update reactotron from 2.13.0 to 2.13.2

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,6 +1,6 @@
 cask 'reactotron' do
-  version '2.13.0'
-  sha256 '32ef6f5b33d953a5551d33ad11bcfb75c2cd0e571af7fe48e14048ca6da4ad1e'
+  version '2.13.2'
+  sha256 '22ec592596feb2db84b97d7f7b24c83ea11e05a970a9801cfe90e26632b9dc17'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron-#{version}-mac.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.