### PR TITLE
Update zoomus from 4.4.53582.0519 to 4.4.53590.0607

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.4.53582.0519'
-  sha256 '28b20c70d924b51a8a6c9c143de905e6f13399298faa6e1ba39d092a70d22693'
+  version '4.4.53590.0607'
+  sha256 '7b589b4697526a9d41b4c50bdfc8a20bae02e36214011f60c01178a73fed7e07'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   appcast 'https://support.zoom.us/hc/en-us/articles/201361963-New-Updates-for-Mac-OS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.