### PR TITLE
Update libreoffice-language-pack from 6.2.4 to 6.2.5

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,558 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '6.2.4'
+  version '6.2.5'
 
   language 'af' do
-    sha256 'e68e023897dc7e9d6e6739df6256206a88991bbc2c5d14212cd5cd92f43038b8'
+    sha256 'a9cd622e746227ea79654c643a2bab35d828449ebc4f52d5c9bf3fb9802c4d01'
     'af'
   end
 
   language 'am' do
-    sha256 '69a6e37e5d73adf5b5a5edeb35943b4e75713865e637f9a0204abb3443fdb803'
+    sha256 '888731bfee5d2c384570efe094ca75f625bc42678caf6d86b0647e7647f52657'
     'am'
   end
 
   language 'ar' do
-    sha256 'b8c0f516eaac7e1aeaabe8c54b6a71f9669fa307324322714978aca4a1f27254'
+    sha256 'e49f26a5d6755283aa78d69d65a01b6fa94153cac13536b88761924b64d64832'
     'ar'
   end
 
   language 'as' do
-    sha256 'a4676958821afb6379f3d09cd131424d599c3fbb3efce2bfa053855bd2babc06'
+    sha256 'c16bc4c5241f90328221c80b1e849ccd0c756b75d5e0c5a894dbdf48461fd177'
     'as'
   end
 
   language 'ast' do
-    sha256 '5b82c29c1a64f6d85dc4d56055d2f79027264dd95407a8fdb623db449056bcf8'
+    sha256 '73d680058f8f2039aa85163225bc49aa1c17e5909531fa158b2307b398c59650'
     'ast'
   end
 
   language 'be' do
-    sha256 'f8182ee0a9af349dd428cf9c9d7e93e7c3b88c1eaf52e72916cef35ecea83fe1'
+    sha256 '225336dbdd252389edf632972cc752bedff221f1508f330c3dcf8169ce8082f0'
     'be'
   end
 
   language 'bg' do
-    sha256 '6ebebb3348c4203714167ca8c5419300f5296839bcd227c8857af65d08bdd72b'
+    sha256 '679d48fc85a44a592c0e34dca9c9c2735b2e91b67b287a0884a5bd2e1ed2184b'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 '849c2911c6c01886698ae9acda0821a1ec22ee6245d755b8e8db1fb892bb25c2'
+    sha256 'be61dba9ba36d380923712e895cb8b19211efbab5d8a7c43a9a3c8800e8c334c'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 '02f9d951308f5782d590864c7f4d4bed0071d4ea45ca91ab17d64e9babd4547a'
+    sha256 'd4c8ed5f3526b77154da8fd4888297a536af9169238bce5eb2fc59a912f59c26'
     'bn'
   end
 
   language 'bo' do
-    sha256 'fcfc67e9ff9add452ae9be9e8ace3f156a9b05dae95a83d1cdd8f35c39a90a7e'
+    sha256 '4de84be61455ba861ed8d4cba01c55cf7c83c10123d74111b9c95af6841de10b'
     'bo'
   end
 
   language 'br' do
-    sha256 '15bf43b743b84d07c9f05e44b014f3a6442b10a29f9a00b8c4c8aca045a4b559'
+    sha256 '20737a08037fb4d653a06f62664c3c74ce794fe17c38ed7c87e7bb321a85f907'
     'br'
   end
 
   language 'brx' do
-    sha256 '5db680c4f3567f6f70fbc9b3d905e660a50d7b1944fcd0f2bae2f80526221895'
+    sha256 '9411b9df63b170269fce1ab88f0293196600841e858f4bcf5a399ac0f2b842d4'
     'brx'
   end
 
   language 'bs' do
-    sha256 'cb472ca89a7dbf3d59c7f256dd6f72133627023f9baf6850e8a7626136779052'
+    sha256 '556963ec926548ba3db2bb773b32e2237335b4de06d4617385ed5ac4e0734749'
     'bs'
   end
 
   language 'ca' do
