### PR TITLE
Update qownnotes from 19.9.9,b4533-145617 to 19.9.10,b4537-081818

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.9,b4533-145617'
-  sha256 'eea4a6d374b1077b824675d09b712dbed568f2789ac4c45c7cc4043a15e32904'
+  version '19.9.10,b4537-081818'
+  sha256 '3ba0fdb67edd14501daf6e305bec8f9cfd381d20f9312bc9311eb0b8c1106b40'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.