### PR TITLE
Update augur from 1.15.1 to 1.16.0

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.15.1'
-  sha256 '4c14d86a84085dcc792bbac8290afb5a0d2ab2236ce0595f18cea954919a391b'
+  version '1.16.0'
+  sha256 'dec23fbd3f78c9c07186e455e3fe860f89abf1ed54fb0397f2db4bbdb6a2f43e'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.