### PR TITLE
Update cisco-proximity from 3.0.5 to 3.0.6.1

### DIFF
--- a/Casks/cisco-proximity.rb
+++ b/Casks/cisco-proximity.rb
@@ -1,5 +1,5 @@
 cask 'cisco-proximity' do
-  version '3.0.5'
+  version '3.0.6.1'
   sha256 'f2d069a5455ca0a42f82f26f77c0c86e4903a00f0df57019074c43a224aaa003'
 
   url 'https://proximity.cisco.com/mac/Proximity.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.