### PR TITLE
Added GSuite shortcuts to Drive File Stream zap

### DIFF
--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -15,6 +15,9 @@ cask 'google-drive-file-stream' do
             pkgutil:    'com.google.drivefs'
 
   zap trash: [
+               '/Applications/Google Docs.app',
+               '/Applications/Google Sheets.app',
+               '/Applications/Google Slides.app',
                '~/Library/Application Support/Google/DriveFS',
                '~/Library/Caches/com.google.drivefs',
                '~/Library/Preferences/Google Drive File Stream Helper.plist',

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -12,8 +12,18 @@ cask 'google-drive-file-stream' do
 
   uninstall login_item: 'Google Drive File Stream',
             quit:       'com.google.drivefs',
-            pkgutil:    ['com.google.drivefs', 'com.google.drivefs.shortcuts', 'com.google.pkg.Keystone'],
-            launchctl:  ['com.google.keystone.agent', 'com.google.keystone.system.agent', 'com.google.keystone.daemon', 'com.google.keystone.xpcservice', 'com.google.keystone.system.xpcservice', 'com.google.keystone.daemon', 'com.google.keystone.system.agent', 'com.google.keystone.system.xpcservice']
+            pkgutil:    [
+                          'com.google.drivefs',
+                          'com.google.drivefs.shortcuts',
+                          'com.google.pkg.Keystone'
+                        ],
+            launchctl:  [
+                          'com.google.keystone.agent',
+                          'com.google.keystone.system.agent',
+                          'com.google.keystone.daemon',
+                          'com.google.keystone.xpcservice',
+                          'com.google.keystone.system.xpcservice',
+                        ]
 
   zap trash: [
                '~/Library/Application Support/Google/DriveFS',

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -12,12 +12,10 @@ cask 'google-drive-file-stream' do
 
   uninstall login_item: 'Google Drive File Stream',
             quit:       'com.google.drivefs',
-            pkgutil:    'com.google.drivefs'
+            pkgutil:    ['com.google.drivefs', 'com.google.drivefs.shortcuts', 'com.google.pkg.Keystone'],
+            launchctl:  ['com.google.keystone.agent', 'com.google.keystone.system.agent', 'com.google.keystone.daemon', 'com.google.keystone.xpcservice', 'com.google.keystone.system.xpcservice', 'com.google.keystone.daemon', 'com.google.keystone.system.agent', 'com.google.keystone.system.xpcservice']
 
   zap trash: [
-               '/Applications/Google Docs.app',
-               '/Applications/Google Sheets.app',
-               '/Applications/Google Slides.app',
                '~/Library/Application Support/Google/DriveFS',
                '~/Library/Caches/com.google.drivefs',
                '~/Library/Preferences/Google Drive File Stream Helper.plist',


### PR DESCRIPTION
A change to Google Drive File Stream adds shortcuts to the GSuite apps (Google Docs, Slides, and Sheets) to the Applications folder. These are not removed on uninstall, so this updated zap stanza takes care of that.

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
