### PR TITLE
Update scratch from 3.4.0 to 3.5.0

### DIFF
--- a/Casks/scratch.rb
+++ b/Casks/scratch.rb
@@ -1,6 +1,6 @@
 cask 'scratch' do
-  version '3.4.0'
-  sha256 'bfe3d9ca5045d78d3d34455b54f3154fcdaaa9e4146f63e52da44b0c51e67440'
+  version '3.5.0'
+  sha256 '29c21e2622d6421fb211d8af14868b391855eb216c3d10734f5e985c5fd57161'
 
   url "https://downloads.scratch.mit.edu/desktop/Scratch%20Desktop-#{version}.dmg"
   name 'Scratch'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.