### PR TITLE
Update seafile-client from 7.0.0 to 7.0.2

### DIFF
--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -1,6 +1,6 @@
 cask 'seafile-client' do
-  version '7.0.0'
-  sha256 '9cba1ccfb91fa8289bb49f91120d58eac9e8a86bb374aa1534247329f2d0935d'
+  version '7.0.2'
+  sha256 'ff138f31047601d99b3a4b875c91eb1e4d1af717dad1d25a5ea2d91abde4509d'
 
   # seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seafile-client-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.