### PR TITLE
Update electron from 5.0.0 to 5.0.1

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '5.0.0'
-  sha256 'f5aaf5115e2be4f4a65b6bce117157baa03ce66630c0dce535a85fe70866421f'
+  version '5.0.1'
+  sha256 '00694c5541385d6709d9652930011cb5f462c222642c7aa64dd266905abfda12'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.