### PR TITLE
Update praat from 6.0.55 to 6.0.56

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.0.55'
-  sha256 '63e3f944a9d42d6d813c33c975d35ad31ac6063623361546d0c0345b1c6c9417'
+  version '6.0.56'
+  sha256 '264c5b1d95726bdc990596604efe92e8b876bb45115194e93262d31111fb1295'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.