### PR TITLE
Update protopie from 4.0.4 to 4.0.5

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '4.0.4'
-  sha256 'd7c1fc3835b3c6d32289d15a9c66c637eb58ec545885155414cd91304c4b6ec6'
+  version '4.0.5'
+  sha256 'cf7b4a0eff06ffeb9941b995563d4f4831c09e01e5d92cd640f7b45b830418f4'
 
   url "http://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.