### PR TITLE
Update paintbrush from 2.4.2 to 2.5.0

### DIFF
--- a/Casks/paintbrush.rb
+++ b/Casks/paintbrush.rb
@@ -1,6 +1,6 @@
 cask 'paintbrush' do
-  version '2.4.2'
-  sha256 'ee1e3175870f9c4271706e646d9a5312d6e098c22dbdc40d32525f9915706eec'
+  version '2.5.0'
+  sha256 'fca1d23f6da1ff1fe6768ba67cd692362cbf86ad9adf72431514740a37c513b6'
 
   # downloads.sourceforge.net/paintbrush was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/paintbrush/Paintbrush%202.x/Paintbrush%20#{version}/Paintbrush-#{version}.zip"

--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.4f1,c63b2af89a85'
-  sha256 '9885cd840757b23594b19f7dc36123a1ed88b57f770c2054110afed93921882a'
+  version '2019.2.5f1,9dace1eed4cc'
+  sha256 '7e03a987738d0d76e85835982b4d32f73d35eeb249fca62eb0cb3e31f3093493'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.