### PR TITLE
Update superproductivity from 2.8.4 to 2.8.5

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.8.4'
-  sha256 '9da2191a625945709f4765a3bb1ef6780c0c807bbd131fea5b6f7ec3118bb344'
+  version '2.8.5'
+  sha256 '7e1e0ba180c7a3383fb5a12535d15a02763a2465bc367a36cd987fcf61ae1f08'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.