### PR TITLE
Update nosqlbooster-for-mongodb from 5.2.0 to 5.2.1

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.2.0'
-  sha256 '13902f919e7a5485e168e86d0523dba44bee7f918c90631c8015358bbb2533d1'
+  version '5.2.1'
+  sha256 '88c037a7b1f60d93435efb66e68df782b39007c7c108c06e3287bfe4fbf60d8f'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   appcast 'https://nosqlbooster.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.