### PR TITLE
Update flipper from 0.23.1 to 0.23.2

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.23.1'
-  sha256 '86029376150290bb78f49ae13ae366679e52cbcaafbb0ca67774022d4da69197'
+  version '0.23.2'
+  sha256 '96040c4d3eb616fc2573c5b24a8f425e559c85dd5d88d32dc574639f57a412b6'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.