### PR TITLE
Update electron from 6.0.3 to 6.0.4

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '6.0.3'
-  sha256 '41a543b444436b4aa04b28af8fce3b31eb608b50fa78569b0d6e35920af8cf4f'
+  version '6.0.4'
+  sha256 '947b1a0a917d0d71daaf12a88cfd05e9bc5136a12100295db8cb5d98fc6cb554'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.