### PR TITLE
Update dynamic-dark-mode from 1.1.4 to 1.1.5

### DIFF
--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -1,6 +1,6 @@
 cask 'dynamic-dark-mode' do
-  version '1.1.4'
-  sha256 '2fb033042bfbdcb39590f74ca6479252e1fdcc1529b05e03e8733c87a7abab6f'
+  version '1.1.5'
+  sha256 'f0bb7542fb46eed2fd69f5e64f72bd15628d9e1b7be063ea41124fbc88aa1222'
 
   url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.zip"
   appcast 'https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.