### PR TITLE
Update dcp-o-matic from 2.14.0 to 2.14.1

### DIFF
--- a/Casks/dcp-o-matic.rb
+++ b/Casks/dcp-o-matic.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic' do
-  version '2.14.0'
-  sha256 'cc9230af1195453c51f15cd9d344f88aed261cb6274c2caf957e56161a800a30'
+  version '2.14.1'
+  sha256 '7ce6cebded02ce73ca3f600519fa5312fd0c5e2e78dfe587e9aea6b00c5b5a99'
 
   url "https://dcpomatic.com/dl.php?id=osx-main&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.