### PR TITLE
Update eclipse-ptp from 4.12.0,2019-06:R to 4.13.0,2019-09:R

### DIFF
--- a/Casks/eclipse-ptp.rb
+++ b/Casks/eclipse-ptp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ptp' do
-  version '4.12.0,2019-06:R'
-  sha256 '09cc4c205fb7b292f2f4ca3980b2fd4fa3a98c3f069cbb37a3a422de75959582'
+  version '4.13.0,2019-09:R'
+  sha256 '5ae481d48490a2180a825a0ab689ebb7bbddc9d51c9e9ad0fbb95498ac4a6d14'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-parallel-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for Parallel Application Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.