### PR TITLE
Update sigil from 0.9.17 to 0.9.18

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,9 +1,9 @@
 cask 'sigil' do
-  version '0.9.17'
-  sha256 '260e7af3455afe6aba8f9cf226704d53297dc8290c217882c21994dc3f03430c'
+  version '0.9.18'
+  sha256 'ecda56b7c6b4daac89c1c2eb38ac69cba7e5edbcd9a65d27be9e40d8e16100f9'
 
   # github.com/Sigil-Ebook/Sigil was verified as official when first introduced to the cask
-  url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil-#{version}-Mac-Package.dmg"
+  url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil.app-#{version}-Mac.txz"
   appcast 'https://github.com/Sigil-Ebook/Sigil/releases.atom'
   name 'Sigil'
   homepage 'https://sigil-ebook.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.