### PR TITLE
Update nvidia-geforce-now from 2.0.8.82,D31EB9 to 2.0.8.85,3AB74C

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.8.82,D31EB9'
-  sha256 '7af7e0bd5cae3035b4e3112cef855f6d3dc0fa91328e9fe13db18720b89e32f5'
+  version '2.0.8.85,3AB74C'
+  sha256 'bfc0966e8580673caae1d4c88ce9c20b1679b40edad0cbfdab98ab71e1263824'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.