### PR TITLE
Update segger-embedded-studio-for-risc-v from 4.18 to 4.20a

### DIFF
--- a/Casks/segger-embedded-studio-for-risc-v.rb
+++ b/Casks/segger-embedded-studio-for-risc-v.rb
@@ -3,7 +3,8 @@ cask 'segger-embedded-studio-for-risc-v' do
   sha256 '708fed7bcb5581a09a9351997061ef286e4f42efc440ec6928ecbdee434ef004'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_RISCV_v#{version.no_dots}_macos_x64.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_RISCV_Mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_RISCV_Mac',
+          configuration: version.no_dots
   name 'Embedded Studio for RISC-V'
   homepage 'https://www.segger.com/products/development-tools/embedded-studio'
 

--- a/Casks/segger-embedded-studio-for-risc-v.rb
+++ b/Casks/segger-embedded-studio-for-risc-v.rb
@@ -1,8 +1,9 @@
 cask 'segger-embedded-studio-for-risc-v' do
-  version '4.18'
-  sha256 '0cf07e1e8884f975ba2957071d10a6f4f5fb3b68d89636838150334f34335126'
+  version '4.20a'
+  sha256 '708fed7bcb5581a09a9351997061ef286e4f42efc440ec6928ecbdee434ef004'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_RISCV_v#{version.no_dots}_macos_x64.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_RISCV_Mac'
   name 'Embedded Studio for RISC-V'
   homepage 'https://www.segger.com/products/development-tools/embedded-studio'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.