### PR TITLE
Update Firefox 66.0 to 67.0

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '66.0.5'
+  version '67.0'
 
   language 'cs' do
-    sha256 '036f4108077dd1e9a42c90fe8ca27822cdfe0ba2b61795999bdaf0f7b132c03c'
+    sha256 'ba63dabfe0749651db5a4a8e5b633aab830cb8aefb80aa7b8336f4a64a8b3efd'
     'cs'
   end
 
   language 'de' do
-    sha256 '6e69eaf5f17c6ec39538245e09cb28dff49c87b2fd4c3ebff9245872aec7fbb0'
+    sha256 '01873b081f9130a654b5150cfdc1239392c6d05b68ee22f7eb43407dc07bc547'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'e873dbdd816a55c6ee8873f005708e48f7b06fd2d40d8ca229da59611d3e89e0'
+    sha256 '12e666a95c30f5d48b001dd8877af34da64c8f2776d4958d2425f5aa39b7ac16'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'cabe2fe0832df2ef1c81a953c28844d78c38d5046ca7cfbaf6601d1c1a465235'
+    sha256 '3fcf0db18898ae0beef97d0a3ae631afc9b6324b251ff575e78787c335ef8fe3'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '7c6bc5983c2775d111819040ecca084a386a08af3cde50119e0be7022504a01d'
+    sha256 '76f94d6b9e19a44508c0282575ed9b033cd0c8ea58bab208d3ecc02018edbfcd'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '2130db562de6c763ce3708f813f5d2a5d93986604e5f71ddf12279136d572dd9'
+    sha256 '179cf1d7877c2c1a39494225f9ae336374f72d0feee156bfbd720cf59d823ce8'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 'bb3a641113ab77e1fc8b2c20143e70f3d9568b8b8d92aa6db90e133d61e291a9'
+    sha256 '7f87272b5cea2b55c070d40de3c1816c56a7a2a75e56724d0594c91b3e0efb8e'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '32e0cbd4292457f11e31f1b4eb48a2bfe51ceec7577bc56ebce174062463d143'
+    sha256 '58c383146d41a6f16a5802a6ee0dbe6002be378946a5a835645f62e45c5255f3'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 'd0d312b60d591ed4c81bc6fff110c1ba4fd1c5d571362243b7518dd65264b894'
+    sha256 '0a7e93aec9f48e091f6eaf165761765bab6f6f465c492d80b01da6434ce19051'
     'fi'
   end
 
   language 'fr' do
-    sha256 '8a0b7b6370a2e5d4856888606ee5ff5442f169afe8b0d0d9ce962e88593032b1'
+    sha256 'dc26e5db415e72b4078b5abe64b9b007acca4a626b05043099ba273e41a50f62'
     'fr'
   end
 
   language 'gl' do
-    sha256 'a153979cd4f755e63fe4f6c22bca3d4c4d908ce267c5fa5083f45afbda371e45'
+    sha256 '8b1a4cf106fd2957bf952c41d4eeaed4604249d3727e7a06f12c50122f653dcb'
     'gl'
   end
 
   language 'in' do
-    sha256 '3e456dbe33fb4a5a8aea8fc4bb870d7429b15be505139de6042eec352a3bcf00'
+    sha256 'b2f822bbad958972b3e966f54571f799ac12fc75329c34ddee6cc03903d4cf8e'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '4cd34d23b8918761877dedfcc1e825f18c10cc429db0d2a2c9889d98093f895e'
+    sha256 '9a64fc97db62e5e8118d8c89ed91e3ebfc40f0576dc879d7fc99a069e57155b8'
     'it'
   end
 
   language 'ja' do
-    sha256 '508cf240caa09b57f02903c631bbb3f0fe89a6fb50982769251ffb40bbaf1006'
+    sha256 '9e24791b760df5c817f4fea961eff4303b2bbee19bfdcf1fd168e5b13e6a3320'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '200375049d18675bfb876d90443b4e6118ac7f83e75530b7d1aaf61220087133'
+    sha256 '53aeb82c45dd54549e6e3973ec8da679e7211c673bcd8b53146f1a25b7fe1f3a'
     'ko'
   end
 
   language 'nl' do
-    sha256 '8cb1520ee2e0aad8585a9eafb9b1943778b77fe4180dadaff7fbb1e714b02549'
+    sha256 'c61044f500a309ef0d7ea174adf617070f9bef9d378559fe1fd87f324742d001'
     'nl'
   end
 
   language 'pl' do
-    sha256 'f5e0f2648017a938b0256b83b6eba2cce5b147239fb09228f98fc60a546c97bc'
+    sha256 '9e278274d16f68b3ffde878d82ce37d66ec4e409d17285addd6fe712e475c7e9'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '66bc98cffee49e452f0162df467b5fc4109868f26211e926c6c7a65b14799474'
+    sha256 'bc95ec4c867a9251b052312798e3ea93115f0ea6657d4baddaca8fd3247c3a27'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '118ae9ed8e6573ac742a975c6028e10758d05a79ebe4ba8734e342b333e5eb12'
+    sha256 '2a41afe57051a3490f6b82476038afa7beb78e7df2fac948175d954cb2781179'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'fefb4c8aeed27b3e535308974e06a22c34942768bffbac48dc0cb2fbe9d7d0f0'
+    sha256 '1372ef5ef6416fd1efd1ab5e7dd21e68215cc56be6e6639584b9c1d80b5ccb47'
     'ru'
   end
 
   language 'tr' do
-    sha256 '70d68ffc6ff97eec5830bebfb2fe17be762d8af0e2202f632116a5321e057a9c'
+    sha256 '1b23a393f72b4f5f2f8e55916da8bd2c62635f56b15ff39582d0594edff3d861'
     'tr'
   end
 
   language 'uk' do
-    sha256 'afc247e505ad58366c3ff05b50d015d3cb8655273034dd48af4aae66de96d0e9'
+    sha256 '2b8fef55060386a1a1e08cf749870df3b82ced7ed7213141c7c5f742c57b64ed'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '01718e17d3a3f6e9485e3d77ed286e9a4d5a8103a23064c99fe08c513a85109b'
+    sha256 '73779aae6db79c28215f41b564871860bff487a79de8311c3af765915ae9d687'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '6ea30a7dd39688b23fce04d45835e1f284df872b6a43a8e23eb373a56f4aa40b'
+    sha256 'ada8ca242dcbaccc6263f441831c4e559b4cd64a675d67e38e13247f30a8839f'
     'zh-CN'
   end
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

**NOTE:** This update will be _officially_ released tomorrow AM, the download is available ahead of time baring any unforeseen issues.