### PR TITLE
Update syncovery from 8.39b to 8.41

### DIFF
--- a/Casks/syncovery.rb
+++ b/Casks/syncovery.rb
@@ -1,6 +1,6 @@
 cask 'syncovery' do
-  version '8.39b'
-  sha256 '25d1a443cf640db5fae541c60b9d1c58f7c773932366a705d1855210681028c3'
+  version '8.41'
+  sha256 '6bad61f3b18ab0ba578a4e80d9dd84540b6893716da2572725f88a2ae68afb66'
 
   url "https://www.syncovery.com/release/SyncoveryMac#{version}.dmg"
   name 'Syncovery'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.