### PR TITLE
Update favro from 1.0.32 to 1.0.33

### DIFF
--- a/Casks/favro.rb
+++ b/Casks/favro.rb
@@ -1,6 +1,6 @@
 cask 'favro' do
-  version '1.0.32'
-  sha256 '424e22dd5d7659e328288e0fb7c3091f1262d3ab2947fff9817394fd08669416'
+  version '1.0.33'
+  sha256 'dd1309fc5d439763b20b2d9ced34fbb124015c6b2f74e2ba80670c74e00ce3a6'
 
   url "https://download.favro.com/FavroDesktop/macOS/x64/Favro-#{version}.dmg"
   appcast 'https://download.favro.com/FavroDesktop/macOS/x64/Latest.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.