### PR TITLE
Update sbrowserq from 3.5 to 3.6

### DIFF
--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -1,8 +1,9 @@
 cask 'sbrowserq' do
-  version '3.5'
-  sha256 'd62efea257215b019421f13b947e4dcb161fb35e1694454b140dc70c5f0fef99'
+  version '3.6'
+  sha256 'cd68f1df6c08ec16746b73504f789c606ebfdbe0bfd1eab04f869881f4d64b46'
 
   url "https://www.sbrowser-q.com/SbrowserQ_V#{version}_mac.dmg"
+  appcast 'https://www.sbrowser-q.com/'
   name 'SbrowserQ'
   homepage 'https://www.sbrowser-q.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.