### PR TITLE
datadog-agent: Fix 6.12.0-1 download url

### DIFF
--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -2,8 +2,8 @@ cask 'datadog-agent' do
   version '6.12.0-1'
   sha256 'ea7b93241fa31ed05b2a73670541d5104e84e387079779c6bb35d9c9dc9ea208'
 
-  # s3.amazonaws.com/dd-agent was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/dd-agent/datadogagent-#{version}.dmg"
+  # dd-agent.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://dd-agent.s3.amazonaws.com/datadog-agent-#{version}.dmg"
   appcast 'https://github.com/DataDog/datadog-agent/releases.atom'
   name 'Datadog Agent'
   homepage 'https://www.datadoghq.com/'


### PR DESCRIPTION
Changes the download URL back to
`dd-agent.s3.amazonaws.com/datadog-agent-<version>.dmg`.

Due to a mistake in the release of `6.12.0-1`, the dmg did not
have the correct name (`datadogagent-6.12.0-1`).
As a result, the cask's URL was modified in #65460 to
another location where the dmg is accessible.

The dmg is now publicly available at:
`dd-agent.s3.amazonaws.com/datadog-agent-6.12.0-1.dmg`,
and future releases will also follow this naming scheme.

Note: `dd-agent.s3.amazonaws.com` and `s3.amazonaws.com/dd-agent`
are equivalent domains, but the former should be preferred
as the latter will be deprecated by Amazon next year.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->
 ----------
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
