### PR TITLE
Update netron from 3.3.0 to 3.3.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.3.0'
-  sha256 '1015adc94caecab87526d8403c34608cf6c7d8e98f3621c5f8c2100c436dce4e'
+  version '3.3.1'
+  sha256 '0a79f7bd5e4dc2dc61845fbd96f0fedbe3e60af18d782fdd6dc07218f60d3903'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.