### PR TITLE
Update archipelago from 3.4.2 to 3.5.0

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.4.2'
-  sha256 '87e024a422e4dbf3fb5a4ef6087615446370396d87a9efbbb5b4f8280ffa8589'
+  version '3.5.0'
+  sha256 '57b0e5e213eb99035237230fed779f3a7eae56cfc8f8015d260b0bf905b020e0'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.