### PR TITLE
Update origin from 10.5.46.29856 to 10.5.47.29954

### DIFF
--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -1,6 +1,6 @@
 cask 'origin' do
-  version '10.5.46.29856'
-  sha256 '9121f2d00524ffffb1e215f9d85be4eceb2b9e447201a0886023dbaf7ec11ee1'
+  version '10.5.47.29954'
+  sha256 'ea074b289ec02910dcc57e11ee7db94c49407b34b92ae072fd2a8a1e554f7591'
 
   # origin-a.akamaihd.net was verified as official when first introduced to the cask
   url "https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/OriginUpdate_#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.