### PR TITLE
Update burn from 2.6.7 to 2.6.8

### DIFF
--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -1,9 +1,9 @@
 cask 'burn' do
-  version '2.6.7'
-  sha256 'ba40371d2b0e557496ecdc61bfaa6778e6b174c0cab4a5c5baa66fa219d7960c'
+  version '2.6.8'
+  sha256 '58858c2cec125ea0aeb410b04e5465e613459c03059353d1d0df6bb32d193703'
 
   # downloads.sourceforge.net/burn-osx was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn#{version.no_dots}.zip"
+  url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn-#{version}.zip"
   appcast 'https://sourceforge.net/projects/burn-osx/rss?path=/Burn'
   name 'Burn'
   homepage 'https://burn-osx.sourceforge.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.