### PR TITLE
Update kube-forwarder from 1.2.0 to 1.3.0

### DIFF
--- a/Casks/kube-forwarder.rb
+++ b/Casks/kube-forwarder.rb
@@ -1,6 +1,6 @@
 cask 'kube-forwarder' do
-  version '1.2.0'
-  sha256 '4951a5f7afcd14172a7ad66c50bb636e7a83ac67d76f2a39e59dae8df9f20459'
+  version '1.3.0'
+  sha256 'aabb0997d1bfcf575b39538623362399eb19e82774bdbb42d16f75c8c0e800c5'
 
   # github.com/pixel-point/kube-forwarder was verified as official when first introduced to the cask
   url "https://github.com/pixel-point/kube-forwarder/releases/download/v#{version}/kube-forwarder.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.