### PR TITLE
Update libreoffice-language-pack from 6.2.5 to 6.3.0

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,558 +1,558 @@
 cask 'libreoffice-language-pack' do
-  version '6.2.5'
+  version '6.3.0'
 
   language 'af' do
-    sha256 'a9cd622e746227ea79654c643a2bab35d828449ebc4f52d5c9bf3fb9802c4d01'
+    sha256 'ed9374ceae038dfa84b40087939c6cbc8ac1d33329df038a22ed4a88c8172650'
     'af'
   end
 
   language 'am' do
-    sha256 '888731bfee5d2c384570efe094ca75f625bc42678caf6d86b0647e7647f52657'
+    sha256 '705f1ec5cd791b9a1a86a5bc9db90db4270e0a4fcdeefe860cf669711366d97e'
     'am'
   end
 
   language 'ar' do
-    sha256 'e49f26a5d6755283aa78d69d65a01b6fa94153cac13536b88761924b64d64832'
+    sha256 '9cfff531700def7ad14821c7796baf6a26797756be902d2856afa32ff9889e87'
     'ar'
   end
 
   language 'as' do
-    sha256 'c16bc4c5241f90328221c80b1e849ccd0c756b75d5e0c5a894dbdf48461fd177'
+    sha256 'd4dd5c54a2677ba624eb1010c38fae96f160ae1c57d376fc7ced6fc8f6477996'
     'as'
   end
 
   language 'ast' do
-    sha256 '73d680058f8f2039aa85163225bc49aa1c17e5909531fa158b2307b398c59650'
+    sha256 'e8ab7670d5298526cf9414e42d4b808ae99b84090573dffab07fe0a8599ad21c'
     'ast'
   end
 
   language 'be' do
-    sha256 '225336dbdd252389edf632972cc752bedff221f1508f330c3dcf8169ce8082f0'
+    sha256 'ba36aadb4154f9112d18f5a230db1f0ed780e8978c2bff2b9908aac825cb1904'
     'be'
   end
 
   language 'bg' do
-    sha256 '679d48fc85a44a592c0e34dca9c9c2735b2e91b67b287a0884a5bd2e1ed2184b'
+    sha256 'eb5ac34719167127cca76c456205f0e426710c58664a58071785aa04bb93b8d9'
     'bg'
   end
 
   language 'bn-IN' do
-    sha256 'be61dba9ba36d380923712e895cb8b19211efbab5d8a7c43a9a3c8800e8c334c'
+    sha256 '63f14ac3c1cefd5a6b022d94666ec7f3a385e50339f4d61a14aee768c522fd9a'
     'bn-IN'
   end
 
   language 'bn' do
-    sha256 'd4c8ed5f3526b77154da8fd4888297a536af9169238bce5eb2fc59a912f59c26'
+    sha256 '1476fe60a6f5e7606db9d7264c0eb6b13f42abeefeef17008549c4eabe704734'
     'bn'
   end
 
   language 'bo' do
-    sha256 '4de84be61455ba861ed8d4cba01c55cf7c83c10123d74111b9c95af6841de10b'
+    sha256 'beccb6cbabf49e6b4581b55b7d68b5faea9e1b25f7c62ea4f3eb811727c4710c'
     'bo'
   end
 
   language 'br' do
-    sha256 '20737a08037fb4d653a06f62664c3c74ce794fe17c38ed7c87e7bb321a85f907'
+    sha256 'd75827eaeb33a9310786d89e464c2c20a5bed3a174614e2cbb85d19263fb27ac'
     'br'
   end
 
   language 'brx' do
-    sha256 '9411b9df63b170269fce1ab88f0293196600841e858f4bcf5a399ac0f2b842d4'
+    sha256 '81b9800c827da1e3c2f110eb9b0c711562c88b489f3c4bf1dd8fa561538f96e8'
     'brx'
   end
 
   language 'bs' do
-    sha256 '556963ec926548ba3db2bb773b32e2237335b4de06d4617385ed5ac4e0734749'
+    sha256 'ced2f06aa5615e493764738640c998233df953f1ae80c6f847419c47606f73ba'
     'bs'
   end
 
   language 'ca' do
