### PR TITLE
Fix Airtool

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,8 +1,8 @@
 cask 'airtool' do
-  version '1.7.3'
-  sha256 '721ed94e45a71a02f211ede7fcd93d0152c51d80b269c49c9b35c62f1c3e7817'
+  version '1.7.5'
+  sha256 '2b06192e1afc4fe92f3b5c73f5416bd8cdcb64b8d9e357d2dbef463236edc010'
 
-  url "https://www.adriangranados.com/downloads/airtool_#{version}.pkg"
+  url "https://www.adriangranados.com/downloads/Airtool_#{version}.pkg"
   appcast 'https://updates.devmate.com/com.adriangranados.Airtool.xml'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'


### PR DESCRIPTION
Bump version to 1.7.5 as 1.7.3 is no longer available for download

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
