### PR TITLE
Update kite from 0.20190918.0 to 0.20190919.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190918.0'
-  sha256 'addab224ec9396973f2de2cdcc505526c8bfc95b21499086decb53f61a328653'
+  version '0.20190919.1'
+  sha256 '92f2efc81608c28f7696ec9e6e0984e06269498db79cac5039b386d178b4f16d'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.