### PR TITLE
Update protopie from 3.11.0 to 3.11.1

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '3.11.0'
-  sha256 'b599a8c7949ab780fb854307e4bd555627b0572682de34dfaa1847ce0ee94f20'
+  version '3.11.1'
+  sha256 '1a0130fe60f29a6be6aa62f4d3e24428de69cc4a6b29174281428d54a7db7e3a'
 
   url "http://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.