### PR TITLE
Update fman from 1.5.8 to 1.6.0

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.5.8'
-  sha256 '27d38fbf1002b93730d10a3ba15a2c14773d40627b573da91c0b1ac1f6f44744'
+  version '1.6.0'
+  sha256 '57b06170cc822367fe3984530c8036d31278439d4d397153e6d5e75e96e25977'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.