### PR TITLE
Update framer-x from 33662,1564062787 to 33905,1564498799

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '33662,1564062787'
-  sha256 'd0f5ff0f3fbe51e1f386c1d89892438a0714dd6160efb9f78c5a2ec866ae641f'
+  version '33905,1564498799'
+  sha256 'f82bbef554c578092c233277ea47686bc151e438e1b179c5e9fb48d615c3cf3b'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.