### PR TITLE
Update powerphotos from 1.6 to 1.6.1

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -12,8 +12,8 @@ cask 'powerphotos' do
     sha256 'ed9be64f4cb5a3d3848ad5177947bd8cd33e36846ea36266ef9d4d7b46813538'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.6'
-    sha256 'e9a37891491ed859b1a8a2cba406fb20cf1b3f54ca3dd09c4d301616e356f45b'
+    version '1.6.1'
+    sha256 '32f3f7b95afe33a03ab6e51a3c113c6804796c0f9f0de42ca79ad47fc8c34db2'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.