### PR TITLE
Update bunch from 1.1.5,31 to 1.1.6,32

### DIFF
--- a/Casks/bunch.rb
+++ b/Casks/bunch.rb
@@ -1,6 +1,6 @@
 cask 'bunch' do
-  version '1.1.5,31'
-  sha256 'eef1d9a7bc093e620f54892c600690e77561a1cb0ef03797535d3ce30874ffb2'
+  version '1.1.6,32'
+  sha256 'ec62c356f75e67de3790ceb289cc34235837415377a104c2960119ae44dd8dad'
 
   url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://brettterpstra.com/updates/bunch/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.