### PR TITLE
Update stereo-tool from 9.34 to 9.35

### DIFF
--- a/Casks/stereo-tool.rb
+++ b/Casks/stereo-tool.rb
@@ -1,6 +1,6 @@
 cask 'stereo-tool' do
-  version '9.34'
-  sha256 '8b0c9044b39c29e26ce5c5f1d7d344290908cab107731992daaddd0a8f7c9b24'
+  version '9.35'
+  sha256 'db3e369592f07206d6a28903434787a03fd3195c36ccd2a14c38ed8d2d3396ff'
 
   url 'https://www.stereotool.com/download/ThimeoStereoTool-Installer.dmg'
   appcast 'https://www.stereotool.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.