### PR TITLE
Update lastpass from 4.31.0 to 4.34.1

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.31.0'
-  sha256 '59e46babc86159d49709713c6cc07214258e344b60316759428c84da1e4695b7'
+  version '4.34.1'
+  sha256 'b35fec64bd6528918827759bb62454bc4410e2d3c32eb03df999e6a106de5225'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.