### PR TITLE
Update flash-npapi from 32.0.0.238 to 32.0.0.255

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '32.0.0.238'
-  sha256 '7b1cdeca4ba17b59899aea540868216b6d1740bc4875c73d7328b57c3768c71f'
+  version '32.0.0.255'
+  sha256 '07448510e5789d9f55cc536f233b2600e79e7cc5c1925aa24975b075fcbcca8b'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.