### PR TITLE
Update lbry from 0.33.1 to 0.33.2

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.33.1'
-  sha256 'ca0bf1cd04bd19ff5c7fceecf94e58fa477142f69230605ad35f0ce8bf660eb0'
+  version '0.33.2'
+  sha256 '1acf4d37a207e2b3329b19611acc26167a0ceaa3f92059cd94e2160c85b4a994'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.