### PR TITLE
Update freefilesync from 10.11 to 10.12

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,5 +1,5 @@
 cask 'freefilesync' do
-  version '10.11'
+  version '10.12'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -4,7 +4,11 @@ cask 'freefilesync' do
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",
       user_agent: :fake,
-      referer:    'https://freefilesync.org/download.php'
+      referer:    'https://freefilesync.org/download.php',
+      cookies:    {
+                    '__cfduid' => 'd0e5d1f63ab8177dd75e7278fc77e2ab21557920468',
+                    'ukey'     => 'crfjj0fjxvxmkx57l9dvqeku0fcy6gbr',
+                  }
   name 'FreeFileSync'
   homepage 'https://www.freefilesync.org/'
 


### PR DESCRIPTION
👉 Closes https://github.com/Homebrew/homebrew-cask/issues/63069

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.