### PR TITLE
Update sabnzbd from 2.3.8 to 2.3.9

### DIFF
--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -1,6 +1,6 @@
 cask 'sabnzbd' do
-  version '2.3.8'
-  sha256 '3abe2edd8b38c64ddde526207f70748970b91680a981d69df0640fecfb44f64c'
+  version '2.3.9'
+  sha256 'dfe5eee0f94b1db79ecbe759ce9c38cec7d9b4357fd58258628e01f46d3ca3ea'
 
   # github.com/sabnzbd/sabnzbd was verified as official when first introduced to the cask
   url "https://github.com/sabnzbd/sabnzbd/releases/download/#{version}/SABnzbd-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.