### PR TITLE
Update zoc from 7.24.1 to 7.24.2

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.24.1'
-  sha256 '36f0c922fa4412eb4d5d5e7f8c0f8d3437f9b284bcdbd681d104337c899c19aa'
+  version '7.24.2'
+  sha256 '70cd4a90e46a27f8840240cc3e9bc3e9505a94828e9a0717fce6f66b305eb10f'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.