### PR TITLE
Update busycontacts from 1.4.1,140101 to 1.4.1,140102

### DIFF
--- a/Casks/busycontacts.rb
+++ b/Casks/busycontacts.rb
@@ -1,6 +1,6 @@
 cask 'busycontacts' do
-  version '1.4.1,140101'
-  sha256 '05ded006794b1b6aaf0b08790f9789e9e94c97e1f18d3fdf873dfa76f8deb814'
+  version '1.4.1,140102'
+  sha256 'b649c1168f9b37413e86329bc2912c0504bffbb9f09641cb8c0762da3e2394f6'
 
   url 'https://www.busymac.com/download/BusyContacts.zip'
   appcast 'https://www.busymac.com/busycontacts/news.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.