### PR TITLE
Update netshade from 7.2.1 to 8.0.1

### DIFF
--- a/Casks/netshade.rb
+++ b/Casks/netshade.rb
@@ -3,7 +3,7 @@ cask 'netshade' do
   sha256 '0c0c680e1084219110f16e2782f0641ffe7c84a7d42bc797aee8ecb03873bad2'
 
   url "https://secure.raynersw.com/downloads/NetShade-#{version.dots_to_hyphens}.app.zip"
-  appcast 'https://secure.raynersw.com/changelog.php?prod=ns&format=std&warnpay=0'
+  appcast 'https://www.raynersw.com/appcast.php'
   name 'NetShade'
   homepage 'https://secure.raynersw.com/netshade.php'
 

--- a/Casks/netshade.rb
+++ b/Casks/netshade.rb
@@ -1,6 +1,6 @@
 cask 'netshade' do
-  version '7.2.1'
-  sha256 '9a447695be84e1f2929bb2526ffc2e1fe05e23c2c74a739617e134ece52042ce'
+  version '8.0.1'
+  sha256 '0c0c680e1084219110f16e2782f0641ffe7c84a7d42bc797aee8ecb03873bad2'
 
   url "https://secure.raynersw.com/downloads/NetShade-#{version.dots_to_hyphens}.app.zip"
   appcast 'https://secure.raynersw.com/changelog.php?prod=ns&format=std&warnpay=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.