### PR TITLE
Update qownnotes from 19.5.1,b4255-104248 to 19.5.2,b4258-143439

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.5.1,b4255-104248'
-  sha256 '9310ac6ba8759ef89cdaf40f913e6eec01c70115ce403b6c14f5fe85a1c827d1'
+  version '19.5.2,b4258-143439'
+  sha256 'd143d17dbc88e9c80e931b026a38e964d8e6a2837d430097e9e17474ed6cdefe'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.