### PR TITLE
Update jumpshare from 2.4.4 to 2.5.0

### DIFF
--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -1,6 +1,6 @@
 cask 'jumpshare' do
-  version '2.4.4'
-  sha256 '39ed08287ec4a7d0999aa0f096e8fc6687189365e3fa4d99a80ca3538d289174'
+  version '2.5.0'
+  sha256 '90145cf8e7499c31ba3ad350a697745127fc2b338297c2d50a03a8176a4ea6b1'
 
   # d21hi1or3tbtjm.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d21hi1or3tbtjm.cloudfront.net/desktop/mac/Jumpshare.zip'

--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -1,10 +1,9 @@
 cask 'jumpshare' do
   version '2.5.0'
-  sha256 '90145cf8e7499c31ba3ad350a697745127fc2b338297c2d50a03a8176a4ea6b1'
+  sha256 'c321f977cd1fd1802b7b4247dbf5d4108432320098b8f40491db837893feda36'
 
-  # d21hi1or3tbtjm.cloudfront.net was verified as official when first introduced to the cask
-  url 'https://d21hi1or3tbtjm.cloudfront.net/desktop/mac/Jumpshare.zip'
-  appcast 'https://rink.hockeyapp.net/api/2/apps/2e15b9ed1bad4078ac88b8fae1771bfb'
+  url 'https://apps.jumpshare.com/desktop/mac/updates/Jumpshare-2.5.0.tar.bz2'
+  appcast 'https://apps.jumpshare.com/desktop/mac/updates/appcast.xml'
   name 'Jumpshare'
   homepage 'https://jumpshare.com/'
 

--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -2,7 +2,7 @@ cask 'jumpshare' do
   version '2.5.0'
   sha256 'c321f977cd1fd1802b7b4247dbf5d4108432320098b8f40491db837893feda36'
 
-  url 'https://apps.jumpshare.com/desktop/mac/updates/Jumpshare-2.5.0.tar.bz2'
+  url "https://apps.jumpshare.com/desktop/mac/updates/Jumpshare-#{version}.tar.bz2"
   appcast 'https://apps.jumpshare.com/desktop/mac/updates/appcast.xml'
   name 'Jumpshare'
   homepage 'https://jumpshare.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.