### PR TITLE
Update SciHubEVA from 2.1.2 to 3.0.0

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -1,6 +1,6 @@
 cask 'scihubeva' do
-  version 'v2.1.2'
-  sha256 '84e4dc32437d6474aa90808cf8d97c3e1797770eb2911e4a0f55176ddb042197'
+  version 'v3.0.0'
+  sha256 'ca6dafe8ece10d542c3aa2dfdca07d2ab87f782f5da7a4de084633104c751b46'
 
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast 'https://github.com/leovan/SciHubEVA/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.