### PR TITLE
Add cask for PDFTK Server

### DIFF
--- a/Casks/pdftk-server.rb
+++ b/Casks/pdftk-server.rb
@@ -1,0 +1,17 @@
+cask 'pdftk-server' do
+  version '2.02'
+  sha256 'c0679a7a12669480dd298c436b0e4d063966f95ed6a77b98d365bb8c86390d1b'
+
+  url 'https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.6-setup.pkg'
+  name 'PDFTK Server'
+  homepage 'https://www.pdflabs.com/tools/pdftk-server/'
+
+  pkg 'pdftk_server-2.02-mac_osx-10.6-setup.pkg'
+
+  postflight do
+    # Restore group write permission after the PKG installer sets 0755 on /usr/local/bin
+    FileUtils.chmod 'g+w', '/usr/local/bin'
+  end
+
+  uninstall pkgutil: 'com.pdflabs.pdftkThePdfToolkit.pdftk.pkg'
+end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

#11351 was closed with the message:

> Let's wait if someone is able to rewrite this formula to a cask, that should really do the trick.

So here's a cask for the app, including a `post_flight` block which restores group write permission on `/usr/local/bin`, since the PDF installer seems to change it to `0755`. I'm not using `set_permissions ` from the mini-DSL, since that method works recursively. 
