### PR TITLE
Update toneprint from 4.1.09-0 to 4.1.10

### DIFF
--- a/Casks/toneprint.rb
+++ b/Casks/toneprint.rb
@@ -1,9 +1,9 @@
 cask 'toneprint' do
-  version '4.1.09-0'
-  sha256 '013b181a44d16f9d2e477b7f325b31f6f20598e96a91fd8597c50fa9b6a6f692'
+  version '4.1.10'
+  sha256 'a0104ea2e55cc44c5c95a7d59e0e8e2b54d15e51d2b7442de425f87879939646'
 
   # downloads.music-group.com was verified as official when first introduced to the cask
-  url "https://downloads.music-group.com/software/tcelectronic/TonePrintEditor/TonePrint-#{version}_Mac.zip"
+  url "https://downloads.music-group.com/software/tcelectronic/TonePrintEditor/TonePrint-#{version}.dmg"
   appcast 'https://www.tcelectronic.com/p/P0CLC/Downloads'
   name 'TonePrint Editor'
   homepage 'https://www.tcelectronic.com/toneprint-editor/support/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.