### PR TITLE
Update banking-4 from 7.1.0,7192 to 7.1.0,7193

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,6 +1,6 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.1.0,7192'
+  version '7.1.0,7193'
   sha256 'c19ed18f5197f0160328018a45209c0f0ea1c4e20aed4046cb545110cde64542'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.