### PR TITLE
Update 4k-video-downloader from 4.7.1.2712 to 4.7.2.2732

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.7.1.2712'
-  sha256 '787422466b475ef7f63cfc76e8620104232dc59155391ff9f937e97d508a7602'
+  version '4.7.2.2732'
+  sha256 '123d6324012597b1fb853cddb3798659e44948d8a54e05aac5435e0f0ebd5ce6'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.