### PR TITLE
Update tableau from 2019.1.3 to 2019.2.0

### DIFF
--- a/Casks/tableau.rb
+++ b/Casks/tableau.rb
@@ -1,6 +1,6 @@
 cask 'tableau' do
-  version '2019.1.3'
-  sha256 '12e11f049412c2a5eddda73433448c6a004448a74b1831be395992fe8f90345b'
+  version '2019.2.0'
+  sha256 '5f292ec62d21b47a2c711879ca844fd59708a0a857e5f7f20719eaeeecc2ba1d'
 
   url "https://downloads.tableau.com/tssoftware/TableauDesktop-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/desktop/mac'

--- a/Casks/tableau.rb
+++ b/Casks/tableau.rb
@@ -4,7 +4,7 @@ cask 'tableau' do
 
   url "https://downloads.tableau.com/tssoftware/TableauDesktop-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/desktop/mac',
-          configuration: version.dots_to_hyphens.to_s
+          configuration: version.dots_to_hyphens
   name 'Tableau Desktop'
   homepage 'https://www.tableau.com/products/desktop/download'
 

--- a/Casks/tableau.rb
+++ b/Casks/tableau.rb
@@ -3,7 +3,8 @@ cask 'tableau' do
   sha256 '5f292ec62d21b47a2c711879ca844fd59708a0a857e5f7f20719eaeeecc2ba1d'
 
   url "https://downloads.tableau.com/tssoftware/TableauDesktop-#{version.dots_to_hyphens}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/desktop/mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/desktop/mac',
+          configuration: version.dots_to_hyphens.to_s
   name 'Tableau Desktop'
   homepage 'https://www.tableau.com/products/desktop/download'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.