### PR TITLE
Update marvel from 8.4 to 8.4.1

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.4'
-  sha256 '9a57e44892ebcad76b7fa09f827ac999be727ec3879eb1131c126bd2a799104f'
+  version '8.4.1'
+  sha256 'c209f2fbab0b66bdc4318ad2246dc7c78a7ee9d1eccab9a8ed3ca2404ee8f363'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.