### PR TITLE
Update trilium-notes from 0.33.7 to 0.34.1

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.33.7'
-  sha256 'abf03a88988b51d22856180636bbf4f7f2f7365e1b1a98e6ec12f882923374e7'
+  version '0.34.1'
+  sha256 '4a9cd69db5cd9124e14fa15e6641d7c8dc377205da540983863bfec5e9d6a6a9'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.