### PR TITLE
Update the-mut from 4.1.0 to 4.2.1

### DIFF
--- a/Casks/the-mut.rb
+++ b/Casks/the-mut.rb
@@ -1,6 +1,6 @@
 cask 'the-mut' do
-  version '4.1.0'
-  sha256 '4fcad3b6b24b76fe322b9e3b3a210abcc843a9bf2b54ca3eab4b21abd5104223'
+  version '4.2.1'
+  sha256 'e72be15dd1923b95dd51e60cf826290f79128688e2f1762f98d46b753d1bce51'
 
   # m-lev.com/uploads was verified as official when first introduced to the cask
   url "https://m-lev.com/uploads/TheMUT_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.