### PR TITLE
Update navicat-premium from 12.1.22 to 12.1.23

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '12.1.22'
-  sha256 '5b82b28d73edf66178fc27435a243aa49a859cf0139dde9d9203d8c89ed4be64'
+  version '12.1.23'
+  sha256 '4a8611f2654b7d1e3c563d40c9ad16a584acd7693030f959101e862900725003'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20Premium&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.