### PR TITLE
Update nvidia-geforce-now from 2.0.6.91 to 2.0.7.52,C1A7AF

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,8 +1,8 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.6.91'
-  sha256 '7f24902a66c41ed34b24a96a4f272eb93567617984bbbb7bb86e768e588d01cc'
+  version '2.0.7.52,C1A7AF'
+  sha256 '34d8563bb5bde038077a7fc0572fbb1da9ffc4b3b021c82233bf81a0f33f055e'
 
-  url 'https://ota-downloads.nvidia.com/ota/GeForceNOW-release_9C7E43.dmg'
+  url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'
   name 'NVIDIA GeForce NOW'
   homepage 'https://www.nvidia.com/en-us/geforce/products/geforce-now/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.