### PR TITLE
Update lbry from 0.34.0 to 0.34.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.34.0'
-  sha256 '0c787ea7b24b8b116b2c3350c1203056000b1e2f1d6e95c61a460d312bcad76e'
+  version '0.34.1'
+  sha256 'd020dd4c0a3651196195e7729de61c51093571d5561d93c38ae6d82ab747b2a0'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.