### PR TITLE
Update alfaview from 7.39311 to 7.41015

### DIFF
--- a/Casks/alfaview.rb
+++ b/Casks/alfaview.rb
@@ -1,6 +1,6 @@
 cask 'alfaview' do
-  version '7.39311'
-  sha256 '5012484e0df944c77791e02924cf7392857cb7140a9f491ad4fa46307781f0cc'
+  version '7.41015'
+  sha256 '1a35c58ac901716d372a905d26c6739424509e23ed10d7718dab76bc1a7fc9a3'
 
   url "https://assets.alfaview.com/stable/mac/alfaview-mac-production-#{version}.dmg"
   appcast 'https://alfaview.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.