### PR TITLE
Update burp-suite from 2.1 to 2.1.01

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -1,6 +1,6 @@
 cask 'burp-suite' do
-  version '2.1'
-  sha256 'bb7121cb68e980ac16d47a2e1e51f03559a8b44f94824c4ca62a89233b2f28f0'
+  version '2.1.01'
+  sha256 '3ad64b373c50f61a278692f3720e9967d4efd5372c3bea4c5eed61996d18d819'
 
   url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=macosx"
   appcast 'https://portswigger.net/burp/communitydownload'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.