### PR TITLE
Update bot-framework-emulator from 4.4.2 to 4.5.0

### DIFF
--- a/Casks/bot-framework-emulator.rb
+++ b/Casks/bot-framework-emulator.rb
@@ -1,6 +1,6 @@
 cask 'bot-framework-emulator' do
-  version '4.4.2'
-  sha256 '55bcaa619a6f150b885f66144322d5b1c907839799a553e5c27137e342084f57'
+  version '4.5.0'
+  sha256 '36a5e6cd0f0c555dbb54835889874efe19010a569e32da34ccc89853fcf44e3a'
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.