### PR TITLE
Update gitahead from 2.5.9 to 2.5.10

### DIFF
--- a/Casks/gitahead.rb
+++ b/Casks/gitahead.rb
@@ -1,6 +1,6 @@
 cask 'gitahead' do
-  version '2.5.9'
-  sha256 '12cb7a3909950d8b3ba1f5ff30de5fcb99731cf546242df2e938fc91264de41a'
+  version '2.5.10'
+  sha256 '2bf53aa0b50fefe580176d4669f7936c8f55ce83115929febb5888e8d5099e13'
 
   url "https://github.com/gitahead/gitahead/releases/download/v#{version}/GitAhead-#{version}.dmg"
   appcast 'https://github.com/gitahead/gitahead/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.