### PR TITLE
Update archipelago from 3.4.0 to 3.4.1

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.4.0'
-  sha256 'b44ff8911eadd692a9eabeafb3eed55700603bb44814d09c12dd6ae55e37a8e6'
+  version '3.4.1'
+  sha256 'b04dfc1f477d0a0ceb5c1dc5423c23e9397054bf3b3a62dc4f533c414be2ff3a'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.