### PR TITLE
Update unity from 2019.1.10f1,f007ed779b7a to 2019.1.12f1,f04f5427219e

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.1.10f1,f007ed779b7a'
-  sha256 'fbbed5b30d20b772c3020cdce6a81e039af85609a82c7d57c01d85dd844c124e'
+  version '2019.1.12f1,f04f5427219e'
+  sha256 '0cdbe4bf2999a0725bb37c574f23acd9e57bc0c2da1d61870e0f2cdaa3d23dd4'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.