### PR TITLE
Update xit from 1.0b12 to 1.0b13

### DIFF
--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -1,6 +1,6 @@
 cask 'xit' do
-  version '1.0b12'
-  sha256 'ceefc58abaf35757b95a3e89e918afdd313bd727ea1f34e473b3d0ceb7398188'
+  version '1.0b13'
+  sha256 '0bab547a6540128b507e8e44794cc8f556407dedd80fb2bab2a439ba76a78d2e'
 
   url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.#{version}.zip"
   appcast 'https://github.com/Uncommon/Xit/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.