### PR TITLE
Update pdf-expert from 2.4.28,636 to 2.4.29,640

### DIFF
--- a/Casks/pdf-expert.rb
+++ b/Casks/pdf-expert.rb
@@ -1,6 +1,6 @@
 cask 'pdf-expert' do
-  version '2.4.28,636'
-  sha256 '3279ebad5021a55469c999ace4be44fd488dc6d3181478b5892b344e2b803ba0'
+  version '2.4.29,640'
+  sha256 '336f0001cad63f9cdff715fcc84608c065b60ef64d9db60599d25f83595d28a9'
 
   # d1ke680phyeohy.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1ke680phyeohy.cloudfront.net/versions/#{version.after_comma}/PDFExpert.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.