### PR TITLE
Update scrutiny from 8.4.1 to 9.0.4

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '8.4.1'
-  sha256 '3ed52a04b9709b19a9e4156ca15b6ed8e75d6de15d9dda40bbc20a328596072f'
+  version '9.0.4'
+  sha256 '832a177a1ed522ed27d1a71b62a33555c3f741fedcd575fedb6c278b09dc4141'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.