### PR TITLE
Update vsee from 4.6.0,39485 to 4.6.1,39627

### DIFF
--- a/Casks/vsee.rb
+++ b/Casks/vsee.rb
@@ -1,6 +1,6 @@
 cask 'vsee' do
-  version '4.6.0,39485'
-  sha256 '357600d9db2a1f88bbe9bbcdce4c912c31521f464a276fc447e36e4c1810f4ee'
+  version '4.6.1,39627'
+  sha256 '6b0c7697bc107f9d020bdef52481a8f3da1028321712d697b5dcfb6756a4fbc8'
 
   # d2q5hugz2rti4w.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2q5hugz2rti4w.cloudfront.net/mac/#{version.after_comma}/vseemac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.