### PR TITLE
Update peakhour from 4.1.2,34599 to 4.1.3,34766

### DIFF
--- a/Casks/peakhour.rb
+++ b/Casks/peakhour.rb
@@ -1,6 +1,6 @@
 cask 'peakhour' do
-  version '4.1.2,34599'
-  sha256 'add77b202dc455c75860e05fe6af84a347caf6c635852624136a66ecff51f678'
+  version '4.1.3,34766'
+  sha256 '8d85cc111acf15d94e33c0e29a365025ac8a792b41d63c67a413a334aba3e902'
 
   url "https://updates.peakhourapp.com/releases/PeakHour%20#{version.before_comma}.zip"
   appcast "https://updates.peakhourapp.com/PeakHour#{version.major}Appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.