### PR TITLE
Update sim-daltonism from 2.0.2 to 2.0.4

### DIFF
--- a/Casks/sim-daltonism.rb
+++ b/Casks/sim-daltonism.rb
@@ -1,8 +1,9 @@
 cask 'sim-daltonism' do
-  version '2.0.2'
-  sha256 '7271501fae76154c53ff6ae4885404f6731e27b4be2bc09e2c2a7a383d9005f1'
+  version '2.0.4'
+  sha256 'c5c930be3f4ba613f780f4877f8555e92d2bc0a30bd0b12913a04226b0eef0d0'
 
   url "https://littoral.michelf.ca/apps/sim-daltonism/sim-daltonism-#{version}.zip"
+  appcast 'https://littoral.michelf.ca/apps/sim-daltonism/'
   name 'Sim Daltonism'
   homepage 'https://michelf.ca/projects/mac/sim-daltonism/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.