### PR TITLE
Update cisdem-document-reader from 4.1.0 to 4.2.0

### DIFF
--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -1,8 +1,8 @@
 cask 'cisdem-document-reader' do
-  version '4.1.0'
-  sha256 '2a9c18b6ef337c59b938d8bbbcd88e9ddc866f05d613f5cc1039aa6abfa6ff47'
+  version '4.2.0'
+  sha256 '3a52424200895d0ae292fce55243de69f82f89f108472a1e42b0e5f56fbcbd00'
 
-  url 'http://download.cisdem.com/cisdem-documentreader.dmg'
+  url 'https://www.cisdem.com/downloads/cisdem-documentreader-18.dmg'
   appcast 'https://www.cisdem.com/document-reader-mac/release-notes.html'
   name 'Cisdem Document Reader'
   homepage 'https://www.cisdem.com/document-reader-mac.html'

--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -2,7 +2,7 @@ cask 'cisdem-document-reader' do
   version '4.2.0'
   sha256 '3a52424200895d0ae292fce55243de69f82f89f108472a1e42b0e5f56fbcbd00'
 
-  url 'https://www.cisdem.com/downloads/cisdem-documentreader-18.dmg'
+  url 'http://download.cisdem.com/cisdem-documentreader.dmg'
   appcast 'https://www.cisdem.com/document-reader-mac/release-notes.html'
   name 'Cisdem Document Reader'
   homepage 'https://www.cisdem.com/document-reader-mac.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.