### PR TITLE
Update brewcask-ci.rb => Enable checking of appcast inside the 'brew audit' check of Travis

### DIFF
--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -40,6 +40,7 @@ module Cask
 
           overall_success &= step "brew cask audit #{cask.token}", "audit" do
             Auditor.audit(cask, audit_download: true,
+                                audit_appcast: true,
                                 check_token_conflicts: added_cask_files.include?(path),
                                 commit_range: ENV["TRAVIS_COMMIT_RANGE"])
           end


### PR DESCRIPTION
this nable checking of appcast inside the 'brew audit' check of Travis, which was discussed here ( https://github.com/Homebrew/brew/pull/5888 ) and which has been made possible now since this ( https://github.com/Homebrew/brew/pull/5972 ) has been merged.