### PR TITLE
Update Aptible to 0.16.2 and change homepage path

### DIFF
--- a/Casks/aptible.rb
+++ b/Casks/aptible.rb
@@ -1,11 +1,11 @@
 cask 'aptible' do
-  version '0.16.1,20180730142201,176'
-  sha256 'b9bc547ffdc1ce6551d0d79690ab7d4192ad4abe831a7ce4aa9a8236feeba7da'
+  version '0.16.2,20190829193451,187'
+  sha256 'c6a27837267bce5698d2581da7aa41cf76eac5005d01c5b6030dedbfff49799d'
 
   # omnibus-aptible-toolbelt.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/#{version.after_comma.after_comma}/pkg/aptible-toolbelt-#{version.before_comma}%2B#{version.after_comma.before_comma}-mac-os-x.10.11.6-1.pkg"
   name 'Aptible Toolbelt'
-  homepage 'https://www.aptible.com/support/toolbelt/'
+  homepage 'https://www.aptible.com/documentation/deploy/cli.html'
 
   pkg "aptible-toolbelt-#{version.before_comma}+#{version.after_comma.before_comma}-mac-os-x.10.11.6-1.pkg"
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

