### PR TITLE
Update sip from 2.1.2 to 2.1.3

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -3,8 +3,8 @@ cask 'sip' do
     version '1.1.6'
     sha256 'bb170a54090aab5703388a3e7a22e9cf4e4d98e84f5658893e1e6f9677b9a51e'
   else
-    version '2.1.2'
-    sha256 '2974ea8fb8aa8348fbaf9b9a349d4c94ff2a417f9512fc03747ea7302f7ba8f4'
+    version '2.1.3'
+    sha256 'a2290347e920211e21b7db0da7898f89e3957a4eb83481fe6e21d09021389a64'
   end
 
   url "https://sipapp.io/updates/v#{version.major}/sip-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.