### PR TITLE
Update eclipse-dsl from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-dsl.rb
+++ b/Casks/eclipse-dsl.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-dsl' do
-  version '4.11.0,2019-03:R'
-  sha256 'e89c05977cbcc53b2127663953366765b64efce9b1c6c3d6f7baf4eb75d52043'
+  version '4.12.0,2019-06:R'
+  sha256 'c3c9e41f1e4a0c521be2613f849ab9363d6d2661478a9a35eca61b1d7339c398'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-dsl-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java and DSL Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.