### PR TITLE
Update dynamic-dark-mode from 1.4.2 to 1.5.1

### DIFF
--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -1,6 +1,6 @@
 cask 'dynamic-dark-mode' do
-  version '1.4.2'
-  sha256 '76fb98e23627ecefc5d426320ff1a433fb06cf4d1e18fa7016e78766a2bd4321'
+  version '1.5.1'
+  sha256 '682da4fad8b3ed527b8efe281e1f7ab4f2c99307feabcfd7e125940a70a0f80a'
 
   url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.zip"
   appcast 'https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.