### PR TITLE
Update telegram from 5.5-175951 to 5.5.1-176350

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '5.5-175951'
-  sha256 '6a02801c282cf9d869517f069c3d68dc2cc6e755146934b7d296caa2571d9bd4'
+  version '5.5.1-176350'
+  sha256 '9a94b1808334cebf8fba6a5bc5d99fdc3b09a17edf0714b259cfad8ab2eb59c8'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.