### PR TITLE
Update gpsdump from 0.51 to 0.53

### DIFF
--- a/Casks/gpsdump.rb
+++ b/Casks/gpsdump.rb
@@ -1,6 +1,6 @@
 cask 'gpsdump' do
-  version '0.51'
-  sha256 '6b39b9e49172fd439cb88d10f9bbb202f502354e4592b8968c08acab8be7955c'
+  version '0.53'
+  sha256 '16b63a1c3fe8c0150c55eb8503056362d28c39cbc5c968a5acce9ca39ce77dad'
 
   url "http://www.gpsdump.no/GpsDumpMac#{version.no_dots}.zip"
   appcast 'http://www.gpsdump.no/body_mac.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.