### PR TITLE
Update notion from 1.0.7 to 1.0.8

### DIFF
--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -1,6 +1,6 @@
 cask 'notion' do
-  version '1.0.7'
-  sha256 '61df08fac6503ed868f1649b2628ecd84c32821d24a53c159740b476321e5e8c'
+  version '1.0.8'
+  sha256 'd67336c53125cf4b2b2723318a52e9ad10976ad3f4d9aeb60da6ad15fdd224b2'
 
   # desktop-release.notion-static.com was verified as official when first introduced to the cask
   url "https://desktop-release.notion-static.com/Notion-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.