### PR TITLE
Update vimr from 0.27.4-326 to 0.27.5-327

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,9 +1,9 @@
 cask 'vimr' do
-  version '0.27.4-326'
-  sha256 '41e06a2d3d6642a50e38d73bfecb6333344a9bad0ff948de1714d721613bcfec'
+  version '0.27.5-327'
+  sha256 '2993a2bfc997574d837ccab384b69af321717a8da6dffed52c437ae060914813'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
-  url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"
+  url "https://github.com/qvacua/vimr/releases/download/v#{version.hyphens_to_dots}/VimR-v#{version}.tar.bz2"
   appcast 'https://github.com/qvacua/vimr/releases.atom'
   name 'VimR'
   homepage 'http://vimr.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
A tag change (probably by accident) happened, so this PR includes an updated `url` stanza. This change will most likely need to be reverted when the next release comes out.