### PR TITLE
Update busycal from 3.6.5,360502 to 3.6.6,360602

### DIFF
--- a/Casks/busycal.rb
+++ b/Casks/busycal.rb
@@ -1,6 +1,6 @@
 cask 'busycal' do
-  version '3.6.5,360502'
-  sha256 'bbc2107afd2292e84461cdd1ce452275ed6a26c576614de2fe81e039c3a1bc30'
+  version '3.6.6,360602'
+  sha256 'f2dc534ed121c8afc2b3f4ab5191cbea8db75e3b6f95d59f1092e2247fa44121'
 
   url 'https://www.busymac.com/download/BusyCal.zip'
   appcast 'https://www.busymac.com/busycal/news.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.