### PR TITLE
Update finicky from 2.1.0 to 2.2.1

### DIFF
--- a/Casks/finicky.rb
+++ b/Casks/finicky.rb
@@ -1,6 +1,6 @@
 cask 'finicky' do
-  version '2.1.0'
-  sha256 '7ae5b94b95170f5e425d2b1da0f6f3c0349ce7e67a4dbd2e15ba8885c471cef2'
+  version '2.2.1'
+  sha256 'fcc1b9fdd1aee42613d1aef1432809bd6dea806e1f2d2074d26b0ed39e21f9c6'
 
   url "https://github.com/johnste/finicky/releases/download/v#{version}/Finicky.zip"
   appcast 'https://github.com/johnste/finicky/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.