### PR TITLE
Update wpsoffice from 1.0.1(1354) to 1.1.0(1454)

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
-  version '1.0.1(1354)'
-  sha256 '6437bc2dd67e72e6a36c22435f0a7657dcefa4a1cb63029c65c98ee9979091cd'
+  version '1.1.0(1454)'
+  sha256 '2d2b28a444c923c63492dab23f48e04c8fb1aaa5d72ebb232d1748c62d380965'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
   url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.major_minor_patch}/WPS_Office_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
