### PR TITLE
Update lastpass from 4.27.2 to 4.28.0

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.27.2'
-  sha256 'd9bc5c2efa0a73cdb59e7117d46dc1b3886e7038e28444c7c04cc28c94f19014'
+  version '4.28.0'
+  sha256 '817392e4d63afb389df73b971f2406fbb52750a19a11657d1fd187f4640bef91'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.