### PR TITLE
Update munki from 3.6.1.3758 to 3.6.2.3776

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,10 +1,11 @@
 cask 'munki' do
-  version '3.6.1.3758'
-  sha256 '2d0d106322a48a4a1f6fd34e372ecb969988a2ecf056ef5980988e9717c1e489'
+  version '3.6.2.3776'
+  sha256 '65868859ff75ca078fe466c5387095374bbb337737f6745ad68cd3db8c8d36e2'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"
-  appcast 'https://github.com/munki/munki/releases.atom'
+  appcast 'https://github.com/munki/munki/releases.atom',
+          configuration: version.major_minor_patch
   name 'Munki'
   homepage 'https://www.munki.org/munki/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.