### PR TITLE
Update macgamestore from 3.4.1,5094 to 3.4.2,5095

### DIFF
--- a/Casks/macgamestore.rb
+++ b/Casks/macgamestore.rb
@@ -1,6 +1,6 @@
 cask 'macgamestore' do
-  version '3.4.1,5094'
-  sha256 '8e7f4de54c956d9ba77b76437bcd51dec9c6ca423d29621b690a6fa9d9a018d7'
+  version '3.4.2,5095'
+  sha256 '8a2fc899fd87f8700d5d4fe6679e3af884163a0538e318cb5932e757bf006db9'
 
   url "https://www.macgamestore.com/api_clientapp/clientupdates/public/core5/MacGameStore_#{version.before_comma}_#{version.after_comma}.tgz"
   appcast 'https://www.macgamestore.com/api_clientapp/clientupdates/public/update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.