### PR TITLE
Update unshaky from 0.5.2 to 0.5.3

### DIFF
--- a/Casks/unshaky.rb
+++ b/Casks/unshaky.rb
@@ -1,6 +1,6 @@
 cask 'unshaky' do
-  version '0.5.2'
-  sha256 'e089d3b7877f21ef96da7cdcbfe8b26b7273ba3e0b569226dc58432231916885'
+  version '0.5.3'
+  sha256 '6217c1574fa60d3eb7cd839cc9cb88529d3f7bb4688c362a7776929321f850c0'
 
   url "https://github.com/aahung/Unshaky/releases/download/v#{version}/Unshaky_v#{version}.zip"
   appcast 'https://github.com/aahung/Unshaky/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.