### PR TITLE
Update pro-motion-ng from 7.2.1 to 7.2.2

### DIFF
--- a/Casks/pro-motion-ng.rb
+++ b/Casks/pro-motion-ng.rb
@@ -1,6 +1,6 @@
 cask 'pro-motion-ng' do
-  version '7.2.1'
-  sha256 '6893524eaca881ec7833d460ddefc227c78e6274a968194d405ca97095c07acd'
+  version '7.2.2'
+  sha256 '19945a13e275234a459e32b18b1e7a17abf172f3584d7d07d109e2f05d7e226b'
 
   url 'https://www.cosmigo.com/wp-content/uploads/pro-motion-ng-mac-os.zip'
   appcast 'https://www.cosmigo.com/pixel_animation_software/downloads/mac_linux_downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.