### PR TITLE
Update dcp-o-matic-batch-converter from 2.14.2 to 2.14.4

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.14.2'
-  sha256 '424e788b254ad009162e587208994932a4a5eedb5fa43a8e2552d3ed70b107cd'
+  version '2.14.4'
+  sha256 '7732225be806e795f3a2333f150638b7476e2727055b7affeedd8fba976ba20b'
 
   url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.