### PR TITLE
Update unity-windows-support-for-editor from 2019.2.3f1,8e55c27a4621 to 2019.2.4f1,c63b2af89a85

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.3f1,8e55c27a4621'
-  sha256 '3862fa44560100a9e6666ec522b56d581878092bef6659b0f2b1e122a0f9b67d'
+  version '2019.2.4f1,c63b2af89a85'
+  sha256 'acc57f9d6322d1c73bf9437a9e76d23ce6f26eafb33e5e62e55de9af44b2ff76'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.