### PR TITLE
Update segger-embedded-studio-for-arm from 4.20a to 4.22

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.20a'
-  sha256 '3c2f2ecf5185657323ec916ca566ec46c947d204f517a908c6a5f0c3aa5e5e74'
+  version '4.22'
+  sha256 '0673272a8f22f8d63f0b37cc4663eda195edc6c02f47757e02a7e4a8e86e6841'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.