### PR TITLE
Update private-internet-access from 1.2.1-02688 to 1.3-02842

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,6 +1,6 @@
 cask 'private-internet-access' do
-  version '1.2.1-02688'
-  sha256 'a9bac826434551b54199721a3d2a97204acdf4585e7ca6ba46725028af2daa36'
+  version '1.3-02842'
+  sha256 '78731b2daf7c5ab72cffe294ea331c6c7577482548b59a94f3241a2b740b84af'
 
   url "https://installers.privateinternetaccess.com/download/pia-macos-#{version}.zip"
   appcast 'https://www.privateinternetaccess.com/pages/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.