### PR TITLE
Update simplenote from 1.5.0 to 1.6.0

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,6 +1,6 @@
 cask 'simplenote' do
-  version '1.5.0'
-  sha256 '003b3e304d592fa5ba35af5bcc434b8388ba8dfba9337c795c24ef74fe8ddba9'
+  version '1.6.0'
+  sha256 '98ebf79cd64cdd12205bad63cccac7b1a0e789a914298d19600d51485bedd072'
 
   url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.dmg"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.