### PR TITLE
Update navicat-for-mariadb from 12.1.20 to 12.1.22

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.20'
-  sha256 'b8af177befcdc88f2f4e783eb86ba4bc9aec2ad85ccb49fe235e9b82b659f014'
+  version '12.1.22'
+  sha256 'ed9ac7cf721a1dce5a393e5b38f75f2eb35424b1fcef4795f5b61a226d282390'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.