### PR TITLE
Update airtame from 3.5.0 to 3.5.1

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '3.5.0'
-  sha256 'bc8f55ab6d11b5815c1484f5345cc151b5a3f8e980292238ffc4c7c5da51c585'
+  version '3.5.1'
+  sha256 '87d18b00238f76855152d26e0f1f69ce45dd56593b13f6be2eefb3bcb3468604'
 
   url "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.