-    sha256 '57e86bec70406dbe92cf9c671b35b2c3df4bfd9926f43fce702630341f597397'
+    sha256 '1d5ad2e41b6aa3a2b8be09ca056cc69c92c84e2819cab8b66c61fab929370bbc'
     'ca'
   end
 
   language 'cs' do
-    sha256 'd990b16f12e7db9e37f9e6c50101073ccc7d58025d2fb87b5997551e66f0a5d7'
+    sha256 '3fb8cb2c21f2b70bdb01966c1920eff03b5473028ae0c8982d8d060955f7bff3'
     'cs'
   end
 
   language 'cy' do
-    sha256 'dfababed7058ce3129cc65199a83b47d96396f907e7886f2bb39114deba7622b'
+    sha256 '7dc90f9c2ab4816a16cf0c96a02c3a22a90a85a5466466cd971b566961ff25fd'
     'cy'
   end
 
   language 'da' do
-    sha256 'f1cd6edffd6a1deb898d51cd76d82327bac23c7e13bc5918cb26fa0e407a7f41'
+    sha256 '9e9a28838fa6904eb64723511f9724d7a05d8368f71f6d14965e9bf0a8f8dcd3'
     'da'
   end
 
   language 'de' do
-    sha256 '4519fbe52c21a9fed282279ce381b0be7786319ab11113c9300ae28951a88d82'
+    sha256 '81d657e9a454c4a6bd649eb9d9ccd43474cae2e89e3996553bc85dc42df42757'
     'de'
   end
 
   language 'dgo' do
-    sha256 'f5567bd837e4c86a0adca224a3ddceb6c19d5e17ad708ebd52f34c96637b45aa'
+    sha256 '21db90c8b98ec4637973da6b865d332d2f69ce135a9650f88b8f477850d76cbe'
     'dgo'
   end
 
   language 'dz' do
-    sha256 '4f151f8c742ee13a4ef16343cd796aa6271baada38b574ba926b9be38392043f'
+    sha256 'd6073b8951428e97b4e000bb55ab11b444b0e724ad0d4cc11b03a2266696dcc3'
     'dz'
   end
 
   language 'el' do
-    sha256 '542862aadab83df5262a9faa1b8da88ace3682c5a72f669129e634456a4e49ae'
+    sha256 'c2e5f9316edc13fd7d0377b31a69ec1303030108723cae0de6527fb97017b7b8'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 '3909bcd35a5f95b73635a6840e3a320e0f8f123a21f1c0cf1d1c98de5a0fd567'
+    sha256 'da72a06b2000c5ff612722a22da959357d0c96bfd13d621406f139379e0f24a0'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 'f633f0c22a0938e22e2979c131ef9c7c50f3e74e7ce214e2f75d148028c8a29a'
+    sha256 'cbcc01d29dc91ba8ef3acc0da94913884608f0fac0f518f5c2a3d0981cdb36af'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '4eb9e6c608e2a8a7eaf699dc5c03ed1da24fbd0982bd675a686dcc800151feec'
+    sha256 '29c52f73ae7415eb486b2765e56bf692c3effe6ce59c9907b4592adf3db6ae2e'
     'eo'
   end
 
   language 'es' do
-    sha256 '424695a9426ba457de67204c2d58600b052c4dd8c0fba6cb878d75aa54f56933'
+    sha256 '644f45c52a6c084840eb35af8916991284ab85f9b6716a0d2c75f3e75a7438b9'
     'es'
   end
 
   language 'et' do
-    sha256 'bfada4e6bbb1a8280cc1567658586548a319bd433f976f4d847ad40e761bd191'
+    sha256 '8d2435106651cdb42262d4dc8db9b67770cb042f5cddb9d8123cb171c5feafab'
     'et'
   end
 
   language 'eu' do
-    sha256 '76d9b4c2566d648f165402e43fd29199ea298fd06ed2ea66c30dd8e59380c3b1'
+    sha256 'f88655d4f39f3602f6ce702c4214958acdaa5574b77d3aec9b2f2f7e4231b7cd'
     'eu'
   end
 
   language 'fa' do
