### PR TITLE
Update fldigi from 4.1.05,4.3.7 to 4.1.06,4.3.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.1.05,4.3.7'
-  sha256 '4afd31b3061b84f58544e8a160c31f6ab9b7927411098b09c84a73d8493597f7'
+  version '4.1.06,4.3.7'
+  sha256 '2058245817425a1f277d4493aba094685d4dfba2d7278647db80c9279d6bcf44'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.