### PR TITLE
Update mudlet from 3.20.1 to 3.21.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '3.20.1'
-  sha256 '27c20c4fc104dab72468b099c21ebc87066a4b3aa473a224c79540ff584b13c2'
+  version '3.21.0'
+  sha256 '56969a16a191d7a6ae34893d65265b785f9c887790f7c87247fe766e5b9aa0c3'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.