### PR TITLE
Update 4k-youtube-to-mp3 from 3.7.0.2852 to 3.7.1.2862

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.7.0.2852'
-  sha256 '442e3935e30b00a58e5843aea470417eb73048b54dfcf614c80f8cdbf1f40e97'
+  version '3.7.1.2862'
+  sha256 '888f7057fce8ac10cf4728e1ba7a9960708a981dd11d9c4f62fd43b1c5ed370e'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.