### PR TITLE
Update soundsource from 4.1.2 to 4.1.4

### DIFF
--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -1,13 +1,13 @@
 cask 'soundsource' do
-  version '4.1.2'
-  sha256 '24a5e99328ae00f2e565dab706f9eca96c902111d696629783911dfce64cb11f'
+  version '4.1.4'
+  sha256 '98b7777c6a24f465cde3e844183364293538e9beae0cb0b53287dbe31518d776'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'
-  appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&version=4008000'
+  appcast 'https://rogueamoeba.com/soundsource/releasenotes.php'
   name 'SoundSource'
   homepage 'https://rogueamoeba.com/soundsource/'
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :sierra'
 
   app 'SoundSource.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.