### PR TITLE
Update satellite-eyes from 1.4.2 to 1.4.3

### DIFF
--- a/Casks/satellite-eyes.rb
+++ b/Casks/satellite-eyes.rb
@@ -1,6 +1,6 @@
 cask 'satellite-eyes' do
-  version '1.4.2'
-  sha256 'aab5f1d05ff9a96b33407f85075373569b90f425dee948986cb245fcc5d4373f'
+  version '1.4.3'
+  sha256 '512ada3ea57aa99853b86e625e5f6675119c85f6308bdbf52adce49513dc1321'
 
   # satellite-eyes.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://satellite-eyes.s3.amazonaws.com/satellite-eyes-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.