### PR TITLE
Update duet from 2.0.7.2 to 2.0.7.4

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,6 +1,6 @@
 cask 'duet' do
-  version '2.0.7.2'
-  sha256 '518e32bdfe69fee656c1a3fabf14a03f47ce7409ae2875468e9f6e45c28a8fb0'
+  version '2.0.7.4'
+  sha256 'ca18990ed9fc84f3b9e83fd8aad60c652974156e286686e2cc2b9edc1b33b964'
 
   # duet.nyc3.cdn.digitaloceanspaces.com/Mac was verified as official when first introduced to the cask
   url "https://duet.nyc3.cdn.digitaloceanspaces.com/Mac/#{version.major_minor.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.