### PR TITLE
Update there from 1.7.9 to 1.8.0

### DIFF
--- a/Casks/there.rb
+++ b/Casks/there.rb
@@ -1,6 +1,6 @@
 cask 'there' do
-  version '1.7.9'
-  sha256 'a6099f096df8de7ca3c76c80c48df44c44873393c7ca3847e5570b24fb7661c3'
+  version '1.8.0'
+  sha256 'fd329837111170c8ae41ec1f19ae1dca6f4991c40002ef44c79705073edd2c1a'
 
   # github.com/therehq/there-desktop was verified as official when first introduced to the cask
   url "https://github.com/therehq/there-desktop/releases/download/v#{version}/There-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.