### PR TITLE
Update unity-download-assistant from 2019.1.1f1,fef62e97e63b to 2019.1.2f1,3e18427e571f

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.1.1f1,fef62e97e63b'
-  sha256 '1e9c21261c88569e00d1296bc7eb7dee555c335f1b22da453e51dc040bdcc2f6'
+  version '2019.1.2f1,3e18427e571f'
+  sha256 'ab4354adbe8352116f924fde978e96572fc63716e92323221a9e77fada470a28'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.