### PR TITLE
Update minizincide from 2.3.0 to 2.3.1

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask 'minizincide' do
-  version '2.3.0'
-  sha256 '5bcc4763cc8cd3c5d21edac974d76ae8860bd5bc184f25c7163989866fca8b95'
+  version '2.3.1'
+  sha256 '288ab1a0a04c6d3e7d37c6b95e80bc1604eb9ba3d57b33a0d12003c7f8f9999b'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.