### PR TITLE
Update path-finder from 8.5.1 to 8.5.2

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '8.5.1'
-  sha256 '8f01547f8decec50f2109f848788e35a933acf4a277bb4088507ba42bbf17a74'
+  version '8.5.2'
+  sha256 'bd76318e356a6cb01aeb492dc16234b510cf7d99dfdaba60744dba222b835a23'
 
   url 'https://get.cocoatech.com/PF8.dmg'
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.