### PR TITLE
Update Parallels to 15.0.0, remove Parallels Service management 

### DIFF
--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -23,15 +23,9 @@ cask 'parallels' do
   end
 
   postflight do
-    # Unhide the application
-    system_command '/usr/bin/chflags',
-                   args: ['nohidden', "#{appdir}/Parallels Desktop.app"],
-                   sudo: true
-
     # Start Parallels Service
     system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/Parallels Service",
-                   args: ['service_start'],
-                   sudo: true
+                   args: ['service_start']
   end
 
   uninstall_preflight do

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -3,7 +3,7 @@ cask 'parallels' do
   sha256 'ed8b991bbbb70142ced8ba450273118e613fcd9b692d00ef75ef8db0b046aa6c'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsDesktop-#{version}.dmg"
-  appcast 'https://kb.parallels.com/eu/124521'
+  appcast 'https://kb.parallels.com/eu/124724'
   name 'Parallels Desktop'
   homepage 'https://www.parallels.com/products/desktop/'
 

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -25,7 +25,8 @@ cask 'parallels' do
   postflight do
     # Start Parallels Service
     system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/Parallels Service",
-                   args: ['service_start']
+                   args: ['service_start'],
+                   sudo: true
   end
 
   uninstall_preflight do

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -1,6 +1,6 @@
 cask 'parallels' do
-  version '14.1.3-45485'
-  sha256 '34c9c345642fa30f9d240a76062c5672e399349d5e5984db9c208d22e099f8b9'
+  version '15.0.0-46967'
+  sha256 'ed8b991bbbb70142ced8ba450273118e613fcd9b692d00ef75ef8db0b046aa6c'
 
   url "https://download.parallels.com/desktop/v#{version.major}/#{version}/ParallelsDesktop-#{version}.dmg"
   appcast 'https://kb.parallels.com/eu/124521'
@@ -16,7 +16,7 @@ cask 'parallels' do
     system_command '/usr/bin/hdiutil',
                    args: ['attach', '-nobrowse', "#{staged_path}/ParallelsDesktop-#{version}.dmg"]
     system_command "/Volumes/Parallels Desktop #{version.major}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ['install', '-t', "#{appdir}/Parallels Desktop.app", '-s'],
+                   args: ['install', '-t', "#{appdir}/Parallels Desktop.app"],
                    sudo: true
     system_command '/usr/bin/hdiutil',
                    args: ['detach', "/Volumes/Parallels Desktop #{version.major}"]
@@ -28,9 +28,9 @@ cask 'parallels' do
                    args: ['nohidden', "#{appdir}/Parallels Desktop.app"],
                    sudo: true
 
-    # Run the initialization script
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ['init', '-b', "#{appdir}/Parallels Desktop.app"],
+    # Start Parallels Service
+    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/Parallels Service",
+                   args: ['service_start'],
                    sudo: true
   end
 

--- a/Casks/parallels.rb
+++ b/Casks/parallels.rb
@@ -22,13 +22,6 @@ cask 'parallels' do
                    args: ['detach', "/Volumes/Parallels Desktop #{version.major}"]
   end
 
-  postflight do
-    # Start Parallels Service
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/Parallels Service",
-                   args: ['service_start'],
-                   sudo: true
-  end
-
   uninstall_preflight do
     set_ownership "#{appdir}/Parallels Desktop.app"
   end


### PR DESCRIPTION
This PR updates Parallels to 15.0.0, and uses the Parallels Service `service_start` functionality over `inittool -b` to avoid requiring a reboot during upgrades from Parallels 14.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Edit:

I opted to remove the functionality of managing the Parallels service since there is no good option to do this currently:

- The previous method (`inittool init`) fails if the kernel extensions are being upgraded instead of just the application bundle (requires system reboot).
- The more updated method (`start_service` used by the Parallels [mass deployment solution](https://kb.parallels.com/en/120093)) can upgrade kernel extensions in-place, but fails with exit code 9 if the Parallels team identifier in not already [whitelisted in macOS](https://developer.apple.com/library/archive/technotes/tn2459/_index.html) via MDM or manual user-approval. 