### PR TITLE
Update lbry from 0.35.2 to 0.35.3

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.35.2'
-  sha256 'be8283e79949b9a3abdbb18bb36c3e595a5295e347b8009b2efdad33639a6562'
+  version '0.35.3'
+  sha256 '729a6c030ed50acd34ca9b2028e31247c0630395d668254f80b6825802325138'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.