### PR TITLE
Update goodsync from 10.9.34.4 to 10.9.35.5

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask 'goodsync' do
-  version '10.9.34.4'
-  sha256 'ca1487a6767c63a810da3f317298bd32dcf63a2a4f45f14ae7c7fb260a80d173'
+  version '10.9.35.5'
+  sha256 'c073d3cbd5b46c9b4222c8495c06f88815521bde25241a0f1148d80ef9843dd8'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast 'https://www.goodsync.com/news-mac'

--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -3,7 +3,8 @@ cask 'goodsync' do
   sha256 'c073d3cbd5b46c9b4222c8495c06f88815521bde25241a0f1148d80ef9843dd8'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
-  appcast 'https://www.goodsync.com/news-mac'
+  appcast 'https://www.goodsync.com/news-mac',
+          configuration: version.major_minor_patch
   name 'GoodSync'
   homepage 'https://www.goodsync.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.