### PR TITLE
Update roblox from 1.2.0.265265,14d81515193c4606 to 1.2.0.307917,3e5f358137714073

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '1.2.0.265265,14d81515193c4606'
-  sha256 '3f5c1e1613e7348938f02df94c48a12cc6ce6c15722cf0f630869b4954995238'
+  version '1.2.0.307917,3e5f358137714073'
+  sha256 'b89e6cef96d4a891729366d8774d4c386c7700a4da5ba969c3d4ea1b087fedf3'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.