### PR TITLE
Update codekit from 3.9,31483 to 3.9,31486

### DIFF
--- a/Casks/codekit.rb
+++ b/Casks/codekit.rb
@@ -1,6 +1,6 @@
 cask 'codekit' do
-  version '3.9,31483'
-  sha256 'f937f4a52f264c38598c57c352cdee44f169d5adbb97038b68f58a86ad64c9c3'
+  version '3.9,31486'
+  sha256 'd1a91eb8605a5f6a9b6110fb6c6a190ec79e9811c600a987f0954021620860ed'
 
   url "https://codekitapp.com/binaries/codekit-#{version.after_comma}.zip"
   appcast "https://codekitapp.com/api/#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.