### PR TITLE
Update thedesk from 18.6.4 to 18.6.5

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.6.4'
-  sha256 'c08945adaa2b0ac48aab07568f9c15e4c10d5dfd4f390ae085e77d5b70d86609'
+  version '18.6.5'
+  sha256 '2251fca51d060a4bf3cd0d9861125e7caca1f0fc63f57826241e472eac5a3faf'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.