### PR TITLE
Update electron from 6.0.9 to 6.0.10

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '6.0.9'
-  sha256 '635cb3a6915fde5e859ed5f4a0641051c1ffd690c468313f339d5654ecdab65a'
+  version '6.0.10'
+  sha256 'e5e1272e75592305d34a10e8cb2d898300f52fe62b0879d0816a87394dea4eb1'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.