### PR TITLE
Update MuteSpotifyAds to v1.10.0

### DIFF
--- a/Casks/mutespotifyads.rb
+++ b/Casks/mutespotifyads.rb
@@ -1,6 +1,6 @@
 cask 'mutespotifyads' do
-  version '1.9.0'
-  sha256 '0c4ad1494d57278780adf56fb07e7229edc18e768bb6704662210a26ab95ecaa'
+  version '1.10.0'
+  sha256 '43fe60985ddcbd2019bf7ee7adb5a4ee2a286bf818d8a169781b1596fddc0879'
 
   url "https://github.com/simonmeusel/MuteSpotifyAds/releases/download/v#{version}/MuteSpotifyAds.app.zip"
   appcast 'https://github.com/simonmeusel/MuteSpotifyAds/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).