### PR TITLE
Update rambox from 0.6.8 to 0.6.9

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,6 +1,6 @@
 cask 'rambox' do
-  version '0.6.8'
-  sha256 '8b5072a4027d84426a9a002a9c3aeba64b5f46bb1655c00de082275f9c62e6e8'
+  version '0.6.9'
+  sha256 '6d943e6a44d50923c2d932a3bc7fd5a01c2b6aadb60cc035b3760e8bc11dfa8b'
 
   # github.com/ramboxapp/community-edition was verified as official when first introduced to the cask
   url "https://github.com/ramboxapp/community-edition/releases/download/#{version}/Rambox-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.