### PR TITLE
Update uniconverter from 11.1.1.2,735 to 11.1.3.1,735

### DIFF
--- a/Casks/uniconverter.rb
+++ b/Casks/uniconverter.rb
@@ -1,6 +1,6 @@
 cask 'uniconverter' do
-  version '11.1.1.2,735'
-  sha256 '5eeea5af8d30e4a0ecc034fb992d5d4ce702c7ef4b24b00047ff9a453c9889d3'
+  version '11.1.3.1,735'
+  sha256 '85f649c30a19b2e63e69731cd99d937b1be36558e60b061edf802f43ac1e75fd'
 
   url "http://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full#{version.after_comma}.dmg"
   name 'UniConverter'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.