### PR TITLE
Update hyper from 3.0.0 to 3.0.2

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,6 +1,6 @@
 cask 'hyper' do
-  version '3.0.0'
-  sha256 '488d838a035ef1294c1fae68724ea6e1f426dbbf7c57f49ee9b4aaa6d52c3eaa'
+  version '3.0.2'
+  sha256 '56ac31f2f8aa99edf03f277b25203eca9d8b6c4d6535f673a996fddca0d21bb5'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.