### PR TITLE
Update djv from 1.2.6 to 1.3.0

### DIFF
--- a/Casks/djv.rb
+++ b/Casks/djv.rb
@@ -1,6 +1,6 @@
 cask 'djv' do
-  version '1.2.6'
-  sha256 'de29b756a8d8cc4f88fa4f5f2718680a7b41c937c48658617d796190aefa19cf'
+  version '1.3.0'
+  sha256 '5702e1a084377e0c0486b68c0fb5014b4e7aa3f4dbcd61bd489359859ad7589f'
 
   # downloads.sourceforge.net/djv was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/djv/djv-stable/#{version}/DJV-#{version}-Darwin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.