### PR TITLE
Update omniplan from 3.12.3 to 3.13

### DIFF
--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,6 +1,6 @@
 cask 'omniplan' do
-  version '3.12.3'
-  sha256 '5ddbed0528fc5fedf59070cc6ee28e99698784e310c890e4f8207ebf092af2b6'
+  version '3.13'
+  sha256 'd721309de6a7c3ff931e34aad066e9dc89c8c200f0c89417cd3617189242817e'
 
   url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniPlan#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.