### PR TITLE
Update thedesk from 18.6.7 to 18.7.0

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.6.7'
-  sha256 '1feed8cf06330f2e41a7ae25466db93d72816058c43d17bdeafffd9fe96abdcb'
+  version '18.7.0'
+  sha256 '12d2a42c0f35b150044df90dc22753f95d42eab6fef916acedbd11b92a37a3c8'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.