### PR TITLE
Update imaging-edge from 1.4.0_1901a,7dLXQ7xm-t to 200_1908a,RXbW3ux0HM

### DIFF
--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,6 +1,6 @@
 cask 'imaging-edge' do
-  version '1.4.0_1901a,7dLXQ7xm-t'
-  sha256 '7481711176061aa36900fd8f0dd4e04b83a6a2e6bee29084960adba588d23f47'
+  version '200_1908a,RXbW3ux0HM'
+  sha256 '0faf40d6acf2e867b250b58d15d8291580115135e20a48c67a9749f321edcf17'
 
   # ids.update.sony.net/IDC was verified as official when first introduced to the cask
   url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma.no_dots}.dmg"

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -12,7 +12,7 @@ cask 'imaging-edge' do
   pkg 'IE_INST.pkg'
 
   uninstall pkgutil: 'com.sony.ImagingEdgeVer.1.pkg',
-            delete:   '/Applications/Imaging Edge'
+            delete:  '/Applications/Imaging Edge'
 
   zap trash: [
                '~/Library/Caches/com.sony.Viewer',

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -3,7 +3,7 @@ cask 'imaging-edge' do
   sha256 '0faf40d6acf2e867b250b58d15d8291580115135e20a48c67a9749f321edcf17'
 
   # ids.update.sony.net/IDC was verified as official when first introduced to the cask
-  url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma.no_dots}.dmg"
+  url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/imagingedge_DL/mac?fm=en',
           configuration: version.after_comma
   name 'Sony Imaging Edge'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -11,12 +11,8 @@ cask 'imaging-edge' do
 
   pkg 'IE_INST.pkg'
 
-  uninstall pkgutil: [
-                       "com.sony.ImagingEdgeVer.#{version.major}.pkg",
-                       'com.sony.ImagingEdgeVer.1.pkg',
-                     ],
-            delete:  '/Applications/Imaging Edge/Viewer.app',
-            rmdir:   '/Applications/Imaging Edge'
+  uninstall pkgutil: 'com.sony.ImagingEdgeVer.1.pkg',
+            delete:   '/Applications/Imaging Edge'
 
   zap trash: [
                '~/Library/Caches/com.sony.Viewer',

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -11,7 +11,10 @@ cask 'imaging-edge' do
 
   pkg 'IE_INST.pkg'
 
-  uninstall pkgutil: "com.sony.ImagingEdgeVer.#{version.major}.pkg",
+  uninstall pkgutil: [
+                       "com.sony.ImagingEdgeVer.#{version.major}.pkg",
+                       'com.sony.ImagingEdgeVer.1.pkg',
+                     ],
             delete:  '/Applications/Imaging Edge/Viewer.app',
             rmdir:   '/Applications/Imaging Edge'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.