### PR TITLE
Updated TablePlus to build 252.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '2.7,246'
-  sha256 '4c0c1592aec9017f0c90149294bd492a7c7666abbeb2503b32bf2ed6af634a3c'
+  version '2.8.1,252'
+  sha256 '42638fa0f54f093504b955ef33f54355ba073268feedae670f7fe8e78c03b05c'
 
   # tableplus-osx-builds.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).