### PR TITLE
Update podman from 1.3.1 to 1.4.2

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -1,6 +1,6 @@
 cask 'podman' do
-  version '1.3.1'
-  sha256 '438f7788fe28e88ae800e99896eb42a07775682e4bc69a2f618fc2c36c8a4a21'
+  version '1.4.2'
+  sha256 '73850911bb49f2e0a970ff44f785634e2aa9a7a1f20845ff508bdccbead17444'
 
   url "https://github.com/containers/libpod/releases/download/v#{version}/podman-v#{version}.dmg"
   appcast 'https://github.com/containers/libpod/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.