### PR TITLE
Update chronos from 3.2.3 to 3.2.4

### DIFF
--- a/Casks/chronos.rb
+++ b/Casks/chronos.rb
@@ -1,6 +1,6 @@
 cask 'chronos' do
-  version '3.2.3'
-  sha256 'ad7d97026c5be38ab689c3e9809a8a73e34c3ce3f07478b78f97043f4a4f03b9'
+  version '3.2.4'
+  sha256 '8abeee610d4b1e369746119597c11c3c3595cfebb216eec4d78773a627fe93ba'
 
   url "https://github.com/web-pal/chronos-timetracker/releases/download/v#{version}/Chronos-#{version}-mac.zip"
   appcast 'https://github.com/web-pal/chronos-timetracker/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.