### PR TITLE
Update universal-media-server from 8.0.1 to 8.1.0

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,6 +1,6 @@
 cask 'universal-media-server' do
-  version '8.0.1'
-  sha256 '2ab6bdebe4686bc29f06b3f64937eaffd60a8e833d44ad2dd1a859af8754a4ef'
+  version '8.1.0'
+  sha256 '42c22f609a8e722a80eba56f9a4e68ae409896806bc15a188323d0bcd51a920c'
 
   # sourceforge.net/unimediaserver was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/unimediaserver/Official%20Releases/OS%20X/UMS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.