### PR TITLE
Update deezer from 4.11.2 to 4.12.2

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.11.2'
-  sha256 'a4e2df87827a4983e20fdd9cfc1b36ea6a8298fa98c3ca675872f63f80f10bee'
+  version '4.12.2'
+  sha256 '7bed8aaf4b17b127123d15366f9f4a108b64e78b546bd0530b07977ebf3aacb8'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.