### PR TITLE
Update chatology from 1.2.3 to 1.2.4

### DIFF
--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,6 +1,6 @@
 cask 'chatology' do
-  version '1.2.3'
-  sha256 'e6c5b5563c692c004b2590ad6956c36c3a8b78a3fcdb5f16d724c82f08f22ab3'
+  version '1.2.4'
+  sha256 'e5ad4c9716afb2b5c1ac56f5b103ff8b8919de0cdda0627abd141c07368df7ad'
 
   # d60ism0l33mmr.cloudfront.net was verified as official when first introduced to the cask
   url "https://d60ism0l33mmr.cloudfront.net/Chatology_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.