### PR TITLE
Update apache-couchdb from 2.3.0 to 2.3.1

### DIFF
--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -1,6 +1,6 @@
 cask 'apache-couchdb' do
-  version '2.3.0'
-  sha256 'ce79e1faee0cc02a9dc480681ea1de49f429d147337092fe8e0f27932ae2a4dd'
+  version '2.3.1'
+  sha256 '768b9b290c5ad50b5055b4453315d739d6b4434fbbc26db7e3a5ba6ed1a9ddfe'
 
   # bintray.com/apache/couchdb was verified as official when first introduced to the cask
   url "https://dl.bintray.com/apache/couchdb/mac/#{version}/Apache-CouchDB-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.