### PR TITLE
Update twist from 1.6.10,6257 to 1.6.11,6301

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.6.10,6257'
-  sha256 'cb4dd5181b66e39833c025f9c6d93d74e2abbce934d01a3121d18559a0e0eb1c'
+  version '1.6.11,6301'
+  sha256 '51fec3d4b0af141c896a847153417a032c8c8bb1a93f7168cdca99d916b16e4d'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.