### PR TITLE
Update zeplin from 2.4.1,691 to 2.4.2,697

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.4.1,691'
-  sha256 '2f9c336cea4262d11271063ea9566a3376efe0206a4319c2c8165bdff0abbd87'
+  version '2.4.2,697'
+  sha256 'ae7e6c6d19351f1b048698009b431024fa88a96dd1431035cf25060e111e44e0'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.