### PR TITLE
Update sf-symbols to latest

### DIFF
--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -1,6 +1,6 @@
 cask 'sf-symbols' do
-  version '1.0'
-  sha256 'f822046b1880377e4c8d1df8fd807d9335404a21245bb8abcb3481c6dd47c5a0'
+  version :latest
+  sha256 :no_check
 
   url 'https://developer.apple.com/design/downloads/SF-Symbols.dmg'
   name 'SF Symbols'
@@ -8,7 +8,7 @@ cask 'sf-symbols' do
 
   depends_on macos: '>= :mojave'
 
-  pkg 'SFSymbols.pkg'
+  pkg 'SF Symbols.pkg'
 
   uninstall pkgutil: 'com.apple.SFSymbols.plist',
             delete:  '/Applications/SF Symbols.app'


### PR DESCRIPTION
There is a new release of SF Symbols since yesterday (1.0 beta2). Since the SFSymbols download is unversioned, I changed the Cask file accordingly. Furthermore either the pkg got renamed or was incorrect in the original version of this cask.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
