### PR TITLE
Update springtoolsuite from 4.2.2.RELEASE,4.11.0 to 4.3.0.RELEASE,4.12.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask 'springtoolsuite' do
-  version '4.2.2.RELEASE,4.11.0'
-  sha256 'f34187f26150dfd7c4b75116593800c3ded87112926cd310ce7e020443d23b86'
+  version '4.3.0.RELEASE,4.12.0'
+  sha256 '644a8281b4e91449bebb9673e597c0fce19bc4cc4b92d9d9a32d50925b089004'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.