### PR TITLE
Update garagesale from 7.0.18 to 7.0.19

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,6 +1,6 @@
 cask 'garagesale' do
-  version '7.0.18'
-  sha256 '52c1bcbf249c3f2b42dd1eaf69e7028169bc9968d4111f43dbd706356ba5b77f'
+  version '7.0.19'
+  sha256 '134ede092a9c72c88db81fac7f49bdb0791dc8318c7b960f7214c08ee0bcb772'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   appcast "https://www.iwascoding.com/cgi-bin/version_check.cgi?APPLICATION=GarageSale&APP_BUNDLE_VERSION=#{version.major}00"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.