### PR TITLE
Update clockify from 2.3.6 to 2.3.7

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
-  version '2.3.6'
-  sha256 'f70c9c922602ba850de6813a6d63d3b3c565d55a89598187785cfef2451fec74'
+  version '2.3.7'
+  sha256 '0d542c92a0321285a656be45d9a34efff9b22924e71fb94f1f01fbacf2c327fd'
 
   # clockify-resources.s3.eu-central-1.amazonaws.com was verified as official when first introduced to the cask
   url 'https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip'
@@ -8,6 +8,7 @@ cask 'clockify' do
   name 'Clockify'
   homepage 'https://clockify.me/mac-time-tracking'
 
+  auto_updates true
   depends_on macos: '>= :sierra'
 
   app 'Clockify Desktop.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.