### PR TITLE
Update lbry from 0.34.2 to 0.35.0

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.34.2'
-  sha256 'd2a6be4c6d00f09aff8d3d137431a217ca60b36240e85515a1d1ca29f0b2e0bd'
+  version '0.35.0'
+  sha256 '8879d070185484a924c87149d18d53419802de9b3b72ae7ab7b0bb4e17e37d8a'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.