### PR TITLE
Add Open eCard App - Open Source implementation of ISO/IEC 24727

### DIFF
--- a/Casks/open-ecard.rb
+++ b/Casks/open-ecard.rb
@@ -1,4 +1,4 @@
-cask 'openecard' do
+cask 'open-ecard' do
   version '1.3.0'
   sha256 'b23d918029403591eb45ac8d52e58df50c1bcb3429b8394173b9063334fc52b1'
 

--- a/Casks/open-ecard.rb
+++ b/Casks/open-ecard.rb
@@ -10,7 +10,7 @@ cask 'open-ecard' do
 
   pkg 'Open eCard App.pkg'
 
-  uninstall delete: "#{appdir}/Open-eCard-App.app"
+  uninstall pkgutil: 'com.openecard.pkg.OpeneCardApp'
 
   zap trash: '~/.openecard'
 end

--- a/Casks/open-ecard.rb
+++ b/Casks/open-ecard.rb
@@ -12,5 +12,5 @@ cask 'open-ecard' do
 
   uninstall delete: "#{appdir}/Open-eCard-App.app"
 
-  zap trash: '~/.openecard/logs/richclient_info.log'
+  zap trash: '~/.openecard'
 end

--- a/Casks/openecard.rb
+++ b/Casks/openecard.rb
@@ -2,12 +2,17 @@ cask 'openecard' do
   version '1.3.0'
   sha256 'b23d918029403591eb45ac8d52e58df50c1bcb3429b8394173b9063334fc52b1'
 
+  # https://www.openecard.org/download/pc/ on project homepage directs to GitHub
   url "https://github.com/ecsec/open-ecard/releases/download/#{version}/Open-eCard-App-#{version}.dmg"
-  appcast "https://github.com/ecsec/open-ecard/releases.atom"
+  appcast 'https://github.com/ecsec/open-ecard/releases.atom'
   name "Open eCard App #{version}"
   homepage 'https://www.openecard.org/'
 
-  pkg "Open eCard App.pkg"
+  pkg 'Open eCard App.pkg'
 
   uninstall delete: "#{appdir}/Open-eCard-App.app/"
+
+  zap trash: [
+               '~/.openecard/logs/richclient_info.log',
+             ]
 end

--- a/Casks/openecard.rb
+++ b/Casks/openecard.rb
@@ -1,0 +1,13 @@
+cask 'openecard' do
+  version '1.3.0'
+  sha256 'b23d918029403591eb45ac8d52e58df50c1bcb3429b8394173b9063334fc52b1'
+
+  url "https://github.com/ecsec/open-ecard/releases/download/#{version}/Open-eCard-App-#{version}.dmg"
+  appcast "https://github.com/ecsec/open-ecard/releases.atom"
+  name "Open eCard App #{version}"
+  homepage 'https://www.openecard.org/'
+
+  pkg "Open eCard App.pkg"
+
+  uninstall delete: "#{appdir}/Open-eCard-App.app/"
+end

--- a/Casks/openecard.rb
+++ b/Casks/openecard.rb
@@ -2,15 +2,15 @@ cask 'openecard' do
   version '1.3.0'
   sha256 'b23d918029403591eb45ac8d52e58df50c1bcb3429b8394173b9063334fc52b1'
 
-  # https://www.openecard.org/download/pc/ on project homepage directs to GitHub
+  # github.com/ecsec/open-ecard was verified as official when first introduced to the cask
   url "https://github.com/ecsec/open-ecard/releases/download/#{version}/Open-eCard-App-#{version}.dmg"
   appcast 'https://github.com/ecsec/open-ecard/releases.atom'
-  name "Open eCard App #{version}"
+  name 'Open eCard'
   homepage 'https://www.openecard.org/'
 
   pkg 'Open eCard App.pkg'
 
-  uninstall delete: "#{appdir}/Open-eCard-App.app/"
+  uninstall delete: "#{appdir}/Open-eCard-App.app"
 
   zap trash: '~/.openecard/logs/richclient_info.log'
 end

--- a/Casks/openecard.rb
+++ b/Casks/openecard.rb
@@ -12,7 +12,5 @@ cask 'openecard' do
 
   uninstall delete: "#{appdir}/Open-eCard-App.app/"
 
-  zap trash: [
-               '~/.openecard/logs/richclient_info.log',
-             ]
+  zap trash: '~/.openecard/logs/richclient_info.log'
 end


### PR DESCRIPTION
Please include my new cask Open eCard App
Open Source implementation of ISO/IEC 24727authentication and signature purposes for SmartCards

This is my first contribution, please be kind :-)

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
  1 offense: "https://www.openecard.org/download/pc/ does not match github.com/ecsec/open-ecard/releases/download/„
  this is because the project homepage download page directs to image which is located at GitHub
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version]

new cask:

- [ ] Named the cask according to the [token reference].
  not sure?!
- [x] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
   hopefully zap is complete (or should we also remove ~/.openecard/ completely?)
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
