### PR TITLE
Update brave-browser from 0.63.48 to 0.63.55

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.63.48'
-  sha256 '7f50c86f45446d6c930f3198c11cacedf64e73915ec65e5d090e274a95760f51'
+  version '0.63.55'
+  sha256 '55bf556a0d8e56037fbd2825ad475be5394d1f514d52f99a9b92e21ae9ac34d8'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.