### PR TITLE
Update iexplorer from 4.3.1,161 to 4.3.2,163

### DIFF
--- a/Casks/iexplorer.rb
+++ b/Casks/iexplorer.rb
@@ -1,6 +1,6 @@
 cask 'iexplorer' do
-  version '4.3.1,161'
-  sha256 'e336f66023a1fd2029d75c569057118243dada0575ecda82fe4b8d2c0f078b9a'
+  version '4.3.2,163'
+  sha256 '7a99708e63eb58357df10dea0cce6a8968e88e9babf1d13f37de84eeba8be90e'
 
   url "https://assets.macroplant.com/download/#{version.after_comma}/iExplorer-#{version.before_comma}.dmg"
   appcast "https://macroplant.com/iexplorer/mac/v#{version.major}/appcast"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.