### PR TITLE
Update get-backup-pro from 3.4.10 to 3.4.11

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,6 +1,6 @@
 cask 'get-backup-pro' do
-  version '3.4.10'
-  sha256 '772c0c409f3a23abc781876b195becdb4e99fe3e1c951f33dc45b79e7fff2fb1'
+  version '3.4.11'
+  sha256 '0f1c75cb1406887a0c78dc478131a9cca9c5902ac3aae9b855a97c35be639dd4'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.