### PR TITLE
Update ivpn from 2.9.8 to 2.9.9

### DIFF
--- a/Casks/ivpn.rb
+++ b/Casks/ivpn.rb
@@ -1,6 +1,6 @@
 cask 'ivpn' do
-  version '2.9.8'
-  sha256 '9d54b1d2123ac76306b3ee5900b3b6e4a0b755091d0f03882f1bf0953ae8a1ad'
+  version '2.9.9'
+  sha256 'c7237eebd7307069f5b181524f8ae709faf3dfe150191d19fbc6d9f1ba5060b5'
 
   url "https://cdn.ivpn.net/releases/osx/IVPN-#{version}.dmg"
   appcast 'https://www.ivpn.net/updates/mac/sparkle/ivpn_mac_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.