### PR TITLE
Update cutter from 1.8.2 to 1.8.3

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.8.2'
-  sha256 '1f1775626d1fa9f454a0cd781ee053237f20dbd048019978a6c17bbef64bcfa9'
+  version '1.8.3'
+  sha256 '02cf1b247767f683fc5179da6070427e37c51727ad89e1893a57e66152fa1ead'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.