### PR TITLE
Update razorsql from 8.3.5 to 8.3.6

### DIFF
--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -1,6 +1,6 @@
 cask 'razorsql' do
-  version '8.3.5'
-  sha256 'f22583095e5b75be26daaa38a227cf04d58b43bf377a1f6028c12af92ffb7da3'
+  version '8.3.6'
+  sha256 '70049a78e20cc2f234ad0cb6b71e6e327ce0573b84b1533280cd126e048129dd'
 
   url "http://downloads.razorsql.com/downloads/#{version.dots_to_underscores}/razorsql#{version.dots_to_underscores}_x64.dmg"
   appcast 'https://razorsql.com/updates.html'

--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -3,7 +3,8 @@ cask 'razorsql' do
   sha256 '70049a78e20cc2f234ad0cb6b71e6e327ce0573b84b1533280cd126e048129dd'
 
   url "http://downloads.razorsql.com/downloads/#{version.dots_to_underscores}/razorsql#{version.dots_to_underscores}_x64.dmg"
-  appcast 'https://razorsql.com/updates.html'
+  appcast 'https://razorsql.com/updates.html',
+          configuration: version.dots_to_underscores
   name 'RazorSQL'
   homepage 'https://razorsql.com/download_mac.html'
 

--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -3,8 +3,7 @@ cask 'razorsql' do
   sha256 '70049a78e20cc2f234ad0cb6b71e6e327ce0573b84b1533280cd126e048129dd'
 
   url "http://downloads.razorsql.com/downloads/#{version.dots_to_underscores}/razorsql#{version.dots_to_underscores}_x64.dmg"
-  appcast 'https://razorsql.com/updates.html',
-          configuration: version.dots_to_underscores
+  appcast 'https://razorsql.com/updates.html'
   name 'RazorSQL'
   homepage 'https://razorsql.com/download_mac.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.