### PR TITLE
Update texpad from 1.8.10,463,4717d3d to 1.8.11,474,9beaeb1

### DIFF
--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -6,8 +6,8 @@ cask 'texpad' do
     version '1.8.5,404,f8f30e5'
     sha256 '676a1b071142c022cdfda57668c811f7747b36ded442548073fe6dda1b9ca934'
   else
-    version '1.8.10,463,4717d3d'
-    sha256 '9eedacdd03518108aa0abdde7718fa4e2d38f2c5d878f3053e4464d1d9f79685'
+    version '1.8.11,474,9beaeb1'
+    sha256 '46b5307e47cefc56ee2395cdd413a4cb95bdc8278ee3975066757a98f08f632d'
   end
 
   # download.texpadapp.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.