### PR TITLE
Update aria-maestosa from 1.4.13c to 1.4.13

### DIFF
--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -8,7 +8,7 @@ cask 'aria-maestosa' do
   name 'Aria Maestosa'
   homepage 'https://ariamaestosa.sourceforge.io/'
 
-  app "AriaMaestosa-#{version}/Aria Maestosa.app"
+  app 'Aria Maestosa.app'
 
   zap trash: [
                '~/Library/Preferences/AriaMaestosa',

--- a/Casks/aria-maestosa.rb
+++ b/Casks/aria-maestosa.rb
@@ -1,9 +1,9 @@
 cask 'aria-maestosa' do
-  version '1.4.13c'
-  sha256 '59d77eb575ed6dcd4d3caeddac78dfe26f44c272e25e480e55733f15428d0946'
+  version '1.4.13'
+  sha256 '51e059957841d63b37af31297150b993034fc40b20fb84f006eb8fd0a75a349f'
 
   # downloads.sourceforge.net/ariamaestosa was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/ariamaestosa/AriaMaestosa-osx-#{version}.zip"
+  url "https://downloads.sourceforge.net/ariamaestosa/AriaMaestosa-osx-64bits-#{version}.zip"
   appcast 'https://sourceforge.net/projects/ariamaestosa/rss'
   name 'Aria Maestosa'
   homepage 'https://ariamaestosa.sourceforge.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.