### PR TITLE
Update majsoul-plus from 1.11.2 to 1.12.1

### DIFF
--- a/Casks/majsoul-plus.rb
+++ b/Casks/majsoul-plus.rb
@@ -1,6 +1,6 @@
 cask 'majsoul-plus' do
-  version '1.11.2'
-  sha256 '380225037efd0c3347266ff00e8bcf2c94e0926499b459101e8f9d12a27aa6a9'
+  version '1.12.1'
+  sha256 'f7f2df64930dc38bd55d1e8f9495158981e04faad5304c0ef372e2653f81bc3a'
 
   url "https://github.com/MajsoulPlus/majsoul-plus/releases/download/v#{version}/Majsoul_Plus-darwin.dmg"
   appcast 'https://github.com/MajsoulPlus/majsoul-plus/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.