### PR TITLE
Update greenfoot from 3.5.4 to 3.6.0

### DIFF
--- a/Casks/greenfoot.rb
+++ b/Casks/greenfoot.rb
@@ -1,6 +1,6 @@
 cask 'greenfoot' do
-  version '3.5.4'
-  sha256 'bb6f2942f6fc6b056917714d63fc1b4d9853a38f85e2296ab529bea45dd4f878'
+  version '3.6.0'
+  sha256 '575413dd4d1c7a0e4e97c39192478e98ca944cbad9684c161e57191204dd1ebe'
 
   url "https://www.greenfoot.org/download/files/Greenfoot-mac-#{version.no_dots}.zip"
   appcast 'https://www.greenfoot.org/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.