### PR TITLE
Update go64 from 1.0.4 to 1.0.5

### DIFF
--- a/Casks/go64.rb
+++ b/Casks/go64.rb
@@ -1,7 +1,7 @@
 cask 'go64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.0.4'
-  sha256 '3a7936c30d55c3a0d45b8df940c3a5075bfec0e9f9829ed1b849aec51e55a99e'
+  version '1.0.5'
+  sha256 '6cb2e323e9d5d9af63e74fc8754240527180d1b2ac501571913b13b9e728d5eb'
 
   url "https://www.stclairsoft.com/download/Go64-#{version}.zip"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?GO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.