### PR TITLE
Update tinymediamanager from 2.9.17_a55d726 to 2.9.17.1_bf18047

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -1,6 +1,6 @@
 cask 'tinymediamanager' do
-  version '2.9.17_a55d726'
-  sha256 'db80b8677f04c53d38441a60b930b81c0cbb1ad41a911e69889656bb64802409'
+  version '2.9.17.1_bf18047'
+  sha256 'b6830f65d39b1e15bff86e24d9667cb4cd296d0150a3b65ef18f9f8c9ab9b6ef'
 
   url "https://release.tinymediamanager.org/v#{version.major}/dist/tmm_#{version}_mac.zip"
   appcast 'https://release.tinymediamanager.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.