### PR TITLE
Update ibackup-viewer from 4.1540 to 4.1550

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1540'
-  sha256 '5f0ec5dcd1142421b2ed6bbb55ec05f25234cf3b28440ac9bd8d1b2de3739992'
+  version '4.1550'
+  sha256 'be6829766424a504eab239f6eeeae78b0594c126937ea25b356c7c57962c44ce'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.