### PR TITLE
Update origin from 10.5.45.29542 to 10.5.46.29856

### DIFF
--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -1,6 +1,6 @@
 cask 'origin' do
-  version '10.5.45.29542'
-  sha256 '285c9bbd05b1e2e739a10981dbfb9eefc1f0edaf3ce2e89f4f2129108ed569c9'
+  version '10.5.46.29856'
+  sha256 '9121f2d00524ffffb1e215f9d85be4eceb2b9e447201a0886023dbaf7ec11ee1'
 
   # origin-a.akamaihd.net was verified as official when first introduced to the cask
   url "https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/OriginUpdate_#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.