### PR TITLE
Update seadrive from 1.0.3 to 1.0.4

### DIFF
--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -1,6 +1,6 @@
 cask 'seadrive' do
-  version '1.0.3'
-  sha256 '37f31127e15bea91b2f814bbca223da4c892f38e6e0418853baadb9cfdf5c667'
+  version '1.0.4'
+  sha256 '168db90129a3c344f88bc174e45c04b774e8f0342d6276cd1de878718f685c8a'
 
   # download.seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seadrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.