### PR TITLE
Update slite from 1.1.2 to 1.1.3

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.1.2'
-  sha256 'b474883f7ce3a334e665ba7835dc67c01752f1e87a354fe7d34dc8854b94d2e0'
+  version '1.1.3'
+  sha256 '39271eedd06c2cc0779e51eb6927825501ee0e6856ec296144f1c3d4eeb3fe7b'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.