### PR TITLE
Update qq from 6.5.3 to 6.5.5

### DIFF
--- a/Casks/qq.rb
+++ b/Casks/qq.rb
@@ -1,6 +1,6 @@
 cask 'qq' do
-  version '6.5.3'
-  sha256 'f8c2db99ace8e5ead93ced6b01ee29460937cd92b9b9df783f2c620306e52a48'
+  version '6.5.5'
+  sha256 '56724bd347d7797f91b90b49aac46bb13d954fff4028e64734781fe810b0a1e2'
 
   url "https://dldir1.qq.com/qqfile/QQforMac/QQ_V#{version}.dmg"
   appcast 'https://im.qq.com/macqq/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.