### PR TITLE
Update sf-symbols from 1.0 to 1.0,12

### DIFF
--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -1,6 +1,6 @@
 cask 'sf-symbols' do
-  version '1.0'
-  sha256 'f822046b1880377e4c8d1df8fd807d9335404a21245bb8abcb3481c6dd47c5a0'
+  version '1.0,12'
+  sha256 'bf5854278d00bd2eaba0c5ae25aa6d4bfbfd7b5113c782a600d6aee5e67caf05'
 
   url 'https://developer.apple.com/design/downloads/SF-Symbols.dmg'
   name 'SF Symbols'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.