### PR TITLE
Update praat from 6.1.01 to 6.1.02

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.1.01'
-  sha256 '1792b9b6f72bfef604b8390a2fb93a43d4a1bc50263225904fc8c7991f8d8a8c'
+  version '6.1.02'
+  sha256 'f5d2ff9cd6a5f89906dfe5b179ada71d399a97a5a33e6565f32ebd27671c3219'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.