### PR TITLE
Update go64 from 1.0.2 to 1.0.3

### DIFF
--- a/Casks/go64.rb
+++ b/Casks/go64.rb
@@ -1,6 +1,6 @@
 cask 'go64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.0.2'
+  version '1.0.3'
   sha256 'f70150c4732fd556d72ed203b3a1f261fd648c56b544aa2c8817c73403f2546e'
 
   url "https://www.stclairsoft.com/download/Go64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.