### PR TITLE
Update flirc from 3.22.4 to 3.24.0

### DIFF
--- a/Casks/flirc.rb
+++ b/Casks/flirc.rb
@@ -1,6 +1,6 @@
 cask 'flirc' do
   version '3.24.0'
-  sha256 '6fffbb04f84d4441caacf3aa8adefb3d7ef8bd48c922af198cb1d474016c7e20'
+  sha256 'fc4996cc47f9e72cc25cff984e5f9c3dbf6bd7103fa78b423b6d5ad8f0510067'
 
   url "https://flirc.tv/software/flirc-usb/GUI/release/mac/Flirc-#{version}.dmg"
   appcast 'https://flirc.tv/software/release/gui/mac/appcast.xml'

--- a/Casks/flirc.rb
+++ b/Casks/flirc.rb
@@ -1,8 +1,8 @@
 cask 'flirc' do
-  version '3.22.4'
+  version '3.24.0'
   sha256 '6fffbb04f84d4441caacf3aa8adefb3d7ef8bd48c922af198cb1d474016c7e20'
 
-  url 'https://flirc.tv/software/release/gui/mac/Flirc.dmg'
+  url "https://flirc.tv/software/flirc-usb/GUI/release/mac/Flirc-#{version}.dmg"
   appcast 'https://flirc.tv/software/release/gui/mac/appcast.xml'
   name 'Flirc'
   homepage 'https://flirc.tv/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.