### PR TITLE
Update comparemerge.rb from 2.11y to 2.11(2)y

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,6 +1,6 @@
 cask 'comparemerge' do
-  version '2.11y'
-  sha256 '174de376f465c036c3da7d74d7f87f4475cb3e3e73ed197645338ba89c8f284d'
+  version '2.11(2)y'
+  sha256 '4f386114f41a4faf2056db5744489aa011b65bc55949194891b2ee7690e7e098'
 
   url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss'

--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,11 +1,11 @@
 cask 'comparemerge' do
-  version '2.11(2)y'
+  version '2.11(2)y,104'
   sha256 '4f386114f41a4faf2056db5744489aa011b65bc55949194891b2ee7690e7e098'
 
-  url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version}.zip"
+  url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version.before_comma}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss'
   name 'CompareMerge'
   homepage 'https://sourceforge.net/projects/comparemergenosandbox/'
 
-  app "CompareMerge #{version}.app"
+  app "CompareMerge #{version.before_comma}.app"
 end


### PR DESCRIPTION
could we add the Bundle version (104) here please?
the short version string hasn't changed inside the app - only the bundle version