### PR TITLE
Update exfalso from 4.2.0 to 4.2.1

### DIFF
--- a/Casks/exfalso.rb
+++ b/Casks/exfalso.rb
@@ -1,6 +1,6 @@
 cask 'exfalso' do
-  version '4.2.0'
-  sha256 'd61a0fa082b69bb4976ee9c6bc2de6b2cbae1ced01a8ae02e6dd3063db825311'
+  version '4.2.1'
+  sha256 'f14267df96269f1b9979f47a82711c61370b0050f006f9bb4b4af07b044cbab6'
 
   # github.com/quodlibet/quodlibet was verified as official when first introduced to the cask
   url "https://github.com/quodlibet/quodlibet/releases/download/release-#{version}/ExFalso-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.