### PR TITLE
Update dmm-player from 1.6.0.4 to 2.0.0

### DIFF
--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -9,7 +9,8 @@ cask 'dmm-player' do
   pkg "DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
 
   uninstall pkgutil: [
-                       'com.apple.ScriptEditor.id.DMMPlayer*',
-                       '3117044984.dmm.player.dmm.com',
+                       'com.dmm.dmmplayerv*',
+                       #'com.apple.ScriptEditor.id.DMMPlayer*',
+                       #'3117044984.dmm.player.dmm.com',
                      ]
 end

--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -8,9 +8,5 @@ cask 'dmm-player' do
 
   pkg "DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
 
-  uninstall pkgutil: [
-                       'com.dmm.dmmplayerv*',
-                       #'com.apple.ScriptEditor.id.DMMPlayer*',
-                       #'3117044984.dmm.player.dmm.com',
-                     ]
+  uninstall pkgutil: 'com.dmm.dmmplayerv*'
 end

--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -1,12 +1,12 @@
 cask 'dmm-player' do
-  version '1.6.0.4'
-  sha256 '177c5b190ce71d6fdff99a6cc78b14e3948bb606ad00dbedd8c02e07807b3d16'
+  version '2.0.0'
+  sha256 '5b5b472b670772c1d144c105bae5429ae85444d211cd02f83696449007ce198d'
 
-  url "http://portalapp.dmm.com/silverlightplayer/dmm/m/#{version.dots_to_underscores}/DMMPlayerInstaller_#{version.dots_to_underscores}.pkg"
+  url "http://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name 'DMM Player'
   homepage 'https://www.dmm.com/digital/howto_dmmplayer_html/'
 
-  pkg "DMMPlayerInstaller_#{version.dots_to_underscores}.pkg"
+  pkg "DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
 
   uninstall pkgutil: [
                        'com.apple.ScriptEditor.id.DMMPlayer*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.