### PR TITLE
Update timeular from latest to 2.3.1

### DIFF
--- a/Casks/timeular.rb
+++ b/Casks/timeular.rb
@@ -1,11 +1,14 @@
 cask 'timeular' do
-  version :latest
-  sha256 :no_check
+  version '2.3.1'
+  sha256 'e1c07868b397d1997853058aaecc6b5369b3c49cb33f03eaa06eb7104794093b'
 
   # timeular-desktop-packages.s3.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://timeular-desktop-packages.s3.amazonaws.com/mac/production/Timeular.dmg'
+  url "https://timeular-desktop-packages.s3.amazonaws.com/mac/production/Timeular-#{version}.dmg"
+  appcast 'https://timeular-desktop-packages.s3.amazonaws.com/mac/production/latest-mac.yml'
   name 'Timeular'
   homepage 'https://timeular.com/'
+
+  auto_updates true
 
   app 'Timeular.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.