### PR TITLE
Update electron-fiddle from 0.8.0 to 0.8.1

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.8.0'
-  sha256 '1249f270b00cee039a795f6e10db1341c7de476b6c777175407876a4a3e886c8'
+  version '0.8.1'
+  sha256 '6d7751a8fb24bdc90ef4762df2ba2f432073719b9c238328fa11a91e22ed8a72'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/electron-fiddle-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.