### PR TITLE
Update fl-studio from 20.5.0.476 to 20.5.1.522

### DIFF
--- a/Casks/fl-studio.rb
+++ b/Casks/fl-studio.rb
@@ -1,6 +1,6 @@
 cask 'fl-studio' do
-  version '20.5.0.476'
-  sha256 'f2e9989850f64a714550e1c8006af0ea488e106a96b795a37315bc1619d7cdfb'
+  version '20.5.1.522'
+  sha256 '283beca8b276b82aa32f2c9fa731191c99192f5be74b43eee98ad28588649043'
 
   url "http://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.image-line.com/redirect/flstudio20_mac_installer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.