### PR TITLE
Parallels 14.1.3: use `inittool` instead of `Install` to skip Software License Agreement popup

### DIFF
--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -46,6 +46,12 @@ cask 'parallels' do
                       '/usr/local/bin/prlctl',
                       '/usr/local/bin/prlexec',
                       '/usr/local/bin/prlsrvctl',
+                      '/Applications/Parallels Desktop.app',
+                      '/Applications/Parallels Desktop.app/Contents/Applications/Parallels Link.app',
+                      '/Applications/Parallels Desktop.app/Contents/Applications/Parallels Mounter.app',
+                      '/Applications/Parallels Desktop.app/Contents/Applications/Parallels Technical Data Reporter.app',
+                      '/Applications/Parallels Desktop.app/Contents/MacOS/Parallels Service.app',
+                      '/Applications/Parallels Desktop.app/Contents/MacOS/Parallels VM.app'
                     ]
 
   zap trash: [

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -15,7 +15,8 @@ cask 'parallels' do
   preflight do
     system_command '/usr/bin/hdiutil',
                    args: ['attach', '-nobrowse', "#{staged_path}/ParallelsDesktop-#{version}.dmg"]
-    system_command "/Volumes/Parallels Desktop #{version.major}/Install.app/Contents/MacOS/Install",
+    system_command "/Volumes/Parallels Desktop #{version.major}/Parallels Desktop.app/Contents/MacOS/inittool",
+                   args: ['install', '-t', "#{appdir}/Parallels Desktop.app", '-s'],
                    sudo: true
     system_command '/usr/bin/hdiutil',
                    args: ['detach', "/Volumes/Parallels Desktop #{version.major}"]

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -51,7 +51,7 @@ cask 'parallels' do
                       '/Applications/Parallels Desktop.app/Contents/Applications/Parallels Mounter.app',
                       '/Applications/Parallels Desktop.app/Contents/Applications/Parallels Technical Data Reporter.app',
                       '/Applications/Parallels Desktop.app/Contents/MacOS/Parallels Service.app',
-                      '/Applications/Parallels Desktop.app/Contents/MacOS/Parallels VM.app'
+                      '/Applications/Parallels Desktop.app/Contents/MacOS/Parallels VM.app',
                     ]
 
   zap trash: [


### PR DESCRIPTION
This PR uses a different Parallels binary `inittool` to avoid the Software License Agreement popup that `Install` initiates. Eventually the install fails if this is not clicked through (like in an unattended install).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).