### PR TITLE
Update jclasslib-bytecode-viewer from 5.3.1 to 5.3.2

### DIFF
--- a/Casks/jclasslib-bytecode-viewer.rb
+++ b/Casks/jclasslib-bytecode-viewer.rb
@@ -1,6 +1,6 @@
 cask 'jclasslib-bytecode-viewer' do
-  version '5.3.1'
-  sha256 'fa3a370b9f3aa4dfce741a8ab7833b00f61a4fb9e998f5bd2bb3ece6c6218601'
+  version '5.3.2'
+  sha256 '8d2c47063bf5c7b5a6c5528ec5a2e6a168d10f338417b9e0f30854022de97120'
 
   url "https://github.com/ingokegel/jclasslib/releases/download/#{version}/jclasslib_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/ingokegel/jclasslib/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.