### PR TITLE
Update swish from 1.0.0 to 1.0.1

### DIFF
--- a/Casks/swish.rb
+++ b/Casks/swish.rb
@@ -1,6 +1,6 @@
 cask 'swish' do
-  version '1.0.0'
-  sha256 '3869a417458d4b9085894596be6e9b939a7d6d58ed74fb6e2d810e3c1e999f2b'
+  version '1.0.1'
+  sha256 '6fa3ab7f37704855c97cd52b854ed9b0ee69787497930011a43da261c0dcaeaf'
 
   url "https://highlyopinionated.co/swish/Swish-#{version}.zip"
   appcast 'https://highlyopinionated.co/swish/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.