### PR TITLE
Update smartgit from 18.2.7 to 18.2.8

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '18.2.7'
-  sha256 '39599e7bd242c776fc4782d264c69f248f3a0ea57512586982c759cb0ae8922c'
+  version '18.2.8'
+  sha256 'f2762a1cd3293557523195ea83df9ac6166cc9a4e1b1e77995fc666c96bddea1'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.