### PR TITLE
Update papyrus from 4.3.0,2019-03 to 4.4.0,2019-06

### DIFF
--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -3,7 +3,7 @@ cask 'papyrus' do
   sha256 '1aee92356a57ecf738a3e801ea306a945a111d4e76bca3234d0bc0f7ae63b93f'
 
   url "https://www.eclipse.org/downloads/download.php?file=/modeling/mdt/papyrus/rcp/#{version.after_comma}/#{version.before_comma}/papyrus-#{version.after_comma}-#{version.before_comma}-macosx64.tar.gz&r=1"
-  appcast 'https://mirrors.dotsrc.org/eclipse//modeling/mdt/papyrus/rcp/'
+  appcast 'https://mirrors.dotsrc.org/eclipse//modeling/mdt/papyrus/rcp/',
           configuration: version.after_comma
   name 'Papyrus'
   homepage 'https://eclipse.org/papyrus/'

--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -4,6 +4,7 @@ cask 'papyrus' do
 
   url "https://www.eclipse.org/downloads/download.php?file=/modeling/mdt/papyrus/rcp/#{version.after_comma}/#{version.before_comma}/papyrus-#{version.after_comma}-#{version.before_comma}-macosx64.tar.gz&r=1"
   appcast 'https://mirrors.dotsrc.org/eclipse//modeling/mdt/papyrus/rcp/'
+          configuration: version.after_comma
   name 'Papyrus'
   homepage 'https://eclipse.org/papyrus/'
 

--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -1,8 +1,9 @@
 cask 'papyrus' do
-  version '4.3.0,2019-03'
-  sha256 '40330141eabf6d41bd49f3d8f37644b6f095cbf49652eaba28b0c80685dd6e6b'
+  version '4.4.0,2019-06'
+  sha256 '1aee92356a57ecf738a3e801ea306a945a111d4e76bca3234d0bc0f7ae63b93f'
 
   url "https://www.eclipse.org/downloads/download.php?file=/modeling/mdt/papyrus/rcp/#{version.after_comma}/#{version.before_comma}/papyrus-#{version.after_comma}-#{version.before_comma}-macosx64.tar.gz&r=1"
+  appcast 'https://mirrors.dotsrc.org/eclipse//modeling/mdt/papyrus/rcp/'
   name 'Papyrus'
   homepage 'https://eclipse.org/papyrus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.