### PR TITLE
Update hook from 2696,1567841179 to 2705,1568408692

### DIFF
--- a/Casks/hook.rb
+++ b/Casks/hook.rb
@@ -1,6 +1,6 @@
 cask 'hook' do
-  version '2696,1567841179'
-  sha256 'c893d4e9b308e37891739e0bef3ba81286b02c3aee18b13399b72d0858367173'
+  version '2705,1568408692'
+  sha256 '18b819e0fd00c898ddfc62c45b7c9c44ba41b4830275421a9a72c428cbb7b9bf'
 
   # dl.devmate.com/com.cogsciapps.hook was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.cogsciapps.hook/#{version.before_comma}/#{version.after_comma}/Hook-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.