### PR TITLE
Update touchosc-editor from 1.8.5 to 1.8.6

### DIFF
--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-editor' do
-  version '1.8.5'
-  sha256 '0873ee00f6e7e135d3dc704fd2f072e29e02b5a6d863851370e81c657a788643'
+  version '1.8.6'
+  sha256 '2ed7aa7ef99f3f1340af31dc54c89623e971ff3ba50ce09f75b1a5f0274de3f9'
 
   url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
   appcast 'https://hexler.net/software/touchosc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.