### PR TITLE
Update preform from 3.0.0,995 to 3.0.2,1267

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,9 +1,10 @@
 cask 'preform' do
-  version '3.0.0,995'
-  sha256 '93fefbd2e9b97cb248cd28f57b39f71a2e799830d749a76b68e3f4bc8d198337'
+  version '3.0.2,1267'
+  sha256 'fafe6f59c63e93997a4367034f7836355e142f7c71fe2b2befabd8e80d683889'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://formlabs.com/download-preform-mac/'
   name 'PreForm'
   homepage 'https://formlabs.com/tools/preform/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.