### PR TITLE
Update trailrunner from 3.8.3230,203 to 3.8.3233,204

### DIFF
--- a/Casks/trailrunner.rb
+++ b/Casks/trailrunner.rb
@@ -1,6 +1,6 @@
 cask 'trailrunner' do
-  version '3.8.3230,203'
-  sha256 '0e4dca11d63d7d274d40a8b3fd176c866804476c316cfdb2ab0c5d40e3d4f40a'
+  version '3.8.3233,204'
+  sha256 '29f061fbb95f436e3bf2fb1db55e63e4bc96906df361a998a70af68ff7f507dd'
 
   # rink.hockeyapp.net was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/83c4086e3f968b874757ba689e71f610/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.