### PR TITLE
Update monal from 2.4b4 to 2.4b5

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,5 +1,5 @@
 cask 'monal' do
-  version '2.5b5'
+  version '2.4b5'
   sha256 'bcaae218600ceacaa307d0ccb1dfeb33ad7bbae63531668cc7169b27f6553140'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
-  version '2.4b4'
-  sha256 'a5816318dabfe7b16d803d2be69172e6f3e0f6d892c0218a9bef1ed9852087b7'
+  version '2.5b5'
+  sha256 'bcaae218600ceacaa307d0ccb1dfeb33ad7bbae63531668cc7169b27f6553140'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.