-    sha256 'c8f9c67942edfff29a7f4d272e0b1a5c18cc93f97f947d4787df5d7cf4c6038a'
+    sha256 '628271b3f20400e4c459fea281249f5005b1f4d4545b11cd8131061507d9511a'
     'fa'
   end
 
   language 'fi' do
-    sha256 'c66543598f2c227a8cbfcb649e895739c81570ba4760737f77b9ac5c91487d18'
+    sha256 '0a8fce14c2efbd4059e5506578223ac7fa92d34a192fe918ab7b0c6d3be1d44a'
     'fi'
   end
 
   language 'fr' do
-    sha256 '42f590a39623a9ce6a7e4e650995140e3dac7154759f12500fcc05df0b40752d'
+    sha256 'f7e48931c55b3e06b598386152997ac10bb6ee4175d36a1adea68d8e6d3668c1'
     'fr'
   end
 
   language 'ga' do
-    sha256 '4480c396ce2b91dca8ebf04233236d5c15abb6c6cf7667daeb8d313009daa1a1'
+    sha256 '81f8999c75096082e1d4a9b1c06acf34c67bb9e813fccb16dc7db6c72aaa5f33'
     'ga'
   end
 
   language 'gd' do
-    sha256 '6dcd5f57d854cfe2c2d56c9e1bc6cbc4d7b56a277724b87eb1e5bcd2059bb8ba'
+    sha256 'a047374f54b92a05b4f82cbf9f468b0ff3bb8005a0c844499afb4d21b64c4007'
     'gd'
   end
 
   language 'gl' do
-    sha256 'fedf1a3c22c80b61cc41be48189c010f343dba6c99cedfbd257b1bce6c4a740e'
+    sha256 'a120b57323513e5a5b3f9184803423efa06af71f6d078500dea7a99d1458f0b3'
     'gl'
   end
 
   language 'gu' do
-    sha256 '3fdd3342b68adaeafc2aa9791e09d3cb632ca58810d05c31575fc3464b4604b7'
+    sha256 'e477f42f94f574a1564c58f952c342af3ec0dfac0ba0fcc33d8c3e771d523fef'
     'gu'
   end
 
   language 'gug' do
-    sha256 '2e02ece98c22733ff9f0bc198c0c1ee5ae3a3b6c5c084687f5d22e6b93a12be4'
+    sha256 '5197817e9a7ca413856b73b11c20f399bc2e90a5ee79c86c79cb3d0d9819dd26'
     'gug'
   end
 
   language 'he' do
-    sha256 '23a029251c8e5b13e5f2591031dca9ac3a6aef6ee7a61fc946672751712fde73'
+    sha256 'ac7d0fadcfd2240e42a0bff31d3c535e1a9496384fe2ecf340f7d0fd4a450f63'
     'he'
   end
 
   language 'hi' do
-    sha256 'bf2a622feaf7625463e3209e5bbe5795b229761757a6b059f56e5b2385a9b5f8'
+    sha256 'd20c31f19aec4c9d960aa3364db34e03f1b0101de58d8f2d0ad350b7d322b04e'
     'hi'
   end
 
   language 'hr' do
-    sha256 '1d11ea104b4acc6f82a594e5a29fed17340bba0a46f5f9e8d4610aa2eac8e893'
+    sha256 '0a000cab3068c4550097772c19cf409334f82da3406cd79e6bf4f2719e7a5eb4'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '85511ff0f1bbd3165dda0cc1be840154af6575b2de16b1e863c19c644a823aae'
+    sha256 '1de4434198e3fd5acb641bd59f9c285b10e7f3e58b9177a4fadc046df5dea53c'
     'hsb'
   end
 
   language 'hu' do
-    sha256 '8801833e8aab1d4b005ee424ed4578f69be239fdbca723e47b981c195b928394'
+    sha256 'ba57a0e463d47433d6b2ab216f4fd8c96768f544d15656ab09c394246d024cc0'
     'hu'
   end
 
   language 'id' do
-    sha256 '95e4218c33d862fe09921a9c7f2cb73a99221e03868d3291007a280a39763b5b'
+    sha256 '50cf330e11cfa523e0b6193a1dde1e24e7f7e04ca513abb91fe0224f82022cb6'
     'id'
   end
 
   language 'is' do
