### PR TITLE
Update superproductivity from 2.7.3 to 2.7.4

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.7.3'
-  sha256 'fd5c31b091f2a916c4f563aba5572af3a7649413818054ddda762af6163717af'
+  version '2.7.4'
+  sha256 '98c90a60308371cf394fed8ec108c18a62769c2eb323d9452befc883a690ad95'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.