### PR TITLE
Update perforce from 18.1 to 19.1

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,8 +1,8 @@
 cask 'perforce' do
-  version '18.1'
+  version '19.1'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://cdist2.perforce.com/perforce/r#{version}/bin.darwin90x86_64/helix-versioning-engine.tgz"
+  url "https://cdist2.perforce.com/perforce/r#{version}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'
   homepage 'https://www.perforce.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.