### PR TITLE
Update rstudio from 1.2.1578 to 1.2.5001

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,6 +1,6 @@
 cask 'rstudio' do
-  version '1.2.1578'
-  sha256 '9874c0c932e71ab106fa95476403573c3dd6046a3c64b9c0084adc6201bb51c0'
+  version '1.2.5001'
+  sha256 '16bfd9dd348109422b9ff56231ec51d9d3fe18536554a0c75f5fdc10385dfa2a'
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.