### PR TITLE
Update coverload from 2.0.0-685 to 2.1.1-752

### DIFF
--- a/Casks/coverload.rb
+++ b/Casks/coverload.rb
@@ -1,6 +1,6 @@
 cask 'coverload' do
-  version '2.0.0-685'
-  sha256 '604461343b12f2bcda6ba18834d44981545d4b2935eef13cb0afbd70a6d2a465'
+  version '2.1.1-752'
+  sha256 'e6cee75fa95facfb3588d9435d7a92e492a2d7d8efc49a3f6aa302dda0f57aa2'
 
   # s3-us-west-2.amazonaws.com/coverloadapp.com was verified as official when first introduced to the cask
   url "https://s3-us-west-2.amazonaws.com/coverloadapp.com/Uploads/CoverLoad-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.