### PR TITLE
Update nvidia-geforce-now from 2.0.10.71,350E76 to 2.0.10.80,9E2D4B

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.10.71,350E76'
-  sha256 '05bed0f13eee22f63e45832712e3d4ac2629107221cc282c564f65ceb7b41f83'
+  version '2.0.10.80,9E2D4B'
+  sha256 '038e46b6d1badaf15fe59aed150573028d9e81627eec7b758551eac81773975d'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.