### PR TITLE
Update mblock from version 3.4.11 to version 5.0.1

### DIFF
--- a/Casks/mblock.rb
+++ b/Casks/mblock.rb
@@ -1,6 +1,6 @@
 cask 'mblock' do
   version '5.0.1'
-  sha256 'fcf814848d47f0c383354870358bf44a375da32f71d35046c5542650769ec4ca'
+  sha256 'eca927eea3673d7ee236394c0c0f4da8d630f4aa94f3bc30815ba781f1088c92'
 
   # dl.makeblock.com was verified as official when first introduced to the cask
   url "https://dl.makeblock.com/mblock#{version.major}/darwin/V#{version}.pkg"

--- a/Casks/mblock.rb
+++ b/Casks/mblock.rb
@@ -4,7 +4,7 @@ cask 'mblock' do
 
   # dl.makeblock.com was verified as official when first introduced to the cask
   url "https://dl.makeblock.com/mblock#{version.major}/darwin/V#{version}.pkg"
-  appcast 'http://www.mblock.cc/mblock-software/'
+  appcast 'https://www.mblock.cc/mblock-software/'
   name 'mBlock'
   homepage 'https://www.mblock.cc/'
 

--- a/Casks/mblock.rb
+++ b/Casks/mblock.rb
@@ -9,6 +9,6 @@ cask 'mblock' do
   homepage 'https://www.mblock.cc/'
 
   pkg "V#{version}.pkg"
-  
-  uninstall pkgutil:   'mblock.pkg'
+
+  uninstall pkgutil: 'mblock.pkg'
 end

--- a/Casks/mblock.rb
+++ b/Casks/mblock.rb
@@ -10,5 +10,5 @@ cask 'mblock' do
 
   pkg "V#{version}.pkg"
 
-  uninstall pkgutil: 'mblock.pkg'
+  uninstall pkgutil: 'com.makeblock.pkg.mblock'
 end

--- a/Casks/mblock.rb
+++ b/Casks/mblock.rb
@@ -1,12 +1,14 @@
 cask 'mblock' do
-  version '3.4.11'
+  version '5.0.1'
   sha256 'fcf814848d47f0c383354870358bf44a375da32f71d35046c5542650769ec4ca'
 
-  # mblock.makeblock.com was verified as official when first introduced to the cask
-  url "https://mblock.makeblock.com/mBlock_mac_V#{version}.zip"
-  appcast 'https://www.mblock.cc/release-logs/'
+  # dl.makeblock.com was verified as official when first introduced to the cask
+  url "https://dl.makeblock.com/mblock#{version.major}/darwin/V#{version}.pkg"
+  appcast 'http://www.mblock.cc/mblock-software/'
   name 'mBlock'
   homepage 'https://www.mblock.cc/'
 
-  app "mBlock_v#{version}.app"
+  pkg "V#{version}.pkg"
+  
+  uninstall pkgutil:   'mblock.pkg'
 end


### PR DESCRIPTION
Version 3.x is still available on their download page, but this should probably go to cask-versions if anyone wants that