### PR TITLE
Update unity-ios-support-for-editor from 2019.1.0f2,292b93d75a2c to 2019.1.1f1,fef62e97e63b

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.1.0f2,292b93d75a2c'
-  sha256 '03ff3d39f5d02f2719b8f10979c3827d002a20f159091866a0e3683a2955f6b1'
+  version '2019.1.1f1,fef62e97e63b'
+  sha256 '412a6f419fc0b540bf192839f907d49dd77c5b8f9b4a1fce3f20ab744a4a9109'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.