### PR TITLE
Update jamovi from 1.0.1.0 to 1.0.2.0

### DIFF
--- a/Casks/jamovi.rb
+++ b/Casks/jamovi.rb
@@ -1,6 +1,6 @@
 cask 'jamovi' do
-  version '1.0.1.0'
-  sha256 '0e32b79504e43843ac189167a79b320c616bc25456bbb1e745d3f418856f6459'
+  version '1.0.2.0'
+  sha256 '00ea85c183ac5198e22cd372d9d5dabab9bb924498def9dd81e5d79595f616a6'
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos.dmg"
   appcast 'https://www.jamovi.org/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.