### PR TITLE
Update thedesk from 18.10.0 to 18.10.1

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.10.0'
-  sha256 'becaa2f493a99d88587b17fc4733800bf4c491aba61a2985d62366d7d9605437'
+  version '18.10.1'
+  sha256 'a648cf19736f29ea0d56882b1c32bbc594fa6e0641ca443088e2bdf1f7e5f652'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.