### PR TITLE
Update lockrattler from 4.20,2019.05 to 4.21,2019.06

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.20,2019.05'
-  sha256 '4c340b693ae4f570a96563e369efacb6d1e3fedc4f12acca36587692f5cdfd3e'
+  version '4.21,2019.06'
+  sha256 '74e8d2f7b7e8dd0b07725e71006f2cac77fcf04231f04c530faf431206c66497'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.major}/#{version.after_comma.minor}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.