### PR TITLE
Update cmake from 3.15.1 to 3.15.2

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.15.1'
-  sha256 '69de89c094fea5673125a48305ea73a150cacbe5ad516f14a8feaaecea64bbfc'
+  version '3.15.2'
+  sha256 '71b16497b09088afe74264ca34c64fa5ac35f0f5849a0aad3e513acb9703c3e1'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   appcast 'https://cmake.org/files/LatestRelease/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.