### PR TITLE
Update cyberghost-vpn from 7.0.2.82 to 7.0.3.83

### DIFF
--- a/Casks/cyberghost-vpn.rb
+++ b/Casks/cyberghost-vpn.rb
@@ -1,6 +1,6 @@
 cask 'cyberghost-vpn' do
-  version '7.0.2.82'
-  sha256 '310d18486eeeced68c93a23d4e9b054cfb6bd8338318ea73ce39e8ffc8f38605'
+  version '7.0.3.83'
+  sha256 '00d64ce5e4d05c96aa1faa686ce6f388aaf5db8ec46590eff6601755d580ff56'
 
   url "https://download.cyberghostvpn.com/mac/updates/v#{version.major}/cg#{version.major}mac_#{version}.dmg"
   appcast "https://download.cyberghostvpn.com/mac/updates/v#{version.major}/cyberghost_mac_update.inf"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.