### PR TITLE
Update axe-edit-iii from 1.03.01 to 1.03.02

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.03.01'
-  sha256 '3a2f7693941ee330d70d06ef39de7d4ffec28a78217c345d83c96d0e83bb7ea0'
+  version '1.03.02'
+  sha256 '4cfa262c93f10e08a5e54aa6a952e2ebfa31ac613a22e0b62929e981e9cbd06c'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.