### PR TITLE
Update fly from 5.4.1 to 5.5.1

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,6 +1,6 @@
 cask 'fly' do
-  version '5.4.1'
-  sha256 '12479a5830575e6c5b76f7dc3b9d064e1a9234671246a5a998a5dcd5cbad4c92'
+  version '5.5.1'
+  sha256 '1ea4bdc057270c9b58411c5750d65014b9931d541ca257f260676e25e55351d4'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/concourse/concourse/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


When running `brew cask audit` against the file locally, I don't have any issues. But when I try to point it to the raw file in my branch, `curl` generates a 416 response code.