### PR TITLE
Update cellprofiler from latest to 3.1.8

### DIFF
--- a/Casks/cellprofiler.rb
+++ b/Casks/cellprofiler.rb
@@ -1,9 +1,10 @@
 cask 'cellprofiler' do
-  version :latest
-  sha256 :no_check
+  version '3.1.8'
+  sha256 '094ed77bdb0cfd40d7b060d8d88c1fc44aab7caf77a65d6f7f4cb80c074f9af8'
 
-  # cellprofiler-org.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://cellprofiler-org.s3.amazonaws.com/CellProfiler.dmg'
+  # dpvpof9ygr7ad.cloudfront.net was verified as official when first introduced to the cask
+  url "https://dpvpof9ygr7ad.cloudfront.net/CellProfiler-#{version}.app.zip"
+  appcast 'https://github.com/CellProfiler/CellProfiler/releases.atom'
   name 'CellProfiler'
   homepage 'https://cellprofiler.org/'
 

--- a/Casks/cellprofiler.rb
+++ b/Casks/cellprofiler.rb
@@ -8,5 +8,5 @@ cask 'cellprofiler' do
   name 'CellProfiler'
   homepage 'https://cellprofiler.org/'
 
-  app 'CellProfiler.app'
+  app "CellProfiler-#{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.