### PR TITLE
Update electron from 5.0.7 to 5.0.8

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '5.0.7'
-  sha256 '896cb88b8d112b181fb77d6259a92a10c234d75b2437ec01180390ee2855d2d4'
+  version '5.0.8'
+  sha256 '9c0fb2403ddecacc4db5a20e7e6a424d27e8fe1ce35610a5d945576e6614f1c0'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.