### PR TITLE
Update scilab

### DIFF
--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -15,6 +15,6 @@ cask 'scilab' do
   binary "#{appdir}/Scilab-#{version}.app/Contents/MacOS/bin/scilab-cli"
 
   caveats do
-    depends_on_java '6'
+    depends_on_java '8'
   end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Requires Java 8.