### PR TITLE
Update dcp-o-matic-encode-server from 2.14.5 to 2.14.7

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.5'
-  sha256 'aa47c4c36d578284b1f9f484a4cfa062b14759221a8a97f2aff562c946173791'
+  version '2.14.7'
+  sha256 '7662c27a4cecec0ba8b0ab888e5bb6acc65d7f09bddf73f7f2eba8ffb7c9203a'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.