### PR TITLE
Use stricter similarity index for finding renames.

### DIFF
--- a/.github/actions/automerge/automerge.rb
+++ b/.github/actions/automerge/automerge.rb
@@ -89,12 +89,7 @@ def merge_pull_request(pr, statuses = GitHub.open_api(pr.fetch("statuses_url")))
 
     cask_path = diff.files.first.a_path
 
-    out, _ = system_command! 'git', args: ['-C', tap.path, 'log', '--pretty=format:', '-G', '\s+version\s+\'', '--follow', '-p', '--', cask_path]
-
-    puts "DIFF for #{pr_name}:"
-    puts "-" * 80
-    puts out
-    puts "-" * 80
+    out, _ = system_command! 'git', args: ['-C', tap.path, 'log', '--pretty=format:', '-G', '\s+version\s+\'', '--follow', '--find-renames=60%', '--patch', '--', cask_path]
 
     version_diff = GitDiff.from_string(out)
     previous_versions = version_diff.additions.select { |l| l.version? }.map { |l| l.version }.uniq


### PR DESCRIPTION
Fixes auto-merging of `clion` which falsely shares history with `webstorm` because of a rename detected with:

```diff
similarity index 57%
```