### PR TITLE
Update appcast url in roboform.rb

### DIFF
--- a/Casks/roboform.rb
+++ b/Casks/roboform.rb
@@ -3,7 +3,7 @@ cask 'roboform' do
   sha256 'b550507a10409748a2a621bb961e11c30742641f93555511f6b40c122a5cddef'
 
   url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg"
-  appcast 'https://www.roboform.com/download'
+  appcast 'https://www.roboform.com/news-mac'
   name 'RoboForm'
   homepage 'https://www.roboform.com/'
 


### PR DESCRIPTION
the former appcast doesn't contain the full version number anymore so perhaps its better to take the version-history site here