### PR TITLE
Update jasper from 0.7.2 to 0.8.0

### DIFF
--- a/Casks/jasper.rb
+++ b/Casks/jasper.rb
@@ -1,6 +1,6 @@
 cask 'jasper' do
-  version '0.7.2'
-  sha256 'b1b323e11a7ecae5e43165f21fb3fbe9ac0ade151c701fecfa0152d0cb1e5031'
+  version '0.8.0'
+  sha256 '4c3c49b4b1b36f59c76fa810400e9f87b783a7d6eefe84cc4f20c9f3e2601110'
 
   # github.com/jasperapp/jasper was verified as official when first introduced to the cask
   url "https://github.com/jasperapp/jasper/releases/download/v#{version}/jasper_v#{version}_mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.