### PR TITLE
Mark Packages 1.2.5 as auto-update

### DIFF
--- a/Casks/packages.rb
+++ b/Casks/packages.rb
@@ -7,6 +7,8 @@ cask 'packages' do
   name 'Packages'
   homepage 'http://s.sudre.free.fr/Software/Packages/about.html'
 
+  auto_updates true
+
   pkg 'packages/Packages.pkg'
 
   uninstall script: 'Extras/uninstall.sh'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

<img width="577" alt="auto-update" src="https://user-images.githubusercontent.com/523041/57848106-6c973180-77d8-11e9-8166-107128cca7b7.png">