### PR TITLE
Update navicat-for-oracle from 12.1.23 to 12.1.24

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '12.1.23'
-  sha256 '5bb7a46a5f3df3e7ee9449fd531bf26eaeb4493319d783d289efe190857317d6'
+  version '12.1.24'
+  sha256 'de862a4fc6564ab46b88eaa73914794186a999d1e39f8d7866bf78714cc672ec'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.