### PR TITLE
Update netron from 3.2.5 to 3.2.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.2.5'
-  sha256 '3db911ca75527801adf2e5ad429579ef6cf24cda72ecb8e86c27af85c5ae885c'
+  version '3.2.6'
+  sha256 '98ebd111e6ae8d371850834f54873658968a8fe6a34eac6fae47ea5c7a96b448'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.