### PR TITLE
change versionnr spelling from 10.10.6 to 10.6.6 goodsync.rb

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,5 +1,5 @@
 cask 'goodsync' do
-  version '10.10.6'
+  version '10.10.6.6'
   sha256 'ef2f6e7168d8af28174117a8986a794af10b424b9d3a15f3df448f38235ef508'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"


### PR DESCRIPTION
could we please stay with this spelling - this is the version number inside the app (bundle version and short version string) thanks 