### PR TITLE
Update eve-launcher from 1531417 to 1533170

### DIFF
--- a/Casks/eve-launcher.rb
+++ b/Casks/eve-launcher.rb
@@ -1,6 +1,6 @@
 cask 'eve-launcher' do
-  version '1531417'
-  sha256 'c418451c6399b3a61edd81a3f4264502eaf83b60e2fbdfeb65ced8bedbb16674'
+  version '1533170'
+  sha256 'a9026d5b92a4ec5fc302bf38d6b446592f946840844cf49907dbb138b9ca64ef'
 
   url "https://binaries.eveonline.com/EveLauncher-#{version}.dmg"
   appcast 'https://launcher.eveonline.com/launcherVersions.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.