### PR TITLE
Update clamxav from 3.0.9_7713 to 3.0.10_7854

### DIFF
--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -1,6 +1,6 @@
 cask 'clamxav' do
-  version '3.0.9_7713'
-  sha256 'aa4159b6e5e6388b8e708a79670fcf5a039467ced99600725d8e352128ef96af'
+  version '3.0.10_7854'
+  sha256 'dbac25f51c23b7ccd672eb10bf7fe75c61c51c5aa6109c60e8c30d19273827df'
 
   url "https://cdn.clamxav.com/ClamXAVdownloads/ClamXAV_#{version}.zip"
   appcast "https://www.clamxav.com/sparkle/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.