### PR TITLE
Update ableton-live-intro from 10.0.6 to 10.1

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-intro' do
-  version '10.0.6'
-  sha256 '33071475dce5b269b8c0030670c10be6d9baa0e4e335cfa746e3bcb391d4a028'
+  version '10.1'
+  sha256 '88a8f5be63b476a7dd05446b75616220fe1620b4ce4c28aa41e21632dfa35f40'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.