### PR TITLE
Update tableflip from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/tableflip.rb
+++ b/Casks/tableflip.rb
@@ -1,6 +1,6 @@
 cask 'tableflip' do
-  version '1.2.1'
-  sha256 '1bda6ec5aa2db25b856527c6770c13e110df06866c0de40f91ed07023bf31625'
+  version '1.2.2'
+  sha256 '009a005c7a1d41d120a9e3d5b819db98e6ca5afdfd065926c8dbf032b20ae6f0'
 
   # update.christiantietze.de/tableflip was verified as official when first introduced to the cask
   url "https://update.christiantietze.de/tableflip/v#{version.major}/TableFlip-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.