### PR TITLE
Update bisq from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '1.1.5'
-  sha256 '564e644f91e886be92fc739906c8909e271453c67f43ab9b2fda15470e9aee69'
+  version '1.1.6'
+  sha256 '5d52b4cfc1c59cc31e132c234d493c563d6f2e3fa3123d0b89b8239107106474'
 
   # github.com/bisq-network/bisq was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.