### PR TITLE
Update dbvisualizer from 10.0.20 to 10.0.21

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -1,6 +1,6 @@
 cask 'dbvisualizer' do
-  version '10.0.20'
-  sha256 'e6e2ef7e999ad8b34d02273564f3cde242b1dd1e48c178e72503de5e62701aec'
+  version '10.0.21'
+  sha256 '0c61d818c0acd57e381dc32deb3747a606da67581160df2c4e90f5b548fef457'
 
   url "https://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.dots_to_underscores}_jre.dmg"
   name 'DbVisualizer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.