### PR TITLE
update binary and home page location to internet archive

### DIFF
--- a/Casks/synth1-vst.rb
+++ b/Casks/synth1-vst.rb
@@ -2,9 +2,9 @@ cask 'synth1-vst' do
   version '1.13beta8'
   sha256 '6b172b9433358bce21f0af75a28505c3365d934fadee04a738336e7f5f601675'
 
-  url "http://www.geocities.jp/daichi1969/softsynth/Synth1macvst#{version.no_dots}.zip"
+  url "https://web.archive.org/web/20190331141735/http://www.geocities.jp/daichi1969/softsynth/Synth1macvst#{version.no_dots}.zip"
   name 'Synth1 (VST)'
-  homepage 'http://www.geocities.jp/daichi1969/softsynth/'
+  homepage 'https://web.archive.org/web/20190331141735/http://www.geocities.jp/daichi1969/softsynth/'
 
   vst_plugin 'Synth1.vst'
 end


### PR DESCRIPTION
Geocities.jp has been shut down, and the original location of this plugin is no more.

The binaries are cached in the Internet Archive, so this update changes the location to that source.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x ] `brew cask audit --download {{cask_file}}` is error-free.
- [x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x ] The commit message includes the cask’s name and version.
- [x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
