### PR TITLE
Update alacritty from 0.3.3-rc1 to 0.3.3-rc2

### DIFF
--- a/Casks/alacritty.rb
+++ b/Casks/alacritty.rb
@@ -1,6 +1,6 @@
 cask 'alacritty' do
-  version '0.3.3-rc1'
-  sha256 '37b90db70726bdcac48307348473ecf544bdea81ed467922d3c703b5ce6b13ff'
+  version '0.3.3-rc2'
+  sha256 '4fbcba810c9247dbfe4378320a5126cddaf27ea32e391b34caf1ba8636e1a84f'
 
   url "https://github.com/jwilm/alacritty/releases/download/v#{version}/Alacritty-v#{version}.dmg"
   appcast 'https://github.com/jwilm/alacritty/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.