### PR TITLE
Update bettertouchtool from 2.830 to 2.835

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.830'
-    sha256 '17665b1f1814b1eb7bcb1b31318a9eb976afc26474f15c628b3dc7027b44d6d8'
+    version '2.835'
+    sha256 '4a2a1b4e93e34e4c1a2f06f10609aa5d98249e55cf3cc5c3be5f3b9826cdab6f'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.