### PR TITLE
Update bunch from 1.1.0,26 to 1.1.2,28

### DIFF
--- a/Casks/bunch.rb
+++ b/Casks/bunch.rb
@@ -1,6 +1,6 @@
 cask 'bunch' do
-  version '1.1.0,26'
-  sha256 '7bd7305ee6ff0b345bb383de614467274d51ed1f77c6b355875a810cd98f45f5'
+  version '1.1.2,28'
+  sha256 '75893e4f96055991d9b5813f38dd5f94ff62977e6219b1fed9fa76b87bb4187c'
 
   url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://brettterpstra.com/updates/bunch/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.