### PR TITLE
Update superproductivity from 2.10.8 to 2.10.9

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.10.8'
-  sha256 'e2a11011d7c71646cb5ff212de34b3e68e97387b7852400871c4fa44bbfcd3a4'
+  version '2.10.9'
+  sha256 '1cb58c2a0069d152c145b5ea63189aaa28245c0a2f371c3cccb49d13a8dd1e9d'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.