### PR TITLE
Update electron from 6.0.6 to 6.0.7

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '6.0.6'
-  sha256 'f42cd08882a42b7ae32b1883edb3f61d48a18f8cbc64ef9c5c54c4d09e78606b'
+  version '6.0.7'
+  sha256 'f8063693e5a04dc74b052db47c1508f8ee8a8e4960e5213a9a52266f52b6246f'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.