### PR TITLE
Update touchdesigner from 099.2019.15840 to 099.2019.16600

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2019.15840'
-  sha256 '8e29d065c21915f72261e2ad678c31df673ba23f7493f3ac638a7330a3821658'
+  version '099.2019.16600'
+  sha256 'd10e67535300864d98ed02db42abff132001694b03d39ef05e0c87cd4aba6ab9'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.