### PR TITLE
Update protonmail-bridge from latest to 1.1.6

### DIFF
--- a/Casks/protonmail-bridge.rb
+++ b/Casks/protonmail-bridge.rb
@@ -1,8 +1,9 @@
 cask 'protonmail-bridge' do
-  version :latest
-  sha256 :no_check
+  version '1.1.6'
+  sha256 '20f31dbd4a278399f568c289945949381e3dc7bc179fbf97ef74b0a18fb19517'
 
   url 'https://protonmail.com/download/Bridge-Installer.dmg'
+  appcast 'https://protonmail.com/download/current_version_darwin.json'
   name 'ProtonMail Bridge'
   homepage 'https://protonmail.com/bridge/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.