### PR TITLE
Update banking-4 from 7.0.3,7044 to 7.0.4,7067

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.0.3,7044'
-  sha256 'a656d59de5104530b126d2a4838e083e0f76e98e3873687b4cf67df4aec2896b'
+  version '7.0.4,7067'
+  sha256 '0e3f86e958aac84a62318dd5fc45b294a2c30b31e757dbd30a5b02017dda3487'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.