### PR TITLE
Update subler from 1.5.14 to 1.5.15

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask 'subler' do
-  version '1.5.14'
-  sha256 'dcbb79add43b936b5323e4ec28f444e906e30ed038d0b30a8d1e6fa99b6ac8f1'
+  version '1.5.15'
+  sha256 '069e3837962fab56881f2664329ed6a5e873b9a070fd4faed66df026bb43d494'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.