### PR TITLE
Update flock from 2.2.257 to 2.2.268

### DIFF
--- a/Casks/flock.rb
+++ b/Casks/flock.rb
@@ -1,6 +1,6 @@
 cask 'flock' do
-  version '2.2.257'
-  sha256 '2e52bd5c5a2d136e9ceaed6e3faddda9aa870c1d73d3395570b720e56edbb94e'
+  version '2.2.268'
+  sha256 'b2514e3915c83be8087f3b801f51496f424eb2462cbb5db95e6b519ddaa79ec4'
 
   # flock.co was verified as official when first introduced to the cask
   url "https://updates.flock.co/fl_mac_electron/Flock-macOS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.