### PR TITLE
Update cisdem-pdf-converter-ocr from 6.8.0 to 7.0.0

### DIFF
--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-pdf-converter-ocr' do
-  version '6.8.0'
-  sha256 'a3ca5b001e0c4d7ebe80d6582122c6e2968770e1726099af3ae5f98baf4c8774'
+  version '7.0.0'
+  sha256 'a92240fb9b280909b83f98718e68ece6998d3c9f0188560b69f91f92dad5859a'
 
   url 'http://download.cisdem.com/cisdem-pdfconverterocr.dmg'
   appcast 'https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.