### PR TITLE
Update ccleaner from 1.16.570 to 1.16.573

### DIFF
--- a/Casks/ccleaner.rb
+++ b/Casks/ccleaner.rb
@@ -1,6 +1,6 @@
 cask 'ccleaner' do
-  version '1.16.570'
-  sha256 'dd866e7d276bdf99d255be3ca01ec1a41a8cbbea06fadf3e13b85f9ca1ddc99e'
+  version '1.16.573'
+  sha256 '90b1ba7e85261bfc9f78f8d60bbf6307af5e365047f2c2e8d3e9c8005ef98044'
 
   url "https://download.ccleaner.com/mac/CCMacSetup#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.ccleaner.com/ccleaner/download?mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.