### PR TITLE
Update version stanza from 5.1.0 to 5.1.0-b003 and url stanza qobuz.rb

### DIFF
--- a/Casks/qobuz.rb
+++ b/Casks/qobuz.rb
@@ -1,8 +1,8 @@
 cask 'qobuz' do
-  version '5.1.0'
+  version '5.1.0-b003'
   sha256 'bf5c0a6a47c56b5192c07d120d4849feb4e02406d463cded8f771e0689210c6d'
 
-  url 'https://desktop.qobuz.com/releases/darwin/x64/elCapitan_sierra/5.1.0-b003/Qobuz.dmg'
+  url "https://desktop.qobuz.com/releases/darwin/x64/elCapitan_sierra/#{version}/Qobuz.dmg"
   name 'Qobuz'
   homepage 'https://www.qobuz.com/applications'
 


### PR DESCRIPTION
could we use the full version number here please?
it's also used inside the downloadlink :) Thanks! 