### PR TITLE
Update progressive-downloader from 4.5.1 to 4.5.2

### DIFF
--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -1,6 +1,6 @@
 cask 'progressive-downloader' do
-  version '4.5.1'
-  sha256 '6d4607126bd4ea7d4adc9f238f53ec22977884a23913ee43d35eb38fe14f56d9'
+  version '4.5.2'
+  sha256 'e3fdce79ccb1c4c7ea1fe4610dc09c56ec9b29cb544752aeec74fb94a4e6dff2'
 
   url "https://www.macpsd.net/update/#{version}/PSD.dmg"
   name 'Progressive Downloader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.