### PR TITLE
Update capture-one from 12.1.0 to 12.1.1.7

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '12.1.0'
-  sha256 '57bd9a4bd598869f282ccb79a93e401912adbfd69a33560a5a6cc3ed4910e812'
+  version '12.1.1.7'
+  sha256 '0f7909964b8d999e0107af40cfeb1e3e84d455bb71cbc26dbe130ef1b88a428d'
 
   url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.