### PR TITLE
Update glyphs from 2.6.2,1247 to 2.6.2,1248

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.2,1247'
-  sha256 '8401e2ab8056e9dcc6d696e884df47be1fb6d559bbd6b482ae5082bba48cd22a'
+  version '2.6.2,1248'
+  sha256 '137853ab7d06f4d2fec6a0789bd4a3fffe810224295046a88a038516b33511f6'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.