### PR TITLE
Update capture-one from 12.0.3.28 to 12.0.4.21

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '12.0.3.28'
-  sha256 '36b679822a772e30a5694fdbd2304fe2b2398eaaae6a39aa4f7bec98a2a1bd9a'
+  version '12.0.4.21'
+  sha256 '4b63fe1c0d72371f66594c80343fe52bed5898d4df331eb81a5b7849031773c6'
 
   url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
   name 'Capture One'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.