### PR TITLE
Revert "Update photoninja from 1.3.8b to 1.3.8"

### DIFF
--- a/Casks/photoninja.rb
+++ b/Casks/photoninja.rb
@@ -1,6 +1,6 @@
 cask 'photoninja' do
-  version '1.3.8'
-  sha256 '8e892330ec4bd9296b97e7a3068de0f6b7e7b0098d0b984d360ff4c836b50431'
+  version '1.3.8b'
+  sha256 '40709d2711ab780054efccc5550941e4f31240311ed62fdf418378eb558a48cb'
 
   # picturecode.cachefly.net was verified as official when first introduced to the cask
   url "https://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_#{version}.dmg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#69716

1.3.8b is the latest version - sorry I've overseen it in the checks 