### PR TITLE
Update qiyimedia from 20190818,5.12.8 to 20190912,5.13.11

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '20190818,5.12.8'
-  sha256 'd2fc916c7836aa10d36a9cd3469d266105bf14eafe6c5428e858f6c5e6f87f8b'
+  version '20190912,5.13.11'
+  sha256 'ac546972d444c41403f709a11286bde2e32a1a55734ba79e5d16b844b2f8e988'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.