### PR TITLE
Update forklift from 3.3.3 to 3.3.4

### DIFF
--- a/Casks/forklift.rb
+++ b/Casks/forklift.rb
@@ -1,6 +1,6 @@
 cask 'forklift' do
-  version '3.3.3'
-  sha256 'b9ed99e7ec22907e9517892b33f5f191425705a06fb185775c1e9f7eb71a7e61'
+  version '3.3.4'
+  sha256 'e69fc7f6436e6f86e1cf0a56c415a6e80bbff792c7bf94786c0d3dd3d13651fc'
 
   url "https://download.binarynights.com/ForkLift#{version}.zip"
   appcast "https://updates.binarynights.com/ForkLift#{version.major}/update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.