### PR TITLE
Update rocket from 1.5,53:1553802737 to 1.5.1,59:1565911546

### DIFF
--- a/Casks/rocket.rb
+++ b/Casks/rocket.rb
@@ -1,6 +1,6 @@
 cask 'rocket' do
-  version '1.5,53:1553802737'
-  sha256 '3241060ebedcb2e1ef6c2be623aa56cc0f3f56eb7b5e86c6e6b4b00632f994ed'
+  version '1.5.1,59:1565911546'
+  sha256 '964f74383f045c4fba107a9bdf43bdc880c1c1a6f2321c8cf85534baf0f54811'
 
   # dl.devmate.com/net.matthewpalmer.Rocket was verified as official when first introduced to the cask
   url "https://dl.devmate.com/net.matthewpalmer.Rocket/#{version.after_comma.before_colon}/#{version.after_colon}/Rocket-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.