### PR TITLE
Updated inkscape.rb to remove X11 dependency

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,8 +1,8 @@
 cask 'inkscape' do
   version '1.0beta1'
-  sha256 '6939e99761009befa23a85b8f0d117c1df83934bb1d5fcb8084b4040e122aa66'
+  sha256 '68831989b3919e3137d5acfb130a844933706748addc8b4cd7f957348c1c60a3'
 
-  url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}.dmg"
+  url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}_OEMhoXK.dmg"
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -8,6 +8,5 @@ cask 'inkscape' do
 
   app 'Inkscape.app'
 
-  zap trash: '~/Library/Application Support/Inkscape',
-      rmdir: '~/Library/Application Support/Inkscape'
+  zap trash: '~/Library/Application Support/Inkscape'
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -8,7 +8,7 @@ cask 'inkscape' do
 
   app 'Inkscape.app'
 
-   zap trash: [
+  zap trash: [
                '~/Library/Application Support/Inkscape',
              ],
       rmdir: [

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,12 +1,10 @@
 cask 'inkscape' do
-  version '0.92.2-1'
-  sha256 'faece7a9a5fa9db7724b0c761f7f2014676d00ef8b90a0ef506fa39d09209fea'
+  version '1.0beta1'
+  sha256 '6939e99761009befa23a85b8f0d117c1df83934bb1d5fcb8084b4040e122aa66'
 
-  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
+  url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}.dmg"
   name 'Inkscape'
   homepage 'https://inkscape.org/'
-
-  depends_on x11: true
 
   app 'Inkscape.app'
   binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -8,10 +8,6 @@ cask 'inkscape' do
 
   app 'Inkscape.app'
 
-  zap trash: [
-               '~/Library/Application Support/Inkscape',
-             ],
-      rmdir: [
-               '~/Library/Application Support/Inkscape',
-             ]
+  zap trash: '~/Library/Application Support/Inkscape',
+      rmdir: '~/Library/Application Support/Inkscape'
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -7,7 +7,11 @@ cask 'inkscape' do
   homepage 'https://inkscape.org/'
 
   app 'Inkscape.app'
-  binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"
 
-  zap trash: '~/.inkscape-etc'
+   zap trash: [
+               '~/Library/Application Support/Inkscape',
+             ],
+      rmdir: [
+               '~/Library/Application Support/Inkscape',
+             ]
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,8 +1,18 @@
 cask 'inkscape' do
-  version '1.0beta1'
-  sha256 '68831989b3919e3137d5acfb130a844933706748addc8b4cd7f957348c1c60a3'
+  if MacOS.version <= :mavericks
+    version '0.92.2-1'
+    sha256 'faece7a9a5fa9db7724b0c761f7f2014676d00ef8b90a0ef506fa39d09209fea'
 
-  url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}_OEMhoXK.dmg"
+    url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
+
+    depends_on x11: true
+  else
+    version '1.0beta1'
+    sha256 '68831989b3919e3137d5acfb130a844933706748addc8b4cd7f957348c1c60a3'
+
+    url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}_OEMhoXK.dmg"
+  end
+
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -6,17 +6,21 @@ cask 'inkscape' do
     url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
 
     depends_on x11: true
+    
+    binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"
+    
+    zap trash: '~/.inkscape-etc'
   else
     version '1.0beta1'
     sha256 '68831989b3919e3137d5acfb130a844933706748addc8b4cd7f957348c1c60a3'
 
     url "https://inkscape.org/gallery/item/14919/Inkscape-#{version}_OEMhoXK.dmg"
+
+    zap trash: '~/Library/Application Support/Inkscape'
   end
 
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 
   app 'Inkscape.app'
-
-  zap trash: '~/Library/Application Support/Inkscape'
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -6,9 +6,9 @@ cask 'inkscape' do
     url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
 
     depends_on x11: true
-    
+
     binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"
-    
+
     zap trash: '~/.inkscape-etc'
   else
     version '1.0beta1'

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,5 +1,5 @@
 cask 'inkscape' do
-  if MacOS.version <= :mavericks
+  if MacOS.version <= :mojave
     version '0.92.2-1'
     sha256 'faece7a9a5fa9db7724b0c761f7f2014676d00ef8b90a0ef506fa39d09209fea'
 

--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,10 +1,10 @@
 cask 'scribus' do
-  version '1.5.5'
-  sha256 'dba7842bf3313c0a2c758a9d8613a7f881774008c10ea1e0445b34b020f6bbbe'
+  version '1.4.8'
+  sha256 '9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5'
 
   # sourceforge.net/scribus was verified as official when first introduced to the cask
-  url "https://sourceforge.net/projects/scribus/files/scribus-devel/#{version}/scribus-#{version}_1013.dmg/download"
-  appcast 'https://wiki.scribus.net/canvas/1.5.5_Release'
+  url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
+  appcast 'https://www.scribus.net/downloads/stable-branch/'
   name 'Scribus'
   homepage 'https://www.scribus.net/'
 

--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,10 +1,10 @@
 cask 'scribus' do
-  version '1.4.8'
-  sha256 '9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5'
+  version '1.5.5'
+  sha256 'dba7842bf3313c0a2c758a9d8613a7f881774008c10ea1e0445b34b020f6bbbe'
 
   # sourceforge.net/scribus was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
-  appcast 'https://www.scribus.net/downloads/stable-branch/'
+  url "https://sourceforge.net/projects/scribus/files/scribus-devel/#{version}/scribus-#{version}_1013.dmg/download"
+  appcast 'https://wiki.scribus.net/canvas/1.5.5_Release'
   name 'Scribus'
   homepage 'https://www.scribus.net/'
 


### PR DESCRIPTION
Inkscape just released 1.0 beta version 1 which is a native mac os x application and remove the need for xquartz.

Updated the cask to include 1.0 beta version.