### PR TITLE
Update ocenaudio from 3.7.0 to 3.7.1

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,7 +2,7 @@ cask 'ocenaudio' do
   version '3.7.1'
 
   if MacOS.version <= :high_sierra
-    sha256 'adf522d3e5f570d988487bfc508f0bf77b6dad7f0409f821d86e083b797b7cbe'
+    sha256 '65dd6ce56f58e5c344e9757a3936786cb985ea3c54a1e1d8b009fd4e08c7c24b'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,12 +1,12 @@
 cask 'ocenaudio' do
-  version '3.7.0'
+  version '3.7.1'
 
   if MacOS.version <= :high_sierra
     sha256 'adf522d3e5f570d988487bfc508f0bf77b6dad7f0409f821d86e083b797b7cbe'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 '2b52f2a918302a49c77e156c2beace9a4baa0a654e7a314e2c35113daf98a3ad'
+    sha256 '94f1ce8048dc06c069c3a5031d1bf8b785f549db243247241ebce27e496bc0c0'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.