### PR TITLE
Update unity-linux-support-for-editor from 2019.1.2f1,3e18427e571f to 2019.1.3f1,dc414eb9ed43

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.1.2f1,3e18427e571f'
-  sha256 '0a86045d5a8daee39a284db48038114bac3cff9abd0d0223e4b3ecb09cb37a76'
+  version '2019.1.3f1,dc414eb9ed43'
+  sha256 '789720704a0bc376eef95feed8a11ae44aa9fbb2be21c298f32276f5290cde76'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.