### PR TITLE
Update launchpad-manager-yosemite from 1.0.8 to 1.0.10

### DIFF
--- a/Casks/launchpad-manager-yosemite.rb
+++ b/Casks/launchpad-manager-yosemite.rb
@@ -12,7 +12,7 @@ cask 'launchpad-manager-yosemite' do
 
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
 
-    app 'Launchpad Manager Yosemite.app'
+    app 'Launchpad Manager.app'
   end
 
   name 'Launchpad Manager'

--- a/Casks/launchpad-manager-yosemite.rb
+++ b/Casks/launchpad-manager-yosemite.rb
@@ -7,11 +7,10 @@ cask 'launchpad-manager-yosemite' do
 
     app 'Launchpad Manager.app'
   else
-    version '1.0.8'
-    sha256 '571c4c5b760e608984d47aa8398e5c1666533158fa65d1afae18ce7f3844a877'
+    version '1.0.10'
+    sha256 '88b37120c0ae022309573c4d2587a6ec85df7895773bca0fd3b5ba6cd86461a6'
 
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
-    appcast 'http://launchpadmanager.com/appyos/sparkle.rss'
 
     app 'Launchpad Manager Yosemite.app'
   end

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -4,19 +4,17 @@ cask 'launchpad-manager' do
     sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'
 
     url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
-
-    app 'Launchpad Manager.app'
   else
     version '1.0.10'
     sha256 '88b37120c0ae022309573c4d2587a6ec85df7895773bca0fd3b5ba6cd86461a6'
 
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
-
-    app 'Launchpad Manager.app'
   end
 
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'
+
+  app 'Launchpad Manager.app'
 
   zap trash: [
                '~/Library/Application Support/Launchpad Manager',

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,4 +1,4 @@
-cask 'launchpad-manager-yosemite' do
+cask 'launchpad-manager' do
   if MacOS.version <= :mavericks
     version '1.3.11'
     sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.