### PR TITLE
Update studio-3t from 2019.2.1 to 2019.3.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2019.2.1'
-  sha256 '73745d76f15bff326f763e94098cdceb5fc5f200f1e3dbd62bed4ca3eee0da63'
+  version '2019.3.0'
+  sha256 '1ec8e8da98e32f645441a79a75d9543339886981e9106ca29c455bca7356d24f'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.