### PR TITLE
Update pyfa from 2.9.4 to 2.9.5

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.9.4'
-  sha256 '17a66ad4af414a9c69458532db3f5c2da0f0504bd58da7d8165de04dfc8f6913'
+  version '2.9.5'
+  sha256 'ca7d4096d22ee4b74ec6f675d2a764480675120e12811ed10d6160fabb455339'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.