### PR TITLE
Update pdfpenpro from 1100.27,1557951331 to 1101.0,1558019343

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1100.27,1557951331'
-  sha256 '86b7f14e220af70c942d4f55a22d359a4be8e47d247d79f5d37d9f14717a3e06'
+  version '1101.0,1558019343'
+  sha256 '7ca7c0530201d242b60c1376e79aa8d2ac8e4fc44a77ec0f38d960c0e256e7b6'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.