### PR TITLE
Update melodics from 2.1.3392 to 2.1.3393

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3392'
-  sha256 '170c0ac92cee21a6e352875bccc530632486d5f84b812ac9e36193e9bc2cef6b'
+  version '2.1.3393'
+  sha256 'cc22710aa29d5dc129d84b70d8ddc2030dc49ab60d4fa952456b6d12931111e4'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.