### PR TITLE
Update scratch from 3.3.0 to 3.4.0

### DIFF
--- a/Casks/scratch.rb
+++ b/Casks/scratch.rb
@@ -1,6 +1,6 @@
 cask 'scratch' do
-  version '3.3.0'
-  sha256 'e1cfa639dd796f0ac3c0cd4743c90396a10a80c82ca0f3cfc08ea514ebe3d5bf'
+  version '3.4.0'
+  sha256 'bfe3d9ca5045d78d3d34455b54f3154fcdaaa9e4146f63e52da44b0c51e67440'
 
   url "https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-#{version}.dmg"
   name 'Scratch'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.