### PR TITLE
Update segger-embedded-studio-for-arm from 4.16 to 4.16a

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.16'
-  sha256 '348aa89f688a90977fd368be94774cc4347110bd69850fd614f6ebea43d027b9'
+  version '4.16a'
+  sha256 '3b0127ce8d739f23f8e65cf1b1e3a06e20c5c9ca8f6dd04c6cc24eaaf9abc109'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   name 'SEGGER Embedded Studio for ARM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.