### PR TITLE
Update avocode from 3.7.3 to 3.8.0

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '3.7.3'
-  sha256 '75688ac966e14328028b1447c0d7cff2a1b3d1f2dd3ba1e412b988ec0c4f1cc1'
+  version '3.8.0'
+  sha256 '6fecc88bf62fad02aea7fb03b7a15d6b3be76db979da87b3d88ab986c29bbd1d'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.