### PR TITLE
Update editready from 2.6.1 to 2.6.2

### DIFF
--- a/Casks/editready.rb
+++ b/Casks/editready.rb
@@ -1,6 +1,6 @@
 cask 'editready' do
-  version '2.6.1'
-  sha256 'f5ee9bbae589fd708f72094f67995becd7e2419a7fe7765ee56efd0a11c949f0'
+  version '2.6.2'
+  sha256 'fb1a25bcb2f94b37c8de566a5791f4070998cdde5b18df6d5b14c241f0d45d72'
 
   url "https://www.divergentmedia.com/fileRepository/EditReady%20#{version}.dmg"
   appcast 'https://www.divergentmedia.com/autoupdater/editready/2_x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.