### PR TITLE
Update joplin from 1.0.165 to 1.0.166

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.165'
-  sha256 '6d10208b410f6c1a4e116c31c348d378cf61a9e2328b07b1ec8418c36824a053'
+  version '1.0.166'
+  sha256 'fcb12fa3f69a1e5518445a99d50aa206f36664c5e579a9444de5bfc1a32237e0'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.