### PR TITLE
Update hubstaff from 1.4.7,938 to 1.4.9,1136

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
   version '1.4.9,86828309'
-  sha256 '53af33ebf4ac2b69d0b729c58088713f4071e15ef23b57d8646b74bba822706b'
+  sha256 '0d6b2a79f032f87068b6bd6b847242b0d7dd958ee33c34c767a022771b2872ae'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.4.7,938'
-  sha256 'd6116e698a2e6341150f077232cdb9bcc08f021cbd979d78acd81eb2e4e3d05b'
+  version '1.4.9,86828309'
+  sha256 '1649f5ad1c9bca8dd3eccbb1ca0aed517e48bad5608850eb35bf49c47b070e4d'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,5 +1,5 @@
 cask 'hubstaff' do
-  version '1.4.9,86828309'
+  version '1.4.9,1136'
   sha256 '0d6b2a79f032f87068b6bd6b847242b0d7dd958ee33c34c767a022771b2872ae'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
   version '1.4.9,86828309'
-  sha256 '1649f5ad1c9bca8dd3eccbb1ca0aed517e48bad5608850eb35bf49c47b070e4d'
+  sha256 '53af33ebf4ac2b69d0b729c58088713f4071e15ef23b57d8646b74bba822706b'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.