### PR TITLE
Update lehreroffice from 2019.11.3 to 2019.11.4

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.11.3'
-  sha256 '19215c01022be8d66d46f259f0038921c514d0ea0faf52ba6ebbd23b5488bef0'
+  version '2019.11.4'
+  sha256 '04c9709d6ee0679aa63d04972ce17ceb797760d9e285e541a4b96cc02850646e'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.