### PR TITLE
Update bettertouchtool from 3.101 to 3.102

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.101'
-    sha256 'f24314b12bbe588a62d2bb26a7f4bede815f2971ffe72c17d3f25afc04cd0305'
+    version '3.102'
+    sha256 '98b924621fb4af92fd0ec2f2c78a13fcc6a16703078cd0420651c398a3fac7e3'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.