### PR TITLE
Update ringcentral from 11.0.1 to 11.0.2

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '11.0.1'
-  sha256 'e24090317a0e3a83b7096f1092fc061077fead343e9445f17a2ca0b040086e2c'
+  version '11.0.2'
+  sha256 '23612cd8bb036d99bd127161e82f82367053e811549203aad8b1e75183ac1c65'
 
   url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads.ringcentral.com/sp/RingCentralForMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.