### PR TITLE
Update fliqlo from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/fliqlo.rb
+++ b/Casks/fliqlo.rb
@@ -1,6 +1,6 @@
 cask 'fliqlo' do
-  version '1.7.1'
-  sha256 'afd741da6dd0dc971a67176509035edfffd0c6bd0295e6796f1b57f03f928d10'
+  version '1.7.2'
+  sha256 '2a771c758dc091a6ecaf498fb79eff8c94573452c88e39073a46d7da8b3b5b8b'
 
   url "https://fliqlo.com/download/fliqlo_#{version.no_dots}.dmg",
       referer: 'https://fliqlo.com/#about'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.