### PR TITLE
Update flipper from 0.22.0 to 0.23.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.22.0'
-  sha256 '54f09654973d3b7c4aada1f6f6c1af6a24c4416f9c23c0172ad57658c8a60132'
+  version '0.23.0'
+  sha256 '9415789435fd4baa52072ee6361ad7c7bf1399a9e4024dbb06c6868c3457d19e'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.