### PR TITLE
Update yourkit-java-profiler from 2019.8-b110 to 2019.8-b115

### DIFF
--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,6 +1,6 @@
 cask 'yourkit-java-profiler' do
-  version '2019.8-b110'
-  sha256 '29c91edef7a6fc6a004a80cedd2fb7f3d2d06199108d10630fd73c89aabb534b'
+  version '2019.8-b115'
+  sha256 '000a356a7991b8eacc06f2935a99066ac88ac984461f81a2658a4e469eebdfd6'
 
   url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version}.dmg"
   appcast 'https://www.yourkit.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.