### PR TITLE
Update macx-dvd-ripper-pro from 6.2.2,20190521 to 6.2.3,20190619

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.2.2,20190521'
-  sha256 '05d2e94458609ef12097c3f5962da52c0cb52e4e267b4f3bccae3f80f9ef63b5'
+  version '6.2.3,20190619'
+  sha256 'c8a4b3b4657bde31a5b2510c1a99caaf6a175491090c46d35250a02d17aa0a67'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
   appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.