### PR TITLE
Update tastyworks from 0.35.0 to 0.41.0

### DIFF
--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -1,6 +1,6 @@
 cask 'tastyworks' do
-  version '0.35.0'
-  sha256 '2d9aa8eac43b6ab0ad7b3accff28a921662d5c524178deab91e4344424746e19'
+  version '0.41.0'
+  sha256 '953862888ee31ed993d6e8cad8b12a817de30c94b82c0324c8cae58d1b938920'
 
   url "https://download.tastyworks.com/desktop/#{version}/tastyworks-#{version}.dmg"
   appcast 'https://tastyworks.com/technology.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.