### PR TITLE
Update mailmate from 5594 to 5634

### DIFF
--- a/Casks/mailmate.rb
+++ b/Casks/mailmate.rb
@@ -1,6 +1,6 @@
 cask 'mailmate' do
-  version '5594'
-  sha256 '830222a54398ab7a198abda849663aee4fa0219044e644b949d2ac56842358eb'
+  version '5634'
+  sha256 'bd10785f49102eca29f8f2e31ca08f406c0bf5004b617b42730ebcc11ab1c9cc'
 
   # mailmate-app.com was verified as official when first introduced to the cask
   url "https://updates.mailmate-app.com/archives/MailMate_r#{version}.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.