### PR TITLE
Update double-commander from 0.9.3-8847 to 0.9.4-8936

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,6 +1,6 @@
 cask 'double-commander' do
-  version '0.9.3-8847'
-  sha256 'ecb8c9335ae178c5e1f29c0781315dc712e9567470d43c21ea6ffb517e0eb7da'
+  version '0.9.4-8936'
+  sha256 'f4b1a1302fb1c33c579349776221ea1e6e8c45958dfd0409a95af2f5bc73af5a'
 
   # downloads.sourceforge.net/doublecmd was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.