### PR TITLE
Update qgroundcontrol from 3.5.3 to 3.5.4

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,6 +1,6 @@
 cask 'qgroundcontrol' do
-  version '3.5.3'
-  sha256 '4f90195a0fd2a85acd803e8249793e5c8961d8d0af5ac3534eba0b156f17912c'
+  version '3.5.4'
+  sha256 'd51a9f4243eac1fe3b4997d8a807187237f81ea5b2aa122898c7e5c1f5d143e4'
 
   # github.com/mavlink/qgroundcontrol was verified as official when first introduced to the cask
   url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.