### PR TITLE
Update splashtop-streamer from 3.3.0.1 to 3.3.2.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-streamer' do
-  version '3.3.0.1'
-  sha256 '17079e75e965eb5722e85eacf90c569fd9ed1ac3618cc88fbbdb7969efaaa4e7'
+  version '3.3.2.0'
+  sha256 '6183a5b3ea9b9fa3f3c68e8d5ff4edfebba38ddc28a78c9abe7a1e7b193b5321'
 
   # d17kmd0va0f0mp.cloudfront.net was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.