### PR TITLE
Update aquamacs from 3.4 to 3.5

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -1,6 +1,6 @@
 cask 'aquamacs' do
-  version '3.4'
-  sha256 '9c4ec15ac7f440a3aa6ea4346543f4550f8e48962a103b49ee1d6f240d16686e'
+  version '3.5'
+  sha256 'c27165c0b42b93ef3c9e5dfd0dd53527b10c683aae35fceedd4fecc52332c2ba'
 
   # github.com/davidswelt/aquamacs-emacs was verified as official when first introduced to the cask
   url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}/Aquamacs-Emacs-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.