### PR TITLE
Update fly from 4.2.2 to 5.1.0

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -7,7 +7,5 @@ cask 'fly' do
   name 'fly'
   homepage 'https://github.com/concourse/concourse'
 
-  container type: :tar
-
-  binary 'fly', target: 'fly'
+  binary 'fly'
 end

--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,13 +1,13 @@
 cask 'fly' do
-  version '4.2.2'
-  sha256 'b8dacaddea09a58b1594186d3c92fdca3899096fc720fe431b4ca8962bf8a6d9'
+  version '5.1.0'
+  sha256 'd0fb842725636536355c67821e7a7fe2be90a41299ae1324b747f50cd88ac9c8'
 
-  url "https://github.com/concourse/concourse/releases/download/v#{version}/fly_darwin_amd64"
+  url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/concourse/concourse/releases.atom'
   name 'fly'
-  homepage 'https://github.com/concourse/fly'
+  homepage 'https://github.com/concourse/concourse'
 
-  container type: :naked
+  container type: :tar
 
-  binary 'fly_darwin_amd64', target: 'fly'
+  binary 'fly', target: 'fly'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.