### PR TITLE
Update amazon-music from 7.5.0,20190626:1927065e20 to 7.5.1,20190723:014052ad97

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask 'amazon-music' do
-  version '7.5.0,20190626:1927065e20'
-  sha256 'b654d9a8f3db7efc5d641061db744be6672838b73fb27588d755e335d350ed90'
+  version '7.5.1,20190723:014052ad97'
+  sha256 '4e47f4f8178c9fee099bfd9b7ad2d25ed816fd3f59018f6b86aa41e2a972f792'
 
   # ssl-images-amazon.com/images was verified as official when first introduced to the cask
   url "https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/#{version.after_comma.before_colon}/#{version.after_colon}/AmazonMusicInstaller.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.