### PR TITLE
Update magicavoxel from 0.99.4.1 to 0.99.4.2

### DIFF
--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,6 +1,6 @@
 cask 'magicavoxel' do
   version '0.99.4.2'
-  sha256 '24a83440e7f71fa52d548d45195f2fa060d754c624bfff518dbd595ac7868de4'
+  sha256 '953ba9242c431eb9c4160accdcf70e8aa8c8609da037bef69248e5372caad7b8'
 
   # github.com/ephtracy/ephtracy.github.io was verified as official when first introduced to the cask
   url "https://github.com/ephtracy/ephtracy.github.io/releases/download/#{version.major_minor_patch}/MagicaVoxel-#{version}-alpha-macos.zip"

--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -4,7 +4,8 @@ cask 'magicavoxel' do
 
   # github.com/ephtracy/ephtracy.github.io was verified as official when first introduced to the cask
   url "https://github.com/ephtracy/ephtracy.github.io/releases/download/#{version.major_minor_patch}/MagicaVoxel-#{version}-alpha-macos.zip"
-  appcast 'https://github.com/ephtracy/ephtracy.github.io/releases.atom'
+  appcast 'https://github.com/ephtracy/ephtracy.github.io/releases.atom',
+          configuration: version.major_minor_patch
   name 'MagicaVoxel'
   homepage 'https://ephtracy.github.io/'
 

--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,6 +1,6 @@
 cask 'magicavoxel' do
   version '0.99.4.2'
-  sha256 '953ba9242c431eb9c4160accdcf70e8aa8c8609da037bef69248e5372caad7b8'
+  sha256 '2ee6e63c45b4e3d7a99b185d48bb9c2b8e8140e88d106c1d86303243379c2729'
 
   # github.com/ephtracy/ephtracy.github.io was verified as official when first introduced to the cask
   url "https://github.com/ephtracy/ephtracy.github.io/releases/download/#{version.major_minor_patch}/MagicaVoxel-#{version}-alpha-macos.zip"

--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -1,6 +1,6 @@
 cask 'magicavoxel' do
-  version '0.99.4.1'
-  sha256 'da875b367cb4a9808fcaf906d3c39321c3715b302c5c2c438571698ed1d66238'
+  version '0.99.4.2'
+  sha256 '24a83440e7f71fa52d548d45195f2fa060d754c624bfff518dbd595ac7868de4'
 
   # github.com/ephtracy/ephtracy.github.io was verified as official when first introduced to the cask
   url "https://github.com/ephtracy/ephtracy.github.io/releases/download/#{version.major_minor_patch}/MagicaVoxel-#{version}-alpha-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.