### PR TITLE
Update iterm2 from 3.2.9 to 3.3.0

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.9'
-  sha256 'de36881fea3b4ff4c9c421a3db68292ad1f6a467af3b7f84b8455b000314c191'
+  version '3.3.0'
+  sha256 '30cdb093764684a65efdf98afde393fcbef0bee985a415346ae4186d72c893c8'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.