### PR TITLE
whoozle-android-file-transfer: conflicts with android-file-transfer only in runtime

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -13,6 +13,4 @@ cask 'whoozle-android-file-transfer' do
   app 'Android File Transfer for Linux.app'
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-mount"
-
-  caveats "#{token} can't be used simultaneously with other MTP clients, like android-file-transfer."
 end

--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -8,12 +8,11 @@ cask 'whoozle-android-file-transfer' do
   name 'Android File Transfer'
   homepage 'https://whoozle.github.io/android-file-transfer-linux/'
 
-  conflicts_with cask: [
-                         'android-file-transfer',
-                         'whoozle-android-file-transfer-nightly',
-                       ]
+  conflicts_with cask: 'whoozle-android-file-transfer-nightly'
 
   app 'Android File Transfer for Linux.app'
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-mount"
+
+  caveats "#{token} can't be used simultaneously with other MTP clients, like android-file-transfer."
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).