### PR TITLE
Update cacher from 2.12.2 to 2.12.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.12.2'
-  sha256 '90c9a3bbbdfef66034d1f32ed7c6302cfa832ea6c132158372bcfacf27ce236b'
+  version '2.12.3'
+  sha256 'c04e371ee9438f44cc543201a08864ad20854547c6ac83c5aca3bcdb173a47e4'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.