### PR TITLE
Update scidavis from 1.25 to 1.25.1

### DIFF
--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -1,6 +1,6 @@
 cask 'scidavis' do
-  version '1.25'
-  sha256 '8a554f90c390426dc04d104814fc2a109b68a55cf272ee25f82e419cfebafbf5'
+  version '1.25.1'
+  sha256 '5bce640bf16b6df9a0733684db5366c9982aa39a79bb6dc9f6a3e289653b79ff'
 
   # downloads.sourceforge.net/scidavis was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scidavis/scidavis-#{version}-mac-dist.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.