### PR TITLE
Update bettertouchtool from 3.097 to 3.093

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.097'
-    sha256 '62675927b2f0d77d6951653e379104ea0b94010d4fd82fa52313e9f24087ef5e'
+    version '3.093'
+    sha256 '16a193fe74b632e08bd91bd683b8a63fd8ecf8a168d3020277b98c2107667a39'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.