### PR TITLE
Update avocode from 3.8.1 to 3.8.3

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '3.8.1'
-  sha256 '78f14d434512b4ef7fbdf92cfe98c429238bed1391fe638968f7c23509d096d5'
+  version '3.8.3'
+  sha256 'c0c72f5f7cb577fd7faa4f8beb4683fb6e0ca7e6c332dc1937977dcbc579f09f'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.