### PR TITLE
Update trezor-bridge from 2.0.25 to 2.0.27

### DIFF
--- a/Casks/trezor-bridge.rb
+++ b/Casks/trezor-bridge.rb
@@ -1,6 +1,6 @@
 cask 'trezor-bridge' do
-  version '2.0.25'
-  sha256 '696cd6b3e7e34a8b72c57b4317a3ef12bb3bb1c6bbce72212a17192e29e2fc2d'
+  version '2.0.27'
+  sha256 'a8a5352f888467cb1bc3b4273ee26c7f0da2a58f60e31aeffea46153aa03be07'
 
   url "https://wallet.trezor.io/data/bridge/#{version}/trezor-bridge-#{version}.pkg"
   appcast 'https://wallet.trezor.io/data/bridge/latest.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.