### PR TITLE
Update sbrowserq from 3.6.2 to 3.6.3

### DIFF
--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -1,5 +1,5 @@
 cask 'sbrowserq' do
-  version '3.6.2'
+  version '3.6.3'
   sha256 'b848b5a2e8523359cc719decd2289b882fd687a13ab7c4711e783bbf45537085'
 
   url "https://www.sbrowser-q.com/SbrowserQ_V#{version.major_minor}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.