### PR TITLE
Update hstracker from 1.6.3 to 1.6.4

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.3'
-  sha256 '0652f2da2383b5024268bcdec931c061ea234beb4d6ed908e027cf11b7cd57a3'
+  version '1.6.4'
+  sha256 'ae52214c2dbd4cf3478e074a17d0c49abbd1ef636874ef95e87c1435591d3274'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.