### PR TITLE
Update time-out from 2.5 to 2.6

### DIFF
--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -3,8 +3,8 @@ cask 'time-out' do
     version '1.7.1'
     sha256 '3c9892344c8313b8ccf0a76cceb00834ddbe26e5114bcd674c4fd53aeb44e310'
   else
-    version '2.5'
-    sha256 '2947b5af6489d4cc5328bd943ec5e0440484970539ee18810bb4f6e6bf1fbbf6'
+    version '2.6'
+    sha256 '7a3787fa9e022a3e3509a11e8adcef75e078dfae17036986ddb0392522aecfe3'
   end
 
   url "https://www.dejal.com/download/timeout-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.