### PR TITLE
Update classroom-assistant from 1.0.3 to 1.0.4

### DIFF
--- a/Casks/classroom-assistant.rb
+++ b/Casks/classroom-assistant.rb
@@ -1,6 +1,6 @@
 cask 'classroom-assistant' do
-  version '1.0.3'
-  sha256 'b5ba0785d3f212b24098cfcd96b4a2d6e16b3aacc75ae732786c8670b7d62aca'
+  version '1.0.4'
+  sha256 '48fecda2ce6d882c1ecf7714844bc613b8fced4b24c75d0e5c8525a9265556e8'
 
   url "https://github.com/education/classroom-assistant/releases/download/v#{version}/Classroom.Assistant-darwin-x64-#{version}.zip"
   appcast 'https://github.com/education/classroom-assistant/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.