### PR TITLE
add real version number to upwork.rb

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,8 +1,8 @@
 cask 'upwork' do
-  version '5_2_3_717_7tq7l0sg49p0kixc'
+  version '3.1.9,5_2_3_717_7tq7l0sg49p0kixc'
   sha256 'a4588d607abd3e8616af117b962047238dfdfb4e0d85d21764ab4c011c479af9'
 
-  url "https://updates-desktopapp.upwork.com/binaries/v#{version}/Upwork.dmg"
+  url "https://updates-desktopapp.upwork.com/binaries/v#{version.after_comma}/Upwork.dmg"
   name 'Upwork'
   homepage 'https://www.upwork.com/'
 


### PR DESCRIPTION
the download-token is a bit confusing - it looks like the app version should be something like 5.2.3 … can we add the "real" version number here?  