### PR TITLE
Update lidarr from 0.6.2.883 to 0.7.0.1347

### DIFF
--- a/Casks/lidarr.rb
+++ b/Casks/lidarr.rb
@@ -1,9 +1,9 @@
 cask 'lidarr' do
-  version '0.6.2.883'
-  sha256 '7d207b86a8bcd1d1d95e2a3df8b27305f467206f6a464083a28395f981d98b1b'
+  version '0.7.0.1347'
+  sha256 '145acae87911e7d3fb58ba14f90a9fa8721b7ecd253696aa91b447c452830841'
 
   # github.com/lidarr/Lidarr was verified as official when first introduced to the cask
-  url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.develop.#{version}.osx-app.zip"
+  url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.master.#{version}.osx-app.zip"
   appcast 'https://github.com/lidarr/Lidarr/releases.atom'
   name 'Lidarr'
   homepage 'https://lidarr.audio/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.