### PR TITLE
Update polymail from 2.1.3 to 2.1.4

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,6 +1,6 @@
 cask 'polymail' do
-  version '2.1.3'
-  sha256 'da8e75c5b5cabfcd39b70a35a61a3d15ebcee85107a1543d8e26a53626a3822e'
+  version '2.1.4'
+  sha256 'f8280b05fcb2923d46830f005d4103235d72228437b8457f666c44026557b1c9'
 
   url "https://sparkle-updater.polymail.io/macos/builds/Polymail-v#{version}.zip"
   name 'Polymail'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.