### PR TITLE
Update kite from 0.20190605.0 to 0.20190606.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190605.0'
-  sha256 '2dc1c03cd2c7985f01285255ae29efc045f63f0ed4c0d8264df63ecf8b7edc1b'
+  version '0.20190606.1'
+  sha256 '6ba41695829dc974fcc7d3e842eefc7c3397f181b506c620fc101844ae0d784d'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.