### PR TITLE
Update joplin from 1.0.157 to 1.0.158

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.157'
-  sha256 '3845c8947f4a7795f0e370b811f425d420e359e9800e7470711dc1d7ec09cd84'
+  version '1.0.158'
+  sha256 '5c51dc022924dc9408299b411933832a409d9612c53157e0c9e1b82d210ab2f9'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.