### PR TITLE
Update yandex-disk from 3.1.4,30 to 3.1.6,30

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
-  version '3.1.4,30'
-  sha256 '2a64a4c1297f84c967459747891ad138966f93cf091b895070dcf23389c457cd'
+  version '3.1.6,30'
+  sha256 '62b8d3a9d6f6b7e01af7c20031f02487198ece58b76cf78a19dc662e7db06059'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.after_comma}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.