### PR TITLE
Update idagio from 0.0.87 to 0.0.88

### DIFF
--- a/Casks/idagio.rb
+++ b/Casks/idagio.rb
@@ -1,6 +1,6 @@
 cask 'idagio' do
-  version '0.0.87'
-  sha256 '81c12c697660b9135f675a75cd8a466bb380aca9c63bad9ace6a802f1191a9c7'
+  version '0.0.88'
+  sha256 '680ab0cf7e22033bdaf51112af5a15bf6377730c3f5a3baa1cfe4b7c1d786eba'
 
   url "https://dl.idagio.com/IDAGIO-#{version}.dmg"
   name 'IDAGIO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.