### PR TITLE
Update exodus from 19.9.12 to 19.9.27

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.9.12'
-  sha256 '5b4961b344f45463ace48c1e1305fcca9f45f922fb26db7a55c17655916e1325'
+  version '19.9.27'
+  sha256 '4d2eabc9aa6fcf11ba4f3c2f05b451987181dee3a77076dbc8aea92aa6a2af82'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.