### PR TITLE
Update dcp-o-matic-player from 2.14.4 to 2.14.5

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.4'
-  sha256 '50f8253079e921edf0f272b71ebb9986f013ac851f007390bf0e4dfd8c8af9f3'
+  version '2.14.5'
+  sha256 'cf0fc1cce589b8610287c192fd5579ba648ab3c9f8a004d2b52364ca20136e81'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.