### PR TITLE
Update springtoolsuite from 4.3.1.RELEASE,4.12.0 to 4.3.2.RELEASE,4.12.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask 'springtoolsuite' do
-  version '4.3.1.RELEASE,4.12.0'
-  sha256 'dc046222956585d382f6e5423ce9be300abcb4e2562bb9f138b8d9f21ead5008'
+  version '4.3.2.RELEASE,4.12.0'
+  sha256 '3e290dfad107538df739f6182d863498f7d528020aae1edb98ee344ac6249ce3'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.