### PR TITLE
Update cloud-pbx from 22.7.0.429 to 22.7.3.176

### DIFF
--- a/Casks/cloud-pbx.rb
+++ b/Casks/cloud-pbx.rb
@@ -1,9 +1,10 @@
 cask 'cloud-pbx' do
-  version '22.7.0.429'
-  sha256 'ea3a1c5a69f52e7c772d60fd89ae1a3cc7474021a7c75f70dcf390b04e0fe882'
+  version '22.7.3.176'
+  sha256 '7c5b080dda8377e01aa841c5e02cae7724d652bcec694b3fab7d99173099ed14'
 
   # cpbx-hilfe.deutschland-lan.de/downloads was verified as official when first introduced to the cask
-  url 'https://cpbx-hilfe.deutschland-lan.de/downloads/desktop-clients/cloud-pbx.osx-22.7.0.429'
+  url "https://cpbx-hilfe.deutschland-lan.de/downloads/desktop-clients/cloud-pbx.osx-#{version}"
+  appcast 'https://cpbx-hilfe.deutschland-lan.de/de/direkthilfe/hilfe-downloads'
   name 'Cloud PBX'
   homepage 'https://geschaeftskunden.telekom.de/startseite/festnetz-internet/tarife/332198/telefonanlage-aus-der-cloud.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.