### PR TITLE
Update ultimate from 3.0.11.625 to 3.0.11.820

### DIFF
--- a/Casks/ultimate.rb
+++ b/Casks/ultimate.rb
@@ -1,6 +1,6 @@
 cask 'ultimate' do
-  version '3.0.11.625'
-  sha256 '9a5c28888add1f8d285a34d80d35c6352198d07137a8a5f5ecdc426c673c76b3'
+  version '3.0.11.820'
+  sha256 'cd144271f8cc4ae6f605253e89394c42ae2dce599835dc8f913d990c653598c5'
 
   url 'https://download.epubor.com/epubor_ultimate.zip'
   appcast 'https://www.epubor.com/ultimate.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.