### PR TITLE
add Another.Redis.Desktop.Manager app to cask repo

### DIFF
--- a/Casks/ardm.rb
+++ b/Casks/ardm.rb
@@ -1,0 +1,10 @@
+cask 'ardm' do
+  version '1.2.5'
+  name 'Another.Redis.Desktop.Manager'
+  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.2.5/Another.Redis.Desktop.Manager.1.2.5.dmg"
+  sha256 "fe1c2c08c1c0972dee58fd4f0876b1bce80ce6ac9d56842e4c34979249f85050"
+  homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'
+
+  app 'Another.Redis.Desktop.Manager.app'
+
+end


### PR DESCRIPTION

## Another.Redis.Desktop.Manager
 version 1.2.5

🚀🚀🚀A faster, better and more stable redis desktop manager, compatible with Linux, windows, mac. What's more, it won't crash when loading a large number of keys.

https://github.com/qishibo/AnotherRedisDesktopManager

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
