### PR TITLE
Update lehreroffice from 2019.11.4 to 2019.11.5

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.11.4'
-  sha256 '04c9709d6ee0679aa63d04972ce17ceb797760d9e285e541a4b96cc02850646e'
+  version '2019.11.5'
+  sha256 '8e567088eb5522ef8191959721f4f5437cad11ab8bd35421e1a9f99656a31bb6'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.