### PR TITLE
Update chronicle from 9.0.0 to 9.1.1

### DIFF
--- a/Casks/chronicle.rb
+++ b/Casks/chronicle.rb
@@ -1,6 +1,6 @@
 cask 'chronicle' do
-  version '9.0.0'
-  sha256 '4862f37a3693b53b08ca0748003b85e2f131deb212ce8763dd11a74a1c248fcc'
+  version '9.1.1'
+  sha256 '883b3ca116959481448b84f1179043edee98f662be7699a74dc83e1557f81ca9'
 
   url 'http://www.chronicleapp.com/static/downloads/chroniclepro.zip'
   appcast 'http://www.littlefin.com/downloads/chronicle8.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.