### PR TITLE
Update swimat from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/swimat.rb
+++ b/Casks/swimat.rb
@@ -1,6 +1,6 @@
 cask 'swimat' do
-  version '1.6.1'
-  sha256 '712719277aea8209bec2bea88438af3a391cacd7dd5a0b490b840868d4f3362d'
+  version '1.6.2'
+  sha256 '0bd8f283d5d396efe8a479910264ade87bf814cf51e65e46bf58c521206a7663'
 
   url "https://github.com/Jintin/Swimat/releases/download/v#{version}/Swimat.zip"
   appcast 'https://github.com/Jintin/Swimat/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.