### PR TITLE
Update react-native-debugger (0.9.14)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,6 +1,6 @@
 cask 'react-native-debugger' do
-  version '0.9.13'
-  sha256 'eb1fb6ab6ad0af1ad7cfcb6beaa914f0fe180cb887d0d66da4fcac2ea575d3fd'
+  version '0.9.14'
+  sha256 '2682d4beb40dae35bf69222395f9a1600a4da4cd25119f1277e350c1f6206705'
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast 'https://github.com/jhen0409/react-native-debugger/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
