### PR TITLE
Update the-battle-for-wesnoth from 1.14.8 to 1.14.8a

### DIFF
--- a/Casks/the-battle-for-wesnoth.rb
+++ b/Casks/the-battle-for-wesnoth.rb
@@ -1,6 +1,6 @@
 cask 'the-battle-for-wesnoth' do
-  version '1.14.8'
-  sha256 '6096e57d6295af33e44d41924ebff93f62c24672b288249acf8714889cf41b16'
+  version '1.14.8a'
+  sha256 '76ec73996376b4b4cf1f40e5a19b9c5e9941690abd610869c369881a5bede28f'
 
   # sourceforge.net/wesnoth was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.