### PR TITLE
Update qownnotes from 19.8.6,b4472-141807 to 19.8.7,b4477-175031

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.8.6,b4472-141807'
-  sha256 '3460bfad727c87497d01a3a460a11d9844bccfb6cd8158d94de80174b9e07615'
+  version '19.8.7,b4477-175031'
+  sha256 '8a1d4f7ef0dc46325ad2ea6b0def2770bd89c37d984936c7cc2dd2a6bb1583ff'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.