### PR TITLE
Update dashlane from 6.1933.0.22570 to 6.1935.0.22755

### DIFF
--- a/Casks/dashlane.rb
+++ b/Casks/dashlane.rb
@@ -1,6 +1,6 @@
 cask 'dashlane' do
-  version '6.1933.0.22570'
-  sha256 '52deda260a5537c22bb128dff22565adf676604838381ec02e5763b7027c8340'
+  version '6.1935.0.22755'
+  sha256 '60960a9fcb426a5c220bc6473887ad0c6c8fc68078d3f1262852bd010deca413'
 
   # d3mfqat9ni8wb5.cloudfront.net/releases was verified as official when first introduced to the cask
   url "https://d3mfqat9ni8wb5.cloudfront.net/releases/#{version.major_minor_patch}/#{version}/release/Dashlane.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.