### PR TITLE
Update the-battle-for-wesnoth from 1.15.0 to 1.15.1

### DIFF
--- a/Casks/the-battle-for-wesnoth.rb
+++ b/Casks/the-battle-for-wesnoth.rb
@@ -1,6 +1,6 @@
 cask 'the-battle-for-wesnoth' do
-  version '1.15.0'
-  sha256 '85ede0eae3bc2f04b81baf458697bd8c017bdffaa5aaa5674654ad51e6c89343'
+  version '1.15.1'
+  sha256 '710ddbf03c979f6c3aa64e39a8062fd540cf42c95a30fd18c0d69c607733915e'
 
   # sourceforge.net/wesnoth was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.