### PR TITLE
Update ledger-live from 1.14.0 to 1.15.0

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.14.0'
-  sha256 '7e4cca707c1e0964005cb7862e7cb505a90793e4eb7e3a7be768bb0344745e47'
+  version '1.15.0'
+  sha256 '5feba1d89b4da67e229d5a6fd0e0e2b10a407d80c124aefbfba60d6ce7d3dc72'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.