### PR TITLE
Update command-tab-plus from 1.92,324:1553250170 to 1.93,328:1561982918

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.92,324:1553250170'
-  sha256 'f5ea01fa03217ef432f0c8cc307c94aa05992f433b89a1b839f0f6919768a5c9'
+  version '1.93,328:1561982918'
+  sha256 '1055101dde4339a580b4792313275cc36a9ad67bdabfc30c0ae1d1d6c8c9f50e'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.