### PR TITLE
Update hstracker from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.0'
-  sha256 'afd0ccfa870f6c0c3fce79731b7aa3fc15b3451863162f9910f056f9b8a2381a'
+  version '1.6.1'
+  sha256 'e31a703a508d4cc4f99d81efe924a5ab808516792f3cffa797a76bef602c13d4'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.