### PR TITLE
Update stremio from 4.4.25 to 4.4.77

### DIFF
--- a/Casks/stremio.rb
+++ b/Casks/stremio.rb
@@ -1,6 +1,6 @@
 cask 'stremio' do
-  version '4.4.25'
-  sha256 '385df67729d8ac7af2f1431b4adfdee91489152e8668687fa2c8e7b8814e6351'
+  version '4.4.77'
+  sha256 'b4d707e38a035aa43fc6ecc3e28c3b43f7624677c8686dc7cb12396f4c2939e0'
 
   url "https://dl.strem.io/mac/v#{version}/Stremio+#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.strem.io/download?platform=mac%26four=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.