### PR TITLE
Update tv-browser from 4.0.1 to 4.2

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -1,6 +1,6 @@
 cask 'tv-browser' do
-  version '4.0.1'
-  sha256 '0f881a81da4a10ee29622e1667df07b9445559746a900a1ac24000f6da9f1e0a'
+  version '4.2'
+  sha256 '130db943301cf1548ae227c5e5f4f8cdf3f4b7591589deb267241e503c323c19'
 
   # sourceforge.net/tvbrowser was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/tvbrowser/tvbrowser_#{version}_macjava.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.