### PR TITLE
Update clone-hero from 0.22.4 to 0.22.5

### DIFF
--- a/Casks/clone-hero.rb
+++ b/Casks/clone-hero.rb
@@ -1,6 +1,6 @@
 cask 'clone-hero' do
-  version '0.22.4'
-  sha256 'e7aae8ad2b62f47d02ef92fb94d8064980e88e77b9061f58a29acb23b2899438'
+  version '0.22.5'
+  sha256 '2c2c4eaee17ff574e2b0f5349c34465950977fadada39ac378d370da6fb5b754'
 
   url "http://dl.clonehero.net/clonehero-v.#{version.minor_patch}/clonehero-mac.dmg"
   name 'Clone Hero'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.