### PR TITLE
Revert weka to stable

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,10 +1,10 @@
 cask 'weka' do
-  version '3.9.3'
-  sha256 '5a2313c2455bdc09439724e4c450bf974bb238355ebda582a043ba310537cb66'
+  version '3.8.3'
+  sha256 '3689a2ef1fbc5de143ca5b751c8b8183351ed4452955bb222a3f6fc5ea9d42c2'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
-  appcast 'https://sourceforge.net/projects/weka/rss'
+  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.cs.waikato.ac.nz/ml/weka/downloading.html&splitter_1=Developer&index_1=0'
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'
 

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -5,6 +5,7 @@ cask 'weka' do
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.cs.waikato.ac.nz/ml/weka/downloading.html&splitter_1=Developer&index_1=0'
+          configuration: version.dots_to_hypens
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'
 

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -4,7 +4,7 @@ cask 'weka' do
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.cs.waikato.ac.nz/ml/weka/downloading.html&splitter_1=Developer&index_1=0'
+  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.cs.waikato.ac.nz/ml/weka/downloading.html&splitter_1=Developer&index_1=0',
           configuration: version.dots_to_hypens
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,6 +1,6 @@
 cask 'weka' do
   version '3.8.3'
-  sha256 '3689a2ef1fbc5de143ca5b751c8b8183351ed4452955bb222a3f6fc5ea9d42c2'
+  sha256 '3ff3f75619f0e175ab4605ef7289e55d53d005bf84fd8385722256bd60e257ab'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -5,7 +5,7 @@ cask 'weka' do
   # sourceforge.net/weka was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.cs.waikato.ac.nz/ml/weka/downloading.html&splitter_1=Developer&index_1=0',
-          configuration: version.dots_to_hypens
+          configuration: version.dots_to_hyphens
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'
 


### PR DESCRIPTION
this reverts pr 65238 which updated weka to unstable developer version again

also the appcast is changed in order to filter these development versions. also the sourceforge RSS changes every other day.