### PR TITLE
Update deckset from 2.0.9,2513 to 2.0.10,2521

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -1,6 +1,6 @@
 cask 'deckset' do
-  version '2.0.9,2513'
-  sha256 '62bc5cebeddd0601c5e7e4b5a1646355549edf4621703e9d7da69cc11a67e7b1'
+  version '2.0.10,2521'
+  sha256 '1bf4aa857a8a2bee28962a6c7b19c2ac50a47b71937b0f97834fa253451c0453'
 
   url "https://dl.decksetapp.com/Deckset+#{version.before_comma}+(#{version.after_comma}).dmg"
   appcast 'https://dl.decksetapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.