### PR TITLE
Update clockify from 2.2.6.73 to 2.2.7.77

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,8 +1,9 @@
 cask 'clockify' do
-  version '2.2.6.73'
-  sha256 'd83bcfb29c79418eb76150d7c01a54f0321a4bc25269fbc92d88ac32a3c82531'
+  version '2.2.7.77'
+  sha256 '9ee5279aedf19b9026d51ab0e3e27741ecb518caff932ef21ed5eaafc246acb0'
 
-  url "https://clockify.me/downloads/ClockifyDesktop_#{version.no_dots}.zip"
+  # clockify-resources.s3.eu-central-1.amazonaws.com was verified as official when first introduced to the cask
+  url "https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop_#{version.no_dots}.zip"
   name 'Clockify'
   homepage 'https://clockify.me/mac-time-tracking'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

