### PR TITLE
Update dropbox-encore from 1.0 to 1.1b1

### DIFF
--- a/Casks/dropbox-encore.rb
+++ b/Casks/dropbox-encore.rb
@@ -1,8 +1,9 @@
 cask 'dropbox-encore' do
-  version '1.0'
-  sha256 '2dfa8abd5a1b48b5e1f323b5167a1ef53559f862520bf358f9500aa328ecaf90'
+  version '1.1b1'
+  sha256 'ed1981700176599d6817a07bd26f75271d77d0fd6da616a66987a63d7cf8af36'
 
   url "https://www.joyofmacs.com/downloads/DropboxEncore#{version}.dmg"
+  appcast 'https://www.joyofmacs.com/software/dropboxencore/'
   name 'Dropbox Encore'
   homepage 'https://www.joyofmacs.com/software/dropboxencore/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.