### PR TITLE
Update powerphotos from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -12,8 +12,8 @@ cask 'powerphotos' do
     sha256 'ed9be64f4cb5a3d3848ad5177947bd8cd33e36846ea36266ef9d4d7b46813538'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.6.1'
-    sha256 '32f3f7b95afe33a03ab6e51a3c113c6804796c0f9f0de42ca79ad47fc8c34db2'
+    version '1.6.2'
+    sha256 'd3f63a453e0b9986492d2ec907787380a6ba8d729c990ac85fa772f278af6b5f'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.