### PR TITLE
Update soulver from 2.6.9-6055 to 3.0.0-19

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,16 +1,16 @@
 cask 'soulver' do
-  version '2.6.9-6055'
-  sha256 'e8f96895e43d28177f458404bfc082ebc940c66ce6f425cdceeedab9389272bf'
+  version '3.0.0-19'
+  sha256 'ecaca54c6ec8fb148301a194237e043b439646eeeb48a87d4a17c869c8c9c8b2'
 
-  url "https://www.acqualia.com/files/sparkle/soulver_#{version}.zip"
-  appcast "https://www.acqualia.com/soulver/appcast/soulver#{version.major}.xml"
+  url "https://soulver.app/mac/sparkle/soulver-#{version}.zip"
+  appcast 'https://soulver.app/mac/sparkle/appcast.xml'
   name 'Soulver'
-  homepage 'https://www.acqualia.com/soulver/'
+  homepage 'https://soulver.app/'
 
   auto_updates true
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :high_sierra'
 
-  app 'Soulver.app'
+  app "Soulver #{version.major}.app"
 
   zap trash: [
                '~/Library/Application Support/Soulver',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.