### PR TITLE
Update shotcut from 19.08.05 to 19.08.16

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '19.08.05'
-  sha256 'd45d9291da60b2e1cb093aa4e4ce3366c946b417d42cefb035104437cc33c4cf'
+  version '19.08.16'
+  sha256 '2bb3eb82a35d2329fd77be47fb79ede62a49703430823b1f5fc40789812bd026'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.