### PR TITLE
Update backuploupe from 2.16.1 to 2.16.2

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,6 +1,6 @@
 cask 'backuploupe' do
-  version '2.16.1'
-  sha256 '19f88ba4d8dad0c271a5249bb4f96743a96069e1a643548bd755bf0ad3ed9d8a'
+  version '2.16.2'
+  sha256 'c4bd353abcb992225ae0ae4db6f677dade15439e81c9260818bce81b36e72df1'
 
   url "https://www.soma-zone.com/download/files/BackupLoupe-#{version}.tar.bz2"
   appcast 'https://www.soma-zone.com/BackupLoupe/a/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.