### PR TITLE
Update cozy-drive from 3.15.0 to 3.15.1

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.15.0'
-  sha256 '25b51f117e0d25d58a62ea15c466332b3263e50d845a8555a00f05339f781645'
+  version '3.15.1'
+  sha256 '9b2d16b5b05399243118adf81bcc750a1459bcab85e5f763fd418bc0af7ecf89'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.