### PR TITLE
Update subethaedit from 5.0.2 to 5.1

### DIFF
--- a/Casks/subethaedit.rb
+++ b/Casks/subethaedit.rb
@@ -1,6 +1,6 @@
 cask 'subethaedit' do
-  version '5.0.2'
-  sha256 '223e9616b8bb27cad84b9db18444035d086b6c6f20c616365c7fac79d47a6984'
+  version '5.1'
+  sha256 '0b41e835a64d358a159467c7c9fc14b50295e1973cb54cf4944b4ad561f1b1ec'
 
   url "https://subethaedit.net/Releases/SubEthaEdit-#{version}.zip"
   appcast 'https://subethaedit.net/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.