### PR TITLE
Update nvidia-geforce-now from 2.0.6.86 to 2.0.6.87

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,5 +1,5 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.6.86'
+  version '2.0.6.87'
   sha256 '2aa9c198646f2c32c8d12eb4bc12970613349120895e3673d3d62a7982140474'
 
   url 'https://ota-downloads.nvidia.com/ota/GeForceNOW-release_E943AA.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.