### PR TITLE
Update kite from 0.20190917.0 to 0.20190918.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190917.0'
-  sha256 'b6fd12d05182f212027a70a69e63c8da904164d27313873cdc3492c7fa6763b1'
+  version '0.20190918.0'
+  sha256 'addab224ec9396973f2de2cdcc505526c8bfc95b21499086decb53f61a328653'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.