### PR TITLE
Update zeebe-modeler from 0.6.2 to 0.7.0

### DIFF
--- a/Casks/zeebe-modeler.rb
+++ b/Casks/zeebe-modeler.rb
@@ -1,6 +1,6 @@
 cask 'zeebe-modeler' do
-  version '0.6.2'
-  sha256 '04bfe8afd7595825451cc65929705d529afccf0deb85b2f5868bfa27564733ee'
+  version '0.7.0'
+  sha256 'a4080bac610ef5ead1789d7bd745f6f71e2f8d33aba1613eb493b37c5a3d992b'
 
   # github.com/zeebe-io/zeebe-modeler was verified as official when first introduced to the cask
   url "https://github.com/zeebe-io/zeebe-modeler/releases/download/v#{version}/zeebe-modeler-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.