### PR TITLE
Update magicavoxel url and zap stanza

### DIFF
--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,9 +1,10 @@
 cask 'magicavoxel' do
   version '0.99.4'
-  sha256 'd7c09a0178d4fd8b6484eae479b2b8f2daf60b8a0b39ba418981846906924e49'
+  sha256 'f42b1ffe2dff0d8aadb806c8359e3cbd53f723a23adcefc5042ce8f8702b4935'
 
-  # dropbox.com/s/abh4jkiopcbuzep was verified as official when first introduced to the cask
-  url "https://www.dropbox.com/s/abh4jkiopcbuzep/MagicaVoxel-#{version}-alpha-macos.zip?dl=1"
+  # github.com/ephtracy/ephtracy.github.io was verified as official when first introduced to the cask
+  url "https://github.com/ephtracy/ephtracy.github.io/releases/download/#{version}/MagicaVoxel-#{version}-alpha-macos.zip"
+  appcast 'https://github.com/ephtracy/ephtracy.github.io/releases.atom'
   name 'MagicaVoxel'
   homepage 'https://ephtracy.github.io/'
 

--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -9,4 +9,9 @@ cask 'magicavoxel' do
   homepage 'https://ephtracy.github.io/'
 
   suite staged_path, target: 'MagicaVoxel'
+
+  zap trash: [
+               '~/Library/Preferences/EPH.MagicaVoxel.plist',
+               '~/Library/Saved Application State/EPH.MagicaVoxel.savedState',
+             ]
 end


### PR DESCRIPTION
magicavoxel was recently updated (#65493) but the url did not point to the download of the new version. This pull request will fix this.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).