### PR TITLE
Update smooze from 1.7.6 to 1.7.7

### DIFF
--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -1,6 +1,6 @@
 cask 'smooze' do
-  version '1.7.6'
-  sha256 '5e485dd2667a58d60d726cb14c146ef9beadfc6d91b54123359c3ac5b5f3fcda'
+  version '1.7.7'
+  sha256 '85575fe31bc0d301ff16208931ac2cbfa4dc67f818f5ba0d40e332f6d8782036'
 
   url 'https://smooze.co/updates/Smooze.dmg'
   appcast 'https://smooze.co/updates/update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.