### PR TITLE
Update fontbase from 2.8.3 to 2.8.5

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,10 +1,9 @@
 cask 'fontbase' do
-  version '2.8.3'
-  sha256 'aa9fcd3907800ad1f953a6015fefe4c23542331a5a5f71418b82a829e6d64d9b'
+  version '2.8.5'
+  sha256 '1644c52d860524ea50bc5d15a256f30ea3e99f13ff5c5b17b6d11b3b748fc7d1'
 
   url "https://releases.fontba.se/mac/FontBase-#{version}.dmg"
-  appcast 'https://fontba.se/updates',
-          configuration: version.major_minor
+  appcast 'https://fontba.se/_next/static/hSC8UGFOdx9C9D5-glqs5/pages/downloads/thankyou.js'
   name 'FontBase'
   homepage 'https://fontba.se/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.