### PR TITLE
Update time-out from 2.6 to 2.6.1

### DIFF
--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -3,8 +3,8 @@ cask 'time-out' do
     version '1.7.1'
     sha256 '3c9892344c8313b8ccf0a76cceb00834ddbe26e5114bcd674c4fd53aeb44e310'
   else
-    version '2.6'
-    sha256 '7a3787fa9e022a3e3509a11e8adcef75e078dfae17036986ddb0392522aecfe3'
+    version '2.6.1'
+    sha256 'c8eca829aa6f7120c742180bbd6e96b4d3e8c98a9cbc7274c83aa86ce56a0375'
   end
 
   url "https://www.dejal.com/download/timeout-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.