### PR TITLE
Update omnigraffle from 7.11.1 to 7.11.2

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -4,8 +4,8 @@ cask 'omnigraffle' do
     sha256 'ab463ea6c12d49c4104d3814ac3280d0359072702d4751f5074f644fc79de0c6'
     url "https://downloads.omnigroup.com/software/Archive/MacOSX/10.12/OmniGraffle-#{version}.dmg"
   else
-    version '7.11.1'
-    sha256 'fbddfbb69232473d722f85954148873f45aa9ac7f4e6b21a9b5511e67edbcc90'
+    version '7.11.2'
+    sha256 'cbb8eab0cd26c4efe7ace3a0424b7e12ffd89492a02e36d4cabd412a383ccc32'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.