### PR TITLE
Update thedesk from 18.8.2 to 18.8.3

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.8.2'
-  sha256 'c779f9144b0ce29a474f5bab55effc91ab50457093773695d6dc2683d57deea2'
+  version '18.8.3'
+  sha256 '4bb3e29a5266b3c9b30601978bbb30c9a02b3914f359dca906a3e46cfd84e057'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.