### PR TITLE
Update termius from 4.9.2 to 4.9.5

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '4.9.2'
-  sha256 '56b437f9d523dd5b2033a695e4b217e912f396d2c3fb268e39569dc8b1ab0cc9'
+  version '4.9.5'
+  sha256 '47604c550fd3be817a22f81d815b7ade460cd065584eaec6f257b5046ef6b0bb'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.