### PR TITLE
Update second-life-viewer from 6.2.0.526190 to 6.2.2.527338

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.2.0.526190'
-  sha256 '38c7e22c85ebdde900ea0bf849464a317910d950f5a76960922f49571854c9f6'
+  version '6.2.2.527338'
+  sha256 '2a30142f20e6844549111be8c702202100c7bf9347eb833e95f1bd636dbc3952'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.