### PR TITLE
Update unity-download-assistant from 2019.1.7f1,f3c4928e5742 to 2019.1.8f1,7938dd008a75

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.1.7f1,f3c4928e5742'
-  sha256 '56857cecef94ba43c758a4309f788081285d2e81f0d2b6a7f4349e82299931f9'
+  version '2019.1.8f1,7938dd008a75'
+  sha256 'a8a211a3867632d7eb3714ea768f4edb55ee21d74a240a88cb39f3b10b94a8d4'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.