### PR TITLE
Update cacher from 2.19.0 to 2.19.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.19.0'
-  sha256 '21e9f452eddd8490e880ba2051f23557928c65a2a0bf1df742bfa8f372422b23'
+  version '2.19.1'
+  sha256 '5cb33f35c26303cf328d770c924e77e84f0797e690685c099548b830bfa2b908'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.