### PR TITLE
Update qownnotes from 19.8.1,b4429-113712 to 19.8.2,b4435-095453

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.8.1,b4429-113712'
-  sha256 '88c08f0dd68e38fff27da6873a20ce82cdf5d1e1951b6aea95b342aacf424bde'
+  version '19.8.2,b4435-095453'
+  sha256 'b23f3289eafa25268da80097522387912f71602d03b065db57a929af437b1ab1'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.