### PR TITLE
Update scrutiny from 9.0.10 to 9.0.11

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '9.0.10'
-  sha256 '68f8cf15b540db7fc6da57c7d5f6ef6048dbc7b9684bd9ee8f955b61b7e40c59'
+  version '9.0.11'
+  sha256 'ff572b22e1b7f0926db51bcace44fcd09decbf1a1d44b55e47a5d3e207d628ce'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.