### PR TITLE
Update unity from 2019.2.4f1,c63b2af89a85 to 2019.2.5f1,9dace1eed4cc

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.4f1,c63b2af89a85'
-  sha256 'ef30a49e32e807e47120d1b78a31ff73e678fb2ece4ab5ca0cf9d97d9e61509d'
+  version '2019.2.5f1,9dace1eed4cc'
+  sha256 '28a791b6778af8708fb6396af52e81606241be05b10aeb285e56bf08e9756ef2'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.