### PR TITLE
Update museeks from 0.11.0 to 0.11.1

### DIFF
--- a/Casks/museeks.rb
+++ b/Casks/museeks.rb
@@ -1,6 +1,6 @@
 cask 'museeks' do
-  version '0.11.0'
-  sha256 'bf818f8c15416bb66122fe7e902224e81501b830b2a4446ed86a6e493350fc3a'
+  version '0.11.1'
+  sha256 '78af4edb2b393176aa60577e6e5858bd25f5db0c0bda70a2695c8869644a4dd8'
 
   # github.com/martpie/museeks was verified as official when first introduced to the cask
   url "https://github.com/martpie/museeks/releases/download/#{version}/museeks.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.