### PR TITLE
Update paintbrush from 2.4.1 to 2.4.2

### DIFF
--- a/Casks/paintbrush.rb
+++ b/Casks/paintbrush.rb
@@ -1,6 +1,6 @@
 cask 'paintbrush' do
-  version '2.4.1'
-  sha256 '2695594cf3797713aae58ea1919a78c01a5efc6e856777cbaeadf69297e3b243'
+  version '2.4.2'
+  sha256 'ee1e3175870f9c4271706e646d9a5312d6e098c22dbdc40d32525f9915706eec'
 
   # downloads.sourceforge.net/paintbrush was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/paintbrush/Paintbrush%202.x/Paintbrush%20#{version}/Paintbrush-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.