### PR TITLE
Update unity-linux-support-for-editor from 2019.1.8f1,7938dd008a75 to 2019.1.9f1,d5f1b37da199

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.1.8f1,7938dd008a75'
-  sha256 'befbf198909090b2da1ef2c37ccd5e563e5ae984e235294fb65dbbc951437ca7'
+  version '2019.1.9f1,d5f1b37da199'
+  sha256 'e5356d09b18a16c4ec3c65a91a60dd41f3670049b378ea74d6a0c5d1bdfc4ffe'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.