### PR TITLE
Update kite from 0.20190829.0 to 0.20190904.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190829.0'
-  sha256 '4ec65a12f483155c2f44c6e08744669341364b9798991ef7f211f591fff9da78'
+  version '0.20190904.0'
+  sha256 'ea881dbd2151058d0ab808e4cca6a755836d8d9157f59155fe16333d656e5ca7'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.