### PR TITLE
Update bdash from 1.5.6 to 1.5.7

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.5.6'
-  sha256 '9de0a27c9f58826341d36518cff441babcc69f285b9e9689af4ce768f781d690'
+  version '1.5.7'
+  sha256 '1cfa66d219e2348994e5a2dc4ca18b976466e27078a6c239ce71336131e64bcf'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.