### PR TITLE
Update imazing from 2.10.2,11447:1568826961 to 2.10.3,11461:1569604829

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.10.2,11447:1568826961'
-  sha256 '1780af5a061feaebbc39e676be6446fd8dcd815305eb3259ca4907468571571a'
+  version '2.10.3,11461:1569604829'
+  sha256 'dd4e9bf6542c129967f01198a47de55d7d1be566c32c8e43a775f8329a491cfe'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.