### PR TITLE
Update kindle from 52077 to 55093

### DIFF
--- a/Casks/kindle.rb
+++ b/Casks/kindle.rb
@@ -1,6 +1,6 @@
 cask 'kindle' do
-  version '52077'
-  sha256 'a069cd4cb4eee382ca7122b1652577b727851d244ffe75e60db08255b75f482b'
+  version '55093'
+  sha256 '580957ca56b1e77b7952f41970836481f37ada3071eaee3552265069b89ef757'
 
   # s3.amazonaws.com/kindleformac was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/kindleformac/#{version}/KindleForMac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.