### PR TITLE
Update suspicious-package from 3.5 to 3.5.1

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -1,6 +1,6 @@
 cask 'suspicious-package' do
-  version '3.5'
-  sha256 '7a60a9e2a3d51ad1fe0784742d77ca91d0c1a00ec09605f0df94a91c6a74fb97'
+  version '3.5.1'
+  sha256 'b5ed2c304745af76ea70f17718dde00bb85b1cc076dfce37da46f1c3b0e3e7f7'
 
   url 'https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
   appcast 'https://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.