### PR TITLE
Update jami from 201907191319 to 20190719.1319

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -3,7 +3,7 @@ cask 'jami' do
   sha256 'bd40a94d31371756a4d7ecdeca49e0592f0d20a786ce60589e97be7091293fb6'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
-  appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
+  appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',
           configuration: version.no_dots
   name 'Jami'
   name 'Savoir-faire Linux Ring'

--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -4,6 +4,7 @@ cask 'jami' do
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
+          configuration: version.no_dots
   name 'Jami'
   name 'Savoir-faire Linux Ring'
   homepage 'https://ring.cx/'

--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,8 +1,8 @@
 cask 'jami' do
-  version '201907191319'
+  version '20190719.1319'
   sha256 'bd40a94d31371756a4d7ecdeca49e0592f0d20a786ce60589e97be7091293fb6'
 
-  url "https://dl.ring.cx/mac_osx/jami-#{version}.dmg"
+  url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml'
   name 'Jami'
   name 'Savoir-faire Linux Ring'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.