### PR TITLE
Update eagle from 9.4.2 to 9.5.0

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,6 +1,6 @@
 cask 'eagle' do
-  version '9.4.2'
-  sha256 '2fa5597c7f996df0a9c47473a4551d5b3c15fd4a52437832bd754e2b7faea7a6'
+  version '9.5.0'
+  sha256 'c16be486d7834a83de5d3e15d177750fd151227f35db47b43954089743477905'
 
   url "https://eagle-updates.circuits.io/downloads/#{version.dots_to_underscores}/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.autodesk.com/eagle-download-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.