### PR TITLE
Update tunnelblick from 3.8.0,5370 to 3.8.1,5400

### DIFF
--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick' do
-  version '3.8.0,5370'
-  sha256 '4131ef7ab1b328e0efd62867cb4a35796fa22aaaa160ab478215f56197669925'
+  version '3.8.1,5400'
+  sha256 'a619a1c01a33a8618fc2489a43241e95c828dcdb7f7c56cfc883dcbb22644693'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.