### PR TITLE
Update abstract from 83.0.0 to 83.0.1

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '83.0.0'
-  sha256 '5792601510c6ae6b8e0e52f9ce5c56e6ec7ea0fb44bd4392658513b3f28a1579'
+  version '83.0.1'
+  sha256 'd516f127837f2ecc14115d0531d2662a1f78f81e4a07c9161da2d09020dc44c9'
 
   url "https://downloads.goabstract.com/Abstract-#{version}.dmg"
   appcast 'https://www.goabstract.com/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.