### PR TITLE
Update understand from 5.1.994 to 5.1.995

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.994'
-  sha256 '73c1df2d2cbdfbac901c88fe581a6b80ff3b53d2efea030099f64fe6c88c7d10'
+  version '5.1.995'
+  sha256 '5cf1032d4e5828f619c4b17765ab0887f13643a7d6951c6f60ac0de35d0962f7'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.