### PR TITLE
Update katalon-studio from 6.1.3 to 6.1.5

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '6.1.3'
-  sha256 '1c7545424645ef88f8efc7a631045d68f45499fb62fefe667e483372ea8d245c'
+  version '6.1.5'
+  sha256 '43c98b5a5b1f9408f9c39c33ef2a12c20954836bb1a7ef3a47de7313f3638e00'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.