### PR TITLE
Update burn from 2.5.1 to 2.6.1

### DIFF
--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -1,9 +1,9 @@
 cask 'burn' do
-  version '2.5.1'
-  sha256 '496b460f09177580c5a3400448c0e399954105147baf1e6fff3fa14dc58031f7'
+  version '2.6.1'
+  sha256 '08887e71be3448a0226f09f3a950dc9686e0c7c46cd98074fb11f8c72565010a'
 
   # downloads.sourceforge.net/burn-osx was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn#{version.no_dots}-64bit.zip"
+  url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn#{version.no_dots}.zip"
   appcast 'https://sourceforge.net/projects/burn-osx/rss?path=/Burn'
   name 'Burn'
   homepage 'https://burn-osx.sourceforge.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.