### PR TITLE
Update unity-windows-support-for-editor from 2019.1.1f1,fef62e97e63b to 2019.1.2f1,3e18427e571f

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.1.1f1,fef62e97e63b'
-  sha256 '14bc809dd60d17fc12e0f00569d612a317c2bdd46e1f8d842598cd1ad5d15205'
+  version '2019.1.2f1,3e18427e571f'
+  sha256 '1edfc8206703384aa5c5a65598afbc6371f2a3640d831d8e9bdfa982edfc78cf'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.