### PR TITLE
Update radarr from 0.2.0.1344 to 0.2.0.1358

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,6 +1,6 @@
 cask 'radarr' do
-  version '0.2.0.1344'
-  sha256 '99fb8a44f5712ce910c87c0e0a4290980edbf5584bdfc62d24ece748a4965456'
+  version '0.2.0.1358'
+  sha256 '0cf9d05c8e971e834a591fef60f1a6f3e685a2999751cb118a537c118d5f5466'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.