### PR TITLE
Update nosqlbooster-for-mongodb from 5.1.12 to 5.1.13

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.1.12'
-  sha256 '54864fe02d2e479e1a31fb360bdf23da9fed2fdd780f13d482f7cfc72a38ae2a'
+  version '5.1.13'
+  sha256 '3c652373520a628759982a22f25f04bcf4633a2485648ba7786d776c4df5fb3b'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   appcast 'https://nosqlbooster.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.