### PR TITLE
Update eclipse-ide from 4.12.0,2019-06:R to 4.13.0,2019-09:R

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.12.0,2019-06:R'
-  sha256 'c2f05fa10a6151f8f41cec3c028f4ec1bef7153cc86b46d06d0eacbdf14d1b5f'
+  version '4.13.0,2019-09:R'
+  sha256 '48b267bfb2ab2a57726f156b4f6692a5cb20d0b3e747696afe19aa04e708121a'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.