### PR TITLE
Update cisdem-pdf-converter-ocr from 7.3.0 to 7.4.0

### DIFF
--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-pdf-converter-ocr' do
-  version '7.3.0'
-  sha256 'd95e762e63668e3beb8edfe050d8ffbea75bf26f34dc97e948ea7afd3d1067fb'
+  version '7.4.0'
+  sha256 '759861d1d975d6193e6656a1389b4f73c612c8595d8f1c20b77a09ae5644eec7'
 
   url 'http://download.cisdem.com/cisdem-pdfconverterocr.dmg'
   appcast 'https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.