### PR TITLE
Update react-native-debugger (0.9.10)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,6 +1,6 @@
 cask 'react-native-debugger' do
-  version '0.9.9'
-  sha256 'ea4f386f92648bf6e007630a5834af2add47f3688ad52d086b54ea2f4700eb53'
+  version '0.9.10'
+  sha256 '7221f1d8e05a1e2bd2aa4389c119bb60ff33bed65b492e8ebc4d66edb76ce296'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
