### PR TITLE
Update nomachine from 6.7.6_6 to 6.8.1_1

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '6.7.6_6'
-  sha256 '908ca2c602afcf17d3c0227bf711b2745946dba4d490be51aa95875529dd991d'
+  version '6.8.1_1'
+  sha256 '82ac992238afa52ec12182298bc3ac8e17cb5e0eddff6ed75d953cf9ea5df02b'
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   appcast 'https://www.nomachine.com/download/download&id=7'

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -12,7 +12,9 @@ cask 'nomachine' do
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
   uninstall delete:    '/Applications/NoMachine.app',
-            launchctl: 'com.nomachine.localnxserver',
-                       'com.nomachine.nxserver`,
-                       'com.nomachine.uninstall',
+            launchctl: [
+                         'com.nomachine.localnxserver',
+                         'com.nomachine.nxserver',
+                         'com.nomachine.uninstall',
+                       ]
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -11,10 +11,17 @@ cask 'nomachine' do
 
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
-  uninstall delete:    '/Applications/NoMachine.app',
+  uninstall pkgutil:   [
+                        'com.nomachine.nomachine.NoMachine-1.pkg',
+                        'com.nomachine.nomachine.NoMachine-2.pkg',
+                        'com.nomachine.nomachine.NoMachine-3.pkg',
+                        'com.nomachine.nomachine.NoMachine-4.pkg',
+                       ]
+            delete:    '/Applications/NoMachine.app',
             launchctl: [
                          'com.nomachine.localnxserver',
                          'com.nomachine.nxserver',
+                         'com.nomachine.server',
                          'com.nomachine.uninstall',
                        ]
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -12,5 +12,7 @@ cask 'nomachine' do
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
   uninstall delete:    '/Applications/NoMachine.app',
-            launchctl: 'com.nomachine.localnxserver'
+            launchctl: 'com.nomachine.localnxserver',
+                       'com.nomachine.nxserver`,
+                       'com.nomachine.uninstall',
 end

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -11,13 +11,13 @@ cask 'nomachine' do
 
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
-  uninstall pkgutil:   [
+  uninstall delete:    '/Applications/NoMachine.app',
+            pkgutil:   [
                          'com.nomachine.nomachine.NoMachine-1.pkg',
                          'com.nomachine.nomachine.NoMachine-2.pkg',
                          'com.nomachine.nomachine.NoMachine-3.pkg',
                          'com.nomachine.nomachine.NoMachine-4.pkg',
                        ],
-            delete:    '/Applications/NoMachine.app',
             launchctl: [
                          'com.nomachine.localnxserver',
                          'com.nomachine.nxserver',

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -12,11 +12,11 @@ cask 'nomachine' do
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
   uninstall pkgutil:   [
-                        'com.nomachine.nomachine.NoMachine-1.pkg',
-                        'com.nomachine.nomachine.NoMachine-2.pkg',
-                        'com.nomachine.nomachine.NoMachine-3.pkg',
-                        'com.nomachine.nomachine.NoMachine-4.pkg',
-                       ]
+                         'com.nomachine.nomachine.NoMachine-1.pkg',
+                         'com.nomachine.nomachine.NoMachine-2.pkg',
+                         'com.nomachine.nomachine.NoMachine-3.pkg',
+                         'com.nomachine.nomachine.NoMachine-4.pkg',
+                       ],
             delete:    '/Applications/NoMachine.app',
             launchctl: [
                          'com.nomachine.localnxserver',

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -12,12 +12,7 @@ cask 'nomachine' do
   # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
   uninstall delete:    '/Applications/NoMachine.app',
-            pkgutil:   [
-                         'com.nomachine.nomachine.NoMachine-1.pkg',
-                         'com.nomachine.nomachine.NoMachine-2.pkg',
-                         'com.nomachine.nomachine.NoMachine-3.pkg',
-                         'com.nomachine.nomachine.NoMachine-4.pkg',
-                       ],
+            pkgutil:   'com.nomachine.nomachine.NoMachine-*.pkg',
             launchctl: [
                          'com.nomachine.localnxserver',
                          'com.nomachine.nxserver',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.