### PR TITLE
Update krita from 4.2.2.3 to 4.2.3

### DIFF
--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -1,6 +1,6 @@
 cask 'krita' do
-  version '4.2.2.3'
-  sha256 'fa2d1e2fa28c4d4cc3d018cabab1c89ef393ad11b6adf3940447a50be047c61e'
+  version '4.2.3'
+  sha256 'a588d33e0c86895cadda6a78c82f3dc41c0398c4e0a13241cc7ccdb9bbf26410'
 
   # kde.org/stable/krita was verified as official when first introduced to the cask
   url "https://download.kde.org/stable/krita/#{version.major_minor_patch}/krita-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.