### PR TITLE
Update ibackup-viewer from 4.1520 to 4.1521

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1520'
-  sha256 'f17a95b6199dbc41a31570fd244f90c2ad4a005bfdd834f14f65a905dded1237'
+  version '4.1521'
+  sha256 '7f7759af908b05404d3277a50ecdbe479f8fb72125d308615acb428001242407'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.