### PR TITLE
Update bdash from 1.5.7 to 1.5.8

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.5.7'
-  sha256 '1cfa66d219e2348994e5a2dc4ca18b976466e27078a6c239ce71336131e64bcf'
+  version '1.5.8'
+  sha256 '10b9650c36e28b04bc56d5c64cb9807824fe982c739cc7bdfccab90e21449581'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.