### PR TITLE
Update unity-ios-support-for-editor from 2019.1.7f1,f3c4928e5742 to 2019.1.8f1,7938dd008a75

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.1.7f1,f3c4928e5742'
-  sha256 'cf9d59477666e105d41ed9e1d1ccd11a7b8fecf9395f7735193b80e1b40487ff'
+  version '2019.1.8f1,7938dd008a75'
+  sha256 'c4fdb70f3fc8fb461e0e1c34704559abbf0687ff6d94c6996b90048f364d3a6d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.