### PR TITLE
Update popo from 3.0.2 to 3.0.3,6177

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
-  version '3.0.2'
-  sha256 '54e51319568c5208423ec7a11e73bcf40e4865c565ac029a1344edf39a7065b5'
+  version '3.0.3,6177'
+  sha256 '4267c77a0132ad0db0bda33cc571f7a1706f7f210f97a76003f249142ae7626e'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores.before_comma}.dmg"
   appcast 'http://popo.netease.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.