### PR TITLE
Update lastpass from 4.31.1 to 4.32.0

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.31.1'
-  sha256 'b35fec64bd6528918827759bb62454bc4410e2d3c32eb03df999e6a106de5225'
+  version '4.32.0'
+  sha256 '61a4bddc08da7c61cc1f95dd6a19d90400d46554ba6dcc69158cd8b65d70511e'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.