### PR TITLE
Update mailplane from 4.1.3,4728 to 4.1.4,4752

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,6 +1,6 @@
 cask 'mailplane' do
-  version '4.1.3,4728'
-  sha256 'e8ad617329046a04125e452b348522df0beb19c36c57981ce5fa5f86974bcaa2'
+  version '4.1.4,4752'
+  sha256 '472e464237727e0bec0c16489800a82292467e770f4d17686b2aafb30b66b26b'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
   appcast "https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.