### PR TITLE
Update preform from 3.0.4,1365 to 3.0.5,1396

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,9 +1,9 @@
 cask 'preform' do
-  version '3.0.4,1365'
-  sha256 '7447246e0aada5f0e99384fd874628cb879b5f261fff15f0d409f638ff47f544'
+  version '3.0.5,1396'
+  sha256 '3e61b54199a4768acbde40d1b984d32d700ab83d54bf2a50385b23ab1ed2dac4'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"
+  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://formlabs.com/download-preform-mac/'
   name 'PreForm'
   homepage 'https://formlabs.com/tools/preform/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.