### PR TITLE
Update qownnotes from 19.9.14,b4553-154844 to 19.9.15,b4557-160159

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.14,b4553-154844'
-  sha256 '369160d0fe3ad68af371e7e1eb40e1dbb6506454e937dd00d118660763daccc0'
+  version '19.9.15,b4557-160159'
+  sha256 '4da6d940bfb4eda0dbc2c26d180a5948c855a10df8a74f0d240dcf9ff781e5f0'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.