### PR TITLE
Update code42-crashplan from 6.9.0 to 6.9.4

### DIFF
--- a/Casks/code42-crashplan.rb
+++ b/Casks/code42-crashplan.rb
@@ -1,9 +1,10 @@
 cask 'code42-crashplan' do
-  version '6.9.0'
-  sha256 '2aa00419b2b02238ec7f96835d2e82fa80de288276a8a46995f4146032115097'
+  version '6.9.4'
+  sha256 'a58050cecec00b2fadf3a81d5f8e536c341d351d238a1d37bc70e490940baad3'
 
   # download.code42.com was verified as official when first introduced to the cask
   url "https://download.code42.com/installs/mac/install/Code42CrashPlan/Code42CrashPlan_#{version}_Mac.dmg"
+  appcast 'https://support.code42.com/Release_Notes/CrashPlan_for_Small_Business_release_notes'
   name 'CrashPlan'
   homepage 'https://www.crashplan.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.