### PR TITLE
Update blender from 2.79b to 2.80

### DIFF
--- a/Casks/blender.rb
+++ b/Casks/blender.rb
@@ -1,8 +1,8 @@
 cask 'blender' do
-  version '2.79b'
+  version '2.80'
   sha256 '07592ebb50749638202d51a6220b05e4c9b070d149fce34bb6ce8757fad2f152'
 
-  url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macOS-10.6.zip"
+  url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macOS.dmg"
   appcast 'https://download.blender.org/release/',
           configuration: version.delete('a-z')
   name 'Blender'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.