### PR TITLE
Update ios-app-signer from 1.2 to 1.13

### DIFF
--- a/Casks/ios-app-signer.rb
+++ b/Casks/ios-app-signer.rb
@@ -1,6 +1,6 @@
 cask 'ios-app-signer' do
-  version '1.2'
-  sha256 '1184ed787db30b0bae3e96bc744af2da9ff891e21a404a3cfd550a08aa402052'
+  version '1.13'
+  sha256 'd6a6e09c430b4827d8e02f6df745383f754a4d99ab53c2baae19bd9eb46d8dd4'
 
   # github.com/DanTheMan827/ios-app-signer was verified as official when first introduced to the cask
   url "https://github.com/DanTheMan827/ios-app-signer/releases/download/#{version}/iOS.App.Signer.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.