### PR TITLE
Update a-better-finder-rename from 10.42 to 10.43

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,6 +1,6 @@
 cask 'a-better-finder-rename' do
-  version '10.42'
-  sha256 '2c16c54d734bb015fdf5c9b5dd62c0e36d1054336c03f25c3f7528868cf0c90c'
+  version '10.43'
+  sha256 '5e3e4cf46cd5612e5c39f65466fa0987c865f12e92c629c9d33aab183b358e1f'
 
   url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
   appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"

--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -2,10 +2,10 @@ cask 'a-better-finder-rename' do
   version '10.43'
   sha256 '5e3e4cf46cd5612e5c39f65466fa0987c865f12e92c629c9d33aab183b358e1f'
 
-  url "http://www.publicspace.net/download/ABFRX#{version.major}.dmg"
-  appcast "http://www.publicspace.net/app/signed_abfr#{version.major}.xml"
+  url "https://www.publicspace.net/download/ABFRX#{version.major}.dmg"
+  appcast "https://www.publicspace.net/app/signed_abfr#{version.major}.xml"
   name 'A Better Finder Rename'
-  homepage 'http://www.publicspace.net/ABetterFinderRename/'
+  homepage 'https://www.publicspace.net/ABetterFinderRename/'
 
   auto_updates true
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.