### PR TITLE
Update pyfa from 2.10.0 to 2.10.1

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.10.0'
-  sha256 '9e1c0db4066482d428e1a0d6ec52ffd6cf1fd5cf45b9baec61164782bdf1e410'
+  version '2.10.1'
+  sha256 'fa6567589e3170c5f5d9a579da2e05c0358066a912627f07e833df5bab69d798'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.