### PR TITLE
Fix vitalsource-bookshelf 8.2.1.313's `sha` and `url`

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,9 +1,9 @@
 cask 'vitalsource-bookshelf' do
   version '8.2.1.313'
-  sha256 '777c56bec59b8caad4992881d39d79f480e2630c2ea1f72837740c3ab60ef5a3'
+  sha256 'f1f430cd242c20f6b7e5899ab3a09b63f5631b9e843f5b33bd0c3c3c675394dc'
 
   # rink.hockeyapp.net/api/2/apps/ was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2/app_versions/162?format=zip&avtoken=285a727626fb1d89ce9afb7c0a99f20f64990f3e&download_origin=hockeyapp'
+  url 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2/app_versions/194?format=zip&avtoken=e335f2d288c8033e895eb9241733cce1281e8c51&download_origin=hockeyapp'
   appcast 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2'
   name 'VitalSource Bookshelf'
   homepage 'https://www.vitalsource.com/bookshelf-features'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.