### PR TITLE
Add Samsung DeX 1.0.0.54

### DIFF
--- a/Casks/samsung-dex.rb
+++ b/Casks/samsung-dex.rb
@@ -1,0 +1,20 @@
+cask 'samsung-dex' do
+  version '1.0.0.54'
+  sha256 'e6541ed3dc7aea4eb5534b92207812c1ec7b1bf4e312a504be134a30e60dbb00'
+
+  url 'http://downloadcenter.samsung.com/content/SW/201909/20190911142048616/SamsungDeXSetup.dmg'
+  name 'Samsung DeX'
+  homepage 'https://www.samsung.com/global/galaxy/apps/samsung-dex/'
+
+  pkg 'Install Samsung DeX.pkg'
+
+  uninstall script: {
+                      executable: "#{staged_path}/Uninstall.app/Contents/MacOS/Uninstall",
+                      sudo:       true,
+                    }
+
+  caveats do
+    kext
+    reboot
+  end
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].
- [X] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md

----

This is the DeX on PC client that provides a VNC-like Samsung DeX session from the phone over USB.

Some notes:

* The pkg forces a reboot. I tried manually `kextload`ing `ssuddrv.kext` after allowing it in the Security preferences, but it still didn’t work till I rebooted. Manual `kextload` won’t work before the user manually allows the kext publisher anyway.
* The uninstaller app (requires user input to continue, and won’t exit with failure on error, so Homebrew will think it’s uninstalled when it isn’t) can very likely be replaced with Cask uninstall stanzas. Aside from uninstalling all the pkgs, killing the processes, and unloading the kext, I don’t think it does anything special.
* Plenty of references to DevMate, but no DevMate appcast that I can see. Closest I can see is from the Info.plist, a URL that returns an auth error:

```xml
<key>LiveUpdate_Mode</key>
<string>A</string>
<key>LiveUpdate_URL</key>
<string>https://dopc-api.linuxondex.com</string>
```