### PR TITLE
Update flash-player from 32.0.0.192 to 32.0.0.207

### DIFF
--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,6 +1,6 @@
 cask 'flash-player' do
-  version '32.0.0.192'
-  sha256 '1a5a09aa128babf0009806d3b9c1ce42633073539099d7a6dee80403ee58f972'
+  version '32.0.0.207'
+  sha256 '9d6bd9bd3cb2a320ff5862f1532df4767d691fe53b1d6b03890970856ca78ca2'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'

--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -3,7 +3,8 @@ cask 'flash-player' do
   sha256 '9d6bd9bd3cb2a320ff5862f1532df4767d691fe53b1d6b03890970856ca78ca2'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
-  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml'
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',
+          configuration: version.tr('.', ',')
   name 'Adobe Flash Player projector'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.