### PR TITLE
Add LastPass.app v4.27.2

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,0 +1,11 @@
+cask 'lastpass' do
+  version '4.27.2'
+  sha256 'd9bc5c2efa0a73cdb59e7117d46dc1b3886e7038e28444c7c04cc28c94f19014'
+
+  url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
+  appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'
+  name 'LastPass'
+  homepage 'https://www.lastpass.com/'
+
+  app 'LastPass.app'
+end


### PR DESCRIPTION
Installs the Mac App which contains the new Safari extension.
See: https://blog.lastpass.com/2019/01/change-safari-extension.html/

Note: There was a previous cask with the same name that was removed because it was only the browser extension only and did not include the app.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
