### PR TITLE
Update thebrain from 10.0.51.0 to 10.0.53.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,6 +1,6 @@
 cask 'thebrain' do
-  version '10.0.51.0'
-  sha256 'dff763a3d69ebc0e260ded17adc7ba6473b88499fe9644864b9beb2a314e3758'
+  version '10.0.53.0'
+  sha256 '1e1f71eaa5c3d1eb1635e3ee0f62f9787e668c0aa41dfa6f975176c7dcd0a706'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.