### PR TITLE
Update kite from 0.20190522.1 to 0.20190523.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190522.1'
-  sha256 'd9e431be8139281a85cfee8661fad9e97a05a33fa761015548870f8d26fc5891'
+  version '0.20190523.0'
+  sha256 'b0534b5fa6154d33a60f2f78124131502009000411a2ff42ec30b2549358f12f'
 
   # s3-us-west-1.amazonaws.com/kite-downloads was verified as official when first introduced to the cask
   url "https://s3-us-west-1.amazonaws.com/kite-downloads/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.