### PR TITLE
Update bettertouchtool from 3.140 to 3.148

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.140'
-    sha256 '68ffffaaeec657fe5d9d151fac4204989f971db3a89232d702334fe17576cab8'
+    version '3.148'
+    sha256 '6bcc24313ef0fa2a2eb7966c8193bc2b7570b50b5abdbead7e78ef801a5e5f53'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.