### PR TITLE
Update lehreroffice from 2019.9.0 to 2019.9.1

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.9.0'
-  sha256 '50dc564d38f98a7d2f50b8466b1197e41d63aea1cb953acad60ca15c97d67707'
+  version '2019.9.1'
+  sha256 'f506ec3a0d878292cd7d7df3b8b2754a385315eeb5b8cac5b2aacca2a8baa567'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.