### PR TITLE
Update kite from 0.20190619.0 to 0.20190620.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190619.0'
-  sha256 '5901bc5ae62015a2f9da65db0da24ca83fd3e26ba0712e2adf0a275429f50f2c'
+  version '0.20190620.0'
+  sha256 '2d95203616dd6ef5b1060088e7d3c6c5db92b1b0fda1a067de4dfcea10201c13'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.