### PR TITLE
Update metashape from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/metashape.rb
+++ b/Casks/metashape.rb
@@ -1,6 +1,6 @@
 cask 'metashape' do
-  version '1.5.2'
-  sha256 '3227831b427078f97d7b05ae34080f2d12794b9a421074101333abbb41a8f8c6'
+  version '1.5.3'
+  sha256 'eb1243767701ef9ce59dae4d8ee6c0d95923ba0fee663f21982bf57d15ea8c3c'
 
   url "http://download.agisoft.com/metashape_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.agisoft.com/downloads/installer/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.