### PR TITLE
Update deltawalker from 2.3.2 to 2.5.0

### DIFF
--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -1,6 +1,6 @@
 cask 'deltawalker' do
-  version '2.3.2'
-  sha256 '03d3e5c7ccc8252dbc12b15d86e647d1e71f59396deb33085b45169d20ea4d28'
+  version '2.5.0'
+  sha256 'e5b51a90058c161c452c30dcd5278477f04c1bc5d12ad6fbff94b52d4cda80db'
 
   # amazonaws.com/deltawalker was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/deltawalker/DeltaWalker-#{version}.dmg"

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -4,6 +4,7 @@ cask 'deltawalker' do
 
   # amazonaws.com/deltawalker was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/deltawalker/DeltaWalker-#{version}.dmg"
+  appcast 'https://www.deltawalker.com/new-and-noteworthy'
   name 'DeltaWalker'
   homepage 'https://www.deltawalker.com/'
 

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -4,7 +4,6 @@ cask 'deltawalker' do
 
   # amazonaws.com/deltawalker was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/deltawalker/DeltaWalker-#{version}.dmg"
-  appcast 'https://www.deltawalker.com/new-and-noteworthy'
   name 'DeltaWalker'
   homepage 'https://www.deltawalker.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.