### PR TITLE
Update duet from 2.0.7.4 to 2.1.0.3

### DIFF
--- a/Casks/duet.rb
+++ b/Casks/duet.rb
@@ -1,10 +1,11 @@
 cask 'duet' do
-  version '2.0.7.4'
-  sha256 'ca18990ed9fc84f3b9e83fd8aad60c652974156e286686e2cc2b9edc1b33b964'
+  version '2.1.0.3'
+  sha256 '2fb86ff310a7977e87ad5f2d675ed45501c05c2e1925d4d448a2ca3c08ccee12'
 
   # duet.nyc3.cdn.digitaloceanspaces.com/Mac was verified as official when first introduced to the cask
   url "https://duet.nyc3.cdn.digitaloceanspaces.com/Mac/#{version.major_minor.dots_to_underscores}/duet-#{version.dots_to_hyphens}.zip"
-  appcast 'https://help.duetdisplay.com/updates'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://updates.duetdisplay.com/latestMac',
+          configuration: version.dots_to_hyphens
   name 'Duet'
   homepage 'https://www.duetdisplay.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.