### PR TITLE
Update freeze from 3.11 to 3.11.1

### DIFF
--- a/Casks/freeze.rb
+++ b/Casks/freeze.rb
@@ -1,6 +1,6 @@
 cask 'freeze' do
-  version '3.11'
-  sha256 '2eb95e0aa4a66b01c33b9693e2a3a41be0910e4d9be3dc513b97f66545cfd11a'
+  version '3.11.1'
+  sha256 '0fd43f3742451b3b1e537a8498be8203b1c3baf1b5ea439ba3e0105e3b370a5e'
 
   url 'https://www.freezeapp.net/download/Freeze.zip'
   appcast 'https://www.freezeapp.net/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.