### PR TITLE
Update clover-configurator from 5.4.4.0 to 5.4.5.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.4.4.0'
-  sha256 '9e7a0ffd1cac3f205f1a871cbaa8ddc5e8350641b6a63c893fd3fae47bb576f4'
+  version '5.4.5.0'
+  sha256 'd882be677980e38dcec3b96ebbad5411b3fbf9e27bd70da7d83a34a7edfa9693'
 
   url 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/builds-data-ccg/CCG.zip'
   appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.