### PR TITLE
Update multimc from 0.6.5 to 0.6.6

### DIFF
--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -1,6 +1,6 @@
 cask 'multimc' do
-  version '0.6.5'
-  sha256 'a33588176c1dd4e680d36f0dbb3fff4c71ebdccc2bf7b1c235e087fe14c3bad2'
+  version '0.6.6'
+  sha256 '34ff64ea13cbd7c25b626482237f65dd84262f1f1c5016ac87cddc78578bfa72'
 
   url 'https://files.multimc.org/downloads/mmc-stable-osx64.tar.gz'
   appcast 'https://github.com/MultiMC/MultiMC5/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.