### PR TITLE
Update kite from 0.20190807.0 to 0.20190808.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190807.0'
-  sha256 'ccd58c8b38237ff7b337abf6d32f79425d9751f4fa34e9e3fb29b051cd2d866f'
+  version '0.20190808.1'
+  sha256 '4538268164cbbf13884e43b81a2da2e65c1372c2994d06d0f99f9e36320c67e5'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.