### PR TITLE
Update wechatwork from 2.8.10.2012 to 2.8.10.2021

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.10.2012'
-  sha256 '6c6be84491c5460951554692fb7b0738a80aa73ae1afdeca9a6a3bda1b2f8b4a'
+  version '2.8.10.2021'
+  sha256 'd977bfb5f8936964d134e84c16d249f9099625af5fd22d6b3eb1b0dbee3c1b8e'
 
   url "https://dldir1.qq.com/foxmail/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.