### PR TITLE
Update notable from 1.7.2 to 1.7.0

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.7.2'
-  sha256 'ff5c29c8932fc76193f2fb43b7410edb60b37a65fe6ea35c07980d314eac7cc6'
+  version '1.7.0'
+  sha256 '3ccb41351c44706c9775fe3f5ed74fdc663cce28f76616e2450abd24c5e190cd'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.