### PR TITLE
Update path-finder from 8.5 to 8.5.1

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '8.5'
-  sha256 '146ddbc2e7a034d746e2a1488b8eb507331985b6308518e387054316d9ccada2'
+  version '8.5.1'
+  sha256 '8f01547f8decec50f2109f848788e35a933acf4a277bb4088507ba42bbf17a74'
 
   url 'https://get.cocoatech.com/PF8.dmg'
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.