### PR TITLE
Update garagesale from 7.0.17 to 7.0.18

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -3,7 +3,7 @@ cask 'garagesale' do
   sha256 '52c1bcbf249c3f2b42dd1eaf69e7028169bc9968d4111f43dbd706356ba5b77f'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
-  appcast 'https://www.iwascoding.com/cgi-bin/version_check.cgi?GZIP=1&APPLICATION=GarageSale&APP_BUNDLE_VERSION=800'
+  appcast "https://www.iwascoding.com/cgi-bin/version_check.cgi?APPLICATION=GarageSale&APP_BUNDLE_VERSION=#{version.major}00"
   name 'GarageSale'
   homepage 'https://www.iwascoding.com/GarageSale/'
 

--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,9 +1,9 @@
 cask 'garagesale' do
-  version '7.0.17'
-  sha256 '89590b6e45b9a6d44cedc652ef39af64359fc8090109403162c3a5457a6bc562'
+  version '7.0.18'
+  sha256 '52c1bcbf249c3f2b42dd1eaf69e7028169bc9968d4111f43dbd706356ba5b77f'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
-  appcast 'https://rink.hockeyapp.net/api/2/apps/b83b659a4c853a6138def4da94c6fcdd.rss'
+  appcast 'https://www.iwascoding.com/cgi-bin/version_check.cgi?GZIP=1&APPLICATION=GarageSale&APP_BUNDLE_VERSION=800'
   name 'GarageSale'
   homepage 'https://www.iwascoding.com/GarageSale/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.