### PR TITLE
Update bitwig-studio from 3.0 to 3.0.1

### DIFF
--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -1,6 +1,6 @@
 cask 'bitwig-studio' do
-  version '3.0'
-  sha256 'fe0a33079a01fdc0aaac5108382926b86d849b0d87299581f22287109499b043'
+  version '3.0.1'
+  sha256 '9f5d16dc7454d1d9ace57363bf7fc0198497e2cd5ae680c3dbfa98b39d79c831'
 
   url "https://downloads.bitwig.com/stable/#{version}/Bitwig%20Studio%20#{version}.dmg"
   appcast 'https://www.bitwig.com/en/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.