### PR TITLE
Update yammer from 3.4.2 to 3.4.3

### DIFF
--- a/Casks/yammer.rb
+++ b/Casks/yammer.rb
@@ -1,6 +1,6 @@
 cask 'yammer' do
-  version '3.4.2'
-  sha256 'cc719a0b308c4db79c207e0f17b8456303fd3071fac8358859768a35a0935a2f'
+  version '3.4.3'
+  sha256 '8dd918fefe4a1b73801cf4d82ce4d1056baaad0a8c8174c93f9617e55bcc0a0a'
 
   # yammerdesktopapp.blob.core.windows.net/binaries/dist was verified as official when first introduced to the cask
   url "https://yammerdesktopapp.blob.core.windows.net/binaries/dist/darwin/x64/#{version}/Yammer-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.