### PR TITLE
Update tableau-public from 2019.1.3 to 2019.2.0

### DIFF
--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -3,7 +3,8 @@ cask 'tableau-public' do
   sha256 '46d27c225a8d7f7a9ba2be82f6d08f529ee09f435835716d6882997155da780f'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac',
+          configuration: version.dots_to_hyphens.to_s
   name 'Tableau Public'
   homepage 'https://public.tableau.com/s/'
 

--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,6 +1,6 @@
 cask 'tableau-public' do
-  version '2019.1.3'
-  sha256 'e9e3b86647fc0656a228210a2a1e766e65fd1a63d200a7be7bd2f2b1fc23c47a'
+  version '2019.2.0'
+  sha256 '46d27c225a8d7f7a9ba2be82f6d08f529ee09f435835716d6882997155da780f'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac'

--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -4,7 +4,7 @@ cask 'tableau-public' do
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac',
-          configuration: version.dots_to_hyphens.to_s
+          configuration: version.dots_to_hyphens
   name 'Tableau Public'
   homepage 'https://public.tableau.com/s/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.