### PR TITLE
Update miditrail from 1.2.3,68138 to 1.2.5,71069

### DIFF
--- a/Casks/miditrail.rb
+++ b/Casks/miditrail.rb
@@ -1,6 +1,6 @@
 cask 'miditrail' do
-  version '1.2.3,68138'
-  sha256 '6be8c1928ae71d3713d884dbaa9e18e243f1c03ae4840bb3936321baf287e6f5'
+  version '1.2.5,71069'
+  sha256 'f9a10420356bc7c49c77b410b5e75e5c70d1a031ff00f53d8dabef4d1c15e1d1'
 
   # dl.osdn.jp/miditrail was verified as official when first introduced to the cask
   url "http://dl.osdn.jp/miditrail/#{version.after_comma}/MIDITrail-Ver.#{version.before_comma}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.