### PR TITLE
Update disk-drill from 3.7.934 to 3.7.942

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,6 +1,6 @@
 cask 'disk-drill' do
-  version '3.7.934'
-  sha256 'ff9258f14907078ebb692c746cce909c5620f4cd04da353e44155279aaa322d7'
+  version '3.7.942'
+  sha256 '42ff300cf10263ee208ec314a19e31cc67a799c277129ce8b33141eabb146fec'
 
   url "https://www.cleverfiles.com/releases/DiskDrill_#{version}.zip"
   appcast 'https://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.