### PR TITLE
Update keep-it from 1.6.7 to 1.6.8

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.6.7'
-  sha256 '484fdc26db9f91a2b1adf88c9b38488cab9553197bddd81a0351c658d55900b2'
+  version '1.6.8'
+  sha256 '24f6a38144e265001736d76eb138398753b0b9a1a4eec0469f309ef2358f38ef'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.