### PR TITLE
Update workflowy from 1.3.1 to 1.3.2

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.1'
-  sha256 '87ce8aa99c54df7ddbb08bc5936ac0a7789b12199be3b966bee954977b185b12'
+  version '1.3.2'
+  sha256 '6a88353160b4d365dc43275e7e5a31a18750495cc254fee7f14fcd155c86d45c'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.