### PR TITLE
Update qobuz from latest to 5.1.0

### DIFF
--- a/Casks/qobuz.rb
+++ b/Casks/qobuz.rb
@@ -1,14 +1,14 @@
 cask 'qobuz' do
-  version :latest
-  sha256 :no_check
+  version '5.1.0'
+  sha256 'bf5c0a6a47c56b5192c07d120d4849feb4e02406d463cded8f771e0689210c6d'
 
-  url 'https://static.qobuz.com/apps/qobuz-desktop/osx/QobuzDesktopInstaller.pkg'
-  name 'Qobuz Desktop'
+  url 'https://desktop.qobuz.com/releases/darwin/x64/elCapitan_sierra/5.1.0-b003/Qobuz.dmg'
+  name 'Qobuz'
   homepage 'https://www.qobuz.com/applications'
 
-  pkg 'QobuzDesktopInstaller.pkg'
+  auto_updates true
 
-  uninstall pkgutil: 'com.qobuz.QobuzDesktop.*'
+  app 'Qobuz.app'
 
   zap trash: [
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.qobuz.qobuzdesktop.sfl*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.