### PR TITLE
Update physicseditor from 1.8.3 to 1.8.4

### DIFF
--- a/Casks/physicseditor.rb
+++ b/Casks/physicseditor.rb
@@ -1,6 +1,6 @@
 cask 'physicseditor' do
-  version '1.8.3'
-  sha256 '8c755faec5432b01940e9651c946d34860d3836b7f7fefba69e91e792d9a27cc'
+  version '1.8.4'
+  sha256 'f2cc85872eebe7bb6e9e0a4f2dbbc60c2fd0607144d1beeb7ca5a837b1c0b2f2'
 
   url "https://www.codeandweb.com/download/physicseditor/#{version}/PhysicsEditor-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/PhysicsEditor/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.