### PR TITLE
Update thedesk from 18.3.1 to 18.3.2

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.3.1'
-  sha256 'e5f72aefed755b61ef3cd2965728e8d70f890090f3d01545369dc407fc9a7f49'
+  version '18.3.2'
+  sha256 'c57f0e0e2151726262683d0a581680f10f3e9c31eca41a4912b9cfd99c158c0c'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.