### PR TITLE
Update serviio from 1.10.1 to 2.0

### DIFF
--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -1,6 +1,6 @@
 cask 'serviio' do
-  version '1.10.1'
-  sha256 '2ffb1263780c7df628fe1e56986fe1a4f23e105d6c3c9ead73303cb9c3f9f704'
+  version '2.0'
+  sha256 '69ca6080fc92d147ee9c6d2bc7d71d9548e5770762e0e73066d4ac82557fbc6e'
 
   url "http://download.serviio.org/releases/serviio-#{version}-osx.tar.gz"
   name 'Serviio'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.