### PR TITLE
Update mweb from 3.2.7 to 3.2.8

### DIFF
--- a/Casks/mweb.rb
+++ b/Casks/mweb.rb
@@ -1,6 +1,6 @@
 cask 'mweb' do
-  version '3.2.7'
-  sha256 '77f5f76b364a33c1668c5a83586c2d94ca97ac4ad2f29a104c89b51fecc05d4b'
+  version '3.2.8'
+  sha256 '85b68d521d0ec7ac76315acc92027233ec086422f57ee06aa9b78fa7c6ce5af0'
 
   # dl.devmate.com/com.coderforart.MWeb3 was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.coderforart.MWeb3/MWeb3-ProMarkdownwriting,notetakingandstaticbloggeneratorApp.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.