### PR TITLE
Update bettertouchtool from 2.854 to 2.858

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '2.854'
-    sha256 '90c6043b6cd10e0e5de808c7d0e625d77c470bd8702861b5f4674c32598abf1a'
+    version '2.858'
+    sha256 '9dda09046d149cde38a1f85dae97c939251397a3b0fb50f629323c91762dfbda'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.