### PR TITLE
Update workflowy from 1.3.2 to 1.3.3

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.2'
-  sha256 '6a88353160b4d365dc43275e7e5a31a18750495cc254fee7f14fcd155c86d45c'
+  version '1.3.3'
+  sha256 '6d27f2460906594866c2bf7308844857b329de32801f0a77ee5416bc2fa3ace0'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.