### PR TITLE
Update catlight from 2.14.5 to 2.26.2

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,8 +1,10 @@
 cask 'catlight' do
-  version '2.14.5'
-  sha256 '912a85e9da25eb65707869cee69c8eb84cbcc5c5169f98ef55df4910300b106e'
+  version '2.26.2'
+  sha256 '2412e4fd47f4509a1b1068f8d1ac697368411ad1ec3b0b86e5d75bd9347aa5bc'
 
-  url "https://www.catlight.io/dl/mac/beta/setup-#{version}.zip"
+  # de2nac35bcll0.cloudfront.net was verified as official when first introduced to the cask
+  url "https://de2nac35bcll0.cloudfront.net/dl/mac/beta/CatLightSetup-#{version}.zip"
+  appcast 'https://catlight.io/downloads'
   name 'catlight'
   homepage 'https://catlight.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.