-    sha256 '1d5ad2e41b6aa3a2b8be09ca056cc69c92c84e2819cab8b66c61fab929370bbc'
+    sha256 '163a6c31a024510b87dbc5d67ed6c2e44a48eefff5655eb0606df8887395414d'
     'ca'
   end
 
   language 'cs' do
-    sha256 '3fb8cb2c21f2b70bdb01966c1920eff03b5473028ae0c8982d8d060955f7bff3'
+    sha256 '7e4a97804985d34d066e6e8f78852c787e6a9ad7c149029ccb98512828af3c85'
     'cs'
   end
 
   language 'cy' do
-    sha256 '7dc90f9c2ab4816a16cf0c96a02c3a22a90a85a5466466cd971b566961ff25fd'
+    sha256 '156272713c13072b15941349f0ba1d7cd7b423d9647f4d0e0e0ab5fcb94aa62d'
     'cy'
   end
 
   language 'da' do
-    sha256 '9e9a28838fa6904eb64723511f9724d7a05d8368f71f6d14965e9bf0a8f8dcd3'
+    sha256 '105ff53d8c82b96540485b219f851fa1aa9b56a2f2c34f29f8ccfcba47e6c7c2'
     'da'
   end
 
   language 'de' do
-    sha256 '81d657e9a454c4a6bd649eb9d9ccd43474cae2e89e3996553bc85dc42df42757'
+    sha256 '7963d9828e92a624d90efe2702eee0bada30fa8be03152a90519335ce81f311b'
     'de'
   end
 
   language 'dgo' do
-    sha256 '21db90c8b98ec4637973da6b865d332d2f69ce135a9650f88b8f477850d76cbe'
+    sha256 '910abd11ec7b01fc586c77fd5065e9dd2ee2f35281199f599a421e6b1c800459'
     'dgo'
   end
 
   language 'dz' do
-    sha256 'd6073b8951428e97b4e000bb55ab11b444b0e724ad0d4cc11b03a2266696dcc3'
+    sha256 '56bd268de2fa824f379b88a15c55d4ac50c7d10fff73113aa236a9b0ac130e9d'
     'dz'
   end
 
   language 'el' do
-    sha256 'c2e5f9316edc13fd7d0377b31a69ec1303030108723cae0de6527fb97017b7b8'
+    sha256 '7cf2fc43f3751e3d0498f3fcce974dc0a6628be45b19bbd457d659dc6f8efa5d'
     'el'
   end
 
   language 'en-GB', default: true do
-    sha256 'da72a06b2000c5ff612722a22da959357d0c96bfd13d621406f139379e0f24a0'
+    sha256 '552319d5953ef2b3ee4a438bd66a97aa469a6255cbd0d14e549c1251d85e286d'
     'en-GB'
   end
 
   language 'en-ZA' do
-    sha256 'cbcc01d29dc91ba8ef3acc0da94913884608f0fac0f518f5c2a3d0981cdb36af'
+    sha256 '95678334d78c1e3def7526d5b3603a74ca1f971cc508f49525a0fc9d2e23da28'
     'en-ZA'
   end
 
   language 'eo' do
-    sha256 '29c52f73ae7415eb486b2765e56bf692c3effe6ce59c9907b4592adf3db6ae2e'
+    sha256 'ecc0231431e4670f858c615e5cfe7a96b9f248932130ca2ecd4393ce414dbca4'
     'eo'
   end
 
   language 'es' do
-    sha256 '644f45c52a6c084840eb35af8916991284ab85f9b6716a0d2c75f3e75a7438b9'
+    sha256 'd512691b0b844450c3c0ac51f35fffeb4128082c6bccbdf95640967358dc362a'
     'es'
   end
 
   language 'et' do
-    sha256 '8d2435106651cdb42262d4dc8db9b67770cb042f5cddb9d8123cb171c5feafab'
+    sha256 '796da0a09863f570c237c634fc6a2854a08c0b10f863a3561c82a85a79f878b7'
     'et'
   end
 
   language 'eu' do
-    sha256 'f88655d4f39f3602f6ce702c4214958acdaa5574b77d3aec9b2f2f7e4231b7cd'
+    sha256 '2ef737c177fcb2148745ad10fecbb4af8f8b8979e0b1cdfdfcbea78a8b7d7511'
     'eu'
   end
 
   language 'fa' do
