### PR TITLE
Update spotify-now-playing from 0.6.1 to 0.7.0

### DIFF
--- a/Casks/spotify-now-playing.rb
+++ b/Casks/spotify-now-playing.rb
@@ -1,6 +1,6 @@
 cask 'spotify-now-playing' do
-  version '0.6.1'
-  sha256 '03577db60b6cc0788ea8a55a0c69509b1b9f979ee23aad9a72dd6552b3e1854f'
+  version '0.7.0'
+  sha256 '3771b0a35b87264f387fbd591c50fd20554508692d3060d0ddce536aac23d17c'
 
   url "https://github.com/davicorreiajr/spotify-now-playing/releases/download/v#{version}/spotify-now-playing-#{version}.dmg"
   appcast 'https://github.com/davicorreiajr/spotify-now-playing/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.