### PR TITLE
Update ios-app-signer from 1.11 to 1.12

### DIFF
--- a/Casks/ios-app-signer.rb
+++ b/Casks/ios-app-signer.rb
@@ -1,6 +1,6 @@
 cask 'ios-app-signer' do
-  version '1.11'
-  sha256 'd81a1ac9e59c4a06754ce0207d13b4b1f716baf172af6b31258303752c2f58e7'
+  version '1.12'
+  sha256 'd8b0eea20984854ebbdb603923087ca0d182aeaeb7a81c08c5dd2d8b734b5235'
 
   # github.com/DanTheMan827/ios-app-signer was verified as official when first introduced to the cask
   url "https://github.com/DanTheMan827/ios-app-signer/releases/download/#{version}/iOS.App.Signer.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.