### PR TITLE
Update ticktick from 3.0.05,94 to 3.0.10,97

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.0.05,94'
-  sha256 '658c769299bba844ec2393a14c13b6890bbfc4d9a7bfc0782867d3054e942937'
+  version '3.0.10,97'
+  sha256 '6b17f32206228b2378876d43cdb41ff6d6750f92a1c5580cc2c04ab5bf3f3c8f'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.