### PR TITLE
Update zeplin from 2.4.3,702 to 2.5,717

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.4.3,702'
-  sha256 '18a92cf56ad0754d428028e13e2974ab774b162601da099afb72cf45b5f2e4bb'
+  version '2.5,717'
+  sha256 '39c4d60e605a4a5ae72d72ccc308bfefec4333e780b4e8d16c25d3d9f03422ed'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.