### PR TITLE
Update aws-vault from 4.6.2 to 4.6.3

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,6 +1,6 @@
 cask 'aws-vault' do
-  version '4.6.2'
-  sha256 '8328eead56d599fdb66ecb941e835249e028231a451e8d72ffa3975a608bf872'
+  version '4.6.3'
+  sha256 'b199a772d3b4b6f31c5e9e67a47688b8a3bc73d89908e74deb324096fa0301a5'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64"
   appcast 'https://github.com/99designs/aws-vault/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.