### PR TITLE
Update runjs from 1.5.3 to 1.5.4

### DIFF
--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -1,6 +1,6 @@
 cask 'runjs' do
-  version '1.5.3'
-  sha256 '40350b0b404778a8ab7da4dabcd2b226585fee3b08299a87ba325505fecdf0ba'
+  version '1.5.4'
+  sha256 'd5164aba5159196d42b4208cabe0f0689b379f721f82d3b3df2f10ccdfc0c152'
 
   # github.com/lukehaas/runjs was verified as official when first introduced to the cask
   url "https://github.com/lukehaas/runjs/releases/download/v#{version}/RunJS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.