### PR TITLE
Update vitalsource-bookshelf from 8.2.1.313 to 8.2.2.318

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,5 +1,5 @@
 cask 'vitalsource-bookshelf' do
-  version '8.2.1.313'
+  version '8.2.2.318'
   sha256 'f1f430cd242c20f6b7e5899ab3a09b63f5631b9e843f5b33bd0c3c3c675394dc'
 
   # rink.hockeyapp.net/api/2/apps/ was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.