### PR TITLE
Update texturepacker from 4.12.1 to 5.0.0

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -1,6 +1,6 @@
 cask 'texturepacker' do
-  version '4.12.1'
-  sha256 '6eb8f9beb30c793cd720c66f43f38a29844ffd5dc6be3428e5d8ff4b6cb7f690'
+  version '5.0.0'
+  sha256 '27399322354ac62fbdc59418c269b5c8779edceeb588c32d19a58e4b498ce8c5'
 
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/TexturePacker/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.