### PR TITLE
Update skype from 8.45.0.43 to 8.46.0.60

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.45.0.43'
-  sha256 '2707f42a1371a6db11394b9c838e06164236bfb36159c75e3926f9dc601f371e'
+  version '8.46.0.60'
+  sha256 '91f7a5626abbbdebfbabfe10a5223c2e2bcda33115816033f4c45ef8c97f2ebd'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.