### PR TITLE
Update navicat-for-mysql from 12.1.23 to 12.1.24

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '12.1.23'
-  sha256 '276dddf8873a0dfcaa33453f55421c91366355be9c776396960c894b2f4d76f7'
+  version '12.1.24'
+  sha256 '8c3500d98ed49b655147164e7536c55abfc49da9d3f00f4ca2fadfa2efe197f9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.