### PR TITLE
Downgrade textmate from 2.0-rc.29 to 2.0-rc.10

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -4,7 +4,8 @@ cask 'textmate' do
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
-  appcast 'https://api.textmate.org/releases/release?os=10.14.6'
+  appcast 'https://api.textmate.org/releases/release?os=10.14.6',
+          configuration: version
   name 'TextMate'
   homepage 'https://macromates.com/'
 

--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,10 +1,10 @@
 cask 'textmate' do
-  version '2.0-rc.29'
-  sha256 '49c14380728d8bf1af1e09298fa616a09ae535f5f106967361b84f6ec81d6249'
+  version '2.0-rc.10'
+  sha256 'b8058fd562701b3bb7aab6bb7b1f3a5ac752f153fe258121aa54033cb154d20b'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
-  appcast 'https://github.com/textmate/textmate/releases.atom'
+  appcast 'https://api.textmate.org/releases/release?os=10.14.6'
   name 'TextMate'
   homepage 'https://macromates.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.