### PR TITLE
Update wechatwebdevtools from 1.02.1904090 to 1.02.1907160

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1904090'
-  sha256 'c5562009effa60f077e2cfc45baa6452f3a78f7a9220e4bd38e1f871c49b0216'
+  version '1.02.1907160'
+  sha256 '94aaa7e251aa976e00f78c8571d0d9a38b8c9bee9d811ba38353426262166024'
 
   url "https://dldir1.qq.com/WechatWebDev/#{version.major}.2.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
   appcast 'https://developers.weixin.qq.com/miniprogram/dev/devtools/stable.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.