### PR TITLE
Update Arduino IDE to 1.8.10

### DIFF
--- a/Casks/arduino.rb
+++ b/Casks/arduino.rb
@@ -1,6 +1,6 @@
 cask 'arduino' do
-  version '1.8.9'
-  sha256 '7868dd8f6d350956b4d0c7e3d443f717209244a2dc3f374da115d5252a45bf56'
+  version '1.8.10'
+  sha256 '086faa08935a4d1056cdc6608feb0979abfbf1ec97775fa2b1809053615e5f65'
 
   url "https://downloads.arduino.cc/arduino-#{version}-macosx.zip"
   appcast 'https://github.com/arduino/Arduino/releases.atom'


### PR DESCRIPTION
This commit bumps Arduino Desktop IDE to 1.8.10.

Release notes: https://www.arduino.cc/en/Main/ReleaseNotes

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).