### PR TITLE
Update rotato from 70.1567179185 to 71.1567786682

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '70.1567179185'
-  sha256 '9168a921dfc89395c60205c8f965105edc80086bab2453383b4113a4dc3abe18'
+  version '71.1567786682'
+  sha256 '49b210d2d746d09bffcea9cb904965b8916c8a9dd6f34eb9ad19d72d97c23d5e'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.