### PR TITLE
Update bartender from 3.0.64 to 3.1.06

### DIFF
--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -3,8 +3,8 @@ cask 'bartender' do
     version '2.1.6'
     sha256 '013bb1f5dcc29ff1ecbc341da96b6e399dc3c85fc95bd8c7bee153ab0d8756f5'
   else
-    version '3.0.64'
-    sha256 '40a65c09f41ff56cd95b247c94ebdeda78748253b86204d0e4617b3f3fd4e261'
+    version '3.1.06'
+    sha256 'bb69b0bd88e0528e31851b6db33fdd99be2cd47d8cec21580e7d5e95cc419f1a'
   end
 
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",

--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -9,7 +9,8 @@ cask 'bartender' do
 
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",
       referer: 'https://www.macbartender.com'
-  appcast 'https://www.macbartender.com/B2/updates/Appcast.xml'
+  appcast 'https://www.macbartender.com/B2/updates/Appcast.xml',
+           configuration: version.dots_to_hyphens
   name 'Bartender'
   homepage 'https://www.macbartender.com/'
 

--- a/Casks/bartender.rb
+++ b/Casks/bartender.rb
@@ -10,7 +10,7 @@ cask 'bartender' do
   url "https://macbartender.com/B2/updates/#{version.dots_to_hyphens}/Bartender%20#{version.major}.zip",
       referer: 'https://www.macbartender.com'
   appcast 'https://www.macbartender.com/B2/updates/Appcast.xml',
-           configuration: version.dots_to_hyphens
+          configuration: version.dots_to_hyphens
   name 'Bartender'
   homepage 'https://www.macbartender.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.