### PR TITLE
Update soulver from 3.0.3-25 to 3.0.4-32

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,6 +1,6 @@
 cask 'soulver' do
-  version '3.0.3-25'
-  sha256 '933d039fd2fa24f9a900dcaa9fda1f7312bd134dc0c8dec477064433c26aaab3'
+  version '3.0.4-32'
+  sha256 '58b3b371987311a565f589f1af0c647866359fdf7776cc1b1f01d43d05a092e2'
 
   url "https://soulver.app/mac/sparkle/soulver-#{version}.zip"
   appcast 'https://soulver.app/mac/sparkle/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.