### PR TITLE
Update stretchly from 0.19.1 to 0.20.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,6 +1,6 @@
 cask 'stretchly' do
-  version '0.19.1'
-  sha256 '9030b02d539bfa3697b4c50d820ebcfb6a28e7c9ed6e966538ca4d3151e2bca6'
+  version '0.20.0'
+  sha256 'efc14533c61f1313dd45ca0edbd7b00b7357ff4e4626e581cf188e252512b58c'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.