### PR TITLE
Update ibettercharge from 1.0.11,1526399595 to 1.0.12,1568119585

### DIFF
--- a/Casks/ibettercharge.rb
+++ b/Casks/ibettercharge.rb
@@ -1,6 +1,6 @@
 cask 'ibettercharge' do
-  version '1.0.11,1526399595'
-  sha256 '569052ef59312935d38ab48009bfdaf39b9d21e08316b2d5bd487d56bfb033b1'
+  version '1.0.12,1568119585'
+  sha256 '33de59c5a1157b23f9313348ef60e213200d007e2b16c4f53859ddcb4c66d696'
 
   # devmate.com/com.softorino.iBetterCharge was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.iBetterCharge/#{version.before_comma}/#{version.after_comma}/iBetterCharge-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.