### PR TITLE
Update blue-jeans from 2.13.1.17 to 2.14.0.487

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.13.1.17'
-  sha256 'e7a5f5faa69000906bb30da34edc415d297174b4c463dd186c00125be58140c9'
+  version '2.14.0.487'
+  sha256 'bb55e0c2c65d1ed748c1db3c7e13255e57b9f29930da4b2a7f8d1f164791fe11'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   appcast 'https://www.bluejeans.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.