### PR TITLE
Update firefox from 67.0.3 to 67.0.4

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '67.0.3'
+  version '67.0.4'
 
   language 'cs' do
-    sha256 '801237d9e155b1857e4f7cec27cabccfe1bd57bc8b3fbcb6085f6ab5c6a2e71c'
+    sha256 '9fd43ff8e6f8fd391dabc11c9b5014b62e5ba62df37bea5bbfadba3285e24376'
     'cs'
   end
 
   language 'de' do
-    sha256 '3939735b16c20339d2205aec26cfb5f6f5fd1704c052224e9fcb08e5dc1ccaab'
+    sha256 'd69d95fd6972f196b4ab1770b6160c114371961e00aef18bb55823ae189d4127'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '9bc1ed6acca08f96b8c5a2d20ef3c25378929dd7009edf8676ec7bc421581366'
+    sha256 '7abc4f0e3e3155999e0771039a7c35d2b53a63c0945de070ece73124b7961ed5'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'ed76929c23ff6587a5d95afaea4a29b0b4558be644a877feff9b5818705b9903'
+    sha256 'b0a2e2f1fdb4aa0949318e0dc48a4a966695bb1356d8523e4e4b470b29831515'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '3a3c481ace56ce1261da71e463c8a88491fc470910a40d8bbb5434f5559299f9'
+    sha256 'f4555a85d8add9362f8442413944c1045c9fb83b9ea0a42955ebaa1a306cefbf'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '8d926da3abb416ed5e4d43ab8612c959424ae825d0c5797b6db07ed8e78ed5ba'
+    sha256 'b12bca00b227b0b5749d5ad60c956a8109c79cdb0a6eb7d4d13414ba17b15410'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '5cd235f5adadbefab30584345b7fe832b57734e036701c91a76389e3a0d66335'
+    sha256 '376eea5a7208bd8eed4e99ca626f920c59e8820baad388a4548c571cfc199584'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'e61a6c7f6658969d3c5c3bf202abe559bc72230622cc58194c76dfb08f7c8197'
+    sha256 '86be6416f5acc97bcdf04f642901ceab3b8deacdfdfc8229d438e58bece10fb2'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 'c15db8309a2d9e32a4c5aa3cd638ce18d9c56a9c84fbb957c97aa0e7a3d9d317'
+    sha256 'fa4cb67dd18259f073932cc130b23ecd151a79e9d55f00702b1868766cf4d4d5'
     'fi'
   end
 
   language 'fr' do
-    sha256 'a2b32ca1328cd1d3f62f073c97ccdf6704c1beb73d8a828760ddd62305788a41'
+    sha256 'feefd28b86d557912fee66d31771c98b8f12233214f1140a1bf343d8504bc042'
     'fr'
   end
 
   language 'gl' do
-    sha256 '4eeb1666d8ee9286915ab61d51eaffc64ff74ee051317ae48cc1be2771302c44'
+    sha256 '9f107660a0001a0bcd62a515570912e51fbca29ca011b6d83d03f105644543f9'
     'gl'
   end
 
   language 'in' do
-    sha256 '2c3eb4ae54c9e8f546236f2e415cee25b4d52df2566fa88d776d89ecd184a5fb'
+    sha256 '4eface76ca8d21be339f50f5ce3b520ae95301ec8acd578da5b8264be4be57a8'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 'cafe00e3c80528addad7e193957553b12f6f80b67462fe428b7a25bc73154128'
+    sha256 'cd46da867b968dfb6c2dd13d947ff59f7558856837ae3661dc5bf8981040b202'
     'it'
   end
 
   language 'ja' do
-    sha256 '7d3a2e1fdfa1eeb7617716ccfafddefff1efa37a7f8821ff5d217094fa3cf8a8'
+    sha256 '81a86490a43f3402ab4600f4192781b96a5ceeeabe405d8c2fac064bec21d3b9'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 'e1c773c6874a8158fb27e7eb4b1eb313c248daad9bc1a446e30bf2adcc2b649e'
+    sha256 '1f013a20da1657cb07bd4b72d07990ec8791dcfae5e8ca7fd00e612ff308c7f0'
     'ko'
   end
 
   language 'nl' do
-    sha256 '77f4e72b300e0628eaa0ea7b4675beb16baa0dd486909b7be46639ca4a5875eb'
+    sha256 '7c89c5cb9c5cd5a43e49d70acb24f59f1784afa69acbe42e915ccfc1ee786e2d'
     'nl'
   end
 
   language 'pl' do
-    sha256 '3a571449dfbcd0f92e01a9679e36e9736e098081bf448ff90d6e42f9da43acc6'
+    sha256 '9cef6fd755f79db591047e75a77c4054053b1801bc468013521aeca4f6ec4ac4'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '3db40f60719efc5595271e9b1526fda89b40f1d86381479759098321b5d4509e'
+    sha256 '9a5ad17f3183e73c0c01dad1ce05c336d8adb794b7d9bf17e377458d88f3f077'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'e6e01953afc8124990a6f94d23daa32bd31c92a306f76c6472924a482cc5559f'
+    sha256 '113aa11716367a00031ee9cd44b2ebd0470987a5d417b12aff02b0d3c770d791'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'fdf4ec8e3e63b3c2e0f26d50424fbc8cf8aaf9e527bdcda65624692cf5f83556'
+    sha256 'f4d3df5e2a19110853731c258a3c7b176604975da97306f5b5323a292fc303fa'
     'ru'
   end
 
   language 'tr' do
-    sha256 '9a27420a0388ce1a50d229ea69ff87d62b9c8eb8a94c90d8e9f0c3f7cd861c35'
+    sha256 '412125475c055f2f3cb89fb4c9d0b9b8e1b60290b80579a2035e426d891c70f5'
     'tr'
   end
 
   language 'uk' do
-    sha256 'a2e8b1b53e083c5e071753a12963f388ec7e3fdf4b4958fac3a5ecf2d62c6ee7'
+    sha256 '767367647d0edff2ae24c0054ad6676bfabb04356c8ab98b76e18f8c72f2e0fe'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '4d3452102b3d3b1d7443cf06bb6b09602c565b2ab63f2457f03ba7d0f840d121'
+    sha256 '88f4397eb52207680c1b4e46144c3682166cb5c32f5aa21affe5ea7dd211d02e'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'e7ecc53767fd806edb1bf0dae405316d69e054aa45ac9673ebb51a9a57a65b20'
+    sha256 '69a8a25f9d428792a21e4f8173651c08b8de4de66428e36d743190b54076e274'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
