### PR TITLE
Update bettertouchtool from 3.086 to 3.088

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.086'
-    sha256 'c0813657084dfabc960615fe4653ad07bd90dcf74e20b26558321a7467f22728'
+    version '3.088'
+    sha256 '9a889718f9b43fe98a5b3c0a1fd0f4fe2a41a8287b2f519d97c364ada66f8071'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.