### PR TITLE
Update archipelago from 3.4.1 to 3.4.2

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.4.1'
-  sha256 'b04dfc1f477d0a0ceb5c1dc5423c23e9397054bf3b3a62dc4f533c414be2ff3a'
+  version '3.4.2'
+  sha256 '87e024a422e4dbf3fb5a4ef6087615446370396d87a9efbbb5b4f8280ffa8589'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.