### PR TITLE
Update Multipass to 0.7.1

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask 'multipass' do
-  version '0.7.0'
-  sha256 'f170958e295860d4c4cc0844afe3cc2a8d6def3c1f7ccca9eb21e0c72edb98df'
+  version '0.7.1'
+  sha256 '650296310e09bba75ae3c7a17e81dbfb0a3399e5ea7990d7bbe39a569bfec6bd'
 
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast 'https://github.com/CanonicalLtd/multipass/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I could not run `cask style`, my ruby is apparently having trouble.

CI will fail due to CPU feature detection for virtualization.