### PR TITLE
Update activedock from 234,1564996999 to 236,1565611909

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '234,1564996999'
-  sha256 '0d27935fba0d3cac4cb73bbef7eda503968c529562509da2a5ef5e5ba2362c98'
+  version '236,1565611909'
+  sha256 '58588a1fb6cbfa729ca252319b99ce91b005dd18542698fbf21bbe93fde2660b'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.