### PR TITLE
Update hype from 3.6.8 to 4.0.0

### DIFF
--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -1,6 +1,6 @@
 cask 'hype' do
-  version '3.6.8'
-  sha256 '0f82b4b9b453eaeb834ec64d277a79c8ac74e938a44d6c6c4efec3ed7ff2623f'
+  version '4.0.0'
+  sha256 '11c6669185ce0a2fca39abbbb9d16ac5746a4e6ba3e27ad1f504069df6ea3cdf'
 
   url 'https://tumult.com/hype/download/Hype.zip'
   appcast 'https://tumult.com/hype/appcast_hype2.xml'

--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -8,5 +8,5 @@ cask 'hype' do
   homepage 'https://tumult.com/hype/'
 
   # Renamed for consistency: app name is different in the Finder and in a shell
-  app 'Hype2.app', target: "Hype #{version.major}.app"
+  app 'Hype4.app', target: "Hype #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.