### PR TITLE
Update obinslab-starter from 1.0.11 to 1.1.0

### DIFF
--- a/Casks/obinslab-starter.rb
+++ b/Casks/obinslab-starter.rb
@@ -1,11 +1,11 @@
 cask 'obinslab-starter' do
-  version '1.0.11'
-  sha256 'f6db6ac1b5de1e1df3fb8095ab1c55e9708e3f6f1587ea69f187404248ce9400'
+  version '1.1.0'
+  sha256 '9a7916ef37ac10f7d65895ebce96575ac64366bcc834085f108578df0e2a98d8'
 
-  url "http://releases.obins.net/occ/darwin/x64/ObinslabStarter_#{version}_x64.dmg"
-  appcast 'http://en.obins.net/obinslab-starter'
+  url "http://releases.obins.net/occ/darwin/x64/ObinsKit_#{version}_x64.dmg"
+  appcast 'http://en.obins.net/obinskit'
   name 'Obinslab Starter'
-  homepage 'http://en.obins.net/obinslab-starter'
+  homepage 'http://en.obins.net/obinskit'
 
-  app 'Obinslab Starter.app'
+  app 'Obinskit.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.