### PR TITLE
Update curio from 13002.3 to 13010.6

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '13002.3'
-  sha256 '275e25cd3acf85183eeae1773e55794fcb2b4a803c80d2859bfb508d6ea808b8'
+  version '13010.6'
+  sha256 'f320e5ca9fa186cf342f09c63938d297d6ce286c9f9d8d91490871456e7d1690'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio13HLwLK2C84LaKptcz.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.