### PR TITLE
Update joplin from 1.0.159 to 1.0.160

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.159'
-  sha256 'd6bc7afc14146c451318a5d3af852e41341639409e0adc80f7d96558b905758e'
+  version '1.0.160'
+  sha256 '6d5b092a4cfc40924d6c4502c0417950faefe62d7bab9068d46b6b4275147353'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.