### PR TITLE
Update qownnotes from 19.9.19,b4576-160445 to 19.9.20,b4582-070906

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.9.19,b4576-160445'
-  sha256 '018da98bfe1e4231faf164a9fa80d3f5ca58d24fa92b1568c50109fb7649626c'
+  version '19.9.20,b4582-070906'
+  sha256 '581e88ec3ddb1bbccd7bf842ee9fda66737437b4c88b0403d620dd11233b078d'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.