### PR TITLE
Update augur from 1.12.0 to 1.13.0

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.12.0'
-  sha256 'c4382e68be6c147bbd8f918556ba0ee3c7ec6bf617149cf9954da98a09dc0f46'
+  version '1.13.0'
+  sha256 'ef83f8d362995139c74457c3f75d09daa14e0c7277c943289924672ed15da517'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.