### PR TITLE
Update iconjar from 1.13.1,30275:1548623927 to 1.13.2,30280:1557084311

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,6 +1,6 @@
 cask 'iconjar' do
-  version '1.13.1,30275:1548623927'
-  sha256 '41544937969f8cb70640b4226b1a67b4c5ae2c4cc7100fbbc734596f09dcab95'
+  version '1.13.2,30280:1557084311'
+  sha256 'f88a2e2d0ab336762521e1bb5753c3745746800d3d77e2284c3d43a16bc05d58'
 
   # dl.devmate.com/com.iconjar.iconjar was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.iconjar.iconjar/#{version.after_comma.before_colon}/#{version.after_colon}/Iconjar-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.