### PR TITLE
Update dcp-o-matic-encode-server from 2.14.2 to 2.14.4

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.2'
-  sha256 '0d4e5c5d99625076a2f315a7f7074519010d5fac9d7a6b9f0f58da3a4b0a3e4b'
+  version '2.14.4'
+  sha256 'ae0a17f9e4367d1eee3c5970476e25f7a459705d637b5c98f624e0bd21ccaf50'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.