### PR TITLE
Update mongodb-compass from 1.19.0 to 1.19.1

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.19.0'
-  sha256 '1f68e8f041e8d0f22a409214eae2ca57957a462ffc4a014e64f901a9bfa9fa5a'
+  version '1.19.1'
+  sha256 '800326a29ccd0d6e2ecdec75f22bae9d192085c37e339971a9805a2ae4d121de'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.