### PR TITLE
Update ark-desktop-wallet from 2.3.2 to 2.4.0

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.3.2'
-  sha256 'f1027e51c905f3ecdb66e3f66e419f8832c267fc53738a70fff86fd0ba346f6e'
+  version '2.4.0'
+  sha256 'c2dbec2d15749355647ec8de8f988b566528a9dc0cdbdd173dce49a5bc62daae'
 
   # github.com/ArkEcosystem/ark-desktop was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/ark-desktop/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.