### PR TITLE
Update bonjeff from 1.0.7 to 1.0.8

### DIFF
--- a/Casks/bonjeff.rb
+++ b/Casks/bonjeff.rb
@@ -1,6 +1,6 @@
 cask 'bonjeff' do
-  version '1.0.7'
-  sha256 '74ce75d3d4119ded7e78850f168cd2921126de5164aa1fd5c9bc6964c959155c'
+  version '1.0.8'
+  sha256 'b352025d99a4eb0624ec15714aa30b434a98f6ec7bebcd040d3301ee7bb120cd'
 
   url "https://github.com/lapcat/Bonjeff/releases/download/v#{version}/Bonjeff.#{version}.zip"
   appcast 'https://github.com/lapcat/Bonjeff/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.