### PR TITLE
Update jalbum from 18.2.1 to 18.3.0

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,6 +1,6 @@
 cask 'jalbum' do
-  version '18.2.1'
-  sha256 'fb7ad297a51c8418485f13afa4e42b9f6e950828ef86148644bc17a6913a9400'
+  version '18.3.0'
+  sha256 '1b872799875ec0e1abc619733c2d056bebedef0dc14c395c6aa4d9726c269acc'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.