### PR TITLE
Update workflowy from 1.2.14 to 1.2.15

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.2.14'
-  sha256 '2618e15a9bb8960e0f5e6e81b0a7b1ead3bfdf0b650393ee33a9552f0beec5cf'
+  version '1.2.15'
+  sha256 '34ec7f2513a8514895532e6c55ef77061b58baadd332474a8c682554c361e6e6'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.