### PR TITLE
Update virtualhostx from 8.7.9,80_58 to 8.7.10,80_59

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.7.9,80_58'
-  sha256 '1cfc0d889f6eceebc16020ffd69cc9b36363412cc0272913379c025282fa6582'
+  version '8.7.10,80_59'
+  sha256 '185eb973ab0b23e7d41c667b10d8874982fca0a64ecb778236b7d3828fec6fc2'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.