### PR TITLE
Update plex-media-player from 2.33.1.979-c4087ea7 to 2.34.0.983-edb7fbf7

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.33.1.979-c4087ea7'
-  sha256 '32c957b720968255f1f678b95b69827cf8d26f1832240792b62484d07be78673'
+  version '2.34.0.983-edb7fbf7'
+  sha256 '1a6a7b4cbd9e6b5125c7193cf381c7efa4e92887a62cac87b1cb750ab14380e0'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.