### PR TITLE
Update second-life-viewer from 6.2.4.529638 to 6.3.0.530115

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.2.4.529638'
-  sha256 '011dcbcb568acdd3328463e55df46d6ab6135c0574738cf287abdf19366b35d5'
+  version '6.3.0.530115'
+  sha256 '21b77b69f6b05a2a744f41908a8946f0497e230533ec7070a9e6b2b4e0c489ad'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.