### PR TITLE
Update mongodb-compass from 1.19.3 to 1.19.6

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass' do
-  version '1.19.3'
-  sha256 'f1ec58598b9014c85bde5d928f444cc9b48cf4a9df483244a1ee2b774cdf0191'
+  version '1.19.6'
+  sha256 '392831d5a860ae0dcc6d5d5d0bb04a1f4224d3202b0970004f11ae16b251f3c5'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.