### PR TITLE
Update preform from 3.0.2,1267 to 3.0.3,1340

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.0.2,1267'
-  sha256 'fafe6f59c63e93997a4367034f7836355e142f7c71fe2b2befabd8e80d683889'
+  version '3.0.3,1340'
+  sha256 'b793d2ab21b9c47b6f983e2f346fa0ddf63f4c880a3f8fd11c3b7dc7e9489eec'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.