### PR TITLE
Update profilecreator from 0.2.5-beta.10 to 0.3.0,201905171401-beta

### DIFF
--- a/Casks/profilecreator.rb
+++ b/Casks/profilecreator.rb
@@ -1,8 +1,8 @@
 cask 'profilecreator' do
-  version '0.2.5-beta.10'
-  sha256 'b493fe7597ce6df0d95b22420a630dba920459e9fec8f95062cfb961555da640'
+  version '0.3.0,201905171401-beta'
+  sha256 'ebdf603bca3b6c72f436c93944d1b2b7342e410ff8509ad970cea4606d39112b'
 
-  url "https://github.com/erikberglund/ProfileCreator/releases/download/v#{version}/ProfileCreator_v#{version}.dmg"
+  url "https://github.com/erikberglund/ProfileCreator/releases/download/v#{version.before_comma}/ProfileCreator_v#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/erikberglund/ProfileCreator/releases.atom'
   name 'ProfileCreator'
   homepage 'https://github.com/erikberglund/ProfileCreator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.