### PR TITLE
New Cask for Synth1 Audio Unit plugin

### DIFF
--- a/Casks/synth1-au.rb
+++ b/Casks/synth1-au.rb
@@ -1,0 +1,10 @@
+cask 'synth1-vst' do
+  version '1.13beta8'
+  sha256 '6b172b9433358bce21f0af75a28505c3365d934fadee04a738336e7f5f601675'
+
+  url "https://web.archive.org/web/20190331141735/http://www.geocities.jp/daichi1969/softsynth/Synth1macau#{version.no_dots}.zip"
+  name 'Synth1 (VST)'
+  homepage 'https://web.archive.org/web/20190331141735/http://www.geocities.jp/daichi1969/softsynth/'
+
+  au_plugin 'Synth1.vst'
+end

--- a/Casks/synth1-au.rb
+++ b/Casks/synth1-au.rb
@@ -1,10 +1,10 @@
-cask 'synth1-vst' do
+cask 'synth1-au' do
   version '1.13beta8'
-  sha256 '6b172b9433358bce21f0af75a28505c3365d934fadee04a738336e7f5f601675'
+  sha256 '78660848d78c19cdda2597bd050a2ec95fa915cc1a1ab598bde0192a1cbc9a6f'
 
   url "https://web.archive.org/web/20190331141735/http://www.geocities.jp/daichi1969/softsynth/Synth1macau#{version.no_dots}.zip"
   name 'Synth1 (VST)'
   homepage 'https://web.archive.org/web/20190331141735/http://www.geocities.jp/daichi1969/softsynth/'
 
-  au_plugin 'Synth1.vst'
+  audio_unit_plugin 'Synth1.component'
 end


### PR DESCRIPTION
Audio Unit version of synth1 plugin. Essentially the same as the synth1 vst already casked, but sometimes the AU is preferred.

As the original source location for this plugin (geocities.jp) has been shut down, this cask references the Internet Archive

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x ] `brew cask audit --download {{cask_file}}` is error-free.
- [x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x ] The commit message includes the cask’s name and version.
- [x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x ] Named the cask according to the [token reference].
- [x ] `brew cask install {{cask_file}}` worked successfully.
- [x ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x ] Checked there are no [open pull requests] for the same cask.
- [x ] Checked the cask was not [already refused].
- [x ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
