### PR TITLE
Update scrutiny from 8.4.0 to 8.4.1

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.4.0'
-  sha256 '524acbbdf02526eeaa777a8cd3ac274da40aa0143f36e16d2b48ce49c26f64e9'
+  version '8.4.1'
+  sha256 '3ed52a04b9709b19a9e4156ca15b6ed8e75d6de15d9dda40bbc20a328596072f'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.