### PR TITLE
Revert "upwork 5.2.3.757"

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,6 +1,6 @@
 cask 'upwork' do
-  version '5.2.3.757,5_2_3_757_3idn3cdxmlq3m6d5'
-  sha256 'd7da1baf90469e23cb3f23da0151a8b897126205998d67502f7f9440386d6800'
+  version '3.1.9,5_2_3_717_7tq7l0sg49p0kixc'
+  sha256 'a4588d607abd3e8616af117b962047238dfdfb4e0d85d21764ab4c011c479af9'
 
   url "https://updates-desktopapp.upwork.com/binaries/v#{version.after_comma}/Upwork.dmg"
   name 'Upwork'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#65115
where did you find this version number @yurikoles ?
my installation still shows 3.1.9, the download too and I can't find a newer version -> see https://github.com/Homebrew/homebrew-cask/pull/63512