### PR TITLE
Update dashcam-viewer from 3.2.4 to 3.2.5

### DIFF
--- a/Casks/dashcam-viewer.rb
+++ b/Casks/dashcam-viewer.rb
@@ -1,6 +1,6 @@
 cask 'dashcam-viewer' do
-  version '3.2.4'
-  sha256 '7fe01d4ccb0cf1dc2e16a2a560a7f034a8766969997a49069400e3f851bc2b6b'
+  version '3.2.5'
+  sha256 '392b9c1608518efc966056918e988bbe619f867fbf63354f7a578f55b435f038'
 
   # s3.amazonaws.com/aws-website-dcv-downloads-c8kwd/dcv was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/aws-website-dcv-downloads-c8kwd/dcv/Dashcam_Viewer_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.