### PR TITLE
Update hashbackup from 2367 to 2376

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,6 +1,6 @@
 cask 'hashbackup' do
-  version '2367'
-  sha256 'd26d0e0cff93d92dd867c643c9a478e6de99bd443c7642b5ef5ef8a28add71b7'
+  version '2376'
+  sha256 'a173e966ce4482d112b97e4fbe1a477b14675e8c1c11aecbc2760560bd35acfc'
 
   url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.x86_64.bz2"
   name 'hashbackup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.