### PR TITLE
Add Luftdaten.info Flashing Tool

### DIFF
--- a/Casks/luftdateninfo-flashing-tool.rb
+++ b/Casks/luftdateninfo-flashing-tool.rb
@@ -1,0 +1,10 @@
+cask 'luftdateninfo-flashing-tool' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://luftdaten.info/flashtool/luftdaten-tool.dmg'
+  name 'Luftdaten.info Flashing Tool'
+  homepage 'https://luftdaten.info/'
+
+  app 'Luftdaten.info Flashing Tool.app'
+end


### PR DESCRIPTION
Software to easily flash the luftdaten.info firmware onto the ESP8266 (Arduino) board.  Luftdaten.info is an open source, open data, citizen science project to measure fine dust.  It can also discover existing sensors in your local network.

You will need toe correct drivers for the hardware board installed, i.e. wch-ch34x-usb-serial-driver from homebrew-cask-drivers.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
