### PR TITLE
Update superproductivity from 2.9.3 to 2.10.7

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.9.3'
-  sha256 '0bb87a6d8e32a0e646e9864864c4083e4072927da73399df6bb9904bd4853ad0'
+  version '2.10.7'
+  sha256 'a5441121e3b9cd05b211ae3231c2dda12e4df462f7726dd6fa6370f5bacb7bb7'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.