### PR TITLE
Update drawio from 10.9.5 to 11.1.1

### DIFF
--- a/Casks/drawio.rb
+++ b/Casks/drawio.rb
@@ -1,6 +1,6 @@
 cask 'drawio' do
-  version '10.9.5'
-  sha256 '0320236501e7d956a1137af672c0fecf9787f46c48af2a9872e32bf8996021cc'
+  version '11.1.1'
+  sha256 '24e81fa7401e7c7e77e716b29e3206170d5ab2b1fc37d89fdf48badbb19baafd'
 
   # github.com/jgraph/drawio-desktop was verified as official when first introduced to the cask
   url "https://github.com/jgraph/drawio-desktop/releases/download/v#{version}/draw.io-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.