### PR TITLE
Upgrade surge-synthesizer to 1.6.1.1

### DIFF
--- a/Casks/surge-synthesizer.rb
+++ b/Casks/surge-synthesizer.rb
@@ -1,6 +1,6 @@
 cask 'surge-synthesizer' do
-  version '1.6.0'
-  sha256 'f60d2006cc9121249c7284bf8af694a00dd0e6713620662e2538e1937688bcaa'
+  version '1.6.1.1'
+  sha256 '7d8775055a89a49640352fd995e89c8cce3494f5a3b24efdccba67e2ec5dd746'
 
   # github.com/surge-synthesizer/releases was verified as official when first introduced to the cask
   url "https://github.com/surge-synthesizer/releases/releases/download/#{version}/Surge-#{version}-Setup.dmg"


### PR DESCRIPTION
In the first week of our 1.6.0 release, users found a collection
of bugs in more extensive use, and surge 1.6.1.1 fixes those
bugs and adds some small new features. Updates won't be this
frequent to our package, but these sets of fixed-in-the-wild
changes are important to all users of the synth on macos.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x ] The commit message includes the cask’s name and version.
- [ x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
