### PR TITLE
Update bitwig-studio from 2.5 to 2.5.1

### DIFF
--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -1,8 +1,9 @@
 cask 'bitwig-studio' do
-  version '2.5'
-  sha256 'b23834a869db96f2b82cc950c42e0cdfbed490f00cd19cf1d2d3d5e4864ae48b'
+  version '2.5.1'
+  sha256 '675e04be1a7ca4a3bd99ff500ae4fc6227bdd29295ffa21eeabe5e0bc70693bf'
 
   url "https://downloads.bitwig.com/stable/#{version}/Bitwig%20Studio%20#{version}.dmg"
+  appcast 'https://www.bitwig.com/en/previous_releases'
   name 'Bitwig Studio'
   homepage 'https://www.bitwig.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.