### PR TITLE
Update joplin from 1.0.143 to 1.0.145

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
   version '1.0.145'
-  sha256 'b20233da76dc744b20b826d8a191e471bed3478fea4c5397384bc9f691689d1e'
+  sha256 'd8d37b53c781322966e36a1560f9124af632f3004102831eb9679f9f501a1878'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"

--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.143'
-  sha256 '24ab42af55eb322fa3201b98b43a10782240657fa0871aee4960e73b918fb905'
+  version '1.0.145'
+  sha256 'b20233da76dc744b20b826d8a191e471bed3478fea4c5397384bc9f691689d1e'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.