### PR TITLE
zoomus: kill and remove persistent webserver

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -22,7 +22,7 @@ cask 'zoomus' do
                     ],
             login_item: 'ZoomOpener',
             delete:     [
-                          '/Applications/zoom.us.app'
+                          '/Applications/zoom.us.app',
                           '~/.zoomus/ZoomOpener.app',
                           '~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin'
                         ]

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -19,7 +19,7 @@ cask 'zoomus' do
             quit:   'us.zoom.ZoomOpener',
             signal: [
                       ['KILL', 'us.zoom.xos'],
-                    ]
+                    ],
             login_item: 'ZoomOpener',
             delete:     '~/.zoomus/ZoomOpener.app'
 

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -15,11 +15,10 @@ cask 'zoomus' do
     set_ownership '~/Library/Application Support/zoom.us'
   end
 
-  uninstall delete: '/Applications/zoom.us.app',
-            quit:   'us.zoom.ZoomOpener',
-            signal: [
-                      ['KILL', 'us.zoom.xos'],
-                    ],
+  uninstall quit:       'us.zoom.ZoomOpener',
+            signal:     [
+                          ['KILL', 'us.zoom.xos'],
+                        ],
             login_item: 'ZoomOpener',
             delete:     [
                           '/Applications/zoom.us.app',

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -23,7 +23,7 @@ cask 'zoomus' do
             delete:     [
                           '/Applications/zoom.us.app',
                           '~/.zoomus/ZoomOpener.app',
-                          '~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin'
+                          '~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin',
                         ]
 
   zap trash: [

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -21,7 +21,10 @@ cask 'zoomus' do
                       ['KILL', 'us.zoom.xos'],
                     ],
             login_item: 'ZoomOpener',
-            delete:     '~/.zoomus/ZoomOpener.app'
+            delete:     [
+                          '/Applications/zoom.us.app'
+                          '~/.zoomus/ZoomOpener.app',
+                        ]
 
   zap trash: [
                '~/.zoomus',

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -24,6 +24,7 @@ cask 'zoomus' do
             delete:     [
                           '/Applications/zoom.us.app'
                           '~/.zoomus/ZoomOpener.app',
+                          '~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin'
                         ]
 
   zap trash: [

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -15,19 +15,13 @@ cask 'zoomus' do
     set_ownership '~/Library/Application Support/zoom.us'
   end
 
-  uninstall quit:       [
-                          'us.zoom.xos',
-                          'us.zoom.ZoomOpener',
-                        ],
-            signal:     [
-                          ['KILL', 'us.zoom.xos'],
-                          ['KILL', 'us.zoom.ZoomOpener'],
-                        ],
+  uninstall delete: '/Applications/zoom.us.app',
+            quit:   'us.zoom.ZoomOpener',
+            signal: [
+                      ['KILL', 'us.zoom.xos'],
+                    ]
             login_item: 'ZoomOpener',
-            delete:     [
-                          '/Applications/zoom.us.app',
-                          '~/.zoomus/ZoomOpener.app',
-                        ]
+            delete:     '~/.zoomus/ZoomOpener.app'
 
   zap trash: [
                '~/.zoomus',

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -15,13 +15,22 @@ cask 'zoomus' do
     set_ownership '~/Library/Application Support/zoom.us'
   end
 
-  uninstall delete: '/Applications/zoom.us.app',
-            quit:   'us.zoom.ZoomOpener',
-            signal: [
-                      ['KILL', 'us.zoom.xos'],
-                    ]
+  uninstall quit:       [
+                          'us.zoom.xos',
+                          'us.zoom.ZoomOpener',
+                        ],
+            signal:     [
+                          ['KILL', 'us.zoom.xos'],
+                          ['KILL', 'us.zoom.ZoomOpener'],
+                        ],
+            login_item: 'ZoomOpener',
+            delete:     [
+                          '/Applications/zoom.us.app',
+                          '~/.zoomus/ZoomOpener.app',
+                        ]
 
   zap trash: [
+               '~/.zoomus',
                '~/Desktop/Zoom',
                '~/Library/Application Support/zoom.us',
                '~/Library/Caches/us.zoom.xos',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

Remove persistent webserver that's installed along with Zoom when uninstalling.

ref: https://medium.com/@jonathan.leitschuh/zoom-zero-day-4-million-webcams-maybe-an-rce-just-get-them-to-visit-your-website-ac75c83f4ef5