### PR TITLE
Update lingon-x from 7.2.0 to 7.2.1

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.4'
     sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
-    version '7.2.0'
-    sha256 '499eb677e002d6b74818152db5b63e928bc3635ea437752c798ebab9cf1c67ec'
+    version '7.2.1'
+    sha256 'd400a15348a2b7ed9fdb54b4df0529eea8e57af388844be238ee6df494f8c85e'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.