### PR TITLE
Update clashx from 1.9.10 to 1.9.11

### DIFF
--- a/Casks/clashx.rb
+++ b/Casks/clashx.rb
@@ -1,6 +1,6 @@
 cask 'clashx' do
-  version '1.9.10'
-  sha256 '6931e87a00754eb144d6ebbaf55c408b254981f3dcf3102dd63fde59a7a8a386'
+  version '1.9.11'
+  sha256 '56f798f97ca08dcbf1c62fb56cf1a076b3a21f225e50c3d3c3da8fcd527d712b'
 
   url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   appcast 'https://github.com/yichengchen/clashX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.