### PR TITLE
Update gemini from 2.5.5,328:1550767892 to 2.5.6,330:1563371706

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,6 +1,6 @@
 cask 'gemini' do
-  version '2.5.5,328:1550767892'
-  sha256 '9af49d94023873016e43ea8ca9dace4b5fa911b03e2f5ef21af7d16e211004c0'
+  version '2.5.6,330:1563371706'
+  sha256 '7bac1118c4caa76e13e0d0686b4ab3424adcd491ef9154acd6105e0aabb19c01'
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_comma.before_colon}/#{version.after_colon}/Gemini#{version.major}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.