### PR TITLE
Update camunda-modeler from 3.1.2 to 3.2.1

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '3.1.2'
-  sha256 'bae7d7f4c4afa82ecf17a3d0725bb506456f49cc2a3ea9ce9ab2495114475b26'
+  version '3.2.1'
+  sha256 'f3882b3b2cb882c6da240ffb255c68c93531121569190217f9a7b055366a075a'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-mac.zip"
   appcast 'https://camunda.com/download/modeler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.