### PR TITLE
Update electrum from 3.3.6 to 3.3.7

### DIFF
--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -1,6 +1,6 @@
 cask 'electrum' do
-  version '3.3.6'
-  sha256 'e9d0f75b20423977e70923679d37fc91c71f4c28df277435e6ddc0c4b067a431'
+  version '3.3.7'
+  sha256 'a35fece53c8ba1bf7d06651901ad4e014761b11851d9cfbcf86786891b66fa37'
 
   url "https://download.electrum.org/#{version}/electrum-#{version}.dmg"
   appcast 'https://github.com/spesmilo/electrum/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.