### PR TITLE
Update fission from 2.4.5 to 2.4.6

### DIFF
--- a/Casks/fission.rb
+++ b/Casks/fission.rb
@@ -1,6 +1,6 @@
 cask 'fission' do
-  version '2.4.5'
-  sha256 'c876f4e48ddbadbce9d60c56467f98eb592a5ae059647eb9f8172ba64e761eae'
+  version '2.4.6'
+  sha256 'b14384e4c322849d2078e18aac32dca05ac1b9844806ae6e90c3fb3fcff1868f'
 
   url 'https://rogueamoeba.com/fission/download/Fission.zip'
   appcast 'https://rogueamoeba.com/fission/releasenotes.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.