### PR TITLE
Update vnc-viewer from 6.19.325 to 6.19.715

### DIFF
--- a/Casks/vnc-viewer.rb
+++ b/Casks/vnc-viewer.rb
@@ -1,6 +1,6 @@
 cask 'vnc-viewer' do
-  version '6.19.325'
-  sha256 '4aa55fb9199920b394f5c518aca8b3e8800d3f54352c7d064f6df0f9c773f688'
+  version '6.19.715'
+  sha256 'c779c80bd4050ec848529af98fc904387666cec25f88c166e667128ba4787424'
 
   url "https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-#{version}-MacOSX-x86_64.dmg"
   appcast 'https://www.realvnc.com/en/connect/download/viewer/macos/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.