### PR TITLE
Update clockify from 2.2.7.77 to 2.2.7.79

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,9 +1,11 @@
 cask 'clockify' do
-  version '2.2.7.77'
-  sha256 '9ee5279aedf19b9026d51ab0e3e27741ecb518caff932ef21ed5eaafc246acb0'
+  version '2.2.7.79'
+  sha256 'dc08e87e274cc81a56a464095bed7512d31f0991de94e93ae967273d43482908'
 
   # clockify-resources.s3.eu-central-1.amazonaws.com was verified as official when first introduced to the cask
   url "https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop_#{version.no_dots}.zip"
+  appcast 'https://clockify.me/mac-time-tracking',
+          configuration: version.no_dots
   name 'Clockify'
   homepage 'https://clockify.me/mac-time-tracking'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.