### PR TITLE
Update quaternion from 0.0.9.4b to 0.0.9.4

### DIFF
--- a/Casks/quaternion.rb
+++ b/Casks/quaternion.rb
@@ -1,6 +1,6 @@
 cask 'quaternion' do
-  version '0.0.9.4b'
-  sha256 'f070c28a0b248b5dff5540de93d47bed75cab8a41d9936eb043d9a28b9634ea2'
+  version '0.0.9.4'
+  sha256 'e33ecf94cbafedd3f665db8ff52764ee403af3acb45aff676788ec96225e8d03'
 
   url "https://github.com/quotient-im/Quaternion/releases/download/#{version}/quaternion-#{version}.dmg"
   appcast 'https://github.com/quotient-im/Quaternion/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.