### PR TITLE
Update fldigi from 4.1.03,4.3.7 to 4.1.04,4.3.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.1.03,4.3.7'
-  sha256 '059b72c165b7bd7c385938a14315664cb3309160a4c43589ba0d8ae53cdde14e'
+  version '4.1.04'
+  sha256 '31d5f23f5898f7ca89d1e99f84c175e33ec90b572d7d2397fb3628d20c391111'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,5 +1,5 @@
 cask 'fldigi' do
-  version '4.1.04'
+  version '4.1.04,4.3.7'
   sha256 '31d5f23f5898f7ca89d1e99f84c175e33ec90b572d7d2397fb3628d20c391111'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.