### PR TITLE
Update dosbox from 0.74-2 to 0.74-3

### DIFF
--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -1,9 +1,9 @@
 cask 'dosbox' do
-  version '0.74-2'
-  sha256 '8bdd3731404db05f9bbe14bb0226ae4e6feb3f9a21a90bbfc9235a7e6e71aa4e'
+  version '0.74-3'
+  sha256 'd2ceb2d2b28f03b4c9ca2455bfe08677e78ef8f1a6263b81e7095d237ab26b0d'
 
   # sourceforge.net/dosbox was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/dosbox/dosbox/#{version}/DOSBox-#{version}_Universal.dmg"
+  url "https://downloads.sourceforge.net/dosbox/dosbox/#{version}/DOSBox-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/dosbox/rss?path=/dosbox'
   name 'DOSBox'
   homepage 'https://www.dosbox.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.