### PR TITLE
Update dcp-o-matic-encode-server from 2.14.7 to 2.14.8

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.7'
-  sha256 '7662c27a4cecec0ba8b0ab888e5bb6acc65d7f09bddf73f7f2eba8ffb7c9203a'
+  version '2.14.8'
+  sha256 '85a2ee483684094df08c65a9d11642839e216ec0e09147c69e99553ebacc1da3'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.