### PR TITLE
Update Fsnotes shasum

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
   version '3.7.0'
-  sha256 '8707d678da485b49a64cd4e1e2311e68630a504d74aab104bb6c166d112ccf86'
+  sha256 'c60d68fe410b53ebe6bcf7f537faf8017149e3540b255da1178a3ae17306dacd'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
Reinstalling the application produced a checksum mismatch for me. Downloading from browser on 2 different networks gave me the same expected checksum. Updating it  here accordingly.