### PR TITLE
Update oracle-jdk from 12.0.1,12:69cfe15208a647278a19ef0990eea691 to 12.0.2,10:e482c34c86bd4bf8b56c0b35558996b9

### DIFF
--- a/Casks/oracle-jdk.rb
+++ b/Casks/oracle-jdk.rb
@@ -1,6 +1,6 @@
 cask 'oracle-jdk' do
-  version '12.0.1,12:69cfe15208a647278a19ef0990eea691'
-  sha256 'cf96dc630cd8efa60b2aa8b12d0092a09a2cd4d99567b330cbe0250206bf29ea'
+  version '12.0.2,10:e482c34c86bd4bf8b56c0b35558996b9'
+  sha256 'e7af8c66c4194ae12ff12d8ef172ae96e89ad512d896d4c98b0256708fe38b90'
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_osx-x64_bin.dmg",
       cookies: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.