### PR TITLE
Update wasabi-wallet from 1.1.7 to 1.1.9

### DIFF
--- a/Casks/wasabi-wallet.rb
+++ b/Casks/wasabi-wallet.rb
@@ -1,6 +1,6 @@
 cask 'wasabi-wallet' do
-  version '1.1.7'
-  sha256 '2ec5131ebc97eace1d5d6e519980536d9467247586e0825388582f455e6203ea'
+  version '1.1.9'
+  sha256 '93659283419e19572425c84a558e80ef25b8ae6a1f66a74c232303289f6d37d4'
 
   # github.com/zkSNACKs/WalletWasabi was verified as official when first introduced to the cask
   url "https://github.com/zkSNACKs/WalletWasabi/releases/download/v#{version}/Wasabi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.