### PR TITLE
Update ark-desktop-wallet from 2.5.1 to 2.6.0

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.5.1'
-  sha256 'fcd535fbb7385ccebcdcd1266db67151d9b417e6751c171ee8dc6e71052c7af4'
+  version '2.6.0'
+  sha256 '327bfcdd4e48f2d029644fdf6f7d475c238ca8fe789dde227c0acc3b7ef2e81f'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.