### PR TITLE
Update scrutiny from 8.3.12 to 8.3.13

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.3.12'
-  sha256 '172f956706c36ad1815545b37ff6a6bc20f227151fba3340b2322dc8bca47b0b'
+  version '8.3.13'
+  sha256 'b5a08d4c766f06f2ff910148c74007ae4e83e03a23ccc3a016c276136e68f6a4'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.