### PR TITLE
Update kite from 0.20190606.1 to 0.20190611.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190606.1'
-  sha256 '6ba41695829dc974fcc7d3e842eefc7c3397f181b506c620fc101844ae0d784d'
+  version '0.20190611.0'
+  sha256 'b573f328444cff1adba974b10017803a8f0fbafe166225efcf1daa25a871f363'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.