### PR TITLE
Update hands-off from 4.1.0 to 4.2.0

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '4.1.0'
-  sha256 'aadb288f73fd927628320bf9231f2efbea5c4ff15116dd619250c05ecbe8748b'
+  version '4.2.0'
+  sha256 '2b050381a964a642ad9ed4d6390a50b6915a618e0da04f51de3445112eaed199'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.