### PR TITLE
Update framer-x from 34013,1565099555 to 34442,1566308141

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '34013,1565099555'
-  sha256 '1d2749c6ccb9b33076ef2b134dbc5a50581cf4c6622c984fb475505a2f57d531'
+  version '34442,1566308141'
+  sha256 '9fbc932500202efae9a3a540d33d83b899357143cec9a1a5fec1623cae85c689'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.