### PR TITLE
Update mockplus from 3.4.1.2 to 3.5.1.0

### DIFF
--- a/Casks/mockplus.rb
+++ b/Casks/mockplus.rb
@@ -1,9 +1,10 @@
 cask 'mockplus' do
-  version '3.4.1.2'
-  sha256 '5cb79d9066fb9a148a546b58c3b07909e9b13c971329ed47210e616c08b22ab5'
+  version '3.5.1.0'
+  sha256 'f14c2e12ca130d25b62a4f7da7db7af09cfecc5cb2170cae924bcc4872d6beb9'
 
   # mockplus-static.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://mockplus-static.s3.amazonaws.com/software/macos/Mockplus_v#{version}.dmg"
+  appcast 'https://www.mockplus.com/download'
   name 'Mockplus'
   name '摩客'
   homepage 'https://www.mockplus.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.