### PR TITLE
Update unity-download-assistant from 2019.1.4f1,ffa3a7a2dd7d to 2019.1.5f1,0ca0f5646614

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.1.4f1,ffa3a7a2dd7d'
-  sha256 'd12589b4040ee886955bc199763cf19a7ad7f15813091061ed64cd7bb0f07350'
+  version '2019.1.5f1,0ca0f5646614'
+  sha256 '04158a83bb637e6f5fa84e49dc98432880452177eb18d924f290102c0c50a9df'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.