### PR TITLE
Update mudlet from 4.1.0 to 4.1.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '4.1.0'
-  sha256 '0530a26ea7e4f3ecfcee0d2caa5b6184ef2cbb4da367946070c8e5730d816648'
+  version '4.1.1'
+  sha256 '4abdc2af15530fcc1422b102f91bb006bc82b8e725ec3ae71abc241395e912a2'
 
   url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'

--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -2,7 +2,7 @@ cask 'mudlet' do
   version '4.1.1'
   sha256 '4abdc2af15530fcc1422b102f91bb006bc82b8e725ec3ae71abc241395e912a2'
 
-  url "https://www.mudlet.org/download/Mudlet-#{version}.dmg"
+  url "https://www.mudlet.org/wp-content/files/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'
   name 'Mudlet'
   homepage 'https://www.mudlet.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.