### PR TITLE
Update garagesale from 7.0.16 to 7.0.17

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,6 +1,6 @@
 cask 'garagesale' do
-  version '7.0.16'
-  sha256 '7e2bcf398121331a819e50970cf306486eb492c0078e8c1376233c232e021f87'
+  version '7.0.17'
+  sha256 '89590b6e45b9a6d44cedc652ef39af64359fc8090109403162c3a5457a6bc562'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   appcast 'https://rink.hockeyapp.net/api/2/apps/b83b659a4c853a6138def4da94c6fcdd.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.