### PR TITLE
Update kiwi-for-g-suite from 2.0.20v to 2.0.21v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask 'kiwi-for-g-suite' do
-  version '2.0.20v'
-  sha256 '19cfcb6676a3dbdc19486faa5b75344ea7464de47eed0dc805c302ba2c16fd6c'
+  version '2.0.21v'
+  sha256 'cdeef417262062d6113d0733867dce14fd5e2622a6d57442640f5bdda0a0a7ee'
 
   # kiwiforgsuite.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.