### PR TITLE
Update mycrypto from 1.6.9 to 1.7.0

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.6.9'
-  sha256 '725eada16df86aa37a66c8cc3777bb69916eed83311209cfc292fde42dcab495'
+  version '1.7.0'
+  sha256 '08a15e8fb3a24b17e5d068a98719bad293e3d8dca7787b18e26e28d870dc01c8'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.