### PR TITLE
Update downie from 3.7.6,2029 to 3.7.7,2033

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.7.6,2029'
-  sha256 '461088c42c9f90569a25a27ba5e7626bbb54cec03fdc17362e82df1dddd4f7c1'
+  version '3.7.7,2033'
+  sha256 'c362426902200cb55f14e11b125c988c3fb989b214a3fb38b018ad4ab05989be'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.zip"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.