### PR TITLE
Update framer-x from 29322,1553614664 to 31780,1557225393

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '29322,1553614664'
-  sha256 'ac591eb5c6c93602941095a9dc0af8e6e442e4b9407f6cfbb5411b05f69816c0'
+  version '31780,1557225393'
+  sha256 '54c2a2739704162fd8c31ead18f85c92ed0d99d804fc35d1713fd196ab1cf51a'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.