### PR TITLE
Update paraview from 5.6.0 to 5.6.1

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,8 +1,8 @@
 cask 'paraview' do
-  version '5.6.0'
-  sha256 '95f1d0eaa36452e2faae2f9d6077c933bfb78a31fca86eff1d80471aea471db7'
+  version '5.6.1'
+  sha256 '749295130032b9e7e1fa0d281934c942d790124bbd4cdaf46aa49baa0a33627f'
 
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.8-64bit.dmg",
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-64bit.unsigned.dmg",
       user_agent: :fake
   appcast 'https://www.paraview.org/files/listing.txt'
   name 'ParaView'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.