### PR TITLE
Update windows95 from 2.0.0 to 2.1.0

### DIFF
--- a/Casks/windows95.rb
+++ b/Casks/windows95.rb
@@ -1,7 +1,7 @@
 cask 'windows95' do
   # note: "95" is not a version number, but an intrinsic part of the product name
-  version '2.0.0'
-  sha256 '9f2ce72b7ec7a79cb3521bd75722b39f99a4234784dc232667ae682e6104637b'
+  version '2.1.0'
+  sha256 'e177a52041ff7b1952ad230c5fc71a94935d65acd8bf8558bf5b7f0cff82f583'
 
   url "https://github.com/felixrieseberg/windows95/releases/download/v#{version}/windows95-macos-#{version}.zip"
   appcast 'https://github.com/felixrieseberg/windows95/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.