### PR TITLE
Update fsnotes from 3.3.6 to 3.3.7

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.3.6'
-  sha256 'f9fbefe5b1fdcd3cb197e307b7b80c9bcaf107b9a46c60a718c53521ab39dd34'
+  version '3.3.7'
+  sha256 'f378ae0458ccd82c318d4202f8483543ad8c503f2eb3cfc9cf3a83148721c803'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.