### PR TITLE
Update augur from 1.15.0 to 1.15.1

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.15.0'
-  sha256 'c22ac263a78b42bcac6f4dfcde46d7487cc35ef24384e31782a8bd7537acb49e'
+  version '1.15.1'
+  sha256 '4c14d86a84085dcc792bbac8290afb5a0d2ab2236ce0595f18cea954919a391b'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.