### PR TITLE
Update isubtitle from 3.2.2 to 3.2.3

### DIFF
--- a/Casks/isubtitle.rb
+++ b/Casks/isubtitle.rb
@@ -1,6 +1,6 @@
 cask 'isubtitle' do
-  version '3.2.2'
-  sha256 '7b00f0b0c8994968e1749139b0e47a78a1db2585e18038365af0d198bbdd6506'
+  version '3.2.3'
+  sha256 '3af9d4c0199720b9cccbd85ae2527565ea45ada176669cfee6f6d6f48cc39bbc'
 
   url "https://www.bitfield.se/isubtitle#{version.major}/download/iSubtitle_#{version}.zip"
   appcast "https://www.bitfield.se/isubtitle#{version.major}/changelog.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.