### PR TITLE
Update paraview from 5.6.1 to 5.6.2

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,6 +1,6 @@
 cask 'paraview' do
-  version '5.6.1'
-  sha256 '749295130032b9e7e1fa0d281934c942d790124bbd4cdaf46aa49baa0a33627f'
+  version '5.6.2'
+  sha256 '52cb3d6e14c410fdb84d76edcf874c49013568025e66df2c35ba5819652d4ada'
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-64bit.unsigned.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.