### PR TITLE
Update buttercup from 1.16.1 to 1.16.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.16.1'
-  sha256 'd4fe98a227cd303555644809acceb78235b310ceef5e89d61a470984539ada70'
+  version '1.16.2'
+  sha256 'c01c9fc30e323de3ac8d05912b2400ccf87248d248211c2382cd9b236c2e1b6d'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.