### PR TITLE
Update vyprvpn from 2.20.0.6706 to 3.0.0.7281

### DIFF
--- a/Casks/vyprvpn.rb
+++ b/Casks/vyprvpn.rb
@@ -1,6 +1,6 @@
 cask 'vyprvpn' do
-  version '2.20.0.6706'
-  sha256 'a7fcf9ac1df173c329a023a81cdf60132614f77e82639caf740ee1dee6196ef3'
+  version '3.0.0.7281'
+  sha256 '1367d62b6d6727369fccb2e6a9d1e97be76f7d0b2c452484ecf0c29ed7392d23'
 
   url "https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/#{version}/VyprVPN_v#{version}.dmg"
   appcast 'https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac-feed.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.