### PR TITLE
Update burn from 2.6.8 to 2.6.9

### DIFF
--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -1,6 +1,6 @@
 cask 'burn' do
-  version '2.6.8'
-  sha256 '58858c2cec125ea0aeb410b04e5465e613459c03059353d1d0df6bb32d193703'
+  version '2.6.9'
+  sha256 'd7b5f118801e58098b1d5cdc5ee0c7995a97ae3e9681773ecda4970eaa472ba7'
 
   # downloads.sourceforge.net/burn-osx was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.