### PR TITLE
Update react-studio from 1.5.8,353 to 1.5.8,354

### DIFF
--- a/Casks/react-studio.rb
+++ b/Casks/react-studio.rb
@@ -1,6 +1,6 @@
 cask 'react-studio' do
-  version '1.5.8,353'
-  sha256 'e2266de3d213a236c7a665c2df74292c5c45a1a28dde0ac99efcd74d5a21701c'
+  version '1.5.8,354'
+  sha256 '0d88b4380ce647e9ef0e211b028fd6b09f6211fcc0cbf113517aa8e1d9ed7ed3'
 
   # s3.amazonaws.com/sc.neonto.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/sc.neonto.com/ReactStudio_v#{version.before_comma.no_dots}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.