### PR TITLE
Update vscodium from 1.34.0 to 1.35.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.34.0'
-  sha256 'b1c3fd7b421d8e97af7e0556956e0d19c06031526a92b3ca19b8103cd167455d'
+  version '1.35.0'
+  sha256 '0508a220c12d7284ddcd7bc24a242e1235143ecefca7dcab9863c2dc7b5d0aca'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.