### PR TITLE
Update tinymediamanager from 3.0 to 3.0.1

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -1,6 +1,6 @@
 cask 'tinymediamanager' do
-  version '3.0'
-  sha256 'a5405fbe427e4a87ab6c9f5cc76348c9c021a6784d58aa186f83c5f155dbbd71'
+  version '3.0.1'
+  sha256 '67bf41198f4b2461f7985ddb9225d620fcc63842bb213a05cc4a8ece260ab5cc'
 
   url "https://release.tinymediamanager.org/v#{version.major}/dist/tmm_#{version}_mac.zip"
   appcast 'https://release.tinymediamanager.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.