### PR TITLE
Update tower from 3.4.1-177,987b69c3 to 3.4.2-181,5d8cea96

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,6 +1,6 @@
 cask 'tower' do
-  version '3.4.1-177,987b69c3'
-  sha256 'd423b45f167461d79fe993f46fc858574f7b4b155894ed95e854b92a24242a1b'
+  version '3.4.2-181,5d8cea96'
+  sha256 '9d8772c76fa5ee6b3b12e063fda4d19e53228a552c3aee70fbdb07580131d19a'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.