### PR TITLE
Update middleclick from 1.0 to Mojave

### DIFF
--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,9 +1,9 @@
 cask 'middleclick' do
-  version '1.0'
-  sha256 '74533304ec68f8e6c716a4b7c3ad6ed34d985b88c66eee7e43cce22883dee08e'
+  version 'Mojave'
+  sha256 'a83a329493b9140cb73b418ddfa2e921555fc7706a11d8ec2ba13c4016392aca'
 
   # github.com was verified as official when first introduced to the cask
-  url "https://github.com/cl3m/MiddleClick/releases/download/#{version}/MiddleClick.zip"
+  url "https://github.com/cl3m/MiddleClick/releases/download/mojave/MiddleClick_#{version}.zip"
   appcast 'https://github.com/cl3m/MiddleClick/releases.atom'
   name 'MiddleClick'
   homepage 'https://rouge41.com/labs/'

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -9,4 +9,8 @@ cask 'middleclick' do
   homepage 'https://rouge41.com/labs/'
 
   app 'MiddleClick.app'
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -3,7 +3,7 @@ cask 'middleclick' do
   sha256 'a83a329493b9140cb73b418ddfa2e921555fc7706a11d8ec2ba13c4016392aca'
 
   # github.com was verified as official when first introduced to the cask
-  url "https://github.com/cl3m/MiddleClick/releases/download/mojave/MiddleClick_#{version}.zip"
+  url "https://github.com/cl3m/MiddleClick/releases/download/mojave/MiddleClick_Mojave.zip"
   appcast 'https://github.com/cl3m/MiddleClick/releases.atom'
   name 'MiddleClick'
   homepage 'https://rouge41.com/labs/'

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,5 +1,5 @@
 cask 'middleclick' do
-  version 'Mojave'
+  version '1.0'
   sha256 'a83a329493b9140cb73b418ddfa2e921555fc7706a11d8ec2ba13c4016392aca'
 
   # github.com was verified as official when first introduced to the cask

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -3,7 +3,7 @@ cask 'middleclick' do
   sha256 'a83a329493b9140cb73b418ddfa2e921555fc7706a11d8ec2ba13c4016392aca'
 
   # github.com was verified as official when first introduced to the cask
-  url "https://github.com/cl3m/MiddleClick/releases/download/mojave/MiddleClick_Mojave.zip"
+  url 'https://github.com/cl3m/MiddleClick/releases/download/mojave/MiddleClick_Mojave.zip'
   appcast 'https://github.com/cl3m/MiddleClick/releases.atom'
   name 'MiddleClick'
   homepage 'https://rouge41.com/labs/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.