### PR TITLE
Update lingon-x from 7.3 to 7.3.1

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.4'
     sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
-    version '7.3'
-    sha256 '7eff602f723735e51169c875ea84778fe79dcb5b01258ebdd44ec54ceeee2389'
+    version '7.3.1'
+    sha256 '13f39ef6859ada42398389376906e12b07b48a4938907f26f7658df0ccfe99a2'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.