### PR TITLE
Update meshcommander from 0.7.4 to 0.7.7

### DIFF
--- a/Casks/meshcommander.rb
+++ b/Casks/meshcommander.rb
@@ -4,7 +4,8 @@ cask 'meshcommander' do
 
   # bintray.com/gomesjj/APPS was verified as official when first introduced to the cask
   url "https://bintray.com/gomesjj/APPS/download_file?file_path=#{version.major}.#{version.minor}#{version.patch}%2FMeshCommander.dmg.zip"
-  appcast 'https://dl.bintray.com/gomesjj/APPS/'
+  appcast 'https://dl.bintray.com/gomesjj/APPS/',
+          configuration: "#{version.major}.#{version.minor}#{version.patch}"
   name 'MeshCommander'
   homepage 'https://www.devtty.uk/apple/Intel_Mesh_Commander_on_Mac_OS_X/'
 

--- a/Casks/meshcommander.rb
+++ b/Casks/meshcommander.rb
@@ -1,9 +1,10 @@
 cask 'meshcommander' do
-  version '0.7.4'
-  sha256 '01258821e3103eea0e499a411c2d86b3d6e00d5ce358953ef55be7b08e51b63d'
+  version '0.7.7'
+  sha256 'ac104f6bd8c79786fdd371064fd6a2a892ba58851e60447a8ce83ad2bed6725c'
 
   # bintray.com/gomesjj/APPS was verified as official when first introduced to the cask
-  url 'https://bintray.com/gomesjj/APPS/download_file?file_path=MeshCommander.dmg'
+  url "https://bintray.com/gomesjj/APPS/download_file?file_path=#{version.major}.#{version.minor}#{version.patch}%2FMeshCommander.dmg.zip"
+  appcast 'https://dl.bintray.com/gomesjj/APPS/'
   name 'MeshCommander'
   homepage 'https://www.devtty.uk/apple/Intel_Mesh_Commander_on_Mac_OS_X/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.