### PR TITLE
Update deckset from 2.0.10,2521 to 2.0.11,2522

### DIFF
--- a/Casks/deckset.rb
+++ b/Casks/deckset.rb
@@ -1,6 +1,6 @@
 cask 'deckset' do
-  version '2.0.10,2521'
-  sha256 '1bf4aa857a8a2bee28962a6c7b19c2ac50a47b71937b0f97834fa253451c0453'
+  version '2.0.11,2522'
+  sha256 'dc84134de72fa0178fb510ab1857a96b03c484af1d38e7ed1dd886731427ca50'
 
   url "https://dl.decksetapp.com/Deckset+#{version.before_comma}+(#{version.after_comma}).dmg"
   appcast 'https://dl.decksetapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.