### PR TITLE
Update mimolive from 5.1-27588 to 5.2-27661

### DIFF
--- a/Casks/mimolive.rb
+++ b/Casks/mimolive.rb
@@ -1,6 +1,6 @@
 cask 'mimolive' do
-  version '5.1-27588'
-  sha256 '0a93fed3bd04fb46e23dc307694fddfae6aa65825b5061ff6cceaba21113f4e0'
+  version '5.2-27661'
+  sha256 '20d06c772733fb9eee92143418ee8b430ab75b952f97bb46011677e46640d46b'
 
   url "https://cdn.boinx.com/software/mimolive/Boinx_mimoLive_#{version}.app.zip"
   appcast 'https://sparkle.boinx.com/appcast.lasso?appName=mimoLive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.