### PR TITLE
Update framer-x from 31932,1558096086 to 32458,1559118743

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '31932,1558096086'
-  sha256 '8e10354597e2236f28281bd29b3a0605614d1f7fa53386b912649aecb185942e'
+  version '32458,1559118743'
+  sha256 '61de9737616f778e0931440dd3d4720e94cfff3213f0359bd385df32b23b7645'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.