### PR TITLE
Update eclipse-scout from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-scout.rb
+++ b/Casks/eclipse-scout.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-scout' do
-  version '4.11.0,2019-03:R'
-  sha256 'eaebe6dbfd2d563d49fbd3fd32aef8ce19113d1b86c839d0bd2835f968bf01f3'
+  version '4.12.0,2019-06:R'
+  sha256 '09249b233f49664c3729e7c1bec19631a6fca35e051dbb5132fc6909671a32b7'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-scout-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for Scout Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.