### PR TITLE
Update dmm-player from 2.0.0 to 2.0.1

### DIFF
--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -1,6 +1,6 @@
 cask 'dmm-player' do
-  version '2.0.0'
-  sha256 '5b5b472b670772c1d144c105bae5429ae85444d211cd02f83696449007ce198d'
+  version '2.0.1'
+  sha256 '7c8119625c36afef95ae6a4e7ea0e8f0449ded7b872d89ebaae9000c91f50c6e'
 
   url "http://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name 'DMM Player'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.