### PR TITLE
Update unity-webgl-support-for-editor from 2019.1.4f1,ffa3a7a2dd7d to 2019.1.5f1,6f1140cf2297

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,8 +1,8 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.1.4f1,ffa3a7a2dd7d'
-  sha256 '779dc58d220063955fc97cc775f9a037aa538c9242625cc9d4a6f3608e7b9205'
+  version '2019.1.5f1,6f1140cf2297'
+  sha256 '675c7043745a60af04e0f837594aa0f0e42b10cc7084557f1f33bafe555c816c'
 
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'
   name 'Unity WebGL Build Support'
   homepage 'https://unity3d.com/unity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.