### PR TITLE
Update julia from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask 'julia' do
-  version '1.1.0'
-  sha256 '8c0f232f84f2abdec7454fde304ff1ca3f250217d0ff63b195b44afd10190243'
+  version '1.1.1'
+  sha256 '2eaee0699ab8cf1bd43ef45eacb1f43f7719e925bdbf916bfa4cfd1a863ee856'
 
   url "https://julialang-s3.julialang.org/bin/mac/x64/#{version.major_minor}/julia-#{version}-mac64.dmg"
   appcast 'https://github.com/JuliaLang/julia/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.