### PR TITLE
Update superproductivity from 2.8.5 to 2.9.3

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.8.5'
-  sha256 '7e1e0ba180c7a3383fb5a12535d15a02763a2465bc367a36cd987fcf61ae1f08'
+  version '2.9.3'
+  sha256 '0bb87a6d8e32a0e646e9864864c4083e4072927da73399df6bb9904bd4853ad0'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.