### PR TITLE
Update patchwork from 3.13.0 to 3.14.1

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.13.0'
-  sha256 '5409829e3d1f05f8e7fb04d4c19d8b3f1f09694dfa0a228919ebef7c8442490e'
+  version '3.14.1'
+  sha256 'f96c886545b6661cbb9be9c5f7e80bb702e810bfceea691db03c6045ef4a9f0b'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.