### PR TITLE
Update catlight from 2.26.2 to 2.26.3

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,6 +1,6 @@
 cask 'catlight' do
-  version '2.26.2'
-  sha256 '2412e4fd47f4509a1b1068f8d1ac697368411ad1ec3b0b86e5d75bd9347aa5bc'
+  version '2.26.3'
+  sha256 'caceeee8810ba2d26cecf714a690562c618d5fe31880f3fa5824452f59a7f732'
 
   # de2nac35bcll0.cloudfront.net was verified as official when first introduced to the cask
   url "https://de2nac35bcll0.cloudfront.net/dl/mac/beta/CatLightSetup-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.