### PR TITLE
Update dcp-o-matic-batch-converter from 2.14.8 to 2.14.10

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.14.8'
-  sha256 'f88224ad4b66b5e944faa2e388fb881ffbbf008a3985bf9814adb8681706a3c4'
+  version '2.14.10'
+  sha256 '4fd29a186511330481d19af23e5af90d39c674996ea88367c1994653669dc1d4'
 
   url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.