### PR TITLE
Update protopie from 3.11.2 to 4.0.0

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '3.11.2'
-  sha256 '830fece8df3e8df67662d2c48568c9d134741697bd679d6c1c20f1c451721bd5'
+  version '4.0.0'
+  sha256 '859fe61e669fa8f16ecef7ed94ccfbb975a3fcbd4c00c78ca7e7ec746ebd5d15'
 
   url "http://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.