### PR TITLE
Update eventstore from 5.0.0 to 5.0.2

### DIFF
--- a/Casks/eventstore.rb
+++ b/Casks/eventstore.rb
@@ -1,6 +1,6 @@
 cask 'eventstore' do
-  version '5.0.0'
-  sha256 '5bcea119d3971c3bf9de5e0ce2a6963818a508a7071909a3d8d2b44a6d9063ed'
+  version '5.0.2'
+  sha256 'c42d61c675416c7537827ab882702c55fd6c19a2b04ad28aec413ef82e9d7675'
 
   url "https://eventstore.org/downloads/macos/EventStore-OSS-MacOS-macOS-v#{version}.tar.gz"
   name 'Event Store'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.