### PR TITLE
Update wordpresscom from 4.0.0 to 4.1.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '4.0.0'
-  sha256 'c55992a869274a1f6d7509f27c15000d3b8842d10584a214570a90c83024f93d'
+  version '4.1.0'
+  sha256 '75ad26ede927a5f3d796b7d9525ec59ffa76f2a64cfc0088a6ad0a1a9b31d2e7'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.