### PR TITLE
Update bbc-iplayer-downloads from 2.8.10 to 2.9.0

### DIFF
--- a/Casks/bbc-iplayer-downloads.rb
+++ b/Casks/bbc-iplayer-downloads.rb
@@ -1,6 +1,6 @@
 cask 'bbc-iplayer-downloads' do
-  version '2.8.10'
-  sha256 '1de1a3ab9d7c1571b08d416a282894b171a4a15118789edae8bc2aead8cf9bc3'
+  version '2.9.0'
+  sha256 '77cf26d082b0e67f214a5b8fa4935f28734fd9571bbd97a6ffcc81b351ed5df4'
 
   # live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://live-downloads-app-bucket-staticassetsbucket-ydn3z4ggyaof.s3.amazonaws.com/releases/darwin-x64/BBCiPlayerDownloads-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.