### PR TITLE
Update comictagger from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,8 +1,8 @@
 cask 'comictagger' do
-  version '1.2.0'
-  sha256 'f33a0bb5bf0b995af31d45388dcb8b9cd77ca86cbdc9dd52287027ccdda423cc'
+  version '1.2.1'
+  sha256 '31b36527b9415544e2f956c849309320bb955524eaa1ebddab6b97d55c5da4f8'
 
-  url "https://github.com/davide-romanini/comictagger/releases/download/#{version}%2B2/ComicTagger-#{version}-osx-10.12.6-x86_64.app.zip"
+  url "https://github.com/davide-romanini/comictagger/releases/download/#{version}/ComicTagger-#{version}-osx-10.12.6-x86_64.app.zip"
   appcast 'https://github.com/davide-romanini/comictagger/releases.atom'
   name 'ComicTagger'
   homepage 'https://github.com/davide-romanini/comictagger'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.