### PR TITLE
Update blink1control from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/blink1control.rb
+++ b/Casks/blink1control.rb
@@ -1,6 +1,6 @@
 cask 'blink1control' do
-  version '2.2.1'
-  sha256 '56c4b028babb20f425450b4fd8a76a46716325c5d2a879548aa76fc07b08640c'
+  version '2.2.2'
+  sha256 '59d7235432e018f6d8152c580b0ec38546fef0215342139b4cf95f6161efa097'
 
   # github.com/todbot/Blink1Control2 was verified as official when first introduced to the cask
   url "https://github.com/todbot/Blink1Control2/releases/download/v#{version}/Blink1Control#{version.major}-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.