### PR TITLE
Update qmapshack.rb: add versions from 1.12.0_2 to 1.13.2 (<10.13 + 10.14)), urls

### DIFF
--- a/Casks/qmapshack.rb
+++ b/Casks/qmapshack.rb
@@ -1,8 +1,16 @@
 cask 'qmapshack' do
-  version '1.12.0_2'
-  sha256 '560a601b17a6642617b3b3239a8e01d1cd4ba5decf998c552d56dd622446a769'
+  version '1.13.2'
 
-  url "https://bitbucket.org/maproom/qmapshack/downloads/QMapShack-MacOSX_#{version}.tar.gz"
+  if MacOS.version <= :high_sierra
+    sha256 'bb63f4d8873bc5b3754d7369bb617c0c2aeb6963cabb4cfd8d2564dd1b6f829b'
+
+    url "https://bitbucket.org/maproom/qmapshack/downloads/QMapShack_OSX.10.XX_#{version}.zip"
+  else
+    sha256 'e5bc99ab6cecf6ea5c3ee26e16695617f658ef12f391b684a37cd5e779674b7a'
+
+    url "https://bitbucket.org/maproom/qmapshack/downloads/QMapShack_OSX.10.14_#{version}.zip"
+  end
+
   appcast 'https://bitbucket.org/maproom/qmapshack/downloads/'
   name 'QMapShack'
   homepage 'https://bitbucket.org/maproom/qmapshack/wiki/Home'


### PR DESCRIPTION
the former download just contained the source code: 
https://bitbucket.org/maproom/qmapshack/downloads/