### PR TITLE
Update cardhop from 1.2.3 to 1.2.4

### DIFF
--- a/Casks/cardhop.rb
+++ b/Casks/cardhop.rb
@@ -1,6 +1,6 @@
 cask 'cardhop' do
-  version '1.2.3'
-  sha256 '567326282b7881d0c4964e5f5824d3ce1499291213c80eed8edcb165a420729b'
+  version '1.2.4'
+  sha256 '5d6865cb77503d134fc2266c888b93cb925089cc2ba5d80b3d2003c10a916f4d'
 
   url "http://cdn.flexibits.com/Cardhop_#{version}.zip"
   appcast 'https://flexibits.com/cardhop/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.