### PR TITLE
Update patchwork from 3.11.6 to 3.12.0

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,8 +1,8 @@
 cask 'patchwork' do
-  version '3.11.6'
-  sha256 '6c085e4ba2146e7e379b3bedfb92c6ce81192ab9866ec0235d2efdfe9a724aeb'
+  version '3.12.0'
+  sha256 '3473a97212cf3fd35cabead07cb6f66850cad176386feb07db435160922f6114'
 
-  url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}-mac.dmg"
+  url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'
   name 'Patchwork'
   homepage 'https://github.com/ssbc/patchwork'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.