### PR TITLE
Update smartgit from 19.1.0 to 19.1.1

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '19.1.0'
-  sha256 '7ad4b3cd14e1bcabdb7f5c388db29dacae1582089840e54e88d97d788a1ce9b7'
+  version '19.1.1'
+  sha256 '50fcc41ff5104c5f4629d1d5b1835de5f98383b5c1bd3894d6930c9d8fb259c6'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.