### PR TITLE
Update polar-bookshelf from 1.19.2 to 1.19.4

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.19.2'
-  sha256 '00dcd3f8db35756cb5fc55b2c3dd014e2b3503c2384c5cd92a7f161a9a93925e'
+  version '1.19.4'
+  sha256 '6853d4c4f34823d99f2ce4d821dac7a2ba6d8bf853a3e2ad2711193c70c10509'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.