### PR TITLE
Update vellum from 2.5.4 to 2.6.1

### DIFF
--- a/Casks/vellum.rb
+++ b/Casks/vellum.rb
@@ -1,6 +1,6 @@
 cask 'vellum' do
-  version '2.5.4'
-  sha256 'f3bb01d79733ac358bde54658f014e7decd94515dcb8a0f3247e061eaad5e544'
+  version '2.6.1'
+  sha256 'c204b34f7217eb306c7f7d4b32f94356350603cd4ae7602760b39a877ed95357'
 
   # 180g.s3.amazonaws.com/downloads was verified as official when first introduced to the cask
   url "https://180g.s3.amazonaws.com/downloads/Vellum-#{version.no_dots}00.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.