### PR TITLE
Update wechatwork from 2.8.5.2046 to 2.8.5.2051

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.5.2046'
-  sha256 'd3cf16298625d3e35b0bb3d0de406a2e847c46ec9e13a110b78e76e2f2b50d05'
+  version '2.8.5.2051'
+  sha256 '6e2763596f4650f2f34ebfeaa6dbe747a2684633407ee7691a23b684e6395a53'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.