### PR TITLE
Update sameboy from 0.11.2 to 0.12

### DIFF
--- a/Casks/sameboy.rb
+++ b/Casks/sameboy.rb
@@ -1,6 +1,6 @@
 cask 'sameboy' do
-  version '0.11.2'
-  sha256 '70fa66740a3c04282fed32e54631252840d9023a0183e05f34c64fdfca91cd0a'
+  version '0.12'
+  sha256 '056b63675bb8c9de5e9f91f151af730ff16f338fb7c6fbd8c3d4f285f29b4dc1'
 
   # github.com/LIJI32/SameBoy was verified as official when first introduced to the cask
   url "https://github.com/LIJI32/SameBoy/releases/download/v#{version}/sameboy_cocoa_v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.