### PR TITLE
Update cisdem-pdf-converter-ocr from 6.6.0 to 6.7.0

### DIFF
--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-pdf-converter-ocr' do
-  version '6.6.0'
-  sha256 '4ad587a08725cf847b4f4abbcfe06f91beea8f6beca933d795457532c74051ad'
+  version '6.7.0'
+  sha256 '15a916e433b284c5891f707b761c546c2c1111a651a77494d929aaa20a7fa946'
 
   url 'http://download.cisdem.com/cisdem-pdfconverterocr.dmg'
   appcast 'https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.