### PR TITLE
Update banking-4 from 7.0.6,7135 to 7.1.0,7143

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.0.6,7135'
-  sha256 'fe90252e7814f848d6602f93d862b8cfb166a81db686b46bfefd4a8d045843fd'
+  version '7.1.0,7143'
+  sha256 'ac448fde7aab80fca99413f4efdfee4af63c7edcfdcde392bcb50908dfd85fd2'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.