### PR TITLE
Update vuescan from 9.6.46 to 9.6.47

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,5 +1,5 @@
 cask 'vuescan' do
-  version '9.6.46'
+  version '9.6.47'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.