### PR TITLE
Update cacher from 2.11.0 to 2.11.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.11.0'
-  sha256 '0207188279e3406b4de73230e56bedd9e243ca0879a4a48685133998d0ba42a4'
+  version '2.11.1'
+  sha256 '26702d18c72d2991fc94a45a35735824df26d03b718cf5913f3f05105d0d96f4'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.