### PR TITLE
Update owasp-zap from 2.7.0 to 2.8.0

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -1,9 +1,9 @@
 cask 'owasp-zap' do
-  version '2.7.0'
-  sha256 '6d163801edf2367506d47f9560d7610aba55a8149f09e2ab34000b597c09e2d0'
+  version '2.8.0'
+  sha256 '8fe3c30411524a05d662c2a2d1e2762a43291db7c39b23963b7de0f259ab122c'
 
   # github.com/zaproxy/zaproxy was verified as official when first introduced to the cask
-  url "https://github.com/zaproxy/zaproxy/releases/download/#{version}/ZAP_#{version}.dmg"
+  url "https://github.com/zaproxy/zaproxy/releases/download/v#{version}/ZAP_#{version}.dmg"
   appcast 'https://github.com/zaproxy/zaproxy/releases.atom'
   name 'OWASP Zed Attack Proxy'
   name 'ZAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.