### PR TITLE
Update carbon-copy-cloner from 5.1.9.5737 to 5.1.9.5740

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.1.9.5737'
-  sha256 'e4d0240149593bde545f8f8349e453eb3d4a1cbfd6db0b17ab8bfd3d869df44b'
+  version '5.1.9.5740'
+  sha256 '7ca89e89472a7d54b3e741a1485359ca34af76f02dd02051941c370580ffd1b7'
 
   # bombich.scdn1.secure.raxcdn.com/software/files was verified as official when first introduced to the cask
   url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.