### PR TITLE
Update eudic from 3.8.9 to 3.9.0

### DIFF
--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -1,6 +1,6 @@
 cask 'eudic' do
-  version '3.8.9'
-  sha256 '918085753c4999a3218522d747ee12e975d995f7a36e1be960e3991a92e3da60'
+  version '3.9.0'
+  sha256 'f80e00a705fa095575ef8f05e750d60af9b640dee47825c553f982b7f263fcbe'
 
   # static.frdic.com was verified as official when first introduced to the cask
   url 'https://static.frdic.com/pkg/eudicmac.dmg'

--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -4,8 +4,7 @@ cask 'eudic' do
 
   # static.frdic.com was verified as official when first introduced to the cask
   url 'https://static.frdic.com/pkg/eudicmac.dmg'
-  appcast 'https://www.eudic.net/update/eudic_mac.xml',
-          configuration: :no_check
+  appcast 'https://www.eudic.net/update/eudic_mac.xml'
   name 'Eudic'
   name '欧路词典'
   homepage 'https://www.eudic.net/eudic/mac_dictionary.aspx'

--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -4,7 +4,8 @@ cask 'eudic' do
 
   # static.frdic.com was verified as official when first introduced to the cask
   url 'https://static.frdic.com/pkg/eudicmac.dmg'
-  appcast 'https://www.eudic.net/update/eudic_mac.xml'
+  appcast 'https://www.eudic.net/update/eudic_mac.xml',
+          configuration: :no_check
   name 'Eudic'
   name '欧路词典'
   homepage 'https://www.eudic.net/eudic/mac_dictionary.aspx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.