### PR TITLE
Update sublime-text from 3.207 to 3.211

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -3,7 +3,8 @@ cask 'sublime-text' do
   sha256 '531c84e24983927c59dc0c5611f605776f917d1c516af80c69c09ea232d24e01'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
-  appcast "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml"
+  appcast "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml",
+          configuration: version.no_dots
   name 'Sublime Text'
   homepage "https://www.sublimetext.com/#{version.major}"
 

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text' do
-  version '3.207'
-  sha256 'ed090251aa852a628ec664c5aa1bdd57e941852458f3ac0128d869e6e012cdcb'
+  version '3.211'
+  sha256 '531c84e24983927c59dc0c5611f605776f917d1c516af80c69c09ea232d24e01'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.