### PR TITLE
Update eclipse-jee from 4.12.0,2019-06:R to 4.13.0,2019-09:R

### DIFF
--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-jee' do
-  version '4.12.0,2019-06:R'
-  sha256 '3284e4790162a1e435a4c1204bbd5f8b6fe9fb8eaad6a77a19e660c70976be48'
+  version '4.13.0,2019-09:R'
+  sha256 'a00560e520107334f7dab0f9463a6687f66cc3e325fa75e439c2004d3dd382e5'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java EE Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.