### PR TITLE
Update bettertouchtool from 3.099 to 3.100

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.099'
-    sha256 '0201f8ce8b911507f02056881ae024146c5016fe8b36f0d720cdf311cbeb3ad1'
+    version '3.100'
+    sha256 '3457d17ab5401ebaabbfbee42b7b58ae9ff13e0d0e5b99c0534bbf7d7fadc0a1'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.