### PR TITLE
Update freesmug-chromium from 74.0.3729.157 to 74.0.3729.169

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '74.0.3729.157'
-  sha256 '0800994c7e54c735ad7302373584a8b31cb829942bd5d11552f84b1e86d3f87c'
+  version '74.0.3729.169'
+  sha256 'd70c12c3063517144ef1fa95b0e479c1c7789fb2ca898a91c50870a10f7b4005'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.