### PR TITLE
Update code42-crashplan from 7.0.0 to 7.2.0

### DIFF
--- a/Casks/code42-crashplan.rb
+++ b/Casks/code42-crashplan.rb
@@ -1,5 +1,5 @@
 cask 'code42-crashplan' do
-  version '7.0.2'
+  version '7.2.0'
   sha256 '365440a5a17c5cab80c291922133bbd961dc04bfe1659f612c5dc951562ed9af'
 
   # download.code42.com was verified as official when first introduced to the cask

--- a/Casks/code42-crashplan.rb
+++ b/Casks/code42-crashplan.rb
@@ -1,6 +1,6 @@
 cask 'code42-crashplan' do
-  version '7.0.0'
-  sha256 'a9de994edd0dc3bcc22564d91edbb153054b29a76904f2464ec9616d22d1c434'
+  version '7.0.2'
+  sha256 '365440a5a17c5cab80c291922133bbd961dc04bfe1659f612c5dc951562ed9af'
 
   # download.code42.com was verified as official when first introduced to the cask
   url "https://download.code42.com/installs/mac/install/Code42CrashPlan/Code42CrashPlan_#{version}_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.