### PR TITLE
Update drawio from 10.8.0 to 10.9.5

### DIFF
--- a/Casks/drawio.rb
+++ b/Casks/drawio.rb
@@ -1,6 +1,6 @@
 cask 'drawio' do
-  version '10.8.0'
-  sha256 '3ac41c607a4a499767a0d1835f41e8b98203b3c9c1f27815aef11c04437eb778'
+  version '10.9.5'
+  sha256 '0320236501e7d956a1137af672c0fecf9787f46c48af2a9872e32bf8996021cc'
 
   # github.com/jgraph/drawio-desktop was verified as official when first introduced to the cask
   url "https://github.com/jgraph/drawio-desktop/releases/download/v#{version}/draw.io-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.