### PR TITLE
Update bisq from 1.1.3 to 1.1.4

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '1.1.3'
-  sha256 'ceff20fbb4c446c236d7d92b05ee82a389c3a05121e23031152b61747b5c007c'
+  version '1.1.4'
+  sha256 'a53cbce3a08c88b92aac8c4f9ed7df6d46792d6e1f4e924293e090393ee2acad'
 
   # github.com/bisq-network/bisq was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.