### PR TITLE
Update smartsynchronize from 4.0.0,3086 to 4.0.1

### DIFF
--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -2,7 +2,7 @@ cask 'smartsynchronize' do
   version '4.0.1'
   sha256 'd952c4b96c7c87a700bf837f7ef0a9f959bb8a4d6e1454a861647bf0aff98da2'
 
-  url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.before_comma}.dmg"
+  url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartsynchronize/changelog.txt',
           configuration: version.major_minor
   name 'SmartSynchronize'

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -4,7 +4,7 @@ cask 'smartsynchronize' do
 
   url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartsynchronize/changelog.txt',
-          configuration: version.chomp(".0")
+          configuration: version.chomp('.0')
   name 'SmartSynchronize'
   homepage 'https://www.syntevo.com/smartsynchronize/'
 

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -1,6 +1,6 @@
 cask 'smartsynchronize' do
-  version '4.0.0,3086'
-  sha256 '0a88efcebd9e969fb1a72b04b483d89253a0eb6b8548c2f4e9aec1be0168e793'
+  version '4.0.1'
+  sha256 'd952c4b96c7c87a700bf837f7ef0a9f959bb8a4d6e1454a861647bf0aff98da2'
 
   url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.before_comma}.dmg"
   appcast 'https://www.syntevo.com/smartsynchronize/changelog.txt',

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -4,7 +4,7 @@ cask 'smartsynchronize' do
 
   url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartsynchronize/changelog.txt',
-          configuration: version.major_minor
+          configuration: version.chomp(".0")
   name 'SmartSynchronize'
   homepage 'https://www.syntevo.com/smartsynchronize/'
 

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -1,6 +1,6 @@
 cask 'smartsynchronize' do
   version '4.0.1'
-  sha256 'd952c4b96c7c87a700bf837f7ef0a9f959bb8a4d6e1454a861647bf0aff98da2'
+  sha256 'd50ed71bd85d32409853a3a2e73006b03d977feea9b7875c71da689491e36b82'
 
   url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartsynchronize/changelog.txt',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.