### PR TITLE
Update gisto from 1.12.8 to 1.12.9

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.12.8'
-  sha256 '97bf0045abb2c3c90034ec12fdaf9697acb32e79c4b198f3dfe8cfe1847ae48b'
+  version '1.12.9'
+  sha256 '6bbeda48efeb733e621e2e71082becc82f2cb205a16e378d45fee2307e196fb8'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.