### PR TITLE
Update bunch from 1.0.8,23 to 1.0.9,24

### DIFF
--- a/Casks/bunch.rb
+++ b/Casks/bunch.rb
@@ -1,6 +1,6 @@
 cask 'bunch' do
-  version '1.0.8,23'
-  sha256 'f54bfd56ce56e8291c35da7a4a7cfc6a8daf678ac9e3db79c344d257617815b7'
+  version '1.0.9,24'
+  sha256 'd96b6a73c83b95755d8c024188c88d82ef0f33ab8518e51845699b4772ea4c68'
 
   url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://brettterpstra.com/updates/bunch/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.