### PR TITLE
Revert "Update integrity from 9.0.5 to 9.0.6"

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,5 +1,5 @@
 cask 'integrity' do
-  version '9.0.6'
+  version '9.0.5'
   sha256 'a674ea5e2fd7715d99bc2907cda23a7f9444dfda35e8908146c6d0fb5e2a43de'
 
   # peacockmedia.co.uk/integrity was verified as official when first introduced to the cask


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#66831

SHA didn't change, despite mention in the changelog it is still version 9.0.5