### PR TITLE
Update hashbackup from 2298 to 2302

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,10 +1,10 @@
 cask 'hashbackup' do
-  version '2295'
-  sha256 'e3930f5f49b742faeb5295b88fed4b42cdbe0cb2c7ddb0ce274101bfdc3203e1'
+  version '2298'
+  sha256 '9747604a5350e8a95ea091de3d7303b2d759ffd9994063123e0b38ba47a25587'
 
-  url "http://www.hashbackup.com/download/hb-#{version}-mac-64bit.tar.gz"
+  url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.i386.bz2"
   name 'hashbackup'
   homepage 'http://www.hashbackup.com/'
 
-  binary "hb-#{version}/hb"
+  binary "hb.r#{version}.Darwin.i386", target: 'hb'
 end

--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,6 +1,6 @@
 cask 'hashbackup' do
-  version '2298'
-  sha256 '9747604a5350e8a95ea091de3d7303b2d759ffd9994063123e0b38ba47a25587'
+  version '2302'
+  sha256 '3f03bd6b565e63a45b7955f83751ef80ecd6a856ef6d699cc5b84e4fcd268a01'
 
   url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.i386.bz2"
   name 'hashbackup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.