### PR TITLE
Update pdfpen from 1100.27,1557951496 to 1101.0,1558019483

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,6 +1,6 @@
 cask 'pdfpen' do
-  version '1100.27,1557951496'
-  sha256 'cecfe326fcca348b71a1153cfd68cc46e5164e003c6249d464eeeedddb38f482'
+  version '1101.0,1558019483'
+  sha256 '9d38da68cdc10b95c15dad0b1a5f4d1f5dace8dad7ac5f49e863afe3ad2be2d9'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.