### PR TITLE
Update peakhour from 4.1.3,34766 to 4.1.4,34890

### DIFF
--- a/Casks/peakhour.rb
+++ b/Casks/peakhour.rb
@@ -1,6 +1,6 @@
 cask 'peakhour' do
-  version '4.1.3,34766'
-  sha256 '8d85cc111acf15d94e33c0e29a365025ac8a792b41d63c67a413a334aba3e902'
+  version '4.1.4,34890'
+  sha256 'd24d2018cf8f4d407dc9bd40880a3841047e703a8d14a095766333e02cd1797a'
 
   url "https://updates.peakhourapp.com/releases/PeakHour%20#{version.before_comma}.zip"
   appcast "https://updates.peakhourapp.com/PeakHour#{version.major}Appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.