### PR TITLE
Update unity-webgl-support-for-editor from 2019.1.1f1,fef62e97e63b to 2019.1.2f1,3e18427e571f

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.1.1f1,fef62e97e63b'
-  sha256 '37453b54ad1607b9d3dd337f0a286cb036a9d2205510d7b799f9ca752be9ada4'
+  version '2019.1.2f1,3e18427e571f'
+  sha256 'b3cbc081c65c921ad50b0a96602ddc64bf88fa68f8f054f71ba1fba3eb103c40'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.