### PR TITLE
Update focuswriter from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,6 +1,6 @@
 cask 'focuswriter' do
-  version '1.7.1'
-  sha256 '2f1763e2bc7ef3363c8006eb3081cb34358be98ae0567bbe007ea8e94579cd61'
+  version '1.7.2'
+  sha256 '78ebc45618f5826cdc216752628fefe6163479803b394d200ef6c0d547e694eb'
 
   url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   name 'FocusWriter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download focuswriter` is error-free.
- [x] `brew cask style --fix focuswriter` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for a stable version.
