### PR TITLE
Update itubedownloader from 6.5.5 to 6.5.6

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,6 +1,6 @@
 cask 'itubedownloader' do
-  version '6.5.5'
-  sha256 '0f7722420dafc024dce039caf040bd81aebf621ced079c0fcd9ed9755fd599e1'
+  version '6.5.6'
+  sha256 '3fe49bf5b46b23d0086db66accc3f5811d42a179714fc095cc35719e82ba1ee7'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/iTubeDownloader.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.