### PR TITLE
Update lockrattler from 4.21,2019.06 to 4.22,2019.07

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -4,7 +4,7 @@ cask 'lockrattler' do
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.major}/#{version.after_comma.minor}/lockrattler#{version.before_comma.no_dots}.zip"
-  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split.cgi?splitters=\[\{%22s%22:%22LockRattler%22,%22i%22:1\},\{%22s%22:%22Version%22,%22i%22:1\},\{%22s%22:%22dict%22,%22i%22:0\}\]&url=https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist'
+  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist&splitter_1=LockRattler&index_1=1&splitter_2=Version&index_2=1&splitter_3=dict&index_3=0'
   name 'Lock Rattler'
   homepage 'https://eclecticlight.co/'
 

--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.21,2019.06'
-  sha256 '74e8d2f7b7e8dd0b07725e71006f2cac77fcf04231f04c530faf431206c66497'
+  version '4.22,2019.07'
+  sha256 'd9f2da8b1cbf996acda2572ad8a23920758448dc4efbc7bbb1c13c9d23f10905'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.major}/#{version.after_comma.minor}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.