### PR TITLE
Update holavpn from 1.0.22 to 1.0.23

### DIFF
--- a/Casks/holavpn.rb
+++ b/Casks/holavpn.rb
@@ -1,6 +1,6 @@
 cask 'holavpn' do
-  version '1.0.22'
-  sha256 'fa164d67dfcde01476e598593737197b1fc26af1c1de9f778dc4fe606a5e3eb2'
+  version '1.0.23'
+  sha256 '7fc8cfa9401c95b545b3ca1fd9d07d21ee5b17633a11fb36e138baa693c54d7a'
 
   url "https://cdn4.hola.org/static/HolaVPN-#{version}.dmg"
   appcast 'https://hola.org/macos_vpn_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.