### PR TITLE
Bumping visualboyadvance-m version to 2.1.3

### DIFF
--- a/Casks/visualboyadvance-m.rb
+++ b/Casks/visualboyadvance-m.rb
@@ -1,9 +1,9 @@
 cask 'visualboyadvance-m' do
-  version '2.1.0'
-  sha256 'ccbb87374dad140d5359758b2c064403e1ea0a3c171525a9df98a7bee9ee3168'
+  version '2.1.3'
+  sha256 'dbaecf3c0688432e4b26b68417cce3a87ccbfe83a279e89dc26b967c4ff9d07d'
 
   # github.com/visualboyadvance-m/visualboyadvance-m was verified as official when first introduced to the cask
-  url "https://github.com/visualboyadvance-m/visualboyadvance-m/releases/download/v#{version}/visualboyadvance-m-Mac.zip"
+  url "https://github.com/visualboyadvance-m/visualboyadvance-m/releases/download/v#{version}/visualboyadvance-m-Mac-64bit.zip"
   appcast 'https://github.com/visualboyadvance-m/visualboyadvance-m/releases.atom'
   name 'Visual Boy Advance - M'
   homepage 'https://vba-m.com/'


### PR DESCRIPTION
Bumps visualboyadvance-m version to 2.1.3. Also switchs to the 64bit
release for post-Mojave compatibility.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download visualboyadvance-m` is error-free.
- [x] `brew cask style --fix visualboyadvance-m` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256