### PR TITLE
Update unity-ios-support-for-editor from 2019.2.0f1,20c1667945cf to 2019.2.2f1,ab112815d860

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.2.0f1,20c1667945cf'
-  sha256 '1557a3dd7168c5f0d91be15b2d7234796939a4cf1eb995f3076b3e596f114a90'
+  version '2019.2.2f1,ab112815d860'
+  sha256 '88450876b87f3c1bde7230f78e960c5a067152b836b2db76236f4d1ca68e861a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.