### PR TITLE
Update melodics from 2.1.3205 to 2.1.3301

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3205'
-  sha256 'ce93f5486a39a222d5d521fe43a9ba129703deff1ad0938578995a2d6d71e4f2'
+  version '2.1.3301'
+  sha256 '340633a3479fb2b23043d525d73671145c86351f8571417a5219b9af8df9ee5d'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.