### PR TITLE
Update imgotv from 6.0.3-mango2 to 6.1.1-mango2

### DIFF
--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -1,6 +1,6 @@
 cask 'imgotv' do
-  version '6.0.3-mango2'
-  sha256 'b69a5fedc1af407f48191d0f1e666bc3edf5f05597efc1e6ef97a7ddadb44cd3'
+  version '6.1.1-mango2'
+  sha256 '010df642af300d03fcf075ffa5cfb7a38ba345e448106d262152396f189a0430'
 
   # download.imgo.tv was verified as official when first introduced to the cask
   url "https://download.imgo.tv/app/pc/mac/mgtv-client-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.