### PR TITLE
Update feeder from 3.6.5 to 3.6.6

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,6 +1,6 @@
 cask 'feeder' do
-  version '3.6.5'
-  sha256 '89b00013e4e3e908de13d3766e65334e696e08d35d0ca25808b99746a779fad2'
+  version '3.6.6'
+  sha256 '99c096d0386e772b90e0cb461714bbef9c0a3b5e3a744dffc4fa4023a21d1178'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.