### PR TITLE
Update qownnotes from 19.9.13,b4549-174751 to 19.9.14,b4553-154844

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.13,b4549-174751'
-  sha256 'bfbb9d74b596ca625ad108b026ce31bbd1f1c82e17e3c5c78decb1c0ab0cb5ae'
+  version '19.9.14,b4553-154844'
+  sha256 '369160d0fe3ad68af371e7e1eb40e1dbb6506454e937dd00d118660763daccc0'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.