### PR TITLE
Update textmate from 2.0-rc.24 to 2.0-rc.27

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,6 +1,6 @@
 cask 'textmate' do
-  version '2.0-rc.24'
-  sha256 'e359be94be7359c67c91c9fe018c678a3f6668619190d7805d36d5dfbe99c9bf'
+  version '2.0-rc.27'
+  sha256 'b54adbbe60171c51a4b9a04192e64d8f70b7752244d9e510dc49a83ca6c14265'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.