### PR TITLE
Update cacher from 2.15.1 to 2.15.2

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.15.1'
-  sha256 'd566883c038e072f1f3fb92e75e295c6380b53222e9dfdb99d44c64851206a06'
+  version '2.15.2'
+  sha256 '3f3bd37584d2c17773075f538ba6abf0e53187807f3609197ac2d8f91f1eca42'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.