### PR TITLE
Fixing checksum for volt app version 0.80

### DIFF
--- a/Casks/volt.rb
+++ b/Casks/volt.rb
@@ -1,6 +1,6 @@
 cask 'volt' do
   version '0.80'
-  sha256 '0496831e619afeea7336bfd234bcf415ef615c25e817cd3390faf1a300e655f6'
+  sha256 'fb25337fd6992aa2aca19f3ed282f67bd7faae52df20b86aa2a0bb43c0daf1e3'
 
   # github.com/voltapp/volt was verified as official when first introduced to the cask
   url "https://github.com/voltapp/volt/releases/download/#{version}/Volt.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Couldn't install the app because of the checksum error even if deleting the dmg. 
> Expected: 0496831e619afeea7336bfd234bcf415ef615c25e817cd3390faf1a300e655f6
  Actual: fb25337fd6992aa2aca19f3ed282f67bd7faae52df20b86aa2a0bb43c0daf1e3

This PR should fix the issue.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

~~Additionally, if **adding a new cask**:~~

~~- [ ] Named the cask according to the [token reference].~~
~~- [ ] `brew cask install {{cask_file}}` worked successfully.~~
~~- [ ] `brew cask uninstall {{cask_file}}` worked successfully.~~
~~- [ ] Checked there are no [open pull requests] for the same cask.~~
~~- [ ] Checked the cask was not [already refused].~~
~~- [ ] Checked the cask is submitted to [the correct repo].~~

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
