### PR TITLE
Update radarr from 0.2.0.1293 to 0.2.0.1344

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,6 +1,6 @@
 cask 'radarr' do
-  version '0.2.0.1293'
-  sha256 '8795a181a575b82c4a0ced7b9325495c58fe2a88740cd758c9122bb9b3fffac2'
+  version '0.2.0.1344'
+  sha256 '99fb8a44f5712ce910c87c0e0a4290980edbf5584bdfc62d24ece748a4965456'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.