### PR TITLE
Update lingon-x from 7.3.2 to 7.4

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.4'
     sha256 'fc788402fa16df39a3d48cdc501dae31368ec6fd69ffe0026ba99932b28cae19'
   else
-    version '7.3.2'
-    sha256 'd45eac91a9e2c278a6242c13dd1394a34391cd9b239b4206e29d7bff190c25ed'
+    version '7.4'
+    sha256 'd4b8857fca09727e6f183109b19b265f098d20bcdf0fabed84dc191c8042ab1a'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.