### PR TITLE
Update keepassxc from 2.4.1 to 2.4.3

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,6 +1,6 @@
 cask 'keepassxc' do
-  version '2.4.1'
-  sha256 '2488d3a3297c9a88f25bf8f2478bf24a941e4f46696dc2457adec43688896015'
+  version '2.4.3'
+  sha256 '148c138fc5fa19185feed5cdcf0cccff3cc224d3a0c454caf18f972ffdfd9bbe'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.