### PR TITLE
Add Swift runtime caveat to Fork

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -19,4 +19,10 @@ cask 'fork' do
                '~/Library/Preferences/com.DanPristupov.Fork.plist',
                '~/Library/Saved Application State/com.DanPristupov.Fork.savedState',
              ]
+
+  caveats <<~EOS
+    Using the `#{token}` CLI command in MacOS versions 10.14.3 or earlier requires installing the "Swift 5 Runtime Support for Command Line Tools" update package. It can be downloaded at:
+
+    https://support.apple.com/kb/DL1998
+  EOS
 end


### PR DESCRIPTION
Adding a `caveats` section for Fork to notify users that the latest version's CLI will not work unless the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998) package is installed.

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).