### PR TITLE
Update framer-x from 32611,1559836113 to 32894,1560951087

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '32611,1559836113'
-  sha256 'b7a69ef615e05b91669bbd7f16b0847c9a548d239c48cc32f9c537ed9c06b9a2'
+  version '32894,1560951087'
+  sha256 '12116b04b5b82bbd24bf382f2068e8dee423059b58e789a2e89ac72416aac21c'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.