### PR TITLE
Update inkscape.rb to remove X11 dependency

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,12 +1,10 @@
 cask 'inkscape' do
-  version '0.92.2-1'
-  sha256 'faece7a9a5fa9db7724b0c761f7f2014676d00ef8b90a0ef506fa39d09209fea'
+  version '1.0beta1'
+  sha256 '6939e99761009befa23a85b8f0d117c1df83934bb1d5fcb8084b4040e122aa66'
 
-  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
+  url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}.dmg"
   name 'Inkscape'
   homepage 'https://inkscape.org/'
-
-  depends_on x11: true
 
   app 'Inkscape.app'
   binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"


### PR DESCRIPTION
Updated the inkscape dmg to 1.0 beta 1 as it is native Mac OS X with updated GTK+.

This is the first Mac OS native inkscape application.