### PR TITLE
Update veraview from 2.4.3 to 3.0.1

### DIFF
--- a/Casks/veraview.rb
+++ b/Casks/veraview.rb
@@ -10,5 +10,6 @@ cask 'veraview' do
 
   pkg 'veraview.pkg'
 
-  uninstall pkgutil: 'gov.casl.VERAView'
+  uninstall pkgutil: 'gov.casl.VERAView',
+            delete: '/Applications/VERAView.app'
 end

--- a/Casks/veraview.rb
+++ b/Casks/veraview.rb
@@ -10,5 +10,5 @@ cask 'veraview' do
 
   pkg 'veraview.pkg'
 
-  uninstall pkgutil: 'veraview'
+  uninstall pkgutil: 'gov.casl.VERAView'
 end

--- a/Casks/veraview.rb
+++ b/Casks/veraview.rb
@@ -8,5 +8,7 @@ cask 'veraview' do
   name 'veraview'
   homepage 'https://github.com/CASL/VERAview'
 
-  app 'VERAView.app'
+  pkg 'veraview.app'
+  
+  uninstall pkgutil: 'veraview'  
 end

--- a/Casks/veraview.rb
+++ b/Casks/veraview.rb
@@ -1,6 +1,6 @@
 cask 'veraview' do
-  version '2.4.3'
-  sha256 '57c7a10cb232ff69294f2aad731d84d3b6ced53ce6650bd4c48f1bb30bbbec80'
+  version '3.0.1'
+  sha256 'e457a2a9cca850ef0e7c264fb91ef14739804cba3417a552997fe0194fb87dda'
 
   # newton.ornl.gov/casl was verified as official when first introduced to the cask
   url "https://newton.ornl.gov/casl/VERAView-#{version}-MacOSX.dmg"

--- a/Casks/veraview.rb
+++ b/Casks/veraview.rb
@@ -8,7 +8,7 @@ cask 'veraview' do
   name 'veraview'
   homepage 'https://github.com/CASL/VERAview'
 
-  pkg 'veraview.app'
-  
-  uninstall pkgutil: 'veraview'  
+  pkg 'veraview.pkg'
+
+  uninstall pkgutil: 'veraview'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.