### PR TITLE
Update framer-x from 31785,1557403596 to 31932,1558096086

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '31785,1557403596'
-  sha256 '0a61c61f097d42ec618ca4df2dfd0bd5c0e7e0c331ba57c1f28f96aa5648557d'
+  version '31932,1558096086'
+  sha256 '8e10354597e2236f28281bd29b3a0605614d1f7fa53386b912649aecb185942e'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.