### PR TITLE
fix(mattermost): fix version 4.2.2 version SHA-256

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
   version '4.2.2'
-  sha256 'a908c990933400de2fb40ca947a3e3dce469ea7cb16fd2e9019324b4a6f491d6'
+  sha256 'a04d09fa0e5f9e23d1c4c07e9007a911319bbaa54c1e234c2e8c9eed60dfd18c'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
   appcast 'https://github.com/mattermost/desktop/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

```
==> Upgrading mattermost
==> Satisfying dependencies
==> Downloading https://releases.mattermost.com/desktop/4.2.2/mattermost-desktop-4.2.2-mac.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'mattermost'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
==> Purging files for version 4.2.2 of Cask mattermost
Error: Checksum for Cask 'mattermost' does not match.
Expected: a908c990933400de2fb40ca947a3e3dce469ea7cb16fd2e9019324b4a6f491d6
  Actual: a04d09fa0e5f9e23d1c4c07e9007a911319bbaa54c1e234c2e8c9eed60dfd18c
```