### PR TITLE
Revert "Update mendeley from 1.19.4 to 1.19.5"

### DIFF
--- a/Casks/mendeley.rb
+++ b/Casks/mendeley.rb
@@ -1,6 +1,6 @@
 cask 'mendeley' do
-  version '1.19.5'
-  sha256 'd315dfdc87eca7788d0cd8a172487d202c59df700eb91e65b97efbac6b8d6578'
+  version '1.19.4'
+  sha256 'bd9584152eb0bd375ce98b874981a44d87435d0e7b5a411734d9db63f48f7260'
 
   url "https://desktop-download.mendeley.com/download/Mendeley-Desktop-#{version}-OSX-Universal.dmg"
   name 'Mendeley'

--- a/Casks/mendeley.rb
+++ b/Casks/mendeley.rb
@@ -3,6 +3,7 @@ cask 'mendeley' do
   sha256 'bd9584152eb0bd375ce98b874981a44d87435d0e7b5a411734d9db63f48f7260'
 
   url "https://desktop-download.mendeley.com/download/Mendeley-Desktop-#{version}-OSX-Universal.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.mendeley.com/autoupdates/installer/Mac-x64/stable-incoming'
   name 'Mendeley'
   homepage 'https://www.mendeley.com/'
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#62787

1.19.5 seems to be a beta, compare this:
https://www.mendeley.com/autoupdates/installers/stable
https://www.mendeley.com/autoupdates/installers/preview


