### PR TITLE
Update eclipse-rcp from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-rcp' do
-  version '4.11.0,2019-03:R'
-  sha256 '321239b909da255f13955514ed3098d533603f97441b9700ef22fa9dc42dc182'
+  version '4.12.0,2019-06:R'
+  sha256 '90a63d402d7422b886fda45962bee0824cfc529e9594d92f03a679219b492402'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-rcp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for RCP and RAP Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.