### PR TITLE
Update roblox from 0.399.0.334382,24faf6e02a924af1 to 0.400.0.336387,226c76bd00be46a2

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.399.0.334382,24faf6e02a924af1'
-  sha256 '034738b4e9ae04e181bf46befa649a9dcd1e51e8bf1addfb6a57cd2caa4fcfd7'
+  version '0.400.0.336387,226c76bd00be46a2'
+  sha256 'f47d318aa6f500a792ef573a47ffa6bd47c1d8070f1bf9f990ee19267386e6d0'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.