### PR TITLE
Update ipfs to 0.8.0

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -1,6 +1,6 @@
 cask 'ipfs' do
-  version '0.7.3'
-  sha256 'b11c8c84508ba75ba09bea6eebff5eb1877344396aae81c84f522d194d9469da'
+  version '0.8.0'
+  sha256 'a1bd934b4f3b4f796b5fbd384a9d552b550d9502981ca1ad167fadcf03d6cffe'
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/ipfs-desktop-#{version}.dmg"
   appcast 'https://github.com/ipfs-shipyard/ipfs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.