### PR TITLE
Add TipToi-Manager v1.4.2

### DIFF
--- a/Casks/tiptoi-manager.rb
+++ b/Casks/tiptoi-manager.rb
@@ -11,6 +11,7 @@ cask 'tiptoi-manager' do
 
   uninstall pkgutil: 'com.ravensburger.tiptoi.TipToiBindings',
             delete: '/Applications/tiptoi®\ Manager.app'
+            quit: 'com.ravensburger.tiptoimanager'
 
   zap trash: [
               '/Applications/tiptoi®\ Manager.app',

--- a/Casks/tiptoi-manager.rb
+++ b/Casks/tiptoi-manager.rb
@@ -2,22 +2,21 @@ cask 'tiptoi-manager' do
   version '4.1.2'
   sha256 '6f3d1a109cffb49c2942243a2ec1101561970fbeb57166f45b00972ce7e72c65'
 
+  # tiptoidata.s3-de.object.vdc.interoute.com was verified as official when first introduced to the cask
   url 'https://tiptoidata.s3-de.object.vdc.interoute.com/installer_flat/tiptoi_Manager_Installer.pkg'
   name 'tiptoi® Manager'
-
   homepage 'https://www.ravensburger.de/entdecken/ravensburger-marken/tiptoi/tiptoi-manager/index.html'
 
   pkg 'tiptoi_Manager_Installer.pkg'
 
   uninstall pkgutil: 'com.ravensburger.tiptoi.TipToiBindings',
-            delete: '/Applications/tiptoi®\ Manager.app',
-            quit: 'com.ravensburger.tiptoimanager'
+            delete:  '/Applications/tiptoi®\ Manager.app',
+            quit:    'com.ravensburger.tiptoimanager'
 
   zap trash: [
-              '/Applications/tiptoi®\ Manager.app',
-              '~/Library/Application\ Support/com.ravensburger.tiptoimanager',
-              '~/Library/Preferences/com.ravensburger.tiptoimanager.plist',
-              '~/Library/Saved\ Application\ State/com.ravensburger.tiptoimanager.savedState'
+               '/Applications/tiptoi®\ Manager.app',
+               '~/Library/Application\ Support/com.ravensburger.tiptoimanager',
+               '~/Library/Preferences/com.ravensburger.tiptoimanager.plist',
+               '~/Library/Saved\ Application\ State/com.ravensburger.tiptoimanager.savedState',
              ]
-
 end

--- a/Casks/tiptoi-manager.rb
+++ b/Casks/tiptoi-manager.rb
@@ -1,0 +1,22 @@
+cask 'tiptoi-manager' do
+  version '4.1.2'
+  sha256 '6f3d1a109cffb49c2942243a2ec1101561970fbeb57166f45b00972ce7e72c65'
+
+  url 'https://tiptoidata.s3-de.object.vdc.interoute.com/installer_flat/tiptoi_Manager_Installer.pkg'
+  name 'tiptoi® Manager'
+
+  homepage 'https://www.ravensburger.de/entdecken/ravensburger-marken/tiptoi/tiptoi-manager/index.html'
+
+  pkg 'tiptoi_Manager_Installer.pkg'
+
+  uninstall pkgutil: 'com.ravensburger.tiptoi.TipToiBindings',
+            delete: '/Applications/tiptoi®\ Manager.app'
+
+  zap trash: [
+              '/Applications/tiptoi®\ Manager.app',
+              '~/Library/Application\ Support/com.ravensburger.tiptoimanager',
+              '~/Library/Preferences/com.ravensburger.tiptoimanager.plist',
+              '~/Library/Saved\ Application\ State/com.ravensburger.tiptoimanager.savedState'
+             ]
+
+end

--- a/Casks/tiptoi-manager.rb
+++ b/Casks/tiptoi-manager.rb
@@ -4,7 +4,7 @@ cask 'tiptoi-manager' do
 
   # tiptoidata.s3-de.object.vdc.interoute.com was verified as official when first introduced to the cask
   url 'https://tiptoidata.s3-de.object.vdc.interoute.com/installer_flat/tiptoi_Manager_Installer.pkg'
-  name 'tiptoi® Manager'
+  name 'tiptoi Manager'
   homepage 'https://www.ravensburger.de/entdecken/ravensburger-marken/tiptoi/tiptoi-manager/index.html'
 
   pkg 'tiptoi_Manager_Installer.pkg'

--- a/Casks/tiptoi-manager.rb
+++ b/Casks/tiptoi-manager.rb
@@ -10,13 +10,13 @@ cask 'tiptoi-manager' do
   pkg 'tiptoi_Manager_Installer.pkg'
 
   uninstall pkgutil: 'com.ravensburger.tiptoi.TipToiBindings',
-            delete:  '/Applications/tiptoi®\ Manager.app',
+            delete:  '/Applications/tiptoi® Manager.app',
             quit:    'com.ravensburger.tiptoimanager'
 
   zap trash: [
-               '/Applications/tiptoi®\ Manager.app',
-               '~/Library/Application\ Support/com.ravensburger.tiptoimanager',
+               '/Applications/tiptoi® Manager.app',
+               '~/Library/Application Support/com.ravensburger.tiptoimanager',
                '~/Library/Preferences/com.ravensburger.tiptoimanager.plist',
-               '~/Library/Saved\ Application\ State/com.ravensburger.tiptoimanager.savedState',
+               '~/Library/Saved Application State/com.ravensburger.tiptoimanager.savedState',
              ]
 end

--- a/Casks/tiptoi-manager.rb
+++ b/Casks/tiptoi-manager.rb
@@ -10,7 +10,7 @@ cask 'tiptoi-manager' do
   pkg 'tiptoi_Manager_Installer.pkg'
 
   uninstall pkgutil: 'com.ravensburger.tiptoi.TipToiBindings',
-            delete: '/Applications/tiptoi®\ Manager.app'
+            delete: '/Applications/tiptoi®\ Manager.app',
             quit: 'com.ravensburger.tiptoimanager'
 
   zap trash: [


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.

My ruby installation seems to be broken. The scirpt won't run with the following error message:

`Gem::Ext::BuildError: ERROR: Failed to build gem native extension.`

- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256