### PR TITLE
Update scrutiny from 8.3.14 to 8.4.0

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.3.14'
-  sha256 'e805829e87cd0d933a582a4b8a24ffffed1ff0f1821ce7f5fec7eda74c241861'
+  version '8.4.0'
+  sha256 '524acbbdf02526eeaa777a8cd3ac274da40aa0143f36e16d2b48ce49c26f64e9'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.