### PR TITLE
Update mirrorop from latest to 2.5.0.52

### DIFF
--- a/Casks/mirrorop.rb
+++ b/Casks/mirrorop.rb
@@ -2,7 +2,8 @@ cask 'mirrorop' do
   version '2.5.0.52'
   sha256 '00583d9f5e282fcd32cc0d940c9eec24aea5aeb34793d274a4cf0df28de924b8'
 
-  url 'https://www.barco.com/services/website/en/TdeFiles/Download?FileNumber=R33050100&TdeType=3&MajorVersion=2&MinorVersion=5&PatchVersion=0&BuildVersion=52&ShowDownloadPage=False'
+  url "https://www.barco.com/services/website/en/TdeFiles/Download?FileNumber=R33050100&TdeType=3&MajorVersion=#{version.major}&MinorVersion=#{version.minor}&PatchVersion=#{version.patch}&BuildVersion=#{version.split('.')[-1]}"
+  appcast 'https://www.barco.com/en/support/mirrorop/drivers'
   name 'MirrorOp Sender'
   homepage 'https://www.barco.com/en/product/mirrorop'
 

--- a/Casks/mirrorop.rb
+++ b/Casks/mirrorop.rb
@@ -1,10 +1,10 @@
 cask 'mirrorop' do
-  version :latest
-  sha256 :no_check
+  version '2.5.0.52'
+  sha256 '00583d9f5e282fcd32cc0d940c9eec24aea5aeb34793d274a4cf0df28de924b8'
 
-  url 'https://www.mirrorop.com/downloads/MirrorOpSender_mac.zip'
+  url 'https://www.barco.com/services/website/en/TdeFiles/Download?FileNumber=R33050100&TdeType=3&MajorVersion=2&MinorVersion=5&PatchVersion=0&BuildVersion=52&ShowDownloadPage=False'
   name 'MirrorOp Sender'
-  homepage 'https://www.mirrorop.com/'
+  homepage 'https://www.barco.com/en/product/mirrorop'
 
   app 'MirrorOp.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.