### PR TITLE
Update local from 5.0.4 to 5.0.5

### DIFF
--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -1,6 +1,6 @@
 cask 'local' do
-  version '5.0.4'
-  sha256 'd5f16e54074f309b491e804b2f835dd93206f0b5acc5664a48393449d1d640df'
+  version '5.0.5'
+  sha256 '38e4c1720310a2ba2d1a6aedbc7dad46e3005382d9669804788d11a588c12d85'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-#{version.dots_to_hyphens}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.