### PR TITLE
Update nteract from 0.14.3 to 0.14.4

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask 'nteract' do
-  version '0.14.3'
-  sha256 '7f711340d09bce6f8f8e06df6b2787425ecc7a7b2b2e2a7c205207fbd3a714d5'
+  version '0.14.4'
+  sha256 '151098f4adafe0e4d614d3f75632c79136e8b73f85fca0bf2a32a7e8abe8c33f'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.