### PR TITLE
Update double-commander from 0.9.4-8936 to 0.9.5-8947

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,6 +1,6 @@
 cask 'double-commander' do
-  version '0.9.4-8936'
-  sha256 'f4b1a1302fb1c33c579349776221ea1e6e8c45958dfd0409a95af2f5bc73af5a'
+  version '0.9.5-8947'
+  sha256 '924e9a25b872ccbb91eacb44bc4a7a4f99a6136c718d2d94a87768deb68cfa85'
 
   # downloads.sourceforge.net/doublecmd was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.