### PR TITLE
Update crypho from 4.1.5 to 4.1.7

### DIFF
--- a/Casks/crypho.rb
+++ b/Casks/crypho.rb
@@ -1,6 +1,6 @@
 cask 'crypho' do
-  version '4.1.5'
-  sha256 'a7b938eed0f90aa02967318cdb60843b30c0738f92d1bb18b77cc3777e6ae686'
+  version '4.1.7'
+  sha256 'd4f5269f27096e86a4a4e57031417f5b9284538d21e4ed8b5a37d4e72b3a9162'
 
   url "https://www.crypho.com/downloads/desktop/Crypho-#{version}.dmg"
   appcast 'https://www.crypho.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.