### PR TITLE
Update mini-program-studio from 0.41.2,ae6e84fb-725c-4525-8fe0-71728b89f1f3 to 0.60.13,98749a98-f00e-4b5c-a5cf-b8e122ba6378

### DIFF
--- a/Casks/mini-program-studio.rb
+++ b/Casks/mini-program-studio.rb
@@ -1,24 +1,18 @@
 cask 'mini-program-studio' do
-  version '0.41.2,ae6e84fb-725c-4525-8fe0-71728b89f1f3'
-  sha256 '2a62c16a1cc7599ab9612b6894482a3264d07929efede3b43d49b2ac44664722'
+  version '0.60.13,98749a98-f00e-4b5c-a5cf-b8e122ba6378'
+  sha256 '71fefcc6ab1114faf861c23d1d5177e9cce033e4c2449a8a1c51a0897cec83ca'
 
   # gw.alipayobjects.com was verified as official when first introduced to the cask
-  url "https://gw.alipayobjects.com/os/volans-demo/#{version.after_comma}/#{version.before_comma}/MiniProgramStudio-#{version.before_comma}.pkg"
+  url "https://gw.alipayobjects.com/os/volans-demo/#{version.after_comma}/#{version.before_comma}/MiniProgramStudio-#{version.before_comma}.dmg"
   name 'Mini Program Studio'
   name '小程序开发者工具'
   homepage 'https://open.alipay.com/channel/miniIndex.htm'
 
-  pkg "MiniProgramStudio-#{version.before_comma}.pkg"
-
-  uninstall pkgutil: 'com.ant.miniprogram'
+  app '小程序开发者工具.app'
 
   zap trash: [
                '~/Library/Application Support/小程序开发者工具',
-               '~/Library/Preferences/com.ant.tiny.helper.plist',
-               '~/Library/Preferences/com.ant.miniprogram.helper.plist',
-               '~/Library/Preferences/com.ant.miniprogram.plist',
                '~/Library/Preferences/com.ant.miniprogram.plist',
                '~/Library/Saved Application State/com.ant.miniprogram.savedState',
-               '~/Library/Saved Application State/com.ant.tiny.savedState',
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.