### PR TITLE
Update fsnotes from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.6.0'
-  sha256 '01ed587b65658fbdbde93cd165a74eef47f2458a65e9be89fa30bd2b6c55e22d'
+  version '3.6.1'
+  sha256 '0b4b5d9e7e0fabbd50f4fb7c0c2f741106a41d008fbcbe35722ff25a3456ee6d'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.