### PR TITLE
Update abstract from 80.0.0 to 80.0.1

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '80.0.0'
-  sha256 '6ca1c8d3ef1864585ccfb991313c67633bc427bd3c0df52fae12f45fad5c085d'
+  version '80.0.1'
+  sha256 '59c40f2bce446cad0d57b6630cb52a967966ea87c3982daa7ff6c19118de8edb'
 
   url "https://downloads.goabstract.com/Abstract-#{version}.dmg"
   appcast 'https://www.goabstract.com/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.