### PR TITLE
Update gzdoom from 4.1.0 to 4.1.1

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '4.1.0'
-  sha256 'cd5c16c0635890d58158a70a43617ecaa7b232b8395ed354f45f4dd07eba91bf'
+  version '4.1.1'
+  sha256 'e53cabe3bf0051263d15d8a8d09af735e74d7c1d32d4cf8e00acaaef1de0aa67'
 
   url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.