### PR TITLE
Update flipper from 0.24.1 to 0.24.2

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.24.1'
-  sha256 '67cae6af9d4ac5e5d58c618efc4548111106dcf57df8bc5ac186fcdfee3cee79'
+  version '0.24.2'
+  sha256 'edcdf93766173ac0374949b59360ad074e534621101f5955af1941db05804095'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.