### PR TITLE
Update pomotroid from 0.6.1 to 0.6.2

### DIFF
--- a/Casks/pomotroid.rb
+++ b/Casks/pomotroid.rb
@@ -1,8 +1,8 @@
 cask 'pomotroid' do
-  version '0.6.1'
-  sha256 'b1d7636f8287b33eacf83444a9e081dd0427f042b68107e58e2f13e0f24ec3d8'
+  version '0.6.2'
+  sha256 '31fe5e68a8bfd830b4a3f252ed201bf38e0b0cd292e346074577a775c070698c'
 
-  url "https://github.com/Splode/pomotroid/releases/download/v#{version}/Pomotroid-setup-#{version}.dmg"
+  url "https://github.com/Splode/pomotroid/releases/download/v#{version}/Pomotroid-#{version}.dmg"
   appcast 'https://github.com/Splode/pomotroid/releases.atom'
   name 'Pomotroid'
   homepage 'https://github.com/Splode/pomotroid'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.