### PR TITLE
Update navicat-premium-essentials from 12.1.20 to 12.1.22

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '12.1.20'
-  sha256 'a1aa1b89a7a3c413260046cd4f1e61800e4caadb140c4f501f9d1603aa0db66b'
+  version '12.1.22'
+  sha256 '76543c2ae4af1f981858c43275a145ab6b836bc0ea0198f46af2dc7f7db7f2f1'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20Premium%20Essentials&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.