### PR TITLE
Update hook from 2552,1562746460 to 2581,1563727455

### DIFF
--- a/Casks/hook.rb
+++ b/Casks/hook.rb
@@ -1,6 +1,6 @@
 cask 'hook' do
-  version '2552,1562746460'
-  sha256 'c278b0d2c186c0c1f0cfff29d4595fe5668b0b63f197d4d330f4bab77a6cef6f'
+  version '2581,1563727455'
+  sha256 '927c17a3941e4ae28f2ae076a6cf3962a1b9869070fb24995faff3729b51fa90'
 
   # dl.devmate.com/com.cogsciapps.hook was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.cogsciapps.hook/#{version.before_comma}/#{version.after_comma}/Hook-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.