### PR TITLE
Update mkvtoolnix from 33.1.0 to 34.0.0

### DIFF
--- a/Casks/mkvtoolnix.rb
+++ b/Casks/mkvtoolnix.rb
@@ -1,6 +1,6 @@
 cask 'mkvtoolnix' do
-  version '33.1.0'
-  sha256 '181b8a126dff77a9e01ba248dc746bc67552d38c1701c888f500b27d4c7f0887'
+  version '34.0.0'
+  sha256 '8528a6d56a51919a55ef30e505c717c43579c2fa766efd75940b8dd8169ae0d8'
 
   url "https://mkvtoolnix.download/macos/MKVToolNix-#{version}.dmg"
   appcast 'https://www.bunkus.org/blog/feed/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.