### PR TITLE
Update appcast url in tag.rb

### DIFF
--- a/Casks/tag.rb
+++ b/Casks/tag.rb
@@ -4,7 +4,7 @@ cask 'tag' do
 
   # feisty-dog.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://feisty-dog.s3.amazonaws.com/versions/binaries/000/000/#{version.after_comma}/Tag-#{version.before_comma}.zip"
-  appcast 'https://www.feisty-dog.com/panel/updates/Tag'
+  appcast 'https://www.feisty-dog.com/tag/'
   name 'Tag'
   homepage 'https://www.feisty-dog.com/tag/'
 


### PR DESCRIPTION
the appcast-url doesn't exist anymore but the homepage url contains the version number 