### PR TITLE
Fix typo (appcat => appcast) in tiles.rb

### DIFF
--- a/Casks/tiles.rb
+++ b/Casks/tiles.rb
@@ -5,7 +5,7 @@ cask 'tiles' do
   # updates.sempliva.com/tiles was verified as official when first introduced to the cask
   url "https://updates.sempliva.com/tiles/Tiles-#{version.after_comma}.dmg"
   appcast 'https://updates.sempliva.com/tiles/updates.xml',
-         configuration: version.after_comma
+          configuration: version.after_comma
   name 'FreeMacSoft Tiles'
   homepage 'https://freemacsoft.net/tiles/'
 

--- a/Casks/tiles.rb
+++ b/Casks/tiles.rb
@@ -4,7 +4,7 @@ cask 'tiles' do
 
   # updates.sempliva.com/tiles was verified as official when first introduced to the cask
   url "https://updates.sempliva.com/tiles/Tiles-#{version.after_comma}.dmg"
-  appcat 'https://updates.sempliva.com/tiles/updates.xml',
+  appcast 'https://updates.sempliva.com/tiles/updates.xml',
          configuration: version.after_comma
   name 'FreeMacSoft Tiles'
   homepage 'https://freemacsoft.net/tiles/'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.

There is a typo in tiles.rb. For example, this is a search output:
```
$ brew search gtk
Warning: Cask 'tiles' is unreadable: undefined method `method_missing_message' for Utils:Module
==> Formulae
clutter-gtk             gtk-gnutella            gtkglext                gtksourceview4          pygtk
gtk+                    gtk-mac-integration     gtkmm                   gtksourceviewmm         pygtkglext
gtk+3 ✔                 gtk-vnc                 gtkmm3                  gtksourceviewmm3        pygtksourceview
gtk-chtheme             gtkdatabox              gtksourceview           gtkspell3               qalculate-gtk
gtk-doc                 gtkextra                gtksourceview3          lablgtk                 spice-gtk

==> Casks
gtkwave
```

Here's what happens when I want brew to show me the info about tiles:
```
$ brew cask info tiles
Warning: Unexpected method 'appcat' called on Cask tiles.
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
tiles: 1.0.1,20190430233520
https://freemacsoft.net/tiles/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/tiles.rb
==> Name
FreeMacSoft Tiles
==> Artifacts
Tiles.app (App)
```

Audit ouptut:
```
$ brew cask audit --download tiles
Warning: Unexpected method 'appcat' called on Cask tiles.
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
==> Downloading https://updates.sempliva.com/tiles/Tiles-20190430233520.dmg
Already downloaded: /Users/w32u/Library/Caches/Homebrew/downloads/1c342ede7fb3052bc1776d4b8f42922abc4f13b8d992975c7dbb938265ccfbd0--Tiles-20190430233520.dmg
==> Verifying SHA-256 checksum for Cask 'tiles'.
audit for tiles: passed
```

Style Checking output:
```
$ brew cask style --fix tiles
Warning: Unexpected method 'appcat' called on Cask tiles.
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs

1 file inspected, no offenses detected
```


[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Checkers say that `brew cask style tiles` is failed: [Github](https://github.com/Homebrew/homebrew-cask/pull/68163/checks?check_run_id=203237255#step:3:17), [Travis-Ci](https://travis-ci.org/Homebrew/homebrew-cask/builds/576780595?utm_source=github_status&utm_medium=notification)