### PR TITLE
Update station from 1.48.1 to 1.49.0

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.48.1'
-  sha256 'be43fb9497756fdbc752df44fdb4fa6ada2d91e3ccf40f9f89ef055e5946fbbe'
+  version '1.49.0'
+  sha256 '059a4a347c5eab599196fa3a9e395cc65926db452e0a0a2c2d13bbeee9f079b2'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.