### PR TITLE
Update boxcryptor from 2.27.977 to 2.28.995

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,6 +1,6 @@
 cask 'boxcryptor' do
-  version '2.27.977'
-  sha256 'd2f94dec6f14f3088de9bc146d4f220dae2aee604b325dfbdaa53e6be70e79ff'
+  version '2.28.995'
+  sha256 'deb416a0ac69e1c501a026b3a26ba47f1cc55fdee145bf97c001f847b984775f'
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.boxcryptor.com/l/download-macosx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.