### PR TITLE
Update leksah from 0.15.2.0-ghc-7.10.3 to 0.16.2.2-ghc-8.0.2

### DIFF
--- a/Casks/leksah.rb
+++ b/Casks/leksah.rb
@@ -1,8 +1,9 @@
 cask 'leksah' do
-  version '0.15.2.0-ghc-7.10.3'
-  sha256 'f94fff34c37367ddd5081e9f8561f1579b2875840e80d647dd6d7af469c542bf'
+  version '0.16.2.2-ghc-8.0.2'
+  sha256 '4ab4e5245d85bfc55b6fc6f347f4abe86728bdef031d3c5e9fb40704e07cd2dc'
 
   url "http://www.leksah.org/packages/leksah-#{version}.dmg"
+  appcast 'http://www.leksah.org/packages/'
   name 'Leksah'
   homepage 'http://leksah.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.