### PR TITLE
Update private-internet-access from 1.3.1-02863 to 1.3.2-02865

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,6 +1,6 @@
 cask 'private-internet-access' do
-  version '1.3.1-02863'
-  sha256 '52b4d803f5062a7fbf8eadb5ba3571f9c37c191b48090850a8daef0a107eb13f'
+  version '1.3.2-02865'
+  sha256 '1b53e9d52f56e5047ed86138d4620d7e5f2a3ab5be9b00e4bf98a9ef52205170'
 
   url "https://installers.privateinternetaccess.com/download/pia-macos-#{version}.zip"
   appcast 'https://www.privateinternetaccess.com/pages/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.