### PR TITLE
Update datadog-agent from 6.11.0-1 to 6.12.0-1

### DIFF
--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -3,7 +3,7 @@ cask 'datadog-agent' do
   sha256 'ea7b93241fa31ed05b2a73670541d5104e84e387079779c6bb35d9c9dc9ea208'
 
   # s3.amazonaws.com/dd-agent was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/dd-agent/datadogagent.dmg'
+  url "https://s3.amazonaws.com/dd-agent/datadogagent-#{version}.dmg"
   appcast 'https://github.com/DataDog/datadog-agent/releases.atom'
   name 'Datadog Agent'
   homepage 'https://www.datadoghq.com/'

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -1,9 +1,9 @@
 cask 'datadog-agent' do
-  version '6.11.0-1'
-  sha256 'b38c9769eaaafa535fe0f5f07910316454c34a0ce85bdd4e43f79cb08051e2d8'
+  version '6.12.0-1'
+  sha256 'ea7b93241fa31ed05b2a73670541d5104e84e387079779c6bb35d9c9dc9ea208'
 
-  # dd-agent.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://dd-agent.s3.amazonaws.com/datadog-agent-#{version}.dmg"
+  # s3.amazonaws.com/dd-agent was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/dd-agent/datadogagent.dmg'
   appcast 'https://github.com/DataDog/datadog-agent/releases.atom'
   name 'Datadog Agent'
   homepage 'https://www.datadoghq.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.