### PR TITLE
Update unity-linux-support-for-editor from 2019.2.0f1,20c1667945cf to 2019.2.1f1,ca4d5af0be6f

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.0f1,20c1667945cf'
-  sha256 'abdd0093532ec3a94227eb16335f702007ac62f16582ddcb27370e3d30c91f51'
+  version '2019.2.1f1,ca4d5af0be6f'
+  sha256 'fce6da90c2f81c0813f4e86c72776b126b44e62e14f5960ce28753c025c46142'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.