### PR TITLE
Update remote-desktop-manager-free from 2019.1.3.0 to 2019.1.4.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '2019.1.3.0'
-  sha256 'b77a63591dfc4a77cb880f47dc7eb134226ccb59edcd1ba2dc45f182e71c2acc'
+  version '2019.1.4.0'
+  sha256 'ed3252c43bf2b921d4d4e36dec8758fc72814c547146ead83ea3626c8cbf1142'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.