-    sha256 '628271b3f20400e4c459fea281249f5005b1f4d4545b11cd8131061507d9511a'
+    sha256 'a02e9af28cf108eca3f4682f5ea9a8b7a244e72c2b861ce1a9acffe5c93e9a35'
     'fa'
   end
 
   language 'fi' do
-    sha256 '0a8fce14c2efbd4059e5506578223ac7fa92d34a192fe918ab7b0c6d3be1d44a'
+    sha256 '9317b96544dfff4fcee096c12ef8eea0d09f5bdf1e4b3be1137e309fe23fa27d'
     'fi'
   end
 
   language 'fr' do
-    sha256 'f7e48931c55b3e06b598386152997ac10bb6ee4175d36a1adea68d8e6d3668c1'
+    sha256 '425acdc9f557e5ef35da3f7cf4b241f6c8343ac4888fecebfc527976a5e5674f'
     'fr'
   end
 
   language 'ga' do
-    sha256 '81f8999c75096082e1d4a9b1c06acf34c67bb9e813fccb16dc7db6c72aaa5f33'
+    sha256 'dca5aa69c49dfc281d20013be76f8eb5c20070c2bfac189f6596afc44236c573'
     'ga'
   end
 
   language 'gd' do
-    sha256 'a047374f54b92a05b4f82cbf9f468b0ff3bb8005a0c844499afb4d21b64c4007'
+    sha256 '64010a8ea51df66a76ba296c3fe4ab0af40eb37f8280ccbfcaea7cff77568dca'
     'gd'
   end
 
   language 'gl' do
-    sha256 'a120b57323513e5a5b3f9184803423efa06af71f6d078500dea7a99d1458f0b3'
+    sha256 'c6b5c1c71380a0b2a44654eeb5cfccbefa5c25c79ccb27beff24108a66204e86'
     'gl'
   end
 
   language 'gu' do
-    sha256 'e477f42f94f574a1564c58f952c342af3ec0dfac0ba0fcc33d8c3e771d523fef'
+    sha256 'f0b265bce6fcbc38b802e8384c839221808ab22aa52c0a085b7c48a7c9995ec2'
     'gu'
   end
 
   language 'gug' do
-    sha256 '5197817e9a7ca413856b73b11c20f399bc2e90a5ee79c86c79cb3d0d9819dd26'
+    sha256 'e9d429ea6bd107f0691fbc4e5a91b7068a2c1dafab83a519754a70e5b4d2b2a3'
     'gug'
   end
 
   language 'he' do
-    sha256 'ac7d0fadcfd2240e42a0bff31d3c535e1a9496384fe2ecf340f7d0fd4a450f63'
+    sha256 '9234b9a446f6e2ad8185da8d8b831a44127f8eb46be767f35a9748f7118c585e'
     'he'
   end
 
   language 'hi' do
-    sha256 'd20c31f19aec4c9d960aa3364db34e03f1b0101de58d8f2d0ad350b7d322b04e'
+    sha256 '89a9751910c017daf7cbb5f31642136937935f8dd428ad7c0c41c728746aef2b'
     'hi'
   end
 
   language 'hr' do
-    sha256 '0a000cab3068c4550097772c19cf409334f82da3406cd79e6bf4f2719e7a5eb4'
+    sha256 '73ac386ec4926416a45c7038ca9c1e8957f93c56cac5e79113028c8ad45f5f5e'
     'hr'
   end
 
   language 'hsb' do
-    sha256 '1de4434198e3fd5acb641bd59f9c285b10e7f3e58b9177a4fadc046df5dea53c'
+    sha256 '7f85daf57760b5cf8ed327db54a082c3f7b09d6a02d4baf5a26d310676d42d82'
     'hsb'
   end
 
   language 'hu' do
-    sha256 'ba57a0e463d47433d6b2ab216f4fd8c96768f544d15656ab09c394246d024cc0'
+    sha256 '8c1debfbe0ec34afd93b1fe45cfb8cdf336ddc8af0e11b2148fa28b5f73bc21f'
     'hu'
   end
 
   language 'id' do
-    sha256 '50cf330e11cfa523e0b6193a1dde1e24e7f7e04ca513abb91fe0224f82022cb6'
+    sha256 '503702aed5e1b755484fed30842966bec96557de752990cbdd63a7fa9fad3274'
     'id'
   end
 
   language 'is' do
