### PR TITLE
Update clockify from 2.2.5.69 to 2.2.6.73

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
-  version '2.2.5.69'
-  sha256 'dc35b3a92338ae794825c1018f836c653e88a1613738592fcd09a9260ddd1a0a'
+  version '2.2.6.73'
+  sha256 'd83bcfb29c79418eb76150d7c01a54f0321a4bc25269fbc92d88ac32a3c82531'
 
   url "https://clockify.me/downloads/ClockifyDesktop_#{version.no_dots}.zip"
   name 'Clockify'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.