### PR TITLE
Update permute from 3.2.5,2140 to 3.2.6,2143

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.2.5,2140'
-  sha256 '742bfe1722aeed845243cc70dae7452a3a2fd6fdf914257fcbad78a189d417b4'
+  version '3.2.6,2143'
+  sha256 '1e75bd2f18eb55705d3e6064a5de5ff5ccfb8e68124e455e82f9f51e75f8290d'
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.