### PR TITLE
Update qlc-plus from 4.12.1 to 4.12.2

### DIFF
--- a/Casks/qlc-plus.rb
+++ b/Casks/qlc-plus.rb
@@ -1,6 +1,6 @@
 cask 'qlc-plus' do
-  version '4.12.1'
-  sha256 '0bcab8cee13d0f09a7bdfc47f83d6be5680f18fe735dea03a2da53c123e6a13f'
+  version '4.12.2'
+  sha256 'fe43befe918da4ebfdd503d1f7852fed3dbd9f4a30a1711f9962051d6ebdb681'
 
   url "https://qlcplus.org/downloads/#{version}/QLC+_#{version}.dmg"
   name 'Q Light Controller+'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.