### PR TITLE
fix Polyphone v2.0 cask for case sensitive FS

### DIFF
--- a/Casks/polyphone.rb
+++ b/Casks/polyphone.rb
@@ -6,5 +6,5 @@ cask 'polyphone' do
   name 'Polyphone'
   homepage 'https://polyphone-soundfonts.com/'
 
-  app 'polyphone.app'
+  app 'Polyphone.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This is a one letter fix to an existing cask - the app file name was not properly cased for case sensitive file systems and caused the cask to fail to install. 

After making all changes to the cask:

- [x ] `brew cask audit --download {{cask_file}}` is error-free.
- [x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x ] The commit message includes the cask’s name and version.
- [x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
