### PR TITLE
Update netnewswire from 5.0 to 5.0.1

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,6 +1,6 @@
 cask 'netnewswire' do
-  version '5.0'
-  sha256 'b917714d2d42f8517f17a2a5463dfc0ca6ae4990b57f175eb3bd8152891055ea'
+  version '5.0.1'
+  sha256 '2d52ba4bd191331d55d1b0e46f78c3cdde9e5e51279b05983fe4f1a22bb92e6c'
 
   # github.com/brentsimmons/NetNewsWire was verified as official when first introduced to the cask
   url "https://github.com/brentsimmons/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.