### PR TITLE
Update aerial from 1.5.0 to 1.6.0

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.5.0'
-  sha256 '2e34483c064297f2ce9a619cde7c607c5cf9528d4455f707191e7e43c8064bc6'
+  version '1.6.0'
+  sha256 'b51e79b1acf51168fb9c4ce3fd5f208f4c0974c16c191ab9908afbe77331423d'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.