### PR TITLE
Update banking-4 from 7.0.4,7076 to 7.0.5,7101

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.0.4,7076'
-  sha256 '524ea9b544f879dd85917fdb44dc31bef626293b0778c05f0308f797527f321a'
+  version '7.0.5,7101'
+  sha256 '23acd8e93544bb1f45ca6610e1905c41c181c60122e283756e0e5deb2df516d6'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.