### PR TITLE
Update musictube from 1.8.1 to 1.9

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,6 +1,6 @@
 cask 'musictube' do
-  version '1.8.1'
-  sha256 'e2d39cc371db386b625b4741a9bc1c3089671fc3bd04cf951e40d934d7fe540d'
+  version '1.9'
+  sha256 '6f43a8007d2d9f172c18ce96545fce788b7f92074fb4b61fcf0a56559181a4b3'
 
   url 'https://flavio.tordini.org/files/musictube/musictube.dmg'
   appcast 'https://flavio.tordini.org/musictube-ws/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.