-    sha256 '4d38f2c3ba44a97bbb35831840e8453176a478802bb615a40f49086f914620a0'
+    sha256 'e00c3f7ccc669cc4102af5a56fd3344d5dcc54a0c0758d29e8521fff550fa7c8'
     'is'
   end
 
   language 'it' do
-    sha256 'db69db021218b1cd9900f1deef8825d38345430f6c016337623c3cf50b5708c1'
+    sha256 '08b1f82de2ffa54f8462d830915b15517c0d7f731cd9348dc9f5d7f4e4036a12'
     'it'
   end
 
   language 'ja' do
-    sha256 '8f9ae98e129362abac70bd9c71bbc5dc26f542d69f75fe07f1442c55cabf9833'
+    sha256 '225cf15d9686d09a88947197afe5a5632dd92ce734e985c7d09be48fde591816'
     'ja'
   end
 
   language 'ka' do
-    sha256 '1083dc509e275b2b01e81ee0febed8e999e11d7d4cedba38baf349ef8d0bbcc0'
+    sha256 'ca656499026b673ffe633efef0d498f186a03a58caf8426ac1d1c1f27062b93b'
     'ka'
   end
 
   language 'kk' do
-    sha256 '2a355406f071f0dce0ef3e4c6bdc0fb8b908d034abfaa5f0a86af4a7847434df'
+    sha256 'd7eecd93deed8d06d33e975cadc8fa069ce186fb61639791ee44cd65b3c4f621'
     'kk'
   end
 
   language 'km' do
-    sha256 'e25a5ceac50ef00c50c11effe71098d0a05a1c8b63dba37471129c6990c041ba'
+    sha256 'd013a1146b7c528d068c97d84dee3b498de93d929cc3b4c5d65aaf887582c3e1'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 '16c6f0ce3d6b371e848a0a0c1bb25a6e97b6259ede878cfd1f7841ad86b696de'
+    sha256 'a0e6f7e8f91c4c573fda583706857b8fd6c320a2a33c926661dee1223b0b0a3b'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'ddabdb1913a8ac47a3fab6ba648ee6f9b47cf2d459dcec1fdc21fa1de9841b46'
+    sha256 'e7b7be90d8d3a76369678d37dbb688fe34230bcc87b26d80eb77dbace2e323a5'
     'kn'
   end
 
   language 'ko' do
-    sha256 '3ed3691f884baad84f1cfc9d5938712ab21f8ae4f1fba0ced14ef68b92241dad'
+    sha256 '908fe5629917fa0ea61dde9c4e13c3c99885de965f6b26889740d73b1a143b88'
     'ko'
   end
 
   language 'kok' do
-    sha256 '82d646c0a76354972c28322452a58454bc2b2877d4c24ed4c01e566b55aa1894'
+    sha256 'acfd27b6a21d292a159e0401b20c7ff5c07a39482b62dd5527fe5f081d6957ce'
     'kok'
   end
 
   language 'ks' do
-    sha256 '628d11137db0794f30f42e4365b62bc376d1aa2d83764db569a47b73dfa173e5'
+    sha256 '126591b076510bc07038567b6fa7b96c36402f8e59a1bd4d3673c50139d40af4'
     'ks'
   end
 
   language 'lb' do
-    sha256 'f761b20f51411813fac290eb42ae5ae8fcb9f6ddcc7caf7e828e4d713e81848a'
+    sha256 '8fc25ba1e641cb3e49a37ffcc6e199f2236627138b2b77f5009dda493bffb642'
     'lb'
   end
 
   language 'lo' do
-    sha256 'feb66221c9934487f7af0da65ac9452a8fb6c09943bde73a2bc1de28d03f6bec'
+    sha256 'a9e1bcdfaab6677c496b0d486e5629664e3965eaca1ae7ced756e6fb0b60747a'
     'lo'
   end
 
   language 'lt' do
-    sha256 'b9c7efa93593c45e47156babfdf0ae3818265b62187f0095685be191c27002d3'
+    sha256 'c94fe64d134b520fdee583078eb50aabb87992f2488de7770c728cc374525b89'
     'lt'
   end
 
   language 'lv' do
