### PR TITLE
Update seadrive from 1.0.5 to 1.0.7

### DIFF
--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -1,9 +1,10 @@
 cask 'seadrive' do
-  version '1.0.5'
-  sha256 '6c1ddeb21ec89e78d0c34f80d8540ab7bc73a930b607bafaae31fe138475783e'
+  version '1.0.7'
+  sha256 '822deefa9821cd6d35474cbd942a0218a29c45814c47d600aafa1d0955d971dd'
 
   # download.seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seadrive-#{version}.dmg"
+  appcast 'https://www.seafile.com/en/download/'
   name 'Seadrive'
   homepage 'https://www.seafile.com/en/home/'
 

--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -4,7 +4,7 @@ cask 'seadrive' do
 
   # download.seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seadrive-#{version}.dmg"
-  appcast 'https://www.seafile.com/en/download/'
+  appcast 'https://raw.githubusercontent.com/haiwen/seafile-docs/master/changelog/drive-client-changelog.md'
   name 'Seadrive'
   homepage 'https://www.seafile.com/en/home/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.