### PR TITLE
Update headset from 2.1.2 to 2.1.3

### DIFF
--- a/Casks/headset.rb
+++ b/Casks/headset.rb
@@ -1,6 +1,6 @@
 cask 'headset' do
-  version '2.1.2'
-  sha256 '715feb2f04eda52d8044b9b968bfbb0a11556c7913aa6792bcd08a762097f90a'
+  version '2.1.3'
+  sha256 '3a0c136df3d491dd53e13440341cec54a2b262eb4ec7e44f19ecd03e6d37ad72'
 
   # github.com/headsetapp/headset-electron was verified as official when first introduced to the cask
   url "https://github.com/headsetapp/headset-electron/releases/download/v#{version}/Headset-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.