### PR TITLE
Update quicken from 5.12.2,512.29221.100 to 5.12.3,512.29258.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.12.2,512.29221.100'
-  sha256 'd697e23e868985c25c890469226c0574f43fb225e395550b47769fcfc73cd983'
+  version '5.12.3,512.29258.100'
+  sha256 'ac41bef56565808b420fc9c3da2f0b980ffc0a19efa2c3f45a4169d6dbc89b45'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.