### PR TITLE
Update hashbackup from 2376 to 2406

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,6 +1,6 @@
 cask 'hashbackup' do
-  version '2376'
-  sha256 'a173e966ce4482d112b97e4fbe1a477b14675e8c1c11aecbc2760560bd35acfc'
+  version '2406'
+  sha256 'eeaab4608dee355afc0730b6a06a733352630eab2c29e1bf208de4e8d374bde7'
 
   url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.x86_64.bz2"
   name 'hashbackup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.