### PR TITLE
Update mysql-shell from 8.0.15 to 8.0.16

### DIFF
--- a/Casks/mysql-shell.rb
+++ b/Casks/mysql-shell.rb
@@ -1,6 +1,6 @@
 cask 'mysql-shell' do
-  version '8.0.15'
-  sha256 'cf7058f4f7281bb63c3a15bea5915c527289ff9440230326817b2cd605c0b564'
+  version '8.0.16'
+  sha256 'db2be050545970b52a46eacbbdd8805a8a5e195760b7ecae09672e6731b6bf56'
 
   url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version}-macos10.14-x86-64bit.dmg"
   name 'MySQL Shell'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.