### PR TITLE
Update whatsapp from 0.3.3790 to 0.3.3792

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'whatsapp' do
-  version '0.3.3790'
-  sha256 'aa3edd638be4527b2af23f76d77b571e6242e718c8c7c48e2136a7dba3480df4'
+  version '0.3.3792'
+  sha256 '530a7aed7eda61556361258c1fb03bf5f685cb61d9808522a6a39f17311db05d'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.