### PR TITLE
Update pingplotter from latest to 5.10.4

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -1,8 +1,9 @@
 cask 'pingplotter' do
-  version :latest
-  sha256 :no_check
+  version '5.10.4'
+  sha256 '3793de83f80f75e309a2c54f51353a32b27cc9c2e21dd5777094d1c24db464ea'
 
   url 'https://www.pingplotter.com/downloads/pingplotter_osx.zip'
+  appcast 'https://www.pingplotter.com/download'
   name 'PingPlotter'
   homepage 'https://www.pingplotter.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.