### PR TITLE
Update rapidweaver from 8.1.7,20674.1553595093 to 8.2,20740.1558691647

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,6 +1,6 @@
 cask 'rapidweaver' do
-  version '8.1.7,20674.1553595093'
-  sha256 '7cded50091d2eb32f3c7c9f5fc98c8cca6ba97a02ee6b1e81337f57b4c26cb51'
+  version '8.2,20740.1558691647'
+  sha256 '49f31d6c85ba5452c8b332dda03e6879945d2b02e4ebffaf4cbf4f1c58c8351a'
 
   # devmate.com/com.realmacsoftware.rapidweaver was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.realmacsoftware.rapidweaver#{version.major}/#{version.after_comma.major}/#{version.after_comma.minor}/RapidWeaver#{version.major}-#{version.after_comma.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.