### PR TITLE
Update browserosaurus from 5.4.3 to 5.4.5

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '5.4.3'
-  sha256 'ded033d1912885c6195e82131b790c0d1dc698d77ec8c98be8960697ea0adbb5'
+  version '5.4.5'
+  sha256 'fbdd63ac27aa38c2d2e4c0bddf98d680f66314904e19de299b845074fa4ffbf7'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.