### PR TITLE
Update lmms from 1.1.3 to 1.2.0

### DIFF
--- a/Casks/lmms.rb
+++ b/Casks/lmms.rb
@@ -1,9 +1,9 @@
 cask 'lmms' do
-  version '1.1.3'
-  sha256 '6d5197e6e5edd4a08cb26fc98ee229308833b4f759e9d9724a745ab1035aba15'
+  version '1.2.0'
+  sha256 'e258aa298b0bdab3b7be88933a83f24bddf39ac62ffaa1c20ecc5927b313bfbf'
 
   # github.com/LMMS/lmms was verified as official when first introduced to the cask
-  url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}-mac10.7.dmg"
+  url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}-mac10.13.dmg"
   appcast 'https://github.com/LMMS/lmms/releases.atom'
   name 'LMMS'
   homepage 'https://lmms.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.