### PR TITLE
Update nosqlbooster-for-mongodb from 5.1.6 to 5.1.7

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.1.6'
-  sha256 '5d7bd62e12ad8f79d2f12dae117a1488a968432355d5dace1333faae39085aba'
+  version '5.1.7'
+  sha256 'c136369ba3cf9ca76f7546478675014408ca6b184d5ed8f5e4924ad3c5e4e38f'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   name 'NoSQLBooster for MongoDB'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.