### PR TITLE
Update mjml from 2.11.0 to 2.12.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,6 +1,6 @@
 cask 'mjml' do
-  version '2.11.0'
-  sha256 'df16f34efa6f145f859e74333d6d37235e04a42e1b7d6cb096807d24551588d9'
+  version '2.12.0'
+  sha256 'a64ceba133100982260eff2ec091239951e2c943df622108ce8e47c6fac15f25'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/v#{version}/mjml-app-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.