### PR TITLE
0xed.rb: added versioning and improved zap uninstall folders

### DIFF
--- a/Casks/0xed.rb
+++ b/Casks/0xed.rb
@@ -3,6 +3,7 @@ cask '0xed' do
   sha256 'b5e5845641964c2c1d481b15962e842c1b8176a2292c37b6f3790155e1fafcee'
 
   url "https://www.suavetech.com/download/0xED-#{version}.tar.bz2"
+  appcast 'https://www.suavetech.com/0xed/history.html'
   name '0xED'
   homepage 'https://www.suavetech.com/0xed/'
 

--- a/Casks/0xed.rb
+++ b/Casks/0xed.rb
@@ -1,8 +1,8 @@
 cask '0xed' do
-  version :latest
-  sha256 :no_check
+  version '1.1.4'
+  sha256 'b5e5845641964c2c1d481b15962e842c1b8176a2292c37b6f3790155e1fafcee'
 
-  url 'https://www.suavetech.com/download/0xED.tar.bz2'
+  url "https://www.suavetech.com/download/0xED-#{version}.tar.bz2"
   name '0xED'
   homepage 'https://www.suavetech.com/0xed/'
 
@@ -11,5 +11,8 @@ cask '0xed' do
   zap trash: [
                '~/Library/Caches/com.suavetech.0xED',
                '~/Library/Logs/0xED.log',
+               '~/Library/Preferences/com.suavetech.0xED.plist',
+               '~/Library/Saved Application State/com.suavetech.0xED.savedState',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.suavetech.0xed.sfl2',
              ]
 end


### PR DESCRIPTION
-  added versioning
-  improved zap folders

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

