### PR TITLE
Update rcloneosx from 1.9.0 to 1.9.2

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask 'rcloneosx' do
-  version '1.9.0'
-  sha256 'bf1bf2676872ceeba7652176eb7ab6e16eb93b11e224889b939a3fa552b27083'
+  version '1.9.2'
+  sha256 '27f5b93fcd66451410d835373eec700b062917d2559aa6b37a692abab0d4ff6c'
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/RcloneOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.