### PR TITLE
Update pliim from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/pliim.rb
+++ b/Casks/pliim.rb
@@ -1,6 +1,6 @@
 cask 'pliim' do
-  version '1.6.0'
-  sha256 '28db19622c1cd2dd1deaa15e02ce3f034123cd4a2ef41bfedaa6bb6fb6eb92e5'
+  version '1.7.0'
+  sha256 'cd44a3e8d0d58b431df288c3ce13a8032f76b270077ac488cb9db5d74e7d17a5'
 
   # github.com/zehfernandes/pliim was verified as official when first introduced to the cask
   url "https://github.com/zehfernandes/pliim/releases/download/v#{version}/Pliim.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.