### PR TITLE
Update unity-vuforia-ar-support-for-editor from 2019.1.4f1,ffa3a7a2dd7d to 2019.1.5f1,0ca0f5646614

### DIFF
--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-vuforia-ar-support-for-editor' do
-  version '2019.1.4f1,ffa3a7a2dd7d'
-  sha256 '57c37d11fb2708779e8a3dab47ec6c5a677599ec4d9a664aea9cc958e9398990'
+  version '2019.1.5f1,0ca0f5646614'
+  sha256 '4e1f60b39fa25eb96e0eb4a97820f126239abafac3ac142a2697b4cb97becbba'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.