### PR TITLE
Update qt-creator from 4.9.0 to 4.9.1

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.9.0'
-  sha256 '11e897c807826d153a159dd0f84e7fda2bf559a44e66a17cb2550ed27dbb0279'
+  version '4.9.1'
+  sha256 'a508505c919d9d5b3c5660afb223ecbba3ea78606b34dedc40feb8c5170d3c4a'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qtcreator/'

--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -3,7 +3,8 @@ cask 'qt-creator' do
   sha256 'a508505c919d9d5b3c5660afb223ecbba3ea78606b34dedc40feb8c5170d3c4a'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
-  appcast 'https://download.qt.io/official_releases/qtcreator/'
+  appcast 'https://download.qt.io/official_releases/qtcreator/',
+          configuration: version.major_minor
   name 'Qt Creator'
   homepage 'https://www.qt.io/developers/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.