### PR TITLE
Update superproductivity from 2.7.4 to 2.7.6

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.7.4'
-  sha256 '98c90a60308371cf394fed8ec108c18a62769c2eb323d9452befc883a690ad95'
+  version '2.7.6'
+  sha256 '763c3f889729f8aabf1c2b6a36b4eb2b4f74cdb9c1f7b93dc4b9f27562dfc963'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.