### PR TITLE
Update outline-manager from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.2.2'
-  sha256 'f68f61c591ec95b7716b08432b58729d9c45dce638b307ea90c3bd196dfb2e03'
+  version '1.2.3'
+  sha256 'a295de5a4789493cd99a31864da0f33a9db8c5474bdeddbd658a6aaacf76f876'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.