### PR TITLE
Update tropy from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.5.2'
-  sha256 '8e2ca3fc3f4e782640bfd76936bd79895683184879a59bb652059a835fdbaf03'
+  version '1.5.3'
+  sha256 'dc1018fe1ecfec17459695635920db01f7f3dbb86377cbb405bb40f14a446728'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.