### PR TITLE
Update netron from 3.0.4 to 3.0.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.0.4'
-  sha256 'e96e2b08b67c19bcf4b19f713aa8f62a83ce7fddf78ae5da4c29a228a1348014'
+  version '3.0.5'
+  sha256 '3b564c4796a3defd8d99440b6d5a6e1dc8d7cbde3d2b6c01f571d1dfc68c1c98'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.