### PR TITLE
Update capto from 1.2.11,1548837086 to 1.2.12,1562218032

### DIFF
--- a/Casks/capto.rb
+++ b/Casks/capto.rb
@@ -1,6 +1,6 @@
 cask 'capto' do
-  version '1.2.11,1548837086'
-  sha256 '8e2e94a6c4d1f0e7abcf3dd26be2317b123a2039c7fdb72fe3c37cb744948ac9'
+  version '1.2.12,1562218032'
+  sha256 'fe53bdb31ff951bd079d2b1ea5ec32d2b41d7e5d3d5ee3ac73addbc3fe1f757a'
 
   # dl.devmate.com/com.globaldelight.Capto was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Capto/#{version.before_comma}/#{version.after_comma}/Capto-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.