### PR TITLE
Update gnucash from 3.6-1 to 3.7-1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask 'gnucash' do
-  version '3.6-1'
-  sha256 'a9275a8d2aef576016b7f58b08bcc71739902e2e81787171af83c2576e21d085'
+  version '3.7-1'
+  sha256 'b687fb0a17b15e735a29be83354409fb8059aebf0bd97079b74eac3dfc4cbeac'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.major_minor_patch}/Gnucash-Intel-#{version}.dmg"

--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -9,7 +9,7 @@ cask 'gnucash' do
   homepage 'https://www.gnucash.org/'
 
   app 'Gnucash.app'
-  
+
   zap trash: [
                '~/Library/Application Support/Gnucash',
                '~/Library/Preferences/org.gnucash.Gnucash.plist',

--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -9,8 +9,6 @@ cask 'gnucash' do
   homepage 'https://www.gnucash.org/'
 
   app 'Gnucash.app'
-  app 'FinanceQuote Update.app'
-
   zap trash: [
                '~/Library/Application Support/Gnucash',
                '~/Library/Preferences/org.gnucash.Gnucash.plist',

--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -9,6 +9,7 @@ cask 'gnucash' do
   homepage 'https://www.gnucash.org/'
 
   app 'Gnucash.app'
+  
   zap trash: [
                '~/Library/Application Support/Gnucash',
                '~/Library/Preferences/org.gnucash.Gnucash.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.