### PR TITLE
Update progressive-downloader from 4.5.5 to 4.5.6

### DIFF
--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -1,6 +1,6 @@
 cask 'progressive-downloader' do
-  version '4.5.5'
-  sha256 '021afecd7ec12f00c72109ae618fe099fbfd1da804be23b01280db8da6cd706f'
+  version '4.5.6'
+  sha256 '447f89a338b37c8e6b8acb61d782faeb892409f6184b9deea0c1a784e4237b7b'
 
   url "https://www.macpsd.net/update/#{version}/PSD.dmg"
   name 'Progressive Downloader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.