### PR TITLE
Update airfoil from 5.8.5 to 5.8.6

### DIFF
--- a/Casks/airfoil.rb
+++ b/Casks/airfoil.rb
@@ -1,6 +1,6 @@
 cask 'airfoil' do
-  version '5.8.5'
-  sha256 'fe1c080d9c1a6a9c04c9ab9f2ba4114e24af667cb2291044c845729fddfb8c89'
+  version '5.8.6'
+  sha256 '57cd3c272332c9f2398fb2fc6517dfdb757c9b52fbb30e5e317f0bd45f837846'
 
   url 'https://rogueamoeba.com/airfoil/download/Airfoil.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Airfoil&platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.