### PR TITLE
Update ogdesign-eagle from 1.9.1,build14 to 1.9.2

### DIFF
--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -3,7 +3,7 @@ cask 'ogdesign-eagle' do
   sha256 '83bb4c55e24a10ad7441d9eef0d9c12fe58482ff57242f06e7a9b9d490a557fc'
 
   # eagleapp.s3-accelerate.amazonaws.com was verified as official when first introduced to the cask
-  url "https://eagleapp.s3-accelerate.amazonaws.com/releases/Eagle-#{version}.dmg?download"
+  url "https://eagleapp.s3-accelerate.amazonaws.com/releases/Eagle-#{version}.dmg"
   appcast 'https://eagle.cool/changelog'
   name 'Eagle'
   homepage 'https://eagle.cool/macOS'

--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -1,9 +1,9 @@
 cask 'ogdesign-eagle' do
-  version '1.9.1,build14'
-  sha256 'eb9fcc1834fd9cd1042cb50fb7e7a8eb3ebb451ab6794264e56012180d06be21'
+  version '1.9.2'
+  sha256 '83bb4c55e24a10ad7441d9eef0d9c12fe58482ff57242f06e7a9b9d490a557fc'
 
   # eagleapp.s3-accelerate.amazonaws.com was verified as official when first introduced to the cask
-  url "https://eagleapp.s3-accelerate.amazonaws.com/releases/Eagle-#{version.before_comma}-#{version.after_comma}.dmg?download"
+  url "https://eagleapp.s3-accelerate.amazonaws.com/releases/Eagle-#{version}.dmg?download"
   appcast 'https://eagle.cool/changelog'
   name 'Eagle'
   homepage 'https://eagle.cool/macOS'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.