### PR TITLE
Update eclipse-java from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-java' do
-  version '4.11.0,2019-03:R'
-  sha256 'a021a89742cda1933acd7d69c06d85224f40f604264155e86ac264b59c27326b'
+  version '4.12.0,2019-06:R'
+  sha256 '3debfc470ccccfc639e148bcbb8ad7c2ed92b6f735fa1d618d759521bff65e36'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.