### PR TITLE
Update sherlock from latest to 1.5.0

### DIFF
--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -3,6 +3,7 @@ cask 'sherlock' do
   sha256 '429ae9abd216d657987acf0b91f502edaeb3d560dd93cef9d88f5310c5e30c7e'
 
   url 'https://sherlock.inspiredcode.io/download-dmg'
+  appcast 'https://updates.devmate.com/io.inspiredcode.Sherlock.xml'
   name 'Sherlock'
   homepage 'https://sherlock.inspiredcode.io/'
 

--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -1,6 +1,6 @@
 cask 'sherlock' do
-  version :latest
-  sha256 :no_check
+  version '1.5.0'
+  sha256 '429ae9abd216d657987acf0b91f502edaeb3d560dd93cef9d88f5310c5e30c7e'
 
   url 'https://sherlock.inspiredcode.io/download-dmg'
   name 'Sherlock'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.