### PR TITLE
change version number from 5.2.3.757 to 3.1.9 upwork.rb

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,5 +1,5 @@
 cask 'upwork' do
-  version '5.2.3.757,5_2_3_757_3idn3cdxmlq3m6d5'
+  version '3.1.9,5_2_3_757_3idn3cdxmlq3m6d5'
   sha256 'd7da1baf90469e23cb3f23da0151a8b897126205998d67502f7f9440386d6800'
 
   url "https://updates-desktopapp.upwork.com/binaries/v#{version.after_comma}/Upwork.dmg"


### PR DESCRIPTION
@yurikoles: my installation still shows 3.1.9 as latest version, the download too and I can't find a newer version - 5_2_3_757 is just part of the download-token :) 
-> see #63512