### PR TITLE
Update zoomus from 4.5.3261.0825 to 4.5.3284.0829

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.5.3261.0825'
-  sha256 '5b6f44e43860e4a7c10473d475da717dcb47f67f0b3a4e18cf23c0fcc2f56a98'
+  version '4.5.3284.0829'
+  sha256 '6e14f629762173e1657750885060e2c81036e899d2ec4b1ec607ddd2d91fdba0'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://zoom.us/client/latest/Zoom.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.