-    sha256 'e00c3f7ccc669cc4102af5a56fd3344d5dcc54a0c0758d29e8521fff550fa7c8'
+    sha256 '105f615aed6fae34ab2e3fe618336116240c86df77e44f65c82b2761c9537e87'
     'is'
   end
 
   language 'it' do
-    sha256 '08b1f82de2ffa54f8462d830915b15517c0d7f731cd9348dc9f5d7f4e4036a12'
+    sha256 '2fe28b768136a51ae95dca78b9e254a8aad018d0d76b1613b5036915473ca9f5'
     'it'
   end
 
   language 'ja' do
-    sha256 '225cf15d9686d09a88947197afe5a5632dd92ce734e985c7d09be48fde591816'
+    sha256 '51438ce23f3242fe1e3374b05ef3415f36068247ece7f4b7bc6689b1a74695a3'
     'ja'
   end
 
   language 'ka' do
-    sha256 'ca656499026b673ffe633efef0d498f186a03a58caf8426ac1d1c1f27062b93b'
+    sha256 '40cb095afd66c86912a7fc029299bd58d24511b740145db34a51f9dffe3420a6'
     'ka'
   end
 
   language 'kk' do
-    sha256 'd7eecd93deed8d06d33e975cadc8fa069ce186fb61639791ee44cd65b3c4f621'
+    sha256 'beaea17651f07da2fd269149f12744e5edea6cfbd790266e7864f9729a02aa5f'
     'kk'
   end
 
   language 'km' do
-    sha256 'd013a1146b7c528d068c97d84dee3b498de93d929cc3b4c5d65aaf887582c3e1'
+    sha256 '034e9ba9d8243d7db32ea2f75a3ac071aaaa4fc403fec4ac68f2446e075e89b8'
     'km'
   end
 
   language 'kmr-Latn' do
-    sha256 'a0e6f7e8f91c4c573fda583706857b8fd6c320a2a33c926661dee1223b0b0a3b'
+    sha256 'ddd500feb26478f83c28748a351052d3de52db2a044343f6fa26e5ee6eb70c86'
     'kmr-Latn'
   end
 
   language 'kn' do
-    sha256 'e7b7be90d8d3a76369678d37dbb688fe34230bcc87b26d80eb77dbace2e323a5'
+    sha256 'da490d0f6f9a3e86ace7e2fa3bca8565384af76389451bd63490db0044d628e9'
     'kn'
   end
 
   language 'ko' do
-    sha256 '908fe5629917fa0ea61dde9c4e13c3c99885de965f6b26889740d73b1a143b88'
+    sha256 'b5c747ca83da40efab6ab50bd72985c189dc1ac4c53747e4d79da645b3228ff8'
     'ko'
   end
 
   language 'kok' do
-    sha256 'acfd27b6a21d292a159e0401b20c7ff5c07a39482b62dd5527fe5f081d6957ce'
+    sha256 '77203775019d4bbefb82f7d6bd19d5ee5c5b9e0ddab8936a4ddf4780ece75ee6'
     'kok'
   end
 
   language 'ks' do
-    sha256 '126591b076510bc07038567b6fa7b96c36402f8e59a1bd4d3673c50139d40af4'
+    sha256 '56fa432102abe646dd9e8a37f4d063476d8ca7baf1ff1f76c74be127f2cf4dfb'
     'ks'
   end
 
   language 'lb' do
-    sha256 '8fc25ba1e641cb3e49a37ffcc6e199f2236627138b2b77f5009dda493bffb642'
+    sha256 '142b751ab4b9a1c8fdce126fff669cb8d554ade372389350f841d322dd97f6ac'
     'lb'
   end
 
   language 'lo' do
-    sha256 'a9e1bcdfaab6677c496b0d486e5629664e3965eaca1ae7ced756e6fb0b60747a'
+    sha256 '71d49dc17d2d2cf46d9e98aeea3d8051237fe280b1d6a8dfd7a7788807c15bd8'
     'lo'
   end
 
   language 'lt' do
-    sha256 'c94fe64d134b520fdee583078eb50aabb87992f2488de7770c728cc374525b89'
+    sha256 '99e9807f8ca18d234ad142ce4229c97fc2111dcbffa506d9e25dc93c42b01bbe'
     'lt'
   end
 
   language 'lv' do
