### PR TITLE
Update unity from 2019.1.0f2,292b93d75a2c to 2019.1.1f1,fef62e97e63b

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.1.0f2,292b93d75a2c'
-  sha256 '995d9c0e73f3efff9b3b86cbec52deaa0c8dda83977622740f9227e2655841b5'
+  version '2019.1.1f1,fef62e97e63b'
+  sha256 '40cf6a1e6c5b121659e8979db2bc0cf0e0c7798ce714afb4ed810e0e86f6210f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.