### PR TITLE
Update pdfpenpro from 1101.0,1558019343 to 1102.3,1559079247

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1101.0,1558019343'
-  sha256 '7ca7c0530201d242b60c1376e79aa8d2ac8e4fc44a77ec0f38d960c0e256e7b6'
+  version '1102.3,1559079247'
+  sha256 '72c677d6f359f43c301e0e6c1575d66a5476db17bbf6e12c606c678a206b7b36'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.