### PR TITLE
Update zoomus from 4.4.52595.0425 to 4.4.52600.0508

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.4.52595.0425'
-  sha256 '85c96d9ee17e700f6cd1a1ca205823ff6cdec8ada0812f2826e02cbd763035be'
+  version '4.4.52600.0508'
+  sha256 '4ae6d43878330fa3cc081fdf366fd2db74b4bd7b71ec9f53f581966053746170'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   appcast 'https://support.zoom.us/hc/en-us/articles/201361963-New-Updates-for-Mac-OS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.