### PR TITLE
Update OpenInTerminal-lite from 0.4.2 to 0.4.3

### DIFF
--- a/Casks/openinterminal-lite.rb
+++ b/Casks/openinterminal-lite.rb
@@ -1,6 +1,6 @@
 cask 'openinterminal-lite' do
-  version '0.4.2'
-  sha256 '25d9b7116c5a9d4b46c7a6e49145b03e01026f03bc6babe8b6e57187e50fd231'
+  version '0.4.3'
+  sha256 'fe2d2e5892632b537118cd8bf46a0d84df137a52c2f795c9492e5d6c2a181661'
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/#{version}/OpenInTerminal-Lite.app.zip"
   appcast 'https://github.com/Ji4n1ng/OpenInTerminal/releases.atom'


### PR DESCRIPTION

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.