### PR TITLE
Update segger-embedded-studio-for-arm from 4.18 to 4.20

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.18'
-  sha256 '3a29e54cd5e10ba2fb5b2f20db88d06527b6086a81ffeca662409db0ea7fd2ef'
+  version '4.20'
+  sha256 'd394094ffd0ce72dbc548c39c1ff6f3053197c88915819bac2199d011223b456'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   name 'SEGGER Embedded Studio for ARM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.