### PR TITLE
Update muse from 4.1 to 4.1.1

### DIFF
--- a/Casks/muse.rb
+++ b/Casks/muse.rb
@@ -1,8 +1,8 @@
 cask 'muse' do
-  version '4.1'
-  sha256 '598ed1ed26f32e886029c30eb531803e8850d45083b488a3dae3b01c61645d3c'
+  version '4.1.1'
+  sha256 '809ba172f9929b4b0d49bfbe5f9210946013761f3cdd27862fc887b31ae5d96c'
 
-  url "https://github.com/xzzz9097/Muse/releases/download/#{version}/Muse.app.zip"
+  url "https://github.com/xzzz9097/Muse/releases/download/v#{version}/Muse.app.zip"
   appcast 'https://github.com/xzzz9097/Muse/releases.atom'
   name 'Muse'
   homepage 'https://github.com/xzzz9097/Muse'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.