### PR TITLE
Update vitamin-r from 3.08 to 3.09

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -3,8 +3,8 @@ cask 'vitamin-r' do
     version '2.58'
     sha256 'c6c631430b44359aa022d9ca5ca6e98dbdf7258f2ceae0353f344a035682661e'
   else
-    version '3.08'
-    sha256 '0be990ba917fbbb09becc2eda05fe47ec7869ffe48b713a6bf57d11d18344d13'
+    version '3.09'
+    sha256 '3abea1f8b4c63cdd51fc451238b000a428e26c0a4c110706e858ed217b21589d'
   end
 
   url "http://www.publicspace.net/download/signedVitamin#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.