### PR TITLE
Update navicat-for-sql-server from 12.1.22 to 12.1.23

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.22'
-  sha256 'f1bd1ba4961b0bd1b5661931a64c3b689bfac0c572705364303807afe81b6ed2'
+  version '12.1.23'
+  sha256 '4974605846fd5912f455f71eef00876e9968809b108d1f422071e3af06ba196f'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.