### PR TITLE
Update keymanager from 2.2.0 to 2.5.0

### DIFF
--- a/Casks/keymanager.rb
+++ b/Casks/keymanager.rb
@@ -1,6 +1,6 @@
 cask 'keymanager' do
-  version '2.2.0'
-  sha256 '2a95a3c4b6ab0919fee7bab8015a6f40beb97efd6e574877ab86b295b7df03f3'
+  version '2.5.0'
+  sha256 '82874c3b541cdc4322a67c58482628ceebf4cdf5b15622eb26b6dc43693fdc72'
 
   # keymanager.trustasia.com was verified as official when first introduced to the cask
   url "https://keymanager.trustasia.com/release/KeyManager-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.