### PR TITLE
change version notation from 1.0.722 to 1.0.7,22 in bunch.rb

### DIFF
--- a/Casks/bunch.rb
+++ b/Casks/bunch.rb
@@ -1,8 +1,8 @@
 cask 'bunch' do
-  version '1.0.722'
+  version '1.0.7,22'
   sha256 'e3a06d0373205e6fefe2d4eae63feff1f02676ddb928f4b53804e5c1bba26a7d'
 
-  url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version}.dmg"
+  url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://brettterpstra.com/updates/bunch/appcast.xml'
   name 'Bunch'
   homepage 'https://brettterpstra.com/projects/bunch/'


### PR DESCRIPTION
would it be possible to use the correct version number here? 
svs: 1.0.7
bv: 22