### PR TITLE
Update camunda-modeler from 3.3.2 to 3.3.4

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '3.3.2'
-  sha256 '47f10cadcda492519a92c03992597de4b1af5aeef14701ca7a95441591d1501e'
+  version '3.3.4'
+  sha256 '2e39e5986aa644b238be8da8af1b369279bc0952822c961d9c32e140ef99ec7b'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-mac.zip"
   appcast 'https://camunda.com/download/modeler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.