### PR TITLE
Update supercollider from 3.10.2 to 3.10.3

### DIFF
--- a/Casks/supercollider.rb
+++ b/Casks/supercollider.rb
@@ -1,6 +1,6 @@
 cask 'supercollider' do
-  version '3.10.2'
-  sha256 '60f82f6e0c88d8e2d572bc5f816b148dc1a697dea280d8694b2012c35d9be264'
+  version '3.10.3'
+  sha256 'df6c764579d699d54679dbc1badde405566918dac2d3adecc17326712d2b81f4'
 
   # github.com/supercollider/supercollider was verified as official when first introduced to the cask
   url "https://github.com/supercollider/supercollider/releases/download/Version-#{version}/SuperCollider-#{version}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.