### PR TITLE
Update ubersicht from 1.3.56 to 1.4.57

### DIFF
--- a/Casks/ubersicht.rb
+++ b/Casks/ubersicht.rb
@@ -1,6 +1,6 @@
 cask 'ubersicht' do
-  version '1.3.56'
-  sha256 '85be4f4273bfa69e424b996e67729b3590f3876d43d5b9ec209ba002a3cff78a'
+  version '1.4.57'
+  sha256 'e4aeec6a6a466c8eac311f37882545d7616f1645549c8d774cfbbc76a029606b'
 
   url "http://tracesof.net/uebersicht/releases/Uebersicht-#{version}.app.zip"
   appcast 'http://tracesof.net/uebersicht/updates.xml.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.