### PR TITLE
Update mavensmate from 0.0.11-beta.7 to 0.0.11

### DIFF
--- a/Casks/mavensmate.rb
+++ b/Casks/mavensmate.rb
@@ -1,8 +1,8 @@
 cask 'mavensmate' do
-  version '0.0.11-beta.7'
-  sha256 'ed657aef9ab474e42e0f4e28f9aaf7fe153e29f9505f673d2dbdbfafdd31b553'
+  version '0.0.11'
+  sha256 'a16344436cebb550f57d3800bf47f3176e2135701462dcd2b41c7f02192d5fd7'
 
-  url "https://github.com/joeferraro/MavensMate-Desktop/releases/download/v#{version}/MavensMate-Desktop-#{version}.dmg"
+  url "https://github.com/joeferraro/MavensMate-Desktop/releases/download/v#{version}/MavensMate-#{version}.dmg"
   appcast 'https://github.com/joeferraro/MavensMate-Desktop/releases.atom'
   name 'MavensMate'
   homepage 'https://github.com/joeferraro/MavensMate-Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.