### PR TITLE
Update omegat from 3.6.0_11 to 4.3.0

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -8,7 +8,7 @@ cask 'omegat' do
   name 'OmegaT'
   homepage 'https://omegat.org/'
 
-  app 'OmegaT.app'
+  app "OmegaT_#{version}_Mac_Signed/OmegaT.app"
 
   caveats do
     depends_on_java '8+'

--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,9 +1,9 @@
 cask 'omegat' do
-  version '3.6.0_11'
-  sha256 'c685471966ad22c8564a923e2e8c9cd99cc6d6b87d723cfd00f3486f49990db9'
+  version '4.3.0'
+  sha256 '0beccd1bcc4633e65f4ed272aaf946c95b17e5d343b39a90a7b742f2768b065b'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}%20update%204/OmegaT_#{version}_Mac_Signed.zip"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}/OmegaT_#{version}_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard'
   name 'OmegaT'
   homepage 'https://omegat.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.