### PR TITLE
Update banking-4 from 7.1.0,7195 to 7.1.0,7199

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.1.0,7195'
-  sha256 '0773e7456ba94f5bce7a3d7356da5ab55dd37e2cba0f235835cc02d202c538a6'
+  version '7.1.0,7199'
+  sha256 'b2277ef8d48f0381f8c427d513ffe6244ea1f8a9345fac27872e69253bfb3e29'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.