### PR TITLE
Update journey from 2.12.4 to 2.12.6

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,6 +1,6 @@
 cask 'journey' do
-  version '2.12.4'
-  sha256 '34e7368dfd6cf731e939dd889055f89c4f699890d08727106aefd2fa6cfeb1bf'
+  version '2.12.6'
+  sha256 '6f2692c20e94ca0366642f3476dc108b3448d62b09a1572fd57b9a629c537eb9'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
   url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.