### PR TITLE
Update megasync from 4.2.3 to 4.2.4

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -1,6 +1,6 @@
 cask 'megasync' do
-  version '4.2.3'
-  sha256 '8b4d01e3f0c6f042440ea2ce8667a72257297778a4b881419de5a44001e9c0c1'
+  version '4.2.4'
+  sha256 'eb486c4203f945bdb57c31fe0667be8c8be4eb3b4f9ffe2b5714289770b0141c'
 
   url 'https://mega.nz/MEGAsyncSetup.dmg'
   appcast 'https://github.com/meganz/MEGAsync/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.