### PR TITLE
Update magicavoxel from 0.99.3 to 0.99.4

### DIFF
--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,5 +1,5 @@
 cask 'magicavoxel' do
-  version '0.99.3'
+  version '0.99.4'
   sha256 'd7c09a0178d4fd8b6484eae479b2b8f2daf60b8a0b39ba418981846906924e49'
 
   # dropbox.com/s/abh4jkiopcbuzep was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.