### PR TITLE
Update cryptobridge from 0.18.7 to 0.18.8

### DIFF
--- a/Casks/cryptobridge.rb
+++ b/Casks/cryptobridge.rb
@@ -1,6 +1,6 @@
 cask 'cryptobridge' do
-  version '0.18.7'
-  sha256 '6771932c1b3fa86883e8a0678c9df107d6306cafbed50a7722f6952442a44390'
+  version '0.18.8'
+  sha256 'ae0c73cf00a5746a42150011e880b6606d1a51fa522b7c1409caf4cd7c5dab2f'
 
   url "https://github.com/CryptoBridge/cryptobridge-ui/releases/download/v#{version}/CryptoBridge-#{version}.dmg"
   appcast 'https://github.com/CryptoBridge/cryptobridge-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.