### PR TITLE
Update opencpn from 5.0.0,9065270 to 5.0.1,0266678

### DIFF
--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -1,6 +1,6 @@
 cask 'opencpn' do
-  version '5.0.0,9065270'
-  sha256 'ce572043a1e58f9b44cfd7904e1080fc202e2ae6152f357e898db4bc0d555ae1'
+  version '5.0.1,0266678'
+  sha256 'b3da4a758d898a9a2f79ba2618ff6cf9529b06dd1ccba14f4dd3e4996660b143'
 
   url "http://download.opencpn.org/#{version.before_comma}/OpenCPN_#{version.before_comma}+#{version.after_comma}.dmg"
   appcast 'https://github.com/OpenCPN/OpenCPN/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.