### PR TITLE
Update smartgit from 18.2.9 to 19.1.0

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '18.2.9'
-  sha256 '5eb66eed6b3c51ae7468807f039cce1c667d942ee5cef7c913d1ed5d66904ded'
+  version '19.1.0'
+  sha256 '7ad4b3cd14e1bcabdb7f5c388db29dacae1582089840e54e88d97d788a1ce9b7'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt'

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -3,7 +3,8 @@ cask 'smartgit' do
   sha256 '7ad4b3cd14e1bcabdb7f5c388db29dacae1582089840e54e88d97d788a1ce9b7'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
-  appcast 'https://www.syntevo.com/smartgit/changelog.txt'
+  appcast 'https://www.syntevo.com/smartgit/changelog.txt',
+          configuration: version.major_minor
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.