### PR TITLE
Update trailer from 1.6.16 to 1.6.17

### DIFF
--- a/Casks/trailer.rb
+++ b/Casks/trailer.rb
@@ -1,6 +1,6 @@
 cask 'trailer' do
-  version '1.6.16'
-  sha256 '45ec1b8795a013f73027d66d1c70e6deaf5f413917f91354c770f9203f236019'
+  version '1.6.17'
+  sha256 '6c4dce7eeacb42f64a3fdc1efb8b8d8af6b46564e2beca05622fed48b37fb699'
 
   # github.com/ptsochantaris/trailer was verified as official when first introduced to the cask
   url "https://github.com/ptsochantaris/trailer/releases/download/#{version}/trailer#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.