### PR TITLE
Update keep-it from 1.6.13 to 1.6.14

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.6.13'
-  sha256 '4ebc73536b8f1c1cf447a089b85fd1c9af9bbb42155c7fa70ed3d64b84deb4ed'
+  version '1.6.14'
+  sha256 'e58afb48f88ea9d57730b2bb4ea873d176829607eeb1731a6f98fbaa55d0a892'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.