### PR TITLE
Update flash-player-debugger-npapi from 32.0.0.223 to 32.0.0.238

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-npapi' do
-  version '32.0.0.223'
-  sha256 'e003f7376eff6d7dbfaf9700b9b1b60238772259ba273d0fc5064f498891fd63'
+  version '32.0.0.238'
+  sha256 '4fabb04472cc82d8cb8587f549e6923b66df20e406bf3f10115edbc5aa6dd1a4'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.