### PR TITLE
Update dosbox-x from 0.82.20,20190731203557 to 0.82.21,20190831133008

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.20,20190731203557'
-  sha256 'd38ba2408dbe4e32bf4c73f60cb016af496b69092885ac2a2beb0331046f8c82'
+  version '0.82.21,20190831133008'
+  sha256 'ec9d95a7603c122979b06c7a03260beb5f0dbd3f1f203bf908957cc7f61f6e3a'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.