### PR TITLE
Update latexdraw from 3.3.8 to 3.3.9

### DIFF
--- a/Casks/latexdraw.rb
+++ b/Casks/latexdraw.rb
@@ -1,6 +1,6 @@
 cask 'latexdraw' do
-  version '3.3.8'
-  sha256 '92f25a620d25af07281d8941174cf6420fde8ce8050938e05c65e1f13a83d2fa'
+  version '3.3.9'
+  sha256 '1197536a5ce3b343e85696fbc5f2821092e885086760d9af4bfe11c073551f6b'
 
   # downloads.sourceforge.net/latexdraw was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/latexdraw/LaTeXDraw-#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.