### PR TITLE
Update 1password from 7.3 to 7.3.1

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,6 +1,6 @@
 cask '1password' do
-  version '7.3'
-  sha256 'fd23cb03afc13cd34690d1a4347d8862517da60ccd234ce873bffd557e974c35'
+  version '7.3.1'
+  sha256 '8f70fa09b185f32154aeabe8a612b75f689568a37c360c38adeaa90351113730'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.