### PR TITLE
Update private-internet-access from 1.3.3-02880 to 1.4-03180

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,6 +1,6 @@
 cask 'private-internet-access' do
-  version '1.3.3-02880'
-  sha256 '9874e8347bc8f29684118fd9d12492f70f4f4c85fa12a212d381c7de9e04f7b4'
+  version '1.4-03180'
+  sha256 '980f6e58047af29180d8c1883607e03edaf691de08f32ae42adbdb16f1b82b13'
 
   url "https://installers.privateinternetaccess.com/download/pia-macos-#{version}.zip"
   appcast 'https://www.privateinternetaccess.com/pages/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.