### PR TITLE
Update keeweb from 1.10.1 to 1.11.4

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.10.1'
-  sha256 'b500e2269a2a49ae8969c6290796c3e2ddaa2429a08ce738d8fc88659e23c599'
+  version '1.11.4'
+  sha256 '4926cc1cbacfa506864200cb433cfbb874a20f5fd3aa9900255f9357a2ce4e37'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.