### PR TITLE
Update psychopy from 3.1.4 to 3.1.5

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '3.1.4'
-  sha256 '12b2036b5ea2ddb1a8b7d71d0356a31dd08db89823eb3d78436c9d4443a50172'
+  version '3.1.5'
+  sha256 '935eac2e7aa6bbac7764fdb8277eb2200cadc6f1aa1057e9a2d2f1097ee7e2a3'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.