### PR TITLE
Upgrade Podman.rb to 1.5.1 & Install Docs

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -1,6 +1,6 @@
 cask 'podman' do
-  version '1.5.0'
-  sha256 '4220d1e513bb2ae7833a7941d140e6c1bbd6e98c8258e766d890cdf3ba6df73b'
+  version '1.5.1'
+  sha256 'f314e9ef5c77d08dfbd0d9a022e45293570bdec91c56f1200e202c8b9379258e'
 
   url "https://github.com/containers/libpod/releases/download/v#{version}/podman-v#{version}.tar.gz"
   appcast 'https://github.com/containers/libpod/releases.atom'
@@ -8,4 +8,21 @@ cask 'podman' do
   homepage 'https://github.com/containers/libpod/'
 
   binary 'brew/podman'
+
+  postflight do
+    man1 = Dir["#{HOMEBREW_PREFIX}/Caskroom/podmand/#{version}/brew/docs/*.1"]
+    FileUtils.mv(man1, "#{HOMEBREW_PREFIX}/share/man/man1/")
+    man5 = Dir["#{HOMEBREW_PREFIX}/Caskroom/podmand/#{version}/brew/docs/*.5"]
+    FileUtils.mkdir("#{HOMEBREW_PREFIX}/share/man/man5/") unless File.exist?("#{HOMEBREW_PREFIX}/share/man/man5/")
+    FileUtils.mv(man5, "#{HOMEBREW_PREFIX}/share/man/man5/")
+  end
+
+  uninstall_postflight do
+    man1 = Dir["#{HOMEBREW_PREFIX}/share/man/man1/podman*.1"]
+    man5 = Dir["#{HOMEBREW_PREFIX}/share/man/man5/podman*.5"]
+    FileUtils.rm(man1)
+    FileUtils.rm(man5)
+  end
+
+  zap trash: '~/.config/containers/podman-remote.config'
 end

--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -10,17 +10,19 @@ cask 'podman' do
   binary 'brew/podman'
 
   postflight do
-    man1 = Dir["#{HOMEBREW_PREFIX}/Caskroom/podmand/#{version}/brew/docs/*.1"]
+    man1 = Dir["#{staged_path}/brew/docs/*.1"]
     FileUtils.mv(man1, "#{HOMEBREW_PREFIX}/share/man/man1/")
-    man5 = Dir["#{HOMEBREW_PREFIX}/Caskroom/podmand/#{version}/brew/docs/*.5"]
+
+    man5 = Dir["#{staged_path}/brew/docs/*.5"]
     FileUtils.mkdir("#{HOMEBREW_PREFIX}/share/man/man5/") unless File.exist?("#{HOMEBREW_PREFIX}/share/man/man5/")
     FileUtils.mv(man5, "#{HOMEBREW_PREFIX}/share/man/man5/")
   end
 
   uninstall_postflight do
     man1 = Dir["#{HOMEBREW_PREFIX}/share/man/man1/podman*.1"]
-    man5 = Dir["#{HOMEBREW_PREFIX}/share/man/man5/podman*.5"]
     FileUtils.rm(man1)
+
+    man5 = Dir["#{HOMEBREW_PREFIX}/share/man/man5/podman*.5"]
     FileUtils.rm(man5)
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Submitting to cask instead of core because https://github.com/Homebrew/homebrew-cask/pull/64042#issuecomment-496993261 

Please let me know if this is better than #67491. I'm learning :)
