### PR TITLE
Update sqlpro-for-sqlite from 1.0.460 to 2019.06.12

### DIFF
--- a/Casks/sqlpro-for-sqlite.rb
+++ b/Casks/sqlpro-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-sqlite' do
-  version '1.0.460'
-  sha256 '911f04b0f24699d55945fa506b14be90c6b2ab61651cef192c880ff197e9910f'
+  version '2019.06.12'
+  sha256 '3c89ccdd366345f10a6c4c3ca56da16e68b56be853b2384963ca5f7bfd3e5a21'
 
   # d3fwkemdw8spx3.cloudfront.net/sqlite was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/sqlite/SQLProSQLite.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.