### PR TITLE
Update manictime from 1.4.2 to 2.0.25

### DIFF
--- a/Casks/manictime.rb
+++ b/Casks/manictime.rb
@@ -1,8 +1,9 @@
 cask 'manictime' do
-  version '1.4.2'
-  sha256 'a42cfb6aaf969d203e5938c2eb4ecbab750cb475cdf67e024e662924794673e2'
+  version '2.0.25'
+  sha256 'd1eb51fff19cce62801d7d150ea68b100978180ab0d511d30346d044ed7639f2'
 
   url "https://cdn.manictime.com/setup/mac/ManicTime-v#{version}.dmg"
+  appcast 'https://www.manictime.com/mac/download'
   name 'ManicTime'
   homepage 'https://www.manictime.com/Mac'
 

--- a/Casks/manictime.rb
+++ b/Casks/manictime.rb
@@ -7,7 +7,7 @@ cask 'manictime' do
   name 'ManicTime'
   homepage 'https://www.manictime.com/Mac'
 
-  pkg "ManicTime-#{version}.pkg"
+  pkg "ManicTime-v#{version}.pkg"
 
   uninstall pkgutil: 'com.finkit.manictime.tracker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.