### PR TITLE
Update aspera-connect from 3.8.1.161274 to 3.9.1.171801

### DIFF
--- a/Casks/aspera-connect.rb
+++ b/Casks/aspera-connect.rb
@@ -13,6 +13,7 @@ cask 'aspera-connect' do
                        'com.aspera.AsperaWeb',
                        'com.aspera.connect',
                        'com.aspera.crypt',
+                       'com.aspera.launcher',
                      ],
             script:  {
                        executable: '/Library/Application Support/Aspera/Aspera Connect/uninstall_connect.sh',

--- a/Casks/aspera-connect.rb
+++ b/Casks/aspera-connect.rb
@@ -3,7 +3,7 @@ cask 'aspera-connect' do
   sha256 '1ffa8417bc41ce1f2f162a380553df5a96693177d7627743e4f4c9a9b15c197d'
 
   url "https://download.asperasoft.com/download/sw/connect/#{version.major_minor_patch}/IBMAsperaConnectInstaller-#{version}.dmg"
-  appcast 'https://asperasoft.com/software/transfer-clients/connect-web-browser-plug-in/#whatsnew-399'
+  appcast 'https://downloads.asperasoft.com/en/documentation/8'
   name 'Aspera Connect'
   homepage 'https://asperasoft.com/software/transfer-clients/connect-web-browser-plug-in/'
 

--- a/Casks/aspera-connect.rb
+++ b/Casks/aspera-connect.rb
@@ -1,6 +1,6 @@
 cask 'aspera-connect' do
-  version '3.8.1.161274'
-  sha256 'a04fd1697ed797242d9201e2ad2be345431fffc89076d96bb637c4efa23eee02'
+  version '3.9.1.171801'
+  sha256 '1ffa8417bc41ce1f2f162a380553df5a96693177d7627743e4f4c9a9b15c197d'
 
   url "https://download.asperasoft.com/download/sw/connect/#{version.major_minor_patch}/IBMAsperaConnectInstaller-#{version}.dmg"
   appcast 'https://asperasoft.com/software/transfer-clients/connect-web-browser-plug-in/#whatsnew-399'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.