### PR TITLE
Update itubedownloader from 6.4.10 to 6.4.11

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,6 +1,6 @@
 cask 'itubedownloader' do
-  version '6.4.10'
-  sha256 '14655a80a24ae64cf825dc707c2a756b915279b71fea3653da5e142c6142d99c'
+  version '6.4.11'
+  sha256 '33145f8ac7f206c239092548896879963e822c9a95496522944bdeed59039e2c'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/iTubeDownloader.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.