### PR TITLE
Update command-tab-plus from 1.93,328:1561982918 to 1.94,330:1563886133

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.93,328:1561982918'
-  sha256 '1055101dde4339a580b4792313275cc36a9ad67bdabfc30c0ae1d1d6c8c9f50e'
+  version '1.94,330:1563886133'
+  sha256 '4e0ca8b0618bafc6e2c5be20e0a4408243078028bec234a1270c84487b48ba13'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.