### PR TITLE
Update gitup from 1.0.11 to 1.1

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,6 +1,6 @@
 cask 'gitup' do
-  version '1.0.11'
-  sha256 '3cd4b67bd76cdcec924895d69f6e867233bcc026fee5507fce43333e8b47fb4d'
+  version '1.1'
+  sha256 '0f59d3c0514e98e4f8fad710c42a12995866305c509b91da0ade7270b95efb4d'
 
   # gitup-builds.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://gitup-builds.s3.amazonaws.com/stable/GitUp.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.