### PR TITLE
Update netron from 3.2.4 to 3.2.5

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.2.4'
-  sha256 '57a2dbbf9a0ac2e79fae7417e505501498ec4e551cf29dc8bf7219ca05cc9c46'
+  version '3.2.5'
+  sha256 '3db911ca75527801adf2e5ad429579ef6cf24cda72ecb8e86c27af85c5ae885c'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.