### PR TITLE
Update pdf-squeezer from 3.10.4 to 3.10.5

### DIFF
--- a/Casks/pdf-squeezer.rb
+++ b/Casks/pdf-squeezer.rb
@@ -1,6 +1,6 @@
 cask 'pdf-squeezer' do
-  version '3.10.4'
-  sha256 'b6b20620491bbb5e50299b5536dd1f4a3ba155767ddbbd658fd87ab616a5cdbc'
+  version '3.10.5'
+  sha256 '557e05b72b98b7bc644c025504dc749d8ba4add935a6fe47bbfb1bc4d9c402af'
 
   url 'https://witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
   appcast 'https://witt-software.com/downloads/pdfsqueezer/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.