### PR TITLE
Update carbon-copy-cloner from 5.1.10.5778 to 5.1.11.5793

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.1.10.5778'
-  sha256 '1a1459c87c6192b756fc17fc3d55471e31b30dae84e11dd3adb98168a6730985'
+  version '5.1.11.5793'
+  sha256 '8bc2c08d2c7b2e9ff5275d32abdfd4624fc2c26d26f3160caed922c441bf3067'
 
   # bombich.scdn1.secure.raxcdn.com/software/files was verified as official when first introduced to the cask
   url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.