### PR TITLE
Change version from 7.11.0 to 7.4.4 for mathtype.rb

### DIFF
--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,5 +1,5 @@
 cask 'mathtype' do
-  version '7.4.3'
+  version '7.4.4'
   sha256 '5c035a10ac85dd86981c3c3523a75388cbf5938ad7f52be4ec401eaabdc5fb31'
 
   url 'https://store.wiris.com/en/products/downloads/mathtype/installer/mac/en'

--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,6 +1,6 @@
 cask 'mathtype' do
   version '7.4.3'
-  sha256 '05efce437d1d00e40384e9ea744b24a4bc6a02983a6fd0216e8008a24d96caf2'
+  sha256 '5c035a10ac85dd86981c3c3523a75388cbf5938ad7f52be4ec401eaabdc5fb31'
 
   url 'https://store.wiris.com/en/products/downloads/mathtype/installer/mac/en'
   appcast 'https://docs.wiris.com/en/mathtype/release_notes/start'

--- a/Casks/mathtype.rb
+++ b/Casks/mathtype.rb
@@ -1,5 +1,5 @@
 cask 'mathtype' do
-  version '7.11.0'
+  version '7.4.3'
   sha256 '05efce437d1d00e40384e9ea744b24a4bc6a02983a6fd0216e8008a24d96caf2'
 
   url 'https://store.wiris.com/en/products/downloads/mathtype/installer/mac/en'


### PR DESCRIPTION
Sorry - I've messed this up: it's MathType Web that has version 7.11.0, 
MathType Desktop has version 7.4.4 
