### PR TITLE
Update local-by-flywheel from 3.2.0 to 3.2.1

### DIFF
--- a/Casks/local-by-flywheel.rb
+++ b/Casks/local-by-flywheel.rb
@@ -1,9 +1,11 @@
 cask 'local-by-flywheel' do
-  version '3.2.0'
-  sha256 '37f392e3eea4bbf1b9e56ba626f7a173ae82f9abf5cc697cc1c141d52e31fca2'
+  version '3.2.1'
+  sha256 'fa23f7e90b0bdaf670a42da905e43f9c4d0e604aa6cc91c1e9ec351c25b4b6e1'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-by-flywheel-#{version.dots_to_hyphens}-mac.zip"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://local-by-flywheel-flywheel.netdna-ssl.com/latest/mac',
+          configuration: version.dots_to_hyphens
   name 'Local by Flywheel'
   homepage 'https://local.getflywheel.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.