### PR TITLE
Add RSA SecurID v4.2.1

### DIFF
--- a/Casks/securid.rb
+++ b/Casks/securid.rb
@@ -1,0 +1,12 @@
+cask 'securid' do
+  version '4.2.1'
+  sha256 'e3d796f263cbdbc4a6c870931e469c64e8c8ffb14aa8ae68b4036cee0eeb0c04'
+
+  url "https://community.rsa.com/servlet/JiveServlet/download/62004-9-60039/RSASecurIDMac#{version.no_dots}.dmg.zip"
+  name 'RSA SecurID'
+  homepage 'https://www.rsa.com/en-us/products/rsa-securid-suite/rsa-securid-access/securid-software-tokens.html'
+
+  pkg "RSASecurIDTokenAutoMac#{version.no_dots}x64.pkg"
+
+  uninstall pkgutil: 'com.rsa.pkg.securidsoftwaretoken'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Hello! I noticed that SecurID was removed in https://github.com/Homebrew/homebrew-cask/pull/47066 but the reason was just that the location was gone. So I went and got the information for the new location of the installer and added SecurID back with the new location (and version).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
