### PR TITLE
Update unity from 2019.2.5f1,9dace1eed4cc to 2019.2.6f1,fe82a0e88406

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.5f1,9dace1eed4cc'
-  sha256 '28a791b6778af8708fb6396af52e81606241be05b10aeb285e56bf08e9756ef2'
+  version '2019.2.6f1,fe82a0e88406'
+  sha256 '96ec98f235ea32e73141b56c2dfe6d4f43551cd4657d55b019019c89a89637a9'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.