### PR TITLE
Update plex-media-server from 1.15.8.1198-eadbcbb45 to 1.16.0.1226-7eb2c8f6f

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.15.8.1198-eadbcbb45'
-  sha256 'c666689b034f27ea409386c9ecc1f739616b759c31e973f154fee8b08ffc4f8b'
+  version '1.16.0.1226-7eb2c8f6f'
+  sha256 'ba4d3a34aeb85e287258a07e87608cb2117aec74b257993a30c87f723b1e553a'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.dmg"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.