### PR TITLE
Update reactotron from 2.15.0 to 2.15.1

### DIFF
--- a/Casks/reactotron.rb
+++ b/Casks/reactotron.rb
@@ -1,6 +1,6 @@
 cask 'reactotron' do
-  version '2.15.0'
-  sha256 'f0a32c7831ae840a7c1345e6149f913b0cc491a6191c9855372c342ddcb62b8b'
+  version '2.15.1'
+  sha256 'd1de3331e0aaefd3c36186f479a84b9b63c2a5c36452679de077fe72912321aa'
 
   url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron-#{version}-mac.zip"
   appcast 'https://github.com/infinitered/reactotron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.