### PR TITLE
Revert "Update Travis image."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 matrix:
   include:
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       rvm: system
   fast_finish: true
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#67535.

`brew cask style` is broken on 10.14 on Travis.