### PR TITLE
Update jd-gui from 1.5.2 to 1.6.0

### DIFF
--- a/Casks/jd-gui.rb
+++ b/Casks/jd-gui.rb
@@ -1,6 +1,6 @@
 cask 'jd-gui' do
-  version '1.5.2'
-  sha256 'd32f94733bf956ef5348600221a211ca45caebb6856a1fa4bb01bd6686528e93'
+  version '1.6.0'
+  sha256 'd8288b16136cb57ca02e60b5d867d27b0beaa09451d339b0bf666a18cf0b3f89'
 
   # github.com/java-decompiler/jd-gui was verified as official when first introduced to the cask
   url "https://github.com/java-decompiler/jd-gui/releases/download/v#{version}/jd-gui-osx-#{version}.tar"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.