### PR TITLE
Update qutebrowser from 1.6.3 to 1.7.0

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,6 @@
 cask 'qutebrowser' do
-  version '1.6.3'
-  sha256 '401c88d55bdb79430727ab2be1d53e618051327bf283067bd68c5446580c2a6d'
+  version '1.7.0'
+  sha256 '7e99facc4b886c64b84ad13f22e5694faa39a7cda73519816b60cc5df5945b81'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.