### PR TITLE
Update qownnotes from 19.7.2,b4361-141852 to 19.7.3,b4369-074114

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.7.2,b4361-141852'
-  sha256 '20ba7d2f7ca6d81b8988309f503052e4a9903121eade26ae6d809a9efb8cdb28'
+  version '19.7.3,b4369-074114'
+  sha256 '0688903277ebedd07e5acfcebfe9ded2ab36aa7e0db9644cc0da4e7d35183e69'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.