### PR TITLE
Update cryptobridge from 0.18.3 to 0.18.4

### DIFF
--- a/Casks/cryptobridge.rb
+++ b/Casks/cryptobridge.rb
@@ -1,6 +1,6 @@
 cask 'cryptobridge' do
-  version '0.18.3'
-  sha256 '6c045987d7913acb71d38ca172005bc755627dbd1097992bbd88ffe45115e6c7'
+  version '0.18.4'
+  sha256 '20f79cfc4c808faf301c7f9fb9ae076a6c7de9fd9602d92473a4af322dce0008'
 
   url "https://github.com/CryptoBridge/cryptobridge-ui/releases/download/v#{version}/CryptoBridge-#{version}.dmg"
   appcast 'https://github.com/CryptoBridge/cryptobridge-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.