### PR TITLE
Update psi-plus from 1.4.670-macOS10.12 to 1.4.672-macOS10.12

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.670-macOS10.12'
-  sha256 'b5d279e99689ea4eac8f37c82bef6e15598482e37a5381d458435d856fe7c1b1'
+  version '1.4.672-macOS10.12'
+  sha256 'ad8bc8af743eaa42ae522237f2176d70236d75cdcbbee16bc302e49a353bdf25'
 
   # downloads.sourceforge.net/psiplus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.