### PR TITLE
Update insomnia from 6.6.0 to 6.6.2

### DIFF
--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -1,6 +1,6 @@
 cask 'insomnia' do
-  version '6.6.0'
-  sha256 '3ea16a0f48fa86fb88d96689bfb4bf812af496ee0856b758c63aca9587ab4832'
+  version '6.6.2'
+  sha256 'e4ce6ce835ecf391f3299a9613ac40e5083ae9915f2cdc9c4166827af26bf9eb'
 
   # github.com/getinsomnia/insomnia was verified as official when first introduced to the cask
   url "https://github.com/getinsomnia/insomnia/releases/download/v#{version}/Insomnia-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.