### PR TITLE
Update remote-desktop-manager from 2019.1.6.0 to 2019.1.7.0

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager' do
-  version '2019.1.6.0'
-  sha256 'a84c3175e01a79525f87fedc28c096a4743441c76b04aefacd46b1f0ff2bb9c0'
+  version '2019.1.7.0'
+  sha256 'e3aaee3596823915d054a407f401c6ea36055cdbfaea160a74d8928b7fd9cf10'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.