### PR TITLE
Update cctalk from 7.5.6.4 to 7.5.7-926

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -3,7 +3,7 @@ cask 'cctalk' do
   sha256 'a70f9f3e5ef8bb22d5ac3dcb87790f435ef35edbf708a9fb41ab0bb90a719ccd'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "http://cc.hjfile.cn/cc/CCtalk.#{version}/8/1/103/CCtalk.#{version}.dmg"
+  url "https://cc.hjfile.cn/cc/CCtalk.#{version}/8/1/103/CCtalk.#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=http://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask 'cctalk' do
-  version '7.5.6.4'
-  sha256 'e5648d376261608cee5d672346ea48e7e9055fd314c208816969f264ff3d49b9'
+  version '7.5.7-926'
+  sha256 'a70f9f3e5ef8bb22d5ac3dcb87790f435ef35edbf708a9fb41ab0bb90a719ccd'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
+  url "http://cc.hjfile.cn/cc/CCtalk.#{version}/8/1/103/CCtalk.#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=http://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.