### PR TITLE
Update hashbackup from 2302 to 2347

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,8 +1,8 @@
 cask 'hashbackup' do
-  version '2302'
-  sha256 '3f03bd6b565e63a45b7955f83751ef80ecd6a856ef6d699cc5b84e4fcd268a01'
+  version '2347'
+  sha256 '571f48bd345ff70d3176b7780a6431c72cfbd245d945b2d77df0d6e34e41048b'
 
-  url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.i386.bz2"
+  url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.x86_64.bz2"
   name 'hashbackup'
   homepage 'http://www.hashbackup.com/'
 

--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -6,5 +6,5 @@ cask 'hashbackup' do
   name 'hashbackup'
   homepage 'http://www.hashbackup.com/'
 
-  binary "hb.r#{version}.Darwin.i386", target: 'hb'
+  binary "hb.r#{version}.Darwin.x86_64", target: 'hb'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.