### PR TITLE
Update texshop from 4.39 to 4.41

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,6 +1,6 @@
 cask 'texshop' do
-  version '4.39'
-  sha256 'afa2537aaa4880ae64d5753e4061c723530bba760e4567a664f9db52f9d58732'
+  version '4.41'
+  sha256 'c2cd51224f993c8a8ad3e45afa5ffea90af8a251554645bc4edfff8f992a6ef5'
 
   url "https://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast 'https://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.