### PR TITLE
Update iexplorer from 4.3.0,158 to 4.3.1,161

### DIFF
--- a/Casks/iexplorer.rb
+++ b/Casks/iexplorer.rb
@@ -1,6 +1,6 @@
 cask 'iexplorer' do
-  version '4.3.0,158'
-  sha256 '19c6e08471ba557b5f252d6769f680a3aa0c2b7de4f1151a783a2f88137480e7'
+  version '4.3.1,161'
+  sha256 'e336f66023a1fd2029d75c569057118243dada0575ecda82fe4b8d2c0f078b9a'
 
   url "https://assets.macroplant.com/download/#{version.after_comma}/iExplorer-#{version.before_comma}.dmg"
   appcast "https://macroplant.com/iexplorer/mac/v#{version.major}/appcast"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.