### PR TITLE
Update evernote from 7.10_457750 to 7.11_457846

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -9,8 +9,8 @@ cask 'evernote' do
     version '7.2.3_456885'
     sha256 'eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97'
   else
-    version '7.10_457750'
-    sha256 '45b787a343d1b83be263d102bb52125f13e99e2a5bad994a67c4f70f297d1895'
+    version '7.11_457846'
+    sha256 'fb8da3b775f8b32cab6fd3759b3ce718b66df5539db8c5c13e9f2335d4b7a513'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.