### PR TITLE
Update typinator from 8.0.1 to 8.1

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,6 +1,6 @@
 cask 'typinator' do
-  version '8.0.1'
-  sha256 '7b81643991a32d00eb667b574e8717d5f4f6dec79329ef45ec1a23cbf7e874e2'
+  version '8.1'
+  sha256 '3e3d06a29042b32e39e92c3515a7764c35439f291c158d236bc183fa66d6f5b7'
 
   url "https://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.