### PR TITLE
Update wiznote.rb version from 2.7.2,2019-04-16 to 2.7.5,2019-04-16

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,5 +1,5 @@
 cask 'wiznote' do
-  version '2.7.2,2019-04-16'
+  version '2.7.5,2019-04-16'
   sha256 'c12a79f12287013d9f817674d11c18e054ab82d3c55605db5d39d06267c2f3f9'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"

--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -3,7 +3,8 @@ cask 'wiznote' do
   sha256 'c12a79f12287013d9f817674d11c18e054ab82d3c55605db5d39d06267c2f3f9'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://url.wiz.cn/u/mac'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://url.wiz.cn/u/mac',
+          configuration: version.after_comma
   name 'WizNote'
   homepage 'https://www.wiz.cn/wiznote-mac.html'
 


### PR DESCRIPTION
The correct version number of wiznote is 2.7.5
(https://www.wiz.cn/wiznote-mac.html)