### PR TITLE
Update lingo from 8.0 to 8.1

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,6 +1,6 @@
 cask 'lingo' do
-  version '8.0'
-  sha256 'bcb5010cfcfe8ccfe14aa63f7586ca966492ef97246e5a19a26b54e7b889c440'
+  version '8.1'
+  sha256 'f2a95c008f7990519d3310aa7496929ba09cf72f61253919a8ea648591cabc4a'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask
   url 'https://nounproject.s3.amazonaws.com/lingo/Lingo.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.