### PR TITLE
Update tcl from 8.6.8.0 to 8.6.9.0,8.6.9.8609.2

### DIFF
--- a/Casks/tcl.rb
+++ b/Casks/tcl.rb
@@ -1,9 +1,9 @@
 cask 'tcl' do
-  version '8.6.8.0'
-  sha256 '8788a7c50b6c9d467bdbf7ae473354173feebc75a8b33b175245ccf4171938d1'
+  version '8.6.9.0,8.6.9.8609.2'
+  sha256 'bd462de2a09198b95c94ac727264f36aebee83f0ac9aab7260150c4f5e0f5c3b'
 
   # downloads.activestate.com/ActiveTcl was verified as official when first introduced to the cask
-  url "https://downloads.activestate.com/ActiveTcl/releases/#{version}/ActiveTcl-#{version}-macosx10.9-x86_64.pkg"
+  url "https://downloads.activestate.com/ActiveTcl/releases/#{version.before_comma}/ActiveTcl-#{version.after_comma}-macosx10.9-x86_64.pkg"
   appcast 'https://downloads.activestate.com/ActiveTcl/releases'
   name 'ActiveTcl'
   homepage 'https://tcl.tk/'

--- a/Casks/tcl.rb
+++ b/Casks/tcl.rb
@@ -8,7 +8,7 @@ cask 'tcl' do
   name 'ActiveTcl'
   homepage 'https://tcl.tk/'
 
-  pkg "ActiveTcl-#{version}-macosx10.9-x86_64.pkg"
+  pkg "ActiveTcl-#{version.after_comma}-macosx10.9-x86_64.pkg"
 
   uninstall pkgutil: "com.activestate.pkg.ActiveTcl#{version.major_minor}"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.