### PR TITLE
Update tableau-reader from 2019.1.3 to 2019.2.0

### DIFF
--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -3,7 +3,8 @@ cask 'tableau-reader' do
   sha256 '1266664c89ec3f1d42027d1cd8f928d47e3a91166c6d1b932218cb5bbb0a9285'
 
   url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac',
+          configuration: version.dots_to_hyphens.to_s
   name 'Tableau Reader'
   homepage 'https://www.tableau.com/products/reader'
 

--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -4,7 +4,7 @@ cask 'tableau-reader' do
 
   url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac',
-          configuration: version.dots_to_hyphens.to_s
+          configuration: version.dots_to_hyphens
   name 'Tableau Reader'
   homepage 'https://www.tableau.com/products/reader'
 

--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -1,6 +1,6 @@
 cask 'tableau-reader' do
-  version '2019.1.3'
-  sha256 'b4e72d88969e0ec478d1ee25774531f22e6401d45772e16db9ef220517862ced'
+  version '2019.2.0'
+  sha256 '1266664c89ec3f1d42027d1cd8f928d47e3a91166c6d1b932218cb5bbb0a9285'
 
   url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.