### PR TITLE
Update marvel from 8.3.5 to 8.4

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.3.5'
-  sha256 '76ba5dfbab396de65448a33761cb940ab89f44de905c17816260e6fdfd4907ee'
+  version '8.4'
+  sha256 '9a57e44892ebcad76b7fa09f827ac999be727ec3879eb1131c126bd2a799104f'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.