### PR TITLE
Update itubedownloader from 6.4.8 to 6.4.9

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,6 +1,6 @@
 cask 'itubedownloader' do
-  version '6.4.8'
-  sha256 '691003498c6214d779e2d78581b13a0af839111cae867f3e1f2ffa0e29f92593'
+  version '6.4.9'
+  sha256 'ccc208d6f6a4587a8ceb6e846c98e00e701c23584deb16962d96488ce3fd4a1e'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/iTubeDownloader.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.