### PR TITLE
Update graphicconverter from 10.7.1,3460 to 11.0,4003

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,9 +1,9 @@
 cask 'graphicconverter' do
-  version '10.7.1,3460'
-  sha256 '2f7be3cb9e04ebcd4d89e44599e0f1ff84a27c1dda85a4d716b9a0eef0280a24'
+  version '11.0,4003'
+  sha256 '1c73db344b870252313962131c23e75a52e373ddf7f072fe959b596eea001675'
 
   # lemkesoft.info was verified as official when first introduced to the cask
-  url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"
+  url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}.dmg"
   appcast "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml"
   name 'GraphicConverter'
   homepage 'https://www.lemkesoft.de/en/products/graphicconverter/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.