### PR TITLE
Update cisdem-data-recovery from 5.6.0 to 5.7.0

### DIFF
--- a/Casks/cisdem-data-recovery.rb
+++ b/Casks/cisdem-data-recovery.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-data-recovery' do
-  version '5.6.0'
-  sha256 'e7d586ed2e52cb77974952f4f3608bf10fd4bfad46d7bd3e251a394e9b8b89bb'
+  version '5.7.0'
+  sha256 'cf9115653d16889874e393ed8ec3fce08e7b7098549baa2ad78ca77716bf7e5c'
 
   url 'http://download.cisdem.com/cisdem-datarecovery.dmg'
   appcast 'https://www.cisdem.com/data-recovery-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.