### PR TITLE
Update sameboy from 0.12.1 to 0.12.2

### DIFF
--- a/Casks/sameboy.rb
+++ b/Casks/sameboy.rb
@@ -1,6 +1,6 @@
 cask 'sameboy' do
-  version '0.12.1'
-  sha256 'e4c9584ab227a5d07b26ace73cbe6ff369ddc7f16b9b78757834d874c3a5fc2c'
+  version '0.12.2'
+  sha256 'ff366d729fe4c18fefa03edd8936f8146075ac3ee5b5a0a71e5d8e8b753a43b3'
 
   # github.com/LIJI32/SameBoy was verified as official when first introduced to the cask
   url "https://github.com/LIJI32/SameBoy/releases/download/v#{version}/sameboy_cocoa_v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.