### PR TITLE
Update scrutiny from 9.1.0 to 9.1.1

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '9.1.0'
-  sha256 '80a4eba7fa2fa6e8acd7f89e26593cf500eef77d8f74a8342fa216e97cbac242'
+  version '9.1.1'
+  sha256 '04de9f24cfae4f514dea12b133402c659f90094449c877dc531abf2bbf95c43f'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.