### PR TITLE
Update jump from 8.2.19 to 8.2.21

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.2.19'
-  sha256 '4b225ce89d58d6ac1eb813768b48b8a5abf7211a3666acde6d766df076229518'
+  version '8.2.21'
+  sha256 'e9922796b811938eb39f7dfddd923466b3db2676f60fee2a5ed6ed75745888b3'
 
   url "https://mirror.jumpdesktop.com/downloads/JumpDesktopMac-#{version}.zip"
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.