### PR TITLE
Update taskpaper from 3.8.4 to 3.8.5

### DIFF
--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,6 +1,6 @@
 cask 'taskpaper' do
-  version '3.8.4'
-  sha256 'aa4812c21d41a32ccdb729de409dbf079dbcaa8230f4182b6433a004dd09b676'
+  version '3.8.5'
+  sha256 'bd6d8f72b38a19d9e64ec81de4b6286569e64e9d3b9bb42e40496269cd97cb7d'
 
   url "https://www.taskpaper.com/assets/app/TaskPaper-#{version}.dmg"
   appcast 'https://www.taskpaper.com/assets/app/TaskPaper.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.