### PR TITLE
Update ocenaudio from 3.7.2 to 3.7.3

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,12 +1,12 @@
 cask 'ocenaudio' do
-  version '3.7.2'
+  version '3.7.3'
 
   if MacOS.version <= :high_sierra
     sha256 '589e62c2f4785ae8dcab530dd6503fbeee6a1d70f77a4da1e5e356a9060f451a'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 '33a08bbfb277e9f5aeae4928265d65c3d5ee47aca96fa5a6409200371f90d33b'
+    sha256 '6d0b42cb13083b7d7559cc060604a73e3e289886b64159e89d7d47b9e0fabd75'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,11 +2,11 @@ cask 'ocenaudio' do
   version '3.7.3'
 
   if MacOS.version <= :high_sierra
-    sha256 '589e62c2f4785ae8dcab530dd6503fbeee6a1d70f77a4da1e5e356a9060f451a'
+    sha256 '1bc0c0742df9a2d683e72f50bef06ca14af2ac6e5c068eb96ebe973fa52a6d37'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 '6d0b42cb13083b7d7559cc060604a73e3e289886b64159e89d7d47b9e0fabd75'
+    sha256 '580a44cef051ae28df615411d53f0328fb94c55a1b600894e394cde2c3862293'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,11 +2,11 @@ cask 'ocenaudio' do
   version '3.7.3'
 
   if MacOS.version <= :high_sierra
-    sha256 '1bc0c0742df9a2d683e72f50bef06ca14af2ac6e5c068eb96ebe973fa52a6d37'
+    sha256 'd359dd72f7bd8ede0e9557b0818336f1418d66b5c50fe740916f4820857079bb'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 '580a44cef051ae28df615411d53f0328fb94c55a1b600894e394cde2c3862293'
+    sha256 '6d0b42cb13083b7d7559cc060604a73e3e289886b64159e89d7d47b9e0fabd75'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.