### PR TITLE
Update station from 1.45.1 to 1.45.2

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.45.1'
-  sha256 '70fa4ff45a3c710f32a30b1a4e856a76161ff757bd54ccb688e76884ff7d60d1'
+  version '1.45.2'
+  sha256 '2d9c66bbfb921e56a4a49a442b1a2a4107d4190b2e7597da5767c86233c4845b'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.