### PR TITLE
Update josm from 15155 to 15234

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask 'josm' do
-  version '15155'
-  sha256 '9757b9c06e52b9630351ad023c51c3429659e056fd7a0d813120483717cfac0b'
+  version '15234'
+  sha256 '6fe3f7d38b2b44e45da5c89382ce08ebc513c658373271bc93c236e210df1b0b'
 
   url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
   appcast 'https://josm.openstreetmap.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.