### PR TITLE
Update displaycal from 3.8.2.0 to 3.8.3.0

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,6 +1,6 @@
 cask 'displaycal' do
-  version '3.8.2.0'
-  sha256 'eb2342d0a7bcdb57fe4bf2092de4ad1bb6e11b5adc11fd113468b5ad8da64619'
+  version '3.8.3.0'
+  sha256 '3815e8678fb7d7760d6af1928cb378738656c61260ab32a37f96e2bd44151ddc'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.