### PR TITLE
Update little-snitch from 4.4 to 4.4.2

### DIFF
--- a/Casks/little-snitch.rb
+++ b/Casks/little-snitch.rb
@@ -1,6 +1,6 @@
 cask 'little-snitch' do
-  version '4.4'
-  sha256 '668a37cd7e97e170ef3b35ff50644ecb9f78550b6f1b536034a9ef777cfb5586'
+  version '4.4.2'
+  sha256 '6899b3aedc377c7d8a39eedce31341b2324d46fe78d0bd7eda23bd2ee9d61131'
 
   url "https://www.obdev.at/downloads/littlesnitch/LittleSnitch-#{version}.dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.