### PR TITLE
Update dcp-o-matic-encode-server from 2.14.0 to 2.14.1

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.0'
-  sha256 '6a4625d87d6954e839e58b97e2d9e0bcde3e24c7e21e092925bc8cbff10fb337'
+  version '2.14.1'
+  sha256 '7ca09c032f46b8dbf910d8552c08bd5693fb03626cfddbd95f4b56eab73c11ee'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.