### PR TITLE
Update airy from 3.9,218 to 3.10,242

### DIFF
--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -1,6 +1,6 @@
 cask 'airy' do
-  version '3.9,218'
-  sha256 '772a8a9374a7b316a97e2990ae3bbd3d4994c9a344c4ecf7ce5dfab37a3a6027'
+  version '3.10,242'
+  sha256 '1c3affa1995c6a7bf8ef341f1bd51c30f201bd007f14c863fe43e6c569229076'
 
   url 'https://cdn.eltima.com/download/airy.dmg'
   appcast 'https://cdn.eltima.com/download/airy-update/airy.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.