### PR TITLE
Update ridibooks from 2.6.1 to 2.6.3

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,6 +1,6 @@
 cask 'ridibooks' do
-  version '2.6.1'
-  sha256 '701646595ece04597839d7ea8a07d09e0afdf88ec6ddc4538ba615981e8718a0'
+  version '2.6.3'
+  sha256 '8b46f1746c48519c4d05495793347e8ffeabdd7da3f7adbebbce2f469d946a70'
 
   url "https://viewer-ota.ridibooks.com/mac/ridibooks-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://getapp.ridibooks.com/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.