### PR TITLE
Update qownnotes from 19.5.2,b4258-143439 to 19.5.3,b4263-074706

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.5.2,b4258-143439'
-  sha256 'd143d17dbc88e9c80e931b026a38e964d8e6a2837d430097e9e17474ed6cdefe'
+  version '19.5.3,b4263-074706'
+  sha256 'b064585f3e2ed7f82fc0846e097c3bccf524651fef8df8ca8bb2fc59ffcea790'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.