### PR TITLE
Update cmake from 3.14.4 to 3.14.5

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.14.4'
-  sha256 'ca56fb4d590c7518f3cb20297be92dae15ab55be4cc907b020c2d8cfe07da678'
+  version '3.14.5'
+  sha256 'a1dd64edb6036fdaa365ed0cd850e437ce6ab2e67da817f080376a2aa05eefc8'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   name 'CMake'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.