### PR TITLE
Update textmate from 2.0-rc.27 to 2.0-rc.28

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,6 +1,6 @@
 cask 'textmate' do
-  version '2.0-rc.27'
-  sha256 'b54adbbe60171c51a4b9a04192e64d8f70b7752244d9e510dc49a83ca6c14265'
+  version '2.0-rc.28'
+  sha256 '16e27c14df20641e4ff949022c776c7954dc2838fe4dd36e6053744442f48903'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.