### PR TITLE
Update synology-chat from 1.1.0-56 to 1.1.1-57

### DIFF
--- a/Casks/synology-chat.rb
+++ b/Casks/synology-chat.rb
@@ -1,6 +1,6 @@
 cask 'synology-chat' do
-  version '1.1.0-56'
-  sha256 '2335cb1aa1918bd9efb19a28bc58e95282bdbd1bf63b6d017f188175347d82b4'
+  version '1.1.1-57'
+  sha256 '1f61431ab0e7ac5646bfedec610e2ca6be527f5ab4001789a14990ebd9aab78c'
 
   url "https://global.download.synology.com/download/Tools/ChatClient/#{version}/Mac/Installer/Chat-#{version}.dmg"
   name 'Synology Chat'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.