### PR TITLE
Update dynamic-dark-mode from 1.5.1 to 1.5.2

### DIFF
--- a/Casks/dynamic-dark-mode.rb
+++ b/Casks/dynamic-dark-mode.rb
@@ -1,6 +1,6 @@
 cask 'dynamic-dark-mode' do
-  version '1.5.1'
-  sha256 '682da4fad8b3ed527b8efe281e1f7ab4f2c99307feabcfd7e125940a70a0f80a'
+  version '1.5.2'
+  sha256 '696d5d605b3c2b54d2485936eff59cd150116f82f584b76938bf80f252d8f194'
 
   url "https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases/download/#{version}/Dynamic_Dark_Mode-#{version}.zip"
   appcast 'https://github.com/ApolloZhu/Dynamic-Dark-Mode/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.