### PR TITLE
Update electron-cash from 4.0.6 to 4.0.7

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.6'
-  sha256 '4af9c56bc833cf7069eeee1a3fb8da7397826f2615bbc0b74ca10703820c9310'
+  version '4.0.7'
+  sha256 'cdc824dc986c6c9e9d468efb02fd2ae40145e47edcabe9b53f7939ba445116be'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/Electron-Cash/Electron-Cash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.