### PR TITLE
Update cacher from 2.14.1 to 2.14.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.14.1'
-  sha256 '13f63b0d1622a397ccddc913ee9bb35c4688f70c0013330f70bfd598db5eb13e'
+  version '2.14.3'
+  sha256 'db3d3dc21c74da26c303b89752e5038854715dc84f49f2528215f5431f3309bd'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.