### PR TITLE
Update trailrunner from 3.8.3221,201 to 3.8.3230,203

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,6 +1,6 @@
 cask 'trailrunner' do
-  version '3.8.3221,201'
-  sha256 '6c699cbce77a26eef24e4ca59cc77978e58c766ca20537270bae9f7f7dd26c0e'
+  version '3.8.3230,203'
+  sha256 '0e4dca11d63d7d274d40a8b3fd176c866804476c316cfdb2ab0c5d40e3d4f40a'
 
   # rink.hockeyapp.net was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.