### PR TITLE
Update browserosaurus from 5.3.1 to 5.4.3

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '5.3.1'
-  sha256 '6f3f525048e0481a1aabfde81a0bea5708fb4a7c9a39f8c30cb00c4db2195c4d'
+  version '5.4.3'
+  sha256 'ded033d1912885c6195e82131b790c0d1dc698d77ec8c98be8960697ea0adbb5'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.