### PR TITLE
Update fsnotes from 3.3.8 to 3.4.0

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.3.8'
-  sha256 'a12dc33be289f2e69bd724a590138c6fe2e1f705205b40b242d45eb3789be89d'
+  version '3.4.0'
+  sha256 'a887156d2c886343517228253d3bfa0da02a951b122b1ee05fc3b26ea40fb49c'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.