### PR TITLE
Update archipelago from 3.5.0 to 3.5.1

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.5.0'
-  sha256 '57b0e5e213eb99035237230fed779f3a7eae56cfc8f8015d260b0bf905b020e0'
+  version '3.5.1'
+  sha256 '91d398d1c74dcf8fc0c030d289ee5019be8aa34b5f48eff141d20d11d6441db6'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.