### PR TITLE
Update permute from 3.2.9,2151 to 3.3,2155

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,8 +1,8 @@
 cask 'permute' do
-  version '3.2.9,2151'
-  sha256 '843261ede566d7cbbe00c252202b053dbf6d6066be5a6c12132ca94c92065ea7'
+  version '3.3,2155'
+  sha256 'b34a7f4173f888df098394158ba4f03a1dbc3b835173e7d1444496f6704378ef'
 
-  url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.zip"
+  url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"
   name 'Permute'
   homepage 'https://software.charliemonroe.net/permute.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.