### PR TITLE
Update mudlet from 4.1.1 to 4.1.2

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '4.1.1'
-  sha256 '4abdc2af15530fcc1422b102f91bb006bc82b8e725ec3ae71abc241395e912a2'
+  version '4.1.2'
+  sha256 '469da0feffb98059f17b20f4fa37401914647d33c0d313d0f4b8d836cf754f5b'
 
   url "https://www.mudlet.org/wp-content/files/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.