### PR TITLE
Update dcp-o-matic-kdm-creator from 2.14.7 to 2.14.8

### DIFF
--- a/Casks/dcp-o-matic-kdm-creator.rb
+++ b/Casks/dcp-o-matic-kdm-creator.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-kdm-creator' do
-  version '2.14.7'
-  sha256 '00a7a4eb6840455845e450f92528b14c856b25083c60fb38249c497b8afd622e'
+  version '2.14.8'
+  sha256 '2231fb93de6767cd82aa426e8d16d37cede289533bd88b56bd38394a3328c152'
 
   url "https://dcpomatic.com/dl.php?id=osx-kdm&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.