### PR TITLE
Update thedesk from 18.9.1 to 18.9.2

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.9.1'
-  sha256 '3bc9119abc33e5093d4393a9221344a40f66c977c7fb7867d695a29fe2b4ef90'
+  version '18.9.2'
+  sha256 '709ec33c36fb3388c811dbb07835e67419eb0bfb241f50b25f2cd307fa3871c1'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.