### PR TITLE
Update framer-x from 34754,1567173519 to 34762,1567605235

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '34754,1567173519'
-  sha256 '7f690b11e1f5b1806949875d38d1f0e7a94eb34278cf95040955a872c37e6ea4'
+  version '34762,1567605235'
+  sha256 'f2777872816d6fef5522b8d41bdd3b10350c1a1b4f24ef4c30360777899ca320'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.