### PR TITLE
Update musaicfm from 1.1 to 1.1.2

### DIFF
--- a/Casks/musaicfm.rb
+++ b/Casks/musaicfm.rb
@@ -1,6 +1,6 @@
 cask 'musaicfm' do
-  version '1.1'
-  sha256 '947c7eb45c680936eb86dc5f2c6f1f188e16d9c7c75bf68bb5216e343c0f6df9'
+  version '1.1.2'
+  sha256 '966b84ee5941ffec8f439daf60e499dd6a07401828dc769411a98b0b1458c0b5'
 
   url "https://github.com/docterd/MusaicFM/releases/download/#{version}/MusaicFM.saver.zip"
   appcast 'https://github.com/docterd/MusaicFM/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.