### PR TITLE
Update renamer from 5.3.1 to 6.0.2

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
-  version '6.0.1'
-  sha256 'c8a3e5109b589a552cc4294217f57f61b90020c651a0fc5a4ac938ccc92c71e3'
+  version '6.0.2'
+  sha256 '9f4a754de2438cca06d1a35c2ca200f8d2432168a099770f1f4e443103ec63d3'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.