### PR TITLE
Update waterfox from 56.2.12 to 56.2.13

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '56.2.12'
-  sha256 '7ad44ec8d1442bbf53a1e28919fe5c3e408bb1544b4b251b377a1676ddceb79f'
+  version '56.2.13'
+  sha256 '8d655e1bc54fe41172b12599a40f677c5757289238d588f3943a98da39710b88'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.