### PR TITLE
Update netron from 3.1.4 to 3.1.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.1.4'
-  sha256 '097bfd0dd126c8894c9a8829bc5808b6d8c22d1f0eb576005f8b68e0bc8a0582'
+  version '3.1.5'
+  sha256 '7ca6c9d7bdbd525edb47c3eebb0a9f715f3c7ab91223548a1d144f55a81fd2e3'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.