### PR TITLE
Update wechat from 2.3.25.18_1558616799 to 2.3.25.19

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,8 +1,8 @@
 cask 'wechat' do
-  version '2.3.25.18_1558616799'
-  sha256 'bab2930993fefdf1cb4bb663c4e365665d67cd96137977408049b1d1c6abe2d6'
+  version '2.3.25.20'
+  sha256 'a71fb87464e456c92545d1c0bd46008a74fe15712099c17d56796ce5bfb30cd5'
 
-  url "https://dldir1.qq.com/weixin/mac/WeChat_#{version}.dmg"
+  url 'https://dldir1.qq.com/weixin/mac/WeChatMac.dmg'
   appcast 'https://dldir1.qq.com/weixin/mac/mac-release.xml'
   name 'WeChat for Mac'
   name '微信 Mac 版'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.