### PR TITLE
Update banking-4 from 7.0.5,7116 to 7.0.6,7132

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.0.5,7116'
-  sha256 '779218cb99d364dcbc94eaef9eb74a8c8b4e8e310d34072368956071454cc9f4'
+  version '7.0.6,7132'
+  sha256 'b7e285d79575b2884feb039f7d7f079039b80736d8fad55c5ba3bc2b97cd9f4d'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.