### PR TITLE
Update phocus from 3.4.3 to 3.4.4

### DIFF
--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -1,6 +1,6 @@
 cask 'phocus' do
-  version '3.4.3'
-  sha256 '8b2b830d92604002a7406c2bbd8a1ec7eb4941e388d62e1b2a73e03ec9de76d2'
+  version '3.4.4'
+  sha256 '325432a385bb2a6aa2799110ddbcd60c3db9f1248d9b159c1970f3c7072c2a27'
 
   url "https://cdn.hasselblad.com/software/Phocus-for-Mac/#{version}/Phocus-#{version}.dmg"
   name 'Hasselblad Phocus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.