### PR TITLE
Update bloodhound from 2.1.0 to 2.2.0

### DIFF
--- a/Casks/bloodhound.rb
+++ b/Casks/bloodhound.rb
@@ -1,6 +1,6 @@
 cask 'bloodhound' do
-  version '2.1.0'
-  sha256 '2e18f54ffc6007a57706d500ea0159baed76eeec31c1a0a2ee2e5ce24b79acc6'
+  version '2.2.0'
+  sha256 'fffaec6a59c6d0b368fd980414500ffeb17f3155ec3353f679dfc6caf392ce84'
 
   url "https://github.com/BloodHoundAD/BloodHound/releases/download/#{version}/BloodHound-darwin-x64.zip"
   appcast 'https://github.com/BloodHoundAD/BloodHound/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.