### PR TITLE
Update cacher from 2.17.3 to 2.18.0

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.17.3'
-  sha256 'fbcd183c74472dca6e036386b61db9a8395f8233580bd2aa1da1a89295a62bdb'
+  version '2.18.0'
+  sha256 '96f74c2bb87d53fa1bdda9be2adc4aa29082c1442ac90f2aa79141a5960735f1'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.