### PR TITLE
Update netnewswire from 5.0b4 to 5.0b5

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -4,7 +4,7 @@ cask 'netnewswire' do
 
   # github.com/brentsimmons/NetNewsWire was verified as official when first introduced to the cask
   url "https://github.com/brentsimmons/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip"
-  appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'
+  appcast 'https://github.com/brentsimmons/NetNewsWire/releases.atom'
   name 'NetNetsWire'
   homepage 'https://ranchero.com/netnewswire/'
 

--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,8 +1,9 @@
 cask 'netnewswire' do
-  version '5.0b4'
-  sha256 '301caddba27bad5c83c3ae6aef73482d726dd0cc4a4e786354d833c13dbb2579'
+  version '5.0b5'
+  sha256 'a5d92567c905e55af806a9f56f8f4a5fe05f560db4bb635c00ec412ee691de4b'
 
-  url "https://ranchero.com/downloads/NetNewsWire#{version}.zip"
+  # github.com/brentsimmons/NetNewsWire was verified as official when first introduced to the cask
+  url "https://github.com/brentsimmons/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip"
   appcast 'https://ranchero.com/downloads/netnewswire-beta.xml'
   name 'NetNetsWire'
   homepage 'https://ranchero.com/netnewswire/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.