### PR TITLE
Update netron from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.3.1'
-  sha256 '0a79f7bd5e4dc2dc61845fbd96f0fedbe3e60af18d782fdd6dc07218f60d3903'
+  version '3.3.2'
+  sha256 '9fa942a1fe92cb28ba1a2a408d9dae4d06dc15fde6477ad278d9c4a9fd6c3225'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.