### PR TITLE
Update screentray from 1.5.0 to 1.6.0

### DIFF
--- a/Casks/screentray.rb
+++ b/Casks/screentray.rb
@@ -1,6 +1,6 @@
 cask 'screentray' do
-  version '1.5.0'
-  sha256 'e2d0fc8ff4fde4299c8c7b1815580c72432dda160eda5696c51c1086f712b10c'
+  version '1.6.0'
+  sha256 '7806c0d81bf714bbd30753398f55af49ac33b09bb79ac7a0495249dffed38474'
 
   # github.com/DSnopov/screentray-distribution was verified as official when first introduced to the cask
   url "https://github.com/DSnopov/screentray-distribution/releases/download/v#{version}/ScreenTray-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.