### PR TITLE
Update adobe-air from 32.0.0.171 to 32.0.0.125

### DIFF
--- a/Casks/adobe-air.rb
+++ b/Casks/adobe-air.rb
@@ -1,6 +1,6 @@
 cask 'adobe-air' do
-  version '32.0.0.171'
-  sha256 'ee89612c7142cf010dc748f4e3e81a21c2682823ec791b005baac56e4a0f1e72'
+  version '32.0.0.125'
+  sha256 'd6abb9c4538f9dc9ca3d7f86629437fa52f5d7ee36ae2a3903adfb42d59fd4ad'
 
   url "https://airdownload.adobe.com/air/mac/download/#{version.major_minor}/AdobeAIR.dmg"
   appcast 'https://helpx.adobe.com/au/air/kb/archived-air-sdk-version.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.