### PR TITLE
Update mindjet-mindmanager from 12.1.177 to 12.1.183

### DIFF
--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -1,6 +1,6 @@
 cask 'mindjet-mindmanager' do
-  version '12.1.177'
-  sha256 'a11c27dd076b2228feea49bcf808ee9e95acb829ebdc9ee349687ad42c67d402'
+  version '12.1.183'
+  sha256 '716287e692bbba2c14ba7d5efae3be6148d4b0c62bb57af7195caaec5fc25fa9'
 
   url "https://download.mindjet.com/Mindjet_MindManager_Mac_#{version}.dmg"
   name 'Mindjet Mindmanager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.