### PR TITLE
Update gswitch from 1.8.2 to 1.9.0

### DIFF
--- a/Casks/gswitch.rb
+++ b/Casks/gswitch.rb
@@ -1,6 +1,6 @@
 cask 'gswitch' do
-  version '1.8.2'
-  sha256 'b0b0169139d188b539789b6f10d0018e14f47bc6fa6a28e37c64e7a2a0ffe7a7'
+  version '1.9.0'
+  sha256 'd8050a6d49808a8b9fec263188379ab70f10c390f94b9306948ac6e825f086b2'
 
   # github.com/CodySchrank/gSwitch was verified as official when first introduced to the cask
   url "https://github.com/CodySchrank/gSwitch/releases/download/#{version}/gSwitch.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.