### PR TITLE
Update runway from 0.9.3 to 0.9.4

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.9.3'
-  sha256 '113e86d4cf8c686c8ee136916facdd092ef52eebc2816a5e10ae586cf11b4ca2'
+  version '0.9.4'
+  sha256 '24c4e0ee3b0fe14b81bd47137d6dfcdcdb38f394bfd6e16f3e35c7c4eb2f9a97'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.