### PR TITLE
Update wifi-explorer from 2.5.4 to 2.5.5

### DIFF
--- a/Casks/wifi-explorer.rb
+++ b/Casks/wifi-explorer.rb
@@ -1,6 +1,6 @@
 cask 'wifi-explorer' do
-  version '2.5.4'
-  sha256 '2dd3a6b42977c77aaa3df7800313306feed172cedbfd58e4b48db737feb42870'
+  version '2.5.5'
+  sha256 'a95d05543d9422cdafb81909ab3c706847e1380fbd9ebb6c1cb643b540488e00'
 
   url "https://www.adriangranados.com/downloads/wifiexplorer_#{version}.zip"
   appcast 'https://www.adriangranados.com/appcasts/wifiexplorercast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.