### PR TITLE
Update qcad from 3.22.1 to 3.23.0

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,11 +1,11 @@
 cask 'qcad' do
-  version '3.22.1'
+  version '3.23.0'
 
   if MacOS.version <= :high_sierra
     sha256 '0003262298641edd4c996cb6312b2340b94c692e998c2c350a5b75f490f74ae2'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 '13bf52d28147e95a7e5fbc0e6f1b6c6a28d37ad0470e3ddf61f53928d69feab7'
+    sha256 '50e721239e6384f836e360c527b0d2b855bbe19da00512620f5ed059274f1daa'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.