### PR TITLE
Update touchosc-editor from 1.8.5 to 1.8.6

### DIFF
--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -7,7 +7,7 @@ cask 'touchosc-editor' do
   name 'TouchOSC Editor'
   homepage 'https://hexler.net/software/touchosc'
 
-  app "touchosc-editor-#{version}-osx/TouchOSC Editor.app"
+  app "touchosc-editor-#{version}-macos/TouchOSC Editor.app"
   artifact "touchosc-editor-#{version}-osx/layouts", target: Pathname.new(File.expand_path('~')).join('Library/Application Support/TouchOSCEditor/layouts')
 
   zap trash: '~/Library/*/*TouchOSCEditor*'

--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -1,8 +1,8 @@
 cask 'touchosc-editor' do
-  version '1.8.5'
-  sha256 '0873ee00f6e7e135d3dc704fd2f072e29e02b5a6d863851370e81c657a788643'
+  version '1.8.6'
+  sha256 '79400ed8df5559286495b72e2b7d0655a69cd5f199c14d65667ee5fbe7e3e9ce'
 
-  url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-osx.zip"
+  url "https://hexler.net/pub/touchosc/touchosc-editor-#{version}-macos.zip"
   appcast 'https://hexler.net/software/touchosc'
   name 'TouchOSC Editor'
   homepage 'https://hexler.net/software/touchosc'

--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -8,7 +8,7 @@ cask 'touchosc-editor' do
   homepage 'https://hexler.net/software/touchosc'
 
   app "touchosc-editor-#{version}-macos/TouchOSC Editor.app"
-  artifact "touchosc-editor-#{version}-osx/layouts", target: Pathname.new(File.expand_path('~')).join('Library/Application Support/TouchOSCEditor/layouts')
+  artifact "touchosc-editor-#{version}-macos/layouts", target: Pathname.new(File.expand_path('~')).join('Library/Application Support/TouchOSCEditor/layouts')
 
   zap trash: '~/Library/*/*TouchOSCEditor*'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.