### PR TITLE
Android File Transfer Switch to Version Specific Download

### DIFF
--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -1,9 +1,9 @@
 cask 'android-file-transfer' do
-  version :latest
+  version '1.0.12-1.0.507.1136'
   sha256 :no_check
 
   # google.com/dl/androidjumper was verified as official when first introduced to the cask
-  url 'https://dl.google.com/dl/androidjumper/mtp/current/androidfiletransfer.dmg'
+  url "https://dl.google.com/dl/androidjumper/mtp/#{version.sub(%r{.*-[0-9]*[.][0-9]*[.]}, '').delete('.')}/AndroidFileTransfer.dmg"
   name 'Android File Transfer'
   homepage 'https://www.android.com/filetransfer/'
 


### PR DESCRIPTION
Cask android-file-transfer has URL containing "5071136", which is the last 2 segments of the build number for version 1.0.12.  About screen reads "Version 1.0.12 (1.0.507.1136)".  Assuming that new releases will follow the same convention, this should allow us to use versioned downloads for this cask.

I used '1.0.12-1.0.507.1136' as the version number and added regex to the download URL for future updates.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X ] `brew cask audit --download {{cask_file}}` is error-free.
- [ X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X ] The commit message includes the cask’s name and version.
- [X ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
