### PR TITLE
Update netnewswire from 5.0a2 to 5.0a3

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,6 +1,6 @@
 cask 'netnewswire' do
-  version '5.0a2'
-  sha256 'a13dcbc084f992998bf339990a4e143e3ede4ae9035439f25991f94573a75563'
+  version '5.0a3'
+  sha256 '576a7bdb059827875d23b6e0cb721a40d70ceb19d8e84177f679a611c2fe1de0'
 
   url "https://ranchero.com/downloads/NetNewsWire#{version}.zip"
   appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.