### PR TITLE
Update blitz from 1.0.7 to 1.0.8

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.0.7'
-  sha256 '5d9ecf8aaed8c18ecbe3383c1d07267708028cb2f06c2810d4e1ba5afa3713d9'
+  version '1.0.8'
+  sha256 '8bdf26265fe0a2fd64d3fed7ee19836ed56c7e12dd669fabcf43313e3da13abe'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.