### PR TITLE
Update deezer from 4.9.2 to 4.10.2

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.9.2'
-  sha256 'ecb2c2d095148b9742fe1207aaf2000a7b25549a78814268d32e39d56e7e1c35'
+  version '4.10.2'
+  sha256 '66acb3f7e00d7b818e4180b6ad0ff31eccdae6e229090949a3da358d6da4a745'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.