### PR TITLE
Update omnigraffle from 7.11 to 7.11.1

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -4,8 +4,8 @@ cask 'omnigraffle' do
     sha256 'ab463ea6c12d49c4104d3814ac3280d0359072702d4751f5074f644fc79de0c6'
     url "https://downloads.omnigroup.com/software/Archive/MacOSX/10.12/OmniGraffle-#{version}.dmg"
   else
-    version '7.11'
-    sha256 '5a03974365571d246b17446d7bd5e9c24682972136dd4b067b9a10a8effeb952'
+    version '7.11.1'
+    sha256 'fbddfbb69232473d722f85954148873f45aa9ac7f4e6b21a9b5511e67edbcc90'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.