### PR TITLE
Update rhinoceros from 5.5.3 to 5.5.4

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,6 +1,6 @@
 cask 'rhinoceros' do
-  version '5.5.3'
-  sha256 '6464801a959fd7528ba386c02d244add6abf457da4558059ebc66acd731ff327'
+  version '5.5.4'
+  sha256 '385af9460b669a8e34296f1194c04f274e11b8e2aea3dd234498a0c729f00e73'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/#{version.major}.0/Mac/Rhinoceros_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.