### PR TITLE
Update hubstaff from 1.4.10,1235 to 1.4.11,1268

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -7,5 +7,5 @@ cask 'hubstaff' do
   name 'Hubstaff'
   homepage 'https://hubstaff.com/'
 
-  app 'Hubstaff/Hubstaff.app'
+  app 'Hubstaff.app'
 end

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.4.11,1300'
-  sha256 '354f2fce95040c7397860d387e1ee244e51c246869bc83265992e63ab414394e'
+  version '1.4.11,1268'
+  sha256 '339096d23fe0a55efdf407eec717af8ecc583ef2f751b6761e682bcdbaf9c289'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -7,5 +7,5 @@ cask 'hubstaff' do
   name 'Hubstaff'
   homepage 'https://hubstaff.com/'
 
-  app 'Hubstaff.app'
+  app 'Hubstaff/Hubstaff.app'
 end

--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.4.10,1235'
-  sha256 'de6b22f850df6c8e306e78f12d289df6d0de5a1232a1d484f331e5290bd54b15'
+  version '1.4.11,1300'
+  sha256 '354f2fce95040c7397860d387e1ee244e51c246869bc83265992e63ab414394e'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.