### PR TITLE
Update nteract from 0.14.4 to 0.14.5

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask 'nteract' do
-  version '0.14.4'
-  sha256 '151098f4adafe0e4d614d3f75632c79136e8b73f85fca0bf2a32a7e8abe8c33f'
+  version '0.14.5'
+  sha256 '92e28683cb8d39c4975eb28109fd5a639cef4d27c0987aff64dd59d9913ec394'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.