### PR TITLE
Update irccloud from 0.10.0 to 0.11.0

### DIFF
--- a/Casks/irccloud.rb
+++ b/Casks/irccloud.rb
@@ -1,6 +1,6 @@
 cask 'irccloud' do
-  version '0.10.0'
-  sha256 '31bc9f2aa35c2d0835183cfa19d10bf6681527e8367d76323f4831fb706b1897'
+  version '0.11.0'
+  sha256 '5ea97e99e59dc329f726dc2bfad6d13d9e479f3c5d454be8aaf6d5b7628011ac'
 
   url "https://github.com/irccloud/irccloud-desktop/releases/download/v#{version}/IRCCloud-#{version}.dmg"
   appcast 'https://github.com/irccloud/irccloud-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.