### PR TITLE
Update banking-4 from 7.1.0,7160 to 7.1.0,7181

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.1.0,7160'
-  sha256 '9fb3e0740daf22372aab4b730776f21c61b29557a74fe128047a77fbf2bb3a07'
+  version '7.1.0,7181'
+  sha256 'a0ca8aa959ae5c423c0e28fec9cf213b1471397cb910e9a23db8182ffbe79da2'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.