### PR TITLE
Update gpxsee from 7.11 to 7.12

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.11'
-  sha256 '7c03ff92d6ff95cfa443d79f6cae70803680690d9c639d10f47b0f1cdcdf8a8f'
+  version '7.12'
+  sha256 '03b2db5fb4972d3816ceeee5d034fd938ef231cb690c207bae216d4d2c7bd1a4'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.