### PR TITLE
Update metasequoia from 4.6.9 to 4.7.0

### DIFF
--- a/Casks/metasequoia.rb
+++ b/Casks/metasequoia.rb
@@ -1,10 +1,10 @@
 cask 'metasequoia' do
-  version '4.6.9'
-  sha256 '6b995b187c0f213cbb6a6217800aece5fa004d88a201ec112e0880f8bc0864e8'
+  version '4.7.0'
+  sha256 '4b7bf9cd9b65417ccb6ea543a554897f132b0a56cc00d770e8c459d74abc7aac'
 
   # metaseq2.sakura.ne.jp was verified as official when first introduced to the cask
   url "http://metaseq2.sakura.ne.jp/metaseq/Metasequoia-#{version}-Installer.dmg"
-  appcast 'http://www.metaseq.net/en/release_note.html'
+  appcast 'http://www.metaseq.net/en/download.html'
   name 'Metasequoia'
   homepage 'http://www.metaseq.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.