### PR TITLE
Update remembear from 1.4.9 to 1.4.10

### DIFF
--- a/Casks/remembear.rb
+++ b/Casks/remembear.rb
@@ -1,6 +1,6 @@
 cask 'remembear' do
-  version '1.4.9'
-  sha256 '30cf92cb4e0c540ab30d8af03738a8d13d60a8cff45fe45f46e0b13038c6b213'
+  version '1.4.10'
+  sha256 'f6f75c626816e4a165eb75fa14f7359573dc9ce2b89ea2001b6bb7645dd59bdf'
 
   # remembear.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://remembear.s3.amazonaws.com/app/release/downloads/macOS/RememBear-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.