### PR TITLE
Update opera from 63.0.3368.75 to 63.0.3368.88

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '63.0.3368.75'
-  sha256 '592cad9d9d28df48386eb10946a64fb6b7cd381a7ca935e313335c450c87fd4d'
+  version '63.0.3368.88'
+  sha256 '2fcb3400ef0ced08ee10b3762ff6d9299fa3d51342a19d0722dce1dedeb5d8ea'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast 'https://ftp.opera.com/pub/opera/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.