### PR TITLE
Update eclipse-rcp from 4.12.0,2019-06:R to 4.13.0,2019-09:R

### DIFF
--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-rcp' do
-  version '4.12.0,2019-06:R'
-  sha256 '90a63d402d7422b886fda45962bee0824cfc529e9594d92f03a679219b492402'
+  version '4.13.0,2019-09:R'
+  sha256 'df92da792c8cf710724c1c6e642d51074a2e06b4fcd3230c10c22a5f7b485d5e'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-rcp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for RCP and RAP Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.