### PR TITLE
Update perforce from 19.1-1813586 to 19.1-1845410

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask 'perforce' do
-  version '19.1-1813586'
-  sha256 '3cd4c1f0e4561f11d435cdca40f32218370e9d8e37ad5edbcdcddea4ba3123df'
+  version '19.1-1845410'
+  sha256 '5ef96eef8f3aee15d823c166ae6244ecf0bd7d2b79af5667994fdc92756e67ff'
 
   url "https://cdist2.perforce.com/perforce/r#{version.major_minor}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.