### PR TITLE
Update preform from 3.0.7,1424 to 3.1.0,1444

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.0.7,1424'
-  sha256 '11ec7f62da1f5510a361ba754f81985e35c52b2f0227ce6e36f3f602043e3de0'
+  version '3.1.0,1444'
+  sha256 '00cfeb1a3cd3810b2172d3b7a3d9f9e165e9a1b8845da8196996f3165ab65730'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.