### PR TITLE
Update malwarebytes from 3.8.17.2526 to 3.9.23.2814

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '3.8.17.2526'
-  sha256 'e9da975b65f2a83c83882802108638356833fe5ef17397fd492b79d07496d8f4'
+  version '3.9.23.2814'
+  sha256 '8bd17eb957941ea5ea62fdbecf3153940475568b53fbd2a427f2ed0da21e130d'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.