### PR TITLE
Update unity-download-assistant from 2019.1.2f1,3e18427e571f to 2019.1.3f1,dc414eb9ed43

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.1.2f1,3e18427e571f'
-  sha256 'ab4354adbe8352116f924fde978e96572fc63716e92323221a9e77fada470a28'
+  version '2019.1.3f1,dc414eb9ed43'
+  sha256 'b9cb832c0477e0211acb0dc05572e6fd88866ed3ddf2b8dd8e4b5223e5478423'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.