### PR TITLE
Update notable from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.6.1'
-  sha256 'b898f849ac10c7ce0b836f2afab7e51f176dfb68a55c30aae6d0a8026513e588'
+  version '1.6.2'
+  sha256 '3549c247834300deefe81b280d602bec5de82e64cae93ea77d8c73a1f8af00ec'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

 * [x] brew cask audit --download --appcast --token-conflicts {{cask_file}} is error-free.
 * [x] brew cask style --fix {{cask_file}} left no offenses.
 * [x] The commit message includes the cask’s name and version.