### PR TITLE
Update atom from 1.36.1 to 1.37.0

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,6 +1,6 @@
 cask 'atom' do
-  version '1.36.1'
-  sha256 '0970553094b7a414d4e409490319a10cb64ee300de8bfa68c8900f970ad976c9'
+  version '1.37.0'
+  sha256 '920648213019519819da2b23213527eba0ddf10bbde9ea600d67b38fbe2f6eee'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.