### PR TITLE
Update gpsdump from 0.50 to 0.51

### DIFF
--- a/Casks/gpsdump.rb
+++ b/Casks/gpsdump.rb
@@ -1,6 +1,6 @@
 cask 'gpsdump' do
-  version '0.50'
-  sha256 '410a95350d28e2806be5e8c7f7697a66685ddc55045af540876f24656ccecba7'
+  version '0.51'
+  sha256 '6b39b9e49172fd439cb88d10f9bbb202f502354e4592b8968c08acab8be7955c'
 
   url "http://www.gpsdump.no/GpsDumpMac#{version.no_dots}.zip"
   appcast 'http://www.gpsdump.no/body_mac.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.