### PR TITLE
Update unity-download-assistant from 2019.2.1f1,ca4d5af0be6f to 2019.2.2f1,ab112815d860

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.2.1f1,ca4d5af0be6f'
-  sha256 '7b19749e5c49dd2d5213f8d5c4fe5ddeb46d61f5b32780fd562bae8108230ace'
+  version '2019.2.2f1,ab112815d860'
+  sha256 '76638ebb9a20274ada3cf19e2907671f2863144374a1bbcb26a017e274a87796'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.