### PR TITLE
Update minizincide from 2.3.1 to 2.3.2

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask 'minizincide' do
-  version '2.3.1'
-  sha256 '288ab1a0a04c6d3e7d37c6b95e80bc1604eb9ba3d57b33a0d12003c7f8f9999b'
+  version '2.3.2'
+  sha256 'e1970ccfdceb94ceaca86b964267c64f079b1518dc36787491068f9c3c724b76'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.