### PR TITLE
Update SciHubEVA from v3.2.0 to v3.2.1

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -1,6 +1,6 @@
 cask 'scihubeva' do
-  version 'v3.2.0'
-  sha256 '59f64e1521cacbbb85fc2b2ab2833c8651bf305512459778615ded40eaa27123'
+  version 'v3.2.1'
+  sha256 '30caed6892906b3f04379150fe4af45eb5b25c40ae3ca37888cd4a0a116b2003'
 
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast 'https://github.com/leovan/SciHubEVA/releases.atom'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.