### PR TITLE
Update ibackup-viewer from 4.1404 to 4.1500

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1404'
-  sha256 '6551641488f55119438cf2241331af146f2628abb4e47c88622880bd2a686e37'
+  version '4.1500'
+  sha256 '1f94b3055d454caed803d55b93937dcea2a0f12a151e9b475917b6e47dc56542'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.