### PR TITLE
Update fsnotes from 3.5.0 to 3.6.0

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.5.0'
-  sha256 '34b90229b6854a101b9032530042d55efcb980cb2b4fb9f70f485e5ef5972cd4'
+  version '3.6.0'
+  sha256 '01ed587b65658fbdbde93cd165a74eef47f2458a65e9be89fa30bd2b6c55e22d'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.