### PR TITLE
Update wasabi-wallet from 1.1.4 to 1.1.5

### DIFF
--- a/Casks/wasabi-wallet.rb
+++ b/Casks/wasabi-wallet.rb
@@ -1,6 +1,6 @@
 cask 'wasabi-wallet' do
-  version '1.1.4'
-  sha256 '4f2aeeec21e321099542d09504dd202d7679b209dd8244a49eb880343ea3f8b3'
+  version '1.1.5'
+  sha256 '35677bbbd97b35fb8fe56e8396ac54447e3fa9a62d49fe5bbcef56d07c347fbe'
 
   # github.com/zkSNACKs/WalletWasabi was verified as official when first introduced to the cask
   url "https://github.com/zkSNACKs/WalletWasabi/releases/download/v#{version}/Wasabi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.