### PR TITLE
Update visicut from 1.8-77 to 1.8-79

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask 'visicut' do
-  version '1.8-77'
-  sha256 'ae49765fd5978e8706db546fa05f0ec69c00cf189cbf287d0e4d41f7f44548cb'
+  version '1.8-79'
+  sha256 '07b01fd9afb3a4f82c5c9fecae6fd9dc88aa75007415bc4d5a8d0c738285d9de'
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}-g840df7cc.zip"
   appcast 'https://github.com/t-oster/VisiCut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.