### PR TITLE
Update ableton-live-standard from 10.1 to 10.1.1

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard' do
-  version '10.1'
-  sha256 '76549681792348c905323af2f57b8b1c817991f25c148207a2098fdeb3c4f6ac'
+  version '10.1.1'
+  sha256 'f5ebd57320539630f2bd8966566f2a7061b5c167e1ff2fad4da2b73cd105ee2c'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.