### PR TITLE
Update qownnotes from 19.6.4,b4314-091632 to 19.6.5,b4340-081321

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.6.4,b4314-091632'
-  sha256 '3460634eb2bb1af6ba621a2e9ea5d09352e7329f90bb73535923da53aced28bb'
+  version '19.6.5,b4340-081321'
+  sha256 'fa64ee57a24ecb8aca66f2a80acc8f71e29dc5231578d20908f1235e4c90de16'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.