### PR TITLE
Update vyprvpn from 3.0.0.7281 to 3.1.0.7459

### DIFF
--- a/Casks/vyprvpn.rb
+++ b/Casks/vyprvpn.rb
@@ -1,6 +1,6 @@
 cask 'vyprvpn' do
-  version '3.0.0.7281'
-  sha256 '1367d62b6d6727369fccb2e6a9d1e97be76f7d0b2c452484ecf0c29ed7392d23'
+  version '3.1.0.7459'
+  sha256 'bb7a4bd1d4b1b33898a2626bd5a79a18748bbe07439fce56bf747645bc204085'
 
   url "https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac/production/#{version}/VyprVPN_v#{version}.dmg"
   appcast 'https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac-feed.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.