### PR TITLE
Update pinegrow from 5.5 to 5.6

### DIFF
--- a/Casks/pinegrow.rb
+++ b/Casks/pinegrow.rb
@@ -1,6 +1,6 @@
 cask 'pinegrow' do
-  version '5.5'
-  sha256 '437b42e4c1f6f8eddf219b36b73166abd52ec5d29f1a199682e41565e4b7076c'
+  version '5.6'
+  sha256 '21b68d9cff80ea439c81b880ba956942a4a8df83048510c087b1b51e79e0500b'
 
   url "http://download.pinegrow.com/PinegrowMac.#{version}.dmg"
   appcast 'https://pinegrow.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.