### PR TITLE
Update extraterm from 0.44.0 to 0.44.1

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -6,7 +6,7 @@ cask 'extraterm' do
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"
   appcast 'https://github.com/sedwards2009/extraterm/releases.atom'
   name 'extraterm'
-  homepage 'http://extraterm.org/'
+  homepage 'https://extraterm.org/'
 
   app "extraterm-#{version}-darwin-x64/extraterm.app"
 

--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,6 +1,6 @@
 cask 'extraterm' do
-  version '0.44.0'
-  sha256 'df36e84a2e156c0eaa1febc65ab2ce0458d23eb03f1dc619089c4b3403cffc3c'
+  version '0.44.1'
+  sha256 '917ba54b9cc88cbe047ce97f6a0d95573ca207b4bea9607963e01a164c003f7c'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.