### PR TITLE
Update navicat-for-mariadb from 12.1.23 to 12.1.24

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.23'
-  sha256 '2ff0e29adbd8717dab70397da4c19c9aa994407cd439f8e778443f8a565ec6ce'
+  version '12.1.24'
+  sha256 'e5a957959ce6a3d6b14278aee9bfc5c01d7bb7fdf37979d491365ea66aba7d69'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.