### PR TITLE
Update screenflow from 8.2.3 to 8.2.4

### DIFF
--- a/Casks/screenflow.rb
+++ b/Casks/screenflow.rb
@@ -1,6 +1,6 @@
 cask 'screenflow' do
-  version '8.2.3'
-  sha256 '8d3db51b4c2b9ba1dfc962eea853811a0e0ec00ec8782ad499e0a3010d158c00'
+  version '8.2.4'
+  sha256 'cae68e858b4f5eef3b8dd6d5d56c3f265d1c24080094f8d88a9b36e44769446a'
 
   url "https://www.telestream.net/download-files/screenflow/#{version.major_minor.dots_to_hyphens}/ScreenFlow-#{version}.dmg"
   appcast 'https://www.telestream.net/updater/screenflow/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.