### PR TITLE
Update tinderbox from 8.0.4 to 8.0.6

### DIFF
--- a/Casks/tinderbox.rb
+++ b/Casks/tinderbox.rb
@@ -4,8 +4,8 @@ cask 'tinderbox' do
     sha256 '765a6245d25f9c2185802f36caa1f620f276637b884260fffa74bf639670e211'
     app 'TinderboxSix.app'
   else
-    version '8.0.4'
-    sha256 '8bd5a8f9c1158f3045de1984819b02981e8fcc929579b42e60eb9c53b3fab6c4'
+    version '8.0.6'
+    sha256 'a62d9f915a526a913824a5ce91d104eced273d713ea888ffd61c5d106ac6da0f'
     app "Tinderbox #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.