### PR TITLE
Update geotag-photos-pro from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/geotag-photos-pro.rb
+++ b/Casks/geotag-photos-pro.rb
@@ -1,6 +1,6 @@
 cask 'geotag-photos-pro' do
-  version '1.2.0'
-  sha256 '104fbb2fc9d9e52304684f3efde3de8b376535116fd97e825fd221cf8fba2cab'
+  version '1.2.1'
+  sha256 '6871192cafab3cb49db73f49456bea9a7cc7c4142fa8eaf47d7df703cafc7ffd'
 
   # github.com/tappytaps was verified as official when first introduced to the cask
   url "https://github.com/tappytaps/geotag-desktop-app/releases/download/v#{version}/geotag-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.