### PR TITLE
Update keka from 1.1.14 to 1.1.15

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,6 +1,6 @@
 cask 'keka' do
-  version '1.1.14'
-  sha256 'f9d5a2c8692f88f812753f07c05997a942e6f78884927675968ca76a9c8b2a57'
+  version '1.1.15'
+  sha256 'b993b73350d7dcb9b3d392717d53e4addce7d66b3fedf98bfbb0530e42d1d63e'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.