### PR TITLE
Remove eID from documentation

### DIFF
--- a/doc/cask_language_reference/token_reference.md
+++ b/doc/cask_language_reference/token_reference.md
@@ -135,8 +135,6 @@ Cask taps have naming conventions specific to each tap.
 
 [Homebrew/cask-drivers](https://github.com/Homebrew/homebrew-cask-drivers/blob/master/CONTRIBUTING.md#naming-driver-casks)
 
-[Homebrew/cask-eid](https://github.com/Homebrew/homebrew-cask-eid/blob/master/CONTRIBUTING.md#naming-eid-casks)
-
 # Special Affixes
 
 A few situations require a prefix or suffix to be added to the token.

--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -191,7 +191,6 @@ We maintain separate Taps for different types of binaries. Our nomenclature is:
 + **Vendorless**: A binary distributed without an official website, like a forum posting.
 + **Walled**: When the download URL is both behind a login/registration form and from a host that differs from the homepage.
 + **Font**: Data file containing a set of glyphs, characters, or symbols, that changes typed text.
-+ **eID**: Software to install electronic identity card software of various countries.
 + **Driver**: Software to make a hardware peripheral recognisable and usable by the system. If the software is useless without the peripheral, it’s considered a driver.
 
 ### Stable Versions
@@ -225,11 +224,6 @@ We do not accept these casks since they offer a higher-than-normal security risk
 ### Fonts
 
 Font Casks live in the [Homebrew/homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts) repository. See the font repo [CONTRIBUTING.md](../../../../../homebrew-cask-fonts/blob/master/CONTRIBUTING.md)
-for details.
-
-### eIDs
-
-eID Casks live in the [Homebrew/homebrew-cask-eid](https://github.com/Homebrew/homebrew-cask-eid) repository. See the eid repo [CONTRIBUTING.md](../../../../../homebrew-cask-eid/blob/master/CONTRIBUTING.md)
 for details.
 
 ### Drivers

--- a/doc/faq/rejected_casks.md
+++ b/doc/faq/rejected_casks.md
@@ -18,6 +18,7 @@ Common reasons to reject a Cask entirely:
 + The author has [specifically asked us not to include it](https://github.com/Homebrew/homebrew-cask/pull/5342).
 + The Cask requires [SIP to be disabled](https://github.com/Homebrew/homebrew-cask/pull/41890) to be installed and/or used.
 + The Cask is a `pkg` that requires [`allow_untrusted: true`](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/pkg.md#pkg-allow_untrusted).
++ The Cask is for an eID, which were [frequently outdated and had too few downloads](https://github.com/Homebrew/homebrew-cask/issues/59021)
 
 Common reasons to reject a Cask from the main repo:
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

I've also updated the documentation to remove references to the eID tap/repo. It's in a separate commit, in case cherry-picking is needed.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
