### PR TITLE
Update framer-x from 33905,1564498799 to 34013,1565099555

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '33905,1564498799'
-  sha256 'f82bbef554c578092c233277ea47686bc151e438e1b179c5e9fb48d615c3cf3b'
+  version '34013,1565099555'
+  sha256 '1d2749c6ccb9b33076ef2b134dbc5a50581cf4c6622c984fb475505a2f57d531'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.