### PR TITLE
Update displaycal from 3.8.5.0 to 3.8.6.0

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,6 +1,6 @@
 cask 'displaycal' do
-  version '3.8.5.0'
-  sha256 'c80d1995ad218cc9f79e5739e0fa785f51347e2130aa674f2eb6579a46690010'
+  version '3.8.6.0'
+  sha256 '26e3c3de3594da241d3c42f1388897beda394f58d5695653a5cd492dda6d587f'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.