### PR TITLE
Update lbry from 0.32.1 to 0.32.2

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,10 +1,10 @@
 cask 'lbry' do
-  version '0.32.1'
-  sha256 '02c304e62a2687212e69e0fbfcb44ca541e30428a016864bdd857f7ed017e935'
+  version '0.32.2'
+  sha256 'daa80d2e57c06260c069197360b5ff18f4338d78af9d00f06e9018d52ad15c80'
 
-  # github.com/lbryio/lbry-app was verified as official when first introduced to the cask
-  url "https://github.com/lbryio/lbry-app/releases/download/v#{version}/LBRY_#{version}.dmg"
-  appcast 'https://github.com/lbryio/lbry-app/releases.atom'
+  # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
+  url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"
+  appcast 'https://github.com/lbryio/lbry-desktop/releases.atom'
   name 'LBRY'
   homepage 'https://lbry.io/'
 

--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -6,7 +6,7 @@ cask 'lbry' do
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"
   appcast 'https://github.com/lbryio/lbry-desktop/releases.atom'
   name 'LBRY'
-  homepage 'https://lbry.io/'
+  homepage 'https://lbry.com/'
 
   app 'LBRY.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.