### PR TITLE
Update OpenInTerminal from 2.0.1 to 2.0.3

### DIFF
--- a/Casks/openinterminal.rb
+++ b/Casks/openinterminal.rb
@@ -1,6 +1,6 @@
 cask 'openinterminal' do
-  version '2.0.1'
-  sha256 '7027aa6a6670c22efa777b5eb50083ab6406aae9dce23ef13f483282c774c55a'
+  version '2.0.3'
+  sha256 '6397d356259546b60236fc882c78b6bb09917eb975832e67176de4b669f45717'
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/#{version}/OpenInTerminal.app.zip"
   appcast 'https://github.com/Ji4n1ng/OpenInTerminal/releases.atom'


### PR DESCRIPTION
Update OpenInTerminal from 2.0.1 to 2.0.3. Thanks for your time!

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
