### PR TITLE
Update dungeon-crawl-stone-soup-tiles from 0.23.0 to 0.23.2

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.23.0'
-  sha256 '7fba6134ed32bf4ec37966ca184eb905d0261ec3d0da841eaf4105bc6d5c38a0'
+  version '0.23.2'
+  sha256 '6ba47351b14a57be65d3c631013d6ed828c9badaf07956f4b3ff2d0461ed4f9a'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.