### PR TITLE
Update feishu from 3.7.5 to 3.8.4

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,6 +1,6 @@
 cask 'feishu' do
-  version '3.7.5'
-  sha256 '90824a2ec4e32f79a5c5f226c689a6845fce31ccfce831ea6a397a40dc5aeb63'
+  version '3.8.4'
+  sha256 'eccdae5b0b3e82beb51543d678c7ccb18eaa31bfb51e981366237611e91b31ce'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.