### PR TITLE
Update invisor-lite from 3.11 to 3.13

### DIFF
--- a/Casks/invisor-lite.rb
+++ b/Casks/invisor-lite.rb
@@ -1,6 +1,6 @@
 cask 'invisor-lite' do
-  version '3.11'
-  sha256 'a888e73b403065d6fb6d4ed5d55b28a1fd931974de5e61fa02bf403ba1a83ec8'
+  version '3.13'
+  sha256 'c6ce3bd8bc12fed3c5b6805939387bf2633ddfd141d70c2e7ca0b8a98e7918c2'
 
   url "https://www.invisorapp.com/download/InvisorLite-#{version}.dmg"
   appcast 'https://www.invisorapp.com/appcast_lite.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.