### PR TITLE
Update ppduck from 3.9.0 to 3.9.1

### DIFF
--- a/Casks/ppduck.rb
+++ b/Casks/ppduck.rb
@@ -1,6 +1,6 @@
 cask 'ppduck' do
-  version '3.9.0'
-  sha256 'a0876b253b560250975fb8decca6ca210cc358ae7d65e5168eee556dee49b7f5'
+  version '3.9.1'
+  sha256 '27a1493d8e6f9c6e8d843249bab6bca6f016e14afa428628cc65ac89e5ee2ba9'
 
   url "http://download.ppduck.com/PPDuck#{version.major}_#{version}.dmg"
   name 'PPDuck'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.