### PR TITLE
Update grandperspective from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/grandperspective.rb
+++ b/Casks/grandperspective.rb
@@ -1,6 +1,6 @@
 cask 'grandperspective' do
-  version '2.2.0'
-  sha256 'debf6e069338793f8f4739b8c27e2bc9b00ff4efea365e50ad87ecf845e06532'
+  version '2.2.1'
+  sha256 'c98d11b61b80abc26fc2fcfe3cd6b61b26e947fe9e69a9f8c3b4fae6cde498a9'
 
   # downloads.sourceforge.net/grandperspectiv was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/grandperspectiv/grandperspective/#{version}/GrandPerspective-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.