### PR TITLE
Update pyfa from 2.9.6 to 2.10.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.9.6'
-  sha256 'ded8f1963b2980da1b44f5a297fb540f0ddaf38e72cd28cbe31060e9eb0a7abb'
+  version '2.10.0'
+  sha256 '9e1c0db4066482d428e1a0d6ec52ffd6cf1fd5cf45b9baec61164782bdf1e410'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.