### PR TITLE
adobe-digital-editions: Fix download URL

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -2,7 +2,7 @@ cask 'adobe-digital-editions' do
   version '4.5.10'
   sha256 '33f784ab50188cc9e5a6c575a739af726cb1deda5970b075851e03b0e9b26d62'
 
-  url "https://download.adobe.com/pub/adobe/digitaleditions/ADE_#{version.major_minor}_Installer.dmg"
+  url "https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_#{version.major_minor}_Installer.dmg"
   appcast 'https://www.adobe.com/solutions/ebook/digital-editions/download.html'
   name 'Adobe Digital Editions'
   homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'


### PR DESCRIPTION
The current URL returns 404.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
