### PR TITLE
Update eclipse-cpp from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-cpp' do
-  version '4.11.0,2019-03:R'
-  sha256 'ca95ee6c442b0d43e9fa03374a869b335ba1f14c113f7b08e59bde66f7700c5b'
+  version '4.12.0,2019-06:R'
+  sha256 'f37d1a77ceb538f1a3a766b23b19e6e77814c008735b29b354f206ea20baa040'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-cpp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for C/C++ Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.