### PR TITLE
Update netron from 3.1.1 to 3.1.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.1.1'
-  sha256 '8c6959ebfe7c8ccac207c09d93bd4b1e2deb4b49da5a2c7300c7dc4652fa3e83'
+  version '3.1.2'
+  sha256 'ad3b82075cda1da1f0587179c1ddf06f3b9685eb5d76582fde1929eeca1141fe'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.