### PR TITLE
Update vivaldi from 2.6.1566.49 to 2.7.1628.30

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.6.1566.49'
-  sha256 '1daa361428f28cba9dcbc8b497d5028f2c9c4c15c9548f8a1275d909b21e2547'
+  version '2.7.1628.30'
+  sha256 '6a492b8ebde2207eec4d621fd33b68b41951f329c26a72d75a5569f96df5cb80'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.