### PR TITLE
Update fedora-media-writer from 4.1.3 to 4.1.4

### DIFF
--- a/Casks/fedora-media-writer.rb
+++ b/Casks/fedora-media-writer.rb
@@ -1,6 +1,6 @@
 cask 'fedora-media-writer' do
-  version '4.1.3'
-  sha256 'b3d437defb0cfbad0be50127f692b3c6592aada6fe4f5e4447514fe703e5428f'
+  version '4.1.4'
+  sha256 '62c07e06b52a844da07cc7b19dee8a377b35f2990e58f9e872736866fe50faad'
 
   # github.com/MartinBriza/MediaWriter was verified as official when first introduced to the cask
   url "https://github.com/MartinBriza/MediaWriter/releases/download/#{version}/FedoraMediaWriter-osx-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.