### PR TITLE
Update lingon-x from 7.3.1 to 7.3.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,7 +1,7 @@
 cask 'lingon-x' do
   if MacOS.version <= :high_sierra
     version '6.6.4'
-    sha256 :no_check
+    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
     version '7.3.2'
     sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'

--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -4,7 +4,7 @@ cask 'lingon-x' do
     sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
     version '7.3.2'
-    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
+    sha256 'd45eac91a9e2c278a6242c13dd1394a34391cd9b239b4206e29d7bff190c25ed'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"

--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -1,10 +1,10 @@
 cask 'lingon-x' do
   if MacOS.version <= :high_sierra
     version '6.6.4'
-    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
+    sha256 :no_check
   else
-    version '7.3.1'
-    sha256 '13f39ef6859ada42398389376906e12b07b48a4938907f26f7658df0ccfe99a2'
+    version '7.3.2'
+    sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.