### PR TITLE
Update kstars from 2.9.8 to 3.2.2

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask 'kstars' do
-  version '2.9.8'
-  sha256 'a01ca011d8c796e8357e3a81520548bcec9b5e788c4d930fe727aaf236c65e90'
+  version '3.2.2'
+  sha256 '46fdd6a34bb0a2e4af09cc2dd2de3933ec6ec363037345f7ed5c9f2d189fc4a4'
 
   # indilib.org/jdownloads/kstars was verified as official when first introduced to the cask
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.