### PR TITLE
Update sigil from 0.9.13 to 0.9.14

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,6 +1,6 @@
 cask 'sigil' do
-  version '0.9.13'
-  sha256 'ebbace26cb597da3f605b1042c492fc230ec549c63c84cf111d88587525a413c'
+  version '0.9.14'
+  sha256 'd8d96cfc95301cbaf5f3d0d8da11b060d2a82334cf1aa86fe65472eb4a2dd2be'
 
   # github.com/Sigil-Ebook/Sigil was verified as official when first introduced to the cask
   url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.