### PR TITLE
Update brave-browser from 0.65.121 to 0.66.99

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.65.121'
-  sha256 '5a87953045c802bd43a86741ac10145ff3db7d5f84a04d6c94f49112a0ff9a11'
+  version '0.66.99'
+  sha256 'bfb50a14d280c7fb5074f73ab9481fa2cc388e74c438cba15792231e585c6d97'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.