### PR TITLE
Update Chromium from 675289 to 675525  

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
   version '675525'
-  sha256 'f4a594a2623d2479d0afc733893f3b57ec24b9c88061d94637e3adb44ca89ae5' 
+  sha256 'f4a594a2623d2479d0afc733893f3b57ec24b9c88061d94637e3adb44ca89ae5'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '675289'
-  sha256 '65833d193327fb822ccfd4dbf7a1162b688855f298111ad3973bf916c483aa00'
+  version '675525'                                                                                                                                                                              
+  sha256 'f4a594a2623d2479d0afc733893f3b57ec24b9c88061d94637e3adb44ca89ae5' 
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,5 +1,5 @@
 cask 'chromium' do
-  version '675525'                                                                                                                                                                              
+  version '675525'
   sha256 'f4a594a2623d2479d0afc733893f3b57ec24b9c88061d94637e3adb44ca89ae5' 
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).