### PR TITLE
Update gisto from 1.12.4 to 1.12.5

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.12.4'
-  sha256 '98f3061866d89eb5194a2405328f70aaa56efdb7e6ada390244e9f93ef82a858'
+  version '1.12.5'
+  sha256 'c9e70ba017ed022a17976bc6cacab495d5641b95e84ff977078493fd4eb52401'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.