### PR TITLE
Update cacher from 2.16.1 to 2.16.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.16.1'
-  sha256 '32e3be0c7eef18486f05d4252940b9cfaa0e7ac0ff11277402f14c1a4f962b6b'
+  version '2.16.3'
+  sha256 '9aaa8e2bab35e1962f88a991cf2032c74108e4cc4263b64e72b46970fb24dbe5'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.