### PR TITLE
Update timely from 0.6.1 to 1.0.1

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,6 +1,6 @@
 cask 'timely' do
-  version '0.6.1'
-  sha256 'd6226090847503ca79b6e871854464bc105ff28243df08795876e4f3d85bf43b'
+  version '1.0.1'
+  sha256 'e6bd970c8ba5c4a649aff87b2c6338996882babd8bd172b97f835060f1cfb502'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"

--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -4,7 +4,7 @@ cask 'timely' do
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"
-  appcast 'https://github.com/Timely/desktop-releases/releases.atom'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://app.timelyapp.com/download/mac'
   name 'Timely'
   homepage 'https://timelyapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.