### PR TITLE
Update soulver from 3.1.1-43 to 3.1.1.1-44

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,6 +1,6 @@
 cask 'soulver' do
-  version '3.1.1-43'
-  sha256 'a5744079a2f0944d5c6a96e31b04bb97c5b5803a7dab4460af2a3f7cab690264'
+  version '3.1.1.1-44'
+  sha256 'efb6b1d45d061feaf8afb399366fd151d5e7e591daa61bd4dfb92c94f937d50a'
 
   url "https://soulver.app/mac/sparkle/soulver-#{version}.zip"
   appcast 'https://soulver.app/mac/sparkle/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.