### PR TITLE
Update ark-desktop-wallet from 2.5.0 to 2.5.1

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.5.0'
-  sha256 '6e1069a2695a13616373b929a16e3685a13893e1d1217feacc5558943f5fea08'
+  version '2.5.1'
+  sha256 'fcd535fbb7385ccebcdcd1266db67151d9b417e6751c171ee8dc6e71052c7af4'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.