### PR TITLE
Update rekordbox from 5.5.0 to 5.6.0

### DIFF
--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -1,6 +1,6 @@
 cask 'rekordbox' do
-  version '5.5.0'
-  sha256 '28228a171c570d19a5c95deedd2e32d8aa61d295c0ef21159cc4f30b912898a7'
+  version '5.6.0'
+  sha256 '1231d3ac99acce3a36f5f572fa21dbdfc75ef302c89a3f3a9c4c649d5faa3b8f'
 
   url "https://rekordbox.com/_app/files/Install_rekordbox_#{version.dots_to_underscores}.pkg.zip"
   appcast 'https://rekordbox.com/en/support/releasenote.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.