### PR TITLE
Fix `appcat` warning when installing Tiles

### DIFF
--- a/Casks/tiles.rb
+++ b/Casks/tiles.rb
@@ -4,8 +4,8 @@ cask 'tiles' do
 
   # updates.sempliva.com/tiles was verified as official when first introduced to the cask
   url "https://updates.sempliva.com/tiles/Tiles-#{version.after_comma}.dmg"
-  appcat 'https://updates.sempliva.com/tiles/updates.xml',
-         configuration: version.after_comma
+  appcast 'https://updates.sempliva.com/tiles/updates.xml',
+          configuration: version.after_comma
   name 'FreeMacSoft Tiles'
   homepage 'https://freemacsoft.net/tiles/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).