### PR TITLE
Update cacher from 2.13.1 to 2.13.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.13.1'
-  sha256 '56c93d2e02428f919dbe30373ee797dce3674f8cc04440e8bd8d81c80ac0eeb0'
+  version '2.13.3'
+  sha256 'c2ffad5b048b943c2a77d7bb2ec5f3e86e4a6346df468982af3f747351ebeeea'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.