### PR TITLE
Update roblox from 0.392.0.317745,454ee36c67ee47c7 to 0.393.0.319623,abb55c6609004bfa

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.392.0.317745,454ee36c67ee47c7'
-  sha256 'e75b408a8d0242876606852d483a39f6dd3153719085d520b49400af12ee2a43'
+  version '5.0.71,abb55c6609004bfa'
+  sha256 '14a1fbe7808e2b965e8e639aa7598af72da75237b6e23aa80ccc0667f33d41fa'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"

--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,5 +1,5 @@
 cask 'roblox' do
-  version '5.0.71,abb55c6609004bfa'
+  version '0.393.0.319623,abb55c6609004bfa'
   sha256 '14a1fbe7808e2b965e8e639aa7598af72da75237b6e23aa80ccc0667f33d41fa'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.