### PR TITLE
Update chronos from 3.2.4 to 3.2.5

### DIFF
--- a/Casks/chronos.rb
+++ b/Casks/chronos.rb
@@ -1,6 +1,6 @@
 cask 'chronos' do
-  version '3.2.4'
-  sha256 '8abeee610d4b1e369746119597c11c3c3595cfebb216eec4d78773a627fe93ba'
+  version '3.2.5'
+  sha256 '5dd38500185043d82c0b5d579de0595aeab9de976648e3ac441f7dc8aa498365'
 
   url "https://github.com/web-pal/chronos-timetracker/releases/download/v#{version}/Chronos-#{version}-mac.zip"
   appcast 'https://github.com/web-pal/chronos-timetracker/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.