### PR TITLE
Update vmware-remote-console from 10.0.5,14161502 to 10.0.6,14247266

### DIFF
--- a/Casks/vmware-remote-console.rb
+++ b/Casks/vmware-remote-console.rb
@@ -1,6 +1,6 @@
 cask 'vmware-remote-console' do
-  version '10.0.5,14161502'
-  sha256 '6a9294034785c466374f3408bf781e45acb878750a5c17d12671cac1def14f13'
+  version '10.0.6,14247266'
+  sha256 '8f1537e40b9e7a7b08015f41cdeaf537e0e07e027872e83349d6781ce6e2c84f'
 
   url "https://softwareupdate.vmware.com/cds/vmw-desktop/vmrc/#{version.before_comma}/#{version.after_comma}/macos/com.vmware.vmrc.zip.tar"
   appcast 'https://softwareupdate.vmware.com/cds/vmw-desktop/vmrc-macos.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.