### PR TITLE
Update aether from 2.0.0-dev.12,1904242038.68b25894 to 2.0.0-dev.13,1906191901.7eaf250

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -1,6 +1,6 @@
 cask 'aether' do
-  version '2.0.0-dev.12,1904242038.68b25894'
-  sha256 '80274498fb471a1fe2db07da2d950493fd594fb98fa7664f5631c47bcf84b17c'
+  version '2.0.0-dev.13,1906191901.7eaf250'
+  sha256 '2a6f02a5e4255d15e57225a76d26ae8d0063dcbf96a6a74848eea26e6d392f95'
 
   url "https://static.getaether.net/Releases/Aether-#{version.before_comma}/#{version.after_comma}/mac/Aether-#{version.before_comma}%2B#{version.after_comma}.dmg"
   appcast 'https://static.getaether.net/WebsiteReleaseLinks/Latest/LatestReleaseLinks.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.