### PR TITLE
Update stamp from 4.14.1 to 4.14.3

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.14.1'
-  sha256 '6823f38eaf60d7c5594e0bd431ace9d206dac53605b19d62dd8a589f8e20af46'
+  version '4.14.3'
+  sha256 '854b7ce95bf1e2c4aca867bce320edd4a8220e41327fd3735e794d0856d74821'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/STAMP#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.