### PR TITLE
Update mycrypto from 1.6.5 to 1.6.6

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.6.5'
-  sha256 'a6e796a43ce11d233f875aee4ab697642808c5067526d8245a2a40a5f039b580'
+  version '1.6.6'
+  sha256 '54ec8e7ed4849ad95768567aa89cd3935f3eb3873879fecb03424cbedb1b4905'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.