### PR TITLE
Update ripcord from 0.4.7 to 0.4.8

### DIFF
--- a/Casks/ripcord.rb
+++ b/Casks/ripcord.rb
@@ -1,6 +1,6 @@
 cask 'ripcord' do
-  version '0.4.7'
-  sha256 'f1172bbe0b93b967afb49e278197c212aa97cc8b81e6f1c514722196e4a7ffa5'
+  version '0.4.8'
+  sha256 '215dd6701406e26c75a55186164cbe1733fb92b2392b9f9a94e4cf62821fcbb2'
 
   url "https://cancel.fm/dl/Ripcord_Mac_#{version}.zip"
   appcast 'https://cancel.fm/ripcord/updates/v1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.