### PR TITLE
Update electron-fiddle from 0.9.0 to 0.10.0

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.9.0'
-  sha256 '99d02565aaa435233d0df1d5b9c6faaa65ec444572ba092b04ff8ad6c556e13e'
+  version '0.10.0'
+  sha256 'aa0c14e437b5910dd46b88d9369f7d1eca8ddb400b218ea0ea80e327aeef91d4'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.