### PR TITLE
Update jami from 20190602.0216 to 201907191319

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -3,8 +3,7 @@ cask 'jami' do
   sha256 'bd40a94d31371756a4d7ecdeca49e0592f0d20a786ce60589e97be7091293fb6'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version}.dmg"
-  appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',
-          configuration: version.major
+  appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
   name 'Jami'
   name 'Savoir-faire Linux Ring'
   homepage 'https://ring.cx/'

--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,8 +1,8 @@
 cask 'jami' do
-  version '20190602.0216'
-  sha256 'fc813559c65295796fd5b9b69da31cec4a5e98fea5213e792f7fcfa9c2dbcf9c'
+  version '201907191319'
+  sha256 'bd40a94d31371756a4d7ecdeca49e0592f0d20a786ce60589e97be7091293fb6'
 
-  url "https://dl.ring.cx/mac_osx/ring-#{version.no_dots}.dmg"
+  url "https://dl.ring.cx/mac_osx/jami-#{version}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',
           configuration: version.major
   name 'Jami'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.