### PR TITLE
Update majsoul-plus from 1.11.1 to 1.11.2

### DIFF
--- a/Casks/majsoul-plus.rb
+++ b/Casks/majsoul-plus.rb
@@ -1,6 +1,6 @@
 cask 'majsoul-plus' do
-  version '1.11.1'
-  sha256 '0d44d28ce2bfd8d2419c2cc37916ee79d94ea153322823cb6edac41f37b7e3f1'
+  version '1.11.2'
+  sha256 '380225037efd0c3347266ff00e8bcf2c94e0926499b459101e8f9d12a27aa6a9'
 
   url "https://github.com/MajsoulPlus/majsoul-plus-client/releases/download/v#{version}/Majsoul_Plus-darwin.dmg"
   appcast 'https://github.com/MajsoulPlus/majsoul-plus-client/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.