### PR TITLE
Update skype from 8.50.0.38 to 8.51.0.72

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.50.0.38'
-  sha256 '01b3edb51860bd239617d7e0723c270ee88529f40c64b0c570278f2bd72cd1ac'
+  version '8.51.0.72'
+  sha256 'c32a537c3e5e1207c816aece2c0e7a8b2043c8d029bab27c12ae9f810cfe94a1'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.