### PR TITLE
Update superproductivity from 2.6.0 to 2.6.1

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.6.0'
-  sha256 '6410c87672603de253d70925749957555372d53585b59b808d45f71ea809330c'
+  version '2.6.1'
+  sha256 '087e07b9a4ad0b91f183b67aa892aa75abd564583b90392bfb19ac5eb8247cab'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.