### PR TITLE
Update securityspy from 4.2.10 to 4.2.11

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,6 +1,6 @@
 cask 'securityspy' do
-  version '4.2.10'
-  sha256 '1b8805efd0f84a37d62891797d1d36b92c1f35429280f24918c502bfe275fd9f'
+  version '4.2.11'
+  sha256 '50cb53ff373593ac141b406f0c5defc13c5b7dfc2dc70aed2e8be9bdf7e5f7bf'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.