### PR TITLE
Update aria2d from 415,1556113519 to 450,1562313341

### DIFF
--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,6 +1,6 @@
 cask 'aria2d' do
-  version '415,1556113519'
-  sha256 'f031ae48b07e46f31df52251aa80f959151a6431697b80c4be2bc40def8fcb0a'
+  version '450,1562313341'
+  sha256 '1dd2f4cd9382486f420abe9c94f23cef314bc10f5eb8bac3b52e1170d898ef26'
 
   # dl.devmate.com/com.xjbeta.Aria2D was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.xjbeta.Aria2D/#{version.before_comma}/#{version.after_comma}/Aria2D-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.