### PR TITLE
Update bibdesk from 1.7 to 1.7.1

### DIFF
--- a/Casks/bibdesk.rb
+++ b/Casks/bibdesk.rb
@@ -1,6 +1,6 @@
 cask 'bibdesk' do
-  version '1.7'
-  sha256 '43daabd2de7abba2a661754b02fec4687dbb87a689dad6b3bee494576341fe2b'
+  version '1.7.1'
+  sha256 'a189023bfa61ec2e53e04fb0a4a5011df182f2e7d106335352bce77b638c842a'
 
   # downloads.sourceforge.net/bibdesk was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/bibdesk/BibDesk/BibDesk-#{version}/BibDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.