### PR TITLE
Update local from 3.3.0 to 5.0.4

### DIFF
--- a/Casks/local-by-flywheel.rb
+++ b/Casks/local-by-flywheel.rb
@@ -11,7 +11,7 @@ cask 'local-by-flywheel' do
 
   depends_on cask: 'virtualbox'
 
-  app 'Local by Flywheel.app'
+  app 'Local.app'
 
   zap trash: [
                '~/Library/Application Support/Local by Flywheel',

--- a/Casks/local-by-flywheel.rb
+++ b/Casks/local-by-flywheel.rb
@@ -1,9 +1,9 @@
 cask 'local-by-flywheel' do
-  version '3.3.0'
-  sha256 'cb3a53663481ce074245d688cfdf9f5cd3c52ac596f8b29ba5594b3527a3e0cd'
+  version '5.0.4'
+  sha256 'd5f16e54074f309b491e804b2f835dd93206f0b5acc5664a48393449d1d640df'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
-  url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-by-flywheel-#{version.dots_to_hyphens}-mac.zip"
+  url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-#{version.dots_to_hyphens}-mac.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://local-by-flywheel-flywheel.netdna-ssl.com/latest/mac',
           configuration: version.dots_to_hyphens
   name 'Local by Flywheel'

--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -1,4 +1,4 @@
-cask 'local-by-flywheel' do
+cask 'local' do
   version '5.0.4'
   sha256 'd5f16e54074f309b491e804b2f835dd93206f0b5acc5664a48393449d1d640df'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.