### PR TITLE
Update m3unify from 1.12.1 to 2.0.0

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,6 +1,6 @@
 cask 'm3unify' do
-  version '1.12.1'
-  sha256 'cc961fb2cd380f646db79d4cc82147d82473a642c4544ae11d6aeef4cd167bdf'
+  version '2.0.0'
+  sha256 'd27935e3b68fd075ca1aeac262077771ef894a095f7911a527e4ccfab8a9cd1a'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.