### PR TITLE
Update mosaic from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/mosaic.rb
+++ b/Casks/mosaic.rb
@@ -1,6 +1,6 @@
 cask 'mosaic' do
-  version '1.2.1'
-  sha256 'a2225a340b71ec815c3391c5bd0d5dff6a2e13adc35863b2fd8dea620e2de2e8'
+  version '1.2.2'
+  sha256 '5389fc7aaf0e66d92f8d4f6d73aa92ecbba1d29de6498d53c316869f256ab51c'
 
   url "https://lightpillar.com/appdata/mosaic/archive/Mosaic_#{version.dots_to_underscores}.pkg"
   appcast 'https://lightpillar.com/appdata/mosaic/features/version-history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.