### PR TITLE
Update cineplay from 1.5.5.1 to 1.5.5.7

### DIFF
--- a/Casks/cineplay.rb
+++ b/Casks/cineplay.rb
@@ -1,6 +1,6 @@
 cask 'cineplay' do
   version '1.5.7.0'
-  sha256 '831cc5d13ead51c4189fb991c68b3dbb4c86e36d46118014cc5694481b4e8948'
+  sha256 'c31ad583b20b6a1589cd739b89dff026618a9f5e9ed3b908f0efb6c1d616e27e'
 
   url "https://www.digitalrebellion.com/download/cineplay?version=#{version.no_dots}"
   appcast 'https://www.digitalrebellion.com/cineplay/download',

--- a/Casks/cineplay.rb
+++ b/Casks/cineplay.rb
@@ -1,8 +1,10 @@
 cask 'cineplay' do
-  version '1.5.5.1'
-  sha256 '34d8ecd90276253fc7ca0e8332f4d6322b294a6f44a6c495ca7292411a02841a'
+  version '1.5.5.7'
+  sha256 '831cc5d13ead51c4189fb991c68b3dbb4c86e36d46118014cc5694481b4e8948'
 
   url "https://www.digitalrebellion.com/download/cineplay?version=#{version.no_dots}"
+  appcast 'https://www.digitalrebellion.com/cineplay/download',
+          configuration: version.no_dots
   name 'CinePlay'
   homepage 'https://www.digitalrebellion.com/cineplay/'
 

--- a/Casks/cineplay.rb
+++ b/Casks/cineplay.rb
@@ -1,5 +1,5 @@
 cask 'cineplay' do
-  version '1.5.5.7'
+  version '1.5.7.0'
   sha256 '831cc5d13ead51c4189fb991c68b3dbb4c86e36d46118014cc5694481b4e8948'
 
   url "https://www.digitalrebellion.com/download/cineplay?version=#{version.no_dots}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.