### PR TITLE
Update cisdem-pdf-converter-ocr from 6.5.0 to 6.6.0

### DIFF
--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-pdf-converter-ocr' do
-  version '6.5.0'
-  sha256 'cb49366f28c3e8815d30ea68bbbf4affbc397a3a2ceb8d03d2d48a812fea9ba9'
+  version '6.6.0'
+  sha256 '4ad587a08725cf847b4f4abbcfe06f91beea8f6beca933d795457532c74051ad'
 
   url 'http://download.cisdem.com/cisdem-pdfconverterocr.dmg'
   appcast 'https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.