### PR TITLE
Update pritunl from 1.0.1953.32 to 1.0.2144.93

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,6 +1,6 @@
 cask 'pritunl' do
-  version '1.0.1953.32'
-  sha256 '179ddc935fa0962989c4c82757e94379f83a5c611216b5060141ddcd87c7b1e6'
+  version '1.0.2144.93'
+  sha256 '846ecbfbed7e5ef48ad6595e75e2e0e1a3250c4ea08af0375ac98934083f06fc'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.