### PR TITLE
Update ableton-live-standard from 10.0.6 to 10.1

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard' do
-  version '10.0.6'
-  sha256 'ba566192b56e74a9b455b307727413e6f2449626c1e83978dac3e18f6040180b'
+  version '10.1'
+  sha256 '76549681792348c905323af2f57b8b1c817991f25c148207a2098fdeb3c4f6ac'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.