### PR TITLE
Update archipelago from 3.5.1 to 3.6.2

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.5.1'
-  sha256 '91d398d1c74dcf8fc0c030d289ee5019be8aa34b5f48eff141d20d11d6441db6'
+  version '3.6.2'
+  sha256 '56415b705b89e3290e9ce00cd26d7d74c4cba235fcfe542c0ca1e4fe06d208ba'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.