### PR TITLE
Update softorino-youtube-converter from 2.1.8,1567086906 to 2.1.9,1568242978

### DIFF
--- a/Casks/softorino-youtube-converter.rb
+++ b/Casks/softorino-youtube-converter.rb
@@ -1,6 +1,6 @@
 cask 'softorino-youtube-converter' do
-  version '2.1.8,1567086906'
-  sha256 '835fb5e344725dda12a9a9c2fe1c0cda442cdf84ebf85f063491b8e34fc4aed8'
+  version '2.1.9,1568242978'
+  sha256 'a3e900c41f76cf493a507280fcb48457a3dce5d91bc1e77a11e3c02ee0d4e374'
 
   # devmate.com/com.softorino.syc2 was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.syc2/#{version.before_comma}/#{version.after_comma}/SYC2-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.