### PR TITLE
Update framer-x from 33072,1561453763 to 33255,1562060195

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '33072,1561453763'
-  sha256 '3c25004916c30588f7f4e0fe0b650dfd443e97d9768cff6f9601cf794723059c'
+  version '33255,1562060195'
+  sha256 '493bdc78ae34093e71b0dacfa855e1cefc8baa83efaa52d1d78133e01f026b5d'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.