### PR TITLE
Update qiyimedia from 20190628,5.10.10 to 20190712,5.10.14

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '20190628,5.10.10'
-  sha256 '38be0152e83714239ca9fd4295fc061b811a66b200907e4f5d6a5f1f0f805762'
+  version '20190712,5.10.14'
+  sha256 'e09129858029b6c6b16b5277032329fffc5848f1dce5e701d51c37056e7baac8'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.