### PR TITLE
Update plex-media-player from 2.37.2.996-bea4f9ca to 2.38.0.999-e14e4d74

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.37.2.996-bea4f9ca'
-  sha256 'a2b876905788e0abebc406f1727c31d4c56d74cbc46337d1ade1b5b9587209f6'
+  version '2.38.0.999-e14e4d74'
+  sha256 '87ff2d03db916cffcf74c61efd55b479a4d00e9fd47a3fa570cf654bd11684f9'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.