### PR TITLE
Update comictagger from 1.1.32-rc1 to 1.2.0

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,8 +1,8 @@
 cask 'comictagger' do
-  version '1.1.32-rc1'
-  sha256 'ef028155c1c7e11104ceaa5c4622ceb6b4e305c9b47085b859034ee63c6095be'
+  version '1.2.0'
+  sha256 'f33a0bb5bf0b995af31d45388dcb8b9cd77ca86cbdc9dd52287027ccdda423cc'
 
-  url "https://github.com/davide-romanini/comictagger/releases/download/#{version}/ComicTagger-#{version}-macOS-mojave-x86_64.zip"
+  url "https://github.com/davide-romanini/comictagger/releases/download/#{version}%2B2/ComicTagger-#{version}-osx-10.12.6-x86_64.app.zip"
   appcast 'https://github.com/davide-romanini/comictagger/releases.atom'
   name 'ComicTagger'
   homepage 'https://github.com/davide-romanini/comictagger'

--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -7,5 +7,5 @@ cask 'comictagger' do
   name 'ComicTagger'
   homepage 'https://github.com/davide-romanini/comictagger'
 
-  app "ComicTagger.app"
+  app 'ComicTagger.app'
 end

--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -7,5 +7,5 @@ cask 'comictagger' do
   name 'ComicTagger'
   homepage 'https://github.com/davide-romanini/comictagger'
 
-  app "ComicTagger-#{version}.app"
+  app "ComicTagger.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.