### PR TITLE
Update Caprine from 2.35.0 to 2.36.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,6 +1,6 @@
 cask 'caprine' do
-  version '2.35.0'
-  sha256 '2a53c27bd5fa01621e66e63285304f8108388b24ca3f9f22692933e9928c94bb'
+  version '2.36.0'
+  sha256 'ffeb137c4b51983f94147930fd5489df7eb807595cd2ab572f5b567d481b0368'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/Caprine-#{version}.dmg"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom'


### PR DESCRIPTION
https://github.com/sindresorhus/caprine/releases/tag/v2.36.0

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
