### PR TITLE
Update clockify from 2.3.3.99 to 2.3.5.105

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
-  version '2.3.3.99'
-  sha256 '27c63bb36ba76590687cda584850ce3001252592d08a479002e0528b00bbe4c5'
+  version '2.3.5.105'
+  sha256 '7d55b3054e6a83029547bd58c42879503090924e752b870c864e6a9b1ef537b7'
 
   # clockify-resources.s3.eu-central-1.amazonaws.com was verified as official when first introduced to the cask
   url "https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop_#{version.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.