### PR TITLE
Update exodus from 19.4.26 to 19.5.10

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.4.26'
-  sha256 '89989652de961e0ff085a903b11fbc93d69982d5e40031b0b40c4a0993973a82'
+  version '19.5.10'
+  sha256 'e1964f75ec6bad201dfd7d5c48ddaded2b218e67f7128e51603bebe10075fa8e'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.