### PR TITLE
Update adguard from 1.5.14 to 2.0.4

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -1,13 +1,17 @@
 cask 'adguard' do
-  version '1.5.14'
-  sha256 'a30b9654bd889e9d5b3e20ee0cf2573b901f784df49336121edfabb9c73bda59'
+  version '2.0.4'
+  sha256 '14a8146d15e1c0e778904a370bad639d51cb714879f26c9813552c6b5015cf9c'
 
   url "https://static.adguard.com/mac/Adguard-#{version}.release.dmg"
   appcast 'https://static.adguard.com/mac/adguard-release-appcast.xml'
   name 'Adguard for Mac'
   homepage 'https://adguard.com/'
 
-  app 'Adguard.app'
+  pkg 'AdGuard.pkg'
+
+  uninstall pkgutil: [
+                       'com.adguard.mac.adguard-pkg',
+                     ]
 
   zap trash: [
                '/Library/Application Support/com.adguard.Adguard',

--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -9,9 +9,7 @@ cask 'adguard' do
 
   pkg 'AdGuard.pkg'
 
-  uninstall pkgutil: [
-                       'com.adguard.mac.adguard-pkg',
-                     ]
+  uninstall pkgutil: 'com.adguard.mac.adguard-pkg'
 
   zap trash: [
                '/Library/Application Support/com.adguard.Adguard',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.