### PR TITLE
Update fastrawviewer from 1.5.0.1472 to 1.5.1.1490

### DIFF
--- a/Casks/fastrawviewer.rb
+++ b/Casks/fastrawviewer.rb
@@ -1,6 +1,6 @@
 cask 'fastrawviewer' do
-  version '1.5.0.1472'
-  sha256 'b08300c6c8508539c0bc58792fb60630d5a90b28d7a2331b69406f3a36f03e93'
+  version '1.5.1.1490'
+  sha256 'b85f9cf1907084e0aab16dfca19d21c81d3a19974549d6554159a518eb745b0b'
 
   url "https://updates.fastrawviewer.com/data/FastRawViewer-#{version}.dmg"
   name 'FastRawViewer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.