### PR TITLE
Update dynamic-dark-mode from 1.4.0 to 1.4.2

### DIFF
--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -1,12 +1,13 @@
 cask 'dynamic-dark-mode' do
-  version '1.4.0'
-  sha256 '55debb60b0dde1b7156ebb87d462ac3940e16dd26d7c954e7cd3dafdab94769d'
+  version '1.4.2'
+  sha256 '76fb98e23627ecefc5d426320ff1a433fb06cf4d1e18fa7016e78766a2bd4321'
 
   url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.zip"
-  appcast 'https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases.atom'
+  appcast 'https://apollozhu.github.io/Dynamic-Dark-Mode/appcast.xml'
   name 'Dynamic Dark Mode'
   homepage 'https://github.com/ApolloZhu/Dynamic-Dark-Mode'
 
+  auto_updates true
   depends_on macos: '>= :mojave'
 
   app 'Dynamic Dark Mode.app'

--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -3,7 +3,7 @@ cask 'dynamic-dark-mode' do
   sha256 '76fb98e23627ecefc5d426320ff1a433fb06cf4d1e18fa7016e78766a2bd4321'
 
   url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.zip"
-  appcast 'https://apollozhu.github.io/Dynamic-Dark-Mode/appcast.xml'
+  appcast 'https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases.atom'
   name 'Dynamic Dark Mode'
   homepage 'https://github.com/ApolloZhu/Dynamic-Dark-Mode'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.