### PR TITLE
Update Suspicious Package to 3.5

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -1,13 +1,11 @@
 cask 'suspicious-package' do
-  version '3.4.1'
-  sha256 'e4673a0c590e7dcb711789d98fcadd2283c2152d262b7809dfd8c8a1b3e9094b'
+  version '3.5'
+  sha256 '7a60a9e2a3d51ad1fe0784742d77ca91d0c1a00ec09605f0df94a91c6a74fb97'
 
   url 'https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
   appcast 'https://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist'
   name 'Suspicious Package'
   homepage 'https://www.mothersruin.com/software/SuspiciousPackage/'
-
-  auto_updates true
 
   app 'Suspicious Package.app'
   binary "#{appdir}/Suspicious Package.app/Contents/SharedSupport/spkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

⚠️ Important:
- I removed the `auto_updates` property as the app has a mechanism to check for new version, but not the mechanism to automatically install the new version;
- Maybe the cask should be marked as without a version (`:latest`) and no check for the shasum as the URL for downloading the dmg does not depend on the version of the app. What do you think?

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256