### PR TITLE
Update deezer from 4.16.3 to 4.17.0

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.16.3'
-  sha256 '28ef9bd6baaba664c07fb91b91ea033af25b54dc964d827333425491ae47f882'
+  version '4.17.0'
+  sha256 '07eb8cb670c13917dc5a8057435bd7bd96acc15cd1b6533cd730471929ca3809'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.