### PR TITLE
Update fsnotes from 3.7.1 to 3.8.1

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '3.7.1'
-  sha256 'bb83d349a8e0c15cb5c5ffef72080667c5c35c16a7d0424dd43057078a2dd0f9'
+  version '3.8.1'
+  sha256 '7265e5ea92ce3f9c348b423a795f5b8d6521b7fad61d2ee7d3a1314fe86c2149'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.