### PR TITLE
Update deeper from 2.4.6 to 2.4.7

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -17,8 +17,8 @@ cask 'deeper' do
     version '2.3.3'
     sha256 '08ac5820428bcce74548786e8fda947edfaa31cf4a822d5c443835e73a11dd3b'
   else
-    version '2.4.6'
-    sha256 '74396fe3ef45dc77946c647cc456351a59d745f10c4075116587ff934b94b176'
+    version '2.4.7'
+    sha256 '7f519d22684783dcf78384fbefe027ee4528aa7516d29ce2aaf2bc431260e2bb'
   end
 
   url "https://www.titanium-software.fr/download/#{macos_release}/Deeper.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.