### PR TITLE
OSXFUSE: Remove MacFUSE compatibility layer

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -11,12 +11,7 @@ cask 'osxfuse' do
   auto_updates true
   conflicts_with cask: 'osxfuse-dev'
 
-  pkg "Extras/FUSE for macOS #{version}.pkg",
-      choices: [
-                 'choiceIdentifier' => 'com.github.osxfuse.pkg.MacFUSE',
-                 'choiceAttribute'  => 'selected',
-                 'attributeSetting' => 1,
-               ]
+  pkg "Extras/FUSE for macOS #{version}.pkg"
 
   postflight do
     set_ownership ['/usr/local/include', '/usr/local/lib']


### PR DESCRIPTION
This was discussed at #26965 but the change didn't get made.

The compatibility layer was [originally added](https://github.com/Homebrew/homebrew-cask/pull/25044) to the formula as a workaround for a [Veracrypt issue](https://github.com/Homebrew/homebrew-cask/issues/25040), however, Veracrypt no [longer needs it](#https://github.com/veracrypt/VeraCrypt/issues/11).

There was concern that fossil might need it, however if you look at its [formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/fossil.rb), it is now being installed with `--disable-fusefs`, so I don't think that's a problem anymore.

On the flip side, installing the compatibility layer is actively harmful. It causes build errors in [python-llfuse](https://github.com/python-llfuse/python-llfuse) (`error: FUSE version too old, 2.9.0 or newer required`) (see https://github.com/borgbackup/borg/issues/4639).

The author of osxfuse [said](https://github.com/osxfuse/osxfuse/issues/114):

> I've noticed that some people are linking file systems against the compatibility layer. This is a really bad idea. Other formulas should link against libosxfuse not libfuse. There should really be no need for the compatibility layer in homebrew.

So, this PR removes installation of the compatibility layer.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