-    sha256 '813a0f9bd5f4269012ca264e3b5d69bd0ad85df21ca12bb6f1d382327028b5e3'
+    sha256 '8735960a8f99d5bb8ddd02a28c6dfd43c9b0dc11eb39163c40ce63b528cb14ec'
     'lv'
   end
 
   language 'mai' do
-    sha256 'c364aee1a7ac4f6b2a09c9c6cc054c9dabd4caccb1c9d7ba03e4f10168e8be40'
+    sha256 '35130e1fd6fd855ee507d5ba895a4ec6c34b36edbac5c004265be1d15af12065'
     'mai'
   end
 
   language 'mk' do
-    sha256 '7e0067807d1b4d0afb261cbc727a94dbd2e8d18a0d1deecd635c5b40f428bb6c'
+    sha256 'c302abdb044a07a7f48a18266c991e462a7a21a23f18c5ee1ffaa73658c524e7'
     'mk'
   end
 
   language 'ml' do
-    sha256 '26a19c003768235ab0a7e1adb50e775e88c365b2a89ec6d272406ef266bb5c0c'
+    sha256 '69a0b2146714d64f8a856bf047fef2122f0dea664b9b9dd7189bb673664a0857'
     'ml'
   end
 
   language 'mn' do
-    sha256 'fe946e3ab8f09a3b4a11c1503a4613df9a49f01bd7bc7e2a35103a30555f2161'
+    sha256 '555600a8d36222f8019c072ef000e0620ac1000919832465fcc280a887e4b14d'
     'mn'
   end
 
   language 'mni' do
-    sha256 '40e58e6cc7d69ee716a10e88310fb8b6e597f6334c9dc77b15e87f1d9680c631'
+    sha256 'ac00ba626b6a9d5f224eef3c560940befd87ee43806a87f1fe9e19177f65e02d'
     'mni'
   end
 
   language 'mr' do
-    sha256 '985b76f4af6fb8975052ade9db5df68b76387e8258c79f01bacbad8001dc49fe'
+    sha256 '873ad64d2aaac9c4604ad21a09f4878354c365b74e69a855556ef1e0d163618e'
     'mr'
   end
 
   language 'my' do
-    sha256 '823124ba5149e17d9e1d0a58e857a8f5af9baebef2c1857ba12f93e1c271b6e3'
+    sha256 '3ba98b59880b3d9640c787ee4aa0eec35141215220ed7c040d58b9fa99c55927'
     'my'
   end
 
   language 'nb' do
-    sha256 '1c977a1bafa8a162685e2c76f188ae3ad6e87e03fdb6c37fadd87aa89138868d'
+    sha256 'feb297ec87b995c35b2889b0a0302bc2a3f0ddff96575eccc2908f517f61be68'
     'nb'
   end
 
   language 'ne' do
-    sha256 '647f65a3c5379677950dc89add0492624532032023e52824cc28cffe0f2939cd'
+    sha256 '9c7f91ff585391fd1b96632f8d548590fd6c3d1d0c325e72b16cbb658d94bf19'
     'ne'
   end
 
   language 'nl' do
-    sha256 '99661106cc73c9d5fb59ae5f262afd33f9db69f2c9d6862216f8276a6a09d7ba'
+    sha256 'f4971d390d41118a11c347d849cbcf12f49914445849da450b82b333a9138d40'
     'nl'
   end
 
   language 'nn' do
-    sha256 'af8453c3ac1533ba14a2347f127bdcd5231fc068a20a552fca64ccd111fd3ea2'
+    sha256 'efa33d1f655ce8f7b87c4be96f2593445dd22bb618f0bb9421ec840c5ff9a50f'
     'nn'
   end
 
   language 'nr' do
-    sha256 '14559c9ef6c6fe2c50b2d41c80bfb8061a217dcd3654ef3354457708ba5f2fd4'
+    sha256 '50061ec496aceaf1ec91edea6d5b646fc11027a467af45186dc074fd742e5f63'
     'nr'
   end
 
   language 'nso' do
-    sha256 'acbbfad1f51b53a4e1811808954512c987d9ebe97c9913f945e966f7558245e7'
+    sha256 'e93180be6dd850ffc33e3b239d66a5248b53086ee16f2b7bc0bd2666e871bbe4'
     'nso'
   end
 
   language 'oc' do
