### PR TITLE
Update reunion from 12.0.0.181218 to 12.0.0.190722

### DIFF
--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -1,6 +1,6 @@
 cask 'reunion' do
-  version '12.0.0.181218'
-  sha256 '6c4946169eb2f57d3726615265b29a6483ddfbccf19e610f832c5fadba8fd1e6'
+  version '12.0.0.190722'
+  sha256 '436b9ef132b711973a6f7a980609bf6d69e000d732a090ac10e4e6d2a471ce73'
 
   url "https://store.leisterpro.com/updates/reunion#{version.major}/Reunion-#{version.dots_to_hyphens}.zip"
   appcast "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.