### PR TITLE
Update malwarebytes from 3.8.17.2526 to 3.9.27.2815

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '3.8.17.2526'
-  sha256 'e9da975b65f2a83c83882802108638356833fe5ef17397fd492b79d07496d8f4'
+  version '3.9.27.2815'
+  sha256 'e647e1af640a8aa9f2f077e0c9ceb8eb4bc050cfb9f63b1350cd20cb03d1d965'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.