### PR TITLE
Update navicat-for-mariadb from 12.1.18 to 12.1.20

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.18'
-  sha256 'a252c67a1c0813c45d69bcd24fab09e45cb86cb46d8bc6fee08048de5689250a'
+  version '12.1.20'
+  sha256 'b8af177befcdc88f2f4e783eb86ba4bc9aec2ad85ccb49fe235e9b82b659f014'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.