### PR TITLE
Update hstracker from 1.5.9 to 1.6.0

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.5.9'
-  sha256 'dad2e1e115bdeb598733f5e66eadf24e41d59115e6f4db348ea2a68fa1bbc0ef'
+  version '1.6.0'
+  sha256 'afd0ccfa870f6c0c3fce79731b7aa3fc15b3451863162f9910f056f9b8a2381a'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.