### PR TITLE
Update cozy-drive from 3.13.2 to 3.13.3

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.13.2'
-  sha256 '11786070596e86459db0593ac5015de5f06646091fb6cd2b378a053a3ee3428c'
+  version '3.13.3'
+  sha256 '30030fa2aa106a1582865a42811f6963ff70068b86633e1ecf66ea3283fbbc90'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.