### PR TITLE
fix for issue #70 - showing the application window and not only the icon for meld version 3.19.2-r6,osx-15

### DIFF
--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -16,6 +16,7 @@ cask 'meld' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
+      rm -rf ~/Library/Saved\ Application\ State/org.gnome.meld.savedState
       exec '#{appdir}/Meld.app/Contents/MacOS/Meld' "$@"
     EOS
   end


### PR DESCRIPTION
fix for showing the application window and not only the icon.
see [issue #70](https://github.com/yousseb/meld/issues/70) for more information.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
