### PR TITLE
Update ridibooks from 2.7.2 to 2.7.3

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,6 +1,6 @@
 cask 'ridibooks' do
-  version '2.7.2'
-  sha256 '7bf5783034ed26881798a6eca84f07d94805bfeefad672ee495b7be77646f3bc'
+  version '2.7.3'
+  sha256 '1654cdf1f7f43969498bc3ea2a76c0094b2aaccb934d89be964a66dbf2bb375e'
 
   url "https://viewer-ota.ridibooks.com/mac/ridibooks-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://getapp.ridibooks.com/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.