### PR TITLE
Update bluej from 4.2.0 to 4.2.1

### DIFF
--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -1,6 +1,6 @@
 cask 'bluej' do
-  version '4.2.0'
-  sha256 '21c5759875e9cbfe63b13b6ae5c7b31b9e1d3cdd8ebee48a2905d81e0fcb0e22'
+  version '4.2.1'
+  sha256 '666d08e2a1c7986328bcdafd9885553cefd9e5974ac26705a3645a2037598d79'
 
   url "https://www.bluej.org/download/files/BlueJ-mac-#{version.no_dots}.zip"
   name 'BlueJ'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.