### PR TITLE
Update intel-power-gadget from 3.5.5,778485 to 3.5.5,828382

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -1,10 +1,10 @@
 cask 'intel-power-gadget' do
-  version '3.5.5,778485'
-  sha256 'ff2f82e095cdea62393e78e69b0616b1d34a95c4b16960891d91943c7c3b62ec'
+  version '3.5.5,828382'
+  sha256 'efd306800c28abda0d5543fbc5bf78eb142a43a96feb56fcf211e3bbc83a78d3'
 
   url "https://software.intel.com/file/#{version.after_comma}/download"
   name 'Intel Power Gadget'
-  homepage 'https://software.intel.com/en-us/articles/intel-power-gadget-20'
+  homepage 'https://software.intel.com/en-us/articles/intel-power-gadget'
 
   depends_on macos: '>= :high_sierra'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.