### PR TITLE
Update cacher from 2.19.3 to 2.19.4

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.19.3'
-  sha256 '095d9aacc26583f710ae7b91485bbe3dfe6d3432faa3f117105da4135c517e40'
+  version '2.19.4'
+  sha256 '0d847995e02b68d73cc69f218de415980954379dd7f50d24385814ab5b67ffa7'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.