### PR TITLE
Update dcp-o-matic-kdm-creator from 2.14.1 to 2.14.2

### DIFF
--- a/Casks/dcp-o-matic-kdm-creator.rb
+++ b/Casks/dcp-o-matic-kdm-creator.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-kdm-creator' do
-  version '2.14.1'
-  sha256 '9a2079cfd0a191926db45abd3bd65154cf805d0d957fda0c4af686f1ca2a9f8e'
+  version '2.14.2'
+  sha256 '70b0d0e5df442f8d045c3ae1ba5ea368ce98a803b378711619429d7daae40cda'
 
   url "https://dcpomatic.com/dl.php?id=osx-kdm&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.