### PR TITLE
Update thonny from 3.1.2 to 3.2.1

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,10 +1,10 @@
 cask 'thonny' do
-  version '3.1.2'
-  sha256 '7a71c31d61a769b0725d745ee2509229f8da086701670d48e02a85fa4b70388a'
+  version '3.2.1'
+  sha256 '922c277c9f1ffee142d717dce7d698a72da1f5bca80636078ee7a0e536d32038'
 
   # github.com/thonny/thonny/releases/download was verified as official when first introduced to the cask
   url "https://github.com/thonny/thonny/releases/download/v#{version}/thonny-#{version}.dmg"
-  appcast 'https://thonny.org/blog/categories/releases.html'
+  appcast 'https://github.com/thonny/thonny/releases.atom'
   name 'Thonny'
   homepage 'https://thonny.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.