### PR TITLE
Update microsoft-office from 16.27.19071500 to 16.28.19081202

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-office' do
-  version '16.27.19071500'
-  sha256 'a43f070675542a7e19b9be21a3957e35c446e3e1ce8a64cae268f86e458e1f76'
+  version '16.28.19081202'
+  sha256 '1c5f385d0a7d0b613d77fe6da77f428a5911d2d4075002b34415d567e71b5aea'
 
   # officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Office_#{version}_Installer.pkg"

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -13,7 +13,6 @@ cask 'microsoft-office' do
   pkg "Microsoft_Office_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
-                         'com.microsoft.OneDrive',
                          'com.microsoft.package.DFonts',
                          'com.microsoft.package.Frameworks',
                          'com.microsoft.package.Microsoft_AutoUpdate.app',
@@ -85,9 +84,12 @@ cask 'microsoft-office' do
                    'com.microsoft.autoupdate.helpertool',
                    'com.microsoft.autoupdate.helper',
                    'com.microsoft.update.agent',
+                   'com.microsoft.OneDriveStandaloneUpdater',
+                   'com.microsoft.OneDriveStandaloneUpdaterDaemon',
                    'com.microsoft.OneDriveUpdaterDaemon',
                  ],
       pkgutil:   [
                    'com.microsoft.package.Microsoft_AutoUpdate.app',
+                   'com.microsoft.OneDrive',
                  ]
 end

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -13,8 +13,7 @@ cask 'microsoft-office' do
   pkg "Microsoft_Office_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
-                         'com.microsoft.package.OneDrive',
-                         'com.microsoft.package.Fonts',
+                         'com.microsoft.package.DFonts',
                          'com.microsoft.package.Frameworks',
                          'com.microsoft.package.Microsoft_AutoUpdate.app',
                          'com.microsoft.package.Microsoft_Excel.app',
@@ -24,6 +23,14 @@ cask 'microsoft-office' do
                          'com.microsoft.package.Microsoft_Word.app',
                          'com.microsoft.package.Proofing_Tools',
                          'com.microsoft.pkg.licensing',
+                       ],
+# Frameworks, DFonts and ProofingTools remain in each applicaiton after pkg uninstall, delete them
+            delete:    [
+                         '/Applications/Microsoft Excel.app',
+                         '/Applications/Microsoft OneNote.app',
+                         '/Applications/Microsoft Outlook.app',
+                         '/Applications/Microsoft PowerPoint.app',
+                         '/Applications/Microsoft Word.app',
                        ],
             launchctl: [
                          'com.microsoft.office.licensing.helper',

--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -13,6 +13,7 @@ cask 'microsoft-office' do
   pkg "Microsoft_Office_#{version}_Installer.pkg"
 
   uninstall pkgutil:   [
+                         'com.microsoft.OneDrive',
                          'com.microsoft.package.DFonts',
                          'com.microsoft.package.Frameworks',
                          'com.microsoft.package.Microsoft_AutoUpdate.app',
@@ -24,7 +25,7 @@ cask 'microsoft-office' do
                          'com.microsoft.package.Proofing_Tools',
                          'com.microsoft.pkg.licensing',
                        ],
-# Frameworks, DFonts and ProofingTools remain in each applicaiton after pkg uninstall, delete them
+            # Frameworks, DFonts and ProofingTools remain in each applicaiton after pkg uninstall, delete them
             delete:    [
                          '/Applications/Microsoft Excel.app',
                          '/Applications/Microsoft OneNote.app',
@@ -88,6 +89,5 @@ cask 'microsoft-office' do
                  ],
       pkgutil:   [
                    'com.microsoft.package.Microsoft_AutoUpdate.app',
-                   'com.microsoft.OneDrive',
                  ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.