### PR TITLE
Update pritunl from 1.0.2144.93 to 1.0.2207.23

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,6 +1,6 @@
 cask 'pritunl' do
-  version '1.0.2144.93'
-  sha256 '846ecbfbed7e5ef48ad6595e75e2e0e1a3250c4ea08af0375ac98934083f06fc'
+  version '1.0.2207.23'
+  sha256 '63a8dc1feeab551e6ea51ae26a74d250b603d18b861cdb3a82b261b0d0519536'
 
   # github.com/pritunl/pritunl-client-electron was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.