### PR TITLE
Update oracle-jdk-javadoc from 11.0.2,9:f51449fcd52f4d52b93a989c5c56ed3c to 12.0.1,12:69cfe15208a647278a19ef0990eea691

### DIFF
--- a/Casks/oracle-jdk-javadoc.rb
+++ b/Casks/oracle-jdk-javadoc.rb
@@ -1,6 +1,6 @@
 cask 'oracle-jdk-javadoc' do
-  version '11.0.2,9:f51449fcd52f4d52b93a989c5c56ed3c'
-  sha256 '8723e26bf097b4b9375851338270870d3b5ef1a3843f0631597adb9039308083'
+  version '12.0.1,12:69cfe15208a647278a19ef0990eea691'
+  sha256 'd77c9d9b38da262dbef88424d6d7e138a27efa26522313ec762126fde560d63f'
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.