### PR TITLE
Update openrefine from 3.1 to 3.2

### DIFF
--- a/Casks/openrefine.rb
+++ b/Casks/openrefine.rb
@@ -1,6 +1,6 @@
 cask 'openrefine' do
-  version '3.1'
-  sha256 'cd076a7da0664dddbdbf2c56026a127722a8f99915d8b80401f9664cfa020a5c'
+  version '3.2'
+  sha256 'acf41ff8627036515cf9a11f7a42af6127ca8e107bb872c388e9252d1f107d87'
 
   # github.com/OpenRefine/OpenRefine was verified as official when first introduced to the cask
   url "https://github.com/OpenRefine/OpenRefine/releases/download/#{version}/openrefine-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.