### PR TITLE
Update bluestacks from 4.90.0.2809 to 4.110.0.2823,685451269560c4c06e62ecf5020f2f3f

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -1,8 +1,8 @@
 cask 'bluestacks' do
-  version '4.90.0.2809'
-  sha256 '7ccf00b60d4e2682cad1a6426b9b796f6996c01cd61e1cab93641ce657dcc2fa'
+  version '4.110.0.2823,685451269560c4c06e62ecf5020f2f3f'
+  sha256 '13b7b5fa312eb015ff99dc7488a9609a8679d98e6925902c8e8e43b57338735b'
 
-  url "https://cdn3.bluestacks.com/downloads/mac/bgp_mac/#{version}/BlueStacksInstaller_#{version}.dmg"
+  url "https://cdn3.bluestacks.com/downloads/mac/bgp64_mac/#{version.before_comma}/#{version.after_comma}/x64/BlueStacksInstaller_#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://cloud.bluestacks.com/api/getdownloadnow?platform=mac'
   name 'BlueStacks'
   homepage 'https://www.bluestacks.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.