### PR TITLE
Update minikube from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/minikube.rb
+++ b/Casks/minikube.rb
@@ -1,6 +1,6 @@
 cask 'minikube' do
-  version '1.1.0'
-  sha256 '3f635089d93ba7bd193b8f015bfa9434b810256daa8ced03816c7f0df7b06a96'
+  version '1.1.1'
+  sha256 'cf6b2c0397147fa998a5c4e36ed7ad045d67f929daa3e46a1d01656b5ab7cac5'
 
   # storage.googleapis.com/minikube was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/minikube/releases/v#{version}/minikube-darwin-amd64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.