-    sha256 '8f693c146c89d84f5ef2fa2c9da037176024b18fe55aac21b990d0d8e26a7332'
+    sha256 '813a0f9bd5f4269012ca264e3b5d69bd0ad85df21ca12bb6f1d382327028b5e3'
     'lv'
   end
 
   language 'mai' do
-    sha256 '49c159c6b9095525e505e6c59d20a5bf551dbf662989292ce14ac0320cb7725c'
+    sha256 'c364aee1a7ac4f6b2a09c9c6cc054c9dabd4caccb1c9d7ba03e4f10168e8be40'
     'mai'
   end
 
   language 'mk' do
-    sha256 '13e2c138d63dc85f424abf9de43e2c01ee34aaed0db8d204e94770e5e538722c'
+    sha256 '7e0067807d1b4d0afb261cbc727a94dbd2e8d18a0d1deecd635c5b40f428bb6c'
     'mk'
   end
 
   language 'ml' do
-    sha256 'bace7c9e10a4b07c8c8ea5c6eaf3eb01b5dd06bed971230c2f3949319b00cab8'
+    sha256 '26a19c003768235ab0a7e1adb50e775e88c365b2a89ec6d272406ef266bb5c0c'
     'ml'
   end
 
   language 'mn' do
-    sha256 '57fd337cf6b336917e84af623b12a6c611c79409407d9d166e6d7fc78567476e'
+    sha256 'fe946e3ab8f09a3b4a11c1503a4613df9a49f01bd7bc7e2a35103a30555f2161'
     'mn'
   end
 
   language 'mni' do
-    sha256 'e5f570b7825cc10a87f6de0af1e6a4e058551cab4f04dd384d96d0fb4ee61cb5'
+    sha256 '40e58e6cc7d69ee716a10e88310fb8b6e597f6334c9dc77b15e87f1d9680c631'
     'mni'
   end
 
   language 'mr' do
-    sha256 '1210e96e2cc8db146ffa264e49b80baa7d97bcb6863221356cc734fd51f8b354'
+    sha256 '985b76f4af6fb8975052ade9db5df68b76387e8258c79f01bacbad8001dc49fe'
     'mr'
   end
 
   language 'my' do
-    sha256 'f748cd1aa3b1cd645cfb359b28dca88f59cf64c9e2489df71e3e59b083208330'
+    sha256 '823124ba5149e17d9e1d0a58e857a8f5af9baebef2c1857ba12f93e1c271b6e3'
     'my'
   end
 
   language 'nb' do
-    sha256 '8c2203211b4b85651e5c9d60d10e66f2f1aee83e94d587953279bd975a821f8c'
+    sha256 '1c977a1bafa8a162685e2c76f188ae3ad6e87e03fdb6c37fadd87aa89138868d'
     'nb'
   end
 
   language 'ne' do
-    sha256 '7667478d102b9d1fcd4dfc4f338edc26caaf96648ce742ee7cc9988f0f1118a6'
+    sha256 '647f65a3c5379677950dc89add0492624532032023e52824cc28cffe0f2939cd'
     'ne'
   end
 
   language 'nl' do
-    sha256 '02926ce47b953e2ed01e1210a22b1e27447fbdc646ab83dc35b48910f0cd4a0c'
+    sha256 '99661106cc73c9d5fb59ae5f262afd33f9db69f2c9d6862216f8276a6a09d7ba'
     'nl'
   end
 
   language 'nn' do
-    sha256 '64dd82de3bae28db93a00ecb55bd6d17d9423c7b1e7d55706d73c36de1a05bde'
+    sha256 'af8453c3ac1533ba14a2347f127bdcd5231fc068a20a552fca64ccd111fd3ea2'
     'nn'
   end
 
   language 'nr' do
-    sha256 'f792698382c88fb1290e284c70b4fd7ad8992909159abf7ed63d96b1c63af15d'
+    sha256 '14559c9ef6c6fe2c50b2d41c80bfb8061a217dcd3654ef3354457708ba5f2fd4'
     'nr'
   end
 
   language 'nso' do
