### PR TITLE
Update editready from 2.6 to 2.6.1

### DIFF
--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -1,6 +1,6 @@
 cask 'editready' do
-  version '2.6'
-  sha256 '687e7af2ba685c51360247c2e8c404704612d1ec965642726d4c230a2b080276'
+  version '2.6.1'
+  sha256 'f5ee9bbae589fd708f72094f67995becd7e2419a7fe7765ee56efd0a11c949f0'
 
   url "https://www.divergentmedia.com/fileRepository/EditReady%20#{version}.dmg"
   appcast 'https://www.divergentmedia.com/autoupdater/editready/2_x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.