### PR TITLE
Update quip from 5.5.13 to 5.5.18

### DIFF
--- a/Casks/quip.rb
+++ b/Casks/quip.rb
@@ -1,6 +1,6 @@
 cask 'quip' do
-  version '5.5.13'
-  sha256 'af9aae5cc570be2f2bf39945812e2a864e3499e2a98438914cea45230613aa20'
+  version '5.5.18'
+  sha256 '1475c86676753dc86729aea87b55c456c3a2f40427054f2b31c9c115cd638fb6'
 
   # quip-clients.com was verified as official when first introduced to the cask
   url "https://quip-clients.com/macosx_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.