### PR TITLE
Update qiyimedia from 5.9.11 to 5.10.10

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,9 +1,9 @@
 cask 'qiyimedia' do
-  version '5.10.10'
+  version '20190628,5.10.10'
   sha256 '38be0152e83714239ca9fd4295fc061b811a66b200907e4f5d6a5f1f0f805762'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
-  appcast 'https://app.iqiyi.com/mac/player/index.html'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   name '爱奇艺视频'
   homepage 'https://app.iqiyi.com/mac/player/index.html'
 

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -3,8 +3,7 @@ cask 'qiyimedia' do
   sha256 '38be0152e83714239ca9fd4295fc061b811a66b200907e4f5d6a5f1f0f805762'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg',
-          configuration: version.before_comma
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   name '爱奇艺视频'
   homepage 'https://app.iqiyi.com/mac/player/index.html'
 

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '5.9.11'
-  sha256 'ae2cc7337ee6132c84c53cca871f743e337ea94fa3ca2a56a7d7ae065468621e'
+  version '5.10.10'
+  sha256 '38be0152e83714239ca9fd4295fc061b811a66b200907e4f5d6a5f1f0f805762'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://app.iqiyi.com/mac/player/index.html'

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -3,7 +3,8 @@ cask 'qiyimedia' do
   sha256 '38be0152e83714239ca9fd4295fc061b811a66b200907e4f5d6a5f1f0f805762'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg',
+          configuration: version.before_comma
   name '爱奇艺视频'
   homepage 'https://app.iqiyi.com/mac/player/index.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.