### PR TITLE
Update ghost-browser from 2.1.1.4 to 2.1.1.5

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.4'
-  sha256 '2d87039ff8228f4a6663dc1ef878592dbd72c197adea032031613a8cd2bce28d'
+  version '2.1.1.5'
+  sha256 '089cf6b6d46e7e430471a4cc007a7c4dc5dcc29a8ce90833fb15f1d0882e6f02'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.