### PR TITLE
Update notable from 1.7.0 to 1.7.1

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.7.0'
-  sha256 '3ccb41351c44706c9775fe3f5ed74fdc663cce28f76616e2450abd24c5e190cd'
+  version '1.7.1'
+  sha256 'e43e38afff6cb2f4997c4f2f6e62b123f57efaef2f7ae63b34e5812cd9c8a576'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.