### PR TITLE
Checks if link exists before trying to delete

### DIFF
--- a/Casks/adobe-air-sdk.rb
+++ b/Casks/adobe-air-sdk.rb
@@ -50,7 +50,7 @@ cask 'adobe-air-sdk' do
   end
 
   uninstall_postflight do
-    FileUtils.rm("#{HOMEBREW_PREFIX}/share/adobe-air-sdk")
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/adobe-air-sdk")
   end
 
   caveats <<~EOS

--- a/Casks/android-ndk.rb
+++ b/Casks/android-ndk.rb
@@ -30,7 +30,7 @@ cask 'android-ndk' do
   ].each { |link_name| binary shimscript, target: link_name }
 
   uninstall_postflight do
-    FileUtils.rm("#{HOMEBREW_PREFIX}/share/android-ndk")
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-ndk")
   end
 
   caveats <<~EOS

--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -26,7 +26,7 @@ cask 'android-sdk' do
   end
 
   uninstall_postflight do
-    FileUtils.rm("#{HOMEBREW_PREFIX}/share/android-sdk")
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-sdk")
   end
 
   caveats do

--- a/Casks/crystax-ndk.rb
+++ b/Casks/crystax-ndk.rb
@@ -29,7 +29,7 @@ cask 'crystax-ndk' do
   ].each { |link_name| binary shimscript, target: link_name }
 
   uninstall_postflight do
-    FileUtils.rm("#{HOMEBREW_PREFIX}/share/crystax-ndk")
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/crystax-ndk")
   end
 
   caveats <<~EOS


### PR DESCRIPTION
Addresses #67983 as well as other locations with the same issue.

Uses `rm_f` instead of `rm` during deletion.
Affects adobe-air-sdk, android-ndk, android-sdk, crystax-ndk

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
