### PR TITLE
Update gns3 from 2.1.16 to 2.1.17

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.16'
-  sha256 'ce4aa0895223a42c26baf9a8dd13ac6665437c42663a0e3dfc7d6ddb065f0dee'
+  version '2.1.17'
+  sha256 'e3429a4ee5efddf690b98473af99d25e859e4a284567487304aa7a3ed00d0167'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.