### PR TITLE
Update metabase from 0.32.9.0 to 0.32.10.0

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.32.9.0'
-  sha256 'dc4f76d093f80aa2f27d4dd8b961afff8fdbe8d94841c0838779c992a6b2436f'
+  version '0.32.10.0'
+  sha256 '06923e5e66e3a2dc0a0e3c4df9e69e5caaa1f25dddadf853772d148833cc5963'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.