### PR TITLE
Update keep-it from 1.6.11 to 1.6.12

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.6.11'
-  sha256 'd071ac33215686eb8ae91750dd04bf5be49ab46d66b600c22e3fd7002d99ca87'
+  version '1.6.12'
+  sha256 'ce5786d1b0a8ceeaefd8c8ce9f9a34a6532b66f6f489ff2ea5094d9c77753316'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.