### PR TITLE
Update melodics from 2.1.3301 to 2.1.3328

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3301'
-  sha256 '340633a3479fb2b23043d525d73671145c86351f8571417a5219b9af8df9ee5d'
+  version '2.1.3328'
+  sha256 '4426b83f6b6f3cae208835c0a48c482d106c5f73862c17383929141e8ec765ef'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.