### PR TITLE
Update maccy from 0.4.0 to 0.4.1

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask 'maccy' do
-  version '0.4.0'
-  sha256 '86f9821c261550556c08940324d3862f890e5ab57bd97e70640f77c89e05f8b1'
+  version '0.4.1'
+  sha256 '467b57e4aeeee528a61942cd8ccf68ddb292a4f4661edbc3db0de399bf20add4'
 
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"
   appcast 'https://github.com/p0deje/Maccy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.