### PR TITLE
Update vanilla from 1.1.1,28:1538098125 to 1.1.3,33:1567125972

### DIFF
--- a/Casks/vanilla.rb
+++ b/Casks/vanilla.rb
@@ -1,6 +1,6 @@
 cask 'vanilla' do
-  version '1.1.1,28:1538098125'
-  sha256 '5a45910f4ea99078884d7cd99563cb19b1cd0c9bda8e120111a235188f121881'
+  version '1.1.3,33:1567125972'
+  sha256 '18a06d1b329673026764f23b75412a2033e0dcc6f476014c756fda974d3ed9c1'
 
   # devmate.com/net.matthewpalmer.Vanilla was verified as official when first introduced to the cask
   url "https://dl.devmate.com/net.matthewpalmer.Vanilla/#{version.after_comma.before_colon}/#{version.after_colon}/Vanilla-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.