### PR TITLE
fix cycling74-max 8.0.6_190611 sha hash

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
   version '8.0.6_190611'
-  sha256 '0cb01d888810863020006dda7e0dc5c3e985730d67721ba954179526b13f89bc'
+  sha256 '2d7bf4dfb26a1ec2fdaa6896669a270fa8966d6982f550a9bf4bbd199e46ef28'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

`brew cask style --fix {{cask_file}}` currently doesn't work on my machine but I hope thats ok since I am just fixing the hash..
