### PR TITLE
Update remembear from 1.4.0 to 1.4.1

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.4.0'
-  sha256 '1d0ea7018567b85b98ef332ea47d9c8cffc5fbbb8772986f3a058474813f6456'
+  version '1.4.1'
+  sha256 '61ba5784bdeeb46f59fe32fba28ef143e13f733b974f485dc6a4b88e49c36a2f'
 
   # s3.amazonaws.com/remembear was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/remembear/app/release/downloads/macOS/RememBear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.