### PR TITLE
Update cmake from 3.14.5 to 3.15.0

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.14.6'
-  sha256 '0e43450c2808121316204e5ff560054e10c84148fe1cb07368833d7c4b1f3b72'
+  version '3.15.0'
+  sha256 'af8f501ef9153a64f907981f6106b0178f41e18d1036355ebcc58034585aef07'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   appcast 'https://cmake.org/files/LatestRelease/'

--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.14.5'
-  sha256 'a1dd64edb6036fdaa365ed0cd850e437ce6ab2e67da817f080376a2aa05eefc8'
+  version '3.14.6'
+  sha256 '0e43450c2808121316204e5ff560054e10c84148fe1cb07368833d7c4b1f3b72'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   appcast 'https://cmake.org/files/LatestRelease/'

--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -12,7 +12,6 @@ cask 'cmake' do
   app 'CMake.app'
   binary "#{appdir}/CMake.app/Contents/bin/cmake"
   binary "#{appdir}/CMake.app/Contents/bin/ccmake"
-  binary "#{appdir}/CMake.app/Contents/bin/cmakexbuild"
   binary "#{appdir}/CMake.app/Contents/bin/cpack"
   binary "#{appdir}/CMake.app/Contents/bin/ctest"
   binary "#{appdir}/CMake.app/Contents/bin/cmake-gui"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.