### PR TITLE
Update hubstaff from 1.4.9,1136 to 1.4.10,1235

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.4.9,1136'
-  sha256 '0d6b2a79f032f87068b6bd6b847242b0d7dd958ee33c34c767a022771b2872ae'
+  version '1.4.10,1235'
+  sha256 'de6b22f850df6c8e306e78f12d289df6d0de5a1232a1d484f331e5290bd54b15'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.