### PR TITLE
Update bot-framework-emulator from 4.3.3 to 4.4.0

### DIFF
--- a/Casks/bot-framework-emulator.rb
+++ b/Casks/bot-framework-emulator.rb
@@ -1,6 +1,6 @@
 cask 'bot-framework-emulator' do
-  version '4.3.3'
-  sha256 'b286b38f06b85d07c3315fbb19afd16b69d2da3a2d2ca787c60334ea38d480de'
+  version '4.4.0'
+  sha256 '066247146eec2197ae00c4bc93d5790985cee66d6181cdb20178d92e259f3085'
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.