### PR TITLE
Update seashore from 2.4.2 to 2.4.3

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.4.2'
-  sha256 '5de45c6ea299722a05d0a6984eba706901bc63b0d8f120bb3b8dc2bec616dd15'
+  version '2.4.3'
+  sha256 '38b317c33bb4de88c54c5bee64c4b446aca9026e3c9314e19339cfd26b1e40fa'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.