### PR TITLE
Update hider from 2.4.9,1536932077 to 2.5,1562920938

### DIFF
--- a/Casks/hider.rb
+++ b/Casks/hider.rb
@@ -1,6 +1,6 @@
 cask 'hider' do
-  version '2.4.9,1536932077'
-  sha256 '4a292ccafc4f5abab106a37e608ece909a200f704926a9ee9ca3dbbfc644352e'
+  version '2.5,1562920938'
+  sha256 'f22f8a1045842cb2f712cc6727eed931e9d60d01ae54443bffdbd4f36da6ed6a'
 
   # dl.devmate.com/com.macpaw.site.Hider was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Hider#{version.major}/#{version.before_comma}/#{version.after_comma}/MacPawHider#{version.major}-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.