### PR TITLE
Update marvel from 8.4.2 to 8.4.3

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.4.2'
-  sha256 '869920c9eb156efef818906fbaaa4699ed27a4b461b2b9c35813b47f107a91d1'
+  version '8.4.3'
+  sha256 '90657ae9c28e6582a453239e5dd57618857c5d08b25ac5a8770c88d8eac82391'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.