### PR TITLE
Fix SHA for Freecad 

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
   version '0.18-16110'
-  sha256 '62aebe92f9a142b7f3c7621f984ba415baf2ba7a691d29f3a19a2b2efc53cce5'
+  sha256 'fcf45dbf845d634a2721118acad70c06eddc04827556930319851c9d35b87f19'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.major_minor}.1/FreeCAD_#{version}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-cask/issues/63024

```bash
openssl sha256 ~/Downloads/FreeCAD_0.18-16110-OSX-x86_64-conda-Qt5-Py3.dmg
SHA256(/Users/Randall/Downloads/FreeCAD_0.18-16110-OSX-x86_64-conda-Qt5-Py3.dmg)= fcf45dbf845d634a2721118acad70c06eddc04827556930319851c9d35b87f19          
```

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

