### PR TITLE
Update metabase from 0.32.6.0 to 0.32.8.0

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.32.6.0'
-  sha256 'e4f28c93c052f7e7a7850136abc87e3782a3c6994ae3a5a55258cc73893a0cf4'
+  version '0.32.8.0'
+  sha256 '0511b709fcddeabe1402e4beb115fe7e40673fabb3abf1a5a87d6d0df5d778d1'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.