### PR TITLE
Update unshaky from 0.5.4 to 0.5.5

### DIFF
--- a/Casks/unshaky.rb
+++ b/Casks/unshaky.rb
@@ -1,6 +1,6 @@
 cask 'unshaky' do
-  version '0.5.4'
-  sha256 '116443f801fbed3487ac19bd9ed9fc8c9843e7501df2fa43f50b85076bd7d46a'
+  version '0.5.5'
+  sha256 '36ce63073977d5fe0a6719842ef67ef56380d4790134d4d0aab96d7b5064619f'
 
   url "https://github.com/aahung/Unshaky/releases/download/v#{version}/Unshaky_v#{version}.zip"
   appcast 'https://github.com/aahung/Unshaky/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.