### PR TITLE
Update opera from 62.0.3331.66 to 62.0.3331.99

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '62.0.3331.66'
-  sha256 'b4ea3417be445b321332040f4d777107da164a599e1f40c06084e72f19e21414'
+  version '62.0.3331.99'
+  sha256 '6a7d455fcdefaf4178ac3675a5b88e4a789a4e0892b01fd881d60ee63eb36669'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast 'https://ftp.opera.com/pub/opera/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.