### PR TITLE
Update jd-gui from 1.4.3 to 1.5.0

### DIFF
--- a/Casks/jd-gui.rb
+++ b/Casks/jd-gui.rb
@@ -1,6 +1,6 @@
 cask 'jd-gui' do
-  version '1.4.3'
-  sha256 'b4eea35d153a81cedc03921605743b520a30ee79b3a59ed69a22a2c21905b5ac'
+  version '1.5.0'
+  sha256 'f86183a7986f985e8188aa34c9fc724355afe031e5174090c4acf12443d8d762'
 
   # github.com/java-decompiler/jd-gui was verified as official when first introduced to the cask
   url "https://github.com/java-decompiler/jd-gui/releases/download/v#{version}/jd-gui-osx-#{version}.tar"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.