### PR TITLE
Update sysdig-inspect from 0.3.4 to 0.4.0

### DIFF
--- a/Casks/sysdig-inspect.rb
+++ b/Casks/sysdig-inspect.rb
@@ -1,6 +1,6 @@
 cask 'sysdig-inspect' do
-  version '0.3.4'
-  sha256 'fc6ce8ce13b359b7638c50786949790ae3501ed0e71ded4eeb848d676da2392f'
+  version '0.4.0'
+  sha256 '1a1b59128cc8c764844a961aa9983d32839bc9c39eb9a88df07b117e7288d3cc'
 
   # download.sysdig.com/stable/sysdig-inspect was verified as official when first introduced to the cask
   url "https://download.sysdig.com/stable/sysdig-inspect/sysdig-inspect-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.