### PR TITLE
Update glip from 19.04.8 to 19.05.2

### DIFF
--- a/Casks/glip.rb
+++ b/Casks/glip.rb
@@ -1,6 +1,6 @@
 cask 'glip' do
-  version '19.04.8'
-  sha256 '0a273227365557f11ac0a80604e0751f0c510cfe83cccf9733cb28ade61adf35'
+  version '19.05.2'
+  sha256 '8e63279f60c471802f1421cda099dba7395e186b8d41084bc1a969ce2ed522f5'
 
   # downloads.ringcentral.com/glip/rc was verified as official when first introduced to the cask
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.