### PR TITLE
Update advancedrestclient from 13.0.6 to 13.0.7

### DIFF
--- a/Casks/advancedrestclient.rb
+++ b/Casks/advancedrestclient.rb
@@ -1,6 +1,6 @@
 cask 'advancedrestclient' do
-  version '13.0.6'
-  sha256 'f5c851323730f0b9301e4e9087ea85074ae308dfebbfcbe70b7c1aba8ebd8364'
+  version '13.0.7'
+  sha256 '1abde754de131b3d2929036950bc363ceaa737abf140259a0938a026d5406c23'
 
   # github.com/advanced-rest-client/arc-electron was verified as official when first introduced to the cask
   url "https://github.com/advanced-rest-client/arc-electron/releases/download/v#{version}/arc-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.