### PR TITLE
Update navicat-for-sqlite from 12.1.24 to 12.1.25

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.24'
-  sha256 '6be55bca3cca358dc6d28ca94b3614b1e0fe6299afcbe7e1a26efd5c72548e7c'
+  version '12.1.25'
+  sha256 '305faa2677f032e5db07299bbe46542ed34af8bd5a67ca8849353523757d16df'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.