-    sha256 '84a25cdba936712cfb053532ba6eb7e8570276694e57d1725e92f66cb8a32226'
+    sha256 'acbbfad1f51b53a4e1811808954512c987d9ebe97c9913f945e966f7558245e7'
     'nso'
   end
 
   language 'oc' do
-    sha256 '7cbc33021d29bf1d8c6287f3508ee883b500861838fbdee94f85db1356b7de76'
+    sha256 '8fc11013a4e78f5b3bdc6fb555485d7bcddeb737fdc39ff3f4db6b1bce6cd316'
     'oc'
   end
 
   language 'om' do
-    sha256 '4c47fe040ec7ba120a5502e89f3b3eac6f8777b62e67191ca8eaf4a895bc38fe'
+    sha256 '51e4b54f03c0cfe6182340dd0d46648efb76d00400b9a7ddc6aca59bbec53564'
     'om'
   end
 
   language 'or' do
-    sha256 'a49719fb0cbb665f82112054a9853eb9b22beabcb861f778b9eccfb75df0aad4'
+    sha256 'f2588e70c002411007ea0021c4e3ebcd76bcf01da7acc08dd67e38d711fb9d80'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '6572851a1282977bf17ab80c72cd852599e7e7b805d6f884a61c0266e6eedd58'
+    sha256 '695edc22d7e3697252cc9027ed8edcdae703ef946c25940559fbbbd4ff955357'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '4a55e8826347cd1d65142f3576b5d6ee11f5c4ac3573ff4ce3e2ef5965ae17d2'
+    sha256 '23c0b0c5b4acc5c15e86f2167f19777a125c51cc4914fca5abff8dd593db3269'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '1718ec436a94981265a460eb1bc5e0f23ff4ee67f98e15e13fbf48b200e9c10e'
+    sha256 '8e520ec06c03f9c26d9c462b03b0f2f188e3dd18bcd44b41748b1625e026e7d8'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '59ee8c82b0f132feb8119689685913ed401c9d999103fa6ab295d4ba3c92c263'
+    sha256 'e59955081087d425b56cb24edb526d7e114e506014cf4f93e58b663c239a7355'
     'pt'
   end
 
   language 'ro' do
-    sha256 '8a55c6613afe370f361983fa326e0439d156f536a02db0609c319bef65eb93d2'
+    sha256 '6666bf5b7237d23e16d651dcac20b8a2193c9b2f82263fd62fa33fbc1927e157'
     'ro'
   end
 
   language 'ru' do
-    sha256 'b2f1a9b70d67b77f2df1bbe22df1decf14cafcd01ed6ba68be3e8fe18b71914e'
+    sha256 '620f22785393b6ef93cb491511df561fbb692a5d1491c9a22e661b8f48a4ae87'
     'ru'
   end
 
   language 'rw' do
-    sha256 '7d551c88f557fa009f6cbb729d576648545a32bcc911d1a2895876910faac35c'
+    sha256 '4ec17a649e523ac17c6443bf8eb9ffd3484013d3d4d98ee681bfdc64e7423c7a'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 '3f5998c25bdab81bab552a0216ef102701b9530614d0d51581202b444ab12eee'
+    sha256 'b45c2df23343c1055dc446bfd3b9e9f8a6d61a3d7a370925a69ea4b00e185443'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '4129e6c7b35c0387261e7547021a409cd16ec23246fab5ed566399544924c83e'
+    sha256 '4dfcb9ba945033b3e650795d6e0f86aad943008e4f850a0ec5934ad4144a1134'
     'sat'
   end
 
   language 'sd' do
-    sha256 'aa345a6f54610da363868c6521b7d6d208165702b5b5ff83d0e46a974882a3b5'
+    sha256 '0a504ec939149599ce429f4ae3bbb15ec786c72bea6db1ce7b071b586011573b'
     'sd'
   end
 
   language 'si' do
