### PR TITLE
Update runway from 0.9.6 to 0.9.7

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.9.6'
-  sha256 '8fe3f22e0119f99b991e742148d7b3efdd2e4b0dfd0c0aaf722d6e06544e9970'
+  version '0.9.7'
+  sha256 'c2dd333e0e0189e7f8989736556c76e725eae0521dfc0809af012f35cd8c6560'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.