### PR TITLE
Update praat from 6.1.00 to 6.1.01

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,9 +1,9 @@
 cask 'praat' do
-  version '6.1.00'
-  sha256 '8fc69caa277cfe833b99bbb470d4c08fabd1e083eeae5574773063cf607ecc9f'
+  version '6.1.01'
+  sha256 '1792b9b6f72bfef604b8390a2fb93a43d4a1bc50263225904fc8c7991f8d8a8c'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
-  url "https://github.com/praat/praat/releases/download/v#{version.major_minor}/praat#{version.no_dots}_mac64.dmg"
+  url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.