### PR TITLE
Update blitz from 1.2.8 to 1.2.9

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.2.8'
-  sha256 'e32632065b6ff12731766144df635074db4d630f14568eb50bacddf209586b50'
+  version '1.2.9'
+  sha256 '1ba061b2f21e341dfad4ae0aa67d10b8f68a919477c9586f4b7376cdd07e70db'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.