### PR TITLE
Update bdash from 1.5.4 to 1.5.6

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.5.4'
-  sha256 '503275abab464eaf07246fd07e9fa81ba0a23f9a1c6dde1a2553eeefc8e0d665'
+  version '1.5.6'
+  sha256 '9de0a27c9f58826341d36518cff441babcc69f285b9e9689af4ce768f781d690'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.