### PR TITLE
Update android-studio from 3.4.1.0,183.5522156 to 3.4.2.0,183.5692245

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '3.4.1.0,183.5522156'
-  sha256 '8c504f8e151260d915bc54ac0c69ec06effcf424f66deb1432a2eb7aafe94522'
+  version '3.4.2.0,183.5692245'
+  sha256 '8e3592438bf7c489eeb00f802b2727241ddafa77451d32a9b82ee76ec3437356'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.