### PR TITLE
Adding zap stanza to NearLock

### DIFF
--- a/Casks/near-lock.rb
+++ b/Casks/near-lock.rb
@@ -8,4 +8,12 @@ cask 'near-lock' do
   homepage 'https://nearlock.me/'
 
   app 'Near Lock.app'
+
+  zap trash: [
+               '~/Library/Application Support/NearLock',
+               '~/Library/Application Support/me.nearlock.Near-Lock',
+               '~/Library/Caches/me.nearlock.Near-Lock',
+               '~/Library/NearLock',
+               '~/Library/Preferences/me.nearlock.Near-Lock.plist',
+             ]
 end


### PR DESCRIPTION
Adding `zap` stanza. to NearLock app.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name

