### PR TITLE
Update flash-player-debugger from 32.0.0.192 to 32.0.0.207

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger' do
-  version '32.0.0.192'
-  sha256 '100f0687e10dc50f6d7b460e7674534b8f6314dce52f30cf1f276c20cdca7f72'
+  version '32.0.0.207'
+  sha256 'a76301f161cd57657673ca3e1173f60e51a0ec3635b30dc5e03bc601bb0b0110'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'

--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -3,7 +3,8 @@ cask 'flash-player-debugger' do
   sha256 'a76301f161cd57657673ca3e1173f60e51a0ec3635b30dc5e03bc601bb0b0110'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
-  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml'
+  appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',
+          configuration: version.tr('.', ',')
   name 'Adobe Flash Player projector content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.