### PR TITLE
Update augur from 1.16.0 to 1.16.1

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.16.0'
-  sha256 'dec23fbd3f78c9c07186e455e3fe860f89abf1ed54fb0397f2db4bbdb6a2f43e'
+  version '1.16.1'
+  sha256 '80ebe4cbd6f66a0649821fc97c7abbf998c746a23b8084342c401db568200495'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.