### PR TITLE
Update ao from 6.8.0 to 6.9.0

### DIFF
--- a/Casks/ao.rb
+++ b/Casks/ao.rb
@@ -1,6 +1,6 @@
 cask 'ao' do
-  version '6.8.0'
-  sha256 'b403a0cef2bf747876f0283b6484d5a3ac4603c8c8d4da63faa02194f9a1e3db'
+  version '6.9.0'
+  sha256 'c69522f78e82476540637fd3a2ab0c9de1e911530a1eb88c9cf757e933debe0e'
 
   url "https://github.com/klaussinani/ao/releases/download/v#{version}/Ao-#{version}.dmg"
   appcast 'https://github.com/klaussinani/ao/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.