### PR TITLE
Update lbry from 0.35.4 to 0.35.6

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.35.4'
-  sha256 '13a8ae4bed3c42f16acf610d4a640cd1874e315a169648c294df4db16b7c9ea9'
+  version '0.35.6'
+  sha256 '6e9d6824cfd5ee1ef683723320d5824d890585a76aeb9092f61fcabcc1ec582b'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.