### PR TITLE
Update vorta from 0.6.19 to 0.6.20

### DIFF
--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -1,6 +1,6 @@
 cask 'vorta' do
-  version '0.6.19'
-  sha256 '89cb69ad4b9fa1d93696538da626c19c3263f1826d6d2b84746ac4e3cf553393'
+  version '0.6.20'
+  sha256 '48e5e8ef136c2ce08adf86ae42c3d84e55aa4d95ba68e227b50840d52b3be2dd'
 
   url "https://github.com/borgbase/vorta/releases/download/v#{version}/vorta-#{version}.dmg"
   appcast 'https://github.com/borgbase/vorta/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.