### PR TITLE
Update jgrasp from 2.0.5_06 to 2.0.5_07

### DIFF
--- a/Casks/jgrasp.rb
+++ b/Casks/jgrasp.rb
@@ -1,6 +1,6 @@
 cask 'jgrasp' do
-  version '2.0.5_06'
-  sha256 '4afbac7f5fac3851dcd7524ef242143f3b7301ff6bc08af5b86e388432020934'
+  version '2.0.5_07'
+  sha256 '022d50615f406b6255e0d7a2cf9fb651fc128e599958a1815b0eab3c4dd5b485'
 
   url "https://jgrasp.org/dl4g/jgrasp/jgrasp#{version.no_dots}.pkg"
   appcast 'https://jgrasp.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.