### PR TITLE
Update ridibooks from 2.6.3 to 2.6.4

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,6 +1,6 @@
 cask 'ridibooks' do
-  version '2.6.3'
-  sha256 '8b46f1746c48519c4d05495793347e8ffeabdd7da3f7adbebbce2f469d946a70'
+  version '2.6.4'
+  sha256 'e6e40614ceea3057f40ac2f45c069164a8ccdea66945d29b4ab1ea1a92cc8840'
 
   url "https://viewer-ota.ridibooks.com/mac/ridibooks-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://getapp.ridibooks.com/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.