### PR TITLE
Update integrity from 9.0.11 to 9.0.12

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,6 +1,6 @@
 cask 'integrity' do
-  version '9.0.11'
-  sha256 '0f3e76eb4ac670b140b4a9c610e5d70a4565a154bf5fb57df873cb1f8d3bcfe2'
+  version '9.0.12'
+  sha256 '8b6ae75089b5e1d2f6dac47ec6a04520f35b78b94289ec57b22eb540ad552a9d'
 
   url 'https://peacockmedia.software/mac/integrity/integrity.dmg'
   appcast 'https://peacockmedia.software/mac/integrity/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.