### PR TITLE
Update bettertouchtool from 3.172 to 3.176

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.172'
-    sha256 '89dfdcd9e58f2d6367b079dc2dd58f0f5915f5081fe9012ad2a4674c93e55390'
+    version '3.176'
+    sha256 '3f58b2a270f0062e61f392e51c9522c09afc78dc33c435892f0c892c15b82e55'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.