### PR TITLE
Update jollysfastvnc from 1.56 to 1.58

### DIFF
--- a/Casks/jollysfastvnc.rb
+++ b/Casks/jollysfastvnc.rb
@@ -1,6 +1,6 @@
 cask 'jollysfastvnc' do
-  version '1.56'
-  sha256 '4ff7a8d187316ee36188de89c7198d942fafe6a1d8f88b6452b331d494c6a190'
+  version '1.58'
+  sha256 '6271124c7b127069a5892075fda914c86e6d82030ce6b5db766d9b5c83b70d9d'
 
   url 'https://www.jinx.de/JollysFastVNC_files/JollysFastVNC.current.dmg'
   appcast 'https://www.jinx.de/JollysFastVNC.update.12.x86_64.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.