### PR TITLE
Update packetsender from 6.1.25 to 6.2.3

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,6 +1,6 @@
 cask 'packetsender' do
-  version '6.1.25'
-  sha256 '9d4d608d3f98f4f66afe6148d1a1e4becd41c08b11432211b33b98a8c65ad6a3'
+  version '6.2.3'
+  sha256 '4a886b351ef7d30906e20d05ea002a6ae2308c28dd1246957bcaa361e054ee2b'
 
   # github.com/dannagle/PacketSender was verified as official when first introduced to the cask
   url "https://github.com/dannagle/PacketSender/releases/download/v#{version}/PacketSender_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.