### PR TITLE
Update battlescribe from 2.03.00 to 2.03.01

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.00'
-  sha256 '0c22c4c4a332338e015a9c1d5ad3efa44b7b486ae113d24e4049d7040c317268'
+  version '2.03.01'
+  sha256 '35756e8af8103f21dff69192108f54e019049730221b9d04e299697521c33f4e'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.