### PR TITLE
Update terminus from 1.0.88 to 1.0.90

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.88'
-  sha256 'a7ce9de7dd374c321391aa2e58737711d5703926b578c5a5a2ca58eb9d91fd2c'
+  version '1.0.90'
+  sha256 '58295ea8e89b42ba7c68c1e8d5d7488657f69de54bd2d3f4f503231d4dd58a07'
 
   # github.com/Eugeny/terminus was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.