### PR TITLE
Update eiskaltdcpp from 2.2.10-569-macOS10.12 to 2.2.10-583-macOS10.12

### DIFF
--- a/Casks/eiskaltdcpp.rb
+++ b/Casks/eiskaltdcpp.rb
@@ -1,6 +1,6 @@
 cask 'eiskaltdcpp' do
-  version '2.2.10-569-macOS10.12'
-  sha256 '94b2214cd36179752d8e944d143af33248dc62f8dcfdac9023349d4b2e60eddd'
+  version '2.2.10-583-macOS10.12'
+  sha256 'fb272380d0892116cfa3a8bfbd4ba746423e7102d1c8ee83f0c7d1c13bc62aad'
 
   url "https://downloads.sourceforge.net/eiskaltdcpp/EiskaltDC++-#{version}-x86_64.dmg"
   appcast 'https://sourceforge.net/projects/eiskaltdcpp/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.