### PR TITLE
Update pdfpen from 1024.1,1554588030 to 1100.27,1557951496

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,6 +1,6 @@
 cask 'pdfpen' do
-  version '1024.1,1554588030'
-  sha256 '586d81cde27480129cdbb506cba80945ef85344b288cf44e2b30379290903977'
+  version '1100.27,1557951496'
+  sha256 'cecfe326fcca348b71a1153cfd68cc46e5164e003c6249d464eeeedddb38f482'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.