### PR TITLE
Update moonitor from 0.7.1 to 1.0.0

### DIFF
--- a/Casks/moonitor.rb
+++ b/Casks/moonitor.rb
@@ -1,6 +1,6 @@
 cask 'moonitor' do
-  version '0.7.1'
-  sha256 'b491f3d61c4c65defbb0b743814841e08c949600cc7eb4f225b5aecb9de47888'
+  version '1.0.0'
+  sha256 'daa4aa6d2339167173e092c9cec3e0e413439e25f8798f6112eb6edf4f9d668b'
 
   url "https://moonitor.io/wp-content/uploads/app/Moonitor-#{version}.dmg"
   appcast 'https://moonitor.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.