### PR TITLE
Update tencent-lemon from 2.1.0 to 2.2.0

### DIFF
--- a/Casks/tencent-lemon.rb
+++ b/Casks/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask 'tencent-lemon' do
-  version '2.1.0'
-  sha256 '669ecbd3b9ad811f04255a869e397aa287c5effdc04083911ea3e6cfb14bf260'
+  version '2.2.0'
+  sha256 'ccddb67876d3d028c60f67c23910ae1012e1c614d94065593588e407737435bc'
 
   # pm.myapp.com/invc/xfspeed/qqpcmgr was verified as official when first introduced to the cask
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/Lemon_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.