### PR TITLE
Update 4k-youtube-to-mp3 from 3.7.1.2862 to 3.7.2.2902

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.7.1.2862'
-  sha256 '888f7057fce8ac10cf4728e1ba7a9960708a981dd11d9c4f62fd43b1c5ed370e'
+  version '3.7.2.2902'
+  sha256 '62ca793ed2b2fa241f1a2b09d9e57857e40e274797600093d2a8ad56d4194c3d'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.