### PR TITLE
Update zeplin from 2.6,737 to 2.7,751

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.6,737'
-  sha256 'ada6f960bfa27bdac5090a5594122867586ff7dc5eab598197719de6b225f637'
+  version '2.7,751'
+  sha256 '6c243af7123e5b19de4be350cf41df2f27722baafd54a64402e81c3a43e6180a'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.