### PR TITLE
Update blue-jeans from 2.12.0.423 to 2.13.0.439

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.12.0.423'
-  sha256 'b553140bbd8b04df915b8b2cef0d12c152943889e3f8221b4024ba3bf4bfc84d'
+  version '2.13.0.439'
+  sha256 '70970f57a67b9ad47008fb3be630be0b5dbf1a5d77d23ab4d696c9aa480d57f3'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   appcast 'https://www.bluejeans.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.