### PR TITLE
Update burn from 2.6.9 to 2.7.0

### DIFF
--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -1,6 +1,6 @@
 cask 'burn' do
-  version '2.6.9'
-  sha256 'd7b5f118801e58098b1d5cdc5ee0c7995a97ae3e9681773ecda4970eaa472ba7'
+  version '2.7.0'
+  sha256 '2126e7924dbd4a69af43d185594e7ed6745d87a818491040193cb98b6cf48e30'
 
   # downloads.sourceforge.net/burn-osx was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.