### PR TITLE
Update balenaetcher from 1.5.46 to 1.5.47

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.46'
-  sha256 '2c0e7fb0e600e0d6501a2e7cda4d4aaf0ff624ce2fb010e735cc0f94dc8e4e15'
+  version '1.5.47'
+  sha256 '37a6a07764dbce9bd47124bc19f2fd9b8f28a1df4aafa226e4e32e852f6fb2a7'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.