### PR TITLE
Update transmit from 5.2.4 to 5.5.0

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -1,6 +1,6 @@
 cask 'transmit' do
-  version '5.2.4'
-  sha256 'b2374738db58a9872e385427ec2aaf139f80fad689d2b81c6de3ffb9a0acc598'
+  version '5.5.0'
+  sha256 'b356950502fb8a220c3a1de10c9f8e19db8cc58c90e8774331ad0dc078167e32'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.