### PR TITLE
Update lidarr from 0.6.1.830 to 0.6.2.883

### DIFF
--- a/Casks/lidarr.rb
+++ b/Casks/lidarr.rb
@@ -1,6 +1,6 @@
 cask 'lidarr' do
-  version '0.6.1.830'
-  sha256 '11c63eacedd9e3d2894dfe64bb09063c423ab1b01eabeffda817470dd8980c72'
+  version '0.6.2.883'
+  sha256 '7d207b86a8bcd1d1d95e2a3df8b27305f467206f6a464083a28395f981d98b1b'
 
   # github.com/lidarr/Lidarr was verified as official when first introduced to the cask
   url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.develop.#{version}.osx-app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.