### PR TITLE
Update dcp-o-matic-player from 2.14.7 to 2.14.8

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.7'
-  sha256 '5156bb8c5684f37ade8adf365250268ac4682151cbf9617574775eb559de72fc'
+  version '2.14.8'
+  sha256 'e228cb99e358e1b4485c9befa54a84271d36c813f3610591a7f7c15b0be6aa68'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.