### PR TITLE
Update cycling74-max from 8.0.5_190409 to 8.0.6_190611

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '8.0.5_190409'
-  sha256 '13bce449729119aa5d46eb689558c85e102b79fac0ef4a04714296cf4769c75d'
+  version '8.0.6_190611'
+  sha256 '0cb01d888810863020006dda7e0dc5c3e985730d67721ba954179526b13f89bc'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.