### PR TITLE
Update dissenter-browser from 0.65.120 to 0.65.121

### DIFF
--- a/Casks/dissenter-browser.rb
+++ b/Casks/dissenter-browser.rb
@@ -1,6 +1,6 @@
 cask 'dissenter-browser' do
-  version '0.65.120'
-  sha256 '7ca67db7eaaa733d960b29f2c233fecdc6128943fb67e9070baed6489aa90e60'
+  version '0.65.121'
+  sha256 'b396651768be214015c190a197f40b928ec012d7302f95fcde3a598c6d5bd6d0'
 
   url "https://dissenter.com/dist/browser/#{version}/dissenter-browser-v#{version}.dmg"
   appcast 'https://dissenter.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.