### PR TITLE
Update stretchly from 0.20.0 to 0.20.1

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,6 +1,6 @@
 cask 'stretchly' do
-  version '0.20.0'
-  sha256 'efc14533c61f1313dd45ca0edbd7b00b7357ff4e4626e581cf188e252512b58c'
+  version '0.20.1'
+  sha256 '1c51f0aeb01bde477c23c7f9908e14729a6661fff78060f3bdda22b9e4609ea5'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.