### PR TITLE
Update mono-mdk from 6.0.0.319 to 6.0.0.327

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk' do
-  version '6.0.0.319'
-  sha256 '6613b724d0a42774241b0a48f3a27336d49351c8d97ac0a13c60bb9dcda9fbfa'
+  version '6.0.0.327'
+  sha256 '5f63095965cdf6646b30b28b522b3f1af36870e90b12fc2eb6ce225a6f8bb384'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://www.mono-project.com/download/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.