### PR TITLE
Update dcp-o-matic-player from 2.14.1 to 2.14.2

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.1'
-  sha256 '72984bc44217b07b4fe2a65a564f65dd7a1836250ef1fff3bc55c811150c5513'
+  version '2.14.2'
+  sha256 'eb808fd625e1022b0fa5782decce24863d2413d159412675c240736b5edbb5a3'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.