### PR TITLE
Update syncovery from 8.30b to 8.31

### DIFF
--- a/Casks/syncovery.rb
+++ b/Casks/syncovery.rb
@@ -1,6 +1,6 @@
 cask 'syncovery' do
-  version '8.30b'
-  sha256 'e36cdc138bb24057e7d58f1ad1223759d437566d1ebea84a7956d07a30d80204'
+  version '8.31'
+  sha256 '6d80426374bf6da2f22a188005c5bc27beac1a7c7c052026441928093dd2a616'
 
   url "https://www.syncovery.com/release/SyncoveryMac#{version}.dmg"
   name 'Syncovery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.