### PR TITLE
Update pascom-client from 50.R318_5cd8b40 to 51.R365_e50571e

### DIFF
--- a/Casks/pascom-client.rb
+++ b/Casks/pascom-client.rb
@@ -1,8 +1,9 @@
 cask 'pascom-client' do
-  version '50.R318_5cd8b40'
-  sha256 '621ec0cc4f5c5f09e94d617c6a8489598f7860f64fc3f59f425be9a4785cbece'
+  version '51.R365_e50571e'
+  sha256 'ac823d6c7c1191c088c51477bfb59c51c5418f4ae92de1393ac934431bcbc8f9'
 
   url "https://download.pascom.net/release-archive/client/stable/pascom%20Client-#{version}.dmg"
+  appcast 'https://my.pascom.net/update/client/stable?_=1559037394513'
   name 'pascom Client'
   homepage 'https://www.pascom.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.