### PR TITLE
Update axe-edit-iii from 1.01.09 to 1.01.10

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.01.09'
-  sha256 '4d13fd51889a9c0812d3ecb2a8362e00befb2ec8f48b838b38c85bb0a5fd14bc'
+  version '1.01.10'
+  sha256 'bc8f0a09750f66c5ec0bc957b9b20d3a63f3e30bb8e9d3f3346b0ef7aba95733'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.