### PR TITLE
Update zoc from 7.23.5 to 7.23.6

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.23.5'
-  sha256 '059d2165e5f1b038f1881bdf1e5ae82540ea14b3a382c614210a3ca874ec174e'
+  version '7.23.6'
+  sha256 'd3a28d61e207c754f460b01226e8345fa93180a94ef990b53b2885939bfd3415'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.