### PR TITLE
Update praat from 6.1.03 to 6.1.04

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.1.03'
-  sha256 '96389dfeaa65de7b6b9738e39b4954707a96f289f2fa5828af329c90ecc5e920'
+  version '6.1.04'
+  sha256 '6cda73a99f8d022062bb18e4b62d31c8b6882b7ce85f476d96bd3f3eea1fd023'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.