### PR TITLE
Update navicat-for-postgresql from 12.1.18 to 12.1.20

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '12.1.18'
-  sha256 '5149e6c4a41a6125bc5f8314f48551fbe9b64a3eaac1e5310a36765ccc45f561'
+  version '12.1.20'
+  sha256 '26f67386c6ec520dee9a8aac167c032e6d6af517233798d3e37461bc91aef522'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.