### PR TITLE
Update vsee from 4.4.2,38214 to 4.5.0,38793

### DIFF
--- a/Casks/vsee.rb
+++ b/Casks/vsee.rb
@@ -1,6 +1,6 @@
 cask 'vsee' do
-  version '4.4.2,38214'
-  sha256 '8a1bed997d3a7500337e8f906fe98dcbac379ab3c12b793a6c24b5af8ec1707d'
+  version '4.5.0,38793'
+  sha256 '6f503d12858f842dfd26d31b378f629030657853e5b9f33fe43c1b7828a942b1'
 
   # d2q5hugz2rti4w.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2q5hugz2rti4w.cloudfront.net/mac/#{version.after_comma}/vseemac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.