### PR TITLE
[WIP] Update blender from 2.79b to 2.80

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -9,7 +9,7 @@ cask 'blender' do
   homepage 'https://www.blender.org/'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
-  app "blender-#{version}-macOS/blender.app", target: 'Blender.app'
+  app "blender-#{version}-macOS/Blender.app", target: 'Blender.app'
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/blender.wrapper.sh"
   binary shimscript, target: 'blender'
@@ -20,7 +20,7 @@ cask 'blender' do
 
     IO.write shimscript, <<~EOS
       #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/blender' "$@"
+      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
     EOS
   end
 end

--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -1,8 +1,8 @@
 cask 'blender' do
-  version '2.79b'
-  sha256 '07592ebb50749638202d51a6220b05e4c9b070d149fce34bb6ce8757fad2f152'
+  version '2.80'
+  sha256 '1f4ee2e3c35f837ede836be4dd75a7ba2f573ac447cb871e073202ab39ed179d'
 
-  url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macOS-10.6.zip"
+  url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macOS.dmg"
   appcast 'https://download.blender.org/release/',
           configuration: version.delete('a-z')
   name 'Blender'
@@ -10,7 +10,6 @@ cask 'blender' do
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "blender-#{version}-macOS-10.6/blender.app", target: 'Blender.app'
-  app "blender-#{version}-macOS-10.6/blenderplayer.app", target: 'Blenderplayer.app'
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/blender.wrapper.sh"
   binary shimscript, target: 'blender'

--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -8,8 +8,7 @@ cask 'blender' do
   name 'Blender'
   homepage 'https://www.blender.org/'
 
-  # Renamed for consistency: app name is different in the Finder and in a shell.
-  app "blender-#{version}-macOS/Blender.app", target: 'Blender.app'
+  app 'Blender.app'
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/blender.wrapper.sh"
   binary shimscript, target: 'blender'

--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -9,7 +9,7 @@ cask 'blender' do
   homepage 'https://www.blender.org/'
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
-  app "blender-#{version}-macOS-10.6/blender.app", target: 'Blender.app'
+  app "blender-#{version}-macOS/blender.app", target: 'Blender.app'
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/blender.wrapper.sh"
   binary shimscript, target: 'blender'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I’ll update the checkboxes once Blender is downloaded (this a major update, so their servers are probably overloaded).

[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
