### PR TITLE
Update axe-edit-iii from 1.01.06 to 1.01.07

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -7,12 +7,7 @@ cask 'axe-edit-iii' do
   name 'Axe-Edit III'
   homepage 'https://www.fractalaudio.com/axe-fx-iii-edit/'
 
-  pkg "Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.pkg"
-
-  uninstall pkgutil: [
-                       'com.FractalAudio.AIIIEdit.pkg',
-                       'com.FractalAudio.AIIIEdit.ReleaseNotes.pkg',
-                     ]
+  app 'Axe-Edit III.app'
 
   zap trash: '~/Library/Application Support/Fractal Audio/Axe-Edit III'
 end

--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.01.06'
-  sha256 '5b025c9407bebe6de4c7d5dd1e432daea605e86ccb7d4985862fb648f785bf2f'
+  version '1.01.07'
+  sha256 '28bceb1b64e4c0ec68dc5ef26cf1c33b496c4155503114cf012dc9b261dc875e'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.