### PR TITLE
Update deltawalker from 2.5.0 to 2.5.1

### DIFF
--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -1,6 +1,6 @@
 cask 'deltawalker' do
-  version '2.5.0'
-  sha256 'e5b51a90058c161c452c30dcd5278477f04c1bc5d12ad6fbff94b52d4cda80db'
+  version '2.5.1'
+  sha256 'fa25263ad38e2a61334fee88603e0b67ba098147376d7812dff1aeb6cc2f9e64'
 
   # amazonaws.com/deltawalker was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/deltawalker/DeltaWalker-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.