### PR TITLE
Update tableau-reader from 2019.2.2 to 2019.2.3

### DIFF
--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -1,6 +1,6 @@
 cask 'tableau-reader' do
-  version '2019.2.2'
-  sha256 'b69a63f83ad922bc1c19baa819fd7da1a24c41dd26341f4c6521e35a74d8def0'
+  version '2019.2.3'
+  sha256 '8baf88d7438402eecccbe9699b4e161614529a60a5689fd3864a00cad68e09d1'
 
   url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.