### PR TITLE
Update electron from 6.0.4 to 6.0.6

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '6.0.4'
-  sha256 '947b1a0a917d0d71daaf12a88cfd05e9bc5136a12100295db8cb5d98fc6cb554'
+  version '6.0.6'
+  sha256 'f42cd08882a42b7ae32b1883edb3f61d48a18f8cbc64ef9c5c54c4d09e78606b'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.