### PR TITLE
Update insync from 3.0.19.40421 to 3.0.20.40428

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '3.0.19.40421'
-  sha256 'f95b2112b708c0e0f68560a4c1a431fd20d2a65555f5a4d7ce033bbfdb88c8c5'
+  version '3.0.20.40428'
+  sha256 '9cc48ccb27a9efce8199845bf0e7625d87efda5948b1c8ca02f5dbeab920255b'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   appcast 'https://www.insynchq.com/downloads?start=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.