### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.0f1,20c1667945cf to 2019.2.1f1,ca4d5af0be6f

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.0f1,20c1667945cf'
-  sha256 '2e57750e3aca126e6e79bb57407dc04fbde0b79a0484e31a52b703d87c35a9fe'
+  version '2019.2.1f1,ca4d5af0be6f'
+  sha256 '5567dfd83cdb9026c3aa33b2676eb6530dd315b55794ab3aa6184e8292a3cb6e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.