### PR TITLE
Update notable from 1.5.1 to 1.6.0

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.5.1'
-  sha256 'a44c9d571342e84bddc7cbcd9bf5310039991898828e605934e23719dd4285ef'
+  version '1.6.0'
+  sha256 '825a306ed960423cf9d2c4970edbdcea5432dd04cf031ee83f00ad340be49aa7'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.