### PR TITLE
Update scrutiny from 8.3.13 to 8.3.14

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.3.13'
-  sha256 'b5a08d4c766f06f2ff910148c74007ae4e83e03a23ccc3a016c276136e68f6a4'
+  version '8.3.14'
+  sha256 '1053ef1587ecdad98a12331936807a2fcb3bd34ae18fbf51d9aa1a43f147316d'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.