### PR TITLE
Update iglance from 1.3.2 to 1.3.3

### DIFF
--- a/Casks/iglance.rb
+++ b/Casks/iglance.rb
@@ -1,6 +1,6 @@
 cask 'iglance' do
-  version '1.3.2'
-  sha256 '4e12a1216e2c2c0025ce37f93d5286adbd6575285fcaa47e41a7fa917b2e56df'
+  version '1.3.3'
+  sha256 '96dbe82f13c4929c47879d6a64bab2a39f8a083cff54cc308f9f6f0895be5dd3'
 
   url "https://github.com/iglance/iglance/releases/download/v#{version}/iGlance.dmg"
   appcast 'https://github.com/iglance/iglance/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.