### PR TITLE
Update blitz from 1.1.3 to 1.1.4

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.1.3'
-  sha256 'afcaccf6657c68d97eaa7a82327b75041961e4ea584c4ecb241465c200a09c97'
+  version '1.1.4'
+  sha256 '64a8ee77463d1e6e895a89545b8da59ed826326b93ac79477a59f0c8cf7e1099'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.