### PR TITLE
Update 4k-youtube-to-mp3 from 3.6.3.2224 to 3.7.0.2852

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.6.3.2224'
-  sha256 'ae719c7330c311c7ce3e2a0c03f0bcf41a7512386ef4f6216c065fdddf3788dc'
+  version '3.7.0.2852'
+  sha256 '442e3935e30b00a58e5843aea470417eb73048b54dfcf614c80f8cdbf1f40e97'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.