### PR TITLE
Update archiver from 3.0.6 to 3.0.7

### DIFF
--- a/Casks/archiver.rb
+++ b/Casks/archiver.rb
@@ -1,6 +1,6 @@
 cask 'archiver' do
-  version '3.0.6'
-  sha256 'c27ec23f93b10599a811597a106b9cdec6655552ddb82c637992f8bdbbc82fd2'
+  version '3.0.7'
+  sha256 '86cbb5fb2c3680b87b911bc642d0bdb6ea495dd11e00323ffcc271d5f863c6c0'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Archiver-#{version.major}/Archiver-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.