### PR TITLE
Update iringg from 1.0.40,1561477920 to 1.0.41,1567697104

### DIFF
--- a/Casks/iringg.rb
+++ b/Casks/iringg.rb
@@ -1,6 +1,6 @@
 cask 'iringg' do
-  version '1.0.40,1561477920'
-  sha256 '3ea98dd633412f193e63d89139a5e78775c261944c686069f60cb473574002cc'
+  version '1.0.41,1567697104'
+  sha256 'a0aedb2bb0e874e2d19be10bc76b078cad1ebb78d575ce16154570a85f8b6039'
 
   # dl.devmate.com/com.softorino.iringg was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.iringg/#{version.before_comma}/#{version.after_comma}/iRinggforMac-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.