### PR TITLE
Update dissenter-browser from 0.67.13 to 67.62

### DIFF
--- a/Casks/dissenter-browser.rb
+++ b/Casks/dissenter-browser.rb
@@ -1,8 +1,8 @@
 cask 'dissenter-browser' do
-  version '0.67.13'
-  sha256 '623ad116b173bf07af4956323147dd376b0261dd2a69c7db40e3fef4a0c3e6a4'
+  version '67.62'
+  sha256 '66c00875864cc101a8301dcbadd3863dbc84e775d2b7cbc5728e6da6686c9ecd'
 
-  url "https://dissenter.com/dist/browser/dissenter-browser-#{version}.dmg"
+  url "https://dissenter.com/dist/browser/dissenter-browser-v#{version}.dmg"
   appcast 'https://dissenter.com/'
   name 'Dissenter'
   homepage 'https://dissenter.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.