### PR TITLE
Update whalebird from 2.8.2 to 2.8.3

### DIFF
--- a/Casks/whalebird.rb
+++ b/Casks/whalebird.rb
@@ -1,6 +1,6 @@
 cask 'whalebird' do
-  version '2.8.2'
-  sha256 '25957b61aa7572a160f8731a691b737aad923b19daf644ef71d162b8ad9998a3'
+  version '2.8.3'
+  sha256 'bebf1a98373d13787fcd8da3dcd9759f81df1a8cc664add6ab9e6f794c6630fb'
 
   # github.com/h3poteto/whalebird-desktop was verified as official when first introduced to the cask
   url "https://github.com/h3poteto/whalebird-desktop/releases/download/#{version}/Whalebird-#{version}-darwin-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.