### PR TITLE
Update navicat-for-sqlite from 12.1.23 to 12.1.24

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.23'
-  sha256 '82fbd8249630cd209728fcd2eaac95f2535363c5b8dd0b902b11b9085c8b8083'
+  version '12.1.24'
+  sha256 '6be55bca3cca358dc6d28ca94b3614b1e0fe6299afcbe7e1a26efd5c72548e7c'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.