### PR TITLE
Update tableau-public from 2019.2.1 to 2019.2.2

### DIFF
--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,6 +1,6 @@
 cask 'tableau-public' do
-  version '2019.2.1'
-  sha256 '4470c129f16a900bf96a8276c0058e90fbb5ebda7f76f81a893c356bb23b66da'
+  version '2019.2.2'
+  sha256 '382aa0ee4d205fb98c0def0f5aaec6431cfc5c1d2d3f43dacb410492cb958757'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.