### PR TITLE
add picard launch wrapper

### DIFF
--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -12,6 +12,17 @@ cask 'musicbrainz-picard' do
 
   app 'MusicBrainz Picard.app'
 
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/picard.wrapper.sh"
+  binary shimscript, target: 'picard'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/MusicBrainz Picard.app/Contents/MacOS/picard' "$@"
+    EOS
+  end
+
   zap trash: [
                '~/.config/MusicBrainz',
                '~/Library/Caches/MusicBrainz',


### PR DESCRIPTION
This adds `picard` wrapper, so you could launch picard from commandline opening pre-defied directory:

before
```
➔ /Applications/MusicBrainz\ Picard.app/Contents/MacOS/picard /media/Music/2019/Ladytron
```

after:
```
➔ picard /media/Music/2019/Ladytron
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
