### PR TITLE
Update enpass from 6.1.1,471 to 6.1.2,495

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -3,7 +3,7 @@ cask 'enpass' do
   sha256 'c02d10b4ba5a2fa38402c1a2af306837e5f55d181b76a894f8763856c0c473d8'
 
   url "https://dl.enpass.io/stable/mac/package/#{version.after_comma}/Enpass.pkg"
-  appcast 'https://dl.sinew.in/mac/package/appcast.xml'
+  appcast 'https://www.enpass.io/release-notes/macos-website-ver/'
   name 'Enpass'
   homepage 'https://www.enpass.io/'
 

--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -1,6 +1,6 @@
 cask 'enpass' do
-  version '6.1.1,471'
-  sha256 'eb69a94631edc39b01698eb2be1afa69d759061317647ed7df98f730cc2ab421'
+  version '6.1.2,495'
+  sha256 'c02d10b4ba5a2fa38402c1a2af306837e5f55d181b76a894f8763856c0c473d8'
 
   url "https://dl.enpass.io/stable/mac/package/#{version.after_comma}/Enpass.pkg"
   appcast 'https://dl.sinew.in/mac/package/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.