### PR TITLE
Update swinsian from 2.1.14 to 2.1.15

### DIFF
--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,6 +1,6 @@
 cask 'swinsian' do
-  version '2.1.14'
-  sha256 '44a05d538fdb071dd02f628cb4fceb7eef27d158ccbb7f19bf8ac5a0a9b284b5'
+  version '2.1.15'
+  sha256 '76987c0a2437f10c67b30e7fffc9b3e768a8c9e373fa16c98d4b8f8fa01979bb'
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.