### PR TITLE
Update fsnotes from 3.3.0 to 3.3.1

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.3.0'
-  sha256 '52bcdb3a8d236525e567406c468bddaa9cbeba0dfbc1457bba748f52acbde590'
+  version '3.3.1'
+  sha256 '3d35d96859c7176b1ebda825f3f857cd6ea7e53d66a25fe81708418ade0448a7'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.