### PR TITLE
Update moonitor from 0.6.6 to 0.7.1

### DIFF
--- a/Casks/moonitor.rb
+++ b/Casks/moonitor.rb
@@ -1,6 +1,6 @@
 cask 'moonitor' do
-  version '0.6.6'
-  sha256 '2a0d59ea68f791ef27a5b0209d1abd43dc4a61c6bed70248a171497b9210d66e'
+  version '0.7.1'
+  sha256 'b491f3d61c4c65defbb0b743814841e08c949600cc7eb4f225b5aecb9de47888'
 
   url "https://moonitor.io/wp-content/uploads/app/Moonitor-#{version}.dmg"
   name 'Moonitor'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.