-    sha256 '8fc11013a4e78f5b3bdc6fb555485d7bcddeb737fdc39ff3f4db6b1bce6cd316'
+    sha256 '387105c13eca229abdc3095d1694892f8b6b919400629b77a69ca9291bbb0f68'
     'oc'
   end
 
   language 'om' do
-    sha256 '51e4b54f03c0cfe6182340dd0d46648efb76d00400b9a7ddc6aca59bbec53564'
+    sha256 'b93ed3d979f0345a73aa97f9692ccccfc1983ac4060b98c8a61eba217c1a0b12'
     'om'
   end
 
   language 'or' do
-    sha256 'f2588e70c002411007ea0021c4e3ebcd76bcf01da7acc08dd67e38d711fb9d80'
+    sha256 'bde8630caa7bf6553b79955882426d168ff57172ab4f59d01a965264cc924a13'
     'or'
   end
 
   language 'pa-IN' do
-    sha256 '695edc22d7e3697252cc9027ed8edcdae703ef946c25940559fbbbd4ff955357'
+    sha256 '98259dffe6d17cdb5140074acb989b5fc87cb3c7d0513e01d8724df872e414f5'
     'pa-IN'
   end
 
   language 'pl' do
-    sha256 '23c0b0c5b4acc5c15e86f2167f19777a125c51cc4914fca5abff8dd593db3269'
+    sha256 '9aca4ce8379410118480c9ac7618dcdfdcd1a5825f805f89c9439bd574e7e337'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '8e520ec06c03f9c26d9c462b03b0f2f188e3dd18bcd44b41748b1625e026e7d8'
+    sha256 '1633c5a066684babbc9b80868e530c27ccf5314fb484ef78db5ceeabfcb9fd38'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'e59955081087d425b56cb24edb526d7e114e506014cf4f93e58b663c239a7355'
+    sha256 '0b6354fcd09dbe53027dc5a1be41680843264f9da363cd33a59268e39962c54e'
     'pt'
   end
 
   language 'ro' do
-    sha256 '6666bf5b7237d23e16d651dcac20b8a2193c9b2f82263fd62fa33fbc1927e157'
+    sha256 '9fd0e1fa66465eb4ca25feff9fefbb5d097ba1b9aa9e8580f91fd82d829ba672'
     'ro'
   end
 
   language 'ru' do
-    sha256 '620f22785393b6ef93cb491511df561fbb692a5d1491c9a22e661b8f48a4ae87'
+    sha256 '590a8a1f9da3fc4257a29dcfa1fd486a6996aa398a489a38361291d7c0204280'
     'ru'
   end
 
   language 'rw' do
-    sha256 '4ec17a649e523ac17c6443bf8eb9ffd3484013d3d4d98ee681bfdc64e7423c7a'
+    sha256 'da6c1f013330e6c959ef63a8c0acc84781b4ff811ea4418da4eed3194d9d578d'
     'rw'
   end
 
   language 'sa-IN' do
-    sha256 'b45c2df23343c1055dc446bfd3b9e9f8a6d61a3d7a370925a69ea4b00e185443'
+    sha256 'd3decc63dc1760031c8df2883a38001d4cb490868412f1760bca2dd900cccc2b'
     'sa-IN'
   end
 
   language 'sat' do
-    sha256 '4dfcb9ba945033b3e650795d6e0f86aad943008e4f850a0ec5934ad4144a1134'
+    sha256 '99a045dba3658e1fe10153c83244939b252064519181bd8d715930c46947b006'
     'sat'
   end
 
   language 'sd' do
-    sha256 '0a504ec939149599ce429f4ae3bbb15ec786c72bea6db1ce7b071b586011573b'
+    sha256 'b93fdb316e0af6ec2de5eff1567593bde9957fab149b65be5d4e38f80bce8774'
     'sd'
   end
 
   language 'si' do
-    sha256 'f42b00fd6d1d09cfcecac18e9f142f9e88fe699ef8d6d4644a8a50b8af9f3ddb'
+    sha256 'de15cfe4f3a1afe86357ff09ae54fec6cfcad1f4426e6fcb818db3067f9decea'
     'si'
   end
 
   language 'sid' do
