### PR TITLE
Update soqlxplorer from 3.1 to 3.2

### DIFF
--- a/Casks/soqlxplorer.rb
+++ b/Casks/soqlxplorer.rb
@@ -1,6 +1,6 @@
 cask 'soqlxplorer' do
-  version '3.1'
-  sha256 '483b940c0ac4dd3e79aa6418379788a6598d8a0d6ab1070f582de4e9aff641a5'
+  version '3.2'
+  sha256 '66103063a180c1c44e42a9c185cc04b38d8e48db752d58f9cd69cf287e86420a'
 
   url "https://www.pocketsoap.com/osx/soqlx/SoqlXplorer_v#{version}.zip"
   appcast 'https://www.pocketsoap.com/osx/soqlx/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.