### PR TITLE
Update imaging-edge

### DIFF
--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -3,7 +3,7 @@ cask 'imaging-edge' do
   sha256 '0faf40d6acf2e867b250b58d15d8291580115135e20a48c67a9749f321edcf17'
 
   # ids.update.sony.net/IDC was verified as official when first introduced to the cask
-  url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma}.dmg"
+  url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma.no_dots}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/imagingedge_DL/mac?fm=en',
           configuration: version.after_comma
   name 'Sony Imaging Edge'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,5 +1,5 @@
 cask 'imaging-edge' do
-  version '200_1908a,RXbW3ux0HM'
+  version '2.0.0_1908a,RXbW3ux0HM'
   sha256 '0faf40d6acf2e867b250b58d15d8291580115135e20a48c67a9749f321edcf17'
 
   # ids.update.sony.net/IDC was verified as official when first introduced to the cask


### PR DESCRIPTION
restore missing dots that have been lost in https://github.com/Homebrew/homebrew-cask/pull/67315

without those dots there is no correlation to the actual version number stored in the app