### PR TITLE
Update dcp-o-matic-player from 2.14.2 to 2.14.4

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.2'
-  sha256 'eb808fd625e1022b0fa5782decce24863d2413d159412675c240736b5edbb5a3'
+  version '2.14.4'
+  sha256 '50f8253079e921edf0f272b71ebb9986f013ac851f007390bf0e4dfd8c8af9f3'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.