### PR TITLE
Update catlight from 2.27.4 to 2.28.0

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,6 +1,6 @@
 cask 'catlight' do
-  version '2.27.4'
-  sha256 '0467c860101ca33d033a31150d74d399eadd5a25432ab30bb66b20fb786a5fcd'
+  version '2.28.0'
+  sha256 '8fcbd19358bd795f144bfa868ceb5fc1e19be3bce3f3d672cd51adf644a8defc'
 
   # de2nac35bcll0.cloudfront.net was verified as official when first introduced to the cask
   url "https://de2nac35bcll0.cloudfront.net/dl/mac/beta/CatLightSetup-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.