### PR TITLE
Update navicat-for-postgresql from 12.1.20 to 12.1.22

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '12.1.20'
-  sha256 '26f67386c6ec520dee9a8aac167c032e6d6af517233798d3e37461bc91aef522'
+  version '12.1.22'
+  sha256 '6ce2931265c6b9ffafa3fb000ca77c931b41c6b7f1dfe69d6994748ba000d0c1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.