### PR TITLE
Update lockrattler from 4.19,2019.04 to 4.20,2019.05

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.19,2019.04'
-  sha256 '4802010dfd82d5699f2002f15d06247e62ebc44498cab4ef25e31d9d652d2df8'
+  version '4.20,2019.05'
+  sha256 '4c340b693ae4f570a96563e369efacb6d1e3fedc4f12acca36587692f5cdfd3e'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.major}/#{version.after_comma.minor}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.