### PR TITLE
Update milanote from 1.4.17 to 1.5.1

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.4.17'
-  sha256 'f5059607327be8ad4bd445a6026b4c36c985494852e4b9759d9962d1e445505d'
+  version '1.5.1'
+  sha256 '101a5ad54a779fc94fdc3b274b025e8e4997cab6408ab979524231a3f2b1ceab'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.