### PR TITLE
Update Caprine from 2.32.1 to 2.33.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,6 +1,6 @@
 cask 'caprine' do
-  version '2.32.1'
-  sha256 '14ec550ea7bd024c43e5c6b566098d7546f3398c7e672faf3069ad49124a205e'
+  version '2.33.0'
+  sha256 '2ae59e707c13f30cbe9ed203a1847ce10b873f8e906df4f3b9e68aa4a33f6e23'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/Caprine-#{version}.dmg"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
  Source: https://github.com/sindresorhus/caprine/releases