### PR TITLE
Update craftmanager from 1.0.87 to 1.0.88

### DIFF
--- a/Casks/craftmanager.rb
+++ b/Casks/craftmanager.rb
@@ -1,6 +1,6 @@
 cask 'craftmanager' do
-  version '1.0.87'
-  sha256 '14faf273dcb13c610a32d10aacace2b8989df4cedab7dc01d53b5c712116d96d'
+  version '1.0.88'
+  sha256 'fa49e98529bca9027113da97467671aa6035837a322284d2a9908b6c6afce663'
 
   url 'https://craft-assets.invisionapp.com/CraftManager/production/CraftManager.zip'
   appcast 'https://craft-assets.invisionapp.com/CraftManager/production/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.