### PR TITLE
Update telegram from 5.5-175930 to 5.5-175951

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '5.5-175930'
-  sha256 '7bfa0f28df41d0c78ac5c457fc9883f4de9ddd4928981ba215817c857043b7fb'
+  version '5.5-175951'
+  sha256 '6a02801c282cf9d869517f069c3d68dc2cc6e755146934b7d296caa2571d9bd4'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.