### PR TITLE
Update roblox from 1.2.0.307917,3e5f358137714073 to 1.2.0.311600,181cd20922f04e75

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,9 +1,11 @@
 cask 'roblox' do
-  version '1.2.0.307917,3e5f358137714073'
-  sha256 'b89e6cef96d4a891729366d8774d4c386c7700a4da5ba969c3d4ea1b087fedf3'
+  version '1.2.0.311600,181cd20922f04e75'
+  sha256 '36901a7b8aba4e65da015256a29c5093354b4272b3f3d0fb6df3f55f3b3d6579'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"
+  appcast 'https://clientsettingscdn.roblox.com/v1/client-version/MacPlayer',
+          configuration: version.after_comma
   name 'Roblox'
   homepage 'https://www.roblox.com/download'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.