### PR TITLE
Update menumeters from 1.9.7bis to 1.9.8

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,6 +1,6 @@
 cask 'menumeters' do
-  version '1.9.7bis'
-  sha256 '6cf2f7b312c1c13f74e9d56082f48b50b7ca5909ee3589df916a65818ac390d9'
+  version '1.9.8'
+  sha256 '7e034975be0d7eac033f0d4fcaf8725d435280411358d50a9828ce62f8bc1cca'
 
   # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
   url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version.major_minor_patch}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.