### PR TITLE
Update unicodechecker from 1.21 to 1.21.1

### DIFF
--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -1,5 +1,5 @@
 cask 'unicodechecker' do
-  version '1.21.1'
+  version '1.21.1,755'
   sha256 '0b6019277bade20ccd2904adf0fd29c7395ab495e02ace8c5b58d4e33ebd6587'
 
   url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
@@ -7,7 +7,7 @@ cask 'unicodechecker' do
   name 'UnicodeChecker'
   homepage 'https://earthlingsoft.net/UnicodeChecker/'
 
-  app "UnicodeChecker #{version}/UnicodeChecker.app"
+  app "UnicodeChecker #{version.before_comma} (#{version.after_comma})/UnicodeChecker.app"
 
   zap trash: [
                '~/Library/Application Support/UnicodeChecker',

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -1,6 +1,6 @@
 cask 'unicodechecker' do
-  version '1.21'
-  sha256 'b478c39d96f58aa355a073ce39b80320c7f717e738a1629ee2653bdf288889f9'
+  version '1.21.1'
+  sha256 '0b6019277bade20ccd2904adf0fd29c7395ab495e02ace8c5b58d4e33ebd6587'
 
   url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
   appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.