### PR TITLE
Update barrier from 2.1.0 to 2.3.0

### DIFF
--- a/Casks/barrier.rb
+++ b/Casks/barrier.rb
@@ -1,8 +1,8 @@
 cask 'barrier' do
-  version '2.1.0'
-  sha256 'f12738524bc002f830e711f1f054c892c5ea71af968a842b9d51a5d4276ca415'
+  version '2.3.0'
+  sha256 'c00706fd2c38c1f0dda0b298f55d2fc0d423dcb15187041c379273da1e347714'
 
-  url "https://github.com/debauchee/barrier/releases/download/v#{version}/barrier-#{version}.dmg"
+  url "https://github.com/debauchee/barrier/releases/download/v#{version}/Barrier-#{version}-Release.dmg"
   appcast 'https://github.com/debauchee/barrier/releases.atom'
   name 'Barrier'
   homepage 'https://github.com/debauchee/barrier/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.