### PR TITLE
Update tidepool-uploader from 2.18.0 to 2.19.0

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.18.0'
-  sha256 'e1259f16790c1a8e099ccb445feb3c85f9486eb2679e5b7a4636ea1da1bd59c0'
+  version '2.19.0'
+  sha256 '242f9d0cc7e5eecea1e54aca83e14e91e0518a9df4d46f75348346a4a63bae02'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.