### PR TITLE
Update memory-tracker-by-timely from 2019.20 to 2019.21

### DIFF
--- a/Casks/memory-tracker-by-timely.rb
+++ b/Casks/memory-tracker-by-timely.rb
@@ -1,6 +1,6 @@
 cask 'memory-tracker-by-timely' do
-  version '2019.20'
-  sha256 '638a6ee46360fb4b63f737509d8963b1265cb9bfa43163c5048d49bec14075f8'
+  version '2019.21'
+  sha256 '5dedf2c011d5e895dcf520643cbf6567105d001e3e17a3a99978b4761f60bc53'
 
   # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'

--- a/Casks/memory-tracker-by-timely.rb
+++ b/Casks/memory-tracker-by-timely.rb
@@ -11,5 +11,5 @@ cask 'memory-tracker-by-timely' do
   auto_updates true
   depends_on macos: '>= :high_sierra'
 
-  app 'Memory Tracker by Timely.app'
+  app 'Memory.app'
 end

--- a/Casks/memory.rb
+++ b/Casks/memory.rb
@@ -1,4 +1,4 @@
-cask 'memory-tracker-by-timely' do
+cask 'memory' do
   version '2019.21'
   sha256 '5dedf2c011d5e895dcf520643cbf6567105d001e3e17a3a99978b4761f60bc53'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.