### PR TITLE
Update navicat-for-oracle from 12.1.18 to 12.1.20

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '12.1.18'
-  sha256 'f44e1d285c6f5a7853b285e523aff4dc4a413d44f4376f15d509e8f16720abd8'
+  version '12.1.20'
+  sha256 '1d9f222968ff60c40472d18a4fea5aef8ca16b711a725bdb1fa66f50ca53d00f'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.