### PR TITLE
Update daisydisk from 4.7.2.2 to 4.8

### DIFF
--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -4,8 +4,8 @@ cask 'daisydisk' do
     sha256 'fe2aa86f2ea8a1f0c4791857a5b7991ecad295b5b969849bb7b15a890ab54b86'
     url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version.dots_to_underscores}.zip"
   else
-    version '4.7.2.2'
-    sha256 'a0374474981ca4bbf836eb1f357d9ca3829149c52fc3b4a08367361160abaa8f'
+    version '4.8'
+    sha256 'f70cacb60dccf465219dc551086a0672d3db6b003c42302bdfff11319c08cd4a'
     url 'https://www.daisydiskapp.com/downloads/DaisyDisk.zip'
     appcast 'https://daisydiskapp.com/downloads/appcastReleaseNotes.php?appEdition=Standard&osVersion=10.13'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.