### PR TITLE
Update drama from 1.0.18 to 1.0.21

### DIFF
--- a/Casks/drama.rb
+++ b/Casks/drama.rb
@@ -1,6 +1,6 @@
 cask 'drama' do
-  version '1.0.18'
-  sha256 'da925a73d94641c039abebc0ad9720608eb753079a64fe475e07fdded7768c6c'
+  version '1.0.21'
+  sha256 'f74d0fc48e4a5520cb331dcdcc8322605ada11e5da8038e8aa7ebd9af767f1e4'
 
   # pixelcut.com/drama was verified as official when first introduced to the cask
   url 'https://www.pixelcut.com/drama/drama.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.