### PR TITLE
Update kite from 0.20190801.0 to 0.20190806.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190801.0'
-  sha256 'bfcc03ea6095bcee19abad7d367ea8b8fbfa89a72f2d05277554befa336f3a22'
+  version '0.20190806.0'
+  sha256 '712521e80b394ac31e032ebcc4c98326e0b7c3251922ea98314c3c98a1ffb7f8'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.