### PR TITLE
Update apple-juice from 1.10.1 to 1.10.2

### DIFF
--- a/Casks/apple-juice.rb
+++ b/Casks/apple-juice.rb
@@ -1,6 +1,6 @@
 cask 'apple-juice' do
-  version '1.10.1'
-  sha256 'e212218fc985b542d784438b523f601103a605d00c2d84d392a89a19c8694d4f'
+  version '1.10.2'
+  sha256 'dedbbf56a4d972ed0ad987be5b2577f2c59c55b0b9e4effd05c60f3c29773677'
 
   url "https://github.com/raphaelhanneken/apple-juice/releases/download/#{version}/Apple.Juice.dmg"
   appcast 'https://github.com/raphaelhanneken/apple-juice/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.