### PR TITLE
Update postbox from 6.1.16 to 6.1.16.1

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '6.1.16'
-  sha256 '2cd1175b73b4bcb5b124abac6ff48d7278c37011e95d5931166ee6ab0dda15f3'
+  version '6.1.16.1'
+  sha256 '423e790140b8231acacd59e9ed1f5d42ed2a71f99c8f41817df187a416788ba7'
 
   # d3nx85trn0lqsg.cloudfront.net/mac was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.