### PR TITLE
Update gzdoom from 4.1.1 to 4.1.2

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '4.1.1'
-  sha256 'e53cabe3bf0051263d15d8a8d09af735e74d7c1d32d4cf8e00acaaef1de0aa67'
+  version '4.1.2'
+  sha256 'd0cd2fd4e83be135301229b2e748c7d168670d519aafb66f8fa6b6547a313392'
 
   url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.