### PR TITLE
Update texshop from 4.31 to 4.35

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,6 +1,6 @@
 cask 'texshop' do
-  version '4.31'
-  sha256 'e7c356f94cda32f79e31158961042e72970181d6463ed3af24c5b26d93ef7725'
+  version '4.35'
+  sha256 'e22943a73b5c778d3669babd635501ecde4681e4a0956acf647a203a157bda3e'
 
   url "https://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'https://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.