### PR TITLE
Update pro-motion-ng from 7.2.0 to 7.2.1

### DIFF
--- a/Casks/pro-motion-ng.rb
+++ b/Casks/pro-motion-ng.rb
@@ -1,6 +1,6 @@
 cask 'pro-motion-ng' do
-  version '7.2.0'
-  sha256 'f7c9a7977153ffc8a3eb837bea86f96bdb8a0264ea4f16472a6a04564b5f9542'
+  version '7.2.1'
+  sha256 '6893524eaca881ec7833d460ddefc227c78e6274a968194d405ca97095c07acd'
 
   url 'https://www.cosmigo.com/wp-content/uploads/pro-motion-ng-mac-os.zip'
   appcast 'https://www.cosmigo.com/pixel_animation_software/downloads/mac_linux_downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.