### PR TITLE
Update orange from 3.21.0 to 3.22.0

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,6 +1,6 @@
 cask 'orange' do
-  version '3.21.0'
-  sha256 'b2ce562780b17ada5fc420adeeedf03003dd26900a397ef003a349b722ccf346'
+  version '3.22.0'
+  sha256 '9bce16067e851164f73444bec367828b81594952826d67d252c4772add95c7a7'
 
   url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
   appcast 'https://orange.biolab.si/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.