### PR TITLE
Update lehreroffice from 2019.11.2 to 2019.11.3

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.11.2'
-  sha256 '569ad7b847241149408367bfc4cc0e252c68f818dbe19ba18f3aa4ea7b892c5e'
+  version '2019.11.3'
+  sha256 '19215c01022be8d66d46f259f0038921c514d0ea0faf52ba6ebbd23b5488bef0'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.