### PR TITLE
Update marvel from 8.3.0 to 8.3.1

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.3.0'
-  sha256 'e68fe1e25acec1e1b716e3453762af8cd2c6306359fa7b05d1eab72f444334a1'
+  version '8.3.1'
+  sha256 'a7f6003ac8ef6c9cf092476c3c02d620012a845ed79d9c84c127ae597cee6c98'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.