### PR TITLE
Update zenmap from 7.70 to 7.80

### DIFF
--- a/Casks/zenmap.rb
+++ b/Casks/zenmap.rb
@@ -1,6 +1,6 @@
 cask 'zenmap' do
-  version '7.70'
-  sha256 'f64d24fecd286af015a2247ca77ac6cb090f1be1ab4e92cdf62bdc5bcd60d267'
+  version '7.80'
+  sha256 '3009b316b719b3f3be6c4279b8a03ba85b2332ccb9eaf4e1469ebfe30f4ff96a'
 
   url "https://nmap.org/dist/nmap-#{version}.dmg"
   appcast 'https://nmap.org/dist/?C=M&O=D'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.