-    sha256 '7ad4ba697b62691212e6d8926d22a298c31f047469e2c596df46f5af6204d667'
+    sha256 '241d5871d84131e2a7dc2252cdf39229d6b3072b42d46060f83deb7d052b9b07'
     'sid'
   end
 
   language 'sk' do
-    sha256 'd77dc19b1fa334eeae4a09183fa7357101f0c71ca701f8c004b39b3222b85499'
+    sha256 'ba9f22559a7341d266fe4bfcdfe7673edd162127d98fbb4b315592efdcb7858a'
     'sk'
   end
 
   language 'sl' do
-    sha256 '6c4cb302e4be7570987b6a65859104e542dbbbdc004a54c5784aafe0feb9f39b'
+    sha256 '0d3442a5e71cb4742140e70b1cc2ab8e6eed7223ce8d7906b0753d174930e965'
     'sl'
   end
 
   language 'sq' do
-    sha256 '41e004ab8a8884cd4b02c2e82f03225c48e9fdbe928506032a5b1c4fbc6dabb0'
+    sha256 'e14f7f4d296fbba32f00a2cd192388259204b0555dfb149318a9f7e21ea47206'
     'sq'
   end
 
   language 'sr-Latn' do
-    sha256 '941666dcd8128c0e7fa923270d5b411d1597d97c4e25589d4b7b11b110c2358a'
+    sha256 '816ed72ff7cf0f50e5fb785d7285d80ca0a68aaca6b9336f602b0b3351809cc1'
     'sr-Latn'
   end
 
   language 'sr' do
-    sha256 'e5b6b02e1efea6481202754d76d84b0e2c513902ddc834c43f404a46f4c18f51'
+    sha256 'e5881988063f258cc2d17092e6aa3e3558a17f964139826d1d3b73e723d34d9e'
     'sr'
   end
 
   language 'ss' do
-    sha256 'dff92fbc0982374e4c242f323af8a37306441eb6899ab286163f8b9c5f296ae1'
+    sha256 'c847131ce9afc143d80bd51b507e4ca7b508132234e13601d895b1b54910bd11'
     'ss'
   end
 
   language 'st' do
-    sha256 'b85a114b7844d2b311a0e7d22429beac62af22b2c7116d6a077d5f77a06cef88'
+    sha256 '8e406956307f96cdad188b3ff45c31bc6dee7425e00cbef1bf555576f798ba67'
     'st'
   end
 
   language 'sv' do
-    sha256 '8fd774d419fc78af1b5b01850b9321d08d6c0703d1dd83252d769c097afe574f'
+    sha256 '487bf620548cac49a3c9492a9f81e9424cb023cb8c1bb63aa3194552f086c29c'
     'sv'
   end
 
   language 'sw-TZ' do
-    sha256 '734226c209a35e53a838b6c9239eb17d0e158d1ae397bf3bdb503a322e0c22a0'
+    sha256 'b8a6225d0a4eb066affa0856024e391ffb0cb5b8870e3a631abe0c930008714e'
     'sw-TZ'
   end
 
   language 'ta' do
-    sha256 '6ff744b67365e1db288c8d2962298d42b726726ab89f64aac8271d676844112e'
+    sha256 '69109e19290ba5d736e454d4b38126563d04381ab15422b4dc71b7848244eb21'
     'ta'
   end
 
   language 'te' do
-    sha256 '5454d2c84773161eef01f511c82659c014c7b55f2697547ad98dfc8df5dd7986'
+    sha256 '40f975a5879cf85bb41582382ac464faa7f234fea7a39fbd2fab61a8ef3c69a8'
     'te'
   end
 
   language 'tg' do
-    sha256 'c47b0a63d883e40a7b65e70b06994765b7ffd5d1e2536dbbd1c49df5a4e974fe'
+    sha256 '2b828f11615119ac06d708b04868416ec793a9dc692346f7aae595808ff323cb'
     'tg'
   end
 
   language 'th' do
-    sha256 '66575be7995fcdad2d160cbce4e6f1d4f242ee994956a823efcf51adcc3d4e6b'
+    sha256 'ef844a35bc49b42961f495923418011de03e67cdc79cf71bb24ba6b16711c8e5'
     'th'
   end
 
   language 'tn' do
