### PR TITLE
Update macx-dvd-ripper-pro from 6.2.1,20190416 to 6.2.2,20190521

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.2.1,20190416'
-  sha256 '5d031b3353e06c45e4e7fa5e81c81708d51885416103b169c281e427aef8cd0c'
+  version '6.2.2,20190521'
+  sha256 '05d2e94458609ef12097c3f5962da52c0cb52e4e267b4f3bccae3f80f9ef63b5'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
   appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,7 +3,7 @@ cask 'macx-dvd-ripper-pro' do
   sha256 '05d2e94458609ef12097c3f5962da52c0cb52e4e267b4f3bccae3f80f9ef63b5'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
-  appcast 'http://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'
+  appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'
   name 'MacX DVD Ripper Pro'
   homepage 'https://www.macxdvd.com/mac-dvd-ripper-pro/'
 

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,7 +3,7 @@ cask 'macx-dvd-ripper-pro' do
   sha256 '05d2e94458609ef12097c3f5962da52c0cb52e4e267b4f3bccae3f80f9ef63b5'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
-  appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'
+  appcast 'http://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'
   name 'MacX DVD Ripper Pro'
   homepage 'https://www.macxdvd.com/mac-dvd-ripper-pro/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.