### PR TITLE
Update osxfuse from 3.9.0 to 3.9.1

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,6 +1,6 @@
 cask 'osxfuse' do
-  version '3.9.0'
-  sha256 '9bd40e487c18abcf94a72b96c9f3b1378b69a1a0906f05c451aa918180bcc394'
+  version '3.9.1'
+  sha256 'b79e3626e3a46d150b4ea77e4e7f9453fc4264fcf358d1f07bd408fbd246396c'
 
   # github.com/osxfuse was verified as official when first introduced to the cask
   url "https://github.com/osxfuse/osxfuse/releases/download/osxfuse-#{version}/osxfuse-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.