### PR TITLE
Update parallels-client from 16.5.3-20740 to 17.0.0-21282

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -3,7 +3,7 @@ cask 'parallels-client' do
   sha256 '8cb12254b5b40ed5207f9d63807c47d0654c49c60c23382963249059b8e9949f'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
-  appcast "https://download.parallels.com/ras/v#{version}/RAS%20Client%20for%20Mac%20Changelog.txt"
+  appcast "https://download.parallels.com/ras/v#{version.major}/RAS%20Client%20for%20Mac%20Changelog.txt"
   name 'Parallels Client'
   homepage 'https://www.parallels.com/products/ras/features/rdp-client/'
 

--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -3,7 +3,7 @@ cask 'parallels-client' do
   sha256 '8cb12254b5b40ed5207f9d63807c47d0654c49c60c23382963249059b8e9949f'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
-  appcast "https://download.parallels.com/ras/v#{version.major_minor}/RAS%20Client%20for%20Mac%20Changelog.txt"
+  appcast "https://download.parallels.com/ras/v#{version}/RAS%20Client%20for%20Mac%20Changelog.txt"
   name 'Parallels Client'
   homepage 'https://www.parallels.com/products/ras/features/rdp-client/'
 

--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,6 +1,6 @@
 cask 'parallels-client' do
-  version '16.5.3-20740'
-  sha256 '2019e3de597659e06261f76569f2ac34c94d0bcb93bbe23a7b0e0378d611de76'
+  version '17.0.0-21282'
+  sha256 '8cb12254b5b40ed5207f9d63807c47d0654c49c60c23382963249059b8e9949f'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
   appcast "https://download.parallels.com/ras/v#{version.major_minor}/RAS%20Client%20for%20Mac%20Changelog.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.