### PR TITLE
Update qutebrowser from 1.7.0 to 1.8.1

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,6 @@
 cask 'qutebrowser' do
-  version '1.7.0'
-  sha256 '7e99facc4b886c64b84ad13f22e5694faa39a7cda73519816b60cc5df5945b81'
+  version '1.8.1'
+  sha256 'cdc19ecd10ceba3fa7b898b5fa30ff06d4ef263b2532552a2aaa221a3efaaa44'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.