### PR TITLE
Update mymonero from 1.1.11 to 1.1.12

### DIFF
--- a/Casks/mymonero.rb
+++ b/Casks/mymonero.rb
@@ -1,6 +1,6 @@
 cask 'mymonero' do
-  version '1.1.11'
-  sha256 '7c53643af43c3c2c38db489372667ef25e16632d0d2b2abb51d4f4c6b2a6b5d9'
+  version '1.1.12'
+  sha256 '8acb1393883787f12caec5afed04198c6fe1cb6bea0f9ed8acc59eb4318993e5'
 
   # github.com/mymonero/mymonero-app-js was verified as official when first introduced to the cask
   url "https://github.com/mymonero/mymonero-app-js/releases/download/v#{version}/MyMonero-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.