### PR TITLE
Update webtorrent from 0.20.0 to 0.21.0

### DIFF
--- a/Casks/webtorrent.rb
+++ b/Casks/webtorrent.rb
@@ -1,6 +1,6 @@
 cask 'webtorrent' do
-  version '0.20.0'
-  sha256 '80b0c58632139e7e537d1a2ee2bbf26e6b65f1e9abde3a5ad7a5a073c3c8f228'
+  version '0.21.0'
+  sha256 'caa0be97dadae10fa2ea45f33e2707bcf203893935dbbd835eed4a7103cca448'
 
   # github.com/webtorrent/webtorrent-desktop was verified as official when first introduced to the cask
   url "https://github.com/webtorrent/webtorrent-desktop/releases/download/v#{version}/WebTorrent-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.