### PR TITLE
Update touchdesigner from 099.2019.18360 to 099.2019.18580

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '099.2019.18360'
-  sha256 '3e50606030de57744ea1c048b3cdb0654c35b31b4131b22e8812c52e18a47e2c'
+  version '099.2019.18580'
+  sha256 'dfab1d159b08d9ab2abd0c4b98f6d731978ea29e95d499c88f80d0ded82c6b79'
 
   url "https://download.derivative.ca/TouchDesigner#{version}.dmg"
   appcast "https://www.derivative.ca/#{version.major}/Downloads/Default.asp"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.