### PR TITLE
Update plex-media-server from 1.16.0.1226-7eb2c8f6f to 1.16.1.1291-158e5b199

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.16.0.1226-7eb2c8f6f'
-  sha256 'ba4d3a34aeb85e287258a07e87608cb2117aec74b257993a30c87f723b1e553a'
+  version '1.16.1.1291-158e5b199'
+  sha256 'cdcc13d67ca242b167aa853fa49ae68248e6fe0cc91e3e9e9c51c85ec9e6aa6c'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.dmg"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.