### PR TITLE
tla-plus-toolbox.rb: depends on java 8

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -11,6 +11,6 @@ cask 'tla-plus-toolbox' do
   app 'TLA+ Toolbox.app'
 
   caveats do
-    depends_on_java
+    depends_on_java '8'
   end
 end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/issues/65251.