### PR TITLE
Update leocad from 18.02 to 19.07.1

### DIFF
--- a/Casks/leocad.rb
+++ b/Casks/leocad.rb
@@ -1,6 +1,6 @@
 cask 'leocad' do
-  version '18.02'
-  sha256 'b4522d1af5f2dac3cfd3ae0dc654ed4a5cb95fff2ea7d85ba3331cf9132fedfa'
+  version '19.07.1'
+  sha256 '5f0a63b32b86d3ec50deb465e492189132fcd170594c0bef0937c1eead57899c'
 
   url "https://github.com/leozide/leocad/releases/download/v#{version}/LeoCAD-macOS-#{version}.dmg"
   appcast 'https://github.com/leozide/leocad/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.