### PR TITLE
Update glyphs from 2.6.2,1233 to 2.6.2,1234

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.2,1233'
-  sha256 '2655f9e3ac5700e612834abf1ca90c656a214ab7845c88496700cf50185560df'
+  version '2.6.2,1234'
+  sha256 '9de8edd615469cb2abe51a909d492f56e1ac344f6dac38b77522254bddebfbfe'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.