### PR TITLE
Update augur from 1.14.2 to 1.15.0

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.14.2'
-  sha256 '76dbd7bacfa4ca0c0301d11b2cecc02f85aa72e684e58c2eb86d518c6b3b3f17'
+  version '1.15.0'
+  sha256 'c22ac263a78b42bcac6f4dfcde46d7487cc35ef24384e31782a8bd7537acb49e'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.