### PR TITLE
Update turtl from 0.7.2.5 to 0.7.2.6

### DIFF
--- a/Casks/turtl.rb
+++ b/Casks/turtl.rb
@@ -1,9 +1,9 @@
 cask 'turtl' do
-  version '0.7.2.5'
-  sha256 '266ad5026910431e1dd16c77b558c8503b178409ed486a98423491fc050b7b19'
+  version '0.7.2.6'
+  sha256 '8b6c71eb35b5a369d8a54417966a7cf4555930254ecea594564494e920fea95f'
 
   # github.com/turtl/desktop was verified as official when first introduced to the cask
-  url "https://github.com/turtl/desktop/releases/download/v#{version}/turtl-#{version}-osx.zip"
+  url "https://github.com/turtl/desktop/releases/download/v#{version}-link-notes/turtl-#{version}-link-notes-osx.zip"
   appcast 'https://github.com/turtl/desktop/releases.atom'
   name 'turtl'
   homepage 'https://turtlapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.