### PR TITLE
Update hsang from 1.8.9 to 1.8.12

### DIFF
--- a/Casks/hsang.rb
+++ b/Casks/hsang.rb
@@ -1,6 +1,6 @@
 cask 'hsang' do
-  version '1.8.9'
-  sha256 '263507d2ec9842e256267b14ce9421d03f42051cc1bac05c8991e1ccd4ff3d67'
+  version '1.8.12'
+  sha256 '76809b3737d3f03abcf06a2b3411e19f214be22d00b3f167ed164e4ac660e797'
 
   # opd.gdl.netease.com was verified as official when first introduced to the cask
   url "https://opd.gdl.netease.com/HSAng_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.