### PR TITLE
Update geotag-photos-pro from 1.2.1 to 1.3.0

### DIFF
--- a/Casks/geotag-photos-pro.rb
+++ b/Casks/geotag-photos-pro.rb
@@ -1,9 +1,9 @@
 cask 'geotag-photos-pro' do
-  version '1.2.1'
-  sha256 '6871192cafab3cb49db73f49456bea9a7cc7c4142fa8eaf47d7df703cafc7ffd'
+  version '1.3.0'
+  sha256 '4e26e5647d5ac55047b47072963d7d1368ccbf9548e0d21180741a459114f30d'
 
   # github.com/tappytaps was verified as official when first introduced to the cask
-  url "https://github.com/tappytaps/geotag-desktop-app/releases/download/v#{version}/geotag-#{version}-mac.zip"
+  url "https://github.com/tappytaps/geotag-desktop-app/releases/download/v#{version}/Geotag-Photos-Pro-2-#{version}-mac.zip"
   appcast 'https://github.com/tappytaps/geotag-desktop-app/releases.atom'
   name 'Geotag Photos Pro'
   homepage 'https://www.geotagphotos.net/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.