### PR TITLE
Update marvel from 8.4.4 to 8.5

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.4.4'
-  sha256 '6df46248a55eb4af686593830fc9eae043353189f9c2c6b87e6135d7347e73ef'
+  version '8.5'
+  sha256 'd3391b68b6aadb8938779b718a7409a14d958af9769f548e54dd607cc0e7bdfa'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.