### PR TITLE
Update unity-ios-support-for-editor from 2019.2.3f1,8e55c27a4621 to 2019.2.4f1,c63b2af89a85

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.2.3f1,8e55c27a4621'
-  sha256 '0ba198c63c2bc4a86ab7d5174d49ca803753582124a7e73635e232147aab08ad'
+  version '2019.2.4f1,c63b2af89a85'
+  sha256 '2ffee37f769566d07ec1592d7389bfeb6c0a11535632913c3b36e79a9e8cab4a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.