### PR TITLE
Update upwork from 5.2.3.757,5_2_3_757_3idn3cdxmlq3m6d5 to 5.2.3.763,5_2_3_763_hzp6dgwl5mhvzul3

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,6 +1,6 @@
 cask 'upwork' do
-  version '5.2.3.757,5_2_3_757_3idn3cdxmlq3m6d5'
-  sha256 'd7da1baf90469e23cb3f23da0151a8b897126205998d67502f7f9440386d6800'
+  version '5.2.3.763,5_2_3_763_hzp6dgwl5mhvzul3'
+  sha256 'be08e93bba9ea97102eb0702d5d0f158d105d1b5f1b9ff95e6c17d22695269d2'
 
   url "https://updates-desktopapp.upwork.com/binaries/v#{version.after_comma}/Upwork.dmg"
   name 'Upwork'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.