### PR TITLE
Update yate from 4.7.0.2 to 4.7.1

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '4.7.0.2'
-  sha256 'ab7e072a2aaca42ea731a64aefe35382e754c3e4d7d6465ccd53f829266673a5'
+  version '4.7.1'
+  sha256 'e62f99e21842b74517ce81ccb58fc2e088a6ddabb241413905f0c132a41896d8'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.