### PR TITLE
Update krita from 4.2.5 to 4.2.6

### DIFF
--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -1,6 +1,6 @@
 cask 'krita' do
-  version '4.2.5'
-  sha256 '4967623a6e7430bb6751b4be367efd300f9a1685d985c0934a7b1b453cca308d'
+  version '4.2.6'
+  sha256 '77497f4d61338ecb7544817b5c2fcd0755e5efad1fcb7dedf0356f6aba229baa'
 
   # kde.org/stable/krita was verified as official when first introduced to the cask
   url "https://download.kde.org/stable/krita/#{version.major_minor_patch}/krita-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.