### PR TITLE
Update memory-tracker-by-timely from 1.2.5 to 1.2.6

### DIFF
--- a/Casks/memory-tracker-by-timely.rb
+++ b/Casks/memory-tracker-by-timely.rb
@@ -1,6 +1,6 @@
 cask 'memory-tracker-by-timely' do
-  version '1.2.5'
-  sha256 '6f8e21fb210e29876293d00af590a6336f0c7b82fed99d053249f045047980a3'
+  version '1.2.6'
+  sha256 '1948e319b139828be9913ca2878a20a1e49eba8a9ba57e900f750bc4973d6132'
 
   # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.