### PR TITLE
Update trinity from 0.6.0 to 0.6.1

### DIFF
--- a/Casks/trinity.rb
+++ b/Casks/trinity.rb
@@ -1,6 +1,6 @@
 cask 'trinity' do
-  version '0.6.0'
-  sha256 '3b3b265cc90b07b79c19750cc0d5d7b1461bbe6128741a9b4d2450b0066c9f74'
+  version '0.6.1'
+  sha256 'a8b38995ab0e9f0d3f7edc56e08a594d0d924e469c33d34ec20037cbbbedcbf0'
 
   # github.com/iotaledger/trinity-wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/trinity-wallet/releases/download/#{version}/trinity-desktop-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.