### PR TITLE
Update cura-lulzbot from 3.6.8 to 3.6.13

### DIFF
--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -1,6 +1,6 @@
 cask 'cura-lulzbot' do
-  version '3.6.8'
-  sha256 'a2c821be2544eda26ee85bf601f28d8774ccce739a1a101c65868fa231d290f9'
+  version '3.6.13'
+  sha256 'd01d6a4643eb55fea783133b3db6fd3c0368070c8124fc48ed42d304ed5cbbd7'
 
   url "https://download.lulzbot.com/Software/cura-lulzbot/mac/cura-lulzbot_#{version}.dmg"
   appcast 'https://download.lulzbot.com/Software/cura-lulzbot/mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.