### PR TITLE
Update lingo from 8.1 to 8.2

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,5 +1,5 @@
 cask 'lingo' do
-  version '8.1'
+  version '8.2'
   sha256 'f2a95c008f7990519d3310aa7496929ba09cf72f61253919a8ea648591cabc4a'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.