### PR TITLE
Update wechatwork from 2.8.9.2000 to 2.8.10.2012

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.9.2000'
-  sha256 '8abb796b1fcdf903b59013fb46fd1f2525a166d4acc5693f97708a6d4d67a7d6'
+  version '2.8.10.2012'
+  sha256 '6c6be84491c5460951554692fb7b0738a80aa73ae1afdeca9a6a3bda1b2f8b4a'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.