### PR TITLE
Update macgamestore from 3.4.0,5093 to 3.4.1,5094

### DIFF
--- a/Casks/macgamestore.rb
+++ b/Casks/macgamestore.rb
@@ -1,6 +1,6 @@
 cask 'macgamestore' do
-  version '3.4.0,5093'
-  sha256 'bcea63ea0c34aa823340a2d03d8eb30b650a613c987202fa1fab40bfbfb1f32f'
+  version '3.4.1,5094'
+  sha256 '8e7f4de54c956d9ba77b76437bcd51dec9c6ca423d29621b690a6fa9d9a018d7'
 
   url "https://www.macgamestore.com/api_clientapp/clientupdates/public/core5/MacGameStore_#{version.before_comma}_#{version.after_comma}.tgz"
   appcast 'https://www.macgamestore.com/api_clientapp/clientupdates/public/update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.