### PR TITLE
Update battlescribe from 2.02.04 to 2.03.00

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.02.04'
-  sha256 '5cdddc9881f4911279fd74fee71b4a1ff408682d3aeaf5641d53cb8a3095e4e9'
+  version '2.03.00'
+  sha256 '0c22c4c4a332338e015a9c1d5ad3efa44b7b486ae113d24e4049d7040c317268'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.