### PR TITLE
Update dropshare from 5.4.1,5113 to 5.4.4,5120

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,6 +1,6 @@
 cask 'dropshare' do
-  version '5.4.1,5113'
-  sha256 '79d907a24191274c29748b71e5d285d31990a41b72bb73db4837a1bbefbc232b'
+  version '5.4.4,5120'
+  sha256 '86eedd0ab392ba7ad303d235c835850d96d942110af6ad930b4f4b73fe858676'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.