### PR TITLE
Update qqlive from 2.4.2.44070 to 2.4.3.44080

### DIFF
--- a/Casks/qqlive.rb
+++ b/Casks/qqlive.rb
@@ -1,6 +1,6 @@
 cask 'qqlive' do
-  version '2.4.2.44070'
-  sha256 'b7d6fb4e5b28fcdc708d9169d9b23192f5a20f50c26366bde5c81fda8a4b8697'
+  version '2.4.3.44080'
+  sha256 'cc181e675695c3b5ff096c575b5efa33ecba42df9dec58dd46eb8d329d3a8e56'
 
   url "https://dldir1.qq.com/qqtv/mac/TencentVideo_V#{version}.dmg"
   appcast 'https://v.qq.com/download.html#mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.