### PR TITLE
Update wraparound from 2.0b3-2020 to 2.0-2021

### DIFF
--- a/Casks/wraparound.rb
+++ b/Casks/wraparound.rb
@@ -1,6 +1,6 @@
 cask 'wraparound' do
-  version '2.0b3-2020'
-  sha256 '6b7626af484bc6070cb822197dbe22014b3a1433ac072caf57d5272ada2437f2'
+  version '2.0-2021'
+  sha256 '4efd0a5051b2ab0487e7d3d4f33093f0d6f23ff0d203d0fc3d66facd6e893474'
 
   url "https://www.digicowsoftware.com/downloads/Wraparound#{version}.zip"
   appcast 'https://www.digicowsoftware.com/detail?_app=Wraparound'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.