### PR TITLE
Update station from 1.46.1 to 1.47.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.46.1'
-  sha256 '739051a37a87d0ecbf44d5ccb1e5f0d801519cd37405f4fae8131b514a7d4259'
+  version '1.47.0'
+  sha256 '98a65c1d2379213a1761ec249a9e8ac81385e3c8fd5f975ec6620e9f5f606c24'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.