### PR TITLE
Update polar-bookshelf from 1.32.0 to 1.32.14

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.32.0'
-  sha256 '59dddd06f5f0344f211e897a013c8f005128a8f8636e9f5fb3be0672ddd4893a'
+  version '1.32.14'
+  sha256 '49d4d710731ea43612a1ede2b85af87d1879f5bdc593c54cbc53dff740f637c3'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.