### PR TITLE
Update adobe-dng-converter from 11.4 to 11.4.1

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -3,8 +3,8 @@ cask 'adobe-dng-converter' do
     version '9.6.1'
     sha256 '087eac5026667e4e6e3c156fd13243c9ea00f6c0238cbbb94d3099ae8772603f'
   else
-    version '11.4'
-    sha256 '76978e22a2c373bf90cf29fb9bbd252dec77fd6c80e26c27f65e40c758ea0e45'
+    version '11.4.1'
+    sha256 'f23b1576231962e0103107c0cbbbf88982d0d89b932e8400d4fc412c52704490'
   end
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.