### PR TITLE
Update deploystudio from 1.7.9 to 1.7.8

### DIFF
--- a/Casks/deploystudio.rb
+++ b/Casks/deploystudio.rb
@@ -1,8 +1,9 @@
 cask 'deploystudio' do
-  version '1.7.9'
-  sha256 '4b4cb0b1517eec001fe74d981341956bc4696f415a426e1aabab66b1a9b1b8ab'
+  version '1.7.8'
+  sha256 'a7d71ed8e72498c8f7b37349458afd0cd74ba7a95313f26ea1ba05f4d1362071'
 
   url "http://www.deploystudio.com/Downloads/DeployStudioServer_v#{version}.dmg"
+  appcast 'http://www.deploystudio.com/category/downloads/'
   name 'DeployStudio Server'
   homepage 'http://www.deploystudio.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.