### PR TITLE
Update armortext from 0.21.30 to 0.21.39

### DIFF
--- a/Casks/armortext.rb
+++ b/Casks/armortext.rb
@@ -1,6 +1,6 @@
 cask 'armortext' do
-  version '0.21.30'
-  sha256 '2a589d1ca54c434d75553f8594f1da9b773d65eca6006e5b3f7fe157b05675c8'
+  version '0.21.39'
+  sha256 'fbe87b9e9d8e8acad6e79ee8af3779e259fe22f7112ce7c5a967848b51fa8191'
 
   # armortext.co was verified as official when first introduced to the cask
   url "https://downloads.armortext.co/desktop/release/#{version}/ArmorText-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.