### PR TITLE
Update soundsource from 4.1.2 to 4.1.4

### DIFF
--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -1,5 +1,5 @@
 cask 'soundsource' do
-  version '4,1,4'
+  version '4.1.4'
   sha256 '98b7777c6a24f465cde3e844183364293538e9beae0cb0b53287dbe31518d776'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'

--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -7,7 +7,7 @@ cask 'soundsource' do
   name 'SoundSource'
   homepage 'https://rogueamoeba.com/soundsource/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   app 'SoundSource.app'
 end

--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -3,7 +3,7 @@ cask 'soundsource' do
   sha256 '98b7777c6a24f465cde3e844183364293538e9beae0cb0b53287dbe31518d776'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'
-  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&version=4008000'
+  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&system=10146&version=4000000'
   name 'SoundSource'
   homepage 'https://rogueamoeba.com/soundsource/'
 

--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -1,6 +1,6 @@
 cask 'soundsource' do
-  version '4.1.2'
-  sha256 '24a5e99328ae00f2e565dab706f9eca96c902111d696629783911dfce64cb11f'
+  version '4,1,4'
+  sha256 '98b7777c6a24f465cde3e844183364293538e9beae0cb0b53287dbe31518d776'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&version=4008000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.