### PR TITLE
Update journey from 2.12.9 to 2.12.11

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,6 +1,6 @@
 cask 'journey' do
-  version '2.12.9'
-  sha256 'b99281dd8b9bdfc9e9d57a86af9b5c38a3f8aff1df936c48c1677cf6f0991364'
+  version '2.12.11'
+  sha256 '569ac0befbee48f75f73f53728de0749d2994c96cbce61cf10401905e8385bfb'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
   url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.