### PR TITLE
Update vectoraster from 7.4.0 to 7.4.1

### DIFF
--- a/Casks/vectoraster.rb
+++ b/Casks/vectoraster.rb
@@ -1,6 +1,6 @@
 cask 'vectoraster' do
-  version '7.4.0'
-  sha256 '8365d3bb056bc493783acf03090bd35e9b1a5879f13c8992820b725bb4bc5488'
+  version '7.4.1'
+  sha256 '70251678707654f252c9b0e2d070300cd206b20153c7c059209fb6065bf50b15'
 
   url "https://www.lostminds.com/downloads/vectoraster#{version.major}.dmg"
   appcast "https://www.lostminds.com/vectoraster#{version.major}/version_history.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.