### PR TITLE
Update Mountain Duck to latest version 3.0.1.14013

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,7 +1,6 @@
 cask 'mountain-duck' do
-  version '2.7.2.9873'
-  sha256 '24e68cd958de9932cd107fc14f192fa2c89ed926ba1b9cb3a93f433007644afb'
-
+  version '3.0.1.14013'
+  sha256 '64450b878dbf4d4b48b1f14f1da74b872c37899b869c8a83a1189be483f021b7'
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss'
   name 'Mountain Duck'

--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,6 +1,7 @@
 cask 'mountain-duck' do
   version '3.0.1.14013'
   sha256 '64450b878dbf4d4b48b1f14f1da74b872c37899b869c8a83a1189be483f021b7'
+
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss'
   name 'Mountain Duck'

--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,6 +1,6 @@
 cask 'mountain-duck' do
   version '3.0.1.14013'
-  sha256 '64450b878dbf4d4b48b1f14f1da74b872c37899b869c8a83a1189be483f021b7'
+  sha256 'a713d33a9b9f865057a6b1a8ad30568b41666caa65897056247d11e4b07325e4'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast 'https://version.mountainduck.io/changelog.rss'


### PR DESCRIPTION
Updates Mountain Duck to version 3.0
Notice : This will break version 2 key owner. 
We should do something to help the version 2 key owner to download a version 2.xx ones too.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).