### PR TITLE
Update yammer from 3.4.3 to 3.4.4

### DIFF
--- a/Casks/yammer.rb
+++ b/Casks/yammer.rb
@@ -1,6 +1,6 @@
 cask 'yammer' do
-  version '3.4.3'
-  sha256 '8dd918fefe4a1b73801cf4d82ce4d1056baaad0a8c8174c93f9617e55bcc0a0a'
+  version '3.4.4'
+  sha256 'bd4333f19af3fe6b73d39f88b93cfce6fbaf1a7370f1a8addf34fe6b663db460'
 
   # yammerdesktopapp.blob.core.windows.net/binaries/dist was verified as official when first introduced to the cask
   url "https://yammerdesktopapp.blob.core.windows.net/binaries/dist/darwin/x64/#{version}/Yammer-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.