### PR TITLE
Update bilibili-live-helper from 1.1.3 to 2.1.1

### DIFF
--- a/Casks/bilibili-live-helper.rb
+++ b/Casks/bilibili-live-helper.rb
@@ -1,11 +1,12 @@
 cask 'bilibili-live-helper' do
-  version '1.1.3'
-  sha256 '77a280c590fdf51eba6c6207055a0ded7c383d25d4a62b0bf5142b4ce4dbece6'
+  version '2.1.1'
+  sha256 '632c07da51aa4431fb51a9e2f0a4474d56cbff9846be44b1d9ad07e92f078a3e'
 
-  url "http://s2.danmaku.live/bilibili-live-helper-mac-v#{version}.zip"
+  url "http://s2.danmaku.live/%E5%BC%B9%E5%B9%95%E5%BA%93-mac-v#{version}.zip"
+  appcast 'http://bilibili.danmaku.live/js/app.240c1034.js'
   name 'Bilibili Live Helper'
   name 'Bilibili直播弹幕库'
   homepage 'http://bilibili.danmaku.live/'
 
-  app 'Bilibili直播弹幕库.app'
+  app '弹幕库.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.