### PR TITLE
Update lunar from 2.6.0 to 2.8.0

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.6.0'
-  sha256 '404f63348f3e1ac85e36d109caa33a95d0092e4cce8734f96acb6414c984f4b5'
+  version '2.8.0'
+  sha256 '9b4fdb9d4f0bf4e457c7f7d6aee1fd689ce5e2833a906ee0e0055b3380807f84'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.