### PR TITLE
Update odrive from 6529 to 6535

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,6 +1,6 @@
 cask 'odrive' do
-  version '6529'
-  sha256 'a7154bb7818cd4a4c2d848b0d611616632635587917194761d06d9430df94c14'
+  version '6535'
+  sha256 'ae8fc2a48911cdbbe604e7f2bb757e153b35ad315854edc334a847ea367ef4c7'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net was verified as official when first introduced to the cask

--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -11,5 +11,6 @@ cask 'odrive' do
 
   pkg "odrive.#{version}.pkg"
 
-  uninstall pkgutil: 'com.oxygen.odrive.*'
+  uninstall quit:    'com.oxygencloud.odrive',
+            pkgutil: 'com.oxygen.odrive.*'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.