### PR TITLE
Update synergy from 1.10.1,b87:8941241e to 1.10.2,b126:8c010140

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '1.10.1,b87:8941241e'
-  sha256 '3e19d18a5ca30f8576d3c0bac861cb23f506044f2fe5872e715b0174076277a4'
+  version '1.10.2,b126:8c010140'
+  sha256 'e85ab316c7783c3da8caba94f31210d80bb8c68f740a9d14322c3a20c8d2adf0'
 
   url "https://binaries.symless.com/synergy/v#{version.before_comma.major}-core-standard/v#{version.before_comma}-stable-#{version.after_colon}/synergy_#{version.before_comma}-stable_#{version.after_comma.before_colon}-#{version.after_colon}_macos.dmg"
   name 'Synergy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.