### PR TITLE
Upgrade Fing to v5.4 (fix dead link)

### DIFF
--- a/Casks/fing.rb
+++ b/Casks/fing.rb
@@ -1,13 +1,12 @@
 cask 'fing' do
-  version '3.0,2016.09'
-  sha256 'a8497ce00d58609d8677c6c7850e479420516d94e9f37d681dbdc970359294c6'
+  version '5.4.0'
+  sha256 'e7e2fe5906c6f6e21ff8d620f463fcae7f895d3f4c732426214dff4b8dc868aa'
 
-  # 39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://39qiv73eht2y1az3q51pykkf-wpengine.netdna-ssl.com/wp-content/uploads/#{version.after_comma.major}/#{version.after_comma.minor}/overlook-fing-#{version.before_comma}.dmg_.zip"
+  url "https://www.fing.com/images/uploads/general/CLI_macOSX_#{version}.zip"
   name 'Fing'
-  homepage 'https://www.fing.io/'
+  homepage 'https://www.fing.com/products/development-toolkit/'
 
-  pkg "overlook-fing-#{version.before_comma}.pkg"
+  pkg "Fing-#{version}-osX.pkg"
 
-  uninstall pkgutil: 'com.Overlook.Fing'
+  uninstall pkgutil: 'Fing'
 end

--- a/Casks/fing.rb
+++ b/Casks/fing.rb
@@ -3,6 +3,7 @@ cask 'fing' do
   sha256 'e7e2fe5906c6f6e21ff8d620f463fcae7f895d3f4c732426214dff4b8dc868aa'
 
   url "https://www.fing.com/images/uploads/general/CLI_macOSX_#{version}.zip"
+  appacast 'https://www.fing.com/products/development-toolkit/'
   name 'Fing'
   homepage 'https://www.fing.com/products/development-toolkit/'
 


### PR DESCRIPTION
This PR fixes https://github.com/Homebrew/homebrew-cask/issues/63726 (and https://github.com/Homebrew/homebrew-cask/issues/62761). Reusing information from previous PR attempt : https://github.com/Homebrew/homebrew-cask/pull/60449.

- update version (fix dead link),
- update homepage
- update functional install/uninstall for version 5

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256