### PR TITLE
Update ppduck from 3.2.5 to 3.7.1

### DIFF
--- a/Casks/ppduck.rb
+++ b/Casks/ppduck.rb
@@ -1,6 +1,6 @@
 cask 'ppduck' do
-  version '3.2.5'
-  sha256 '32a8d91b368f98b43c0e4d383fcefc50d3f670935611a4c9fff7fe76b8247c02'
+  version '3.7.1'
+  sha256 '6fef89f5d7d83fc0d787cd414a149bca91ef7b99f1473fd18cd69e2ac76c2b4a'
 
   url "http://download.ppduck.com/PPDuck#{version.major}_#{version}.dmg"
   name 'PPDuck'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.