### PR TITLE
Update firestormos from 6.0.2.56680 to 6.2.4.57588

### DIFF
--- a/Casks/firestorm.rb
+++ b/Casks/firestorm.rb
@@ -1,4 +1,4 @@
-cask 'firestormos' do
+cask 'firestorm' do
   version '6.2.4.57588'
   sha256 '3fad8ab8e2980d1d3fa13af8cec7d765177e082d1575d07c50cd9f038bec8521'
 
@@ -7,7 +7,7 @@ cask 'firestormos' do
   name 'Phoenix Firestorm viewer for Second Life'
   homepage 'https://www.firestormviewer.org/'
 
-  app 'FirestormOS-Releasex64.app'
+  app 'Firestorm-Releasex64.app'
 
   caveats <<~EOS
     This version does not contain Havok engine (does not matter if you're not a content creator).

--- a/Casks/firestormos.rb
+++ b/Casks/firestormos.rb
@@ -1,8 +1,8 @@
 cask 'firestormos' do
-  version '6.0.2.56680'
-  sha256 'f8e5fa3b1a72aff67ce91d44f82f536d898a9b4c3a818414799ccb8d288e7e97'
+  version '6.2.4.57588'
+  sha256 '3fad8ab8e2980d1d3fa13af8cec7d765177e082d1575d07c50cd9f038bec8521'
 
-  url "https://downloads.firestormviewer.org/mac/Phoenix-FirestormOS-Releasex64_#{version.dots_to_underscores}_x86_64.dmg"
+  url "https://downloads.firestormviewer.org/mac/Phoenix-Firestorm-releasex64_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://www.firestormviewer.org/mac/'
   name 'Phoenix Firestorm viewer for Second Life'
   homepage 'https://www.firestormviewer.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.