### PR TITLE
Update chromium from 675525 to 677992

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '675525'
-  sha256 'f4a594a2623d2479d0afc733893f3b57ec24b9c88061d94637e3adb44ca89ae5'
+  version '677992'
+  sha256 'd142da7e06f4a1d5d7ae21822b5257e2e5d27dc8869dd0db2fe5f8922af14155'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.