### PR TITLE
Update cardhop from 1.2.5 to 1.3

### DIFF
--- a/Casks/cardhop.rb
+++ b/Casks/cardhop.rb
@@ -1,6 +1,6 @@
 cask 'cardhop' do
-  version '1.2.5'
-  sha256 'eca1b753351cc73a303c0c9a3f077e2fdcc22205eaed268e4b167a8ca211aa9f'
+  version '1.3'
+  sha256 'bc6bf626ac0b972cda0db4965d67a93a25e3458ef7d63535feb0d43f5ac93bf1'
 
   url "http://cdn.flexibits.com/Cardhop_#{version}.zip"
   appcast 'https://flexibits.com/cardhop/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.