### PR TITLE
Update electron from 6.0.7 to 6.0.8

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '6.0.7'
-  sha256 'f8063693e5a04dc74b052db47c1508f8ee8a8e4960e5213a9a52266f52b6246f'
+  version '6.0.8'
+  sha256 '5fc554f4e0965e2ddd4ad0295ae7b5429ce8ea9a19c169c90829c6c913d3b2c9'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.