### PR TITLE
Update netron from 3.1.5 to 3.2.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.1.5'
-  sha256 '7ca6c9d7bdbd525edb47c3eebb0a9f715f3c7ab91223548a1d144f55a81fd2e3'
+  version '3.2.0'
+  sha256 'c76af31d919c4665b02659bc0b451c7b7c2c4509370943022d9a03d114e9be44'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.