### PR TITLE
Update lingon-x from 7.2.1 to 7.2.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
   if MacOS.version <= :high_sierra
     version '6.6.4'
-    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
+    sha256 :no_check
   else
-    version '7.2.1'
-    sha256 'd400a15348a2b7ed9fdb54b4df0529eea8e57af388844be238ee6df494f8c85e'
+    version '7.2.2'
+    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"

--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
   if MacOS.version <= :high_sierra
     version '6.6.4'
-    sha256 :no_check
+    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
     version '7.2.2'
-    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
+    sha256 'bbc6939fd4cfa3dcf1da534b4ea4daef0c5241d644374d6cdcd59c91e3040ec9'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.