### PR TITLE
Update appcast url redcine-x-pro.rb

### DIFF
--- a/Casks/redcine-x-pro.rb
+++ b/Casks/redcine-x-pro.rb
@@ -4,7 +4,7 @@ cask 'redcine-x-pro' do
 
   # red_3.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://red_3.s3.amazonaws.com/downloads/software/rcx/RELEASE%20CANDIDATE/REDCINE-X_PRO_Build_#{version.major_minor}.pkg"
-  appcast 'https://www.red.com/download/redcine-x-pro-mac'
+  appcast 'https://www.red.com/RedSuiteCentric/SCA-Kilimanjaro/services/Download.Service.ss?downloadIdentifier=redcine-x-pro-mac'
   name 'REDCINE-X PRO'
   homepage 'https://www.red.com/'
 


### PR DESCRIPTION
could we perhaps use this appcast?
it really contains the version number instead of the old one