### PR TITLE
Update blue-jeans from 2.13.0.439 to 2.13.1.17

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.13.0.439'
-  sha256 '70970f57a67b9ad47008fb3be630be0b5dbf1a5d77d23ab4d696c9aa480d57f3'
+  version '2.13.1.17'
+  sha256 'e7a5f5faa69000906bb30da34edc415d297174b4c463dd186c00125be58140c9'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   appcast 'https://www.bluejeans.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.