### PR TITLE
Update suitcase-fusion from 9,20.0.6 to 9,20.0.7

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,6 +1,6 @@
 cask 'suitcase-fusion' do
-  version '9,20.0.6'
-  sha256 '51bf38757c8e1e8a3e77a5b1ffa49cf14fc6c9453cb76e4d706bf5568b43b6cc'
+  version '9,20.0.7'
+  sha256 '3301f192a5cc6eb4c56c8057b8b2ee2595f124a55bcb02884902249a99f43188'
 
   url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
   appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.