### PR TITLE
Update signal from 1.26.0 to 1.26.1

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.26.0'
-  sha256 'cd990ff34ee6bcc7a9018de04b5c68a24615969ae6ba52d79523c76005498961'
+  version '1.26.1'
+  sha256 '885871075e1e5e59f2937bd6a46fe43a8a16b9d77b480d05ab408187081c1f71'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.