### PR TITLE
Update thedesk from 18.4.0 to 18.5.0

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.4.0'
-  sha256 '2248c451c0666e39e9c150e76f49f388243c36201e2d66ab2ec578a63be9e3b5'
+  version '18.5.0'
+  sha256 '6433be5ffab864d6d157e9d95f7b979f91dd82dd765d9178824a21638217765b'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.