### PR TITLE
Update jollysfastvnc from 1.54 to 1.56

### DIFF
--- a/Casks/jollysfastvnc.rb
+++ b/Casks/jollysfastvnc.rb
@@ -1,9 +1,9 @@
 cask 'jollysfastvnc' do
-  version '1.54'
-  sha256 '2d205f98db9afaef25e591166a82aab84263df9def3214eea53af423f43e8017'
+  version '1.56'
+  sha256 '4ff7a8d187316ee36188de89c7198d942fafe6a1d8f88b6452b331d494c6a190'
 
   url 'https://www.jinx.de/JollysFastVNC_files/JollysFastVNC.current.dmg'
-  appcast 'https://www.jinx.de/JollysFastVNC.update.11.i386.xml'
+  appcast 'https://www.jinx.de/JollysFastVNC.update.12.x86_64.xml'
   name 'JollysFastVNC'
   homepage 'https://www.jinx.de/JollysFastVNC.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.