### PR TITLE
Update spamsieve from 2.9.35 to 2.9.36

### DIFF
--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -1,6 +1,6 @@
 cask 'spamsieve' do
-  version '2.9.35'
-  sha256 'bf06986d7f6d215a30e97bca0ffecd16b9fb32fcb194a92f23a75ec7c38a62b8'
+  version '2.9.36'
+  sha256 '5f42dfbc1b3e999bb185c0e8cef02e05de4e4077df4f96df5e0db11cac18f2d9'
 
   url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
   appcast 'https://c-command.com/spamsieve/help/version-history'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.