### PR TITLE
Update aware from 1.0.3 to 1.0.5

### DIFF
--- a/Casks/aware.rb
+++ b/Casks/aware.rb
@@ -1,9 +1,9 @@
 cask 'aware' do
-  version '1.0.3'
-  sha256 '65dcaef6735c649e2b6a406f48583609ca9d66e7680ca69eb61871502613dec3'
+  version '1.0.5'
+  sha256 'be402c451387555348864df72f31b63845a42423a8debe67304efdd6138a99cb'
 
   # github.com/josh/Aware was verified as official when first introduced to the cask
-  url "https://github.com/josh/Aware/releases/download/v#{version}/Aware.zip"
+  url "https://github.com/josh/Aware/releases/download/v#{version}/Aware.app.zip"
   appcast 'https://github.com/josh/Aware/releases.atom'
   name 'Aware'
   homepage 'https://awaremac.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.