### PR TITLE
Update screaming-frog-seo-spider from 11.2 to 11.3

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -1,6 +1,6 @@
 cask 'screaming-frog-seo-spider' do
-  version '11.2'
-  sha256 '83e920807c3e69286e8594c93caec9514657352d86f5f51e7062a361336effb9'
+  version '11.3'
+  sha256 '66f3de6f0a4309c1ef6bf9f69c558be55ed4ede146b70b31f77dd269a86b1b83'
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.