### PR TITLE
Update protonmail-unofficial from 1.0.0 to 1.0.2

### DIFF
--- a/Casks/protonmail-unofficial.rb
+++ b/Casks/protonmail-unofficial.rb
@@ -1,8 +1,8 @@
 cask 'protonmail-unofficial' do
-  version '1.0.0'
-  sha256 '33d6e5006c3b16b3c10386b5a41e7c773d710854b9eaae46a75a13d17d1ec7ec'
+  version '1.0.2'
+  sha256 '818ecd4db48954332300a3295467add6f0d62efc72d4fb32a88877edad3abae0'
 
-  url "https://github.com/protonmail-desktop/application/releases/download/v#{version}/protonmail-desktop-#{version}.dmg"
+  url "https://github.com/protonmail-desktop/application/releases/download/v#{version}/protonmail-desktop-unofficial-#{version}.dmg"
   appcast 'https://github.com/protonmail-desktop/application/releases.atom'
   name 'Protonmail Desktop'
   homepage 'https://github.com/protonmail-desktop/application'

--- a/Casks/protonmail-unofficial.rb
+++ b/Casks/protonmail-unofficial.rb
@@ -7,5 +7,5 @@ cask 'protonmail-unofficial' do
   name 'Protonmail Desktop'
   homepage 'https://github.com/protonmail-desktop/application'
 
-  app 'Protonmail Desktop.app'
+  app 'Protonmail Desktop (unofficial).app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.