### PR TITLE
Update storyboarder from 1.9.2 to 1.10.1

### DIFF
--- a/Casks/storyboarder.rb
+++ b/Casks/storyboarder.rb
@@ -1,6 +1,6 @@
 cask 'storyboarder' do
-  version '1.9.2'
-  sha256 '121efaa9281970ce70e5896051c0a13627aadbedc3692a0ccac24541daf2db72'
+  version '1.10.1'
+  sha256 '3fd740d2fe729a35114264e75055608f31d02d3adf96d9742ebf901a7830609e'
 
   # github.com/wonderunit/storyboarder was verified as official when first introduced to the cask
   url "https://github.com/wonderunit/storyboarder/releases/download/v#{version}/Storyboarder-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.