### PR TITLE
Update itunes-volume-control from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -1,6 +1,6 @@
 cask 'itunes-volume-control' do
-  version '1.5.2'
-  sha256 '741cd1503c9ac4f3ac4a6a50c24b53a5d4ab9a327b9b750caedb2a99a908284f'
+  version '1.5.3'
+  sha256 '82e570350fb97e6ebb4f5573ac9b0059ea9b789b8f3836b78edc7f245dad17fe'
 
   # uni-bonn.de/alberti/iTunesVolumeControl was verified as official when first introduced to the cask
   url "http://quantum-technologies.iap.uni-bonn.de/alberti/iTunesVolumeControl/iTunesVolumeControl-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.