### PR TITLE
Update remotix-agent from 1.0.6 to 1.1

### DIFF
--- a/Casks/remotix-agent.rb
+++ b/Casks/remotix-agent.rb
@@ -1,5 +1,5 @@
 cask 'remotix-agent' do
-  version '1.0.6'
+  version '1.1'
   sha256 '66ecec55fa40ead964ad8da472c99d4eda3a1cbf65e60e531f0fd790f5743b11'
 
   url 'https://downloads.remotixcloud.com/agent-mac/RemotixAgent.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.