### PR TITLE
Update tg-pro from 2.39 to 2.40

### DIFF
--- a/Casks/tg-pro.rb
+++ b/Casks/tg-pro.rb
@@ -1,8 +1,8 @@
 cask 'tg-pro' do
-  version '2.39'
-  sha256 'f8ff20046976a6223ce72a8ca96bbd5f08718e97c03c04647f66c9053882a752'
+  version '2.40'
+  sha256 '4be77575620073ce89018fe2d321766d1a8d2fbd54037555fd2e39c75b35d731'
 
-  url "https://www.tunabellysoftware.com/resources/TGPro_#{version}.zip"
+  url "https://www.tunabellysoftware.com/resources/TG%20Pro%20#{version}.dmg"
   appcast 'https://www.tunabellysoftware.com/resources/sparkle/tgpro.xml'
   name 'TG Pro'
   homepage 'https://www.tunabellysoftware.com/tgpro/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.