### PR TITLE
Update tagspaces from 3.1.4 to 3.1.6

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask 'tagspaces' do
-  version '3.1.4'
-  sha256 '563cdddaf9e48f3cafa60a245cb3ef332f15f9d90d1f58de0dbb9cba0d8fd73d'
+  version '3.1.6'
+  sha256 'b556439397b2f16554efa7f3f7ce21b626523a19b2735d3d984fd65e21e45f5c'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.