### PR TITLE
Update zerotier-one from 1.4.4 to 1.4.6

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -1,6 +1,6 @@
 cask 'zerotier-one' do
-  version '1.4.4'
-  sha256 '6df4bc0f24fbabed67b8c0cd39a4d164550f859e551453175ca28954c7cb00e8'
+  version '1.4.6'
+  sha256 '160d63776aa2eef90cdc7658ad8759a3947b0c2ea7fb41295f51efb93ff0029e'
 
   url 'https://download.zerotier.com/dist/ZeroTier%20One.pkg'
   appcast 'https://github.com/zerotier/ZeroTierOne/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.