### PR TITLE
Update melodics from 2.1.3331 to 2.1.3392

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3331'
-  sha256 '1ebc9e9e530b402a756988ba1d16aa9afa651c2b7a9567a6efaa428b7178e2ec'
+  version '2.1.3392'
+  sha256 '170c0ac92cee21a6e352875bccc530632486d5f84b812ac9e36193e9bc2cef6b'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.