### PR TITLE
Update workflowy from 1.2.16 to 1.2.17

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.2.16'
-  sha256 '5d3580fa949d92b872288754dd9bde888e5723adbae221485e89413a1406edcd'
+  version '1.2.17'
+  sha256 '83fad16efdf6d42d8c7bf4879a8593d824ecbf134da56a355c0c18afecdfefb1'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.