### PR TITLE
Update fldigi from 4.1.07,4.3.7 to 4.1.08,4.3.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.1.07,4.3.7'
-  sha256 '90ef411202f934db17f9264d6d1f02da56c7c89c1eab262cf02ab009d2cf3395'
+  version '4.1.08,4.3.7'
+  sha256 '032272da952c5c3882e9c34c6b1a4a8cf1af16a3d7eae76a0ff31ef777441107'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.