### PR TITLE
Update profilecreator from 0.3.0,201905171401-beta to 0.3.1,201905222119-beta

### DIFF
--- a/Casks/profilecreator.rb
+++ b/Casks/profilecreator.rb
@@ -1,6 +1,6 @@
 cask 'profilecreator' do
-  version '0.3.0,201905171401-beta'
-  sha256 'ebdf603bca3b6c72f436c93944d1b2b7342e410ff8509ad970cea4606d39112b'
+  version '0.3.1,201905222119-beta'
+  sha256 '820311b25535b52d3e2bb631d6adae904d2e9d3c46fda56798be28c7742b4878'
 
   url "https://github.com/erikberglund/ProfileCreator/releases/download/v#{version.before_comma}/ProfileCreator_v#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/erikberglund/ProfileCreator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.