### PR TITLE
Update itunes-volume-control from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -1,6 +1,6 @@
 cask 'itunes-volume-control' do
-  version '1.6.0'
-  sha256 '357599dd672eba43fc8368741ada4a5e676cf95b350e1e16fe03b02289ecbb0c'
+  version '1.6.1'
+  sha256 '80963a03a13c3437e01c833d5a0cf4bd0777f38cc3146e60e3dfb6888400bfcd'
 
   # uni-bonn.de/alberti/iTunesVolumeControl was verified as official when first introduced to the cask
   url "http://quantum-technologies.iap.uni-bonn.de/alberti/iTunesVolumeControl/iTunesVolumeControl-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.