### PR TITLE
Update visual-studio-code from 1.38.0 to 1.38.1

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code' do
-  version '1.38.0'
-  sha256 '7e4e08d715c46b35821ecbefa7bfe57bb4ed9d5aaba91cd3e82a83d4279832c6'
+  version '1.38.1'
+  sha256 '73e3181111ab143298935ca96db79a8e18154345bb58250ab25b0dbee1e069bd'
 
   url "https://update.code.visualstudio.com/#{version}/darwin/stable"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/stable/VERSION'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.