### PR TITLE
Update keep-it from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.7.1'
-  sha256 '6f02c97993e094962ed3ffd40d005ae773754e9049ecccbed8fa2907899fe5e3'
+  version '1.7.2'
+  sha256 '96c87eba47cfdc4a37c48fe1100912168b1946d563b8d19d60c9f834c5274e0b'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.