### PR TITLE
Update elan-avfx from 5.5 to 5.6

### DIFF
--- a/Casks/elan-avfx.rb
+++ b/Casks/elan-avfx.rb
@@ -1,6 +1,6 @@
 cask 'elan-avfx' do
-  version '5.5'
-  sha256 '0e884443161cd07c846972571d65cf670f73d52522edd481a3ce03d1882de852'
+  version '5.6'
+  sha256 'aaa6c841c72a4c3a033524d7660dad8603a6ea32648d384b850885633a250eb7'
 
   url "https://www.mpi.nl/tools/elan/ELAN_#{version.dots_to_hyphens}-AVFX_mac.zip"
   appcast 'https://tla.mpi.nl/tools/tla-tools/elan/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.