### PR TITLE
Update feeder from 3.6.6 to 3.6.7

### DIFF
--- a/Casks/feeder.rb
+++ b/Casks/feeder.rb
@@ -1,6 +1,6 @@
 cask 'feeder' do
-  version '3.6.6'
-  sha256 '99c096d0386e772b90e0cb461714bbef9c0a3b5e3a744dffc4fa4023a21d1178'
+  version '3.6.7'
+  sha256 'f197322d4b94b089421b60b7a971ca5028edb206940ad17628728f2f9db5a1f1'
 
   url "https://reinventedsoftware.com/feeder/downloads/Feeder_#{version}.dmg"
   appcast "https://reinventedsoftware.com/feeder/downloads/Feeder#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.