### PR TITLE
Update rotato from 73.1568717846 to 74.1568818382

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '73.1568717846'
-  sha256 'c74b75f7d07fe9da9da7c9d37db5491269d6f50378785cf7773ab1417319c1a8'
+  version '74.1568818382'
+  sha256 'af400b873724f40c5727f768de6c7889c19329b82beaed6e3f8812958ac93090'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.