### PR TITLE
Update balenaetcher from 1.5.52 to 1.5.53

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.52'
-  sha256 'a5f2924d2b97b86ca6e878f000eddb7193cf015d2e038b4b60b9aad30333f62f'
+  version '1.5.53'
+  sha256 'c217613adf483f97149649c9784bc42e9821cce8098c1802810ac3db23fb925e'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.