### PR TITLE
Update itunes-volume-control from 1.6.2 to 1.6.3.1

### DIFF
--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -1,6 +1,6 @@
 cask 'itunes-volume-control' do
-  version '1.6.2'
-  sha256 '30bb9dd08c199ced8afc3a64217fd9abec592f8c671d8773c2330b195e8791ef'
+  version '1.6.3.1'
+  sha256 'e073056ac3f276ee79d69d6010c04a8f2c19ab525378b0d76e6951288d05889d'
 
   # uni-bonn.de/alberti/iTunesVolumeControl was verified as official when first introduced to the cask
   url "http://quantum-technologies.iap.uni-bonn.de/alberti/iTunesVolumeControl/iTunesVolumeControl-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.