### PR TITLE
Update alfred from 4.0_1076 to 4.0.1_1078

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -1,6 +1,6 @@
 cask 'alfred' do
-  version '4.0_1076'
-  sha256 'e950b0b360c4e9c4d73da905de3d5676499917411f4be1ee3b171119fd189f7a'
+  version '4.0.1_1078'
+  sha256 'c77fe23d9cd2987b5f49d84cc2e5e50972c8c37f0df9c88f01ff29ac2881a5a3'
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.dmg"
   appcast 'https://www.alfredapp.com/app/update/general.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.