### PR TITLE
Update rubitrack-pro from 5.2.4 to 5.2.5

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,6 +1,6 @@
 cask 'rubitrack-pro' do
-  version '5.2.4'
-  sha256 '6d142672962e906d530ffc17a361283be014fbe21e663fc451a7948b00676981'
+  version '5.2.5'
+  sha256 'dcc8804fc43807a21b56085648e8b3253d0ee51d7ff0139b8f614dcd70b3203f'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.