### PR TITLE
Update macx-dvd-ripper-pro from 6.2.3,20190619 to 6.2.4,20190924

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.2.3,20190619'
-  sha256 'c8a4b3b4657bde31a5b2510c1a99caaf6a175491090c46d35250a02d17aa0a67'
+  version '6.2.4,20190924'
+  sha256 '40a681f4aac4eb271ba2875ab07b16b66bf8b30d05890755560eef21dcf92744'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
   appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.