### PR TITLE
Update fman from 1.6.3 to 1.6.4

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.6.3'
-  sha256 'bffb9ee85b694c9451fe0e48f675fc795579f808ffede8f19881821327d981f6'
+  version '1.6.4'
+  sha256 'e2cffda7e96fdb43b6eeef9235aa075487243bb689ebc8ce886d417cf5f73cf0'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.