### PR TITLE
Update mathpix-snipping-tool from 2.0.0.94 to 2.0.1.97

### DIFF
--- a/Casks/mathpix-snipping-tool.rb
+++ b/Casks/mathpix-snipping-tool.rb
@@ -1,6 +1,6 @@
 cask 'mathpix-snipping-tool' do
-  version '2.0.0.94'
-  sha256 '658473f87b52d3d4787208071197a4d886ca0f7d88f27c877d12e36a1a397d9d'
+  version '2.0.1.97'
+  sha256 'ed977f4ef15869d1c5119651d07f4f27dc683042949bdd831b00bac5e112aee4'
 
   url "https://mathpix.com/dmg/SnippingTool-v#{version}.dmg"
   appcast 'https://mathpix.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.