### PR TITLE
Update favro from 1.0.22 to 1.0.25

### DIFF
--- a/Casks/favro.rb
+++ b/Casks/favro.rb
@@ -1,8 +1,9 @@
 cask 'favro' do
-  version '1.0.22'
-  sha256 '71c2f7a06fd609e5a4f44d94cbcb2b7b712d179f6359de3112786041f5b5d8df'
+  version '1.0.25'
+  sha256 'ab554e74c697b3d3f4477e3d4a3f3cda8aa564e6789e6128d364e744f7882dd5'
 
   url "https://download.favro.com/FavroDesktop/macOS/x64/Favro-#{version}.dmg"
+  appcast 'https://download.favro.com/FavroDesktop/macOS/x64/Latest.json'
   name 'Favro'
   homepage 'https://www.favro.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.