### PR TITLE
Update edex-ui from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/edex-ui.rb
+++ b/Casks/edex-ui.rb
@@ -1,6 +1,6 @@
 cask 'edex-ui' do
-  version '2.2.1'
-  sha256 '5ac85a8d3a866520a170842b3baed6673b930101c5acf62f2a173aaa741f4319'
+  version '2.2.2'
+  sha256 '5a7d232331dd06d61db39568e02f4bd3fa27262cb653f30ac6ff3b0ab570872c'
 
   url "https://github.com/GitSquared/edex-ui/releases/download/v#{version}/eDEX-UI.MacOS.Image.dmg"
   appcast 'https://github.com/GitSquared/edex-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.