### PR TITLE
Update odrive from 6518 to 6523

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,6 +1,6 @@
 cask 'odrive' do
-  version '6518'
-  sha256 '26c95ec3212a78956a3a5646d9c2e525fcb3f19be0d0902e710c7df1d0b25dc0'
+  version '6523'
+  sha256 'e5a77d37f3672607cdf2a0f9ef7efd83f06f3c8d9592f8b97847a809830ea08f'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.