### PR TITLE
Reverts keepassxc from 2.4.2 to 2.4.1

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,6 +1,6 @@
 cask 'keepassxc' do
-  version '2.4.2'
-  sha256 'ef903cfc7005c93faf3fd5a41574542c0d40fc4c4ea9039ae340a5cd9eb3568d'
+  version '2.4.1'
+  sha256 '2488d3a3297c9a88f25bf8f2478bf24a941e4f46696dc2457adec43688896015'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"


### PR DESCRIPTION
As noted https://github.com/Homebrew/homebrew-cask/pull/64213#issuecomment-498160667, the cask for keepassxc 2.4.2 is currently broken:

```
==> Satisfying dependencies
==> Downloading https://github.com/keepassxreboot/keepassxc/releases/download/2.4.2/KeePassXC-2.4.2.dmg
curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'keepassxc' with message: Download failed: https://github.com/keepassxreboot/keepassxc/releases/download/2.4.2/KeePassXC-2.4.2.dmg
```

If you visit https://keepassxc.org/download/#mac, you'll see the following message (as of this writing on 2019-06-03):

> Note: Version 2.4.2 has a packaging error on macOS that prevents use of the browser extension. This version has been withheld until further notice.

Moreover, per https://github.com/keepassxreboot/keepassxc/issues/3209, it looks like it won't be fixed till next week:

> We cannot publish a new macOS release until next week. The lead maintainer with the signing key is AFK.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
