### PR TITLE
Update curio from 13000.17 to 13002.3

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '13000.17'
-  sha256 '9601606dfc33d001381694a29b4f3a54709e8099c93345c99b9b05726f7b95d5'
+  version '13002.3'
+  sha256 '275e25cd3acf85183eeae1773e55794fcb2b4a803c80d2859bfb508d6ea808b8'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio13HLwLK2C84LaKptcz.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.