### PR TITLE
Update tableflip from 1.1.11 to 1.2.0

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,6 +1,6 @@
 cask 'tableflip' do
-  version '1.1.11'
-  sha256 '18c40cd0c210b314d9a164a98448a9efdfd2810308b30072098602e46efe8dac'
+  version '1.2.0'
+  sha256 '4da5f365d1e7023c13e391f668b0ccf16837a486e7b1df4c9f828656d1b1f832'
 
   # update.christiantietze.de/tableflip was verified as official when first introduced to the cask
   url "https://update.christiantietze.de/tableflip/v#{version.major}/TableFlip-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.