### PR TITLE
Update jd-gui from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/jd-gui.rb
+++ b/Casks/jd-gui.rb
@@ -1,6 +1,6 @@
 cask 'jd-gui' do
-  version '1.6.1'
-  sha256 '4f0c0ed6afbf6097559722756e689fe3018ffb386661350466f13bcec97e0601'
+  version '1.6.2'
+  sha256 'd034481f7c21ed0c17f04b87a4d886a3a28c0e0bca46e01b864a7afd119947ae'
 
   # github.com/java-decompiler/jd-gui was verified as official when first introduced to the cask
   url "https://github.com/java-decompiler/jd-gui/releases/download/v#{version}/jd-gui-osx-#{version}.tar"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.