### PR TITLE
Update windows95 from 2.1.1 to 2.2.0

### DIFF
--- a/Casks/windows95.rb
+++ b/Casks/windows95.rb
@@ -1,7 +1,7 @@
 cask 'windows95' do
   # note: "95" is not a version number, but an intrinsic part of the product name
-  version '2.1.1'
-  sha256 '99c030b3bdce8a69629429e44da88855cce938e58c216f649e532d497bda4ca9'
+  version '2.2.0'
+  sha256 'd2b5ac638f0a2c5735f9683c9312587b4a491e089623c194f4bb7fa358cf8fc0'
 
   url "https://github.com/felixrieseberg/windows95/releases/download/v#{version}/windows95-macos-#{version}.zip"
   appcast 'https://github.com/felixrieseberg/windows95/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.