### PR TITLE
Update visicut from 1.8-80-g681e741c to 1.8-90-ga030e4e8

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask 'visicut' do
-  version '1.8-80-g681e741c'
-  sha256 '29d319637d16e9c32d9181726274e8a1bd7e3bcf70e5f5d04cbff58ca257d270'
+  version '1.8-90-ga030e4e8'
+  sha256 '6e95152d946101a3afe9c442c6ec24dc277c39eaffc1ff07fe94d1870f0138c9'
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast 'https://download.visicut.org'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.