### PR TITLE
Update unity-ios-support-for-editor from 2019.1.1f1,fef62e97e63b to 2019.1.2f1,3e18427e571f

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.1.1f1,fef62e97e63b'
-  sha256 '412a6f419fc0b540bf192839f907d49dd77c5b8f9b4a1fce3f20ab744a4a9109'
+  version '2019.1.2f1,3e18427e571f'
+  sha256 'd06650497d135846a20ee019d9632d6638aeb0f1b0f1357c4615b1abefb64d5b'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.