### PR TITLE
Update mathtype from 7.4.2 to 7.4.3

### DIFF
--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,6 +1,6 @@
 cask 'mathtype' do
-  version '7.4.2'
-  sha256 'd2b2bfcd37f212edd1d7241d11ecc345cafe6adffcc2fc7a0e1565afb2759e89'
+  version '7.4.3'
+  sha256 '05efce437d1d00e40384e9ea744b24a4bc6a02983a6fd0216e8008a24d96caf2'
 
   url 'https://store.wiris.com/en/products/downloads/mathtype/installer/mac/en'
   appcast 'https://docs.wiris.com/en/mathtype/release_notes/start'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.