### PR TITLE
Update dropshare from 5.3,5107 to 5.3.1,5109

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,6 +1,6 @@
 cask 'dropshare' do
-  version '5.3,5107'
-  sha256 '65b0bca963a499d70e21594f58716d390a82381a9cb1d1de8a88513767a1b357'
+  version '5.3.1,5109'
+  sha256 'fc859502030355c9bd3de2b9f9ed64db61903491e651c9bd9d42e725b8f46ded'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.