### PR TITLE
Update mongodb-compass-community from 1.16.3 to 1.17.0

### DIFF
--- a/Casks/mongodb-compass-community.rb
+++ b/Casks/mongodb-compass-community.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-community' do
-  version '1.16.3'
-  sha256 '5c87a9b8a042decea07b625564cc12f6b056ebb4288e249ba0bfd7c6c4f1b953'
+  version '1.17.0'
+  sha256 'a36eed167ac3867fa395d454b2310507b5155a513fb809e99bcf2d5e7a5c67a1'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-community-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass Community'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.