### PR TITLE
Update opera from 62.0.3331.119 to 63.0.3368.35

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '62.0.3331.119'
-  sha256 'a99a1b5a89581a67ad7b1e0b2e4825fca8db5ad69a7f5e87ec225d4e5d11b822'
+  version '63.0.3368.35'
+  sha256 '8417804ad1e53f7e607fca5dbaf2734d02b6038b230bda91a85a94d4735e5a38'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast 'https://ftp.opera.com/pub/opera/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.