### PR TITLE
Update tunnelblick from 3.7.8,5180 to 3.7.9,5320

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick' do
-  version '3.7.8,5180'
-  sha256 '0918551e80b3f861eb075cae790f3834a81a163a2793d2414064a1451bda3370'
+  version '3.7.9,5320'
+  sha256 '352c298056d4c01c2563755ac2980b841451fe4e4937c31c8c4af0184341d4ec'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.