### PR TITLE
Update x-lite from 5.6.1_99140 to 5.7.0_100772

### DIFF
--- a/Casks/x-lite.rb
+++ b/Casks/x-lite.rb
@@ -1,6 +1,6 @@
 cask 'x-lite' do
-  version '5.6.1_99140'
-  sha256 'de59e5367222520dcd6482c7f75f2305d49c38a79f933e522e3b74197317ca7a'
+  version '5.7.0_100772'
+  sha256 'ef37feeadd35bd65d54718bfb1859d6cbe885eaa07b38dd820bc5c3c55888957'
 
   # counterpath.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://counterpath.s3.amazonaws.com/downloads/X-Lite_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.