### PR TITLE
Update zettlr from 1.2.3 to 1.3.0

### DIFF
--- a/Casks/zettlr.rb
+++ b/Casks/zettlr.rb
@@ -1,6 +1,6 @@
 cask 'zettlr' do
-  version '1.2.3'
-  sha256 'c7216c862175deb535edd18aa2770af07e36c8e2dd131fd8e74234a81e30e6f1'
+  version '1.3.0'
+  sha256 'f4d51b09927e6cd35efe7e39e9d0ec56e93825ad1ba92f984a767a892643c350'
 
   # github.com/Zettlr/Zettlr was verified as official when first introduced to the cask
   url "https://github.com/Zettlr/Zettlr/releases/download/v#{version}/Zettlr-macos-x64-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.