### PR TITLE
Update notable from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.6.0'
-  sha256 '825a306ed960423cf9d2c4970edbdcea5432dd04cf031ee83f00ad340be49aa7'
+  version '1.6.1'
+  sha256 'b898f849ac10c7ce0b836f2afab7e51f176dfb68a55c30aae6d0a8026513e588'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.