### PR TITLE
Update squeak from 5.2-18228 to 5.2-18229

### DIFF
--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -1,8 +1,9 @@
 cask 'squeak' do
-  version '5.2-18228'
-  sha256 '7bd3de9beedcce792db32f1253f9243a299909368bad6f1ac21dd128f11b289d'
+  version '5.2-18229'
+  sha256 '78191157f46bbcd04f8c7d36190d5e0247a238eac01b26911badd5c622a3300f'
 
   url "https://files.squeak.org/#{version.major_minor}/Squeak#{version}-64bit/Squeak#{version}-64bit-All-in-One.zip"
+  appcast 'https://squeak.org/downloads/'
   name 'Squeak'
   homepage 'https://squeak.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.