### PR TITLE
Update scrutiny from 8.3.9 to 8.3.11

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.3.9'
-  sha256 'b4eeb3d8b8db2924de84fad5d672e3b53904a0fed13b4215dc7eba3fbce12efa'
+  version '8.3.11'
+  sha256 '7ab71e2b1901ac5a192adb3b2789ff28dc299957d9c490b3fe1d15ad5d9afedb'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.