### PR TITLE
Update blitz from 1.0.11 to 1.1.1

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.0.11'
-  sha256 'c713228817346b3872d2adc0150401aa0a8cdf2644d81c8e029bbb2e212ee5e8'
+  version '1.1.1'
+  sha256 '3ea49b79e963aa7274e726f04328db16daa242b7e3786cbbd3d1b223a5a83caf'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.