### PR TITLE
Update eclipse-ide from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.11.0,2019-03:R'
-  sha256 '1b2aa90766c3e7e2fcb8aefcdf7e877e87b4b5b398fb41b7aef0f701e72a170c'
+  version '4.12.0,2019-06:R'
+  sha256 'c2f05fa10a6151f8f41cec3c028f4ec1bef7153cc86b46d06d0eacbdf14d1b5f'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.