### PR TITLE
Update geekbench from 4.4.1 to 4.4.2

### DIFF
--- a/Casks/geekbench.rb
+++ b/Casks/geekbench.rb
@@ -3,8 +3,8 @@ cask 'geekbench' do
     version '3.4.2'
     sha256 '05e1b977a46648d38cf6c641be7ef34722200d0168a10d4372fca771ffa24e28'
   else
-    version '4.4.1'
-    sha256 'a0f56599a6a94974953500a2b82165dfbf20a624667a190d056f68901763ddf4'
+    version '4.4.2'
+    sha256 '3c46e630a28a0752afd702fc1cd379edd2420001be22302c932e61751284c0cc'
   end
 
   url "https://cdn.geekbench.com/Geekbench-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.