### PR TITLE
Update jumpcut from 0.70 to 0.71

### DIFF
--- a/Casks/jumpcut.rb
+++ b/Casks/jumpcut.rb
@@ -1,6 +1,6 @@
 cask 'jumpcut' do
-  version '0.70'
-  sha256 '976448c206dfe844b7e444482df6ea977b5456d6f92dc3cb9b30133dc4337432'
+  version '0.71'
+  sha256 '7446e74f195390e74336cd3e3a9ea6b865f1db12e173b7b8237ae75c7568d17a'
 
   # github.com/snark/jumpcut was verified as official when first introduced to the cask
   url "https://github.com/snark/jumpcut/releases/download/v#{version}/Jumpcut-#{version}.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.