### PR TITLE
Update toggl from 7.4.484 to 7.4.1012

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.484'
-  sha256 'a65926853104485ee545595ada8ea5bbd518489e97d97f7bdae04bde87090bfc'
+  version '7.4.1012'
+  sha256 '65ae18e69385131492ebd6746a218c31940e86428c08a7031b4486affd5c09a7'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.