### PR TITLE
Update reaper from 5.97.900 to 5.98.0

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,10 +1,10 @@
 cask 'reaper' do
-  version '5.97.900'
-  sha256 'dd87ab39b73db930b3876d3d18208732fa3550645a5a72b6a1962d95958eb120'
+  version '5.98.0'
+  sha256 'ce199c7fe47f8d3d057b27f0310c6ad221500f9ffa10b83a12f3d619e0a16811'
 
-  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
+  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',
-          configuration: "#{version.major}.#{version.minor}#{version.patch.sub(%r{0*$}, '')}"
+          configuration: "#{version.major}.#{version.minor}#{version.patch}"
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.