### PR TITLE
Update uninstallpkg from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/uninstallpkg.rb
+++ b/Casks/uninstallpkg.rb
@@ -1,9 +1,9 @@
 cask 'uninstallpkg' do
-  version '1.1.5'
-  sha256 '8a92278d73334007d1df581584f7364adede9b74d4d46580055a435484c459cd'
+  version '1.1.6'
+  sha256 '6c565f556383b3ab7ea878a43f3fb25656fdbbe4a4b466f936a43470482594da'
 
   url "https://www.corecode.io/downloads/uninstallpkg_#{version}.zip"
-  appcast 'https://macupdater.net/uninstallpkg/uninstallpkg.xml'
+  appcast 'https://www.corecode.io/uninstallpkg/uninstallpkg.xml'
   name 'UninstallPKG'
   homepage 'https://www.corecode.io/uninstallpkg/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.