### PR TITLE
Update roblox from 0.393.0.319623,abb55c6609004bfa to 0.394.0.322464,9c9e3266c5e94c13

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.393.0.319623,abb55c6609004bfa'
-  sha256 '14a1fbe7808e2b965e8e639aa7598af72da75237b6e23aa80ccc0667f33d41fa'
+  version '0.394.0.322464,9c9e3266c5e94c13'
+  sha256 'abcaf38dcce968505d26900dfb3f6c3f50286998313a75e9f8621637dc829254'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.