### PR TITLE
Update Forticlient v6.0.5 sha256 checksum

### DIFF
--- a/Casks/forticlient.rb
+++ b/Casks/forticlient.rb
@@ -1,6 +1,6 @@
 cask 'forticlient' do
   version '6.0'
-  sha256 'ef54a8fcc3588c6a7a87b6a94c976d58bf6fabbf4a48626be8d52ab72b0d01f1'
+  sha256 '473ee0af69d03a859f0b55d4e30f5f5368e8c3d42cbf30beb02569e9e591d4b7'
 
   # filestore.fortinet.com/forticlient was verified as official when first introduced to the cask
   url "https://filestore.fortinet.com/forticlient/downloads/FortiClientOnlineInstaller_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

It seems that the checksum of the installer has been changed due to a new patch version released... (the dmg download link remains at `v6.0` but internally the installer shows `v.6.0.5`)

It also seems that what really happens on #59725 was a prior patch version update (something between `v.6.0.2` and `v.6.0.4`) 

![Screen Shot 2019-05-04 at 12 05 34 PM](https://user-images.githubusercontent.com/24572406/57183078-ed633e80-6e64-11e9-9c09-084a09fe949d.png)

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256