### PR TITLE
Update armortext from 0.21.39 to 0.22.10

### DIFF
--- a/Casks/armortext.rb
+++ b/Casks/armortext.rb
@@ -1,6 +1,6 @@
 cask 'armortext' do
-  version '0.21.39'
-  sha256 'fbe87b9e9d8e8acad6e79ee8af3779e259fe22f7112ce7c5a967848b51fa8191'
+  version '0.22.10'
+  sha256 '218175b138fec2b44b0721ad459fc18933863f6efabc1b297976b12c00a9e2e5'
 
   # armortext.co was verified as official when first introduced to the cask
   url "https://downloads.armortext.co/desktop/release/#{version}/ArmorText-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.