### PR TITLE
Add SideQuest 0.4.2

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,0 +1,16 @@
+cask 'sidequest' do
+  version '0.4.2'
+  sha256 '23c74f3db8728595afaaea4b76f48f60db1d2387ea92c84485b2175cc02388a3'
+
+  # github.com/the-expanse/SideQuest was verified as official when first introduced to the cask
+  url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"
+  appcast 'https://github.com/the-expanse/SideQuest/releases.atom'
+  name 'SideQuest'
+  homepage 'https://sidequestvr.com/'
+
+  depends_on macos: '>= :sierra'
+
+  app 'SideQuest.app'
+
+  zap trash: '~/Library/Application Support/SideQuest'
+end


### PR DESCRIPTION
Adding the application SideQuest to Homebrew Cask. SideQuest is an open app store application that makes sideloading to the Oculus Quest, Oculus Go, and Moverio BT 300 easy. It also supports patching legal copies of BeatSaber to support community-developed modifications.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
