### PR TITLE
updated SHA256 digest for deeper 2.4.4

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -18,7 +18,7 @@ cask 'deeper' do
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   else
     version '2.4.4'
-    sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
+    sha256 'd26d224345ee87f09908c30b324d86b043b191758eabe861f0eff4a0509d958e'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
