### PR TITLE
Update gns3 from 2.1.17 to 2.1.18

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.1.17'
-  sha256 'e3429a4ee5efddf690b98473af99d25e859e4a284567487304aa7a3ed00d0167'
+  version '2.1.18'
+  sha256 '7ea3e271e3e15651fcdda4e521a546861de3216fe47cc73ce8c82b107c81db56'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.