### PR TITLE
Update liclipse from 5.2.4,u9a8kuvxrcxdw71 to 5.3.0,c0dcsho551y0brr

### DIFF
--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -1,6 +1,6 @@
 cask 'liclipse' do
-  version '5.2.4,u9a8kuvxrcxdw71'
-  sha256 'dac86c4f478d67dbb20787aa9857fbf92ebe942c2ebef84c049cbec58d9009f1'
+  version '5.3.0,c0dcsho551y0brr'
+  sha256 '6c1c342018cf8f76c84bcce82536ccfc4100fe9d05aeb4a67f5dcadf810ec08b'
 
   # mediafire.com/file was verified as official when first introduced to the cask
   url "https://www.mediafire.com/file/#{version.after_comma}/liclipse_#{version.before_comma}_macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.