### PR TITLE
Update nozbe from 3.9.3 to 3.10.0

### DIFF
--- a/Casks/nozbe.rb
+++ b/Casks/nozbe.rb
@@ -1,6 +1,6 @@
 cask 'nozbe' do
-  version '3.9.3'
-  sha256 'ae5400dc2cb06daa08e13bdf83c4fcfa5e5e93abb2bbec69904ddb7f734db504'
+  version '3.10.0'
+  sha256 'e168c265171a0bb2cb5639a0c43b3954696b7cb5fa9e706720fde087be0f96d3'
 
   url "https://files.nozbe.com/#{version.no_dots}/release/Nozbe.app.zip"
   name 'Nozbe'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.