### PR TITLE
Update mosaic from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/mosaic.rb
+++ b/Casks/mosaic.rb
@@ -1,6 +1,6 @@
 cask 'mosaic' do
-  version '1.2.2'
-  sha256 '5389fc7aaf0e66d92f8d4f6d73aa92ecbba1d29de6498d53c316869f256ab51c'
+  version '1.2.3'
+  sha256 '1cca6ee0e5615ece7027e7d443bf58a9ef0d770190366cf0d701fc8bf1db286f'
 
   url "https://lightpillar.com/appdata/mosaic/archive/Mosaic_#{version.dots_to_underscores}.pkg"
   appcast 'https://lightpillar.com/appdata/mosaic/features/version-history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.