### PR TITLE
Update kite from 0.20190815.0 to 0.20190822.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190815.0'
-  sha256 '5d9cf6c62f2b4ffffe9cc6f62513da0bc27c9c06dc3025b58a5df65085981949'
+  version '0.20190822.0'
+  sha256 '75c27e274225644bda020a2979c09635a0f5ec173569d37fbd67e3034c85f36b'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.