### PR TITLE
Update visit from 2.13.3 to 3.0.1

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,9 +1,9 @@
 cask 'visit' do
-  version '2.13.3'
-  sha256 '984d85a597ecd391ff4fcf05fede6d320ef7eb138ce296aa88b7136b0ea1ea50'
+  version '3.0.1'
+  sha256 '476e407dc3b085191e52f0eaffe8dde36db7b912faad5cd35bdca56e93bbcf6e'
 
   # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
-  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}.dmg"
+  url "https://portal.nersc.gov/project/visit/releases/#{version}/VisIt-#{version}-10.13.dmg"
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.