### PR TITLE
Update yandex-disk from 3.1.3,30 to 3.1.4,30

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
-  version '3.1.3,30'
-  sha256 'fa5e6819426d0f4ad442e7ee298593699d9b72e4e455e322419f33df6bee1043'
+  version '3.1.4,30'
+  sha256 '2a64a4c1297f84c967459747891ad138966f93cf091b895070dcf23389c457cd'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.after_comma}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.