### PR TITLE
Update banking-4 from 7.1.0,7143 to 7.1.0,7146

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.1.0,7143'
-  sha256 'ac448fde7aab80fca99413f4efdfee4af63c7edcfdcde392bcb50908dfd85fd2'
+  version '7.1.0,7146'
+  sha256 'fcc82b4d820f1aa0181fb43b52eaf874739eb959912a4ed7ede55e2c71c4138f'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.