### PR TITLE
Upgrade Maltego to 4.2.7.12570

### DIFF
--- a/Casks/maltego.rb
+++ b/Casks/maltego.rb
@@ -1,8 +1,8 @@
 cask 'maltego' do
-  version '4.1.13.11516'
-  sha256 '84e4a60a488e676928ffabef25f7de94a57ad7252f8a88e29321cf3b65e26910'
+  version '4.2.7.12570'
+  sha256 '66b18e7bac3f039d8e13080f1dce63f1ca2d530e9a89a7f23fe5ec91aa918036'
 
-  url "https://www.paterva.com/malv#{version.major_minor.no_dots}/Maltego.v#{version}.dmg"
+  url "https://www.paterva.com/malv#{version.major_minor_patch.no_dots}/Maltego.v#{version}.dmg"
   name 'Maltego'
   homepage 'https://www.paterva.com/web7/buy/maltego-clients.php'
 


### PR DESCRIPTION
I was not able to get `brew cask style` to work correctly.

Also note, Maltego depends on Java 8 but that is no longer available via Homebrew and must be installed manually [here](https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html). May want to look at updating that messaging.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).