### PR TITLE
Update workflowy from 1.2.12 to 1.2.13

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.2.12'
-  sha256 'cad0a4a8837a4800a1cd21aeb1dfa42b8176e5aeee51763c242d1c619bf37149'
+  version '1.2.13'
+  sha256 '56c53ded88b30b18ad18fbd354f7556712783e02fe6688f0796a5fa5cada3136'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.