### PR TITLE
Update rcloneosx from 1.8.1 to 1.9.0

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask 'rcloneosx' do
-  version '1.8.1'
-  sha256 'f0792030aee807cf274a0a757176a407cfcf5d13619a71528dda868e3ff1a6d2'
+  version '1.9.0'
+  sha256 'bf1bf2676872ceeba7652176eb7ab6e16eb93b11e224889b939a3fa552b27083'
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/RcloneOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.