### PR TITLE
Update wpsoffice from 1.3.1(1688) to 1.4.0(1935)

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,5 +1,5 @@
 cask 'wpsoffice' do
-  version '1.3.1(1688)'
+  version '1.4.0(1935)'
   sha256 '7220f1f13079cdbe8ab439e9e4eff0124c6831cfc35a1a8ecdbb23459db0c68e'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask

--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
   version '1.4.0(1935)'
-  sha256 '7220f1f13079cdbe8ab439e9e4eff0124c6831cfc35a1a8ecdbb23459db0c68e'
+  sha256 'c44192907d1e973672624f00128c8b5d35701f22a3a2d8d207e7e71c1b259d8d'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
   url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.major_minor_patch}/WPS_Office_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.