### PR TITLE
Update ezip from 1.7.3 to 1.7.5

### DIFF
--- a/Casks/ezip.rb
+++ b/Casks/ezip.rb
@@ -1,6 +1,6 @@
 cask 'ezip' do
-  version '1.7.3'
-  sha256 '829cfcd2f07897039e6000651c3d4b2a9a92a7c790e887e9fbb678bc49321e62'
+  version '1.7.5'
+  sha256 '21b137cb41f561b0438d792680c8be3ae0dcb1a4fae949a5c7f4d09050dd9e1a'
 
   url "https://cdn.awehunt.com/ezip/release/eZip_V#{version}.dmg"
   appcast 'https://ezip.awehunt.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.