### PR TITLE
Update pyfa from 2.9.5 to 2.9.6

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.9.5'
-  sha256 'ca7d4096d22ee4b74ec6f675d2a764480675120e12811ed10d6160fabb455339'
+  version '2.9.6'
+  sha256 'ded8f1963b2980da1b44f5a297fb540f0ddaf38e72cd28cbe31060e9eb0a7abb'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.