### PR TITLE
Update vnc-viewer from 6.19.715 to 6.19.923

### DIFF
--- a/Casks/vnc-viewer.rb
+++ b/Casks/vnc-viewer.rb
@@ -1,6 +1,6 @@
 cask 'vnc-viewer' do
-  version '6.19.715'
-  sha256 'c779c80bd4050ec848529af98fc904387666cec25f88c166e667128ba4787424'
+  version '6.19.923'
+  sha256 '918b0e5653265c6b272e538e3517d0ee0c6ec49e9dc2da1a04e4582b3b768fc9'
 
   url "https://www.realvnc.com/download/file/viewer.files/VNC-Viewer-#{version}-MacOSX-x86_64.dmg"
   appcast 'https://www.realvnc.com/en/connect/download/viewer/macos/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.