### PR TITLE
Update dcp-o-matic-player from 2.14.0 to 2.14.1

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.0'
-  sha256 '10182cdecde04568a6a53c43359ac5b2f149fbec5e94d5349f6f57936af89ab0'
+  version '2.14.1'
+  sha256 '72984bc44217b07b4fe2a65a564f65dd7a1836250ef1fff3bc55c811150c5513'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.