### PR TITLE
Update iringg from 1.0.38,1547826574 to 1.0.40,1561477920

### DIFF
--- a/Casks/iringg.rb
+++ b/Casks/iringg.rb
@@ -1,6 +1,6 @@
 cask 'iringg' do
-  version '1.0.38,1547826574'
-  sha256 'b0f83393fb0067e996f5b2d791fbdffb230fe8a2fb340772a671e54746a6ed4d'
+  version '1.0.40,1561477920'
+  sha256 '3ea98dd633412f193e63d89139a5e78775c261944c686069f60cb473574002cc'
 
   # dl.devmate.com/com.softorino.iringg was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.iringg/#{version.before_comma}/#{version.after_comma}/iRinggforMac-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.