### PR TITLE
Update telegram from 5.2.2-170992 to 5.2.2-171178

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '5.2.2-170992'
-  sha256 'f857e51cf154a4248f4e73323feaefc422916fdfad8aa86c9f8262c8db5b54a4'
+  version '5.2.2-171178'
+  sha256 '2ca57e9dbd861765db5f1f38189c6bb09d4300e2bc41bd170c1539c94f1f9094'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.