### PR TITLE
Update seafile-client from 6.2.11 to 7.0.0

### DIFF
--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -1,6 +1,6 @@
 cask 'seafile-client' do
-  version '6.2.11'
-  sha256 'f71a003603c8f49410ac753153f39bd2c92210ccbb10d2878e07e98cfaedc5fd'
+  version '7.0.0'
+  sha256 '9cba1ccfb91fa8289bb49f91120d58eac9e8a86bb374aa1534247329f2d0935d'
 
   # seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seafile-client-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.