### PR TITLE
Update smartgit from 19.1.2 to 19.1.3

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '19.1.2'
-  sha256 '06d03899892be79ab8cc965b775d88752f9676b3f135c2d33ce46cac40d07767'
+  version '19.1.3'
+  sha256 'd57b5ff33e35805aac05221a115ad1ffb89495909dab32cff82176ef59083c39'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.