### PR TITLE
Update dcp-o-matic from 2.14.2 to 2.14.4

### DIFF
--- a/Casks/dcp-o-matic.rb
+++ b/Casks/dcp-o-matic.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic' do
-  version '2.14.2'
-  sha256 '8e8de4636e557ff87f72a8ac638a76d630a4140e3d77a4c449e503383275fafa'
+  version '2.14.4'
+  sha256 '1f59d5cbd42313e38e6ec25c43ebff30affe1aa08bad03f93a5c9f8e32f77e7f'
 
   url "https://dcpomatic.com/dl.php?id=osx-main&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.