### PR TITLE
Update terminus from 1.0.78 to 1.0.79

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.78'
-  sha256 '1fcf32a8ea5abcc4f8965bd216a8ef7a996aa15e77540122b040c3349d62cbde'
+  version '1.0.79'
+  sha256 'd61c7d9d82b94abe243bfe39a8d7327ebedd708734aa9330af2b85745b268807'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.