### PR TITLE
Update psi-plus from 1.4.873-macOS10.12 to 1.4.877-macOS10.12

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.873-macOS10.12'
-  sha256 'f29ce6f952ca9c41034d4c76e01fe16c17a355ba29b75034962195742710e9d8'
+  version '1.4.877-macOS10.12'
+  sha256 '37611e4a6f3f2952c5d19f57904009f80e28c321b2db8248313fc29623ba6131'
 
   # downloads.sourceforge.net/psiplus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.