### PR TITLE
Update backuploupe from 2.14.5 to 2.15

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,6 +1,6 @@
 cask 'backuploupe' do
-  version '2.14.5'
-  sha256 '34d5cef368fa5d931a6510bd579bbd1be47f0fd1c2a735d76c59625a4e4cfcac'
+  version '2.15'
+  sha256 'c5ee73b68a3f002119fbcac5246c7d69c3f4bcb67f08fb299818ec18a219ec71'
 
   url "https://www.soma-zone.com/download/files/BackupLoupe-#{version}.tar.bz2"
   appcast 'https://www.soma-zone.com/BackupLoupe/a/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.