### PR TITLE
Update endlesssky from 0.9.8 to 0.9.10

### DIFF
--- a/Casks/endlesssky.rb
+++ b/Casks/endlesssky.rb
@@ -1,9 +1,9 @@
 cask 'endlesssky' do
-  version '0.9.8'
-  sha256 'b233c7b7aa3c87346abc325ea2958c7d36a17d276760b926184af7a23b454ec2'
+  version '0.9.10'
+  sha256 'f2e7aa2bcd29c6070cac386111362bd353239cbaf6061c22dfa3b440426fd06b'
 
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
-  url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macosx-#{version}.dmg"
+  url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macos-#{version}.dmg"
   appcast 'https://github.com/endless-sky/endless-sky/releases.atom'
   name 'Endless Sky'
   homepage 'https://endless-sky.github.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.