### PR TITLE
netlogo 6.1.0: Update NetLogo version to 6.1.0, with updated sha256sum

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,6 +1,6 @@
 cask 'netlogo' do
-  version '6.0.4'
-  sha256 '07657a6c464bf27762f866c952e2acea31e801c26798c66282efacfbe7271841'
+  version '6.1.0'
+  sha256 '4a074f0edcc4e977e08eb72ca4f02a8eb45cb7cffaf3ad33df56029658ba41d1'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).