### PR TITLE
Update whatsapp from 0.3.3328 to 0.3.3330

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'whatsapp' do
-  version '0.3.3328'
-  sha256 'e3ea29bf862653a010d604fde664618c6e5e0051005c736f6d4014dfe20c9fd8'
+  version '0.3.3330'
+  sha256 '486b8d7a2d3ca863679ee5d78eeea854c32c3f9fed56c3d7c11d3fa599db5e57'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.