### PR TITLE
Update wpsoffice from 1.1.0(1454) to 1.2.0(1574)

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
-  version '1.1.0(1454)'
-  sha256 '2d2b28a444c923c63492dab23f48e04c8fb1aaa5d72ebb232d1748c62d380965'
+  version '1.2.0(1574)'
+  sha256 '39b6f1c68d5a6cc5205d1d35144d4369b8380a65acb7769fae1482a904e9e738'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
   url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.major_minor_patch}/WPS_Office_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.