### PR TITLE
Update parallels-toolbox from 3.5.0-2481 to 3.6.0-2591

### DIFF
--- a/Casks/parallels-toolbox.rb
+++ b/Casks/parallels-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'parallels-toolbox' do
-  version '3.5.0-2481'
-  sha256 '7522c5ea7112db53c09d7928cec910420c3275f52cdff840dba7a0a03f03064b'
+  version '3.6.0-2591'
+  sha256 'dcca08d52e18b268a8a4b8cc6615c742fba40e26dbaf720e214f404df35ceec4'
 
   url "https://download.parallels.com/toolbox/v#{version.major}/#{version}/ParallelsToolbox-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.parallels.com/directdownload/toolbox/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.