### PR TITLE
Update viscosity from 1.7.14 to 1.7.15

### DIFF
--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,6 +1,6 @@
 cask 'viscosity' do
-  version '1.7.14'
-  sha256 '71e0d6e63b86122fc771095cb0c4a6c99758c8a71f48f31651a03e64bc7705c5'
+  version '1.7.15'
+  sha256 '24d29a1375fe24e4cfcd44575d1475612445971601f7f6f309b899c6ff4bc3a4'
 
   url "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%20#{version}.dmg"
   appcast 'https://swupdate.sparklabs.com/appcast/mac/release/viscosity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.