### PR TITLE
Update notable from 1.4.0 to 1.5.0

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.4.0'
-  sha256 'cac9eb54d7e45fe38cae6a5083e8af2de93adbc0c43079e72c0938cd1c417cbf'
+  version '1.5.0'
+  sha256 '895529b835bfe465d4036f4b5edfa510eb22f8b9b540eb1fa26679e559ce99f3'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.