### PR TITLE
Secure URLs

### DIFF
--- a/Casks/air-video-server-hd.rb
+++ b/Casks/air-video-server-hd.rb
@@ -6,7 +6,7 @@ cask 'air-video-server-hd' do
   url "https://s3.amazonaws.com/AirVideoHD/Download/Air+Video+Server+HD+#{version}.dmg"
   appcast 'https://s3.amazonaws.com/AirVideoHD/Download/appcast.xml'
   name 'Air Video Server HD'
-  homepage 'http://www.inmethod.com/airvideohd'
+  homepage 'https://airvideo.app/'
 
   app 'Air Video Server HD.app'
 

--- a/Casks/fastscripts.rb
+++ b/Casks/fastscripts.rb
@@ -2,7 +2,7 @@ cask 'fastscripts' do
   version '2.7.7'
   sha256 'f909d9ab3f55f77f98a2407008f707dd7c1ae10f3fbb366052318fe6d33603e4'
 
-  url "https://www.red-sweater.com/fastscripts/FastScripts#{version}.zip"
+  url "https://red-sweater.com/fastscripts/FastScripts#{version}.zip"
   appcast 'https://red-sweater.com/fastscripts/appcast2.php'
   name 'FastScripts'
   homepage 'https://red-sweater.com/fastscripts/'

--- a/Casks/finereader.rb
+++ b/Casks/finereader.rb
@@ -2,7 +2,7 @@ cask 'finereader' do
   version :latest
   sha256 :no_check
 
-  url 'http://fr7.abbyy.com/mac/fr/ABBYY_FineReader_Pro_ESD.dmg'
+  url 'https://fr7.abbyy.com/mac/fr/ABBYY_FineReader_Pro_ESD.dmg'
   name 'ABBYY FineReader Pro'
   homepage 'https://www.abbyy.com/finereader/pro-for-mac/'
 

--- a/Casks/fontexplorer-x-pro.rb
+++ b/Casks/fontexplorer-x-pro.rb
@@ -3,7 +3,7 @@ cask 'fontexplorer-x-pro' do
   sha256 '40231d4a0da8c799e7c00dc9788cf97008e52a3bf06119b6be2a668984c174af'
 
   url "https://fast.fontexplorerx.com/FontExplorerXPro#{version.no_dots}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://fex.linotype.com/download/mac/FontExplorerXPro.dmg',
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://fex.linotype.com/download/mac/FontExplorerXPro.dmg',
           configuration: version.no_dots
   name 'FontExplorer X Pro'
   homepage 'https://www.fontexplorerx.com/'

--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -2,7 +2,8 @@ cask 'lyx' do
   version '2.3.2'
   sha256 'e121a6fdbe3db24d920019295c41bd6d0116b11b4605ad1c90448c625d3e8332'
 
-  url "http://ftp.lyx.org/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg"
+  # ftp.lip6.fr/pub/lyx/ was verified as official when first introduced to the cask
+  url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg"
   appcast 'https://www.lyx.org/misc/rss/lyx_news_feed.xml'
   name 'LyX'
   homepage 'https://www.lyx.org/'

--- a/Casks/marvin.rb
+++ b/Casks/marvin.rb
@@ -4,7 +4,7 @@ cask 'marvin' do
 
   # s3.amazonaws.com/amazingmarvin was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/amazingmarvin/Marvin-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://amazingmarvin.s3-website-us-east-1.amazonaws.com/Marvin.dmg'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://s3.amazonaws.com/amazingmarvin/Marvin.dmg'
   name 'Amazing Marvin'
   homepage 'https://www.amazingmarvin.com/'
 

--- a/Casks/paper.rb
+++ b/Casks/paper.rb
@@ -4,7 +4,7 @@ cask 'paper' do
 
   url "http://paperimg.meiyuan.in/pap.er_v#{version}.dmg"
   name 'Paper'
-  homepage 'http://paper.meiyuan.in/'
+  homepage 'https://paper.meiyuan.in/'
 
   app 'pap.er.app'
 

--- a/Casks/powerword.rb
+++ b/Casks/powerword.rb
@@ -2,7 +2,7 @@ cask 'powerword' do
   version '1.1.1,1.0.1'
   sha256 '87c5347065f37342939b9d9c1874a582f9a144d0a5d494152035cffcc4ca8a5b'
 
-  url "http://download.iciba.com/mac/mac#{version.after_comma}/PowerWord.dmg"
+  url "https://download.iciba.com/mac/mac#{version.after_comma}/PowerWord.dmg"
   name 'PowerWord'
   name '金山词霸'
   homepage 'https://cp.iciba.com/mac/'

--- a/Casks/rapidminer-studio.rb
+++ b/Casks/rapidminer-studio.rb
@@ -2,7 +2,7 @@ cask 'rapidminer-studio' do
   version :latest
   sha256 :no_check
 
-  url 'http://go.rapidminer.com/rm-studio-download-mac'
+  url 'https://releases.rapidminer.com/latest/rapidminer-studio/rapidminer-studio-osx.dmg'
   name 'RapidMiner Studio'
   homepage 'https://rapidminer.com/products/studio/'
 

--- a/Casks/sharemouse.rb
+++ b/Casks/sharemouse.rb
@@ -2,9 +2,9 @@ cask 'sharemouse' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.keyboard-and-mouse-sharing.com/ShareMouseSetup.dmg'
+  url 'https://www.sharemouse.com/ShareMouseSetup.dmg'
   name 'ShareMouse'
