### PR TITLE
Update lincastor from 2.0 to 2.1

### DIFF
--- a/Casks/lincastor.rb
+++ b/Casks/lincastor.rb
@@ -1,10 +1,10 @@
 cask 'lincastor' do
-  version '2.0'
-  sha256 'fbe3af69e932cebdd0ddb76460018a4cc9194d60bb9476c2a42c2ccf59bdbba2'
+  version '2.1'
+  sha256 '2c51215bef97b0fc1fdc8b74e147dd13707d44129d37d029d3165ea8f3d3a1bd'
 
-  # dropbox.com/s/43fuhic0mhvhb6f was verified as official when first introduced to the cask
-  url 'https://www.dropbox.com/s/43fuhic0mhvhb6f/LinCastor.zip?dl=1'
-  appcast 'https://onflapp.appspot.com/lincastor'
+  # onflapp.github.io/blog/releases was verified as official when first introduced to the cask
+  url 'https://onflapp.github.io/blog/releases/lincastor/LinCastor.zip'
+  appcast 'https://onflapp.github.io/blog/releases/lincastor/appcast.xml'
   name 'LinCastor'
   homepage 'https://onflapp.wordpress.com/lincastor/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.