### PR TITLE
Update jalbum from 18.3.1 to 18.4.0

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,6 +1,6 @@
 cask 'jalbum' do
-  version '18.3.1'
-  sha256 '0bdb2e6c64d7996cd15ef58687c109b5627f6c2b2a3b18910c4d9215df51f5b1'
+  version '18.4.0'
+  sha256 'f4f3558e7153ff443bc2209efcff8514fcb043b0a8e599bfc6bee80dab6a9f1f'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.