### PR TITLE
Update mongodb-compass-community from 1.19.3 to 1.19.6

### DIFF
--- a/Casks/mongodb-compass-community.rb
+++ b/Casks/mongodb-compass-community.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-community' do
-  version '1.19.3'
-  sha256 '917ccda640f0be826cc3fff017b1b92fc42880811ceef7406de7e6768d5f25e4'
+  version '1.19.6'
+  sha256 'f8a5b9fb67edeaa1d62ba9c789255da54ca7546eaccbb8dcc15050195049e7a3'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-community-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.