### PR TITLE
Update electrumsv from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/electrumsv.rb
+++ b/Casks/electrumsv.rb
@@ -1,8 +1,9 @@
 cask 'electrumsv' do
-  version '1.2.0'
-  sha256 '37d2612c2dc8c1b8a0c61051f138bdcaaea75ef38c25187041f78cc50e3a378d'
+  version '1.2.1'
+  sha256 'b139694b7eaa67e9719c07c405f6a12a02dae000bef81094c41a99ed9d12e13b'
 
-  url "https://electrumsv.io/download/#{version}/ElectrumSV-#{version}.dmg"
+  # s3.us-east-2.amazonaws.com/electrumsv-downloads was verified as official when first introduced to the cask
+  url "https://s3.us-east-2.amazonaws.com/electrumsv-downloads/releases/#{version}/ElectrumSV-#{version}.dmg"
   appcast 'https://github.com/electrumsv/electrumsv/releases.atom'
   name 'ElectrumSV'
   homepage 'https://electrumsv.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.