### PR TITLE
Update sciebo from 2.5.4.2540 to 2.5.4.2575

### DIFF
--- a/Casks/sciebo.rb
+++ b/Casks/sciebo.rb
@@ -1,6 +1,6 @@
 cask 'sciebo' do
-  version '2.5.4.2540'
-  sha256 '8c37cee3b4318bc892525e9bc4e73d2ec767627552b29b13b358007c440c287b'
+  version '2.5.4.2575'
+  sha256 '47df66856eb4a269154c322a0ae7d488a70c2943c76cdccedf724a01fc88589e'
 
   url "https://www.sciebo.de/install/sciebo-#{version}.pkg"
   appcast 'https://www.sciebo.de/updateserver/?version=2.3.3.1812&platform=macos&oem=sciebo&sparkle=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.