### PR TITLE
Update airflow from 2.3.15 to 2.4.0

### DIFF
--- a/Casks/airflow.rb
+++ b/Casks/airflow.rb
@@ -1,9 +1,9 @@
 cask 'airflow' do
-  version '2.3.15'
-  sha256 'b9152b2173dcc0e18550717b57922104e08e5146254a4f6bfc32e40e5ea08231'
+  version '2.4.0'
+  sha256 '6cdcbd0cb05beec9a6e27d42a239582bc3705458ffc473a4df644e8601f80fac'
 
-  # s3.amazonaws.com/Airflow was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/Airflow/Download/Airflow%20#{version}.zip"
+  # cdn.downloads.iocave.net/Airflow was verified as official when first introduced to the cask
+  url "https://cdn.downloads.iocave.net/Airflow/Airflow%20#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://airflowapp.com/download/latest?mac'
   name 'Airflow'
   homepage 'https://airflowapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.