### PR TITLE
Update wacom-inkspace from 2.7.0 to 2.7.3

### DIFF
--- a/Casks/wacom-inkspace.rb
+++ b/Casks/wacom-inkspace.rb
@@ -1,6 +1,6 @@
 cask 'wacom-inkspace' do
-  version '2.7.0'
-  sha256 'efbf407f39c58394b8037280da4f05ccb354494c00ff3e65aee78a442dc19735'
+  version '2.7.3'
+  sha256 'bff10c04528e30ec9ee4d1e291cac1d4e951bafd7a5ed5320289fe582136110e'
 
   url "https://cdn.wacom.com/i/m/mac/WacomInkspaceApp_#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://link.wacom.com/i/m?os=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.