### PR TITLE
Update sus-inspector from 0.3.1 to 0.3.2

### DIFF
--- a/Casks/sus-inspector.rb
+++ b/Casks/sus-inspector.rb
@@ -1,6 +1,6 @@
 cask 'sus-inspector' do
-  version '0.3.1'
-  sha256 '19fd4c117f2efd631399491cff599a005df61adcd0b771c4b43747c663b56db7'
+  version '0.3.2'
+  sha256 '19e70b858263087fbdbe442cbc8d84546e0ade06bedc7a6d3aafd0cfa6730bd3'
 
   url "https://github.com/hjuutilainen/sus-inspector/releases/download/v#{version}/SUS-Inspector-#{version}.dmg"
   appcast 'https://github.com/hjuutilainen/sus-inspector/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.