### PR TITLE
Update tableau-prep from 2019.2.3 to 2019.3.1

### DIFF
--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -1,6 +1,6 @@
 cask 'tableau-prep' do
-  version '2019.2.3'
-  sha256 '8ca54ed7f822a66ebb8f90992b1842f01310b2e41ceae15c0f8bdbf4c04cb8c1'
+  version '2019.3.1'
+  sha256 'beede349e13496876a84f6620be5a2626ad222a826fb7e91b6d2de874ca9647d'
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/prep/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.