### PR TITLE
Update 4k-video-downloader from 4.8.2.2902 to 4.9.0.3032

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.8.2.2902'
-  sha256 '74991a4c0bd0ff0bd1f90119c16132bc8e113cddd8eafc722c260c9f80337e5f'
+  version '4.9.0.3032'
+  sha256 '4c3fed2388b2d5bc50f34bdee6fbbf002c14d877c9e24d8aa1cd99c4d9fda483'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.