### PR TITLE
Update typora from 0.9.9.28.4 to 0.9.9.28.5

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.28.4'
-  sha256 '74fe7c0085b0c5b504c7adbb34e38994030e05eb24efcc0e98b7ecf0833cc266'
+  version '0.9.9.28.5'
+  sha256 '35c20e7cae726a83b2ac69e128db41d56f9f8f2bf57ea0c8da8c9f8696bf7e1b'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.