### PR TITLE
Update dosbox-x from 0.82.18,20190427181609 to 0.82.19,20190531205412

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.18,20190427181609'
-  sha256 'fae850fe9088fc47fe1a64398898a7f58a9c54f1e748fac4be0be4a718c9848a'
+  version '0.82.19,20190531205412'
+  sha256 'ba93f2f87e8aa92eaa2c6540d1f08e23cbd499cbc74d66d676c65a7cdaea773c'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.