### PR TITLE
Update unity-windows-support-for-editor from 2019.2.4f1,c63b2af89a85 to 2019.2.6f1,fe82a0e88406

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.4f1,c63b2af89a85'
-  sha256 'acc57f9d6322d1c73bf9437a9e76d23ce6f26eafb33e5e62e55de9af44b2ff76'
+  version '2019.2.6f1,fe82a0e88406'
+  sha256 '6785cc016c998f734e7a0d69fcef3b45c0b0f6799a978df4136bb1d400d36315'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.