### PR TITLE
Update miditrail from 1.2.5,71069 to 1.2.6,71183

### DIFF
--- a/Casks/miditrail.rb
+++ b/Casks/miditrail.rb
@@ -1,6 +1,6 @@
 cask 'miditrail' do
-  version '1.2.5,71069'
-  sha256 'f9a10420356bc7c49c77b410b5e75e5c70d1a031ff00f53d8dabef4d1c15e1d1'
+  version '1.2.6,71183'
+  sha256 '37ab9b7689ba2cb0be9991a2b2cfd21972176b00c06ac667a3de6e7459c186f6'
 
   # dl.osdn.jp/miditrail was verified as official when first introduced to the cask
   url "http://dl.osdn.jp/miditrail/#{version.after_comma}/MIDITrail-Ver.#{version.before_comma}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.