### PR TITLE
Update socket-io-tester from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/socket-io-tester.rb
+++ b/Casks/socket-io-tester.rb
@@ -1,6 +1,6 @@
 cask 'socket-io-tester' do
-  version '1.2.2'
-  sha256 '41f9ecde7b503c7f1e30f8d3c58a6b78d320eabc024627ec2fb9b55b01e997d1'
+  version '1.2.3'
+  sha256 'dad65ffd41c8062d5bf5983af233307efc3257ee4c675a5e97f23f7694916e73'
 
   # github.com/AppSaloon/socket.io-tester was verified as official when first introduced to the cask
   url "https://github.com/AppSaloon/socket.io-tester/releases/download/v#{version}/socket-io-tester-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.