### PR TITLE
Update clickup from 1.5.2 to 1.5.5

### DIFF
--- a/Casks/clickup.rb
+++ b/Casks/clickup.rb
@@ -1,6 +1,6 @@
 cask 'clickup' do
-  version '1.5.2'
-  sha256 'ca8f4fc593b2dc5202ac7ff717c3931cbeec03e4410f006908400afbe5ad75d1'
+  version '1.5.5'
+  sha256 '1714120a8eacbe20436e478b44a6fc698d633922a0f13616806cc13b1232fc46'
 
   url "https://attachments.clickup.com/desktop/clickup-desktop-#{version}-mac.dmg"
   name 'ClickUp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.