### PR TITLE
Update wavebox from 4.10.5 to 4.10.7

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.10.5'
-  sha256 '9ee1b14c8ce28a313eef73ca4c029c6a9937e11cd360d2f14bdb1d97c384d8c8'
+  version '4.10.7'
+  sha256 '0ee2b52b834ee04559a1a48dfca77e205d9a529e5b070eb3a6bb88f73b5570ed'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.