### PR TITLE
Update sleipnir from 4.6.5 to 4.6.6

### DIFF
--- a/Casks/sleipnir.rb
+++ b/Casks/sleipnir.rb
@@ -1,6 +1,6 @@
 cask 'sleipnir' do
-  version '4.6.5'
-  sha256 'fd87b83113fa4205c1ba371f8b05a87aa30b46953549276ee1d28a87653ad6ec'
+  version '4.6.6'
+  sha256 'fe2906b890886e757207340ea3ede318a255f7ca9a0f4d5f6bac7c8ac87d2330'
 
   url 'https://www.fenrir-inc.com/services/download.php?file=Sleipnir.dmg'
   appcast 'https://update.fenrir.co.jp/smartupdate/mac/sleipnir/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.