### PR TITLE
Update cisdem-document-reader from 4.2.0 to 4.2.1

### DIFF
--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-document-reader' do
-  version '4.2.0'
-  sha256 '3a52424200895d0ae292fce55243de69f82f89f108472a1e42b0e5f56fbcbd00'
+  version '4.2.1'
+  sha256 'cb9e907f3afaa9d47698122545a22ee9f01b4c6d143d7fd3af0f67f0ea1a9837'
 
   url 'http://download.cisdem.com/cisdem-documentreader.dmg'
   appcast 'https://www.cisdem.com/document-reader-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.