### PR TITLE
Update ableton-live-suite from 10.1 to 10.1.1

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite' do
-  version '10.1'
-  sha256 '063583b61c5ccd925a241a37bd52bee7406d704f642880b883cd36de6a762d10'
+  version '10.1.1'
+  sha256 '9770ebe0f514339fbacd4de114f93a4fd978f26f388f9839162b38a304e74aae'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.