### PR TITLE
Update quip from 5.5.9 to 5.5.13

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.5.9'
-  sha256 'b4624a1d15e41125fbd5d74da05065aa5064cb6ef2daf6a5d51f1947ea8b1d0a'
+  version '5.5.13'
+  sha256 'af9aae5cc570be2f2bf39945812e2a864e3499e2a98438914cea45230613aa20'
 
   # quip-clients.com was verified as official when first introduced to the cask
   url "https://quip-clients.com/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.