### PR TITLE
Update cycling74-max from 8.0.6_190611 to 8.0.8_190808

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '8.0.6_190611'
-  sha256 '2d7bf4dfb26a1ec2fdaa6896669a270fa8966d6982f550a9bf4bbd199e46ef28'
+  version '8.0.8_190808'
+  sha256 'de8fa20df64522e9d3c19f59a77bf65c43b3477062dca56f14d6e1246dc64f88'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.