### PR TITLE
Update visual-studio-code from 1.37.0,036a6b1d3ac84e5ca96a17a44e63a87971f8fcc8 to 1.37.1,f06011ac164ae4dc8e753a3fe7f9549844d15e35

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code' do
-  version '1.37.0,036a6b1d3ac84e5ca96a17a44e63a87971f8fcc8'
-  sha256 '8635ff8d5ff22589896ffdb87384b21ff678222ef1f00249194b50b8ad2240c7'
+  version '1.37.1,f06011ac164ae4dc8e753a3fe7f9549844d15e35'
+  sha256 '6c73a4e909339007605d04fad68f306e817bbdde8043785cea71b3a5c3660739'
 
   # az764295.vo.msecnd.net/stable was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/stable/#{version.after_comma}/VSCode-darwin-stable.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.