### PR TITLE
Update cacher from 2.8.3 to 2.9.0

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.8.3'
-  sha256 'a8791a50081f55057be5f94b1aebe1e063610ae843e5ff69eadcd376fcb6a2c4'
+  version '2.9.0'
+  sha256 'fae0043716483d2cbbb23067b8659f8889b90372ff26a8ffe1a70001ff82047d'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.