### PR TITLE
Update unity-android-support-for-editor from 2019.2.1f1,ca4d5af0be6f to 2019.2.2f1,ab112815d860

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.2.1f1,ca4d5af0be6f'
-  sha256 'ab967cfa854d68c58d9cdba20763ea7fde835e9f49b5516c51abb45051893148'
+  version '2019.2.2f1,ab112815d860'
+  sha256 '4d9522c208ba9c1cd88a463f2d4c53bbcda89891767f4e2ab54bf1f546514e0d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.