### PR TITLE
Add symlink to gimp 2.10.12 to support command-line use cases (#69939)

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -8,6 +8,7 @@ cask 'gimp' do
   homepage 'https://www.gimp.org/'
 
   app "GIMP-#{version.major_minor}.app"
+  binary "#{appdir}/GIMP-#{version.major_minor}.app/Contents/MacOS/gimp"
 
   postflight do
     set_permissions "#{appdir}/GIMP-#{version.major_minor}.app/Contents/MacOS/gimp", 'a+rx'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This pull request is to implement #69939

I have tested that the the symlink is correctly added and deleted:

```
~$ brew cask install gimp
==> Satisfying dependencies
==> Downloading https://download.gimp.org/pub/gimp/v2.10/osx/gimp-2.10.12-x86_64.dmg
Already downloaded: /Users/boris/Library/Caches/Homebrew/downloads/790e11ca6ea71b5c3efbc531af5318a82fbe8b67819fa1b140309c505bc7a407--gimp-2.10.12-x86_64.dmg
==> Verifying SHA-256 checksum for Cask 'gimp'.
==> Installing Cask gimp
==> Moving App 'GIMP-2.10.app' to '/Applications/GIMP-2.10.app'.
==> Linking Binary 'gimp' to '/usr/local/bin/gimp'.
🍺  gimp was successfully installed!
~$ brew cask uninstall gimp
==> Uninstalling Cask gimp
==> Backing App 'GIMP-2.10.app' up to '/usr/local/Caskroom/gimp/2.10.12/GIMP-2.10.app'.
==> Removing App '/Applications/GIMP-2.10.app'.
==> Unlinking Binary '/usr/local/bin/gimp'.
==> Purging files for version 2.10.12 of Cask gimp
```

Here are the additional tests:

```
~$ brew cask audit gimp --download
==> Downloading https://download.gimp.org/pub/gimp/v2.10/osx/gimp-2.10.12-x86_64.dmg
Already downloaded: /Users/boris/Library/Caches/Homebrew/downloads/790e11ca6ea71b5c3efbc531af5318a82fbe8b67819fa1b140309c505bc7a407--gimp-2.10.12-x86_64.dmg
==> Verifying SHA-256 checksum for Cask 'gimp'.
audit for gimp: passed
~$ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask$ brew cask style Casks/gimp.rb 

1 file inspected, no offenses detected
```

Note that currently, calling `gimp` from the command-line results in a runtime error:

```
~$ gimp
/usr/local/bin/gimp: line 43: /usr/local/bin/gimp-bin: No such file or directory
/usr/local/bin/gimp: line 43: exec: /usr/local/bin/gimp-bin: cannot execute: No such file or directory
```

This is a separate issue that can be either fixed upstream, or fixed in a follow-up commit using a shimscript.
More info:
#69939
https://gitlab.gnome.org/Infrastructure/gimp-macos-build/issues/5