### PR TITLE
Update musescore from 3.2.2 to 3.2.3

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,9 +1,9 @@
 cask 'musescore' do
-  version '3.2.2'
-  sha256 '6b238ee08096a15e153c5da43ede03ea887f10edd696bc15dca1ff1db9266ffc'
+  version '3.2.3'
+  sha256 '22222dcbaf784f04f3dff5c8fd84597d56d54f4f846f77ea4b74be3b5924ce5a'
 
   # github.com/musescore/MuseScore was verified as official when first introduced to the cask
-  url "https://github.com/musescore/MuseScore/releases/download/v#{version}/Musescore-#{version}.dmg"
+  url "https://github.com/musescore/MuseScore/releases/download/v#{version}/MuseScore-#{version}.dmg"
   appcast 'https://github.com/musescore/MuseScore/releases.atom'
   name 'MuseScore'
   homepage 'https://musescore.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.