### PR TITLE
Update blitz from 1.1.10 to 1.2.0

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.1.10'
-  sha256 '64904b7cbebbc26ddce7581b38d5c0034593c48977318a33e2c978a5f4d9df37'
+  version '1.2.0'
+  sha256 'b50aebefc40673efdb7c46623eb27c9b15e18c0c1d4a388aca7800519082e814'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.