### PR TITLE
Update telegram from 5.7-181132 to 5.7-181136

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '5.7-181132'
-  sha256 '2fe145292d62a14e543bd2edd3ddf811c31cc15c8ec07965e5de64eb5ec8cf58'
+  version '5.7-181136'
+  sha256 'd143412e5b2a3fadc37eeca3040e5815c16fa5d2b9b5d280f17dba916e150352'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.