### PR TITLE
Update kitty from 0.14.3 to 0.14.4

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,6 +1,6 @@
 cask 'kitty' do
-  version '0.14.3'
-  sha256 '0ae51c340e515134c0275705e46b61879a8b536ab2be3f8d98f801fe76368d65'
+  version '0.14.4'
+  sha256 'a441f896ae4f883feafb149c3bee328073deaa60e3f10bfeab3d313a5c8c2ba1'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.