### PR TITLE
Update mimecast from 2.9 to 2.10,87301327:6013e89f434a2ce2aeb6

### DIFF
--- a/Casks/mimecast.rb
+++ b/Casks/mimecast.rb
@@ -1,9 +1,9 @@
 cask 'mimecast' do
-  version '2.9'
-  sha256 'eab4d1617d3bb0ab86b195a52b6c60ca53022e97cb475ad4eb3d3e16aa668a09'
+  version '2.10,87301327:6013e89f434a2ce2aeb6'
+  sha256 '0c57d1daf2298dc067c73b09ee556b894111d0afd978dd5743b306f02e9782dd'
 
   # system.na3.netsuite.com was verified as official when first introduced to the cask
-  url 'https://system.na3.netsuite.com/core/media/media.nl?id=57223086&c=601905&h=8cc4b2493f0770cef5f0'
+  url "https://system.na3.netsuite.com/core/media/media.nl?id=#{version.after_comma.before_colon}&c=601905&h=#{version.after_colon}"
   appcast 'http://updates-us.mimecast.com/update/descriptors/msm/latest'
   name 'Mimecast for Mac'
   homepage 'https://community.mimecast.com/community/knowledge-base/mimecast-for-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.