### PR TITLE
Update textadept from 10.5 to 10.6

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -1,6 +1,6 @@
 cask 'textadept' do
-  version '10.5'
-  sha256 'ab691e3a4a8958d390dcaacff1083f8acdc28539b7d54de77077d5145401308b'
+  version '10.6'
+  sha256 '602baface4d78efd0e651bda4bbb1f78e6f2cfb3493dae664e1facb42b5afa42'
 
   url "https://foicica.com/textadept/download/textadept_#{version}.osx.zip"
   appcast 'https://foicica.com/textadept/feed'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.