### PR TITLE
Update roblox from 0.396.0.327208,0ce8eb9947e2462f to 0.397.0.329146,f5c2fbb4aff5434e

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.396.0.327208,0ce8eb9947e2462f'
-  sha256 '3302493de2c813f0bf6b6db53e2fad042787332b9858a970e2d162a6c76514b5'
+  version '0.397.0.329146,f5c2fbb4aff5434e'
+  sha256 '2ae155a7cc324ad8a422473e3b2947af9b8127ea59b974e89c8875d7174c603d'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.