### PR TITLE
Update media-converter from 1.2 to 2.0

### DIFF
--- a/Casks/media-converter.rb
+++ b/Casks/media-converter.rb
@@ -1,6 +1,6 @@
 cask 'media-converter' do
-  version '1.2'
-  sha256 '4893e6e5bc18b9cb0f0d8e1bcb861f92595314e4f9768ef638affdfc866f37e1'
+  version '2.0'
+  sha256 '2e1da59af62a994cf45de697cfab39952030210d8c355648edf233c43fa06324'
 
   # downloads.sourceforge.net/media-converter was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/media-converter/media-converter/#{version}/media-converter-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.