### PR TITLE
Update crypho from 4.1.7 to 4.1.8

### DIFF
--- a/Casks/crypho.rb
+++ b/Casks/crypho.rb
@@ -1,6 +1,6 @@
 cask 'crypho' do
-  version '4.1.7'
-  sha256 'd4f5269f27096e86a4a4e57031417f5b9284538d21e4ed8b5a37d4e72b3a9162'
+  version '4.1.8'
+  sha256 'f8e5d7ed52984a3ddaa1477ffca2a00f208111de7e76139041615be286be9b2b'
 
   url "https://www.crypho.com/downloads/desktop/Crypho-#{version}.dmg"
   appcast 'https://www.crypho.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.