### PR TITLE
Update unity-ios-support-for-editor from 2019.1.4f1,ffa3a7a2dd7d to 2019.1.5f1,6f1140cf2297

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,8 +1,8 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.1.4f1,ffa3a7a2dd7d'
-  sha256 '24cc2ab50d638ee3431866a17cddbc0ef92bee7489acc36509f1da92985e6071'
+  version '2019.1.5f1,6f1140cf2297'
+  sha256 'b71cdc392df250a6a2ebd4e0a65c4f59c77a40622f5bc9ef1111814a617a00f7'
 
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity iOS Build Support'
   homepage 'https://unity3d.com/unity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.