### PR TITLE
Update thebrain from 10.0.53.0 to 10.0.56.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,6 +1,6 @@
 cask 'thebrain' do
-  version '10.0.53.0'
-  sha256 '1e1f71eaa5c3d1eb1635e3ee0f62f9787e668c0aa41dfa6f975176c7dcd0a706'
+  version '10.0.56.0'
+  sha256 'f02a1287ff1aaf99635089d894a6d7380306478d3767c47b354572dcbf3cba8b'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.