### PR TITLE
Update geogebra from 6.0.536.0 to 6.0.541.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -4,6 +4,7 @@ cask 'geogebra' do
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt"
+          configuration: version.dots_to_hyphens
   name 'GeoGebra'
   homepage 'https://www.geogebra.org/'
 

--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -3,7 +3,7 @@ cask 'geogebra' do
   sha256 'fc2b1b8ed46ed67ca130d2fe8a7150c85fbeb0def4fc59cb9f82195315f44789'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
-  appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt"
+  appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt",
           configuration: version.dots_to_hyphens
   name 'GeoGebra'
   homepage 'https://www.geogebra.org/'

--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.536.0'
-  sha256 '75581d260fb7f07725d533eabf7ae9e420eeae748e2ef55915c994a432a98863'
+  version '6.0.541.0'
+  sha256 'fc2b1b8ed46ed67ca130d2fe8a7150c85fbeb0def4fc59cb9f82195315f44789'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.