### PR TITLE
Update pulse-sms from 3.4.4 to 3.4.5

### DIFF
--- a/Casks/pulse-sms.rb
+++ b/Casks/pulse-sms.rb
@@ -1,6 +1,6 @@
 cask 'pulse-sms' do
-  version '3.4.4'
-  sha256 '424f41c7014df59e80c6edf5ba25a6058576be59ad5fca81558f8090f094bc57'
+  version '3.4.5'
+  sha256 '383f37ffa3a614f8674d99b1f35dd76494b571a4e9298e1a35d6030bda99ac15'
 
   # github.com/klinker-apps/messenger-desktop was verified as official when first introduced to the cask
   url "https://github.com/klinker-apps/messenger-desktop/releases/download/v#{version}/pulse-sms-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.