### PR TITLE
Update zulip from 2.3.82 to 4.0.0

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,12 +1,12 @@
 cask 'zulip' do
-  version '2.3.82'
-  sha256 '368d7ddcb672d6e6e3428ff56e5330f69eae0c2b80e9f088a0e51131ffefdaf8'
+  version '4.0.0'
+  sha256 '3028a7d4820fa42b94eb43717715e2d8c677dac1111bf604bd868bf062081117'
 
-  # github.com/zulip/zulip-electron was verified as official when first introduced to the cask
-  url "https://github.com/zulip/zulip-electron/releases/download/v#{version}/Zulip-#{version}.zip"
-  appcast 'https://github.com/zulip/zulip-electron/releases.atom'
+  # github.com/zulip/zulip-desktop was verified as official when first introduced to the cask
+  url "https://github.com/zulip/zulip-desktop/releases/download/v#{version}/Zulip-#{version}.dmg"
+  appcast 'https://github.com/zulip/zulip-desktop/releases.atom'
   name 'Zulip'
-  homepage 'https://zulipchat.com/'
+  homepage 'https://zulipchat.com/apps/'
 
   auto_updates true
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.