### PR TITLE
Update pencil2d from 0.6.3 to 0.6.4

### DIFF
--- a/Casks/pencil2d.rb
+++ b/Casks/pencil2d.rb
@@ -1,6 +1,6 @@
 cask 'pencil2d' do
-  version '0.6.3'
-  sha256 'a5ef7afa72ec437471f9aa86bd70a09e57b7b9b49718bff7078e6c3b37bddba3'
+  version '0.6.4'
+  sha256 'af744904373c33f7a18a6cb52af577d13ee8ffae62dd81472fc141b549925a0b'
 
   # github.com/pencil2d/pencil was verified as official when first introduced to the cask
   url "https://github.com/pencil2d/pencil/releases/download/v#{version}/pencil2d-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.