### PR TITLE
Update navicat-for-mysql from 12.1.20 to 12.1.22

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.20'
-  sha256 '7b68e6f40e6f20e4c5bc94e9d6a963c167182943a2e9892b20b682852dfa71a5'
+  version '12.1.22'
+  sha256 '6eba8cdffa60948b5ddbee6ac8441c5b892da8a0fc6346732358a6fb80d8b6bd'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.