### PR TITLE
Update extraterm from 0.42.0 to 0.42.1

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,6 +1,6 @@
 cask 'extraterm' do
-  version '0.42.0'
-  sha256 'ef4d126759465ee053d7e8830f8f8eda6b0f0f42a6a5ad417fd6db039285f909'
+  version '0.42.1'
+  sha256 '9f3daa5acca3a90334aabb532973ebaeaeb0393666f4085708d2a4ff729d452b'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.