### PR TITLE
Update audirvana from 3.5.17 to 3.5.18

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.17'
-  sha256 'a77b3146f2f716a701af579e384a644fd3712aca6d6c76ec44eedbc70a566f94'
+  version '3.5.18'
+  sha256 '7cb07b50e22a27031d8ebd268b7d98a5f643db264f2c03bc90d227af19c57cfd'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.