### PR TITLE
Update unity-android-support-for-editor from 2019.1.5f1,0ca0f5646614 to 2019.1.7f1,f3c4928e5742

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.1.5f1,0ca0f5646614'
-  sha256 '01850c1617f2dbd69fc4ce8800c550eec25fa4a4e72188a152234646f634031a'
+  version '2019.1.7f1,f3c4928e5742'
+  sha256 '0f2aa2c21f8fff5acf5dd4426601eea6d6dabafadb6b1e95b8f3f8accd7a25ec'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.