### PR TITLE
Update birdfont from 3.28.1 to 3.29.4

### DIFF
--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -3,8 +3,8 @@ cask 'birdfont' do
     version '2.19.4'
     sha256 '013d9c42c2252b57079453bd27e4c18dbbc09eda55563ff1516fd079c0499f76'
   else
-    version '3.28.1'
-    sha256 '548c6a0a037f758569b25bd0c40d26e6114bb9c48df4da72e171bf35c7bfff85'
+    version '3.29.4'
+    sha256 '3c0619f16f1590ae416aa76462f069f71894da64818cb4d80ebfcb0f49e08757'
   end
 
   url "https://birdfont.org/download/birdfont-#{version}-free.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.