### PR TITLE
Delete Plex media player saved state

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -16,6 +16,7 @@ cask 'plex-media-player' do
                '~/Library/Application Support/Plex Media Player',
                '~/Library/Caches/Plex Media Player',
                '~/Library/Logs/Plex Media Player',
+               '~/Library/Saved Application State/tv.plex.Plex Media Player.savedState',
                '~/Library/Preferences/tv.plex.Plex Media Player.plist',
              ]
 end


### PR DESCRIPTION
As per the recommendations on https://support.plex.tv/articles/207336318-uninstalling-plex-media-player/, delete the 'tv.plex.Plex Media Player.savedState' when uninstalling Plex Media Player

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offences.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
