### PR TITLE
Update datovka from 4.13.1 to 4.14.0

### DIFF
--- a/Casks/datovka.rb
+++ b/Casks/datovka.rb
@@ -1,6 +1,6 @@
 cask 'datovka' do
-  version '4.13.1'
-  sha256 '987b6be02b0565be2bc7b133be1cc96af33fec6a6e7a082a3688d2272f9fab95'
+  version '4.14.0'
+  sha256 '93c0cbe70c9f7f9ceab79e93d0a2e2e31a3dd4182ac5f4142fd7a103d51e9e1d'
 
   # secure.nic.cz/files/datove_schranky was verified as official when first introduced to the cask
   url "https://secure.nic.cz/files/datove_schranky/#{version}/datovka-#{version}-64bit-osx10.7.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.