### PR TITLE
Update hyperbackupexplorer from 2.2.0-0131 to 2.2.1-0133

### DIFF
--- a/Casks/hyperbackupexplorer.rb
+++ b/Casks/hyperbackupexplorer.rb
@@ -1,6 +1,6 @@
 cask 'hyperbackupexplorer' do
-  version '2.2.0-0131'
-  sha256 'b42b28177227c4fb1f37a302bc1afccdcd97d1a6cc5aa21bba2c964758046f82'
+  version '2.2.1-0133'
+  sha256 'b11ad0a60d3cbac84e9a39dff5b602591daa075c959c072e46e8f205aeac96ef'
 
   url "https://global.download.synology.com/download/Tools/HyperBackupExplorer/#{version}/Mac/x86_64/HyperBackupExplorer-#{version}-mac.zip"
   appcast 'https://archive.synology.com/download/Tools/HyperBackupExplorer/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.