### PR TITLE
Update ibackup-viewer from 4.1510 to 4.1520

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1510'
-  sha256 '9d4e4c24fbb84d0dbeca3441aaa04a34891561c970852891280b87f80ffb4a36'
+  version '4.1520'
+  sha256 'f17a95b6199dbc41a31570fd244f90c2ad4a005bfdd834f14f65a905dded1237'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.