### PR TITLE
Update mediathekview from 13.3.0 to 13.5.0

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,6 +1,6 @@
 cask 'mediathekview' do
-  version '13.3.0'
-  sha256 '805dd68de99f018b2549984c379535419fed43a7281dd38699ed6b2947fbdacb'
+  version '13.5.0'
+  sha256 'efaccc25cd5bc9cefb3249868bed22d46de2309d1ae46d834face79b6950e02f'
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}-mac.dmg"
   appcast 'https://mediathekview.de/changelog/index.xml'

--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -7,5 +7,5 @@ cask 'mediathekview' do
   name 'MediathekView'
   homepage 'https://mediathekview.de/'
 
-  app 'MediathekView.app'
+  suite 'MediathekView'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.