-  homepage 'http://www.keyboard-and-mouse-sharing.com/'
+  homepage 'https://www.sharemouse.com/'
 
   app 'ShareMouse.app'
 end

--- a/Casks/tomighty.rb
+++ b/Casks/tomighty.rb
@@ -2,11 +2,10 @@ cask 'tomighty' do
   version '1.2'
   sha256 '0ebee4c2c913a75b15fed071d68c22c866a3d8436ad359eb2ee66e27d39b2214'
 
-  # github.com/tomighty/tomighty-osx was verified as official when first introduced to the cask
   url "https://github.com/tomighty/tomighty-osx/releases/download/#{version}/Tomighty-#{version}.dmg"
   appcast 'https://github.com/tomighty/tomighty-osx/releases.atom'
   name 'Tomighty'
-  homepage 'http://tomighty.org/'
+  homepage 'https://github.com/tomighty/tomighty-osx'
 
   app 'Tomighty.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
==> Downloading https://s3.amazonaws.com/AirVideoHD/Download/Air+Video+Server+HD
Already downloaded: ~/Library/Caches/Homebrew/downloads/f109caab6e31a44db08f0006712c46bafafce67cfcf45b6e22d6096bc10694d9--Air Video Server HD 2.3.0-beta1u1.dmg
==> Verifying SHA-256 checksum for Cask 'air-video-server-hd'.
audit for air-video-server-hd: passed

1 file inspected, no offenses detected
==> Downloading https://red-sweater.com/fastscripts/FastScripts2.7.7.zip
Already downloaded: ~/Library/Caches/Homebrew/downloads/5f4b97e11f0e44d7e1bebf013a9410695f7e3d2e1e4aaf747dafac7c749a625b--FastScripts2.7.7.zip
==> Verifying SHA-256 checksum for Cask 'fastscripts'.
audit for fastscripts: passed

1 file inspected, no offenses detected
==> Downloading https://fr7.abbyy.com/mac/fr/ABBYY_FineReader_Pro_ESD.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/c784501a5870d2c547d8a7b4f3e1e570f5f1c04e3204ae8c19d920b1972d9e07--ABBYY_FineReader_Pro_ESD.dmg
==> No SHA-256 checksum defined for Cask 'finereader', skipping verification.
audit for finereader: passed

1 file inspected, no offenses detected
==> Downloading https://fast.fontexplorerx.com/FontExplorerXPro607.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/3b58d60c5a8caca882b48817b64752c05e9e37d8f95cca815c6541e404befc34--FontExplorerXPro607.dmg
==> Verifying SHA-256 checksum for Cask 'fontexplorer-x-pro'.
audit for fontexplorer-x-pro: passed

1 file inspected, no offenses detected
==> Downloading https://ftp.lip6.fr/pub/lyx/bin/2.3.2/LyX-2.3.2+qt5-x86_64-cocoa
Already downloaded: ~/Library/Caches/Homebrew/downloads/0ac2ba06364531d5dca4a907e732f570745b83d7e305e46c917f82494eab677e--LyX-2.3.2 qt5-x86_64-cocoa.dmg
==> Verifying SHA-256 checksum for Cask 'lyx'.
audit for lyx: passed

1 file inspected, no offenses detected
==> Downloading https://s3.amazonaws.com/amazingmarvin/Marvin-1.41.2.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/631e707e4b41d65831f3eea881cbfa20211e0853280d760cef0f3f1ce961d98a--Marvin-1.41.2.dmg
==> Verifying SHA-256 checksum for Cask 'marvin'.
audit for marvin: passed

1 file inspected, no offenses detected
==> Downloading http://paperimg.meiyuan.in/pap.er_v3.3.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/ce326534d6e019d761105f198164008bc1389107044f6f015eeabc15a61884b3--pap.er_v3.3.dmg
==> Verifying SHA-256 checksum for Cask 'paper'.
audit for paper: passed

1 file inspected, no offenses detected
==> Downloading https://download.iciba.com/mac/mac1.0.1/PowerWord.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/79d34ce483f4cb4fb1e782c75ab76f547f0aff34653506b9eddb97b313c535b3--PowerWord.dmg
==> Verifying SHA-256 checksum for Cask 'powerword'.
audit for powerword: passed

1 file inspected, no offenses detected
==> Downloading https://releases.rapidminer.com/latest/rapidminer-studio/rapidmi
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'rapidminer-studio', skipping verificat
audit for rapidminer-studio: passed

1 file inspected, no offenses detected
==> Downloading https://www.sharemouse.com/ShareMouseSetup.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/289bd2e0201f8e483952d7c0081f8de68ca091d88ba27cd6ca759f89f5e2fe7f--ShareMouseSetup.dmg
==> No SHA-256 checksum defined for Cask 'sharemouse', skipping verification.
audit for sharemouse: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/tomighty/tomighty-osx/releases/download/1.2/T
Already downloaded: ~/Library/Caches/Homebrew/downloads/50832396ad3b181878de8f4ca17a3b3ddcbe3cb2255b6fc3ded9762724c61935--Tomighty-1.2.dmg
==> Verifying SHA-256 checksum for Cask 'tomighty'.
audit for tomighty: passed
```
