### PR TITLE
Update chronosync from 4.9.3 to 4.9.4

### DIFF
--- a/Casks/chronosync.rb
+++ b/Casks/chronosync.rb
@@ -1,6 +1,6 @@
 cask 'chronosync' do
-  version '4.9.3'
-  sha256 '3a99ac0e514b8a7cc065d4a87dea30da3f871962f0e7a5dece1aa50dd6c7a6cd'
+  version '4.9.4'
+  sha256 '7c5d982fda2e0f7c0e367264dd84c0c3a51546bf6a55e139eeda0e89ff0ca108'
 
   url 'https://downloads.econtechnologies.com/CS4_Download.dmg'
   appcast "https://www.econtechnologies.com/UC/updatecheck.php?prod=ChronoSync&vers=#{version.major_minor}.0&lang=en&plat=mac&os=10.14.1&hw=i64&req=1"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.