### PR TITLE
Update Synergy from 1.10.2,b126:8c010140 to 1.10.3,b139:ca35737a

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,6 +1,6 @@
 cask 'synergy' do
-  version '1.10.2,b126:8c010140'
-  sha256 'e85ab316c7783c3da8caba94f31210d80bb8c68f740a9d14322c3a20c8d2adf0'
+  version '1.10.3,b139:ca35737a'
+  sha256 '10824301d3079abbdcecfb6b2f83dc9371d929331049fd1f405b58d749f22fee'
 
   url "https://binaries.symless.com/synergy/v#{version.before_comma.major}-core-standard/v#{version.before_comma}-stable-#{version.after_colon}/synergy_#{version.before_comma}-stable_#{version.after_comma.before_colon}-#{version.after_colon}_macos.dmg"
   name 'Synergy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
