### PR TITLE
Update id3-editor from 1.26.43 to 1.27.46

### DIFF
--- a/Casks/id3-editor.rb
+++ b/Casks/id3-editor.rb
@@ -1,6 +1,6 @@
 cask 'id3-editor' do
-  version '1.26.43'
-  sha256 '9c1a2c03cec450cdda78c4ac1d27347c4a95cb4afdd9a9a7452b07b7c96522c2'
+  version '1.27.46'
+  sha256 '40fd2500d0dbe6d0131e1340e1fcc0c7afadd8f23fcfc6f78d2b6f98f82515c0'
 
   url "http://www.pa-software.com/release/ID3Editor.ub.#{version}.dmg"
   appcast 'http://www.pa-software.com/id3editor/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.