### PR TITLE
DBVisualizer 10.0.21 remove Java 8 dependency

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -15,8 +15,4 @@ cask 'dbvisualizer' do
   uninstall signal: [['TERM', 'com.dbvis.DbVisualizer']]
 
   zap trash: '~/.dbvis'
-
-  caveats do
-    depends_on_java '8'
-  end
 end


### PR DESCRIPTION
The pull request #56049 has made `depends on java8` obsolete.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
