### PR TITLE
Update qownnotes from 19.9.7,b4524-170022 to 19.9.8,b4528-160811

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.7,b4524-170022'
-  sha256 '94768aa6a897a8c8fdfa553f42c934f476e669032a80643695d58e66a6cecbfb'
+  version '19.9.8,b4528-160811'
+  sha256 '421de96aa28602ff488958b9da3790339a42e2f0236a289608c71a1000876056'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.