### PR TITLE
Update smartgit to revert changes to circumvent travis check

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -4,7 +4,7 @@ cask 'smartgit' do
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',
-          configuration: version.major_minor
+          configuration: version.chomp(".0")
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -4,7 +4,7 @@ cask 'smartgit' do
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',
-          configuration: version.chomp(".0")
+          configuration: version.chomp('.0')
   name 'SmartGit'
   homepage 'https://www.syntevo.com/smartgit/'
 


### PR DESCRIPTION
i am not particularly happy about
`configuration: version.major_minor`
being used (introduced in https://github.com/Homebrew/homebrew-cask/pull/67353)
it will not prevent any beta or invalid versions being submitted iff major_minor is still ok.

(the same applies to other casks)

in our experience most beta releases floating around are actually beta's of minor releases, so it is just as important to prevent those as it is to prevent beta's of (semi) minor versions.

the actual problem that is often tried to solve by using 
`configuration: version.major_minor`
is that the appcast does not contain a trailing '.0' for major releases.

so lets than use the proper solution here and remove the trailing '.0' from the version if it exists to check the version number instead of killing the system nearly completely by using "major_minor"

so, i propse using 
`version.chomp('.0')`
instead