### PR TITLE
Update talon from 101-0.0.8.41 to 102-0.0.8.42

### DIFF
--- a/Casks/talon.rb
+++ b/Casks/talon.rb
@@ -1,6 +1,6 @@
 cask 'talon' do
-  version '101-0.0.8.41'
-  sha256 '222bb22a94ae32521c0fd5df1150ce26ac2edc50c301a5ff493134795a52f347'
+  version '102-0.0.8.42'
+  sha256 '3131a3600285a40696595619d74dbd1f268c60704e4e27898d59659d36532094'
 
   url "https://talonvoice.com/update/nmi5s3faoq6NzROd2dbCRg/Talon-#{version}.dmg"
   appcast 'https://talonvoice.com/update/nmi5s3faoq6NzROd2dbCRg/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.