### PR TITLE
Update altair-graphql-client from 2.1.9 to 2.2.0

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.1.9'
-  sha256 'f274cd2b82aa31ac92beeee54f57b1455de8d216de749363087c0907ce690301'
+  version '2.2.0'
+  sha256 '953fbbd9d331efc0e92dbe5c70e0a21e5e2dce425a88ab65efd08e50203ad7d4'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.