### PR TITLE
Update Parallels Desktop to 14.1.3, resolve install permissions issue with >14.1

### DIFF
--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -9,7 +9,16 @@ cask 'parallels' do
 
   auto_updates true
 
-  app 'Parallels Desktop.app'
+  container type: :naked
+
+  preflight do
+    system_command '/usr/bin/hdiutil',
+                   args: ['attach', '-nobrowse', "#{staged_path}/ParallelsDesktop-#{version}.dmg"]
+    system_command "/Volumes/Parallels Desktop #{version.major}/Install.app/Contents/MacOS/Install",
+                   sudo: true
+    system_command '/usr/bin/hdiutil',
+                   args: ['detach', "/Volumes/Parallels Desktop #{version.major}"]
+  end
 
   postflight do
     # Unhide the application

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -1,6 +1,6 @@
 cask 'parallels' do
-  version '14.0.1-45154'
-  sha256 '2d3157fa684c9e255927ae4a04f303107427a3ea166eea6ea86f0963cb24e4bb'
+  version '14.1.3-45485'
+  sha256 '34c9c345642fa30f9d240a76062c5672e399349d5e5984db9c208d22e099f8b9'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsDesktop-#{version}.dmg"
   appcast 'https://kb.parallels.com/eu/124521'

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -8,7 +8,6 @@ cask 'parallels' do
   homepage 'https://www.parallels.com/products/desktop/'
 
   auto_updates true
-
   container type: :naked
 
   preflight do

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -9,7 +9,7 @@ cask 'parallels' do
 
   auto_updates true
   # This .dmg cannot be extracted normally
-  # Original discussion: https://github.com/Homebrew/homebrew-cask/issues/26872
+  # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/67202
   container type: :naked
 
   preflight do

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -8,6 +8,8 @@ cask 'parallels' do
   homepage 'https://www.parallels.com/products/desktop/'
 
   auto_updates true
+  # This .dmg cannot be extracted normally
+  # Original discussion: https://github.com/Homebrew/homebrew-cask/issues/26872
   container type: :naked
 
   preflight do


### PR DESCRIPTION
This PR updates the version of the `parallels` cask to Parallels 14.1.3, and resolves issue #57388 introduced with 14.1.0. The `Install` binary included with Parallels is used to manage the installation rather than relying on an `app` stanza, which fails to copy `bom` contents with an `Operation not permitted` error. A similar issue (#26872) with the Parallels Access cask was [resolved](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/parallels-access.rb#L9L11) via similar methodology. 

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).