### PR TITLE
Update pdfelement from 7.2.0,5237 to 7.3.1,5237

### DIFF
--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,6 +1,6 @@
 cask 'pdfelement' do
-  version '7.2.0,5237'
-  sha256 '9b91cddf6830a6605fe0736c1f97e9339558f7549ffa04f3a72f5079bea4c569'
+  version '7.3.1,5237'
+  sha256 '3edb40bd86cb6edb7a4ed8f9209d3bc4839a76285a0891a6dedab753bf5d3bf0'
 
   url "http://download.wondershare.com/cbs_down/mac-pdfelement_full#{version.after_comma}.dmg"
   appcast 'https://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.