### PR TITLE
Update mongodb-compass-community from 1.19.6 to 1.19.12

### DIFF
--- a/Casks/mongodb-compass-community.rb
+++ b/Casks/mongodb-compass-community.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-community' do
-  version '1.19.6'
-  sha256 'f8a5b9fb67edeaa1d62ba9c789255da54ca7546eaccbb8dcc15050195049e7a3'
+  version '1.19.12'
+  sha256 '1db39b78580f1e8675f995a7b98d2ae97c6dde597b5bef3827f9b5855430fc89'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-community-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.