### PR TITLE
Update termius from 4.9.5 to 	4.9.7

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '4.9.5'
-  sha256 '47604c550fd3be817a22f81d815b7ade460cd065584eaec6f257b5046ef6b0bb'
+  version '	4.9.7'
+  sha256 '8c8ab4e0b5dae496cef7337c04c800940e1ccd4d49d49d74c9497d66b39109b9'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'

--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,5 +1,5 @@
 cask 'termius' do
-  version '	4.9.7'
+  version '4.9.7'
   sha256 '8c8ab4e0b5dae496cef7337c04c800940e1ccd4d49d49d74c9497d66b39109b9'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.