### PR TITLE
Update toggl from 7.4.479 to 7.4.484

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.479'
-  sha256 '4ed9a4fa41429eff53c1c136a6b12dc5fddfeb8a74e4a70ffeabe5c4e71c0f6e'
+  version '7.4.484'
+  sha256 '8aa8d739138053dec2081bfbf47c4b3f27f73ab810af13a29497bd54846fd2e3'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.