### PR TITLE
Update dashcam-viewer from 3.2.6 to 3.2.7

### DIFF
--- a/Casks/dashcam-viewer.rb
+++ b/Casks/dashcam-viewer.rb
@@ -1,6 +1,6 @@
 cask 'dashcam-viewer' do
-  version '3.2.6'
-  sha256 '8d2c1991bf68f2870798f7ceb4f9805008cad0f0018d5d781b04d790329bfbb9'
+  version '3.2.7'
+  sha256 '112a950db5ab95acaa5c659321bf744ee2b3b0615737754845dabb8028714e23'
 
   # aws-website-dcv-downloads-c8kwd.s3.amazonaws.com/dcv was verified as official when first introduced to the cask
   url "https://aws-website-dcv-downloads-c8kwd.s3.amazonaws.com/dcv/Dashcam_Viewer_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.