### PR TITLE
Update unity-ios-support-for-editor from 2019.1.8f1,7938dd008a75 to 2019.1.9f1,d5f1b37da199

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.1.8f1,7938dd008a75'
-  sha256 'c4fdb70f3fc8fb461e0e1c34704559abbf0687ff6d94c6996b90048f364d3a6d'
+  version '2019.1.9f1,d5f1b37da199'
+  sha256 '58c3361f37861efbea2048533291e01ea8dc3ae2db9ef7328dd29dd469629a60'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.