### PR TITLE
Update iterm2 from 3.3.3 to 3.3.4

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,7 +1,7 @@
 cask 'iterm2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.3'
-  sha256 'be7ee93b73e759a7e14dd5587826c4703df2e0f86df0c7015f5a7e98318abcd9'
+  version '3.3.4'
+  sha256 'c053efa721ab0f6311144d2e3f06ffd88cafb2cd23132cdd7929c12610b3ddf9'
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/final.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.