### PR TITLE
Update little-snitch from 4.3.2 to 4.4

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -1,6 +1,6 @@
 cask 'little-snitch' do
-  version '4.3.2'
-  sha256 '7308800f84558d3c1d30a77cc2034e073ffa1673583297403e644288fab07425'
+  version '4.4'
+  sha256 '668a37cd7e97e170ef3b35ff50644ecb9f78550b6f1b536034a9ef777cfb5586'
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.