### PR TITLE
Update gzdoom from 4.2.0 to 4.2.1

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,8 +1,9 @@
 cask 'gzdoom' do
-  version '4.2.0'
-  sha256 'b680a970935fcb5e809eb1f51c6df4ea5004a34f7ea97a2212198f1ac2cf92f2'
+  version '4.2.1'
+  sha256 '5d21570eed7bd05f269ca0c60dcbf1589cffad174e344aa1889a6a00a441a385'
 
-  url "https://zdoom.org/files/gzdoom/bin/gzdoom-bin-#{version.dots_to_hyphens}-macOS.dmg"
+  # github.com/coelckers/gzdoom was verified as official when first introduced to the cask
+  url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.dmg"
   appcast 'https://github.com/coelckers/gzdoom/releases.atom'
   name 'gzdoom'
   homepage 'https://zdoom.org/index'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.