### PR TITLE
Update ibackup-viewer from 4.1402 to 4.1403

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1402'
-  sha256 '4d258eb2f8b7bacbb2d572d9b991a0b2fbe7dd42ff60e349d1b8b38effa28217'
+  version '4.1403'
+  sha256 'a5097234e64faca8110d30af45dfe7f6db3c116955293562c6e6cafb9c5de543'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.