### PR TITLE
miniconda - use a stable install path

### DIFF
--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -24,5 +24,9 @@ cask 'miniconda' do
                '~/.continuum',
              ]
 
-  caveats "Please run the following to setup your shell:\nconda init $(basename $SHELL)"
+  caveats <<~EOS
+    Please run the following to setup your shell:
+
+      conda init "$(basename "${SHELL}")"
+  EOS
 end

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -12,11 +12,11 @@ cask 'miniconda' do
 
   installer script: {
                       executable: "Miniconda3-#{version}-MacOSX-x86_64.sh",
-                      args:       ['-b', '-p', "#{staged_path}/miniconda3"],
+                      args:       ['-b', '-p', "#{caskroom_path}/base"],
                     }
-  binary 'miniconda3/condabin/conda'
+  binary "#{caskroom_path}/base/condabin/conda"
 
-  uninstall delete: "#{staged_path}/miniconda3"
+  uninstall delete: "#{caskroom_path}/base"
 
   zap trash: [
                '~/.condarc',

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -23,4 +23,6 @@ cask 'miniconda' do
                '~/.conda',
                '~/.continuum',
              ]
+
+  caveats "Please run the following to setup your shell:\nconda init $(basename $SHELL)"
 end


### PR DESCRIPTION
Conda updates itself (as noted by the use of `auto_updates true`) so as noted by @janosh in https://github.com/Homebrew/homebrew-cask/pull/65618 by installing into `staged_path` we end up using a path with the version number of the initial install of miniconda. So when we update conda with itself using:

```
$ conda update conda
```

We'll end up with a version that's different then the install path indicates which could cause confusion:

```
$ conda info --base
/usr/local/Caskroom/miniconda/4.6.14/miniconda3

$ conda --version
conda 4.7.10
```

This change uses `#{caskroom_path}/base` as the install path which gives us a nicer looking path for the base Conda env:

```
$ conda env list
base                  *  /usr/local/Caskroom/miniconda/base
```

And it will be stable across Conda updates:

```
$ conda info

     active environment : base
    active env location : /usr/local/Caskroom/miniconda/base
            shell level : 1
       user config file : /Users/xyu/.condarc
 populated config files :
          conda version : 4.7.10
    conda-build version : not installed
         python version : 3.7.3.final.0
       virtual packages :
       base environment : /usr/local/Caskroom/miniconda/base  (writable)
           channel URLs : https://repo.anaconda.com/pkgs/main/osx-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/osx-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /usr/local/Caskroom/miniconda/base/pkgs
                          /Users/xyu/.conda/pkgs
       envs directories : /usr/local/Caskroom/miniconda/base/envs
                          /Users/xyu/.conda/envs
               platform : osx-64
             user-agent : conda/4.7.10 requests/2.22.0 CPython/3.7.3 Darwin/18.6.0 OSX/10.14.5
                UID:GID : 501:20
             netrc file : None
           offline mode : False
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
