### PR TITLE
Update harvest from 2.1.14 to 2.1.15

### DIFF
--- a/Casks/harvest.rb
+++ b/Casks/harvest.rb
@@ -1,6 +1,6 @@
 cask 'harvest' do
-  version '2.1.14'
-  sha256 '763cecd2b10e390d096864ecfbefeb4683fc827c510d6e678822d8aa5e298f6e'
+  version '2.1.15'
+  sha256 '42c4add82b44df516996e193e18183c811c4fed988f39cc7823bd41428f1b922'
 
   url "https://www.getharvest.com//harvest/mac/Harvest-#{version}.zip"
   appcast 'https://www.getharvest.com/harvest/mac/appcast.xml'


### PR DESCRIPTION
Update harvest from 2.1.14 to 2.1.15

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).