### PR TITLE
Update sbrowserq from 3.6 to 3.6.2

### DIFF
--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -1,8 +1,8 @@
 cask 'sbrowserq' do
-  version '3.6'
-  sha256 'cd68f1df6c08ec16746b73504f789c606ebfdbe0bfd1eab04f869881f4d64b46'
+  version '3.6.2'
+  sha256 'b848b5a2e8523359cc719decd2289b882fd687a13ab7c4711e783bbf45537085'
 
-  url "https://www.sbrowser-q.com/SbrowserQ_V#{version}_mac.dmg"
+  url "https://www.sbrowser-q.com/SbrowserQ_V#{version.major_minor}_mac.dmg"
   appcast 'https://www.sbrowser-q.com/'
   name 'SbrowserQ'
   homepage 'https://www.sbrowser-q.com/'

--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -3,7 +3,8 @@ cask 'sbrowserq' do
   sha256 'b848b5a2e8523359cc719decd2289b882fd687a13ab7c4711e783bbf45537085'
 
   url "https://www.sbrowser-q.com/SbrowserQ_V#{version.major_minor}_mac.dmg"
-  appcast 'https://www.sbrowser-q.com/'
+  appcast 'https://www.sbrowser-q.com/',
+          configuration: version.major_minor
   name 'SbrowserQ'
   homepage 'https://www.sbrowser-q.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.