### PR TITLE
Update eclipse-modeling from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-modeling' do
-  version '4.11.0,2019-03:R'
-  sha256 '91a01856a9dd33a5b6e8d9d5d4acb19e75ee06afb18919090fd6d7a46aedeac9'
+  version '4.12.0,2019-06:R'
+  sha256 '8b0c958a5b2e7d4e388341ca0dc8b0fbd72469a84f052d4a0f789aa0bc33b4ff'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-modeling-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse Modeling Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.