### PR TITLE
Update electrum-ltc from 3.3.6.1 to 3.3.8.1

### DIFF
--- a/Casks/electrum-ltc.rb
+++ b/Casks/electrum-ltc.rb
@@ -1,6 +1,6 @@
 cask 'electrum-ltc' do
-  version '3.3.6.1'
-  sha256 '64700719b5e7cc3b346ca07361a3175e55961ff76ff7773942d1e5df9667dc0a'
+  version '3.3.8.1'
+  sha256 '167c6d7eb21b1f064254e215adf826c6c77f22bcad8e1851645d33d1a4af65d4'
 
   url "https://electrum-ltc.org/download/electrum-ltc-#{version}.dmg"
   appcast 'https://electrum-ltc.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.