### PR TITLE
Update bettertouchtool from 2.813 to 2.819

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.813'
-    sha256 'c82f20d6996d9ee543b1aec660610df12e5158bc607cb02ff3b5a3781ea75ab3'
+    version '2.819'
+    sha256 'faaf84f5c32fcdd846dad2275088cfbd311f5e89e0857c1f2c46113bbe995969'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.