### PR TITLE
Update packages from 1.2.5 to 1.2.6

### DIFF
--- a/Casks/packages.rb
+++ b/Casks/packages.rb
@@ -1,6 +1,6 @@
 cask 'packages' do
   version '1.2.6'
-  sha256 'fcaa90e25ef2325c81f5e01be40916864fadc5d70e651bec3e341ec54d0a50d6'
+  sha256 'a24225be6981228f16f17140af2af91c0d27cac82c879de98e6ca788a4591f18'
 
   url 'http://s.sudre.free.fr/Software/files/Packages.dmg'
   appcast 'http://s.sudre.free.fr/Software/documentation/RemoteVersion.plist'

--- a/Casks/packages.rb
+++ b/Casks/packages.rb
@@ -1,6 +1,6 @@
 cask 'packages' do
-  version '1.2.5'
-  sha256 '44682aff97b6c9b4a87ede9ade95fa3b3ec9b44affb6bbb6f5ea016df72a3dde'
+  version '1.2.6'
+  sha256 'fcaa90e25ef2325c81f5e01be40916864fadc5d70e651bec3e341ec54d0a50d6'
 
   url 'http://s.sudre.free.fr/Software/files/Packages.dmg'
   appcast 'http://s.sudre.free.fr/Software/documentation/RemoteVersion.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.