### PR TITLE
Update thedesk from 18.8.0 to 18.8.1

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.8.0'
-  sha256 '43315b531f471e51459b298fc13d58a9dafdc73936102033ffadde8afe4a1a4a'
+  version '18.8.1'
+  sha256 'c682b582fddfd7e61637ffdd33fc803df9dfd81d2dd5694d88791aebbdc62da1'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.