### PR TITLE
Update cacher from 2.10.4 to 2.10.5

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.10.4'
-  sha256 '130ac7881e11732d59331969f9b4bf76c44c5873497b4a94857ce710fff456f6'
+  version '2.10.5'
+  sha256 '42e756066dbf81bd4783283ac7f9a48598d72120b198b8dd55572c5543d5d13b'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.