### PR TITLE
Update chronos from 3.2.5 to 3.2.6

### DIFF
--- a/Casks/chronos.rb
+++ b/Casks/chronos.rb
@@ -1,6 +1,6 @@
 cask 'chronos' do
-  version '3.2.5'
-  sha256 '5dd38500185043d82c0b5d579de0595aeab9de976648e3ac441f7dc8aa498365'
+  version '3.2.6'
+  sha256 'd9252b42d1a18211dc5d639593a51bee8593ee14309b86c991cc1c36bcf580cd'
 
   url "https://github.com/web-pal/chronos-timetracker/releases/download/v#{version}/Chronos-#{version}-mac.zip"
   appcast 'https://github.com/web-pal/chronos-timetracker/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.