### PR TITLE
Update zeplin from 2.5.1,723 to 2.6,737

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.5.1,723'
-  sha256 '2daeaa07c2675c67cf295617b2b8e54b836242585f69991a07cb6fda4e9feee1'
+  version '2.6,737'
+  sha256 'ada6f960bfa27bdac5090a5594122867586ff7dc5eab598197719de6b225f637'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.