### PR TITLE
Update exodus from 19.8.30 to 19.9.12

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.8.30'
-  sha256 '4a2b89845fd4ef5d4833966a434c5906683b475d06939a7398915bc946a9d3ff'
+  version '19.9.12'
+  sha256 '5b4961b344f45463ace48c1e1305fcca9f45f922fb26db7a55c17655916e1325'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.