### PR TITLE
Update roblox from 0.395.0.324413,149545f52f7d49a9 to 0.396.0.327208,0ce8eb9947e2462f

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.395.0.324413,149545f52f7d49a9'
-  sha256 '2f595890efdca0d9092fbfcc0af69a96c2ebd4b617f3ae4502a8283f88d3a015'
+  version '0.396.0.327208,0ce8eb9947e2462f'
+  sha256 '3302493de2c813f0bf6b6db53e2fad042787332b9858a970e2d162a6c76514b5'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.