### PR TITLE
Update qownnotes from 19.6.0,b4295-082541 to 19.6.1,b4298-170510

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.6.0,b4295-082541'
-  sha256 '9c4c6f9c925ce70d9a80f7afc4fc59a159532174f657eb25a1d022045ab45e78'
+  version '19.6.1,b4298-170510'
+  sha256 '0e36a1e5479b42a67611e03923a177a0d8d144b9990d7da93e0ad9f9add55a60'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.