### PR TITLE
Update fastonosql from 2.4.0 to 2.5.0

### DIFF
--- a/Casks/fastonosql.rb
+++ b/Casks/fastonosql.rb
@@ -1,6 +1,6 @@
 cask 'fastonosql' do
-  version '2.4.0'
-  sha256 'e10ff9703e960adbf9054957e11a5384d12e96d58146529532bc7caa8d6539b1'
+  version '2.5.0'
+  sha256 '7385d2015237fd8b5d00b4dc7766e03f3fe0ff24821e924d93aeb4f71a03da56'
 
   url "https://fastonosql.com/downloads_pro/macosx/fastonosql_pro-#{version}-x86_64.dmg"
   appcast 'https://github.com/fastogt/fastonosql/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.