### PR TITLE
Update nvidia-geforce-now from 2.0.8.85,3AB74C to 2.0.10.71,350E76

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.8.85,3AB74C'
-  sha256 'bfc0966e8580673caae1d4c88ce9c20b1679b40edad0cbfdab98ab71e1263824'
+  version '2.0.10.71,350E76'
+  sha256 '05bed0f13eee22f63e45832712e3d4ac2629107221cc282c564f65ceb7b41f83'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -3,7 +3,7 @@ cask 'nvidia-geforce-now' do
   sha256 '05bed0f13eee22f63e45832712e3d4ac2629107221cc282c564f65ceb7b41f83'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
-  appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=1.17.2.0&channel=OFFICIAL'
+  appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL"
   name 'NVIDIA GeForce NOW'
   homepage 'https://www.nvidia.com/en-us/geforce/products/geforce-now/'
 

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -3,7 +3,7 @@ cask 'nvidia-geforce-now' do
   sha256 '05bed0f13eee22f63e45832712e3d4ac2629107221cc282c564f65ceb7b41f83'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
-  appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL"
+  appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=2.0.8.85&channel=OFFICIAL'
   name 'NVIDIA GeForce NOW'
   homepage 'https://www.nvidia.com/en-us/geforce/products/geforce-now/'
 

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -3,7 +3,8 @@ cask 'nvidia-geforce-now' do
   sha256 '05bed0f13eee22f63e45832712e3d4ac2629107221cc282c564f65ceb7b41f83'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
-  appcast 'https://ota.nvidia.com/release/available?product=GFN-mac&version=2.0.8.85&channel=OFFICIAL'
+  appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",
+          configuration: '[]' # Only happens when there are no newer versions
   name 'NVIDIA GeForce NOW'
   homepage 'https://www.nvidia.com/en-us/geforce/products/geforce-now/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.