### PR TITLE
Update imgotv from 3.3.3_20180514 to 6.0.3-mango2

### DIFF
--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -3,7 +3,7 @@ cask 'imgotv' do
   sha256 'b69a5fedc1af407f48191d0f1e666bc3edf5f05597efc1e6ef97a7ddadb44cd3'
 
   # download.imgo.tv was verified as official when first introduced to the cask
-  url "http://download.imgo.tv/app/pc/mac/mgtv-client-#{version}.dmg"
+  url "https://download.imgo.tv/app/pc/mac/mgtv-client-#{version}.dmg"
   appcast 'https://www.mgtv.com/app/'
   name 'hunantv'
   name '芒果视频'

--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -1,16 +1,18 @@
 cask 'imgotv' do
-  version '3.3.3_20180514'
-  sha256 'f457b02aa7bca895677a21e55fd3c7fa05d02cfaefdc46c8558fc99b577e3c5a'
+  version '6.0.3-mango2'
+  sha256 'b69a5fedc1af407f48191d0f1e666bc3edf5f05597efc1e6ef97a7ddadb44cd3'
 
-  url "http://downloadimgo.hunantv.com/app/mac/mgtv_#{version}_release.dmg"
+  # download.imgo.tv was verified as official when first introduced to the cask
+  url "http://download.imgo.tv/app/pc/mac/mgtv-client-#{version}.dmg"
+  appcast 'https://www.mgtv.com/app/'
   name 'hunantv'
   name '芒果视频'
-  homepage 'http://www.hunantv.com/app'
+  homepage 'https://www.mgtv.com/app/'
 
   auto_updates true
   depends_on macos: '>= :yosemite'
 
-  app 'Imgotv-Mac.app'
+  app '芒果TV极速版.app'
 
   zap trash: [
                '~/Library/Preferences/com.hunantv.osx.imgotv.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.