### PR TITLE
Update fsnotes from 3.4.0 to 3.4.2

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.4.0'
-  sha256 'a887156d2c886343517228253d3bfa0da02a951b122b1ee05fc3b26ea40fb49c'
+  version '3.4.2'
+  sha256 '3b75cbe4a0d3335dac62d1910e09a81426a68d36d7c49d401ed8bb22342c2783'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.