### PR TITLE
Update framer-x from 31780,1557225393 to 31785,1557403596

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '31780,1557225393'
-  sha256 '54c2a2739704162fd8c31ead18f85c92ed0d99d804fc35d1713fd196ab1cf51a'
+  version '31785,1557403596'
+  sha256 '0a61c61f097d42ec618ca4df2dfd0bd5c0e7e0c331ba57c1f28f96aa5648557d'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.