### PR TITLE
Update touchdesigner from 099.2019.14650 to 099.2019.15230

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2019.14650'
-  sha256 'd9c271a94ed0df469b31000179cd0be314e2b8470d529f167c915f6f0f35693b'
+  version '099.2019.15230'
+  sha256 '106c27ffa58dc29136c6db5942b09a8653c4ef78098b74e017ea7b511c0650eb'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.