### PR TITLE
Update gisto from 1.12.5 to 1.12.7

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.12.5'
-  sha256 'c9e70ba017ed022a17976bc6cacab495d5641b95e84ff977078493fd4eb52401'
+  version '1.12.7'
+  sha256 '368ed5c8350cff2a40ee680cfef8f2bca6f550a125e739150a91dce12404c78c'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.