### PR TITLE
Update qownnotes from 19.7.0,b4352-083342 to 19.7.1,b4357-174238

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.7.0,b4352-083342'
-  sha256 '72351755ec99e0cf50856a7ac2c1adb3cbadb8528cd29ba5a7d1c1b3c9667a11'
+  version '19.7.1,b4357-174238'
+  sha256 '638a357b856c5afb84010d710518c9ba7c9b253873e3f4d49b882a929b73ebcf'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.