### PR TITLE
Update whoozle-android-file-transfer from 3.8 to 3.9

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -1,6 +1,6 @@
 cask 'whoozle-android-file-transfer' do
-  version '3.8'
-  sha256 '723a25c75c6e97cc9f5468231eea802326687911ae6723bcfcee9a8ce32f84ff'
+  version '3.9'
+  sha256 'd0ccedbd2d5e67c2cfbec0bddf7a5696833531e36809ca6162e69dbfc4308d43'
 
   # github.com/whoozle/android-file-transfer-linux was verified as official when first introduced to the cask
   url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version}/AndroidFileTransferForLinux.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.