### PR TITLE
Update ipfs from 0.9.3 to 0.9.4

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -1,6 +1,6 @@
 cask 'ipfs' do
-  version '0.9.3'
-  sha256 '3f009d08ac5412fb6920d04f646708104e903c20152959f13ef3b439d3b2be59'
+  version '0.9.4'
+  sha256 '786c8c349f5845c580f6275f677002e3e59762c4b788f3bebd48c2eaba7fe744'
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/ipfs-desktop-#{version}.dmg"
   appcast 'https://github.com/ipfs-shipyard/ipfs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} left no offenses.
- [x] The commit message includes the cask’s name and version.