### PR TITLE
Update ark-desktop-wallet from 2.4.0 to 2.4.1

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.4.0'
-  sha256 'c2dbec2d15749355647ec8de8f988b566528a9dc0cdbdd173dce49a5bc62daae'
+  version '2.4.1'
+  sha256 '93b8f282635524c593d51fc3e507b4f3d34fc3e013309df325d78ef67ff986a3'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.