### PR TITLE
Update sourcetrail from 2019.2.25 to 2019.2.39

### DIFF
--- a/Casks/sourcetrail.rb
+++ b/Casks/sourcetrail.rb
@@ -1,6 +1,6 @@
 cask 'sourcetrail' do
-  version '2019.2.25'
-  sha256 '13caae8924683c9edb07325697e2c55279f3c455f089308021757971f8429730'
+  version '2019.2.39'
+  sha256 '4ba6b422ca7027acd94325a1425eaf324a567107a8a0ad6ee37521336370ed37'
 
   url "https://www.sourcetrail.com/downloads/#{version}/osx/64bit"
   appcast 'https://raw.githubusercontent.com/CoatiSoftware/SourcetrailBugTracker/master/README.md'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.