### PR TITLE
Updated TablePlus version to 2.5 build 233.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,5 +1,5 @@
 cask 'tableplus' do
-  version '2.5,233'
+  version '2.4,233'
   sha256 '45c4f67a4471e7ec482b9b85669eb1694f3cb30caf81d738ccaf9fbe47709236'
 
   # tableplus-osx-builds.s3.amazonaws.com was verified as official when first introduced to the cask

--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,10 +1,11 @@
 cask 'tableplus' do
-  version '2.4,233'
+  version '2.4.233'
   sha256 '45c4f67a4471e7ec482b9b85669eb1694f3cb30caf81d738ccaf9fbe47709236'
 
   # tableplus-osx-builds.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.after_comma}/TablePlus.dmg"
-  appcast 'https://tableplus.io/osx/version.xml'
+  url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.patch}/TablePlus.dmg"
+  appcast 'https://tableplus.io/osx/version.xml',
+          configuration: version.patch
   name 'TablePlus'
   homepage 'https://tableplus.io/'
 

--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '2.4,228'
-  sha256 'bf3350deeba7d62df1e9e2cf35d8e43c5f785d8e9e5e109d951797e6e1bef1c0'
+  version '2.5,233'
+  sha256 '45c4f67a4471e7ec482b9b85669eb1694f3cb30caf81d738ccaf9fbe47709236'
 
   # tableplus-osx-builds.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download Casks/tableplus.rb` is error-free.
- [x] `brew cask style --fix Casks/tableplus.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).