### PR TITLE
Update superproductivity from 2.7.6 to 2.7.7

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.7.6'
-  sha256 '763c3f889729f8aabf1c2b6a36b4eb2b4f74cdb9c1f7b93dc4b9f27562dfc963'
+  version '2.7.7'
+  sha256 'fb16e40859cff975474063aa8f99afb0e5db7a616198fdfb953c5c0b7d92fe18'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.