### PR TITLE
Update unity-android-support-for-editor from 2019.1.0f2,292b93d75a2c to 2019.1.1f1,fef62e97e63b

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.1.0f2,292b93d75a2c'
-  sha256 'efac338b756cf0796703e9607374dd744e2309d94b349beb7dcd01369a75a8d6'
+  version '2019.1.1f1,fef62e97e63b'
+  sha256 'c211ed9c9b7897f15ebb6ecaf6bbbabb5aacc0883a00c554fee471d2f78a8c96'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.