### PR TITLE
Update freecad from 0.18.1,16117 to 0.18.2,16117

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
-  version '0.18.1,16117'
-  sha256 '121f35cbe93a163c4784731cbcffb8be2523df7ab3e5350ed7aa352fb6f2c73a'
+  version '0.18.2,16117'
+  sha256 '8ca8085379eaf4903fafa808c313e4b9659be846454597d27fd54184f71a8369'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
👉 Closes https://github.com/Homebrew/homebrew-cask/issues/64395

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.