### PR TITLE
Update photosweeper-x from 3.4.1 to 3.4.2

### DIFF
--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,6 +1,6 @@
 cask 'photosweeper-x' do
-  version '3.4.1'
-  sha256 '92ec97ad68f26b7dadd60f45d8a7f5c59c5b9bae7cef04f5dd486025021f9ab4'
+  version '3.4.2'
+  sha256 '7320db1cc9b28c2696a45410d42e1529b9297481885ab9e841e386d73a6e25af'
 
   url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
   appcast 'https://overmacs.com/photosweeper/updates/photosweeper_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.