### PR TITLE
Update fsnotes from 3.3.3 to 3.3.4

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.3.3'
-  sha256 'eaeabf8d136c05faeaedb6e658793ab1608b7f1e1a356ab60ef5cab06e6ebadc'
+  version '3.3.4'
+  sha256 '2f4dd5d5ee7ee5a97e5ca98eef989f5cd618269b47010f96f2194eca950a9fc3'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.