### PR TITLE
Update sampler from 1.0.1 to 1.0.2

### DIFF
--- a/Casks/sampler.rb
+++ b/Casks/sampler.rb
@@ -1,6 +1,6 @@
 cask 'sampler' do
-  version '1.0.1'
-  sha256 '7bb4585522bace2646b7f87e8d7b100a2cf5f31bdc5ac23ff54454317d8a64b5'
+  version '1.0.2'
+  sha256 '04202bba199f34974f20fa291a87ca04b84ff022c3733820432913fd3db68b87'
 
   # github.com/sqshq/sampler was verified as official when first introduced to the cask
   url "https://github.com/sqshq/sampler/releases/download/v#{version}/sampler-#{version}-darwin-amd64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.