### PR TITLE
Update onlyoffice from 5.2.3 to 5.3.3

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,6 +1,6 @@
 cask 'onlyoffice' do
-  version '5.2.3'
-  sha256 'e761b54b958fe917c9d50cd598226b70840b442e772055d7a341a58df6c00221'
+  version '5.3.3'
+  sha256 'e0348f505e0698a14f5b3366aca5957eafab5e4639a77e97a7edd7fc88c9ab9b'
 
   url "https://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'https://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.