### PR TITLE
Update openscad from 2015.03-3 to 2019.05

### DIFF
--- a/Casks/openscad.rb
+++ b/Casks/openscad.rb
@@ -1,6 +1,6 @@
 cask 'openscad' do
-  version '2015.03-3'
-  sha256 '1f2e8e52e04bbb6d3b2c8699d314d1ca28d2fcf68164eca7d0a20e248cee01a7'
+  version '2019.05'
+  sha256 'df6f6f3d34ac0d07f533ec4ccf59082189fb37c0276c1b8df651291e2509420e'
 
   url "https://files.openscad.org/OpenSCAD-#{version}.dmg"
   appcast 'https://github.com/openscad/openscad/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.