### PR TITLE
add depends on sierra to mathpix-snipping-tool.rb

### DIFF
--- a/Casks/mathpix-snipping-tool.rb
+++ b/Casks/mathpix-snipping-tool.rb
@@ -8,6 +8,7 @@ cask 'mathpix-snipping-tool' do
   homepage 'https://mathpix.com/'
 
   auto_updates true
+  depends_on macos: '>= :sierra'
 
   app 'Mathpix Snipping Tool.app'
 


### PR DESCRIPTION
depends on 10.12 ❤️ 