### PR TITLE
Update dust3d from 1.0.0-beta.19 to 1.0.0-beta.21

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-beta.19'
-  sha256 '33e0fcc4dc4ce6786e4750def044fb13de32e2cc9b8daa3f080b85eab78ef42c'
+  version '1.0.0-beta.21'
+  sha256 'e7b89774cae1ae583fcec108aabca05759878f4d8f1e42751fefed1fbd32cfd7'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.