### PR TITLE
Update mycrypto from 1.6.4 to 1.6.5

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.6.4'
-  sha256 '008444591ba9b58a2b190fb25eb41b1c514f2c216b9a83f970140a2280a44c7a'
+  version '1.6.5'
+  sha256 'a6e796a43ce11d233f875aee4ab697642808c5067526d8245a2a40a5f039b580'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.