### PR TITLE
Update firefox from 67.0 to 67.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '67.0'
+  version '67.0.1'
 
   language 'cs' do
-    sha256 'ba63dabfe0749651db5a4a8e5b633aab830cb8aefb80aa7b8336f4a64a8b3efd'
+    sha256 '85f43f9e2c4004ac48cca5551e7bdaa8fdbe748f51d4e1f8ba327cd2be7982a3'
     'cs'
   end
 
   language 'de' do
-    sha256 '01873b081f9130a654b5150cfdc1239392c6d05b68ee22f7eb43407dc07bc547'
+    sha256 '5d3e391a33b91016786ac3fafabc6ce12ed3fbcdd377164781bb846ab9981d2d'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '12e666a95c30f5d48b001dd8877af34da64c8f2776d4958d2425f5aa39b7ac16'
+    sha256 'f5946d695739aeaebb3e7dfb873d8c8c7487ec78bbca80381b59875fbea498f5'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '3fcf0db18898ae0beef97d0a3ae631afc9b6324b251ff575e78787c335ef8fe3'
+    sha256 'a740bf0d9f406c689135cf1bddf185ad7ed80b9af74e2387b87063fbbc0e20a6'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '76f94d6b9e19a44508c0282575ed9b033cd0c8ea58bab208d3ecc02018edbfcd'
+    sha256 '50d485189481a6d600742949b2db11df8d79fdc03a66d344bf8c2871e2d317ae'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '179cf1d7877c2c1a39494225f9ae336374f72d0feee156bfbd720cf59d823ce8'
+    sha256 '26d8c61c6ac11747533dfd75cb6f4fb155fab2e82a45606d3970b364d6364916'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '7f87272b5cea2b55c070d40de3c1816c56a7a2a75e56724d0594c91b3e0efb8e'
+    sha256 'c061f70513d324651e98b9425b2a91c0990bfeb86be0d467f52a796ede227618'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '58c383146d41a6f16a5802a6ee0dbe6002be378946a5a835645f62e45c5255f3'
+    sha256 '9e8e28edce41dd3f1b79b5dd2d4925cff49cbb798df698525b5639d7fcadc968'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '0a7e93aec9f48e091f6eaf165761765bab6f6f465c492d80b01da6434ce19051'
+    sha256 '1788d83551a39569f08a6d097a123e211d8d934c5cb833dfb94c678328139713'
     'fi'
   end
 
   language 'fr' do
-    sha256 'dc26e5db415e72b4078b5abe64b9b007acca4a626b05043099ba273e41a50f62'
+    sha256 '27d17d200725c1aa04157917c4fa906721a7ef9b35d34cae4b2c0f85990f089a'
     'fr'
   end
 
   language 'gl' do
-    sha256 '8b1a4cf106fd2957bf952c41d4eeaed4604249d3727e7a06f12c50122f653dcb'
+    sha256 '4bd4b23073d6b56a7edd47fb84caede82c0a4d35f5acbdc7b12cd531863f69f6'
     'gl'
   end
 
   language 'in' do
-    sha256 'b2f822bbad958972b3e966f54571f799ac12fc75329c34ddee6cc03903d4cf8e'
+    sha256 '96e0e0f901ca7a09f0c16756816069b3553a9ee05efe49b70fc14f35c828abeb'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '9a64fc97db62e5e8118d8c89ed91e3ebfc40f0576dc879d7fc99a069e57155b8'
+    sha256 'b628ec8005ae7294abeafbb69b397a40b9905588faab010b333e7dfeab0a4e25'
     'it'
   end
 
   language 'ja' do
-    sha256 '9e24791b760df5c817f4fea961eff4303b2bbee19bfdcf1fd168e5b13e6a3320'
+    sha256 '491a3da8812e22968569d18087f61d7a27292eee3d71470b9bff01668d9dfef8'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '53aeb82c45dd54549e6e3973ec8da679e7211c673bcd8b53146f1a25b7fe1f3a'
+    sha256 '8341949c1e384d44982448467fc53224cc26070e4846e80c0800c9cd49e781f0'
     'ko'
   end
 
   language 'nl' do
-    sha256 'c61044f500a309ef0d7ea174adf617070f9bef9d378559fe1fd87f324742d001'
+    sha256 '09a7b10a17bd8fc0a6f5c95692e2db3eb1a9afbc96b5ed145123217d8084161d'
     'nl'
   end
 
   language 'pl' do
-    sha256 '9e278274d16f68b3ffde878d82ce37d66ec4e409d17285addd6fe712e475c7e9'
+    sha256 '891c579c30773620752753f2efa33ee452c0cb6d56f6a9cf52418f06a286e0cb'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'bc95ec4c867a9251b052312798e3ea93115f0ea6657d4baddaca8fd3247c3a27'
+    sha256 '724d7e0c914d074662db10e704a49c97ea4d6d0487ed3f8d92230ebfae62676c'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '2a41afe57051a3490f6b82476038afa7beb78e7df2fac948175d954cb2781179'
+    sha256 '15064b084fb28d2d07894e1f995e25137b778be15f35cdf9c9286c50a6a25c58'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '1372ef5ef6416fd1efd1ab5e7dd21e68215cc56be6e6639584b9c1d80b5ccb47'
+    sha256 '1fd1c63496d120f5cdfba82f09c018d81f27cd61ca313c1b01d191afd2444a3a'
     'ru'
   end
 
   language 'tr' do
-    sha256 '1b23a393f72b4f5f2f8e55916da8bd2c62635f56b15ff39582d0594edff3d861'
+    sha256 'e80429b4f8a6aa49f75ef2c0fc234eb26f5035cd9276926675d4d602a0541c05'
     'tr'
   end
 
   language 'uk' do
-    sha256 '2b8fef55060386a1a1e08cf749870df3b82ced7ed7213141c7c5f742c57b64ed'
+    sha256 '55ade12b09a1283859488ab5a4412fe86f1ceb0da186734c3cbcdb42833fa628'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '73779aae6db79c28215f41b564871860bff487a79de8311c3af765915ae9d687'
+    sha256 '38f402baf8d53df7e25a3adc992c14782eaeb4e9b5f33216a708b0353650b2fe'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'ada8ca242dcbaccc6263f441831c4e559b4cd64a675d67e38e13247f30a8839f'
+    sha256 '49015f352ab83a12e5982e3309ce1d7be0754485fa89a3c110f89eee73d2acf7'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
