### PR TITLE
adding "Another Redis Desktop Manager" to casks

### DIFF
--- a/Casks/another-redis-desktop-manager.rb
+++ b/Casks/another-redis-desktop-manager.rb
@@ -1,4 +1,4 @@
-cask 'ardm' do
+cask 'another-redis-desktop-manager' do
   version '1.2.5'
   sha256 'fe1c2c08c1c0972dee58fd4f0876b1bce80ce6ac9d56842e4c34979249f85050'
 

--- a/Casks/ardm.rb
+++ b/Casks/ardm.rb
@@ -8,5 +8,4 @@ cask 'ardm' do
   homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'
 
   app 'Another.Redis.Desktop.Manager.app'
-
 end

--- a/Casks/ardm.rb
+++ b/Casks/ardm.rb
@@ -1,8 +1,10 @@
 cask 'ardm' do
   version '1.2.5'
-  name 'Another.Redis.Desktop.Manager'
-  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.2.5/Another.Redis.Desktop.Manager.1.2.5.dmg"
-  sha256 "fe1c2c08c1c0972dee58fd4f0876b1bce80ce6ac9d56842e4c34979249f85050"
+  sha256 'fe1c2c08c1c0972dee58fd4f0876b1bce80ce6ac9d56842e4c34979249f85050'
+
+  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another.Redis.Desktop.Manager.1.2.5.dmg"
+  appcast 'https://github.com/qishibo/AnotherRedisDesktopManager/releases.atom'
+  name 'Another Redis Desktop Manager'
   homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'
 
   app 'Another.Redis.Desktop.Manager.app'

--- a/Casks/ardm.rb
+++ b/Casks/ardm.rb
@@ -1,0 +1,10 @@
+cask 'ardm' do
+  version '1.2.5'
+  name 'Another.Redis.Desktop.Manager'
+  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.2.5/Another.Redis.Desktop.Manager.1.2.5.dmg"
+  sha256 "fe1c2c08c1c0972dee58fd4f0876b1bce80ce6ac9d56842e4c34979249f85050"
+  homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'
+
+  app 'Another.Redis.Desktop.Manager.app'
+
+end


### PR DESCRIPTION
## Another Redis Desktop Manager

🚀🚀🚀A faster, better and more stable redis desktop manager, compatible with Linux, windows, mac. What's more, it won't crash when loading a large number of keys.

site: https://github.com/qishibo/AnotherRedisDesktopManager
version: v1.2.5

`brew cask install ardm`

------
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
