### PR TITLE
Update gramps from 5.0.1-1 to 5.0.2-3

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,9 +1,9 @@
 cask 'gramps' do
-  version '5.0.1-1'
-  sha256 '6e53348fdbd3e30b1e7979e5037824091963b66dae98db203d5c1b631f7a3742'
+  version '5.0.2-3'
+  sha256 '28e5f457d37f8b4ad738874b92a9edbfb1e92f4d44abc1229f42579b1aa233f1'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
-  url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-#{version}.dmg"
+  url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"
   appcast 'https://github.com/gramps-project/gramps/releases.atom'
   name 'Gramps'
   homepage 'https://gramps-project.org/introduction-WP/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.