### PR TITLE
Update coteditor from 3.7.3 to 3.7.4

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -6,8 +6,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.7.3'
-    sha256 '1f0ba5c7ed3d731c60b6f8f0e838189ce92c2beedad07d26b2bebd10265c8d8a'
+    version '3.7.4'
+    sha256 '4482b825a8f0f400b0b7cad12bf57f071bf080ad79b229bd773cc5f783cc3ab3'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.