### PR TITLE
Update blitz from 1.2.13 to 1.2.14

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.2.13'
-  sha256 'e915cba8e4ffbb901d12da4bd8167f51fec20573e66dacebe0fe52f507f7a718'
+  version '1.2.14'
+  sha256 '4ae45c395e2404950511e27f23739823ed6cf31c2e1d5aea35e8497baddddbb4'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.