### PR TITLE
Update lastpass from 4.28.0 to 4.29.0

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.28.0'
-  sha256 '817392e4d63afb389df73b971f2406fbb52750a19a11657d1fd187f4640bef91'
+  version '4.29.0'
+  sha256 'b210471ca26ecd7c60ca1df540ffa44f64a326094d14f396e69cbccf7542c3e4'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.