### PR TITLE
Update qownnotes from 19.7.3,b4369-074114 to 19.7.7,b4385-072215

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.7.3,b4369-074114'
-  sha256 '0688903277ebedd07e5acfcebfe9ded2ab36aa7e0db9644cc0da4e7d35183e69'
+  version '19.7.7,b4385-072215'
+  sha256 '92c52a603a2a9fb5b827d1d3a0d99203556ff9d967425b6e10eebb12225970a0'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.