### PR TITLE
Update plex from 1.2.0.875-b7362913 to 1.3.1.916-1cb2c34d

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask 'plex' do
-  version '1.2.0.875-b7362913'
-  sha256 '41fe0038c1990dded6677ff6517ac9189c07bc2b7dab731ba4ab144da1527efa'
+  version '1.3.1.916-1cb2c34d'
+  sha256 'f43f89b758a4531c350c5ca20b8e76512630e0090d0a6754e2c09acf98093416'
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.dmg"
   appcast 'https://plex.tv/api/downloads/6.json'

--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -2,7 +2,7 @@ cask 'plex' do
   version '1.3.1.916-1cb2c34d'
   sha256 'f43f89b758a4531c350c5ca20b8e76512630e0090d0a6754e2c09acf98093416'
 
-  url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.dmg"
+  url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/6.json'
   name 'Plex'
   homepage 'https://www.plex.tv/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.