### PR TITLE
Update android-messages from 2.0.0 to 3.0.0

### DIFF
--- a/Casks/android-messages.rb
+++ b/Casks/android-messages.rb
@@ -1,8 +1,8 @@
 cask 'android-messages' do
-  version '2.0.0'
-  sha256 'dd8f2d6391d4ae1a04677acfdad6a6032633d5893495de28c526fb824740d49c'
+  version '3.0.0'
+  sha256 'c3a3e3c98373c6098d93b857e517e5f6afc1ea37129d2b62811fd5b4ed315703'
 
-  url "https://github.com/chrisknepper/android-messages-desktop/releases/download/v#{version}/android-messages-desktop-#{version}.dmg"
+  url "https://github.com/chrisknepper/android-messages-desktop/releases/download/v#{version}/Android-Messages-#{version}.dmg"
   appcast 'https://github.com/chrisknepper/android-messages-desktop/releases.atom'
   name 'Android Messages Desktop'
   homepage 'https://github.com/chrisknepper/android-messages-desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.