### PR TITLE
Update balenaetcher from 1.5.49 to 1.5.50

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.49'
-  sha256 'e8b516fdf6c419ca289f24664744bf08c8553a9af487682f820ec66b2c49bb93'
+  version '1.5.50'
+  sha256 'd4392cb27b56cbd563a38c0d6bc2bfdcf05b1bf7da3001b593674937280e101d'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.