### PR TITLE
Update get-backup-pro from 3.4.12 to 3.4.14

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,6 +1,6 @@
 cask 'get-backup-pro' do
-  version '3.4.12'
-  sha256 'da2711ba740331816af8a3f7b71f7dd2bc7e538b372cf350aadcc2c05405b63e'
+  version '3.4.14'
+  sha256 'b49695b4b4463f8b606c5e5ca5286311bfbb8ee978c8f77897ce94c218d82c9f'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.