### PR TITLE
Update hook from 2595,1565469253 to 2696,1567841179

### DIFF
--- a/Casks/hook.rb
+++ b/Casks/hook.rb
@@ -1,6 +1,6 @@
 cask 'hook' do
-  version '2595,1565469253'
-  sha256 'eda2ded7a1d69962a76102fd06dd1093a8d813c122fcba76b24094af07921fe6'
+  version '2696,1567841179'
+  sha256 'c893d4e9b308e37891739e0bef3ba81286b02c3aee18b13399b72d0858367173'
 
   # dl.devmate.com/com.cogsciapps.hook was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.cogsciapps.hook/#{version.before_comma}/#{version.after_comma}/Hook-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.