### PR TITLE
Update arq from 5.16 to 5.16.1

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '5.16'
-  sha256 '9e54d4da3259e80ce8f82209622d47ea1fb38fab70e8db23bc53c63fb626263e'
+  version '5.16.1'
+  sha256 '9517eecae50d7164a868387b383c6a32895496c6db03cceb8d4bd22980a2a8f5'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arqbackup/arq#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.