### PR TITLE
Update fman from 1.6.2 to 1.6.3

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.6.2'
-  sha256 'ed868cab1f416c2e2d71a9c0258b9063e234c57e86d487b00b45cefbc2f0c03b'
+  version '1.6.3'
+  sha256 'bffb9ee85b694c9451fe0e48f675fc795579f808ffede8f19881821327d981f6'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.