### PR TITLE
Update electron from 5.0.4 to 5.0.5

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '5.0.4'
-  sha256 '2d6dc206cc2c241377071272402bfe6b28323ec4dfe482b260a6259d57d2a9c7'
+  version '5.0.5'
+  sha256 'd14b45e16618251515a2fcb2301abab1cc105aa42e6a24cd7f6c4f0370b166fa'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.