### PR TITLE
Update listen1 from 2.2.0 to 2.3.1

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '2.2.0'
-  sha256 'd711e172b0d5a25b61e91e74fed20c7fb160b05d71bb3ec2fc79312973e8cafe'
+  version '2.3.1'
+  sha256 '25be33d799cecd6068ee0126cd857388097400fe5bdbb6d1687dedf43486b1c7'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.