### PR TITLE
Update unity-download-assistant from 2019.1.9f1,d5f1b37da199 to 2019.1.10f1,f007ed779b7a

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.1.9f1,d5f1b37da199'
-  sha256 '500957879b684aa063d6f4a0915fd06c0c598c42397fa2eaba2cd3f446b83365'
+  version '2019.1.10f1,f007ed779b7a'
+  sha256 'f6019477e12d6974c4f07e76b7a72497ffd36cfd9f2711a0a1f507d5b7629971'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.