### PR TITLE
Update bettertouchtool from 3.105 to 3.108

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.105'
-    sha256 '7bfd5211bccb6859345a4d9bc0200c0e84528f9fe2051562680007b17eea09f4'
+    version '3.108'
+    sha256 '255078abffbcc62634cb0604570f0012a215bbebc86963520b0a1a4bff9faad4'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.