### PR TITLE
Update krisp from 1.3.5 to 1.4.10

### DIFF
--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -1,6 +1,6 @@
 cask 'krisp' do
-  version '1.3.5'
-  sha256 'fb7bbd3fbf7c1e50102405a88996f82b788c2cb987922ad36bca4843c1004be3'
+  version '1.4.10'
+  sha256 '21103f0123982ab608fffe56e7124e80a80f58f718f635ae789981a7fda4ac79'
 
   url "https://cdn.krisp.ai/mac/release/v#{version.major}.#{version.minor}/krisp_#{version}.pkg"
   appcast 'https://krisp.ai/index.html'

--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -3,9 +3,9 @@ cask 'krisp' do
   sha256 '21103f0123982ab608fffe56e7124e80a80f58f718f635ae789981a7fda4ac79'
 
   url "https://cdn.krisp.ai/mac/release/v#{version.major}.#{version.minor}/krisp_#{version}.pkg"
-  appcast 'https://krisp.ai/index.html'
+  appcast 'https://krisp.ai/'
   name 'Krisp'
-  homepage 'https://krisp.ai/index.html'
+  homepage 'https://krisp.ai/'
 
   auto_updates true
   depends_on macos: '>= :sierra'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.