### PR TITLE
Update borgbackup from 1.1.9 to 1.1.10

### DIFF
--- a/Casks/borgbackup.rb
+++ b/Casks/borgbackup.rb
@@ -1,6 +1,6 @@
 cask 'borgbackup' do
-  version '1.1.9'
-  sha256 '29908ee70db3bc64395633bf804872bb242c342f31432e4ffdf3344b9ba838ca'
+  version '1.1.10'
+  sha256 'a9432478993d29f4e5c2523473ebe814ed583f03a19ee2ec7f7d371cd45c2d43'
 
   # github.com/borgbackup/borg was verified as official when first introduced to the cask
   url "https://github.com/borgbackup/borg/releases/download/#{version}/borg-macosx64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.