### PR TITLE
Update fastonosql from 2.2.2 to 2.4.0

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '2.2.2'
-  sha256 'afc63a1926c74732bbab20b0a9cbefad9628935abb29539b295a4464b703026f'
+  version '2.4.0'
+  sha256 'e10ff9703e960adbf9054957e11a5384d12e96d58146529532bc7caa8d6539b1'
 
   url "https://fastonosql.com/downloads_pro/macosx/fastonosql_pro-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.