### PR TITLE
Update springtoolsuite from 4.3.2.RELEASE,4.12.0 to 4.4.0.RELEASE,4.13.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask 'springtoolsuite' do
-  version '4.3.2.RELEASE,4.12.0'
-  sha256 '3e290dfad107538df739f6182d863498f7d528020aae1edb98ee344ac6249ce3'
+  version '4.4.0.RELEASE,4.13.0'
+  sha256 'f8ca0eaefabd3f1229f4a440094716b7df4f3ea78bdba19fb9c38e572939fecc'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.