### PR TITLE
Update pdf-expert from 2.4.26,634 to 2.4.27,635

### DIFF
--- a/Casks/pdf-expert.rb
+++ b/Casks/pdf-expert.rb
@@ -1,6 +1,6 @@
 cask 'pdf-expert' do
-  version '2.4.26,634'
-  sha256 '5434c35470fd4f187e3d27865e0f59efb81894faa37dd549f1a5114532ee1ec1'
+  version '2.4.27,635'
+  sha256 'bb2f1fcd753c23d8c24273fb451a0bf589c64b0ed2573d5973957298b52b820a'
 
   # d1ke680phyeohy.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1ke680phyeohy.cloudfront.net/versions/#{version.after_comma}/PDFExpert.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.