### PR TITLE
Update vitalsource-bookshelf from 8.1.0.207 to 8.2.1.313

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,5 +1,5 @@
 cask 'vitalsource-bookshelf' do
-  version '8.1.0.207'
+  version '8.2.1.313'
   sha256 '777c56bec59b8caad4992881d39d79f480e2630c2ea1f72837740c3ab60ef5a3'
 
   # rink.hockeyapp.net/api/2/apps/ was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.