### PR TITLE
Update docker from 2.0.0.3-ce-mac81,31259 to 2.1.0.0,36874

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -3,8 +3,8 @@ cask 'docker' do
     version '18.06.1-ce-mac73,26764'
     sha256 '3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5'
   else
-    version '2.0.0.3-ce-mac81,31259'
-    sha256 'a55462f153284ff212f8857945a69d4e128afb6753f5572984877f7b6fc3fc25'
+    version '2.1.0.0,36874'
+    sha256 '6571554a70dc5c5cea4f05c03038019411d5d8310fcea514a50110b038de715b'
   end
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.