### PR TITLE
Add Engine Prime v1.3.1

### DIFF
--- a/Casks/engine-prime.rb
+++ b/Casks/engine-prime.rb
@@ -1,0 +1,15 @@
+cask 'engine-prime' do
+  version '1.3.1'
+  sha256 '626a9c4c3bc3f2e21f2e121d11739cd414442a1acb8d5c20c73621cf63e11f03'
+
+  # inmusicbrands.com was verified as official when first introduced to the cask
+  url "https://cdn.inmusicbrands.com/denondj/EnginePrime/Engine_Prime_#{version}_Setup.dmg"
+  name 'Engine Prime'
+  homepage 'https://www.denondj.com/engineprime'
+
+  pkg "Engine Prime_#{version}_Setup.pkg"
+
+  uninstall pkgutil: 'com.airmusictechnology.engineprime.application'
+
+  zap trash: '~/Music/Engine Library'
+end


### PR DESCRIPTION
Engine Prime is a management and DJ software to be used with Denon's Prime hardware series. It is equivalent to what Rekordbox is to Pioneer. The latter also has a cask in the stable repo.

The Prime Cask was already rejected for being a `walled build` here https://github.com/Homebrew/homebrew-cask/pull/46199

The situation changed in the meantime. There is no E-Mail address required to download the software anymore. Also the download page https://www.denondj.com/engine-prime now clarifies at the footer that Denon is a brand of the InMusic-group which contains the download URL.

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].
- [X] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
