### PR TITLE
Update gisto from 1.12.2 to 1.12.3

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.12.2'
-  sha256 '34ddec96777205c82bdbaca90b50ecce04006ea92051895fb3a7ef99e87ed2ba'
+  version '1.12.3'
+  sha256 '1bd3180cf78987bf841c0c39ffce4925b58e66b8ef00f18e24f26ad232cd5276'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.