### PR TITLE
Update fontbase from 2.8.2 to 2.8.3

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -3,7 +3,8 @@ cask 'fontbase' do
   sha256 'aa9fcd3907800ad1f953a6015fefe4c23542331a5a5f71418b82a829e6d64d9b'
 
   url "https://releases.fontba.se/mac/FontBase-#{version}.dmg"
-  appcast 'https://fontba.se/updates'
+  appcast 'https://fontba.se/updates',
+          configuration: version.major_minor
   name 'FontBase'
   homepage 'https://fontba.se/'
 

--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.8.2'
-  sha256 'e120cff005b12b8452e928bfd16cba7e535a7a2603d231ca30063952dfe9930c'
+  version '2.8.3'
+  sha256 'aa9fcd3907800ad1f953a6015fefe4c23542331a5a5f71418b82a829e6d64d9b'
 
   url "https://releases.fontba.se/mac/FontBase-#{version}.dmg"
   appcast 'https://fontba.se/updates'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.