### PR TITLE
Update mongodb-compass-isolated-edition from 1.15.2 to 1.18.0

### DIFF
--- a/Casks/mongodb-compass-isolated-edition.rb
+++ b/Casks/mongodb-compass-isolated-edition.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-isolated-edition' do
-  version '1.15.2'
-  sha256 '743cf33e9e09306a58e2f88f8ef2cd9b7dfcfd8ba37eef9938ceacbf35bf433b'
+  version '1.18.0'
+  sha256 '33841ca51d9fcd04dcaebf84e2950de25f02a0b1e543e260ee01f7292e5cf923'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-isolated-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass Isolated'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.