### PR TITLE
Update exodus from 19.5.10 to 19.5.24

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.5.10'
-  sha256 'e1964f75ec6bad201dfd7d5c48ddaded2b218e67f7128e51603bebe10075fa8e'
+  version '19.5.24'
+  sha256 '2a9c7ed82f3672992021abdf983bafa667ae5a6f7e8d945c2b61858a18c2a3c4'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.