### PR TITLE
Update kite from 0.20190509.1 to 0.20190516.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190509.1'
-  sha256 'c6919fecc6d48f0feb8d93ae456746e10eaeeed43ed8b9acab566e3b334fe266'
+  version '0.20190516.0'
+  sha256 'ec9ff857a782fd909504f75e9edbd3c114cdcc47bcbe8bc62093e71f67e76916'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.