### PR TITLE
Update wifispoof from 3.4.3 to 3.4.4

### DIFF
--- a/Casks/wifispoof.rb
+++ b/Casks/wifispoof.rb
@@ -1,6 +1,6 @@
 cask 'wifispoof' do
-  version '3.4.3'
-  sha256 '31465240307e6e2f36f9345c0600489e3458d81922f3a4ded66fe9881503f606'
+  version '3.4.4'
+  sha256 '36b9a36fcb9010e28bf42b4c32f04ae8cbe72f616cd8ae978a5ab3494c5fc260'
 
   # sweetpproductions.com/products was verified as official when first introduced to the cask
   url "https://sweetpproductions.com/products/wifispoof#{version.major}/WiFiSpoof#{version.major}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.