### PR TITLE
Update activedock from 236,1565611909 to 237,1568037944

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '236,1565611909'
-  sha256 '58588a1fb6cbfa729ca252319b99ce91b005dd18542698fbf21bbe93fde2660b'
+  version '237,1568037944'
+  sha256 'afaf9a0ce57b27b9795a2a99d6a2a0068e6174f984742182c7f76ed846dc2d33'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.