### PR TITLE
Update patchwork from 3.14.1 to 3.15.0

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.14.1'
-  sha256 'f96c886545b6661cbb9be9c5f7e80bb702e810bfceea691db03c6045ef4a9f0b'
+  version '3.15.0'
+  sha256 '58f81fcaadd6a348f476848f65901e29ff0cb848f4081a35a012e780946dfc62'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.