### PR TITLE
Update cctalk from 7.5.0.3 to 7.5.2.6

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,6 +1,6 @@
 cask 'cctalk' do
-  version '7.5.0.3'
-  sha256 '377515a077cc05960f7e92e2e3307fff9f4afe4c68276d546b67e7153e4618f2'
+  version '7.5.2.6'
+  sha256 'ddea13ecc5bae49dd6d9348fe8cea2ef01644959d007a91f27415dc4a64aaaf4'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
   url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.