### PR TITLE
Update riot from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,6 +1,6 @@
 cask 'riot' do
-  version '1.2.0'
-  sha256 '469bc2bc9aa5ac2940eaa4b79b6be3466d5561c2120d0f960ac71fea96fa9c37'
+  version '1.2.1'
+  sha256 'fa21a216aed0782a866afb0eda7223ae06596e9822ec8c38dc9c6fd8a57be512'
 
   url "https://packages.riot.im/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://riot.im/download/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.