### PR TITLE
Update nosql-workbench-for-amazon-dynamodb from 0.1.0 to 0.2.0

### DIFF
--- a/Casks/nosql-workbench-for-amazon-dynamodb.rb
+++ b/Casks/nosql-workbench-for-amazon-dynamodb.rb
@@ -1,6 +1,6 @@
 cask 'nosql-workbench-for-amazon-dynamodb' do
-  version '0.1.0'
-  sha256 '8f5879c748f9b99a09744e37bd4eab67fcdaf9ba0351bfd47496c3efb6e9b0b8'
+  version '0.2.0'
+  sha256 'a3300b4ac00f4f82ff0ea0114f3280c50eaa2e22aee602162c87989d605251b8'
 
   # nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com/NoSQL+Workbench+for+Amazon+DynamoDB+(Preview)-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.