### PR TITLE
Update eclipse-testing from 4.11.0,2019-03:R to 4.12.0,2019-06:R

### DIFF
--- a/Casks/eclipse-testing.rb
+++ b/Casks/eclipse-testing.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-testing' do
-  version '4.11.0,2019-03:R'
-  sha256 '6dfdcfeddbe1feada08bc6521382c3e9e97de3d55581769828baa880f6fd9f42'
+  version '4.12.0,2019-06:R'
+  sha256 'b0cdaba4c66762ea1878ec0ed081c78a7d16aff34a8ffd74085a398bcff2ab41'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-testing-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for Testers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.