### PR TITLE
Update kite from 0.20190521.0 to 0.20190522.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190521.0'
-  sha256 'f60083d2bc5e9a627c4cd496f35bcd2d71975d42669307605a94085465a13762'
+  version '0.20190522.1'
+  sha256 'd9e431be8139281a85cfee8661fad9e97a05a33fa761015548870f8d26fc5891'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.