### PR TITLE
Update postbird from 0.8.1 to 0.8.2

### DIFF
--- a/Casks/postbird.rb
+++ b/Casks/postbird.rb
@@ -1,6 +1,6 @@
 cask 'postbird' do
-  version '0.8.1'
-  sha256 'd7077ca9fe61bf5f4c204ebeec91fbe65e54bb23c8df3fa0d134be01c23c7028'
+  version '0.8.2'
+  sha256 'ef8d979c256e9d5308c6beee0805adb63ef1d7862da05b2f96c7489c6bec8848'
 
   url "https://github.com/Paxa/postbird/releases/download/#{version}/Postbird-#{version}.dmg"
   appcast 'https://github.com/Paxa/postbird/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.