### PR TITLE
Update electron-cash from 4.0.2 to 4.0.3

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.2'
-  sha256 'edce2676a1c57814f99c95dd6a31d2b8778b6129d64559d61103f09daf0f3579'
+  version '4.0.3'
+  sha256 '3c3e43a397c06c73fb00fcc924f3c64ed030e3a8342ef2fda013dbc4006212d5'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/fyookball/electrum/releases.atom'

--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -3,7 +3,7 @@ cask 'electron-cash' do
   sha256 '3c3e43a397c06c73fb00fcc924f3c64ed030e3a8342ef2fda013dbc4006212d5'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
-  appcast 'https://github.com/fyookball/electrum/releases.atom'
+  appcast 'https://github.com/Electron-Cash/Electron-Cash/releases.atom'
   name 'Electron Cash'
   homepage 'https://www.electroncash.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.