### PR TITLE
Update localdev from 0.5.0 to 0.5.3

### DIFF
--- a/Casks/localdev.rb
+++ b/Casks/localdev.rb
@@ -1,6 +1,6 @@
 cask 'localdev' do
-  version '0.5.0'
-  sha256 '564f1dc7e0a748d01e9397e30d2d0ea341a8dd4184c940a092e2d777b12ec9d4'
+  version '0.5.3'
+  sha256 '10d90bc32dff51b192f93257b5241a52c752b2afe6d772f62cadce6ba0c61b71'
 
   # pantheon-localdev.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://pantheon-localdev.s3.amazonaws.com/Localdev-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.