### PR TITLE
Update feishu from 3.6.3 to 3.7.5

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,9 +1,9 @@
 cask 'feishu' do
-  version '3.6.3'
-  sha256 '8ea622f24938354ec95d79946b21b7f10c7bd36f7198b1290375631f6eaad537'
+  version '3.7.5'
+  sha256 '90824a2ec4e32f79a5c5f226c689a6845fce31ccfce831ea6a397a40dc5aeb63'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
-  url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu_#{version}.dmg"
+  url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu-#{version}.dmg"
   appcast 'https://www.feishu.cn/api/downloads'
   name 'feishu'
   homepage 'https://www.feishu.cn/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.