### PR TITLE
Update slite from 1.1.1 to 1.1.2

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.1.1'
-  sha256 '903dce9c987e127b2f0d55f4f489eedf6972e14e6e525a68743df0f6ff31aadd'
+  version '1.1.2'
+  sha256 'b474883f7ce3a334e665ba7835dc67c01752f1e87a354fe7d34dc8854b94d2e0'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.