### PR TITLE
Update qbserve from 1.84 to 1.85

### DIFF
--- a/Casks/qbserve.rb
+++ b/Casks/qbserve.rb
@@ -1,6 +1,6 @@
 cask 'qbserve' do
-  version '1.84'
-  sha256 '9abbb6e71c68118bf435864312a62d3bf06dc4320f457ca6f529b4ce94120c75'
+  version '1.85'
+  sha256 '8125b32c2e93dc8be0d55da9b9c11a84d957314d296a2b21120e053ff610c96a'
 
   url "https://qotoqot.com/qbserve/app/Qbserve-#{version}.zip"
   appcast 'https://qotoqot.com/qbserve/app/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.