### PR TITLE
Update ios-app-signer from 1.10 to 1.11

### DIFF
--- a/Casks/ios-app-signer.rb
+++ b/Casks/ios-app-signer.rb
@@ -1,6 +1,6 @@
 cask 'ios-app-signer' do
-  version '1.10'
-  sha256 '0263f1185fc1a4d1b5e1bddb11be82e6a12d8a54845f5e5ace1780da75368190'
+  version '1.11'
+  sha256 'd81a1ac9e59c4a06754ce0207d13b4b1f716baf172af6b31258303752c2f58e7'
 
   # github.com/DanTheMan827/ios-app-signer was verified as official when first introduced to the cask
   url "https://github.com/DanTheMan827/ios-app-signer/releases/download/#{version}/iOS.App.Signer.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.