### PR TITLE
Update butt from 0.1.17 to 0.1.18

### DIFF
--- a/Casks/butt.rb
+++ b/Casks/butt.rb
@@ -1,6 +1,6 @@
 cask 'butt' do
-  version '0.1.17'
-  sha256 'fa0b00284f29fda75272dc40480333c9a86ec9d41a30f7c41700127b539dec16'
+  version '0.1.18'
+  sha256 'a1beae6647ae4cb3463cba90a55e04a4c02a2f694995082a9a4e81fd792f28a9'
 
   # sourceforge.net/butt was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/butt/butt-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.