### PR TITLE
Update navicat-premium from 12.1.18 to 12.1.20

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '12.1.18'
-  sha256 '045c34b8c51fb34cf6df87a30efb0eb5f2880d04bf880022518f0076058e8d7f'
+  version '12.1.20'
+  sha256 'a6e653cd3ddd490f74cec46a56fe6f39d8b53ed98e2481ad56359899228338f5'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20Premium&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.