### PR TITLE
Update remembear from 1.4.3 to 1.4.4

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.4.3'
-  sha256 '8463cff3d914ef4049628c28c95ce61ae78e2fd339f002e84bf1c9a9c05a08e1'
+  version '1.4.4'
+  sha256 '190a23eb4687659c98cb21e8d7f5c30fa332c6f6b0f99ebce17c4c6a914ba2af'
 
   # remembear.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://remembear.s3.amazonaws.com/app/release/downloads/macOS/RememBear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.