### PR TITLE
Update vivaldi from 2.8.1664.40 to 2.8.1664.43

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.8.1664.40'
-  sha256 '46e06c85c6fb5e7c68ef2901a3bc469f9d17a60fc274a63ef549ffed587ad5b5'
+  version '2.8.1664.43'
+  sha256 'd76ce2caf3047d9e86b413a6e6717419ce883ad64002f7fe6b12993eb1fe6072'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.