### PR TITLE
Update unity-linux-support-for-editor from 2019.1.0f2,292b93d75a2c to 2019.1.1f1,fef62e97e63b

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.1.0f2,292b93d75a2c'
-  sha256 'e2ad2799e1f09913a4dcca37636c044a960fcef383884c74bd1ee12903f51b3b'
+  version '2019.1.1f1,fef62e97e63b'
+  sha256 '1b235451c059158c5f10cfe00701dbce833280480129098369f7d752cc044b9b'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.