### PR TITLE
Update pdfpenpro from 1102.3,1559079247 to 1103.3,1560869374

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1102.3,1559079247'
-  sha256 '72c677d6f359f43c301e0e6c1575d66a5476db17bbf6e12c606c678a206b7b36'
+  version '1103.3,1560869374'
+  sha256 '3b2530928201bd2197fa884c00c0f05c4b06d62d5670ef407cc2b284c5e6e924'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.