### PR TITLE
Update textbar from 3.2.96 to 3.2.182

### DIFF
--- a/Casks/textbar.rb
+++ b/Casks/textbar.rb
@@ -1,6 +1,6 @@
 cask 'textbar' do
-  version '3.2.96'
-  sha256 '38ef0e9729a2882ff8788ae0fcf92a017235b9895f86ec53892b04cbf8c46d92'
+  version '3.2.182'
+  sha256 '911e5a309b57df82872dae9c3ae0986a9618f1a69983166a8f8918843e4ade01'
 
   url "http://richsomerfield.com/apps/textbar/TextBar.app-#{version}.zip"
   appcast 'http://richsomerfield.com/apps/textbar/sparkle_textbar.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.