### PR TITLE
Update amadeus-pro from 2.6 to 2.6.1

### DIFF
--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -4,7 +4,8 @@ cask 'amadeus-pro' do
 
   # s3.amazonaws.com/AmadeusPro2 was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/AmadeusPro2/AmadeusPro.zip'
-  appcast 'https://s3.amazonaws.com/AmadeusPro2/versions.rtf'
+  appcast 'https://s3.amazonaws.com/AmadeusPro2/versions.rtf',
+          configuration: version.major_minor
   name 'Amadeus Pro'
   homepage 'https://www.hairersoft.com/pro.html'
 

--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -1,6 +1,6 @@
 cask 'amadeus-pro' do
-  version '2.6'
-  sha256 'a9866858d14561e5bc596a7fd6064747726447385a40585ea2b3c171be25542a'
+  version '2.6.1'
+  sha256 'fde9153e92501534d65bb299b428b25092f36a852ab81a71d205cef552e6df09'
 
   # s3.amazonaws.com/AmadeusPro2 was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/AmadeusPro2/AmadeusPro.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.