### PR TITLE
Update kube-forwarder from 1.4.0 to 1.4.1

### DIFF
--- a/Casks/kube-forwarder.rb
+++ b/Casks/kube-forwarder.rb
@@ -1,6 +1,6 @@
 cask 'kube-forwarder' do
-  version '1.4.0'
-  sha256 '10df5ea1228341f692c6e0e48499e5f04596e0c7a3808f1fc7f0f5213257df56'
+  version '1.4.1'
+  sha256 '648788b32991a48916d9d411ee32112e9e2a672f07ea9fcbec4974424344e50f'
 
   # github.com/pixel-point/kube-forwarder was verified as official when first introduced to the cask
   url "https://github.com/pixel-point/kube-forwarder/releases/download/v#{version}/kube-forwarder.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.