### PR TITLE
Fix duplicati download URLs

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -2,8 +2,9 @@ cask 'duplicati' do
   version '2.0.4.23,2019-07-14'
   sha256 '160ed45028da188853e714df922a6498cebae12170a77d4c2c087e49c8d7b5de'
 
-  url "https://updates.duplicati.com/beta/duplicati-#{version.before_comma}_beta_#{version.after_comma}.dmg"
-  appcast 'https://updates.duplicati.com/beta/latest-installers.js'
+  # github.com/duplicati/duplicati was verified as official when first introduced to the cask
+  url "https://github.com/duplicati/duplicati/releases/download/v#{version.before_comma}-#{version.before_comma}_beta_#{version.after_comma}/duplicati-#{version.before_comma}_beta_#{version.after_comma}.dmg"
+  appcast 'https://github.com/duplicati/duplicati/releases.atom'
   name 'Duplicati'
   homepage 'https://www.duplicati.com/'
 


### PR DESCRIPTION
The current one gives a 502 Bad Gateway error and the Duplicati forum recommends downloading via Github.

Same version as before.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
