### PR TITLE
Update qownnotes from 19.7.10,b4408-053212 to 19.7.11,b4415-184948

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.7.10,b4408-053212'
-  sha256 '5115ee1f1cae6b49a207353adb240288423e81918cd031f86386d9f155009aa1'
+  version '19.7.11,b4415-184948'
+  sha256 'c644a3d6f5d2518d79959c6a764eee4c21e64e403cdf37d973fe844368d6322c'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.