### PR TITLE
Update unity-vuforia-ar-support-for-editor from 2019.1.4f1,ffa3a7a2dd7d to 2019.1.5f1,6f1140cf2297

### DIFF
--- a/Casks/unity-vuforia-ar-support-for-editor.rb
+++ b/Casks/unity-vuforia-ar-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-vuforia-ar-support-for-editor' do
-  version '2019.1.4f1,ffa3a7a2dd7d'
-  sha256 '57c37d11fb2708779e8a3dab47ec6c5a677599ec4d9a664aea9cc958e9398990'
+  version '2019.1.5f1,6f1140cf2297'
+  sha256 '44f91ecb1a42af0905b7e78fcc3a6b6a1bb64650fc16c9c247dd294bb76abda8'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Vuforia-AR-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.