### PR TITLE
Update gpxsee from 7.13 to 7.14

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.13'
-  sha256 '80e85a24aa41d9b514f1571f73ae35d51885cd42564ae7bf367905e37bd6bf92'
+  version '7.14'
+  sha256 '55cfea3b2c63bc6e8de48f77bbd1f71294b64e9b1327ef95871ddba2f2282fc5'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.