### PR TITLE
Update understand from 5.1.991 to 5.1.992

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.991'
-  sha256 '5229efd8fe46fd593e3d77a15f789d38c60deaf84717f90d2a06faddab8adc37'
+  version '5.1.992'
+  sha256 'ca4f0bc398fc1484061037cd0bc11a966eda3a0f0136337ebcb27f5426fd0b0d'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.