### PR TITLE
Update brook from 20190401 to 20190601

### DIFF
--- a/Casks/brook.rb
+++ b/Casks/brook.rb
@@ -1,6 +1,6 @@
 cask 'brook' do
-  version '20190401'
-  sha256 '382aa8e252e95dcef0619f4de63af08484768511e0ae2986929bfb1b3561a5ee'
+  version '20190601'
+  sha256 '221c3e4fc2a0505fc76638b76d94fe2535b8f3d84b7640dc4fafad56523156f4'
 
   url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.dmg"
   appcast 'https://github.com/txthinking/brook/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.