### PR TITLE
Update geogebra from 6.0.541.0 to 6.0.544.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.541.0'
-  sha256 'fc2b1b8ed46ed67ca130d2fe8a7150c85fbeb0def4fc59cb9f82195315f44789'
+  version '6.0.544.0'
+  sha256 '55b7b327c3ffcc7811f751e275b98dfdab1f09a5099c4297d1abbac57784bfb3'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.