### PR TITLE
Update reunion from 12.0.0.181218 to 12.0.0.190924

### DIFF
--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -5,7 +5,7 @@ cask 'reunion' do
   url "https://store.leisterpro.com/updates/reunion#{version.major}/Reunion-#{version.dots_to_hyphens}.zip"
   appcast "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml"
   name 'Reunion'
-  homepage 'http://www.leisterpro.com/'
+  homepage 'https://www.leisterpro.com/'
 
   app "Reunion #{version.major}.app"
 end

--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -1,6 +1,6 @@
 cask 'reunion' do
-  version '12.0.0.181218'
-  sha256 '6c4946169eb2f57d3726615265b29a6483ddfbccf19e610f832c5fadba8fd1e6'
+  version '12.0.0.190924'
+  sha256 '729de26b38a0f97990378795a4f372f70880dafa4864da91d7c7e018b88497bf'
 
   url "https://store.leisterpro.com/updates/reunion#{version.major}/Reunion-#{version.dots_to_hyphens}.zip"
   appcast "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.