### PR TITLE
Update mumble from 1.2.19 to 1.3.0

### DIFF
--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -1,6 +1,6 @@
 cask 'mumble' do
-  version '1.2.19'
-  sha256 '3784911cff35d1611c1aad1bdce74dda4d3a7f682cd83e256b1e4283d82bf368'
+  version '1.3.0'
+  sha256 'ffe648f07e3749dac1b7e9e82eb15b032e4547b8bfd48d568a618057dea6ee49'
 
   # github.com/mumble-voip/mumble was verified as official when first introduced to the cask
   url "https://github.com/mumble-voip/mumble/releases/download/#{version}/Mumble-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.