### PR TITLE
Update melodics from 2.0.2952 to 2.0.2957

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2952'
-  sha256 'ef5aa21b7e74966728615f7b3567508ab207e7c4de036e69e5f007524bcd0d37'
+  version '2.0.2957'
+  sha256 'a7bcd3dadbaf77132ebe19fd3b7025b567850313de58d2ec7da1daeddea2c140'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.