### PR TITLE
Update use-engine from 2.1.3 to 2.1.4

### DIFF
--- a/Casks/use-engine.rb
+++ b/Casks/use-engine.rb
@@ -1,6 +1,6 @@
 cask 'use-engine' do
-  version '2.1.3'
-  sha256 '8f6176a398176ccf9457b8cd855cdc2ae7dbcfc0002ae683e8a44d3ee93f6a56'
+  version '2.1.4'
+  sha256 '1f88d089dc8d83ef2a62f77fc5cde86c509d76c4e89255e8b11f03ebfb7bfb93'
 
   url "https://repository.use-together.com/stable/use-engine/macos/#{version.major}.x/#{version}/use-engine.dmg"
   name 'USE Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.