### PR TITLE
Update snowflake-snowsql from 1.1.67 to 1.1.84

### DIFF
--- a/Casks/snowflake-snowsql.rb
+++ b/Casks/snowflake-snowsql.rb
@@ -1,9 +1,10 @@
 cask 'snowflake-snowsql' do
-  version '1.1.67'
-  sha256 '0dfceecc8cf2f86319bae3222983ac54984bdd127c2bd8eb6ae9fe67b994b41e'
+  version '1.1.84'
+  sha256 '9ab879bed19bdeb99dd0d6aaad3cd03e61c2cd9004f653f54450375f59d758ec'
 
   # sfc-snowsql-updates.s3.us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://sfc-snowsql-updates.s3.us-west-2.amazonaws.com/bootstrap/#{version.major_minor}/darwin_x86_64/snowsql-#{version}-darwin_x86_64.pkg"
+  appcast 'https://sfc-snowsql-updates.s3.us-west-2.amazonaws.com'
   name 'SnowSQL'
   homepage 'https://www.snowflake.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.