### PR TITLE
Update 4k-youtube-to-mp3 from 3.7.2.2902 to 3.8.0.3032

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.7.2.2902'
-  sha256 '62ca793ed2b2fa241f1a2b09d9e57857e40e274797600093d2a8ad56d4194c3d'
+  version '3.8.0.3032'
+  sha256 '9068d8ba3717b307292ce6f6188fc6f3252efc39c2dc791097ef886aa5f41a4b'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.