### PR TITLE
Update tropy from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.5.0'
-  sha256 '7864380ad06a7b7c0d4606beb6a76b3b3b8636c3fb211ab565c788c5935c5a76'
+  version '1.5.1'
+  sha256 'e18f28c5476b51f13ce5af0077fa558b45d126573d2b13ec27c42ba2a525bd76'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.