### PR TITLE
Update freefilesync from 10.11 to 10.12

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,5 +1,5 @@
 cask 'freefilesync' do
-  version '10.11'
+  version '10.12'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.freefilesync.org/download/FreeFileSync_#{version}_macOS.zip",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.