### PR TITLE
Update bisq from 1.1.1 to 1.1.2

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '1.1.1'
-  sha256 '1d664747db39926ef630a051ef732455b2056b3e2dee232debc503b5740975ed'
+  version '1.1.2'
+  sha256 '81d67fcfa4dff1a1a39fb6d6c135df19ca4dc8f8089f57aa88167bb79ec0ead5'
 
   # github.com/bisq-network/bisq was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.