### PR TITLE
Update mongodb-compass-isolated-edition from 1.19.3 to 1.19.6

### DIFF
--- a/Casks/mongodb-compass-isolated-edition.rb
+++ b/Casks/mongodb-compass-isolated-edition.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-isolated-edition' do
-  version '1.19.3'
-  sha256 'd8d0be19ec53235748672059f97a65a87a7a50263ddf1acc8eff939431e9e542'
+  version '1.19.6'
+  sha256 '24fe0d67e5eb2014fe695f08259c5a19b582bcc9935bc03e0c60a7b4cbb03f07'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-isolated-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.