### PR TITLE
Update remembear from 1.4.4 to 1.4.5

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.4.4'
-  sha256 '190a23eb4687659c98cb21e8d7f5c30fa332c6f6b0f99ebce17c4c6a914ba2af'
+  version '1.4.5'
+  sha256 'b055fcaebfcaa2f9c7857a3c95867e5a8f1dde44ba524941767811fc5955cb78'
 
   # remembear.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://remembear.s3.amazonaws.com/app/release/downloads/macOS/RememBear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.