### PR TITLE
Update find-empty-folders from 1.2 to 1.2.1

### DIFF
--- a/Casks/find-empty-folders.rb
+++ b/Casks/find-empty-folders.rb
@@ -1,6 +1,6 @@
 cask 'find-empty-folders' do
-  version '1.2'
-  sha256 '7b397f4c4e3bf26a90fdf1233b7ceef64e43899911bb2ae2ee33ffbd75acf9b1'
+  version '1.2.1'
+  sha256 '63033d326f44c7eda130e0a1ce54d4b5a7009a095afa4bd8b3d557d2c357cece'
 
   url 'https://files.tempel.org/FindEmptyFolders/FindEmptyFolders.zip'
   appcast 'https://www.tempel.org/FindEmptyFolders'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.