### PR TITLE
Update wireshark from 3.0.3 to 3.0.4

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,6 +1,6 @@
 cask 'wireshark' do
-  version '3.0.3'
-  sha256 '71d0196e7368715958598c8286f5219eb24fad08acf1cfe9186ef19d29e04ae9'
+  version '3.0.4'
+  sha256 '82e5d5ac1379488e7de40965d68c0f66f50a409ebf1f0b94386d40d8b4b88951'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.wireshark.org/download.html&splitter_1=stable&index_1=1&splitter_2=development&index_2=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.