### PR TITLE
Update lehreroffice from 2019.9.1 to 2019.10.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.9.1'
-  sha256 'f506ec3a0d878292cd7d7df3b8b2754a385315eeb5b8cac5b2aacca2a8baa567'
+  version '2019.10.0'
+  sha256 'dcedd9b99c34ce529f31b58052e770674a5dd8b9e7ac820e0448ff414a7597af'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.