### PR TITLE
Update FontForge to 2019.08.01.ac635b8

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,6 +1,6 @@
 cask 'fontforge' do
-  version '2019.04.13.7f6f1d0'
-  sha256 '365e4d406ee524e8bdb5646754cf1ebcb94ad68866a1bdc6870a17c4a14e1a46'
+  version '2019.08.01.ac635b8'
+  sha256 'c5c117b083d8fa73c2ffa19e000d698a3e3cb323b47002c54c1b9047633a227e'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
   url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"
@@ -8,13 +8,7 @@ cask 'fontforge' do
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'
 
-  depends_on x11: true
   depends_on macos: '>= :yosemite'
 
   app 'FontForge.app'
-
-  caveats <<~EOS
-    #{token} will only run from within /Applications,
-    and will request to be moved at launch.
-  EOS
 end

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -4,7 +4,8 @@ cask 'fontforge' do
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
   url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"
-  appcast 'https://github.com/fontforge/fontforge/releases.atom'
+  appcast 'https://github.com/fontforge/fontforge/releases.atom',
+          configuration: version.dots_to_hyphens
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'
 

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -5,7 +5,7 @@ cask 'fontforge' do
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
   url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"
   appcast 'https://github.com/fontforge/fontforge/releases.atom',
-          configuration: version.dots_to_hyphens
+          configuration: version.major_minor_patch.dots_to_hyphens
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'
 


### PR DESCRIPTION
* Remove x11 dependency which is no longer true.
* Drop caveat note which is also no longer true.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).