### PR TITLE
Update use-engine from 2.1.5 to 2.1.6

### DIFF
--- a/Casks/use-engine.rb
+++ b/Casks/use-engine.rb
@@ -1,6 +1,6 @@
 cask 'use-engine' do
-  version '2.1.5'
-  sha256 'a63ecd6007c937c34b7e4996004af29bc301475061c90ece186504e156633272'
+  version '2.1.6'
+  sha256 '7508037123d06a4f0e10c3c53a4e19aadb865e7351f61fe151433ea63994cebc'
 
   url "https://repository.use-together.com/stable/use-engine/macos/#{version.major}.x/#{version}/use-engine.dmg"
   name 'USE Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.