### PR TITLE
Update prusaslicer from 2.0.0-rc2,201905190649 to 2.0.0,201905201652

### DIFF
--- a/Casks/prusaslicer.rb
+++ b/Casks/prusaslicer.rb
@@ -1,6 +1,6 @@
 cask 'prusaslicer' do
-  version '2.0.0-rc2,201905190649'
-  sha256 '9b6d8d42c6ea63a19682b0aa4cfd214d1fce9be2a5b093d0c94707e3a5f52987'
+  version '2.0.0,201905201652'
+  sha256 '2882e0e58be97c50570f9aca931f2ea6eff206c748ce94bb42ff341dd4938c4b'
 
   # github.com/prusa3d/PrusaSlicer was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/PrusaSlicer/releases/download/version_#{version.before_comma}/PrusaSlicer-#{version.before_comma}+-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.