### PR TITLE
Update asciidocfx from 1.6.9 to 1.7.0

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
-  version '1.6.9'
-  sha256 '2cb7492ace5fbe1a384954f7cc68fabf6d3b7f5dfd3f35cfe546a301869ea47f'
+  version '1.7.0'
+  sha256 'c110cf444860245b672561aa83c2a4edbe802dd17159e1b7d2b5c8f23ac31292'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.