-    sha256 '8e59c61778c519e586d05f7198289df38fb94a3c1d96c5f5284a45215831b41f'
+    sha256 '2cd2ef241f9141d0f841bddb5ddc74032d25ed568edf0e1ece4a69f9329359fe'
     'tn'
   end
 
   language 'tr' do
-    sha256 'bbdbad9e868207a3ebcb715e815e38daa465aef02ff660e0019e671e75483d22'
+    sha256 '6e4881c2b27ec8aa93663eb18e803612f4eb1fe4a8a93aa373a907ea64b1a14e'
     'tr'
   end
 
   language 'ts' do
-    sha256 '2835e03c159746156e585d2abef2b72c0bc2c83cd69344022ab21d997aab2a39'
+    sha256 'd8706b48ceba966c48091960c9a7eb2b698314614f95be1b1239cc9e61c72ab8'
     'ts'
   end
 
   language 'tt' do
-    sha256 '8c2149f37a5fb64477c656921cba72e66e1d2a480afc95f4d03bf4a4c97ebec8'
+    sha256 'a2e36e39849e65fee92b90ac75bc385fef6397b84a9e3c8a3ea7472f6208cbc9'
     'tt'
   end
 
   language 'ug' do
-    sha256 '75ab88e65aedae7d4d72b34e6ffeb30324a89bc51d5e665357c4d5f7469f4505'
+    sha256 '00b8813d6b96d3dc325e09a30567b025ee24847667636d2258702a45b8ebdfe6'
     'ug'
   end
 
   language 'uk' do
-    sha256 '08dddfe2311069fae1385fb0e02beeb38ac5443944387028bac6adfdeed07c53'
+    sha256 '806693612a64164e9fc6e29eda5e79e1967e7becd982993ae00b459ae10dcd5d'
     'uk'
   end
 
   language 'uz' do
-    sha256 '0981fe40851ba4ef3fd1807e3b99eca9df469e7f96be0ef730ab8042fad538c0'
+    sha256 'd81a2623c8049d15c29660f48daaa5531e578e6b3e7817b2900f4cde6ffb1a85'
     'uz'
   end
 
   language 've' do
-    sha256 '4cff67ba6b806a898b73092a9325f919eeb88040da895f997d62935439044248'
+    sha256 'eacbd842fb6c69b13a46a89c759937bbf2d33b8d5951c3446625feaf0df3a057'
     've'
   end
 
   language 'vec' do
-    sha256 '177392a0802b96950655f752d95d434f59e839b0fa7ea455b6176a57cc44f4f8'
+    sha256 '5559d79206a942fcde60f1adcb741ad5dcb299ba7a4bce2c8a1aaacbba463466'
     'vec'
   end
 
   language 'vi' do
-    sha256 '7c43526b53fd5585578e971f339333b538ac2e2d32f3823f4c6aef2a3fa74407'
+    sha256 '660bc4e76a97a44edb308f4481b8a643a04ebb8a26247523fcf23079483b5a32'
     'vi'
   end
 
   language 'xh' do
-    sha256 'cd809d43e41da054dbb12f124025e4d4e7eeb6167cd36db0a0072a0ce1a26bca'
+    sha256 '91913db6703c7b3f7587652e7899e975cffdaeabd89b70cb74309128872a5a96'
     'xh'
   end
 
   language 'zh-CN' do
-    sha256 'e44e226b3b55dbb3483e19e8214306b99f0a876eaae820023294eb6da9e87dc9'
+    sha256 '298fe9a9f828d6eafe908cd12bec21d5868151da27b0f3df4e4655bb6f04d49c'
     'zh-CN'
   end
 
   language 'zh-TW' do
-    sha256 '8389749b6d9f89e963ebf341955df5adc39f7b020e42338d272370a2aace6af8'
+    sha256 'a38b737f7932c271b7cf7d04d36f610f9fb9f2893365811e8f3a04721a9739d6'
     'zh-TW'
   end
 
   language 'zu' do
-    sha256 '27ebac5cbf613001e0bc308a60b832b954e89d9925f1b273debee22839e3a104'
+    sha256 'f0cda6030e2f6dcc4292a9d9a18fd6b101a20a3aba1c0731648917ed4a2276a1'
     'zu'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
