### PR TITLE
Update qbittorrent from 4.1.7 to 4.1.8

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'qbittorrent' do
-  version '4.1.7'
-  sha256 '16b3cfa69fae39ef3352e5fd79f4b2306d565a3d37c6d60f25ac01fddf487ed8'
+  version '4.1.8'
+  sha256 '8f12487b2d6be51442778ae196ad3e73c6fe4474feb929b5d4b4e11443d9c108'
 
   # sourceforge.net/qbittorrent was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.