### PR TITLE
Update thedesk from 18.6.6 to 18.6.7

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.6.6'
-  sha256 '9bc157bdb2b3d54313006859fbbc61ef9afbbde13bf6ab9319ed2dcae9d977e5'
+  version '18.6.7'
+  sha256 '1feed8cf06330f2e41a7ae25466db93d72816058c43d17bdeafffd9fe96abdcb'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.