### PR TITLE
Update gpxsee from 7.6 to 7.7

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.6'
-  sha256 'c918506d235f407d6c3a806d7837c43f80070e1525c6f7bca714b1a092f5e853'
+  version '7.7'
+  sha256 'bb0a2c6c19bd8fcb9732ca0afa457358fa3226a5c06081444ac83b331ce99920'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.