### PR TITLE
Update polymail from 2.1.4 to 2.1.5

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,6 +1,6 @@
 cask 'polymail' do
-  version '2.1.4'
-  sha256 'f8280b05fcb2923d46830f005d4103235d72228437b8457f666c44026557b1c9'
+  version '2.1.5'
+  sha256 'b6665f4e7fcd1789be9732830e4bde135f70b42cb7bf3b20c461dc747d3d4994'
 
   url "https://sparkle-updater.polymail.io/macos/builds/Polymail-v#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sparkle-updater.polymail.io/osx/Polymail-Latest.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.