### PR TITLE
Update OpenInTerminal-Lite from 0.4.3 to 0.4.4

### DIFF
--- a/Casks/openinterminal-lite.rb
+++ b/Casks/openinterminal-lite.rb
@@ -1,6 +1,6 @@
 cask 'openinterminal-lite' do
-  version '0.4.3'
-  sha256 'fe2d2e5892632b537118cd8bf46a0d84df137a52c2f795c9492e5d6c2a181661'
+  version '0.4.4'
+  sha256 'd9630dcb803eca0ec9a000e60b5252a10a9d5d56d79baf4335012177e1cdbca8'
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/#{version}/OpenInTerminal-Lite.app.zip"
   appcast 'https://github.com/Ji4n1ng/OpenInTerminal/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
