### PR TITLE
Update qownnotes from 19.9.2,b4498-170644 to 19.9.3,b4501-161121

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.2,b4498-170644'
-  sha256 'e1308a25b458e6530d5014c77607f38f4b45723aefc4dfb201ed23f069763328'
+  version '19.9.3,b4501-161121'
+  sha256 'e35fa3f65a0af3dbb3682a07171cf08b6ea3a5d40635e2295cbf18e245071c57'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.