### PR TITLE
Update fontbase from 2.8.2 to 2.8.0

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.8.2'
-  sha256 'e120cff005b12b8452e928bfd16cba7e535a7a2603d231ca30063952dfe9930c'
+  version '2.8.0'
+  sha256 '3fb23c7c0bb1bfeb12baa761bcb6d253b4691c7d2d27ebc2a5742b79ca1297ac'
 
   url "https://releases.fontba.se/mac/FontBase-#{version}.dmg"
   appcast 'https://fontba.se/updates'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.