### PR TITLE
Add eid-ee cask

### DIFF
--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '17.6.0.1724'
-  sha256 'e4d5df99d0ace588024ebe98e694d1f3d30ef13fa8ac9918dc998243841cf984'
+  version '17.10.0.1750'
+  sha256 '52d1c2cc7b2e5509267d28cd9d99b6c8a9d2ec952afb303703c0099f21e92cb5'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'
@@ -12,6 +12,7 @@ cask 'eid-ee' do
   uninstall script: {
                       executable: 'uninstall.sh',
                       input:      ['y'],
+                      sudo:       true,
                     }
 
   caveats <<~EOS

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -14,7 +14,7 @@ cask 'eid-ee' do
                       input:      ['y'],
                     }
 
-  caveats <<-EOS.undent
+  caveats <<~EOS
     DigiDoc3 Client and ID-card Utility are available in the App Store:
       http://appstore.com/mac/ria
   EOS

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '18.9.0.1792'
-  sha256 'fa2bb3c7a426d749fea8a863c1bdd95aa8219c912e4e121d19014148dff1b424'
+  version '18.12.0.1815'
+  sha256 '3247750cf358833fa56db51b8f161a5d442a2b3d23c503b62c3de04238c0ac3e'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -6,7 +6,6 @@ cask 'eid-ee' do
   name 'Electronic identity card software for Estonia'
   name 'eID Estonia'
   homepage 'https://installer.id.ee/?lang=eng'
-  license :gpl
 
   pkg 'Open-EID.pkg'
 

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,0 +1,22 @@
+cask 'eid-ee' do
+  version '3.12.4.1666'
+  sha256 'a5a7b2824da4efb9479e4b70a952981d41c50a75b00839d0216133b04e32b5b5'
+
+  url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
+  name 'Electronic identity card software for Estonia'
+  name 'eID Estonia'
+  homepage 'https://installer.id.ee/?lang=eng'
+  license :gpl
+
+  pkg 'Open-EID.pkg'
+
+  uninstall script: {
+                      executable: 'uninstall.sh',
+                      input:      %w[y],
+                    }
+
+  caveats <<-EOS.undent
+    DigiDoc3 Client and ID-card Utility are available in the App Store:
+      http://appstore.com/mac/ria
+  EOS
+end

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '17.01.1686'
-  sha256 '1cae314556d643663ea13d79abd67ff84aade76d5b50b331faf42cfa6b785b02'
+  version '17.6.0.1724'
+  sha256 'e4d5df99d0ace588024ebe98e694d1f3d30ef13fa8ac9918dc998243841cf984'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '17.12.0.1770'
-  sha256 '74aed82ed10ea0f3b851c2e6b3b48b106445f017c2e708db8398cf77ae002e55'
+  version '18.2.0.1778'
+  sha256 '3aec337cbfea4709139c43bda2162ab92bcef8a569a21b421175f670efb400b0'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '3.12.4.1666'
-  sha256 'a5a7b2824da4efb9479e4b70a952981d41c50a75b00839d0216133b04e32b5b5'
+  version '3.12.5.1673'
+  sha256 'f68f76ad009b661c3f1ad76856ddc39e430a72963a2d3dec3093781067caed66'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '17.10.0.1750'
-  sha256 '52d1c2cc7b2e5509267d28cd9d99b6c8a9d2ec952afb303703c0099f21e92cb5'
+  version '17.11.0.1762'
+  sha256 '0edaff51d72b864602f3d18dd4363157fccfe7e4651d42e67879ad649abe1af8'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -17,7 +17,7 @@ cask 'eid-ee' do
             quit:   'ee.ria.TokenSigningApp'
 
   caveats <<~EOS
-    DigiDoc3 Client and ID-card Utility are available in the App Store:
+    DigiDoc4 Client and ID-card Utility are available in the App Store:
       https://appstore.com/mac/ria
   EOS
 end

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '18.6.0.1791'
-  sha256 'd1f938969a02f94eaae3a1f063d0e91199b56b2e33fa74e2ab8bce59c191a179'
+  version '18.9.0.1792'
+  sha256 'fa2bb3c7a426d749fea8a863c1bdd95aa8219c912e4e121d19014148dff1b424'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'
@@ -13,7 +13,8 @@ cask 'eid-ee' do
                       executable: 'uninstall.sh',
                       input:      ['y'],
                       sudo:       true,
-                    }
+                    },
+            quit:   'ee.ria.TokenSigningApp'
 
   caveats <<~EOS
     DigiDoc3 Client and ID-card Utility are available in the App Store:

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -11,7 +11,7 @@ cask 'eid-ee' do
 
   uninstall script: {
                       executable: 'uninstall.sh',
-                      input:      %w[y],
+                      input:      ['y'],
                     }
 
   caveats <<-EOS.undent

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '3.12.5.1673'
-  sha256 'f68f76ad009b661c3f1ad76856ddc39e430a72963a2d3dec3093781067caed66'
+  version '17.01.1686'
+  sha256 '1cae314556d643663ea13d79abd67ff84aade76d5b50b331faf42cfa6b785b02'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '18.2.0.1778'
-  sha256 '3aec337cbfea4709139c43bda2162ab92bcef8a569a21b421175f670efb400b0'
+  version '18.6.0.1791'
+  sha256 'd1f938969a02f94eaae3a1f063d0e91199b56b2e33fa74e2ab8bce59c191a179'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'

--- a/Casks/eid-ee.rb
+++ b/Casks/eid-ee.rb
@@ -1,6 +1,6 @@
 cask 'eid-ee' do
-  version '17.11.0.1762'
-  sha256 '0edaff51d72b864602f3d18dd4363157fccfe7e4651d42e67879ad649abe1af8'
+  version '17.12.0.1770'
+  sha256 '74aed82ed10ea0f3b851c2e6b3b48b106445f017c2e708db8398cf77ae002e55'
 
   url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
   name 'Electronic identity card software for Estonia'
@@ -17,6 +17,6 @@ cask 'eid-ee' do
 
   caveats <<~EOS
     DigiDoc3 Client and ID-card Utility are available in the App Store:
-      http://appstore.com/mac/ria
+      https://appstore.com/mac/ria
   EOS
 end


### PR DESCRIPTION
This imports eid-ee (Electronic identity card software for Estonia) cask from homebrew-cask-eid (with history).

Could not comment because all commenting is locked:
- https://github.com/Homebrew/homebrew-cask/issues/59021
- https://github.com/Homebrew/homebrew-cask-eid/pull/72