### PR TITLE
Update and change version notation from 1.0.823 to 1.0.8,23 in  bunch.rb

### DIFF
--- a/Casks/bunch.rb
+++ b/Casks/bunch.rb
@@ -1,8 +1,8 @@
 cask 'bunch' do
-  version '1.0.722'
-  sha256 'e3a06d0373205e6fefe2d4eae63feff1f02676ddb928f4b53804e5c1bba26a7d'
+  version '1.0.8,23'
+  sha256 'f54bfd56ce56e8291c35da7a4a7cfc6a8daf678ac9e3db79c344d257617815b7'
 
-  url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version}.dmg"
+  url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://brettterpstra.com/updates/bunch/appcast.xml'
   name 'Bunch'
   homepage 'https://brettterpstra.com/projects/bunch/'


### PR DESCRIPTION
would it be possible to use the correct version notation here?
svs: 1.0.8 and bv is 23?