### PR TITLE
Update nvivo from 12.3.0.3508 to 12.4.0.3621

### DIFF
--- a/Casks/nvivo.rb
+++ b/Casks/nvivo.rb
@@ -1,6 +1,6 @@
 cask 'nvivo' do
-  version '12.3.0.3508'
-  sha256 '46156e0065cd6c5a7cdf141b3b2ab27be41e3ef0a02361867a80090af1befc3d'
+  version '12.4.0.3621'
+  sha256 'ffb0a91c2f90df1bd26a9dfe36802b63c5257306944ca478c287a3cc9c5e6700'
 
   url "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/#{version}/NVivo%20#{version.major}.dmg"
   appcast "https://download.qsrinternational.com/Software/NVivo#{version.major}forMac/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.