### PR TITLE
Update transtype from 4 to 5099

### DIFF
--- a/Casks/transtype.rb
+++ b/Casks/transtype.rb
@@ -1,9 +1,9 @@
 cask 'transtype' do
-  version '4'
+  version '5099'
   sha256 :no_check # required as upstream package is updated in-place
 
-  # fontlab.us was verified as official when first introduced to the cask
-  url "http://www.fontlab.us/downloads/installers/TR#{version}MacFull.dmg"
+  # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://fontlab.s3.amazonaws.com/transtype-4/5099/TR4MacFull-#{version}.dmg"
   name 'TransType'
   homepage 'https://www.fontlab.com/font-converter/transtype/'
 

--- a/Casks/transtype.rb
+++ b/Casks/transtype.rb
@@ -1,11 +1,11 @@
 cask 'transtype' do
-  version '5099'
+  version '4,5099'
   sha256 :no_check # required as upstream package is updated in-place
 
   # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://fontlab.s3.amazonaws.com/transtype-4/5099/TR4MacFull-#{version}.dmg"
+  url "https://fontlab.s3.amazonaws.com/transtype-4/5099/TR4MacFull-#{version.after_comma}.dmg"
   name 'TransType'
   homepage 'https://www.fontlab.com/font-converter/transtype/'
 
-  app "TransType #{version}.app"
+  app "TransType #{version.before_comma}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.