### PR TITLE
Update understand from 5.1.981 to 5.1.989

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -2,7 +2,8 @@ cask 'understand' do
   version '5.1.989'
   sha256 'f562bfe30005ed484ba99c9b75d4bfd8a66937e217dfc8b235ea2f19cc2bde30'
 
-  url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
+  url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg",
+      configuration: version.patch
   appcast 'https://scitools.com/build-notes/'
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'

--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -2,9 +2,9 @@ cask 'understand' do
   version '5.1.989'
   sha256 'f562bfe30005ed484ba99c9b75d4bfd8a66937e217dfc8b235ea2f19cc2bde30'
 
-  url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg",
+  url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
+  appcast 'https://scitools.com/build-notes/',
       configuration: version.patch
-  appcast 'https://scitools.com/build-notes/'
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'
 

--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.981'
-  sha256 '5b72bba4814aa56e0f18f9730b47f70bd56c3da2e4e619bc20560499c231dbea'
+  version '5.1.989'
+  sha256 'f562bfe30005ed484ba99c9b75d4bfd8a66937e217dfc8b235ea2f19cc2bde30'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/'

--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -4,7 +4,7 @@ cask 'understand' do
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',
-      configuration: version.patch
+          configuration: version.patch
   name 'SciTools Understand'
   homepage 'https://scitools.com/features/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.