### PR TITLE
Update deeper from 2.4.5 to 2.4.6

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -17,8 +17,8 @@ cask 'deeper' do
     version '2.3.3'
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   else
-    version '2.4.5'
-    sha256 'd17d51b8e1e6cfd4aca2d61e81b59355bfe6a93e054ae9e6af0c7465f2a82989'
+    version '2.4.6'
+    sha256 '74396fe3ef45dc77946c647cc456351a59d745f10c4075116587ff934b94b176'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.