### PR TITLE
Update redcine-x-pro from 50.5 to 51.0.47074

### DIFF
--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -1,13 +1,13 @@
 cask 'redcine-x-pro' do
-  version '50.5'
-  sha256 '443b4e92e8b4c23dad9478f96e8d88159944d904e61d07ad41e402377cc8aafe'
+  version '51.0.47074'
+  sha256 '4f8021224cd4e705ca18f2709540731046e991efb23e7232e157ad59b89604c1'
 
-  # s3.amazonaws.com/red-4/ was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/red-4/downloads/software/rcx/REDCINE-X_PRO_Build_#{version}.pkg"
+  # s3.amazonaws.com/red_3/ was verified as official when first introduced to the cask
+  url "http://s3.amazonaws.com/red_3/downloads/software/rcx/RELEASE%20CANDIDATE/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'
 
-  pkg "REDCINE-X_PRO_Build_#{version}.pkg"
+  pkg "REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
 
   uninstall pkgutil: [
                        'com.red.pkg.REDCINE-X PRO',

--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -3,7 +3,7 @@ cask 'redcine-x-pro' do
   sha256 '4f8021224cd4e705ca18f2709540731046e991efb23e7232e157ad59b89604c1'
 
   # s3.amazonaws.com/red_3/ was verified as official when first introduced to the cask
-  url "http://s3.amazonaws.com/red_3/downloads/software/rcx/RELEASE%20CANDIDATE/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
+  url "https://s3.amazonaws.com/red_3/downloads/software/rcx/RELEASE%20CANDIDATE/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
   appcast 'https://www.red.com/downloads/options?itemInternalId=16144'
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'

--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -4,6 +4,7 @@ cask 'redcine-x-pro' do
 
   # s3.amazonaws.com/red_3/ was verified as official when first introduced to the cask
   url "http://s3.amazonaws.com/red_3/downloads/software/rcx/RELEASE%20CANDIDATE/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
+  appcast 'https://www.red.com/downloads/options?itemInternalId=16144'
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.