### PR TITLE
Update blitz from 1.0.5 to 1.0.6

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.0.5'
-  sha256 '22e499b1ebaf9e3037838f1b65975b1bea04b78f8a8c7a7f3acc2a1047ff12d5'
+  version '1.0.6'
+  sha256 'a9b964ed078411c5b1430ac9f06eb613b78916faa5507d49bba0ef4794b2330b'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.