### PR TITLE
Update boom-3d from 1.3.0,1564581734 to 1.3.1,1565964449

### DIFF
--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -1,6 +1,6 @@
 cask 'boom-3d' do
-  version '1.3.0,1564581734'
-  sha256 'e9d8f37d337a56770c17bb4f813fde95dea0b8e940e50215177593b3a2f0aa13'
+  version '1.3.1,1565964449'
+  sha256 '55c9d23898cf8ccaf5bf13efa097d102d1e73e96fabba1eacb5ef6d6dea976b4'
 
   # devmate.com/com.globaldelight.Boom3D was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Boom3D/#{version.before_comma}/#{version.after_comma}/Boom3D-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.