### PR TITLE
Update melodics from 2.0.2989 to 2.0.3006

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.0.2989'
-  sha256 '5bec07741036d227288e3b378c866642661972e4cceb3a0c900ad493829c89f4'
+  version '2.0.3006'
+  sha256 '59ebc046efdc646b67b2b8bf2afa0faee01071d43bf9d4d7733a3941d4f57a01'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.