### PR TITLE
Update vectoraster from 7.4.3 to 7.4.4

### DIFF
--- a/Casks/vectoraster.rb
+++ b/Casks/vectoraster.rb
@@ -1,6 +1,6 @@
 cask 'vectoraster' do
-  version '7.4.3'
-  sha256 '42e2d6f21849b07d01e3a9c888ae18b86bfd1a5e1e201da8af4c80bbb6884b74'
+  version '7.4.4'
+  sha256 '3c218dab7f1f017cfc3fb90b2022173d8197ff1cc76799ae665dfde195fc1f6c'
 
   url "https://www.lostminds.com/downloads/vectoraster#{version.major}.dmg"
   appcast "https://www.lostminds.com/vectoraster#{version.major}/version_history.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.