### PR TITLE
Finicky 2.0 requires MacOS 10.12

### DIFF
--- a/Casks/finicky.rb
+++ b/Casks/finicky.rb
@@ -7,5 +7,7 @@ cask 'finicky' do
   name 'Finicky'
   homepage 'https://github.com/johnste/finicky'
 
+  depends_on macos: '>= :sierra'
+
   app 'Finicky.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

- [ ] `brew cask style --fix {{cask_file}}` reports no offenses — dunno because “Gem::Ext::BuildError: ERROR: Failed to build gem native extension. An error occurred while installing nokogiri (1.10.3), and Bundler cannot continue.” It's a one-line change, though.