### PR TITLE
Update kite from 0.20190716.0 to 0.20190717.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190716.0'
-  sha256 '9b3c83f478552bbcf1e5c97c874e8251bfed1294e4481337619ddebfb0c6b1cd'
+  version '0.20190717.0'
+  sha256 'b97176a7b85c4c5402d7d62b8c528647ce013430857321698e580ad4a6bfd610'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.