### PR TITLE
Update typora from 0.9.9.25.3 to 0.9.9.27

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.25.3'
-  sha256 'ac03a88ed447db53005ca99bd52a262ab7bcc7ff5a344280d8ab440d1075e3a8'
+  version '0.9.9.27'
+  sha256 '28652fc6f5223c692e77a54eaefafeed83dbc1b4cecbb9dc21aeb22bb9f3bc3a'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.