### PR TITLE
Update fman from 1.6.4 to 1.6.5

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.6.4'
-  sha256 'e2cffda7e96fdb43b6eeef9235aa075487243bb689ebc8ce886d417cf5f73cf0'
+  version '1.6.5'
+  sha256 '09feb91e12f3fcac5dfaa123475dcc9cc7ad2a4fc596129ead08cfe88d2efb91'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.