### PR TITLE
Update protege from 5.5.0-beta-9 to 5.5.0

### DIFF
--- a/Casks/protege.rb
+++ b/Casks/protege.rb
@@ -1,6 +1,6 @@
 cask 'protege' do
-  version '5.5.0-beta-9'
-  sha256 'caba39e1c84a02a3160c288a9ccb08537ade57f65c73c0b07dae1d7ade4f2f58'
+  version '5.5.0'
+  sha256 '9975fd2e361e70e5ed76f0278ec03d8ec23455b0aa70027276b169823a3b08b8'
 
   # github.com/protegeproject/protege-distribution was verified as official when first introduced to the cask
   url "https://github.com/protegeproject/protege-distribution/releases/download/v#{version}/Protege-#{version}-os-x.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.