### PR TITLE
Update downie from 3.7.4,2015 to 3.7.5,2018

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.7.4,2015'
-  sha256 '9cb007255702bc2f9bbc3d281bf49eb2ae7d52586307c96a568be4e5ae449fae'
+  version '3.7.5,2018'
+  sha256 '4e8e71f1f302458c1207eb14cf8d4a898c0c01db14e87c7e4a54566ce1474c47'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.