### PR TITLE
Update unity-android-support-for-editor from 2019.1.12f1,f04f5427219e to 2019.2.0f1,20c1667945cf

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.1.12f1,f04f5427219e'
-  sha256 'f23c54f3f76a858f402a7d5324e11b25b72b034edf717623eb62773ec0a715a0'
+  version '2019.2.0f1,20c1667945cf'
+  sha256 '5dd76a7f63b170a3bf626cced44d7dd5354417e90c945ebf5ab3f4854f234aba'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.