### PR TITLE
Update dosbox-x from 0.82.19,20190531205412 to 0.82.20,20190731203557

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.19,20190531205412'
-  sha256 'ba93f2f87e8aa92eaa2c6540d1f08e23cbd499cbc74d66d676c65a7cdaea773c'
+  version '0.82.20,20190731203557'
+  sha256 'd38ba2408dbe4e32bf4c73f60cb016af496b69092885ac2a2beb0331046f8c82'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"

--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -6,7 +6,7 @@ cask 'dosbox-x' do
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"
   appcast 'https://github.com/joncampbell123/dosbox-x/releases.atom'
   name 'DOSBox-X'
-  homepage 'http://dosbox-x.com/'
+  homepage 'https://dosbox-x.com/'
 
   app 'dosbox-x/dosbox-x.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.