### PR TITLE
Update kite from 0.20190815.0 to 0.20190821.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190815.0'
-  sha256 '5d9cf6c62f2b4ffffe9cc6f62513da0bc27c9c06dc3025b58a5df65085981949'
+  version '0.20190821.0'
+  sha256 '59007a4b154663c76fa4d8b5945308f43c20e9fd3926b4277b4e097bb647453f'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.