### PR TITLE
Update pennywise from 0.6.3 to 0.8.0

### DIFF
--- a/Casks/pennywise.rb
+++ b/Casks/pennywise.rb
@@ -1,6 +1,6 @@
 cask 'pennywise' do
-  version '0.6.3'
-  sha256 'b80fe0af58748fbfe43a7d29dd302ffbc23a7883de89a66fc1ccc1649c3a4daa'
+  version '0.8.0'
+  sha256 '9e6195f1096d399aafd77da74e4461964364fdbeec3b667cd91ecf9704e73b69'
 
   url "https://github.com/kamranahmedse/pennywise/releases/download/v#{version}/Pennywise-#{version}.dmg"
   appcast 'https://github.com/kamranahmedse/pennywise/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.