### PR TITLE
Update weka from 3.8.3 to 3.9.3

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,12 +1,12 @@
 cask 'weka' do
-  version '3.8.3'
-  sha256 '3689a2ef1fbc5de143ca5b751c8b8183351ed4452955bb222a3f6fc5ea9d42c2'
+  version '3.9.3'
+  sha256 '5a2313c2455bdc09439724e4c450bf974bb238355ebda582a043ba310537cb66'
 
-  # sourceforge.net/weka was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-oracle-jvm.dmg"
+  # sourceforge.net/projects/weka was verified as official when first introduced to the cask
+  url 'https://sourceforge.net/projects/weka/files/latest/download'
   appcast 'https://sourceforge.net/projects/weka/rss'
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'
 
-  app "weka-#{version.dots_to_hyphens}-oracle-jvm.app"
+  app "weka-#{version.dots_to_hyphens}-corretto-jvm.app"
 end

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -2,8 +2,8 @@ cask 'weka' do
   version '3.9.3'
   sha256 '5a2313c2455bdc09439724e4c450bf974bb238355ebda582a043ba310537cb66'
 
-  # sourceforge.net/projects/weka was verified as official when first introduced to the cask
-  url 'https://sourceforge.net/projects/weka/files/latest/download'
+  # sourceforge.net/weka was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
   appcast 'https://sourceforge.net/projects/weka/rss'
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.