### PR TITLE
Update qfinder-pro from 2.6.2.0306 to 7.1.1.0527

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,9 +1,9 @@
 cask 'qfinder-pro' do
-  version '2.6.2.0306'
-  sha256 '46d8e1af1723bbe6dcc0f1e9a59527045c5531ed57f6f4cb042013ee8bc819b2'
+  version '7.1.1.0527'
+  sha256 '47f0d0236c6ee37dde6b4fba889d879341d523460100a3b82489d0eb427ff223'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
-  appcast 'https://update.qnap.com/SoftwareRelease.xml'
+  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://update.qnap.com/SoftwareRelease.xml&splitter_1=Mac_for_QT&index_1=1&splitter_2=downloadURL&index_2=1'
   name 'Qnap Qfinder Pro'
   homepage 'https://www.qnap.com/en/utilities#utliity_5'
 

--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -9,5 +9,8 @@ cask 'qfinder-pro' do
 
   pkg 'Qfinder Pro.pkg'
 
-  uninstall pkgutil: 'qnap.com.qfinder.*'
+  uninstall pkgutil: [
+                       'qnap.com.qfinder.*',
+                       'qnap.com.Qfinder',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.