### PR TITLE
Update aerial from 1.4.9 to 1.5.0

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.4.9'
-  sha256 '407445e740d397960d27f51fcf14dfc4085e87e2073388e8aec5d27398d22562'
+  version '1.5.0'
+  sha256 '2e34483c064297f2ce9a619cde7c607c5cf9528d4455f707191e7e43c8064bc6'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.