### PR TITLE
Update perforce from 19.1 to 19.1-1813586

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,8 +1,8 @@
 cask 'perforce' do
-  version '19.1'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '19.1-1813586'
+  sha256 '3cd4c1f0e4561f11d435cdca40f32218370e9d8e37ad5edbcdcddea4ba3123df'
 
-  url "https://cdist2.perforce.com/perforce/r#{version}/bin.macosx1010x86_64/helix-core-server.tgz"
+  url "https://cdist2.perforce.com/perforce/r#{version.major_minor}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'
   homepage 'https://www.perforce.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.