### PR TITLE
Update studio-3t from 2019.4.1 to 2019.5.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2019.4.1'
-  sha256 'ed7b326120f8c072de2068680e565468f4027ce343713602c154e8a5701fdeeb'
+  version '2019.5.0'
+  sha256 '47ac7a86253983d1092d7da8748102953c5b888fe19f25a99a2c3d2487fd372d'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.