### PR TITLE
Update vmware-horizon-client from 5.0.0-12557381,CART20FQ1 to 5.1.0-13920831,CART20FQ2

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -1,6 +1,6 @@
 cask 'vmware-horizon-client' do
-  version '5.0.0-12557381,CART20FQ1'
-  sha256 'ac3c7338c536c766ac2bad7f4f9b98a9e970c1c053beae2941d5f449829f7328'
+  version '5.1.0-13920831,CART20FQ2'
+  sha256 '2341c1e1265b38117b74660d748b4625edf1248bfc86932523d1abf947b005db'
 
   url "https://download3.vmware.com/software/view/viewclients/#{version.after_comma}/VMware-Horizon-Client-#{version.before_comma}.dmg"
   appcast 'https://docs.vmware.com/en/VMware-Horizon-Client-for-Mac/'

--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -3,7 +3,8 @@ cask 'vmware-horizon-client' do
   sha256 '2341c1e1265b38117b74660d748b4625edf1248bfc86932523d1abf947b005db'
 
   url "https://download3.vmware.com/software/view/viewclients/#{version.after_comma}/VMware-Horizon-Client-#{version.before_comma}.dmg"
-  appcast 'https://docs.vmware.com/en/VMware-Horizon-Client-for-Mac/'
+  appcast 'https://docs.vmware.com/en/VMware-Horizon-Client-for-Mac/',
+          configuration: version.major_minor
   name 'VMware Horizon Client'
   homepage 'https://www.vmware.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.