### PR TITLE
Update slite from 1.0.23 to 1.1.0

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.0.23'
-  sha256 '6648fbf3722b80147192ee3d332377a6c920bfbd219d4aeaf1dee585ca04a760'
+  version '1.1.0'
+  sha256 '45dbfdd803fdee3e6afe5028f793c887d3d1a743f7ffeba4070643fb82dab1ca'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.