### PR TITLE
Update thebrain from 10.0.48.0 to 10.0.50.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,6 +1,6 @@
 cask 'thebrain' do
-  version '10.0.48.0'
-  sha256 '8fc3f33fa0ee35655a5bffe3e68272b68cae81bcb2b4cc67fa813b413a058903'
+  version '10.0.50.0'
+  sha256 '32eab7a6baa5887abd875a860ab4efdf9b0f4a63e84d35eedecc1244a28d0440'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.