### PR TITLE
Fix FreeCAD 0.18.1 (16110) SHA256 hash

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
   version '0.18.1,16110'
-  sha256 '1cbafba2177eee06a742fd6b75d32a0cb81e77f45de07024b4f2282f5a2086b1'
+  sha256 '7ac248f792e0b324515f2e70fa064baa976c0519d570584220b5ee7e08ed04c0'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).