### PR TITLE
Revert "Update smartsvn from 11.0.1 to 11.0.2"

### DIFF
--- a/Casks/smartsvn.rb
+++ b/Casks/smartsvn.rb
@@ -1,6 +1,6 @@
 cask 'smartsvn' do
-  version '11.0.2'
-  sha256 '150c3f0aa71b4b75be99865e52429c81160a59b779de697de684486bd1646edf'
+  version '11.0.1'
+  sha256 '8327315545c7be2f43599a9bb5ca4b55bd183936535410d7f0b90e937112674b'
 
   url "https://www.smartsvn.com/downloads/smartsvn/smartsvn-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.smartsvn.com/documents/smartsvn/changelog.txt'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#63233

I'm not sure what happend but the official download is 11.0.1 
https://www.smartsvn.com/download/
@ran-dall v 11.0.2 seems to be withdrawed
