### PR TITLE
Update psychopy from 3.1.3 to 3.1.4

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '3.1.3'
-  sha256 'f477b08777aa7cf28626b3ea6a08ea1c1325564b03025436d16972bb0e2db594'
+  version '3.1.4'
+  sha256 '12b2036b5ea2ddb1a8b7d71d0356a31dd08db89823eb3d78436c9d4443a50172'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.