### PR TITLE
Update baiducloud from 2.4.5 to 2.2.2

### DIFF
--- a/Casks/baiducloud.rb
+++ b/Casks/baiducloud.rb
@@ -1,9 +1,9 @@
 cask 'baiducloud' do
-  version '2.4.5'
-  sha256 '7694edba46c8e53ffd2d2485dad4d68b06e27cc038d18cdd40699d1c0e559ba2'
+  version '2.2.2'
+  sha256 '89e3bdc7da7860e55f3fa6edf756a74bd7d7f55607db0358922f7e96c4cc8590'
 
   # issuecdn.baidupcs.com was verified as official when first introduced to the cask
-  url "https://issuecdn.baidupcs.com/issue/netdisk/macapk/BaiduNetdisk_mac_#{version}.dmg"
+  url "http://issuecdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
   name 'Baidu Cloud'
   name 'Baidu Yun Tong Bu Pan'
   name '百度云同步盘'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.