### PR TITLE
Update balenaetcher from 1.5.41 to 1.5.42

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.41'
-  sha256 '88d30e91e4b7a6c0786466f168d6042d8f279a48223dbbe0c85d14b225117948'
+  version '1.5.42'
+  sha256 'a1b1b69084e6498c65fa6f7dbcef87f84c942b04ff38ff521b78b2b47e0207da'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.