### PR TITLE
Update dotnet from 2.2.3 to 2.2.6

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,8 +1,8 @@
 cask 'dotnet' do
-  version '2.2.3'
-  sha256 '85fa291a86baaed7ae7b2806ae610d40e96155c15eb64ebbc8c9572d9f7534b9'
+  version '2.2.6'
+  sha256 'a11b08ccc66436443f7ba6d533c6f85c1711bd912274a07d2320fe9d2e669485'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/872243f8-de92-480f-accd-9a22304cd3f9/aad669c10799a3e6e1deac73e8559c49/dotnet-runtime-#{version}-osx-x64.pkg"
+  url "https://dotnet.microsoft.com/download/thank-you/dotnet-runtime-#{version}-macos-x64-installer"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.Net Core Runtime'
   homepage 'https://www.microsoft.com/net/core#macos'

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,8 +1,8 @@
 cask 'dotnet' do
-  version '2.2.6'
+  version '2.2.6,7fd8704c-560f-47dc-8fe0-b777e5e743e7:d7a4476f50828bf4095455b49c02cc01
   sha256 'ae58557457f2876e639cf166362456e76b17939f065784c146a0a459b1cfb389'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/7fd8704c-560f-47dc-8fe0-b777e5e743e7/d7a4476f50828bf4095455b49c02cc01/dotnet-runtime-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.Net Core Runtime'
   homepage 'https://www.microsoft.com/net/core#macos'

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,5 +1,5 @@
 cask 'dotnet' do
-  version '2.2.6,7fd8704c-560f-47dc-8fe0-b777e5e743e7:d7a4476f50828bf4095455b49c02cc01
+  version '2.2.6,7fd8704c-560f-47dc-8fe0-b777e5e743e7:d7a4476f50828bf4095455b49c02cc01'
   sha256 'ae58557457f2876e639cf166362456e76b17939f065784c146a0a459b1cfb389'
 
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version}-osx-x64.pkg"

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,8 +1,8 @@
 cask 'dotnet' do
   version '2.2.6'
-  sha256 'a11b08ccc66436443f7ba6d533c6f85c1711bd912274a07d2320fe9d2e669485'
+  sha256 'ae58557457f2876e639cf166362456e76b17939f065784c146a0a459b1cfb389'
 
-  url "https://dotnet.microsoft.com/download/thank-you/dotnet-runtime-#{version}-macos-x64-installer"
+  url "https://download.visualstudio.microsoft.com/download/pr/7fd8704c-560f-47dc-8fe0-b777e5e743e7/d7a4476f50828bf4095455b49c02cc01/dotnet-runtime-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.Net Core Runtime'
   homepage 'https://www.microsoft.com/net/core#macos'

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -14,7 +14,7 @@ cask 'dotnet' do
                        ]
   depends_on macos: '>= :sierra'
 
-  pkg "dotnet-runtime-#{version}-osx-x64.pkg"
+  pkg "dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   binary '/usr/local/share/dotnet/dotnet'
 
   uninstall pkgutil: 'com.microsoft.dotnet.*',

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -2,7 +2,7 @@ cask 'dotnet' do
   version '2.2.6,7fd8704c-560f-47dc-8fe0-b777e5e743e7:d7a4476f50828bf4095455b49c02cc01'
   sha256 'ae58557457f2876e639cf166362456e76b17939f065784c146a0a459b1cfb389'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.Net Core Runtime'
   homepage 'https://www.microsoft.com/net/core#macos'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.