### PR TITLE
Update craftmanager from 1.0.82 to 1.0.83

### DIFF
--- a/Casks/craftmanager.rb
+++ b/Casks/craftmanager.rb
@@ -1,6 +1,6 @@
 cask 'craftmanager' do
-  version '1.0.82'
-  sha256 '9abbc68baa8c47c0ae813ef56d622b034504d7d53eab2f97b9bdf29c89d8728c'
+  version '1.0.83'
+  sha256 'd2791b040554ca27a88edc048ae8e67f6a69388094a2bac7c3677bd88cb1a6e7'
 
   url 'https://craft-assets.invisionapp.com/CraftManager/production/CraftManager.zip'
   appcast 'https://craft-assets.invisionapp.com/CraftManager/production/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.