### PR TITLE
Update photosweeper-x from 3.3.1 to 3.4.0

### DIFF
--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,6 +1,6 @@
 cask 'photosweeper-x' do
-  version '3.3.1'
-  sha256 'd89af6358d3547103ea7cbc65f3beec50dafeb32e35c1fdaf436e14c2234f5d1'
+  version '3.4.0'
+  sha256 'bc509436c91f33374661518fca9c3fc675b072f2507fb72172f5d4b4c7745bbb'
 
   url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
   appcast 'https://overmacs.com/photosweeper/updates/photosweeper_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.