### PR TITLE
Update youdaonote from 3.5.3 to 3.5.4

### DIFF
--- a/Casks/youdaonote.rb
+++ b/Casks/youdaonote.rb
@@ -1,6 +1,6 @@
 cask 'youdaonote' do
-  version '3.5.3'
-  sha256 'cbc129f9164edc945f72bee970b30eb1fd1a485cd6bc00be4c5437b72ff62977'
+  version '3.5.4'
+  sha256 '7c1d00df2303e0fa605a4c87767e0222d4c62aa7c45d2e4840ed4699573d1924'
 
   # download.ydstatic.com/notewebsite/downloads was verified as official when first introduced to the cask
   url 'https://download.ydstatic.com/notewebsite/downloads/YoudaoNote.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.