### PR TITLE
Update listen1 from 2.4.0 to 2.5.0

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '2.4.0'
-  sha256 '6d33cf6ba0ae9a48ccb666905fb0edda9eecc345ece607eb299503a0ba95ebfe'
+  version '2.5.0'
+  sha256 'e58a20144bebcf9e6d3fb3bdf21cfea0c8250a409d1f752dc9961cd7f97a5d01'
 
   # github.com/listen1/listen1_desktop was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.