### PR TITLE
Update ibackup-viewer from 4.1500 to 4.1510

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1500'
-  sha256 '1f94b3055d454caed803d55b93937dcea2a0f12a151e9b475917b6e47dc56542'
+  version '4.1510'
+  sha256 '9d4e4c24fbb84d0dbeca3441aaa04a34891561c970852891280b87f80ffb4a36'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.