### PR TITLE
Update altair-graphql-client from 2.3.0 to 2.3.1

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,9 +1,9 @@
 cask 'altair-graphql-client' do
-  version '2.3.0'
-  sha256 'ddc66f0e588d3e070b2c8196198874b1b2f41e13aca34a0d23f140c87da1a2d6'
+  version '2.3.1'
+  sha256 '900459dcaed6cd2c61a7886ff603689eab871ec565be7344d2450f716cbe0de8'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
-  url "https://github.com/imolorhe/altair/releases/download/v#{version}/Altair-GraphQL-Client-#{version}-mac.zip"
+  url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair_#{version}_mac.zip"
   appcast 'https://github.com/imolorhe/altair/releases.atom'
   name 'Altair GraphQL Client'
   homepage 'https://altair.sirmuel.design/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.