### PR TITLE
Update eclipse-ptp from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ptp' do
-  version '4.11.0,2019-03:R'
-  sha256 'dae4fb9ed0ca62a9ffd520181b123f77bddf9a024eab45598563e4339e4bc7b0'
+  version '4.12.0,2019-06:R'
+  sha256 '09cc4c205fb7b292f2f4ca3980b2fd4fa3a98c3f069cbb37a3a422de75959582'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-parallel-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for Parallel Application Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.