### PR TITLE
Update pingplotter from 5.11.2 to 5.11.3

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -1,6 +1,6 @@
 cask 'pingplotter' do
-  version '5.11.2'
-  sha256 '77d6983fb1b58da903d24369762fef96901921037531f1e9fd300bcc3d1cd40f'
+  version '5.11.3'
+  sha256 '0b00c13301faaea9ae71d1fe3ac3c63090e29924eaa0333852337e1c8e0ec59a'
 
   url 'https://www.pingplotter.com/downloads/pingplotter_osx.zip'
   appcast 'https://www.pingplotter.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.