### PR TITLE
Update kite from 0.20190502.0 to 0.20190509.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190502.0'
-  sha256 '52b87b914ae9f7798a2cedd312a99065950dc0d14a351b5caaf65f81e51c2cbd'
+  version '0.20190509.1'
+  sha256 'c6919fecc6d48f0feb8d93ae456746e10eaeeed43ed8b9acab566e3b334fe266'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.