### PR TITLE
Update datadog-agent from 6.7.0-1 to 6.11.0-1

### DIFF
--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -1,6 +1,6 @@
 cask 'datadog-agent' do
-  version '6.7.0-1'
-  sha256 '2f9c4ddd300bedf388d2239b0db7b4dce8f373d90139416d5989e519decd6f55'
+  version '6.11.0-1'
+  sha256 'b38c9769eaaafa535fe0f5f07910316454c34a0ce85bdd4e43f79cb08051e2d8'
 
   # s3.amazonaws.com/dd-agent was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dd-agent/datadog-agent-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.