### PR TITLE
Update lyricsx from 1.4.6,2122 to 1.5.0,2139

### DIFF
--- a/Casks/lyricsx.rb
+++ b/Casks/lyricsx.rb
@@ -1,6 +1,6 @@
 cask 'lyricsx' do
-  version '1.4.6,2122'
-  sha256 '39f1f764c82891e73362dcf17b0a0dd9a82d817c2dd73567b1ab4ccc85990aa2'
+  version '1.5.0,2139'
+  sha256 '620c4a1dbb98e01f690319158eebbdfae3aa5250ab4d766b6cffdbec9e140cf0'
 
   url "https://github.com/ddddxxx/LyricsX/releases/download/v#{version.before_comma}/LyricsX_#{version.before_comma}+#{version.after_comma}.zip"
   appcast 'https://github.com/ddddxxx/LyricsX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.