### PR TITLE
Update hashbackup from 2347 to 2367

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,6 +1,6 @@
 cask 'hashbackup' do
-  version '2347'
-  sha256 '571f48bd345ff70d3176b7780a6431c72cfbd245d945b2d77df0d6e34e41048b'
+  version '2367'
+  sha256 'd26d0e0cff93d92dd867c643c9a478e6de99bd443c7642b5ef5ef8a28add71b7'
 
   url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.x86_64.bz2"
   name 'hashbackup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.