### PR TITLE
itsycal: update to 0.12.1 & fix 0.11.17 for high_sierra

### DIFF
--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -2,30 +2,21 @@ cask 'itsycal' do
   if MacOS.version <= :mavericks
     version '0.8.15'
     sha256 '6470719a1f702c807f98a992880def5f499858231bf35924eaf3e0d5df48b436'
-
-    # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
-    url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
   elsif MacOS.version <= :el_capitan
     version '0.10.16'
     sha256 'dbf1b104c7a3a2ca3ead9879145cb0557955c29d53f35a92b42f48e68122957c'
-
-    # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
-    url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
   elsif MacOS.version <= :high_sierra
     version '0.11.17'
     sha256 'fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11'
-
-    # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
-    url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
   else
     version '0.12.0'
     sha256 '1e3138394c30553a17af5a5b331052eb0af78f94d80d24175571437ebf59510c'
 
-    # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
-    url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
     appcast 'https://itsycal.s3.amazonaws.com/itsycal.xml'
   end
 
+  # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
   name 'Itsycal'
   homepage 'https://www.mowglii.com/itsycal/'
 

--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -11,6 +11,12 @@ cask 'itsycal' do
 
     # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
     url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
+  elsif MacOS.version <= :high_sierra
+    version '0.11.17'
+    sha256 'fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11'
+
+    # itsycal.s3.amazonaws.com was verified as official when first introduced to the cask
+    url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip"
   else
     version '0.12.0'
     sha256 '1e3138394c30553a17af5a5b331052eb0af78f94d80d24175571437ebf59510c'

--- a/Casks/itsycal.rb
+++ b/Casks/itsycal.rb
@@ -8,10 +8,10 @@ cask 'itsycal' do
   elsif MacOS.version <= :high_sierra
     version '0.11.17'
     sha256 'fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11'
+    appcast 'https://itsycal.s3.amazonaws.com/itsycal.xml'
   else
-    version '0.12.0'
-    sha256 '1e3138394c30553a17af5a5b331052eb0af78f94d80d24175571437ebf59510c'
-
+    version '0.12.1'
+    sha256 'deba5db668d5c488da48e6cfdd3740b61e1b22d2ee808f5f84bc9cdb6ba55a9a'
     appcast 'https://itsycal.s3.amazonaws.com/itsycal.xml'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


According to https://www.mowglii.com/itsycal/versionhistory.html, version `0.12.0` and up require macOS 10.14+