### PR TITLE
Update freac url, appcast and version

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,10 +1,10 @@
 cask 'freac' do
-  version '1.1-alpha-20181201a'
-  sha256 'dc9053232c0336f789ab57776a69ae4718e98d4fcf53afac1b0e1fefd35a0c76'
+  version '1.1-alpha-20190423'
+  sha256 'ce10882ca82198ec84397ab3a2d1fb3292dd9272ab59db2e22226cf09cab2739'
 
-  # sourceforge.net/bonkenc was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/bonkenc/freac-#{version}-macosx.dmg"
-  appcast 'https://sourceforge.net/projects/bonkenc/rss'
+  # github.com/enzo1982/freac was verified as official when first introduced to the cask
+  url "https://github.com/enzo1982/freac/releases/download/v#{version}/freac-#{version}-macosx.dmg"
+  appcast 'https://github.com/enzo1982/freac/releases.atom'
   name 'fre:ac'
   homepage 'https://www.freac.org/'
 


### PR DESCRIPTION
The binaries are available from [GitHub](https://github.com/enzo1982/freac/releases) which I believe is preferable to [SourceForge](https://sourceforge.net/projects/bonkenc/files/). The [homepage](https://www.freac.org/index.php/downloads-mainmenu-33) also points at GitHub instead of SourceForge. This commit makes the corresponding adjustments to `url` and `appcast` and also updates the cask from `1.1-alpha-20181201a` to `1.1-alpha-20190423`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Since I'm just editing the cask, I haven't bothered to check if this should go [under stable or versions](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask). The homepage seems to imply 1.0.32 is the stable version and 1.1 is alpha. Let me know if we should refactor the cask into two versions.