### PR TITLE
Update diskcatalogmaker from 7.5.4 to 7.5.5

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.5.4'
-  sha256 '9e8a48136b7ec8a63bf298c6e1b811f4ab6aba269a5099e40dbffcbe2be47130'
+  version '7.5.5'
+  sha256 '8c29273038682cb67e25217b996510827388aefbbe5d1d4d3420b7b74e326c7d'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.