### PR TITLE
Update peakhour from 4.1.4,34890 to 4.1.5,34918

### DIFF
--- a/Casks/peakhour.rb
+++ b/Casks/peakhour.rb
@@ -1,6 +1,6 @@
 cask 'peakhour' do
-  version '4.1.4,34890'
-  sha256 'd24d2018cf8f4d407dc9bd40880a3841047e703a8d14a095766333e02cd1797a'
+  version '4.1.5,34918'
+  sha256 '26b1b71d23bc1421c821f238d64b27db8bf01de9d3938b19f04928a4234f2c50'
 
   url "https://updates.peakhourapp.com/releases/PeakHour%20#{version.before_comma}.zip"
   appcast "https://updates.peakhourapp.com/PeakHour#{version.major}Appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.