### PR TITLE
Update podman from 1.4.2 to 1.5.0

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -1,11 +1,11 @@
 cask 'podman' do
-  version '1.4.2'
-  sha256 '73850911bb49f2e0a970ff44f785634e2aa9a7a1f20845ff508bdccbead17444'
+  version '1.5.0'
+  sha256 '4220d1e513bb2ae7833a7941d140e6c1bbd6e98c8258e766d890cdf3ba6df73b'
 
-  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-v#{version}.dmg"
+  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-v#{version}.tar.gz"
   appcast 'https://github.com/containers/libpod/releases.atom'
   name 'podman'
   homepage 'https://github.com/containers/libpod/'
 
-  binary 'podman'
+  binary 'brew/podman'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
