### PR TITLE
Update flipper from 0.23.3 to 0.23.4

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.23.3'
-  sha256 '6a15432795e393336116ab8bc2ae906e23d0fd3709eac8477930560fd1655aa5'
+  version '0.23.4'
+  sha256 'e0b2ac86c560252a062f72e7e138135dc6d4090f7724e1729f78fcde62934281'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.