### PR TITLE
Update tropy from 1.4.5 to 1.5.0

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.4.5'
-  sha256 '458e95049a3a51db8084f1cf7c791804a41bdd2e13d9d8c2eb4cd25e1daf3252'
+  version '1.5.0'
+  sha256 '7864380ad06a7b7c0d4606beb6a76b3b3b8636c3fb211ab565c788c5935c5a76'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.