### PR TITLE
Update zotero from 5.0.70 to 5.0.71

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.70'
-  sha256 '1ee127d1c732c4d45e280fa6d3fca0ebe330ca46c9bcd9afac0edf9e2d746d41'
+  version '5.0.71'
+  sha256 '1b2e235df7b9dfde9dcdb09f55d64a8fef4ba3b6875721b36edf016d62e4283a'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.