### PR TITLE
Update qownnotes from 19.7.1,b4357-174238 to 19.7.2,b4361-141852

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.7.1,b4357-174238'
-  sha256 '638a357b856c5afb84010d710518c9ba7c9b253873e3f4d49b882a929b73ebcf'
+  version '19.7.2,b4361-141852'
+  sha256 '20ba7d2f7ca6d81b8988309f503052e4a9903121eade26ae6d809a9efb8cdb28'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.