### PR TITLE
Update 1password from 7.2.5 to 7.2.6

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,6 +1,6 @@
 cask '1password' do
-  version '7.2.5'
-  sha256 '119125cdc54fdf889bf48b28b18db93cf9ce91a96b4cc1f4ecb015cba8311bbd'
+  version '7.2.6'
+  sha256 'a16490cb5bf2b4de9fea71499fad8058514e91c051011f32233d25210abfdd0b'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.