### PR TITLE
Update kid3 from 3.7.1 to 3.8.0

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,7 +1,7 @@
 cask 'kid3' do
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  version '3.7.1'
-  sha256 'b169a044d7cf5e8aa2fd8303ccb94e4d5e525835fc29f60dc2445f1499facd44'
+  version '3.8.0'
+  sha256 '51639f5d869740f723b680fa8f070da0e73709183612c0dfe3afee497068f486'
 
   # downloads.sourceforge.net/kid3 was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.