### PR TITLE
Update compositor from 1.12.0 to 1.12.1

### DIFF
--- a/Casks/compositor.rb
+++ b/Casks/compositor.rb
@@ -1,6 +1,6 @@
 cask 'compositor' do
-  version '1.12.0'
-  sha256 '5e98cb97b63f3f670b521d537aa4922281c3ddae5d2ee419b00c192f0af7a157'
+  version '1.12.1'
+  sha256 '9ed45b72511cd56aa5a8d92b364d8f56040f9fba96d84a1f9ff08b1b1b124c44'
 
   url "https://compositorapp.com/updates/Compositor_#{version}.zip"
   appcast 'https://compositorapp.com/updates/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.