### PR TITLE
Update kite from 0.20190919.1 to 0.20190924.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20190919.1'
-  sha256 '92f2efc81608c28f7696ec9e6e0984e06269498db79cac5039b386d178b4f16d'
+  version '0.20190924.0'
+  sha256 'b03d9e3422d43accdbf3f64c7149f1afe2a93a8e4378f9206b90882e0fce1249'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.