### PR TITLE
Update gramps from 5.0.2-3 to 5.1.0-1

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,6 +1,6 @@
 cask 'gramps' do
-  version '5.0.2-3'
-  sha256 '28e5f457d37f8b4ad738874b92a9edbfb1e92f4d44abc1229f42579b1aa233f1'
+  version '5.1.0-1'
+  sha256 '43941d4231ca0e2239b14a319edf5f1dc436a017563950c34e4f8a844da90923'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.major_minor_patch}/Gramps-Intel-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.