### PR TITLE
Update armortext from 0.21.27 to 0.21.30

### DIFF
--- a/Casks/armortext.rb
+++ b/Casks/armortext.rb
@@ -1,6 +1,6 @@
 cask 'armortext' do
-  version '0.21.27'
-  sha256 '303cd21df3841fca6ec0cd22d67713c78805e1d9104bb9e376f1ec332e72363c'
+  version '0.21.30'
+  sha256 '2a589d1ca54c434d75553f8594f1da9b773d65eca6006e5b3f7fe157b05675c8'
 
   # armortext.co was verified as official when first introduced to the cask
   url "https://downloads.armortext.co/desktop/release/#{version}/ArmorText-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.