### PR TITLE
Update qcad 3.22.1 with correct SHA256 sum

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -2,7 +2,7 @@ cask 'qcad' do
   version '3.22.1'
 
   if MacOS.version <= :high_sierra
-    sha256 'a05bd044702f3e1f582e4b527a4d520ac433ad6231fd3161f3c85ccf3574db17'
+    sha256 '0003262298641edd4c996cb6312b2340b94c692e998c2c350a5b75f490f74ae2'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
     sha256 '13bf52d28147e95a7e5fbc0e6f1b6c6a28d37ad0470e3ddf61f53928d69feab7'


### PR DESCRIPTION
The SHA256 sum needs to be corrected. I've downloaded the DMG from 
https://www.qcad.org/en/download 
several times from different IP addresses. I have derived 
0x0003262298641edd4c996cb6312b2340b94c692e998c2c350a5b75f490f74ae2  
as the valid SHA256 sum by using OpenSSL v1.0.2s

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
brew cask audit --download qcad
pulls the current qcad.rb which is incorrect and fails. 

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256