### PR TITLE
Update augur from 1.13.0 to 1.13.1

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.13.0'
-  sha256 'ef83f8d362995139c74457c3f75d09daa14e0c7277c943289924672ed15da517'
+  version '1.13.1'
+  sha256 'ad06980f5b00e5aa1b77b0d16ea49126add2b2e8f72dc89473690392c746e63a'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.