### PR TITLE
mysqlworkbench.rb: depends on Mojave

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -7,7 +7,7 @@ cask 'mysqlworkbench' do
   name 'MySQL Workbench'
   homepage 'https://www.mysql.com/products/workbench/'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :mojave'
 
   app 'MySQLWorkbench.app'
 


### PR DESCRIPTION
From report in https://github.com/Homebrew/homebrew-cask/issues/69926.

Pinging @suschizu in case it’s wrong, since you tend to be on top of the OS requirements.