### PR TITLE
Update navicat-for-sql-server from 12.1.23 to 12.1.24

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.23'
-  sha256 '4974605846fd5912f455f71eef00876e9968809b108d1f422071e3af06ba196f'
+  version '12.1.24'
+  sha256 '5a254b14332ac11c05adcf6357cf25f4287db66a13ad6e6aff56de572a9e5480'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.