### PR TITLE
Update karabiner-elements from 12.4.0 to 12.5.0

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -3,8 +3,8 @@ cask 'karabiner-elements' do
     version '11.6.0'
     sha256 'c1b06252ecc42cdd8051eb3d606050ee47b04532629293245ffdfa01bbc2430d'
   else
-    version '12.4.0'
-    sha256 '17e8a2ebaf4581f0fcb915ef417b848c317fcfc72f2f758a43a1c87a81824c41'
+    version '12.5.0'
+    sha256 'f3840a6d4e0301c5268848cd1ca44402fb65783d504432b092e025025326fdb8'
   end
 
   url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.