### PR TITLE
Update yate from 4.6.1 to 4.7.0.1

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,5 +1,5 @@
 cask 'yate' do
-  version '4.7.0'
+  version '4.7.0.1'
   sha256 'c4d6f2aae89801aaccbf0a684fe4edc5e95b302b6c4bfec2ee2d633314dde91a'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'

--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '4.6.1'
-  sha256 '268b3cd4ae5ef4584cc7348e2a2c331ad30a119e7742b6631dd19ea55f09356e'
+  version '4.7.0'
+  sha256 'c4d6f2aae89801aaccbf0a684fe4edc5e95b302b6c4bfec2ee2d633314dde91a'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.