### PR TITLE
Update nisus-thesaurus from 1.1.4 to 1.2

### DIFF
--- a/Casks/nisus-thesaurus.rb
+++ b/Casks/nisus-thesaurus.rb
@@ -1,6 +1,6 @@
 cask 'nisus-thesaurus' do
-  version '1.1.4'
-  sha256 '463e4db2cf02766f606b86fb3e2e656a866358da4d0c8c444cb38bbebd6b9566'
+  version '1.2'
+  sha256 'c2f55568bbb129bb6f779dcea154d6b0c608ebe7f35c839d3371bcc936325775'
 
   url "https://nisus.com/files/free/NisusThesaurus-v#{version.no_dots}.zip"
   appcast 'https://nisus.com/Thesaurus/updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.