### PR TITLE
Update asciidocfx from 1.7.0 to 1.7.1

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
-  version '1.7.0'
-  sha256 '3a458f99feced260ada12e1e510f7fec09c57d193e60b1b33baa310cffe4dfd5'
+  version '1.7.1'
+  sha256 'a28c53326a46295069c29ca79751e99a35f8fcef38cb18f95ebd787a6e51cf57'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.