### PR TITLE
Update downie from 3.8.3,2055 to 3.8.4,2062

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.8.3,2055'
-  sha256 '22c6e19dce2a609745679bef92c1a90bc1b27b48c2e1a229d01b9df06379b374'
+  version '3.8.4,2062'
+  sha256 'a0b92c2a3b80ff3568acbe7b560a003514da2c29887f1d94fabc95cbb3b1188b'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.