### PR TITLE
Update pdfelement from 7.0.4,5237 to 7.0.5,5237

### DIFF
--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,6 +1,6 @@
 cask 'pdfelement' do
-  version '7.0.4,5237'
-  sha256 '97896572661c3c9baa7c4fbe60c6d78baeada672a0087e1c4e3287a8275ba599'
+  version '7.0.5,5237'
+  sha256 '7085be4c2b402d3fa2be6634060e71da24a2038df1d312337ec2c26690ce5209'
 
   url "http://download.wondershare.com/cbs_down/mac-pdfelement_full#{version.after_comma}.dmg"
   appcast 'https://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.