### PR TITLE
Update understand from 5.1.989 to 5.1.990

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.989'
-  sha256 'f562bfe30005ed484ba99c9b75d4bfd8a66937e217dfc8b235ea2f19cc2bde30'
+  version '5.1.990'
+  sha256 '7d8007ee1502bc2cafd8c8e1d2849342295085296a0ddf90deb5206f9fa76bb5'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.