### PR TITLE
Update activedock from 237,1568037944 to 245,1569415216

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '237,1568037944'
-  sha256 'afaf9a0ce57b27b9795a2a99d6a2a0068e6174f984742182c7f76ed846dc2d33'
+  version '245,1569415216'
+  sha256 'c3c9ba0ae2d7c0b18f4d0daa396b9f13cb065410817fc2b6ea6079db8df7d2df'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.