### PR TITLE
Update fldigi from 4.1.04,4.3.7 to 4.1.05

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.1.04,4.3.7'
-  sha256 '31d5f23f5898f7ca89d1e99f84c175e33ec90b572d7d2397fb3628d20c391111'
+  version '4.1.05'
+  sha256 '4afd31b3061b84f58544e8a160c31f6ab9b7927411098b09c84a73d8493597f7'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -2,7 +2,7 @@ cask 'fldigi' do
   version '4.1.05'
   sha256 '4afd31b3061b84f58544e8a160c31f6ab9b7927411098b09c84a73d8493597f7'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,8 +1,8 @@
 cask 'fldigi' do
-  version '4.1.05'
+  version '4.1.05,4.3.7'
   sha256 '4afd31b3061b84f58544e8a160c31f6ab9b7927411098b09c84a73d8493597f7'
 
-  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version}_x86_64.dmg"
+  url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'
   name 'fldigi'
   homepage 'https://sourceforge.net/projects/fldigi/files/fldigi/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.