### PR TITLE
Update chemdoodle from 9.0.3 to 9.1.0

### DIFF
--- a/Casks/chemdoodle.rb
+++ b/Casks/chemdoodle.rb
@@ -1,8 +1,9 @@
 cask 'chemdoodle' do
-  version '9.0.3'
-  sha256 '854b9346397ce6b0f133c0a8fb2204f3914f31d396fd2bae614931fec5aa2f10'
+  version '9.1.0'
+  sha256 'c254f172ac197e0183fcacb6c60995f9f8545167b9684fb08559787d6abe5893'
 
   url "https://www.chemdoodle.com/downloads/ChemDoodle-osx-#{version}.dmg"
+  appcast 'https://www.chemdoodle.com/download/osx-installation-instructions/'
   name 'ChemDoodle'
   homepage 'https://www.chemdoodle.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.