### PR TITLE
Update touche from 1.1.3 to 1.1.4

### DIFF
--- a/Casks/touche.rb
+++ b/Casks/touche.rb
@@ -1,6 +1,6 @@
 cask 'touche' do
-  version '1.1.3'
-  sha256 '787494f695f33b2f1eb9ccfc522f7bbc5bc8aae72d393e1948b29e0b6b4a3ddd'
+  version '1.1.4'
+  sha256 '275a2885214befd088fe20707f306d3ad1743cf8181334ed4ef976391fff6c7f'
 
   url "https://red-sweater.com/touche/Touch%C3%A9#{version}.zip"
   appcast 'https://red-sweater.com/touche/appcast.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.