### PR TITLE
Update tropy from 1.5.3 to 1.5.4

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.5.3'
-  sha256 'dc1018fe1ecfec17459695635920db01f7f3dbb86377cbb405bb40f14a446728'
+  version '1.5.4'
+  sha256 '7655dec6751c99896ba4af8ee067d2ad806b80fe863eccd87aabcbff3e712ca5'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.