### PR TITLE
Update mongodb-compass-readonly from 1.18.0 to 1.19.0

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.18.0'
-  sha256 '76652eea53584c70ac838005c97c03e150ccb321aa09f1cc6b8ad230401014df'
+  version '1.19.0'
+  sha256 'df6dfb949b3591669fd7bd858ac1fc6cfb6a1f9e29ae47e90ca0a0f4b66776e5'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.