### PR TITLE
Update go64 from 1.0.1 to 1.0.2

### DIFF
--- a/Casks/go64.rb
+++ b/Casks/go64.rb
@@ -1,7 +1,7 @@
 cask 'go64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.0.1'
-  sha256 '538110901c2e8ebe59a4e5df4c431139a9c02e21a4c574f61647f8bc582ef81e'
+  version '1.0.2'
+  sha256 'f70150c4732fd556d72ed203b3a1f261fd648c56b544aa2c8817c73403f2546e'
 
   url "https://www.stclairsoft.com/download/Go64-#{version}.zip"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?GO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.