### PR TITLE
Update photoninja from 1.3.7a to 1.3.8

### DIFF
--- a/Casks/photoninja.rb
+++ b/Casks/photoninja.rb
@@ -1,6 +1,6 @@
 cask 'photoninja' do
-  version '1.3.7a'
-  sha256 'a3edcb3ec6f3b2449165b713102cb09dbb8a8f8108c2c317355e11e902bc8e2b'
+  version '1.3.8'
+  sha256 '8e892330ec4bd9296b97e7a3068de0f6b7e7b0098d0b984d360ff4c836b50431'
 
   # picturecode.cachefly.net was verified as official when first introduced to the cask
   url "https://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.