### PR TITLE
Update family-tree-builder from 8.2.0,474 to 8.2.0.8516

### DIFF
--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -2,7 +2,7 @@ cask 'family-tree-builder' do
   version '8.2.0.8516'
   sha256 'babd0029c007932e0339a97e080608a06ffbc64f77c49879a2b8fd0a93f956c5'
 
-  # mhcache-myheritage.netdna-ssl.com was verified as official when first introduced to the cask
+  # mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder was verified as official when first introduced to the cask
   url "https://mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/family_tree_builder_#{version.split('.').last}.dmg"
   appcast 'https://www.myheritage.com/FP/FamilyTreeBuilder/appcast.xml'
   name 'Family Tree Builder'

--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -1,9 +1,10 @@
 cask 'family-tree-builder' do
-  version '8.2.0,474'
-  sha256 '852a30b1ae53ec656fb8045c9b830f71ed7da91667bbf68f421f3311c4c0a742'
+  version '8.2.0.8516'
+  sha256 'babd0029c007932e0339a97e080608a06ffbc64f77c49879a2b8fd0a93f956c5'
 
   # mhcache-myheritage.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/family_tree_builder_#{version.major}#{version.after_comma}.dmg"
+  url "https://mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/family_tree_builder_#{version.split('.').last}.dmg"
+  appcast 'https://www.myheritage.com/FP/FamilyTreeBuilder/appcast.xml'
   name 'Family Tree Builder'
   homepage 'https://www.myheritage.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.