### PR TITLE
Update mailplane from 4.1.4,4752 to 4.1.4,4753

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,6 +1,6 @@
 cask 'mailplane' do
-  version '4.1.4,4752'
-  sha256 '472e464237727e0bec0c16489800a82292467e770f4d17686b2aafb30b66b26b'
+  version '4.1.4,4753'
+  sha256 '250ebb35e8d36c2aa1a3476c7465fb4f74d13a819752bedca35cb4719e1c4840'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
   appcast "https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.