### PR TITLE
Update ghost-browser from 2.1.1.3 to 2.1.1.4

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.3'
-  sha256 '7b7a3a3a40abf492cb8f0cb5ee12b7292e0169c0b586cfcc0d0e1d063d528021'
+  version '2.1.1.4'
+  sha256 '2d87039ff8228f4a6663dc1ef878592dbd72c197adea032031613a8cd2bce28d'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.