### PR TITLE
Update rekordbox from 5.6.0 to 5.6.1

### DIFF
--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -1,6 +1,6 @@
 cask 'rekordbox' do
-  version '5.6.0'
-  sha256 '1231d3ac99acce3a36f5f572fa21dbdfc75ef302c89a3f3a9c4c649d5faa3b8f'
+  version '5.6.1'
+  sha256 'aa3cce56b6e6661fe872d1d7b0acceae3f11435ab2071d85fa8849089f0ee454'
 
   url "https://rekordbox.com/_app/files/Install_rekordbox_#{version.dots_to_underscores}.pkg.zip"
   appcast 'https://rekordbox.com/en/support/releasenote.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.