-    sha256 '6dfdfc49e1b527b23869ab42ab6680b58ca5c476481f0716d78d3ba709dbc3c3'
+    sha256 'f42b00fd6d1d09cfcecac18e9f142f9e88fe699ef8d6d4644a8a50b8af9f3ddb'
     'si'
   end
 
   language 'sid' do
-    sha256 'd8dcec0eb466045b554aeaea1047d7cd856e3f906edba14d46c444c597ad315a'
+    sha256 '7ad4ba697b62691212e6d8926d22a298c31f047469e2c596df46f5af6204d667'
     'sid'
   end
 
   language 'sk' do
-    sha256 '02b84da55d442f0bc321f288f04bd413700328bdffba0d6fcf29237ccc333cb1'
+    sha256 'd77dc19b1fa334eeae4a09183fa7357101f0c71ca701f8c004b39b3222b85499'
     'sk'
   end
 
   language 'sl' do
-    sha256 'c7bbaea92e2934e1b4daa3803c38fa740af6da06210ed5dd4f47b50bbbf0a22b'
+    sha256 '6c4cb302e4be7570987b6a65859104e542dbbbdc004a54c5784aafe0feb9f39b'
     'sl'
   end
 
   language 'sq' do
-    sha256 '4049e198667663a145d7098d4f9c217a010ed47e96fd323b4b86ef0cc644d42b'
+    sha256 '41e004ab8a8884cd4b02c2e82f03225c48e9fdbe928506032a5b1c4fbc6dabb0'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 'd90bd7c8478e2538e61e6a416a5e2b101a6cb44da2f5f1eeb33cbae8eff53a81'
+    sha256 '941666dcd8128c0e7fa923270d5b411d1597d97c4e25589d4b7b11b110c2358a'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 '91aaba0a2e774de337996e2bd6c418b6b43228286beefbd0762a38a70b9a4423'
+    sha256 'e5b6b02e1efea6481202754d76d84b0e2c513902ddc834c43f404a46f4c18f51'
     'sr'
   end
 
   language 'ss' do
-    sha256 'a603fcf349ad97528264d9ae96a194d0eab9f11a80c75abe90426bacaefab264'
+    sha256 'dff92fbc0982374e4c242f323af8a37306441eb6899ab286163f8b9c5f296ae1'
     'ss'
   end
 
   language 'st' do
-    sha256 'a31e9ce43b87e6422137222f6444d18aaef57112dbf35211e4b375cc60ce008a'
+    sha256 'b85a114b7844d2b311a0e7d22429beac62af22b2c7116d6a077d5f77a06cef88'
     'st'
   end
 
   language 'sv' do
-    sha256 'e98f312c001e689d089b6d68c45bd2b716124088c919d17f742c0f53ff91935d'
+    sha256 '8fd774d419fc78af1b5b01850b9321d08d6c0703d1dd83252d769c097afe574f'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 'f77da6b0b7179900c6e10cbb601334c465516f77da676f00714f6e32a415b55d'
+    sha256 '734226c209a35e53a838b6c9239eb17d0e158d1ae397bf3bdb503a322e0c22a0'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 'a6c0ef1bb9f1e0c417a0563d0543444dce4179936d29ce73f2f94f358d151840'
+    sha256 '6ff744b67365e1db288c8d2962298d42b726726ab89f64aac8271d676844112e'
     'ta'
   end
 
   language 'te' do
-    sha256 '0efb9eb468db8361ff593470ba0a780cc91052239ed8c719293f88a440a071ac'
+    sha256 '5454d2c84773161eef01f511c82659c014c7b55f2697547ad98dfc8df5dd7986'
     'te'
   end
 
   language 'tg' do
-    sha256 'ac60b3ba2b29b7d09d333f294d0f3d901b95018a33b916be8fbd7c8c4d4192f1'
+    sha256 'c47b0a63d883e40a7b65e70b06994765b7ffd5d1e2536dbbd1c49df5a4e974fe'
     'tg'
   end
 
   language 'th' do
-    sha256 '46212293393e5677d247733d8c4588b1957452c6815db0e4aa531de96edc7b81'
+    sha256 '66575be7995fcdad2d160cbce4e6f1d4f242ee994956a823efcf51adcc3d4e6b'
     'th'
   end
 
   language 'tn' do
