### PR TITLE
Update rubitrack-pro from 5.2.7 to 5.2.8

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,6 +1,6 @@
 cask 'rubitrack-pro' do
-  version '5.2.7'
-  sha256 '066e403389cbe044d6619b844b169971b1db2c94c5055a361b01a3fb6ce87787'
+  version '5.2.8'
+  sha256 'c2ec857d9d5511342ac6dc07a87bad45de0142e42ef00e7fc1ac9c1d71485116'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.