### PR TITLE
Update daisydisk from 4.7.2 to 4.7.2.1

### DIFF
--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -4,8 +4,8 @@ cask 'daisydisk' do
     sha256 'fe2aa86f2ea8a1f0c4791857a5b7991ecad295b5b969849bb7b15a890ab54b86'
     url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version.dots_to_underscores}.zip"
   else
-    version '4.7.2'
-    sha256 '67e7df4b3caa8c7f20114b9a1ddb22de67f159475468b3e8527f828f06583122'
+    version '4.7.2.1'
+    sha256 '3a12ecc575af4b8d6ecbd25ae4c88015e3b326ce2e25926f1b08e3a7b53db2b6'
     url 'https://www.daisydiskapp.com/downloads/DaisyDisk.zip'
     appcast 'https://daisydiskapp.com/downloads/appcastReleaseNotes.php?appEdition=Standard&osVersion=10.13'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.