### PR TITLE
Update pingplotter from 5.11.3 to 5.11.5

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -1,6 +1,6 @@
 cask 'pingplotter' do
-  version '5.11.3'
-  sha256 '0b00c13301faaea9ae71d1fe3ac3c63090e29924eaa0333852337e1c8e0ec59a'
+  version '5.11.5'
+  sha256 '2458949db124965761b929302d2752f9e3605cf89241fd06a99c7c447ab61b01'
 
   url 'https://www.pingplotter.com/downloads/pingplotter_osx.zip'
   appcast 'https://www.pingplotter.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.