### PR TITLE
Update use-engine from 2.1.4 to 2.1.5

### DIFF
--- a/Casks/use-engine.rb
+++ b/Casks/use-engine.rb
@@ -1,6 +1,6 @@
 cask 'use-engine' do
-  version '2.1.4'
-  sha256 '1f88d089dc8d83ef2a62f77fc5cde86c509d76c4e89255e8b11f03ebfb7bfb93'
+  version '2.1.5'
+  sha256 'a63ecd6007c937c34b7e4996004af29bc301475061c90ece186504e156633272'
 
   url "https://repository.use-together.com/stable/use-engine/macos/#{version.major}.x/#{version}/use-engine.dmg"
   name 'USE Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.