### PR TITLE
Update lego-mindstorms-ev3 from 1.3.1 to 1.4.3

### DIFF
--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -1,10 +1,11 @@
 cask 'lego-mindstorms-ev3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '1.3.1'
-  sha256 '15ea0a61d87aa5172a0fd1587c904470287fa750ad9d47a3abf53233872808b2'
+  version '1.4.3'
+  sha256 '90a2a3a904065ae751afb4d78ac23a38eecf2b9e3683c92c6147b7aea7dc7f5d'
 
   # le-www-live-s.legocdn.com/downloads/LMS-EV3 was verified as official when first introduced to the cask
   url "https://le-www-live-s.legocdn.com/downloads/LMS-EV3/LMS-EV3_Full-setup_#{version}_en-us_osx.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://go.api.education.lego.com/v1/lms-ev3_en-us_osx'
   name 'Lego Mindstorms EV3 Home Edition'
   homepage 'https://www.lego.com/en-us/mindstorms'
 

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -15,6 +15,12 @@ cask 'lego-mindstorms-ev3' do
                        "com.ni.pkg.lego.ev3.Eng.#{version}",
                        "com.ni.pkg.lego.x3.#{version}.core",
                        "com.ni.pkg.lego.x3.#{version}.update",
+                       "com.microsoft.silverlight.plugin",
+                       "com.ni.pkg.lego.ev3.Eng",
+                       "com.ni.pkg.lego.x3.core",
+                       "com.ni.pkg.lego.x3.update",
+                       "com.ni.pkg.legodriver",
+                       "com.xamarin.mono-MDK.pkg",
                      ]
 
   zap pkgutil: [

--- a/Casks/lego-mindstorms-ev3.rb
+++ b/Casks/lego-mindstorms-ev3.rb
@@ -15,12 +15,12 @@ cask 'lego-mindstorms-ev3' do
                        "com.ni.pkg.lego.ev3.Eng.#{version}",
                        "com.ni.pkg.lego.x3.#{version}.core",
                        "com.ni.pkg.lego.x3.#{version}.update",
-                       "com.microsoft.silverlight.plugin",
-                       "com.ni.pkg.lego.ev3.Eng",
-                       "com.ni.pkg.lego.x3.core",
-                       "com.ni.pkg.lego.x3.update",
-                       "com.ni.pkg.legodriver",
-                       "com.xamarin.mono-MDK.pkg",
+                       'com.microsoft.silverlight.plugin',
+                       'com.ni.pkg.lego.ev3.Eng',
+                       'com.ni.pkg.lego.x3.core',
+                       'com.ni.pkg.lego.x3.update',
+                       'com.ni.pkg.legodriver',
+                       'com.xamarin.mono-MDK.pkg',
                      ]
 
   zap pkgutil: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.