### PR TITLE
Update sourcetree from 3.1.2_216 to 3.2_224

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
     url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
   else
-    version '3.1.2_216'
-    sha256 '4c5fb503f2cb486d2cc6aaf4192749ee2679ccfbbf1eaa981b2b3ed13a643e27'
+    version '3.2_224'
+    sha256 'd32e51702b4aedac7a11cacb62ff5a8ee29ad3a9a1787d6c7c11581587276631'
 
     # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
     url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.