### PR TITLE
Update sqlpro-for-sqlite from 2019.07.08 to 2019.09.09

### DIFF
--- a/Casks/sqlpro-for-sqlite.rb
+++ b/Casks/sqlpro-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-sqlite' do
-  version '2019.07.08'
-  sha256 '0ec69e6222eac4ce6642600d6331fb46e89f7686da5db3354fe9b97ca91ca010'
+  version '2019.09.09'
+  sha256 'e87c59b48ac267c1f4abb7195223a7e7166e513a364b70065625b8aa898508ba'
 
   # d3fwkemdw8spx3.cloudfront.net/sqlite was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/sqlite/SQLProSQLite.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.