### PR TITLE
Update birdfont from 3.24.1 to 3.25.0

### DIFF
--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -3,8 +3,8 @@ cask 'birdfont' do
     version '2.19.4'
     sha256 '013d9c42c2252b57079453bd27e4c18dbbc09eda55563ff1516fd079c0499f76'
   else
-    version '3.24.1'
-    sha256 '52723fa22729762464a8fa4b96c69fad3c57fb110a829e94f14e556450df6c75'
+    version '3.25.0'
+    sha256 'e33f427693e8c5d2089f0871b563f2fc04283f6afb8882666f8cbe46c4888933'
   end
 
   url "https://birdfont.org/download/birdfont-#{version}-free.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.