### PR TITLE
Update gimp from 2.10.10 to 2.10.12

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,6 +1,6 @@
 cask 'gimp' do
-  version '2.10.10'
-  sha256 '343beabe02de11b1988c13d1157a732fbb6edf32f7f10b3654c780a75b729bed'
+  version '2.10.12'
+  sha256 '8b964ad3dbbe31d0fa48fb834aa4c17fc0eb81becbc4595a57b04e3d4fc6efeb'
 
   url "https://download.gimp.org/pub/gimp/v#{version.major_minor}/osx/gimp-#{version}-x86_64.dmg"
   appcast 'https://download.gimp.org/pub/gimp/stable/osx/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.