### PR TITLE
Add OpenInEditor-Lite.app v0.4.5

### DIFF
--- a/Casks/openineditor-lite.rb
+++ b/Casks/openineditor-lite.rb
@@ -1,0 +1,11 @@
+cask 'openineditor-lite' do
+  version '0.4.5'
+  sha256 '3381f9468790d4d9c2e0f373923d8038ef7f059bb0d4a95056f9db7d69bb92b8'
+
+  url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/#{version}/OpenInEditor-Lite.app.zip"
+  appcast 'https://github.com/Ji4n1ng/OpenInTerminal/releases.atom'
+  name 'OpenInEditor-Lite'
+  homepage 'https://github.com/Ji4n1ng/OpenInTerminal'
+
+  app 'OpenInEditor-Lite.app'
+end


### PR DESCRIPTION
https://github.com/Ji4n1ng/OpenInTerminal/blob/master/Resources/README-Lite.md

`OpenInEditor-Lite` is a Finder toolbar app for macOS to open the current directory in editors, like `VSCode`, `Sublime Text` and `Atom`.

I have submitted OpenInTerminal.app(#62873) and OpenInTerminal-Lite.app(#62294). OpenInEditor-Lite.app is another application.

Thank you very much for your time. 😀

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
