### PR TITLE
Update unity-ios-support-for-editor from 2019.2.5f1,9dace1eed4cc to 2019.2.6f1,fe82a0e88406

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.2.5f1,9dace1eed4cc'
-  sha256 'b528d585a8198130c775eff743b60df11534a9939814dede77d612a4532a8eec'
+  version '2019.2.6f1,fe82a0e88406'
+  sha256 '94a28ad8c8a400201373efd02e4b7af135eb500dbb8813678c7ea72036d64368'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.