### PR TITLE
Update geneious-prime from 2019.2.1 to 2019.2.3

### DIFF
--- a/Casks/geneious-prime.rb
+++ b/Casks/geneious-prime.rb
@@ -1,6 +1,6 @@
 cask 'geneious-prime' do
-  version '2019.2.1'
-  sha256 'c8c9690e6722be830705320bd2361686965cdc80db273d6eda8453ca751adb75'
+  version '2019.2.3'
+  sha256 'cd452e9c8ef668164f6fdeab869784bf6260fc9182d6b16acf2672cfc8e3fbef'
 
   url "https://assets.geneious.com/installers/geneious/release/Geneious_Prime_mac64_#{version.dots_to_underscores}_with_jre.dmg"
   appcast 'https://www.geneious.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.