### PR TITLE
Update sidequest from 0.6.4 to 0.6.6

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,6 +1,6 @@
 cask 'sidequest' do
-  version '0.6.4'
-  sha256 '35e4aac6322e0c7cf13657f903ce9197482fe42ec8d75ab3a23528118ee3972f'
+  version '0.6.6'
+  sha256 '96accbc328c3d071989de9a3f86a988f4796bad634e37f799995c1c8bcf7eb57'
 
   # github.com/the-expanse/SideQuest was verified as official when first introduced to the cask
   url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.