### PR TITLE
Link dotnet binary in dotnet cask

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -15,6 +15,7 @@ cask 'dotnet' do
   depends_on macos: '>= :sierra'
 
   pkg "dotnet-runtime-#{version}-osx-x64.pkg"
+  binary '/usr/local/share/dotnet/dotnet'
 
   uninstall pkgutil: 'com.microsoft.dotnet.*',
             delete:  '/etc/paths.d/dotnet'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This PR improves the installation of the `dotnet` cask so that the `dotnet` command works after the install completes.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
