### PR TITLE
Update sourcetree from 3.2_224 to 3.2.1_225

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -6,8 +6,8 @@ cask 'sourcetree' do
     # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
     url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
   else
-    version '3.2_224'
-    sha256 'd32e51702b4aedac7a11cacb62ff5a8ee29ad3a9a1787d6c7c11581587276631'
+    version '3.2.1_225'
+    sha256 '4bd82affa3402814c3d07ff613fbc8f45da8b0cda294d498ffbb0667bf729c9f'
 
     # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
     url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.