### PR TITLE
Update polar-bookshelf from 1.19.0 to 1.19.2

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.19.0'
-  sha256 '6a60a425e6e3c5be90fd8744dc3657e91fbfa66cb076019a0b1e53f05579825a'
+  version '1.19.2'
+  sha256 '00dcd3f8db35756cb5fc55b2c3dd014e2b3503c2384c5cd92a7f161a9a93925e'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.