### PR TITLE
Update oracle-jdk-javadoc from 12.0.1,12:69cfe15208a647278a19ef0990eea691 to 12.0.2,10:e482c34c86bd4bf8b56c0b35558996b9

### DIFF
--- a/Casks/oracle-jdk-javadoc.rb
+++ b/Casks/oracle-jdk-javadoc.rb
@@ -1,6 +1,6 @@
 cask 'oracle-jdk-javadoc' do
-  version '12.0.1,12:69cfe15208a647278a19ef0990eea691'
-  sha256 'd77c9d9b38da262dbef88424d6d7e138a27efa26522313ec762126fde560d63f'
+  version '12.0.2,10:e482c34c86bd4bf8b56c0b35558996b9'
+  sha256 '8541ec6ff1d78f7e36ea6b5cfcf8cf84b8431ebe67d0f68a1f29fd00debd12aa'
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.