### PR TITLE
Update touchdesigner from 099.2019.17550 to 099.2019.18360

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2019.17550'
-  sha256 '3b573ae4d50ce6d67f2d208602507d2a279f0c99106a931ebead6261e4cb3709'
+  version '099.2019.18360'
+  sha256 '3e50606030de57744ea1c048b3cdb0654c35b31b4131b22e8812c52e18a47e2c'
 
   url "https://download.derivative.ca/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.