### PR TITLE
Update nosqlbooster-for-mongodb from 5.1.8 to 5.1.9

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.1.8'
-  sha256 'd3a6218771a5e0d46cf7332bbf1f9a6539d40f7dd27198509637c4b9d55228a0'
+  version '5.1.9'
+  sha256 '02dc75060a5cf1469955f915d519161160bb7b8df1c7d1aa6347fc2bc725c2d3'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   appcast 'https://nosqlbooster.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.