### PR TITLE
Update katalon-studio from 6.2.1 to 6.2.2

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '6.2.1'
-  sha256 '80bcbcd54a9938aec9748fc2b85606a18bba64645ab80af909f73949fdfe8a57'
+  version '6.2.2'
+  sha256 '28588997abe8cc8c40c8848b174e49c5ef30524f6b35bae41d69f6a05a6a0387'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.