### PR TITLE
Update cisdem-pdf-converter-ocr from 7.0.0 to 7.1.0

### DIFF
--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-pdf-converter-ocr' do
-  version '7.0.0'
-  sha256 'a92240fb9b280909b83f98718e68ece6998d3c9f0188560b69f91f92dad5859a'
+  version '7.1.0'
+  sha256 '6c37718bfe063813eac936254860b0d22277281a3b1781c688eb60066b6ef93c'
 
   url 'http://download.cisdem.com/cisdem-pdfconverterocr.dmg'
   appcast 'https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.