### PR TITLE
Update sqlpro-for-mysql from 2019.06.28 to 2019.07.03

### DIFF
--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-mysql' do
-  version '2019.06.28'
-  sha256 'f094ae34f89738afc6487d3fa83575caeb0b3763594d61dc78b80f8aaae791d7'
+  version '2019.07.03'
+  sha256 'd5a6928846fdec1c4d07cd4042b261292c5de5570620efa324eb7c7f44e93717'
 
   # d3fwkemdw8spx3.cloudfront.net/mysql was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.