### PR TITLE
Update betterzip from 4.2.3 to 4.2.4

### DIFF
--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -1,6 +1,6 @@
 cask 'betterzip' do
-  version '4.2.3'
-  sha256 '643ea6cbec156ace28ccb6af4a6ef583b34ca16fa714b2e53b29828b3705e4ba'
+  version '4.2.4'
+  sha256 '62c254f0e0c6632150ef50cfe928dfb444ab6e764f5ae0809d71ce5b4d80bf66'
 
   url "https://macitbetter.com/dl/BetterZip-#{version}.zip"
   appcast 'https://macitbetter.com/BetterZip.rss'

--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -3,7 +3,8 @@ cask 'betterzip' do
   sha256 '62c254f0e0c6632150ef50cfe928dfb444ab6e764f5ae0809d71ce5b4d80bf66'
 
   url "https://macitbetter.com/dl/BetterZip-#{version}.zip"
-  appcast 'https://macitbetter.com/BetterZip.rss'
+  appcast 'https://macitbetter.com/BetterZip.rss',
+          configuration: version.major_minor
   name 'BetterZip'
   homepage 'https://macitbetter.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.