### PR TITLE
Update suitcase-fusion from 9,20.0.4 to 9,20.0.5

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,6 +1,6 @@
 cask 'suitcase-fusion' do
-  version '9,20.0.4'
-  sha256 '32810dd6f8abac60e431f6dae266c39206f2be7ed8ea9774f60ba6a23b78db1e'
+  version '9,20.0.5'
+  sha256 '7ff1c6d472f72967febfad27658c5ccfcb32e66ca9247efe3de6c8094746f089'
 
   url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
   appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.