### PR TITLE
Update jalbum from 18.3.0 to 18.3.1

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -3,7 +3,8 @@ cask 'jalbum' do
   sha256 '0bdb2e6c64d7996cd15ef58687c109b5627f6c2b2a3b18910c4d9215df51f5b1'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
-  appcast 'https://jalbum.net/en/software/download/previous'
+  appcast 'https://jalbum.net/en/software/download/previous',
+          configuration: version.major_minor
   name 'jAlbum'
   homepage 'https://jalbum.net/'
 

--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,6 +1,6 @@
 cask 'jalbum' do
-  version '18.3.0'
-  sha256 '1b872799875ec0e1abc619733c2d056bebedef0dc14c395c6aa4d9726c269acc'
+  version '18.3.1'
+  sha256 '0bdb2e6c64d7996cd15ef58687c109b5627f6c2b2a3b18910c4d9215df51f5b1'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.