### PR TITLE
Update fman from 1.6.5 to 1.6.6

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.6.5'
-  sha256 '09feb91e12f3fcac5dfaa123475dcc9cc7ad2a4fc596129ead08cfe88d2efb91'
+  version '1.6.6'
+  sha256 'a9f1effdd6ab90472c596a4cb7c18a3bd8c23c01f2c1cb52023a66f384d3d575'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.