### PR TITLE
cleanmymac.rb: Even more zaps

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -36,16 +36,16 @@ cask 'cleanmymac' do
                "~/Library/Caches/CleanMyMac #{version.major}",
                "~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/com.macpaw.CleanMyMac#{version.major}.help*",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}",
-               "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.HealthMonitor"
+               "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.HealthMonitor",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.KnowledgeBase",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Menu",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Scheduler",
-               "~/Library/LaunchAgents/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist"
+               "~/Library/LaunchAgents/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist",
                "~/Library/Logs/CleanMyMac #{version.major}.log",
-               "~/Library/Logs/CleanMyMac X Menu/HealthMonitor"
+               "~/Library/Logs/CleanMyMac X Menu/HealthMonitor",
                "~/Library/Logs/com.macpaw.CleanMyMac#{version.major}",
                "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.major}-Helper.plist",
-               "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist"
+               "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist",
                "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.KnowledgeBase.plist",
                "~/Library/Preferences/com.macpaw.cleanmymac#{version.major}.menu.plist",
                "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.Scheduler.plist",

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -42,7 +42,7 @@ cask 'cleanmymac' do
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Scheduler",
                "~/Library/LaunchAgents/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist",
                "~/Library/Logs/CleanMyMac #{version.major}.log",
-               "~/Library/Logs/CleanMyMac X Menu/HealthMonitor",
+               '~/Library/Logs/CleanMyMac X Menu/HealthMonitor',
                "~/Library/Logs/com.macpaw.CleanMyMac#{version.major}",
                "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.major}-Helper.plist",
                "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist",

--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -32,15 +32,20 @@ cask 'cleanmymac' do
                "~/Library/Application Support/CleanMyMac #{version.major}",
                "~/Library/Application Support/CleanMyMac #{version.major} Menu",
                '~/Library/Application Support/CleanMyMac X',
+               '~/Library/Application Support/CleanMyMac X Menu',
                "~/Library/Caches/CleanMyMac #{version.major}",
                "~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/com.macpaw.CleanMyMac#{version.major}.help*",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}",
+               "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.HealthMonitor"
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.KnowledgeBase",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Menu",
                "~/Library/Caches/com.macpaw.CleanMyMac#{version.major}.Scheduler",
+               "~/Library/LaunchAgents/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist"
                "~/Library/Logs/CleanMyMac #{version.major}.log",
+               "~/Library/Logs/CleanMyMac X Menu/HealthMonitor"
                "~/Library/Logs/com.macpaw.CleanMyMac#{version.major}",
                "~/Library/Preferences/com.macpaw.CleanMyMac-#{version.major}-Helper.plist",
+               "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.HealthMonitor.plist"
                "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.KnowledgeBase.plist",
                "~/Library/Preferences/com.macpaw.cleanmymac#{version.major}.menu.plist",
                "~/Library/Preferences/com.macpaw.CleanMyMac#{version.major}.Scheduler.plist",


### PR DESCRIPTION
As if this list couldn't get any bigger, I just discovered this "HealthMonitor" has stuck around on my system months after deleting the program.

----

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).