### PR TITLE
Update sqlpro-studio from 1.0.465 to 2019.05.03.01

### DIFF
--- a/Casks/sqlpro-studio.rb
+++ b/Casks/sqlpro-studio.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-studio' do
-  version '1.0.465'
-  sha256 '6fc9adec8eb6f146b8f0b82cb5a2efd0efdccb3c94f8bfbcaa2c5944521b8514'
+  version '2019.05.03.01'
+  sha256 '0e44c9b3a1c0a3e1eb00dd3360ac98a40f154bda4d243fc3f8727d3b337686c1'
 
   # d3fwkemdw8spx3.cloudfront.net/studio was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/studio/SQLProStudio.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.