### PR TITLE
Update wechatwork from 2.8.12.2044 to 2.8.15.2065

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.12.2044'
-  sha256 '2ebe947a49e354c01bff3d9540c901b7a583dc4f3a31c704d9ca828985da127f'
+  version '2.8.15.2065'
+  sha256 '7f055943251d636689d81518a5523f4dd2cf94373a38dd74a7136af7c36016b1'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.