### PR TITLE
Update nucleo from 2.5.4 to 2.5.5

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,6 +1,6 @@
 cask 'nucleo' do
-  version '2.5.4'
-  sha256 'a06d37b19fd6bef6d9e32121b1651251619c9341b5f1bed58384a6813e48d0c1'
+  version '2.5.5'
+  sha256 '2cbe0e752f87a5fef86b59a180e78ec249a710fba56eea7144f5e1dd6eab9e59'
 
   # s3-us-west-2.amazonaws.com/nucleo-app-releases was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/nucleo-app-releases/mac/Nucleo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.