### PR TITLE
Update mactex.rb

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -12,7 +12,10 @@ cask 'mactex' do
                          'basictex',
                          'mactex-no-gui',
                        ]
-  depends_on formula: 'ghostscript'
+  depends_on formula:  [
+                         'ghostscript',
+                         'perl',
+                       ]
   depends_on macos: '>= :sierra'
 
   pkg "mactex-#{version.no_dots}.pkg",
@@ -77,4 +80,8 @@ cask 'mactex' do
                '/usr/local/texlive',
                '~/Library/texlive',
              ]
+
+  echo "Updating Perl dependencies for latexindent..."
+  cpan -i -f Log::Log4perl Log::LogDispatch Log::Dispatch::File YAML::Tiny File::HomeDir Unicode::GCString
+
 end


### PR DESCRIPTION
Add `perl` as a dependency and run a script to update `latexindent` Perl dependencies at the end of the installation process. Perhaps there is a better way to do this, I'm just hoping to get the issue addressed...

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
