### PR TITLE
Add supermicro-ipmiview 2.15.0

### DIFF
--- a/Casks/supermicro-ipmiview.rb
+++ b/Casks/supermicro-ipmiview.rb
@@ -1,0 +1,34 @@
+cask 'supermicro-ipmiview' do
+  version '2.15.0,190109'
+  sha256 '3314341589b22cf00792bc66ed309605d43eff708a1d09de7a4517d3852e5545'
+
+  filename = "IPMIView_#{version.before_comma}_build.#{version.after_comma}_bundleJRE_Linux_x64"
+
+  url "ftp://ftp.supermicro.com/utility/IPMIView/Linux/#{filename}.tar.gz"
+  name 'Supermicro IPMIView'
+  homepage 'https://www.supermicro.com/en/solutions/management-software/ipmi-utilities'
+
+  depends_on cask: 'java'
+
+  app_contents = "#{appdir}/Supermicro IPMIView.app/Contents"
+  app_macos = "#{app_contents}/MacOS"
+  app_resources = "#{app_contents}/Resources"
+  shimscript = "#{app_macos}/Supermicro IPMIView"
+
+  preflight do
+    # Setup app directory
+    system_command '/bin/mkdir', args: ['-p', "#{app_macos}", "#{app_resources}"]
+    system_command '/bin/cp', args: ['-r', "#{staged_path}/#{filename}/", "#{app_resources}"]
+    # Generate shimscript
+    system_command '/usr/bin/touch', args: ["#{shimscript}"]
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+      cd "${DIR}/../Resources"
+      java -jar IPMIView20.jar
+    EOS
+    system_command '/bin/chmod', args: ['a+x', "#{shimscript}"]
+  end
+
+  uninstall delete: "#{appdir}/Supermicro IPMIView.app"
+end

--- a/Casks/supermicro-ipmiview.rb
+++ b/Casks/supermicro-ipmiview.rb
@@ -17,18 +17,21 @@ cask 'supermicro-ipmiview' do
 
   preflight do
     # Setup app directory
-    system_command '/bin/mkdir', args: ['-p', "#{app_macos}", "#{app_resources}"]
-    system_command '/bin/cp', args: ['-r', "#{staged_path}/#{filename}/", "#{app_resources}"]
+    system_command '/bin/mkdir', args: ['-p', app_macos.to_s, app_resources.to_s]
+    system_command '/bin/cp', args: ['-r', "#{staged_path}/#{filename}/", app_resources.to_s]
     # Generate shimscript
-    system_command '/usr/bin/touch', args: ["#{shimscript}"]
+    system_command '/usr/bin/touch', args: [shimscript.to_s]
     IO.write shimscript, <<~EOS
       #!/bin/sh
       DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
       cd "${DIR}/../Resources"
-      java -jar IPMIView20.jar
+      /usr/bin/java -jar IPMIView20.jar
     EOS
-    system_command '/bin/chmod', args: ['a+x', "#{shimscript}"]
+    system_command '/bin/chmod', args: ['a+x', shimscript.to_s]
   end
 
   uninstall delete: "#{appdir}/Supermicro IPMIView.app"
 end
+
+html = Nokogiri::HTML(open("#{url}"))
+html = Nokogiri::HTML(open(url.to_s))

--- a/Casks/supermicro-ipmiview.rb
+++ b/Casks/supermicro-ipmiview.rb
@@ -32,6 +32,3 @@ cask 'supermicro-ipmiview' do
 
   uninstall delete: "#{appdir}/Supermicro IPMIView.app"
 end
-
-html = Nokogiri::HTML(open("#{url}"))
-html = Nokogiri::HTML(open(url.to_s))


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

The Supermicro IPMIView application can be used to gain remote access to servers using IPMI.
If this application fits better in `homebrew-cask-drivers`, let me know.

The application is a Java `jar` that I wrapped inside an `app` bundle.
This requires the creation of several directories and the generation of a shimscript.