### PR TITLE
Update stamp from 4.15.0 to 4.15.1

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.15.0'
-  sha256 'a1d700d6a298dfa31c11cd530e7e703faae390cd3028f1d3a851df46810e3ff2'
+  version '4.15.1'
+  sha256 'b3b30a67e14782be5d354bf76d3210081c3c4f14f4b7a322d96893e6ef4b0378'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/STAMP#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.