### PR TITLE
Update sysdig-inspect from 0.4.1 to 0.4.2

### DIFF
--- a/Casks/sysdig-inspect.rb
+++ b/Casks/sysdig-inspect.rb
@@ -1,6 +1,6 @@
 cask 'sysdig-inspect' do
-  version '0.4.1'
-  sha256 'f5b9d52e74c711ea622ee73827c0e62c9af749e7b9f7bc0d22213961646c5571'
+  version '0.4.2'
+  sha256 '15cd21f309258f5017129e0983e475423d95eb54cbe6e4e25b2e509282122a8e'
 
   # download.sysdig.com/stable/sysdig-inspect was verified as official when first introduced to the cask
   url "https://download.sysdig.com/stable/sysdig-inspect/sysdig-inspect-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.