### PR TITLE
OnionShare 2.1

### DIFF
--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -2,12 +2,12 @@ cask 'onionshare' do
   version '2.1'
   sha256 '5f1d861eeb1422f592b388b200286704c9d94288a20c146164ebed57fef6b077'
 
-  url "https://onionshare.org/dist/#{version}/OnionShare-#{version.major}.pkg"
+  url "https://onionshare.org/dist/#{version}/OnionShare-#{version}.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom'
   name 'OnionShare'
   homepage 'https://onionshare.org/'
 
-  pkg "OnionShare-#{version.major}.pkg"
+  pkg "OnionShare-#{version}.pkg"
 
   uninstall pkgutil: 'com.micahflee.onionshare'
 end

--- a/Casks/onionshare.rb
+++ b/Casks/onionshare.rb
@@ -1,9 +1,8 @@
 cask 'onionshare' do
-  version '2.0'
-  sha256 '117f7373b3e23b6ad8a1f0105cbe81d467fedb9dcce89baf59ffd2c851903710'
+  version '2.1'
+  sha256 '5f1d861eeb1422f592b388b200286704c9d94288a20c146164ebed57fef6b077'
 
-  # github.com/micahflee/onionshare was verified as official when first introduced to the cask
-  url "https://github.com/micahflee/onionshare/releases/download/v#{version}/OnionShare-#{version.major}.pkg"
+  url "https://onionshare.org/dist/#{version}/OnionShare-#{version.major}.pkg"
   appcast 'https://github.com/micahflee/onionshare/releases.atom'
   name 'OnionShare'
   homepage 'https://onionshare.org/'


### PR DESCRIPTION
I'm the upstream developer of OnionShare. This PR updates OnionShare from version 2.0 to 2.1, and also changes the URL of the packages to download directly from https://onionshare.org/ rather than github.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).