### PR TITLE
Update trilium-notes from 0.33.6 to 0.33.7

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.33.6'
-  sha256 'cb41390dc359c9878b6b16b4acd40c9ec0ae58fad20747279d57ba7902d61ca4'
+  version '0.33.7'
+  sha256 'abf03a88988b51d22856180636bbf4f7f2f7365e1b1a98e6ec12f882923374e7'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.