### PR TITLE
postbox v6 moved the location of some Library data

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -14,9 +14,11 @@ cask 'postbox' do
 
   zap trash: [
                '~/Library/Application Support/Postbox',
+               '~/Library/Application Support/PostboxApp',
                '~/Library/Caches/com.crashlytics.data/com.postbox-inc.postbox',
                '~/Library/Caches/com.postbox-inc.postbox',
                '~/Library/Caches/Postbox',
+               '~/Library/Caches/PostboxApp',
                '~/Library/PDF Services/Mail PDF with Postbox',
                '~/Library/Preferences/com.postbox-inc.postbox.plist',
                '~/Library/Saved Application State/com.postbox-inc.postbox.savedState',


### PR DESCRIPTION
Version 6.0+ of Postbox moved the location of some `~/Library` data. These new directories must be cleaned up as well on `zap`. I suggest leaving the old directories in the `zap` list as the intention of the user during `zap` is to get rid of all data.

checked against Postbox 6.1.18 (current stable release).

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
