### PR TITLE
Update eclipse-modeling from 4.12.0,2019-06:R to 4.13.0,2019-09:R

### DIFF
--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-modeling' do
-  version '4.12.0,2019-06:R'
-  sha256 '8b0c958a5b2e7d4e388341ca0dc8b0fbd72469a84f052d4a0f789aa0bc33b4ff'
+  version '4.13.0,2019-09:R'
+  sha256 '25de915772eb75f6aba6a18f785d2f086ad39d8793e11fb6c38e35ac026d7db4'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-modeling-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse Modeling Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.