### PR TITLE
Update lrtimelapse from 5.2.2 to 5.3

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,5 +1,5 @@
 cask 'lrtimelapse' do
-  version '5.2.2'
+  version '5.3'
   sha256 'f375279bdc4fa33d01e0243ad5bf9b84e645157f77fae6bc59acc64ad1817f82'
 
   url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.