### PR TITLE
Update nteract from 0.14.5 to 0.15.0

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask 'nteract' do
-  version '0.14.5'
-  sha256 '92e28683cb8d39c4975eb28109fd5a639cef4d27c0987aff64dd59d9913ec394'
+  version '0.15.0'
+  sha256 '1356996bce666439052cec6322105f80c9da592866384c711040c5a285f1988e'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.