### PR TITLE
Update qownnotes from 19.9.17,b4569-170719 to 19.9.19,b4576-160445

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.17,b4569-170719'
-  sha256 'c9e4e22b52314ee63711a3fbe42ffbf0634c711f71ce429dfbc9272946887dc0'
+  version '19.9.19,b4576-160445'
+  sha256 '018da98bfe1e4231faf164a9fa80d3f5ca58d24fa92b1568c50109fb7649626c'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.