### PR TITLE
Update touchdesigner from 099.2019.16600 to 099.2019.17550

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2019.16600'
-  sha256 'd10e67535300864d98ed02db42abff132001694b03d39ef05e0c87cd4aba6ab9'
+  version '099.2019.17550'
+  sha256 '135261081607355f7829ceb7662396934a52ecb61e6593acd2c58d06776f7c9f'
 
   url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -2,7 +2,7 @@ cask 'touchdesigner' do
   version '099.2019.17550'
   sha256 '135261081607355f7829ceb7662396934a52ecb61e6593acd2c58d06776f7c9f'
 
-  url "https://www.derivative.ca/Builds/TouchDesigner#{version}.dmg"
+  url "https://download.derivative.ca/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"
   name 'Derivative TouchDesigner'
   homepage 'https://www.derivative.ca/'

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
   version '099.2019.17550'
-  sha256 '135261081607355f7829ceb7662396934a52ecb61e6593acd2c58d06776f7c9f'
+  sha256 '3b573ae4d50ce6d67f2d208602507d2a279f0c99106a931ebead6261e4cb3709'
 
   url "https://download.derivative.ca/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.