### PR TITLE
Update macdive from 2.11.0 to 2.11.3

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,6 +1,6 @@
 cask 'macdive' do
-  version '2.11.0'
-  sha256 '3dadb11aa5c3fafbecd1cbe89058473b0690b8a09b66e8a3a1e2ae1795e01a7f'
+  version '2.11.3'
+  sha256 '5b8375f90051e382cdef581c1bed104010347de566c6532dbca591c1e6904ec7'
 
   url "https://www.mac-dive.com/downloads/MacDive_#{version}.dmg"
   appcast 'https://www.mac-dive.com/shimmer/?appcast&appName=MacDive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.