### PR TITLE
Update igdm from 2.7.0 to 2.7.1

### DIFF
--- a/Casks/igdm.rb
+++ b/Casks/igdm.rb
@@ -1,6 +1,6 @@
 cask 'igdm' do
-  version '2.7.0'
-  sha256 '11e740cfd6760e1389156eb5c57dd91f08adaccdbf592cda75a844a0d59df1ab'
+  version '2.7.1'
+  sha256 '7564f0f2b1e828a755b8fc998ff418dd32bd0b5d3be102c9ad4d39ef6106ff37'
 
   # github.com/ifedapoolarewaju/igdm was verified as official when first introduced to the cask
   url "https://github.com/ifedapoolarewaju/igdm/releases/download/v#{version}/IGdm-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.