### PR TITLE
Update flame from 0.2.1 to 0.2.2

### DIFF
--- a/Casks/flame.rb
+++ b/Casks/flame.rb
@@ -1,11 +1,12 @@
 cask 'flame' do
-  version '0.2.1'
-  sha256 'b81f216caf290fc34824661b06b68eb538a675eada627c3606276762f1d1786e'
+  version '0.2.2'
+  sha256 '72e7b5959ab608dbf38bbb33fac086c33544f97702ec16fdf1194f4a9bdf843c'
 
-  url "http://husk.org/apps/Flame-#{version}-universal.zip"
-  appcast 'http://husk.org/apps/flame/'
+  # tominsam-web.s3.amazonaws.com/uploads was verified as official when first introduced to the cask
+  url "https://tominsam-web.s3.amazonaws.com/uploads/2012/Flame-#{version}.zip"
+  appcast 'https://movieos.org/code/flame/'
   name 'Flame'
-  homepage 'http://husk.org/apps/flame/'
+  homepage 'https://movieos.org/code/flame/'
 
   app 'Flame.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.