### PR TITLE
Update lingon-x from 7.2.2 to 7.2.3

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.4'
     sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
-    version '7.2.2'
-    sha256 'bbc6939fd4cfa3dcf1da534b4ea4daef0c5241d644374d6cdcd59c91e3040ec9'
+    version '7.2.3'
+    sha256 '88685a4fdd252019ed62d3c99f02f69a35c2f75fc13f19985654f0abaec9020b'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.