### PR TITLE
Update ghost-browser from 2.1.1.1 to 2.1.1.2

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.1'
-  sha256 'aa58712cfdbffb697f9917716d665d28d1759447d854e816a4c49f4d18dc4bce'
+  version '2.1.1.2'
+  sha256 '0d8ebaaef70e6770787cfecd98f7d022d761a27f9dd92b52579352923e97f80d'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.