### PR TITLE
Update superproductivity from 2.10.7 to 2.10.8

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.10.7'
-  sha256 'a5441121e3b9cd05b211ae3231c2dda12e4df462f7726dd6fa6370f5bacb7bb7'
+  version '2.10.8'
+  sha256 'e2a11011d7c71646cb5ff212de34b3e68e97387b7852400871c4fa44bbfcd3a4'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.