### PR TITLE
Update polar-bookshelf from 1.30.6 to 1.30.8

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.30.6'
-  sha256 '8e9ccad5a4fc894ee4150a49bfe5672759a59631b954c911367579585a19ac7b'
+  version '1.30.8'
+  sha256 '15ede45841d2cd4b10ac529c7544c10299fb0aa628caa509070bf9e8808cafaa'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.