### PR TITLE
Update grandperspective from 2.2.2 to 2.2.3

### DIFF
--- a/Casks/grandperspective.rb
+++ b/Casks/grandperspective.rb
@@ -1,6 +1,6 @@
 cask 'grandperspective' do
-  version '2.2.2'
-  sha256 'd80a38c9a1ee87b22e0daeef6d976d7d8a8ecec8cf98ba3c11d1beb9fd19ff8e'
+  version '2.2.3'
+  sha256 '9278e4264ae173945e59dc2567b3a4dd7ac1c16f1e587f5f53a1fd10532c8c47'
 
   # downloads.sourceforge.net/grandperspectiv was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/grandperspectiv/grandperspective/#{version}/GrandPerspective-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.