### PR TITLE
Update cozy-drive from 3.13.0 to 3.13.1

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.13.0'
-  sha256 '70665c41a8d113cac9b8a3751169f4df65c045d0f6e8f3217b40255c0b4365b6'
+  version '3.13.1'
+  sha256 '247e0f03b7e0670d0d58d5b1e01a517f35a7a8e0a96ca67b4c79173136944e29'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.