### PR TITLE
Update ibackup-viewer from 4.1400 to 4.1401

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1400'
-  sha256 'a171756a9d2af6cf21299907cbf74603758b86de81a520fa5bb51b477706365b'
+  version '4.1401'
+  sha256 'cee136a22cdfef31f1fc85c295d1451d6d6d5c0f278227d1d81e156f6f2c51aa'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.