### PR TITLE
Update screenflow from 8.2.2 to 8.2.3

### DIFF
--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -1,6 +1,6 @@
 cask 'screenflow' do
-  version '8.2.2'
-  sha256 'a183be6fd0bf0c03a8e631833febf7f3491589fec40a773240a4899b8741bb4c'
+  version '8.2.3'
+  sha256 '8d3db51b4c2b9ba1dfc962eea853811a0e0ec00ec8782ad499e0a3010d158c00'
 
   url "https://www.telestream.net/download-files/screenflow/#{version.major_minor.dots_to_hyphens}/ScreenFlow-#{version}.dmg"
   appcast 'https://www.telestream.net/updater/screenflow/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.