### PR TITLE
Update glyphs from 2.6.2,1235 to 2.6.2,1236

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.2,1235'
-  sha256 '4adee5fb923b5cf5d859759d5c6927e9356afde3d42ff7350a287f7ca71d7353'
+  version '2.6.2,1236'
+  sha256 'de1fe0755d7e69c43971915740e9f8670ed57f6bfeb06c3e63f45a1cc46c242e'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.