### PR TITLE
Update unity-windows-support-for-editor from 2019.1.7f1,f3c4928e5742 to 2019.1.8f1,7938dd008a75

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.1.7f1,f3c4928e5742'
-  sha256 'f9eec9f3f03a574f706c9dbe5e75e3382db7d9d1a9dca5d04b2111c066287a32'
+  version '2019.1.8f1,7938dd008a75'
+  sha256 '87a07caf90749eda07cd586c3f3b2dda88a860d9cac30fbcc5f180187a87feab'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.