### PR TITLE
Update geekbench from 4.3.3 to 4.3.4

### DIFF
--- a/Casks/geekbench.rb
+++ b/Casks/geekbench.rb
@@ -3,8 +3,8 @@ cask 'geekbench' do
     version '3.4.2'
     sha256 '05e1b977a46648d38cf6c641be7ef34722200d0168a10d4372fca771ffa24e28'
   else
-    version '4.3.3'
-    sha256 'bb5218957dc262430befbe2431e0f54b2f09914aff1a026e06eaac9e975e1d45'
+    version '4.3.4'
+    sha256 'd05684b63a858df0bc70cc7b282b7fc240c3aeb2656dc4f4ff38e65fc7b38788'
   end
 
   url "https://cdn.geekbench.com/Geekbench-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.