### PR TITLE
Update 4k-youtube-to-mp3 from 3.8.1.3052 to 3.8.2.3082

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.8.1.3052'
-  sha256 '407ced0ae8749bcce506062259dc59419edacc353f5624b82b0c68d573950a0c'
+  version '3.8.2.3082'
+  sha256 '0812a18e2971a6a02ed6eb9a184b84ab9ef1f25bb9dc9e040c060e289bddefc9'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.