### PR TITLE
Update remembear from 1.4.7 to 1.4.8

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.4.7'
-  sha256 '9943c74841d9deeea274b66ffbb43b2d5a2b6f9a42f38034a0d48827062c3294'
+  version '1.4.8'
+  sha256 '236b123a6667ba6823cbe9ef251e852411d1f227a767b8f419c1fbf62c2c5040'
 
   # remembear.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://remembear.s3.amazonaws.com/app/release/downloads/macOS/RememBear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.