### PR TITLE
Update axe-edit-iii from 1.03.04 to 1.03.05

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.03.04'
-  sha256 '0eef4d84bf216f3671b73d81b38d51e2a47fe80b9f3365d0322badabe585f75c'
+  version '1.03.05'
+  sha256 'df29e628e6117a5be48d21eb9d326b295ab9e1f9265d8075c238c1df782f2a59'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.