### PR TITLE
Update spectacle-editor from 0.1.5 to 0.1.6

### DIFF
--- a/Casks/spectacle-editor.rb
+++ b/Casks/spectacle-editor.rb
@@ -1,6 +1,6 @@
 cask 'spectacle-editor' do
-  version '0.1.5'
-  sha256 'c09b6b19f1dd47e83d55df0096a47dc45c4a0838d83836e62b643738412ad780'
+  version '0.1.6'
+  sha256 '5dc93387bc6026dd44dbf2f88c9bf7730d931663d5b72f382c0a51bc6c57517b'
 
   # github.com/FormidableLabs/spectacle-editor was verified as official when first introduced to the cask
   url "https://github.com/FormidableLabs/spectacle-editor/releases/download/v#{version}/Spectacle.Editor-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.