### PR TITLE
Update ipfs from 0.9.0 to 0.9.1

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -1,6 +1,6 @@
 cask 'ipfs' do
-  version '0.9.0'
-  sha256 '7e49c3793e288be9fcf714989b435a8ecc8f488ea14dc4a5298f2d1ee7c20e54'
+  version '0.9.1'
+  sha256 '7a0dbabba71f90de55b8da22b8295e5e3b6d9d540b68f50156ce65d98da7e1a9'
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/ipfs-desktop-#{version}.dmg"
   appcast 'https://github.com/ipfs-shipyard/ipfs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} left no offenses.
- [x] The commit message includes the cask’s name and version.