### PR TITLE
Update multimc from 0.6.6 to 0.6.7

### DIFF
--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -1,6 +1,6 @@
 cask 'multimc' do
-  version '0.6.6'
-  sha256 '34ff64ea13cbd7c25b626482237f65dd84262f1f1c5016ac87cddc78578bfa72'
+  version '0.6.7'
+  sha256 '56b912bcbac9c91dc9651963b8575837718a2b4f239897b399ff6afdb552b301'
 
   url 'https://files.multimc.org/downloads/mmc-stable-osx64.tar.gz'
   appcast 'https://github.com/MultiMC/MultiMC5/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.