### PR TITLE
Update keeweb from 1.11.4 to 1.11.5

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.11.4'
-  sha256 '4926cc1cbacfa506864200cb433cfbb874a20f5fd3aa9900255f9357a2ce4e37'
+  version '1.11.5'
+  sha256 '4325a10a6f4005e509e5e73c77542955b741ec019f21e843f9a2abc8725bec13'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.