### PR TITLE
Update libreoffice from 6.2.3 to 6.2.4

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '6.2.3'
-  sha256 '390aaf569b766790b72662c9d3325141748d588befef5aafc993646cbdb7b2e4'
+  version '6.2.4'
+  sha256 'ac70cea572bd739eba454d8512e0d688f317a42e643e3172947073c74a8af2fc'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.