### PR TITLE
Update memory-tracker-by-timely from 1.2.7 to 1.2.8

### DIFF
--- a/Casks/memory-tracker-by-timely.rb
+++ b/Casks/memory-tracker-by-timely.rb
@@ -1,6 +1,6 @@
 cask 'memory-tracker-by-timely' do
-  version '1.2.7'
-  sha256 '9f9f3e2eb5130d174fb2f961e694232721c56e51eeb2e1f89376d1cb1ba0a690'
+  version '1.2.8'
+  sha256 '711c94cf0e6479e1610f03ec32261f1a51c922490c6e31cad798f9ee354fa3a6'
 
   # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.