### PR TITLE
Burp Suite 2.1: fix permissions, ownership

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -13,6 +13,11 @@ cask 'burp-suite' do
                       sudo:       true,
                     }
 
+  postflight do
+    set_ownership '/Applications/Burp Suite Community Edition.app'
+    set_permissions '/Applications/Burp Suite Community Edition.app', 'a+rX'
+  end
+
   uninstall delete: '/Applications/Burp Suite Community Edition.app'
 
   zap trash: '~/.BurpSuite'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

I did a `brew cask install burp-suite` tonight, and `/Applications/Burp Suite Community Edition.app` ended up in a state where I could not run it as my normal, non-`admin` user:

```
$ ls -ld /Applications/Burp\ Suite\ Community\ Edition.app
drwxr-x--- 3 root admin 96 Jun 27 08:17 '/Applications/Burp Suite Community Edition.app'/
```

This PR sets ownership and then permissions on the installed app bundle.  (I couldn't seem to `set_permissions` without first owning the file as my user; I am guessing `set_ownership` may sudo whereas `set_permissions` will not use sudo.)

Thank you very much, Homebrew maintainers!