### PR TITLE
Update waterfox from 56.2.9 to 56.2.10

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -4,9 +4,9 @@ cask 'waterfox' do
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"
-  appcast 'https://www.waterfoxproject.org/en-US/waterfox/new/'
+  appcast 'https://www.waterfox.net/releases/'
   name 'Waterfox'
-  homepage 'https://www.waterfoxproject.org/en-US/'
+  homepage 'https://www.waterfox.net'
 
   app 'Waterfox.app'
 

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -6,7 +6,7 @@ cask 'waterfox' do
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"
   appcast 'https://www.waterfox.net/releases/'
   name 'Waterfox'
-  homepage 'https://www.waterfox.net'
+  homepage 'https://www.waterfox.net/'
 
   app 'Waterfox.app'
 

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.2.9'
-  sha256 '9cad039a395cc42edaf889f30426fbae07a259cf239afd8eb3d69a443dc1e982'
+  version '56.2.10'
+  sha256 '7c75729f186d4467d8c85aea12f0ae2142b295a5f3f51ae33c961c3ad6e35142'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.