### PR TITLE
Update kube-forwarder from 1.4.2 to 1.5.0

### DIFF
--- a/Casks/kube-forwarder.rb
+++ b/Casks/kube-forwarder.rb
@@ -1,6 +1,6 @@
 cask 'kube-forwarder' do
-  version '1.4.2'
-  sha256 '2dd2d5bbb9da8656dc125a148f98a1dd2065cf8522baa341e86b64e7d234c5e0'
+  version '1.5.0'
+  sha256 'c6aeb2bd94dce460f08e517b8236332c563d67b8e186cbf4dc1b8acfda2b744a'
 
   # github.com/pixel-point/kube-forwarder was verified as official when first introduced to the cask
   url "https://github.com/pixel-point/kube-forwarder/releases/download/v#{version}/kube-forwarder.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.