### PR TITLE
Update katalon-studio from 6.1.2 to 6.1.3

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '6.1.2'
-  sha256 'df651b9e044c7ecd6d6f4dc68a41869b126f1ee3b80412a096e4805bf205415d'
+  version '6.1.3'
+  sha256 '1c7545424645ef88f8efc7a631045d68f45499fb62fefe667e483372ea8d245c'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.