### PR TITLE
Update lehreroffice from 2019.11.0 to 2019.11.1

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.11.0'
-  sha256 '43405d814d9a2394b9bb98ad186ff292b674dfd4489f8c1e138ea132ff95a995'
+  version '2019.11.1'
+  sha256 '437ee56ccda365e73f368e38f8c2affef7fd036eed7d0f2e690469f616adf11a'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.