### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.3f1,8e55c27a4621 to 2019.2.5f1,9dace1eed4cc

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.4f1,c63b2af89a85'
-  sha256 '9885cd840757b23594b19f7dc36123a1ed88b57f770c2054110afed93921882a'
+  version '2019.2.5f1,9dace1eed4cc'
+  sha256 '7e03a987738d0d76e85835982b4d32f73d35eeb249fca62eb0cb3e31f3093493'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.3f1,8e55c27a4621'
-  sha256 '64aa48c7f8a06a06c787507f9018d138854daf1c27aac61412847f9a519a215b'
+  version '2019.2.5f1,9dace1eed4cc'
+  sha256 '0f0304d4774212951a01fadecf68ba6b3815ebb6d69e80ae3c2c7cae877deb1e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.