### PR TITLE
Update paste from 2.4.3,27 to 2.4.4,29

### DIFF
--- a/Casks/paste.rb
+++ b/Casks/paste.rb
@@ -1,6 +1,6 @@
 cask 'paste' do
-  version '2.4.3,27'
-  sha256 'afd5b5188763e15001d1acdce9c3df66a9887dbb9abfc6768ac56bd103220361'
+  version '2.4.4,29'
+  sha256 '431b06e68acb7f1804d6c862410d18bdff25677388bc2582f26c978dfd20fa1c'
 
   # rink.hockeyapp.net/api/2/apps/f44b38c5d9824344acdb920513bbbf8f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/f44b38c5d9824344acdb920513bbbf8f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.