### PR TITLE
Update thingsmacsandboxhelper from 3.15 to 3.16

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -1,6 +1,6 @@
 cask 'thingsmacsandboxhelper' do
-  version '3.15'
-  sha256 'c1cdb5254ff618418f6cf2a59d2b249e6d4ad0b78ca844cdb157f00362aa5f49'
+  version '3.16'
+  sha256 '8b9b19ffb406823124bdf60acd0107764d9f5a3e8a98c71f0bd6feb06b38b5d8'
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.