### PR TITLE
Update jameica from 2.8.4 to 2.8.5

### DIFF
--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -1,6 +1,6 @@
 cask 'jameica' do
-  version '2.8.4'
-  sha256 '7770468d9fb143958d19bb7c0570b3219b8f4b456de9bcaa2699b650fdc47e48'
+  version '2.8.5'
+  sha256 '398aa78e1c319ae774464e6674536c7b46c8f5b6db264a084a48247f3b49a6a3'
 
   url "https://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64-#{version}.zip"
   name 'Jameica'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.