### PR TITLE
Update remote-desktop-manager-free from 2019.1.6.0 to 2019.1.7.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '2019.1.6.0'
-  sha256 '5830a919e32e46a87c1860d9a2b321f92fa880e9d12a37fd07ec1a7aabc0630f'
+  version '2019.1.7.0'
+  sha256 '0eda9a48ba72a43406947b17278b5161ef0932acdd79ddd8a1b36010972fabe0'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.