### PR TITLE
Update nvidia-geforce-now from 2.0.8.74,767C12 to 2.0.8.78,1592B5

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.8.74,767C12'
-  sha256 'f0fb61856d142294fe29aca6251adb9a08ca0d1468bf4d9132fda8697c501912'
+  version '2.0.8.78,1592B5'
+  sha256 'dfdb9025505e5d6912a4f801640a8df9a394d6c22af3f8e2dddfdf7c6359891e'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.