### PR TITLE
Update rocks-n-diamonds from 4.1.2.0 to 4.1.3.0

### DIFF
--- a/Casks/rocks-n-diamonds.rb
+++ b/Casks/rocks-n-diamonds.rb
@@ -1,6 +1,6 @@
 cask 'rocks-n-diamonds' do
-  version '4.1.2.0'
-  sha256 '7ecea6a331f804a6295161ce1bf6bf37ab23c172bcb0c574fd8463207e678aee'
+  version '4.1.3.0'
+  sha256 '4492c98a14b7b4f6c80d08f66d16d92f912059b0205b20ca5d1193b2c9b59987'
 
   url "https://www.artsoft.org/RELEASES/macosx/rocksndiamonds/rocksndiamonds-#{version}.dmg"
   appcast 'https://www.artsoft.org/RELEASES/macosx/rocksndiamonds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.