### PR TITLE
Update unity-webgl-support-for-editor from 2019.1.9f1,d5f1b37da199 to 2019.1.10f1,f007ed779b7a

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.1.9f1,d5f1b37da199'
-  sha256 '7addc5a12ef79f303e7d68b6802c03bc3fb579fb5dbb47adaeeb4a1dee334686'
+  version '2019.1.10f1,f007ed779b7a'
+  sha256 '8cb9d9174bafca80ceb8a7feba5459eeb6d8a20415b6760839d02fea6131f39a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.