### PR TITLE
Update lingon-x from 7.4.1 to 7.4.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.5'
     sha256 'b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8'
   else
-    version '7.4.1'
-    sha256 'd034009c681a06750f825304d64ffa17555d084cea09625dd9fe8d57ec0eea01'
+    version '7.4.2'
+    sha256 'aec57253a69d1a86a7e85f4ac0a01983ec1a8f68b309cc070547ed4369155e74'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.