### PR TITLE
Update inkdrop from 4.0.0 to 4.1.0

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,6 +1,6 @@
 cask 'inkdrop' do
-  version '4.0.0'
-  sha256 '5d95fce48753218741efd523e2e30064411c8aacc1373a6aad1fbc59bfa8e88c'
+  version '4.1.0'
+  sha256 '4396ca6e051e9cf2e998ce00e041bcd20f61094d176f9d1085c3e2be17721973'
 
   # d3ip0rje8grhnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.