### PR TITLE
Update farrago from 1.2.5 to 1.2.6

### DIFF
--- a/Casks/farrago.rb
+++ b/Casks/farrago.rb
@@ -1,6 +1,6 @@
 cask 'farrago' do
-  version '1.2.5'
-  sha256 '9ef80c9861495a45516abf8d630a34a6e67b989a24028a0e23a35f485d5364c2'
+  version '1.2.6'
+  sha256 'a1ee4f390f087ea18a7e6547e655ca40af2f18b093560807e64583a106f87636'
 
   url 'https://rogueamoeba.com/farrago/download/Farrago.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.farrago&system=10140'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.