### PR TITLE
Update roblox from 0.391.0.313677,4094770ca34f4ff0 to 0.392.0.317745,454ee36c67ee47c7

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.391.0.313677,4094770ca34f4ff0'
-  sha256 'a623f13d4ce33bce3a9124ea574dceae0d69c5f19f9992bd16b82cc51ccf20b5'
+  version '0.392.0.317745,454ee36c67ee47c7'
+  sha256 'e75b408a8d0242876606852d483a39f6dd3153719085d520b49400af12ee2a43'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.