### PR TITLE
Update cmake from 3.14.3 to 3.14.4

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.14.3'
-  sha256 '91b94a073d9bf312c997d9f78dbc40b851225c067d81e282186e587559432b09'
+  version '3.14.4'
+  sha256 'ca56fb4d590c7518f3cb20297be92dae15ab55be4cc907b020c2d8cfe07da678'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.