### PR TITLE
Update barrier from 2.3.0 to 2.3.1

### DIFF
--- a/Casks/barrier.rb
+++ b/Casks/barrier.rb
@@ -1,11 +1,18 @@
 cask 'barrier' do
-  version '2.3.0'
-  sha256 'c00706fd2c38c1f0dda0b298f55d2fc0d423dcb15187041c379273da1e347714'
+  version '2.3.1'
+  sha256 'e8238c109293c8a33fed8604725bd5c0275c24adbc223d1f4c01663cd2d9b45f'
 
   url "https://github.com/debauchee/barrier/releases/download/v#{version}/Barrier-#{version}-Release.dmg"
   appcast 'https://github.com/debauchee/barrier/releases.atom'
   name 'Barrier'
   homepage 'https://github.com/debauchee/barrier/'
 
+  depends_on macos: '>= :sierra'
+
   app 'Barrier.app'
+
+  zap trash: [
+               '~/Library/Application Support/barrier',
+               '~/Library/Saved Application State/barrier.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.