-    sha256 'fdaf11d0d88fd5411d9b4d5ac5ad6082829553d73d7398a4057bad50a303970c'
+    sha256 '8e59c61778c519e586d05f7198289df38fb94a3c1d96c5f5284a45215831b41f'
     'tn'
   end
 
   language 'tr' do
-    sha256 'fcac591fdb094c706750600c90d9a9a8a542cd3764ff45ff0c3b23f0b350c7f8'
+    sha256 'bbdbad9e868207a3ebcb715e815e38daa465aef02ff660e0019e671e75483d22'
     'tr'
   end
 
   language 'ts' do
-    sha256 '2527afbc117f52f92b7a0db7e65daab9bdba8e2428ecebf414d248931fb6ba1c'
+    sha256 '2835e03c159746156e585d2abef2b72c0bc2c83cd69344022ab21d997aab2a39'
     'ts'
   end
 
   language 'tt' do
-    sha256 'bb348a12577f219662bef4201ca4fcd7285e480d7048cb4f0d056c492982da27'
+    sha256 '8c2149f37a5fb64477c656921cba72e66e1d2a480afc95f4d03bf4a4c97ebec8'
     'tt'
   end
 
   language 'ug' do
-    sha256 'f07cbd81c3f18b0e16d10efb3ad79c2e4d20a0648ee476e78a1ecd987237e25d'
+    sha256 '75ab88e65aedae7d4d72b34e6ffeb30324a89bc51d5e665357c4d5f7469f4505'
     'ug'
   end
 
   language 'uk' do
-    sha256 'ed27f4b9959fdf6b08bc5fc9f30cc0de4d3082c16f3f1196e44e6ef2fde74e72'
+    sha256 '08dddfe2311069fae1385fb0e02beeb38ac5443944387028bac6adfdeed07c53'
     'uk'
   end
 
   language 'uz' do
-    sha256 '469c1f505850d94020a6a3756aca4d4a0f01a4a43fb7715fcfad3422f2d977b6'
+    sha256 '0981fe40851ba4ef3fd1807e3b99eca9df469e7f96be0ef730ab8042fad538c0'
     'uz'
   end
 
   language 've' do
-    sha256 'eb876cea03d32774e2878b2f290c29ab39197e4b1e24686c84e75da660c5f54d'
+    sha256 '4cff67ba6b806a898b73092a9325f919eeb88040da895f997d62935439044248'
     've'
   end
 
   language 'vec' do
-    sha256 'f258ae14f7b43001c68c2c51d0926a5cd69fc2d5835aadc65fa09deab19f2da9'
+    sha256 '177392a0802b96950655f752d95d434f59e839b0fa7ea455b6176a57cc44f4f8'
     'vec'
   end
 
   language 'vi' do
-    sha256 'c42ac95122a7d02876762b9151684960450280dbdf6745d90221996786d1bc8e'
+    sha256 '7c43526b53fd5585578e971f339333b538ac2e2d32f3823f4c6aef2a3fa74407'
     'vi'
   end
 
   language 'xh' do
-    sha256 '7e5499b4557a83aca997e672340d5392c7332c5bf5aaaa416f9a1e8b9cc78d69'
+    sha256 'cd809d43e41da054dbb12f124025e4d4e7eeb6167cd36db0a0072a0ce1a26bca'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'd808e997965627c8ee8626ab554937f34a632134c28b6c7f8345ade7dd1f1e1f'
+    sha256 'e44e226b3b55dbb3483e19e8214306b99f0a876eaae820023294eb6da9e87dc9'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '6e534786036624947cb50abad471c1e454bd178f87f6f13f4b92be68bd145182'
+    sha256 '8389749b6d9f89e963ebf341955df5adc39f7b020e42338d272370a2aace6af8'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '0d946d64b4410163f05e6dd20f391d2d70a7a4cbae5bfdf513973c2efb8ddca8'
+    sha256 '27ebac5cbf613001e0bc308a60b832b954e89d9925f1b273debee22839e3a104'
     'zu'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
