### PR TITLE
Update frhelper from 3.9.0 to 3.9.1

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,6 +1,6 @@
 cask 'frhelper' do
-  version '3.9.0'
-  sha256 'd7f86e4876b82fd4dac2fda677e5b7e7fdcadd8c1908b242e95c5c907bba7e5e'
+  version '3.9.1'
+  sha256 'cb6825c62657f4c8d229294d1239fedc804850d4a5832bd126c8745489b79591'
 
   # static.frdic.com was verified as official when first introduced to the cask
   url 'https://static.frdic.com/pkg/fhmac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.