### PR TITLE
Update dissenter-browser from 0.66.99 to 0.68.131,5d3f93a29dd49a5b1d9fc27f:5d8287329001ac55509c6aa0

### DIFF
--- a/Casks/dissenter-browser.rb
+++ b/Casks/dissenter-browser.rb
@@ -1,8 +1,9 @@
 cask 'dissenter-browser' do
-  version '0.66.99'
-  sha256 '1192c8a0fae4621dd26fd7fbf65ed32ea07617c112f9ec65395b7ec3e67ff940'
+  version '0.68.131,5d3f93a29dd49a5b1d9fc27f:5d8287329001ac55509c6aa0'
+  sha256 '540f1446253de671dae6a36ae9c50a21d035d81cd848116fb0a4f0a204b6423f'
 
-  url "https://dissenter.com/dist/browser/#{version}/dissenter-browser-v#{version}.dmg"
+  # apps.gab.com was verified as official when first introduced to the cask
+  url "https://apps.gab.com/application/#{version.after_comma.before_colon}/resource/#{version.after_colon}/content"
   appcast 'https://dissenter.com/'
   name 'Dissenter'
   homepage 'https://dissenter.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.