### PR TITLE
Update gzdoom from 4.1.3 to 4.2.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,8 +1,8 @@
 cask 'gzdoom' do
-  version '4.1.3'
-  sha256 'a0545705aa952e76554e412c2c05479107989457de6f19bd2f8f7330c902fb80'
+  version '4.2.0'
+  sha256 'b680a970935fcb5e809eb1f51c6df4ea5004a34f7ea97a2212198f1ac2cf92f2'
 
-  url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}.dmg"
+  url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}-macOS.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom'
   name 'gzdoom'
   homepage 'https://zdoom.org/index'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.