### PR TITLE
Update squadanimator-rugby from 1.0.1 to 1.0.2

### DIFF
--- a/Casks/squadanimator-rugby.rb
+++ b/Casks/squadanimator-rugby.rb
@@ -1,6 +1,6 @@
 cask 'squadanimator-rugby' do
-  version '1.0.1'
-  sha256 'e9db96ef2a1dee2af84329124c9de5ebe86f79667e7a628d4eb98da94d375fc9'
+  version '1.0.2'
+  sha256 'd001ddfc424ae3e47fd9fab318e4b85aa8af40a4a5755a99b717e79fa877c33b'
 
   url "https://www.squadanimator.com/downloads/SquadAnimatorRugbyOSX-#{version}.zip"
   name 'SquadAnimator-Rugby'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.