### PR TITLE
Update minishift from 1.33.0 to 1.34.1

### DIFF
--- a/Casks/minishift.rb
+++ b/Casks/minishift.rb
@@ -1,6 +1,6 @@
 cask 'minishift' do
-  version '1.33.0'
-  sha256 'c5b41cb995d2b22fc2ebc045e835f71e4d206035083c16c0fc82bdb08ca4d797'
+  version '1.34.1'
+  sha256 '1d5181b3547f88ef14372cd9c743f3fd3962d7d3ebf2915b8ab8b306af78c97d'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.