### PR TITLE
Update app-tamer from 2.4.6 to 2.4.7

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,6 +1,6 @@
 cask 'app-tamer' do
-  version '2.4.6'
-  sha256 '7e4333a3661c20c64fcb1b982ced17228e094253eaaf5d843fc1f7813d919098'
+  version '2.4.7'
+  sha256 '55be04d6bab9d7cf61ab2ddcd79052d2735774db7c14fc7fbc440c41204b52ce'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.