### PR TITLE
Update onionshare from 2.0 to 2.1

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,14 +1,14 @@
 cask 'onionshare' do
-  version '2.0'
-  sha256 '117f7373b3e23b6ad8a1f0105cbe81d467fedb9dcce89baf59ffd2c851903710'
+  version '2.1'
+  sha256 '5f1d861eeb1422f592b388b200286704c9d94288a20c146164ebed57fef6b077'
 
   # github.com/micahflee/onionshare was verified as official when first introduced to the cask
-  url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare-#{version.major}.pkg"
+  url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare-#{version}.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
 
-  pkg "OnionShare-#{version.major}.pkg"
+  pkg "OnionShare-#{version}.pkg"
 
   uninstall pkgutil: 'com.micahflee.onionshare'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.