### PR TITLE
krisp: Bump to 1.0.1

### DIFF
--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -1,8 +1,8 @@
 cask 'krisp' do
-  version '0.7.6'
-  sha256 'ee24ebc63110528e7a7e2681fe595936174c7b33b4c7a7070bd64e19cd7c33d1'
+  version '1.0.1'
+  sha256 '61ae1e9231a0e479786edf65c63c691a29146b76761227cfb2176263bbac429e'
 
-  url "https://cdn.krisp.ai/installer/release/krisp_#{version}.pkg"
+  url "https://cdn.krisp.ai/mac/release/v#{version.major}.#{version.minor}/krisp_#{version}.pkg"
   appcast 'https://krisp.ai/index.html'
   name 'Krisp'
   homepage 'https://krisp.ai/index.html'


### PR DESCRIPTION
Updates krisp to use the new URL structure and download the latest and
greatest version available.

<hr>

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
