### PR TITLE
Update blitz from 1.2.2 to 1.2.4

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.2.2'
-  sha256 '6e894a06e8fa632696aa72673fc847677c244ee9a35ef2a1ef382d9ccf72c1c6'
+  version '1.2.4'
+  sha256 'f9816a7aa55a43e6168547a01831bddd3e743079a4d1ca222c4c2e896619eba5'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.