### PR TITLE
Update buddi from latest to 3.4.1.16

### DIFF
--- a/Casks/buddi.rb
+++ b/Casks/buddi.rb
@@ -1,8 +1,10 @@
 cask 'buddi' do
-  version :latest
-  sha256 :no_check
+  version '3.4.1.16'
+  sha256 'a8731374d07a245556a286bf72c15d30a414bc28fcaa8d72e551e0d638adff73'
 
-  url 'http://buddi.digitalcave.ca/buddi.dmg'
+  # downloads.sourceforge.net/buddi was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/buddi/Buddi%20%28Stable%29/#{version}/Buddi-#{version}.dmg"
+  appcast 'https://sourceforge.net/projects/buddi/rss'
   name 'Buddi'
   homepage 'http://buddi.digitalcave.ca/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.