### PR TITLE
Update cryptobridge from 0.2.11 to 0.2.14

### DIFF
--- a/Casks/cryptobridge.rb
+++ b/Casks/cryptobridge.rb
@@ -1,6 +1,6 @@
 cask 'cryptobridge' do
-  version '0.2.11'
-  sha256 '2a0a315889f67eb76cc0583107ee0acd7dda4aea5ae307898f97c8a088507fa4'
+  version '0.2.14'
+  sha256 '9ddebb00f2ecff80c8b8fb8cbcf168f813f98a34b98b78c14f83f420bfd73281'
 
   url "https://github.com/CryptoBridge/cryptobridge-ui/releases/download/v#{version}/CryptoBridge-#{version}.dmg"
   appcast 'https://github.com/CryptoBridge/cryptobridge-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.