### PR TITLE
Update diskcatalogmaker from 7.5.2 to 7.5.3

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.5.2'
-  sha256 'b9e6ea45c903a8ed2b6fd0b1c2a6de7a6bce4b7c799e2907f3a6951f500298e7'
+  version '7.5.3'
+  sha256 'c257264e44a052f14d0f5271f98bcdf1e92045beb7ebe8f425c2b78f4be1b937'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.