### PR TITLE
Update ableton-live from 10.1 to 10.1.1

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live' do
-  version '10.1'
-  sha256 '5c82141b8a1874d5703201ffa17a58d4d944987b21186ff0838c38890d3ca945'
+  version '10.1.1'
+  sha256 'bd3330b0872de294bf92bd852a02f2f66340b5419a7ef2e343bdeed2cf517534'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.