### PR TITLE
Update capture-one from 12.1.2 to 12.1.3

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
-  version '12.1.2'
-  sha256 '4eabc3996bea957eb95f384a748326653fb8446c4c3668f2eb6fcc96d1ae572e'
+  version '12.1.3'
+  sha256 '120174eeef6fcdc90d8d1cccdcd7b03203febb622b4743c3b5776e5698eb4333'
 
   url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.