### PR TITLE
Update pext from 0.23 to 0.24.0

### DIFF
--- a/Casks/pext.rb
+++ b/Casks/pext.rb
@@ -1,6 +1,6 @@
 cask 'pext' do
-  version '0.23'
-  sha256 'c18043a018910df22cd782a190049c9e20f5a06c013110c4e15975c33b70e050'
+  version '0.24.0'
+  sha256 '96ab3802e5dd80a1524bce0ecc28d0d9557e75bacd7856c107ce09aa2c343562'
 
   # github.com/Pext/Pext was verified as official when first introduced to the cask
   url "https://github.com/Pext/Pext/releases/download/v#{version}/Pext-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.