### PR TITLE
Update hubstaff from 1.4.5,839 to 1.4.7,938

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.4.5,839'
-  sha256 '739748284062ca9b095eb2ce150834b99b477f726e5d3aa0a76e70b499bd1520'
+  version '1.4.7,938'
+  sha256 'd6116e698a2e6341150f077232cdb9bcc08f021cbd979d78acd81eb2e4e3d05b'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.