### PR TITLE
Update brave-browser from 0.68.139 to 0.68.140

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.68.139'
-  sha256 '5e5466d4d52b165815c426a189d847f18b50cbb43b3bfaeb7775d7e8fc3d3e05'
+  version '0.68.140'
+  sha256 '0ac37b3721999859b406173caafb39272869dbc532b6396ee6f955a870f4479b'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.