### PR TITLE
Update multipass from 0.7.1 to 0.8.0

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask 'multipass' do
-  version '0.7.1'
-  sha256 '650296310e09bba75ae3c7a17e81dbfb0a3399e5ea7990d7bbe39a569bfec6bd'
+  version '0.8.0'
+  sha256 '386a015745eabfdd548fa44326ccfcfafbc93747e36af99cfc2936a4432aa613'
 
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast 'https://github.com/CanonicalLtd/multipass/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.