### PR TITLE
Update kactus from 0.3.21 to 0.3.22

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,6 +1,6 @@
 cask 'kactus' do
-  version '0.3.21'
-  sha256 '328e39e262d271a9240452a64d002151c4cef5880c42c319eb417b48593499ac'
+  version '0.3.22'
+  sha256 'f4bc4c4678fbb2bc0016848f4fa04b5bb3030ac94c3b834b506dfac3e4f12c48'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.