### PR TITLE
Update ibackup-viewer from 4.1300 to 4.1400

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1300'
-  sha256 '8c36604ba646ac75a3d7f2168ffaaf775222f331c40a6f1d3db7155c8719c2f5'
+  version '4.1400'
+  sha256 'a171756a9d2af6cf21299907cbf74603758b86de81a520fa5bb51b477706365b'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.