### PR TITLE
Update pagico from 8.18.2405 to 8.18.2424

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -3,7 +3,8 @@ cask 'pagico' do
   sha256 'b3b1ac854bc5e4755c422cea05477ce3d81ab8faa52d03a65c6e60ba2f1ac5e8'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
-  appcast 'https://www.pagico.com/api/pagico8.mac.xml'
+  appcast "https://www.pagico.com/api/pagico#{version.major}.mac.xml",
+          configuration: version.patch
   name 'Pagico'
   homepage 'https://www.pagico.com/'
 

--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '8.18.2405'
-  sha256 'c21443cd5b27bf995d7054551eef3fc1ae74a4626e223434c7488d0dd576805a'
+  version '8.18.2424'
+  sha256 'b3b1ac854bc5e4755c422cea05477ce3d81ab8faa52d03a65c6e60ba2f1ac5e8'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast 'https://www.pagico.com/api/pagico8.mac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.