### PR TITLE
Update qiyimedia from 20190818,5.12.8 to 20190912,5.13.11

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '20190818,5.12.8'
-  sha256 'd2fc916c7836aa10d36a9cd3469d266105bf14eafe6c5428e858f6c5e6f87f8b'
+  version '20190912,5.13.11'
+  sha256 'ac546972d444c41403f709a11286bde2e32a1a55734ba79e5d16b844b2f8e988'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'

--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.4f1,c63b2af89a85'
-  sha256 '9885cd840757b23594b19f7dc36123a1ed88b57f770c2054110afed93921882a'
+  version '2019.2.5f1,9dace1eed4cc'
+  sha256 '7e03a987738d0d76e85835982b4d32f73d35eeb249fca62eb0cb3e31f3093493'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.