### PR TITLE
Update understand from 5.1.995 to 5.1.996

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.995'
-  sha256 '5cf1032d4e5828f619c4b17765ab0887f13643a7d6951c6f60ac0de35d0962f7'
+  version '5.1.996'
+  sha256 '13698578b9585fa5fa7ab97df780f132768679229d4f87055296c7cab053b329'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.