### PR TITLE
Update context-free from 3.1 to 3.2

### DIFF
--- a/Casks/context-free.rb
+++ b/Casks/context-free.rb
@@ -1,6 +1,6 @@
 cask 'context-free' do
-  version '3.1'
-  sha256 '57e93777b37f14ad697964fd435a638ef17216503011ebf87b861958cd16ccc3'
+  version '3.2'
+  sha256 '506fc01ac271ee0e4157605201578aedb1ea81e82f1bd9c7fa240ca60cb1bee8'
 
   url "https://www.contextfreeart.org/download/ContextFree#{version}.dmg"
   appcast 'https://github.com/MtnViewJohn/context-free/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.