### PR TITLE
Update blitz from 1.2.7 to 1.2.8

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.2.7'
-  sha256 '48eafd9c718287b4601bca71fc07473df4a3df38553de6ddadc19274674bca28'
+  version '1.2.8'
+  sha256 'e32632065b6ff12731766144df635074db4d630f14568eb50bacddf209586b50'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.