### PR TITLE
Update docker from 2.1.0.2,37877 to 2.1.0.3,38240

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -3,8 +3,8 @@ cask 'docker' do
     version '18.06.1-ce-mac73,26764'
     sha256 '3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5'
   else
-    version '2.1.0.2,37877'
-    sha256 '39f26d00020f981dd0b254254328fe28f8aac309cf0556170a053f142c44bec3'
+    version '2.1.0.3,38240'
+    sha256 '01718c3b468e6d4c9703407d5b7291485bee57a72d37babdbf2e304f75fe8685'
   end
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.