### PR TITLE
Update unity-linux-support-for-editor from 2019.1.3f1,dc414eb9ed43 to 2019.1.4f1,ffa3a7a2dd7d

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.1.3f1,dc414eb9ed43'
-  sha256 '789720704a0bc376eef95feed8a11ae44aa9fbb2be21c298f32276f5290cde76'
+  version '2019.1.4f1,ffa3a7a2dd7d'
+  sha256 'd96bc4a4c1a0eae4b360e35bd6514768e302b99e47336afe4125d665ce32689e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.