### PR TITLE
Update touchosc-editor from 1.8.5 to 1.8.6

### DIFF
--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -1,8 +1,8 @@
 cask 'touchosc-editor' do
   version '1.8.6'
-  sha256 '5f5b618f026ef38c82577b3c324d8b035f5fdd1212f55d253012382d72efef9c'
+  sha256 '409d530276b2b7903c75855feb14e9dcaea24b75c98129645fed1ec3645a2415'
 
-  url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
+  url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-macos.zip"
   appcast 'https://hexler.net/software/touchosc'
   name 'TouchOSC Editor'
   homepage 'https://hexler.net/software/touchosc'

--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-editor' do
-  version '1.8.5'
-  sha256 '0873ee00f6e7e135d3dc704fd2f072e29e02b5a6d863851370e81c657a788643'
+  version '1.8.6'
+  sha256 '8ca5f88adfffc5c0e2028cb63fe1c4a4b0c4aafd690eedbe2e6f42ad456070d1'
 
   url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
   appcast 'https://hexler.net/software/touchosc'

--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-editor' do
   version '1.8.6'
-  sha256 '8ca5f88adfffc5c0e2028cb63fe1c4a4b0c4aafd690eedbe2e6f42ad456070d1'
+  sha256 '5f5b618f026ef38c82577b3c324d8b035f5fdd1212f55d253012382d72efef9c'
 
   url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
   appcast 'https://hexler.net/software/touchosc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.