### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.2f1,ab112815d860 to 2019.2.3f1,8e55c27a4621

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.2f1,ab112815d860'
-  sha256 '3624122d2fba7a43531ed4e13107fb960f81624a4ddeff8ee24f211c43f35dd4'
+  version '2019.2.3f1,8e55c27a4621'
+  sha256 '64aa48c7f8a06a06c787507f9018d138854daf1c27aac61412847f9a519a215b'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.