### PR TITLE
Update amazon-workspaces from 2.5.8 to 2.5.9

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,6 +1,6 @@
 cask 'amazon-workspaces' do
-  version '2.5.8'
-  sha256 '739a7babc51863a6696264d0ce915a64f0416ea4676fe5c385e7662ae246333b'
+  version '2.5.9'
+  sha256 '215c762adc7fcc35cb161604a74f25f0b7ac9e94f9c9727c4945349826b1bcfe'
 
   # d2td7dqidlhjx7.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.