### PR TITLE
Update unity-windows-support-for-editor from 2019.1.4f1,ffa3a7a2dd7d to 2019.1.5f1,6f1140cf2297

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,8 +1,8 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.1.4f1,ffa3a7a2dd7d'
-  sha256 'fb51e0a9611fb6ccd489e462257fc52417dcb09bb97f420c0f39b0ccd6b4a53d'
+  version '2019.1.5f1,6f1140cf2297'
+  sha256 'fa54977fba03360e746c64995118a61c2f70907c8624a7f22a401b2bc74d871f'
 
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity Windows (Mono) Build Support'
   homepage 'https://unity3d.com/unity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.