### PR TITLE
Update path-finder from 8.3.9 to 8.5

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '8.3.9'
-  sha256 'c001cd646ab09df0206f8324b537e8b7b8efbd02f80d61ea64ae4c2e06553f8c'
+  version '8.5'
+  sha256 '146ddbc2e7a034d746e2a1488b8eb507331985b6308518e387054316d9ccada2'
 
   url 'https://get.cocoatech.com/PF8.dmg'
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.