### PR TITLE
Update amethyst from 0.14.0 to 0.14.1

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -8,8 +8,8 @@ cask 'amethyst' do
     sha256 '9fd1ac2cfb8159b2945a4482046ee6d365353df617f4edbabc4e8cadc448c1e7'
     url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   else
-    version '0.14.0'
-    sha256 'c2fb966d0f9dc56aaff33b28717aae9c724954d7bc898457913a6a27cbd9f474'
+    version '0.14.1'
+    sha256 '7b87afd1de5191ac126616d6ae1671832d5c8f4d689c1bc8f4cf0c00409fd574'
     # github.com/ianyh/Amethyst was verified as official when first introduced to the cask
     url "https://github.com/ianyh/Amethyst/releases/download/v#{version}/Amethyst.zip"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.