### PR TITLE
Update lastfm from 2.1.37 to 2.1.39

### DIFF
--- a/Casks/lastfm.rb
+++ b/Casks/lastfm.rb
@@ -1,6 +1,6 @@
 cask 'lastfm' do
-  version '2.1.37'
-  sha256 'dc46e58111f8555fc0b1d6d2bd11e8fd4e4c45c6c7e953d106e07be8d6d8b448'
+  version '2.1.39'
+  sha256 '0b86111e68c3e54edd68e1a00a4390e3b13d10f6166161619cc8cadcfd053eba'
 
   url "https://cdn.last.fm/client/Mac/Last.fm-#{version}.zip"
   appcast 'https://cdn.last.fm/client/Mac/updates.xml'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[Notice](https://getsatisfaction.com/lastfm/topics/-mac-os-10-15-beta?topic-reply-list[settings][filter_by]=all&topic-reply-list[settings][reply_id]=20278421#reply_20278421) from lastfm staff of this latest version that introduces support for OS X Catalina