### PR TITLE
Update joplin from 1.0.145 to 1.0.152

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.145'
-  sha256 'd8d37b53c781322966e36a1560f9124af632f3004102831eb9679f9f501a1878'
+  version '1.0.152'
+  sha256 '1c9c169c2035c7900782e101d9e79b59ae9387c649cd65b050b91f222399b9b5'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.