### PR TITLE
Update terminus from 1.0.82 to 1.0.85

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,9 +1,9 @@
 cask 'terminus' do
-  version '1.0.82'
-  sha256 '2e00b814031e1bef2ced9aa49c4ed87c3fee21545a038259553dbd34f48c98af'
+  version '1.0.85'
+  sha256 'd7f2c521adeae20d1f4fa64e757820f4a5e19035d28ae2b2b9ebe61ddf8dde3e'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
-  url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.dmg"
+  url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.zip"
   appcast 'https://github.com/Eugeny/terminus/releases.atom'
   name 'Terminus'
   homepage 'https://eugeny.github.io/terminus/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.