### PR TITLE
Update malwarebytes from 3.8.16.2524 to 3.8.17.2526

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '3.8.16.2524'
-  sha256 'ad25fcc176fc223f145ac291f20e5aa02044b81f1b21c1e3d3bdd4988d740c10'
+  version '3.8.17.2526'
+  sha256 'e9da975b65f2a83c83882802108638356833fe5ef17397fd492b79d07496d8f4'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.