### PR TITLE
Update flash-npapi from 32.0.0.192 to 32.0.0.207

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '32.0.0.192'
-  sha256 'dd84ded0e08460057ddb40f2205cad0b0a3a401f6573a404bc7de8f79ab3a872'
+  version '32.0.0.207'
+  sha256 'e2948a75e9807458425c9114065b26eddcced8479a8c984d0752bb4a65c18078'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'

--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -3,7 +3,8 @@ cask 'flash-npapi' do
   sha256 'e2948a75e9807458425c9114065b26eddcced8479a8c984d0752bb4a65c18078'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
-  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',
+          configuration: version.tr('.', ',')
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox)'
   homepage 'https://get.adobe.com/flashplayer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.