### PR TITLE
Update zoho-mail from 1.0.16 to 1.0.17

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.0.16'
-  sha256 '70a9408a4e20596ccaa933196c64edd06d1edab8c70a9d01249f3a8ef4984f3e'
+  version '1.0.17'
+  sha256 '7470adcc126cd94a6973be5efc4821ae3f3bc4a073a100f799841cda6be3625d'
 
   # downloads.zohocdn.com/zmail-desktop/mac was verified as official when first introduced to the cask
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.