### PR TITLE
Update electron from 5.0.5 to 5.0.6

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '5.0.5'
-  sha256 'd14b45e16618251515a2fcb2301abab1cc105aa42e6a24cd7f6c4f0370b166fa'
+  version '5.0.6'
+  sha256 'f07099acfcecf25f37222c6de5c9190d75aa6abb878a299aa9bdc61bb379c126'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.