### PR TITLE
Update goodsync from 10.9.26.82,649 to 10.9.32.2

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -2,7 +2,7 @@ cask 'goodsync' do
   version '10.9.32.2'
   sha256 '6312c1b4c37a377f119d9d9971336720e15ecdeba1e01d832f365d01efc6d332'
 
-  url 'https://www.goodsync.com/download/goodsync-v10-mac.dmg'
+  url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast 'https://www.goodsync.com/news-mac'
   name 'GoodSync'
   homepage 'https://www.goodsync.com/'

--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,10 +1,9 @@
 cask 'goodsync' do
-  version '10.9.26.82,649'
-  sha256 '6ffcb05e29bcea3ad43cd8b686052bb6e5bad08d49f1a544192eea4dfc9e1937'
+  version '10.9.32.2'
+  sha256 '6312c1b4c37a377f119d9d9971336720e15ecdeba1e01d832f365d01efc6d332'
 
-  # rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef/app_versions/#{version.after_comma}?format=zip&avtoken=6b1e930b304f74f53ebe6e776a505fa3bfbe6e6d&download_origin=hockeyapp"
-  appcast 'https://rink.hockeyapp.net/api/2/apps/8b491acdaa8942108b5d8b019be7fcef'
+  url 'https://www.goodsync.com/download/goodsync-v10-mac.dmg'
+  appcast 'https://www.goodsync.com/news-mac'
   name 'GoodSync'
   homepage 'https://www.goodsync.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.