### PR TITLE
Update remote-desktop-manager-free from 6.2.1.0 to 2019.1.3.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '6.2.1.0'
-  sha256 'b177bf15efa403f61d6df1ade874e08ba7a2bbd0a4cbd629f87b3c4c4b70ded1'
+  version '2019.1.3.0'
+  sha256 'b77a63591dfc4a77cb880f47dc7eb134226ccb59edcd1ba2dc45f182e71c2acc'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.