### PR TITLE
Update mongodb-compass-readonly from 1.15.2 to 1.18.0

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.15.2'
-  sha256 '304d6787a1d50d351f37455c0b1744ff1c1c688c0f8b133fa6f3c006640e42f7'
+  version '1.18.0'
+  sha256 '76652eea53584c70ac838005c97c03e150ccb321aa09f1cc6b8ad230401014df'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass Readonly'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.