### PR TITLE
Update subsurface from 4.9.1 to 4.9.3

### DIFF
--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,6 +1,6 @@
 cask 'subsurface' do
-  version '4.9.1'
-  sha256 'c71bab895466d4c7baf7d58a158b60b53cc0488e9eab62ab4d4d74c92ab73db0'
+  version '4.9.3'
+  sha256 '00f6b59d75c6435f64045d0b452be9e61223592761a0d88c4f93c45330308fab'
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   appcast 'https://subsurface-divelog.org/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.