### PR TITLE
Update netron from 3.0.7 to 3.0.8

### DIFF
--- a/Casks/flutter.rb
+++ b/Casks/flutter.rb
@@ -1,0 +1,11 @@
+cask 'flutter' do
+  version '1.5.4-hotfix.2'
+  sha256 '6a2554c3754322848aa6b38e449c42d5aa9149ea82bf97f168782f68a8efa0b1'
+
+  # storage.googleapis.com/flutter_infra/releases/stable/macos/flutter_macos_v was verified as official when first introduced to the cask
+  url "https://storage.googleapis.com/flutter_infra/releases/stable/macos/flutter_macos_v#{version}-stable.zip"
+  name 'flutter'
+  homepage 'https://flutter.io/'
+
+  binary 'flutter/bin/flutter', target: 'flutter'
+end

--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.0.7'
-  sha256 'e4cac435cf16d36f4444e25b9846fa7bfe61cf130a9e6fd50d5698df71942a16'
+  version '3.0.8'
+  sha256 'a1a65006f696ab218b29d7cb09e4de59a0b5ab09e230031e190347fb501d3df2'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.