### PR TITLE
Update eclipse-javascript from 4.12.0,2019-06:R to 4.13.0,2019-09:R

### DIFF
--- a/Casks/eclipse-javascript.rb
+++ b/Casks/eclipse-javascript.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-javascript' do
-  version '4.12.0,2019-06:R'
-  sha256 'f33dd60bdb656b77c8e1bc521d85a70c9d61f01a6a1a655d36497e4398a60d2d'
+  version '4.13.0,2019-09:R'
+  sha256 '35d650642a557b740624409e7952ff9a7d39c85a401669dc1119d3b797cdec67'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-javascript-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for JavaScript and Web Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.