### PR TITLE
Update airdroid from 3.6.4.0 to 3.6.5.0

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
-  version '3.6.4.0'
-  sha256 'ff8326016e22f89016bbcec84991ff3152a0495ef12a520b6442802286e7d892'
+  version '3.6.5.0'
+  sha256 '497d16cf895ca81beb745dddc07e1a225d72d2e9631192aadf11db069d026478'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.