### PR TITLE
Update busycal from 3.6.7,360719 to 3.6.9

### DIFF
--- a/Casks/busycal.rb
+++ b/Casks/busycal.rb
@@ -1,6 +1,6 @@
 cask 'busycal' do
-  version '3.6.7,360719'
-  sha256 '4a1b29f46d4ecb1135112b85095ee28c7e269cdf47993da01003711503ccee46'
+  version '3.6.9'
+  sha256 'e4ba6475a6ec90f7e2c075e393e006d840bfbdd8fa3cacd143053a8a8bad301f'
 
   url 'https://www.busymac.com/download/BusyCal.zip'
   appcast 'https://www.busymac.com/busycal/news.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.