### PR TITLE
Update bettertouchtool from 2.809 to 2.813

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.809'
-    sha256 '8f3ee5ad14eae3e0a6ee2139b1d67df0cce18c92fbc9d94ef915ba5b658e38eb'
+    version '2.813'
+    sha256 'c82f20d6996d9ee543b1aec660610df12e5158bc607cb02ff3b5a3781ea75ab3'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.