### PR TITLE
Update lbry from 0.33.0 to 0.33.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.33.0'
-  sha256 '087d0b95921585416d28c4182a42a9467dce97b5e47b50b86bb385087d042036'
+  version '0.33.1'
+  sha256 'ca0bf1cd04bd19ff5c7fceecf94e58fa477142f69230605ad35f0ce8bf660eb0'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.