### PR TITLE
Update timely from 1.0.1 to 1.0.2

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,6 +1,6 @@
 cask 'timely' do
-  version '1.0.1'
-  sha256 'e6bd970c8ba5c4a649aff87b2c6338996882babd8bd172b97f835060f1cfb502'
+  version '1.0.2'
+  sha256 'e572fc334da36f41f053676daf45793b693e893faf04d8edb8c557593c033daf'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.