### PR TITLE
Update amazon-workspaces from 2.5.6 to 2.5.7

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,6 +1,6 @@
 cask 'amazon-workspaces' do
-  version '2.5.6'
-  sha256 '0f98a9d262ed1b8c2f66509a05eb3ef2c9c2b9716aa2f7d9a77c76b272342ebd'
+  version '2.5.7'
+  sha256 '285328dfa8ed38dcc188167f59307de302f3ece1d20161fcf7778808071e9fbb'
 
   # d2td7dqidlhjx7.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.