### PR TITLE
Update remotix-agent from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/remotix-agent.rb
+++ b/Casks/remotix-agent.rb
@@ -1,6 +1,6 @@
 cask 'remotix-agent' do
-  version '1.2.2'
-  sha256 '9172c606d571c9664f847bcdcf77f71b623e6f17b01bc502c34d3402018d970e'
+  version '1.2.3'
+  sha256 '55e6acd216c697c875c31bd674a126ce06deac50472bff9d8b8b66555881c426'
 
   url 'https://downloads.remotixcloud.com/agent-mac/RemotixAgent.pkg'
   name 'Remotix Agent'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.