### PR TITLE
Update tableau-reader from 2019.2.1 to 2019.2.2

### DIFF
--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -1,6 +1,6 @@
 cask 'tableau-reader' do
-  version '2019.2.1'
-  sha256 '1f13609e357abf57132bf2ec04a2de36db2921d8b23b1660d2e79367da922b3f'
+  version '2019.2.2'
+  sha256 'b69a63f83ad922bc1c19baa819fd7da1a24c41dd26341f4c6521e35a74d8def0'
 
   url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.