### PR TITLE
Update metabase from 0.33.0.0 to 0.33.2.0

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.33.0.0'
-  sha256 '0313a15b3d3f28aa5fba49fd17e76ff975a63c57c68707756b604ed3e18162fe'
+  version '0.33.2.0'
+  sha256 'fa7bc7cab9e68335ef3bfa92b5f9323e86e4f5f17d55e50e4b2f004f6852508e'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.