### PR TITLE
Update moonlight from 1.0.1 to 1.1.0

### DIFF
--- a/Casks/moonlight.rb
+++ b/Casks/moonlight.rb
@@ -1,6 +1,6 @@
 cask 'moonlight' do
-  version '1.0.1'
-  sha256 '7ed0d2438cb615ec8732c4c46416e26cf4f3929064dc9e73c6c8e3d554cbaaa9'
+  version '1.1.0'
+  sha256 'fdbda47439f97b554f55ba3919b23cbf10c1765ecbb2eca249330c29eda1fc2c'
 
   # github.com/moonlight-stream/moonlight-qt was verified as official when first introduced to the cask
   url "https://github.com/moonlight-stream/moonlight-qt/releases/download/v#{version}/Moonlight-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.