### PR TITLE
Update microsoft-teams from 1.2.00.21868 to 1.2.00.22561

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -11,5 +11,8 @@ cask 'microsoft-teams' do
 
   pkg 'Teams_osx.pkg'
 
-  uninstall pkgutil: 'com.microsoft.teams'
+  uninstall pkgutil: [
+                       'com.microsoft.teams',
+                       'com.microsoft.teams.TeamsUpdaterDaemon',
+                     ]
 end

--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -11,8 +11,6 @@ cask 'microsoft-teams' do
 
   pkg 'Teams_osx.pkg'
 
-  uninstall pkgutil: [
-                       'com.microsoft.teams',
-                       'com.microsoft.teams.TeamsUpdaterDaemon',
-                     ]
+  uninstall pkgutil:   'com.microsoft.teams',
+            launchctl: 'com.microsoft.teams.TeamsUpdaterDaemon'
 end

--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-teams' do
-  version '1.2.00.21868'
-  sha256 '6b537e7f3e1c6cee298a738cb3c567675ad556e0dd8702032aec7fbe51399551'
+  version '1.2.00.22561'
+  sha256 'a64489e0fd96b488901ee811aaf171ff10bc9edaa92aabd517d86d75a95935cf'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.pkg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.