### PR TITLE
Update dogecoin from 1.10.0 to 1.14.0

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -1,9 +1,9 @@
 cask 'dogecoin' do
-  version '1.10.0'
-  sha256 'be854af97efecf30ee18ed846a3bf3a780a0eb0e459a49377d7a8261c212b322'
+  version '1.14.0'
+  sha256 '7804e9aad19b23df74820c9cc718208332c35f2467449802b99c71e1dc3c0e43'
 
   # github.com/dogecoin/dogecoin was verified as official when first introduced to the cask
-  url "https://github.com/dogecoin/dogecoin/releases/download/v#{version}/dogecoin-#{version}-osx-signed.dmg"
+  url "https://github.com/dogecoin/dogecoin/releases/download/v#{version}/dogecoin-#{version}-osx.dmg"
   appcast 'https://github.com/dogecoin/dogecoin/releases.atom'
   name 'Dogecoin'
   homepage 'https://dogecoin.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.