### PR TITLE
Update c0re100-qbittorrent from 4.1.7.1 to 4.1.8.1

### DIFF
--- a/Casks/c0re100-qbittorrent.rb
+++ b/Casks/c0re100-qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'c0re100-qbittorrent' do
-  version '4.1.7.1'
-  sha256 '487310954af206550cd0eafff1b56d84aaf968e64086e66819aad9b2b0fa0bf3'
+  version '4.1.8.1'
+  sha256 '640624ec1b27d9027e06ffab111c235a4daf9098ba056ca6eb8ff8d0c32b971e'
 
   url "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-#{version}/qBittorrent-#{version}.dmg"
   appcast 'https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.