### PR TITLE
Update rightfont from 5.5.2 to 5.5.3

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,6 +1,6 @@
 cask 'rightfont' do
-  version '5.5.2'
-  sha256 '18408d9203b236290db71591cb5c2fd3c649130a10b50fe72e079655f2ca8f25'
+  version '5.5.3'
+  sha256 'e758a45ae3a1cf574e3f4bbed447eecfb1e28e2ffabc39158414857c3f7e75f8'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
   appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.