### PR TITLE
Update wechat from 2.3.26.17 to 2.3.26.18

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,5 +1,5 @@
 cask 'wechat' do
-  version '2.3.26.17'
+  version '2.3.26.18'
   sha256 '4f1800709f75bbffd43c12913d8ba06ee2373adca52600d44014beed522cdf7b'
 
   url 'https://dldir1.qq.com/weixin/mac/WeChatMac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.