### PR TITLE
Update yourkit-java-profiler from 2019.8-b108 to 2019.8-b109

### DIFF
--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,6 +1,6 @@
 cask 'yourkit-java-profiler' do
-  version '2019.8-b108'
-  sha256 'bc92c98066f3c369eaed50b8b339bb4dd13818d25340ee007a828e938228aedf'
+  version '2019.8-b109'
+  sha256 '15543270e915fbf37f897a171665ec7465b165318517eab269327a08ec78259e'
 
   url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version}.dmg"
   appcast 'https://www.yourkit.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.