### PR TITLE
Update diskcatalogmaker from 7.4.13 to 7.4.14

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.4.13'
-  sha256 'bf79d87d943ef9b6bfa97df17238d2fa57d0fca9774b12c4492c89b5a0303b79'
+  version '7.4.14'
+  sha256 '44bb8d95d9dd9457c236328ca33d2f74dfac2cf42ed87c29512fabe1d3a02c37'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://fujiwara.sakura.ne.jp/info/appcast/DiskCatalogMaker.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.