### PR TITLE
Update seashore from 2.4.10 to 2.4.11

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.4.10'
-  sha256 'ffee7733e38e9f9b12f5734e6b4bd33cf5eb4ec4a32b9865ce72a523715bcf68'
+  version '2.4.11'
+  sha256 'f9882ec71e55915bb93e5e4f3f5087b27e02a51ce43e9df9bf2961b7c8b5c733'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.