### PR TITLE
Fix Tiles 1.0.1 organization name and homepage

### DIFF
--- a/Casks/tiles.rb
+++ b/Casks/tiles.rb
@@ -2,12 +2,11 @@ cask 'tiles' do
   version '1.0.1,20190430233520'
   sha256 '65e630a26c74f49a879a13317aa7b874788dd14216feb677d9e578e4e45ef77a'
 
-  # updates.sempliva.com/tiles was verified as official when first introduced to the cask
   url "https://updates.sempliva.com/tiles/Tiles-#{version.after_comma}.dmg"
   appcast 'https://updates.sempliva.com/tiles/updates.xml',
           configuration: version.after_comma
-  name 'FreeMacSoft Tiles'
-  homepage 'https://freemacsoft.net/tiles/'
+  name 'Sempliva Tiles'
+  homepage 'https://www.sempliva.com/tiles/'
 
   app 'Tiles.app'
 


### PR DESCRIPTION
Minor fix to reflect the correct name of the development organization behind Tiles; no version change.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).