### PR TITLE
Update axe-edit-iii from 1.03.02 to 1.03.03

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.03.02'
-  sha256 '4cfa262c93f10e08a5e54aa6a952e2ebfa31ac613a22e0b62929e981e9cbd06c'
+  version '1.03.03'
+  sha256 '0babdb30a7acf32bfc9681452a9e600762c42d36943cd37a5d6136e0b2d728e8'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.