### PR TITLE
Update flash-player-debugger-ppapi from 32.0.0.192 to 32.0.0.207

### DIFF
--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -3,7 +3,8 @@ cask 'flash-player-debugger-ppapi' do
   sha256 'b1fbe7cfcb4997b6e6c0b2e3301a011223a9f8b8aefd7a65a6b1f9049c048cf6'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
-  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',
+          configuration: version.tr('.', ',')
   name 'Adobe Flash Player PPAPI (plugin for Opera and chromium) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 

--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-ppapi' do
-  version '32.0.0.192'
-  sha256 '46b0784eb5532c9a3669f80c8d69c7bcb6fed21594704ff20f1ab975e9d3fb6f'
+  version '32.0.0.207'
+  sha256 'b1fbe7cfcb4997b6e6c0b2e3301a011223a9f8b8aefd7a65a6b1f9049c048cf6'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.