### PR TITLE
Update vitalsource-bookshelf from 8.2.2.318 to 8.3.1.343

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,10 +1,10 @@
 cask 'vitalsource-bookshelf' do
-  version '8.2.2.318'
-  sha256 'f1f430cd242c20f6b7e5899ab3a09b63f5631b9e843f5b33bd0c3c3c675394dc'
+  version '8.3.1.343'
+  sha256 '2c9960601c34e439213b96a3e79838fbf3c251475ba6114c6585e6132d8b44c6'
 
-  # rink.hockeyapp.net/api/2/apps/ was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2/app_versions/194?format=zip&avtoken=e335f2d288c8033e895eb9241733cce1281e8c51&download_origin=hockeyapp'
-  appcast 'https://rink.hockeyapp.net/api/2/apps/ed52bc178e094f39a32f4aaa99ad71c2'
+  # downloads.vitalbook.com was verified as official when first introduced to the cask
+  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor_patch}/mac/bookshelf/Bookshelf_#{version}.dmg"
+  appcast 'https://rink.hockeyapp.net/api/2/apps/eed59906dc1a41199db911c5220234fb'
   name 'VitalSource Bookshelf'
   homepage 'https://www.vitalsource.com/bookshelf-features'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.