### PR TITLE
Update electrum-ltc from 3.3.4.1 to 3.3.5.1

### DIFF
--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -1,6 +1,6 @@
 cask 'electrum-ltc' do
-  version '3.3.4.1'
-  sha256 'bfc082b692905fe279b5666adf2fe62ba83652d4b6162e539f7a81f651d70bfe'
+  version '3.3.5.1'
+  sha256 'c266dae2e694b7ccf943f42ad068d0f188d3d683881c2f2686969f018c393b40'
 
   url "https://electrum-ltc.org/download/electrum-ltc-#{version}.dmg"
   appcast 'https://electrum-ltc.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.