### PR TITLE
secure URLs

### DIFF
--- a/Casks/adobe-acrobat-reader.rb
+++ b/Casks/adobe-acrobat-reader.rb
@@ -2,7 +2,7 @@ cask 'adobe-acrobat-reader' do
   version '19.012.20036'
   sha256 '5204461bf90aec7a8b52ecea4845fb67fc218c5170495e7728e54ed404dfc8e5'
 
-  url "http://ardownload.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.no_dots}/AcroRdrDC_#{version.no_dots}_MUI.dmg"
+  url "https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/#{version.no_dots}/AcroRdrDC_#{version.no_dots}_MUI.dmg"
   appcast 'https://get.adobe.com/reader/'
   name 'Adobe Acrobat Reader DC'
   homepage 'https://acrobat.adobe.com/us/en/acrobat/pdf-reader.html'

--- a/Casks/adventure.rb
+++ b/Casks/adventure.rb
@@ -2,10 +2,10 @@ cask 'adventure' do
   version '2.1'
   sha256 '743c6912a29cb225a4e44bdf59f65286fd00ada32e7747e83c8379bb532f9f5d'
 
-  url 'http://www.lobotomo.com/products/downloads/Adventure.dmg'
-  appcast 'http://www.lobotomo.com/products/Adventure/profileInfo.php'
+  url 'https://www.lobotomo.com/products/downloads/Adventure.dmg'
+  appcast 'https://www.lobotomo.com/products/Adventure/profileInfo.php'
   name 'Adventure'
-  homepage 'http://www.lobotomo.com/products/Adventure/'
+  homepage 'https://www.lobotomo.com/products/Adventure/'
 
   app 'Adventure.app'
 end

--- a/Casks/atlantis.rb
+++ b/Casks/atlantis.rb
@@ -2,10 +2,10 @@ cask 'atlantis' do
   version '0.9.9.4'
   sha256 '52957a5b92b1fd3612aa7a3a07f5238236dad4397a6a256a03355c331433e540'
 
-  url "http://www.riverdark.net/atlantis/downloads/Atlantis-#{version}.dmg"
-  appcast 'http://www.riverdark.net/atlantis/downloads/'
+  url "https://www.riverdark.net/atlantis/downloads/Atlantis-#{version}.dmg"
+  appcast 'https://www.riverdark.net/atlantis/downloads/'
   name 'Atlantis'
-  homepage 'http://www.riverdark.net/atlantis/'
+  homepage 'https://www.riverdark.net/atlantis/'
 
   app 'Atlantis.app'
 end

--- a/Casks/cgoban.rb
+++ b/Casks/cgoban.rb
@@ -2,7 +2,7 @@ cask 'cgoban' do
   version :latest
   sha256 :no_check
 
-  url 'http://files.gokgs.com/javaBin/cgoban.dmg'
+  url 'https://files.gokgs.com/javaBin/cgoban.dmg'
   name 'CGoban'
   homepage 'https://www.gokgs.com/download.jsp'
 

--- a/Casks/commandq.rb
+++ b/Casks/commandq.rb
@@ -2,7 +2,7 @@ cask 'commandq' do
   version '1.0.4'
   sha256 '1183a2baf3775bd47851c94636ebe41356e4b53fce1dd35b4b70b9298294a107'
 
-  url "http://dl.clickontyler.com/commandq/commandq_#{version}.zip"
+  url "https://dl.clickontyler.com/commandq/commandq_#{version}.zip"
   appcast 'https://shine.clickontyler.com/appcast.php?id=16'
   name 'CommandQ'
   homepage 'https://clickontyler.com/commandq/'

--- a/Casks/factor.rb
+++ b/Casks/factor.rb
@@ -2,8 +2,8 @@ cask 'factor' do
   version '0.98'
   sha256 '045847b1cf01e1dda270b834c34effd796ce52da40ada8e2fe52b55e3358db17'
 
-  url "http://downloads.factorcode.org/releases/#{version}/factor-macosx-x86-64-#{version}.dmg"
-  appcast 'http://downloads.factorcode.org/releases/'
+  url "https://downloads.factorcode.org/releases/#{version}/factor-macosx-x86-64-#{version}.dmg"
+  appcast 'https://downloads.factorcode.org/releases/'
   name 'Factor'
   homepage 'https://factorcode.org/'
 

--- a/Casks/ipsecuritas.rb
+++ b/Casks/ipsecuritas.rb
@@ -7,10 +7,10 @@ cask 'ipsecuritas' do
     sha256 '4e23830ab3a8b15f25bfe602c6f1b29c9766ae680afcaf0831047216b05836df'
   end
 
-  url "http://www.lobotomo.com/products/downloads/IPSecuritas%20#{version}.dmg"
-  appcast 'http://www.lobotomo.com/products/IPSecuritas/'
+  url "https://www.lobotomo.com/products/downloads/IPSecuritas%20#{version}.dmg"
+  appcast 'https://www.lobotomo.com/products/IPSecuritas/'
   name 'IPSecuritas'
-  homepage 'http://www.lobotomo.com/products/IPSecuritas/'
+  homepage 'https://www.lobotomo.com/products/IPSecuritas/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/openarena.rb
+++ b/Casks/openarena.rb
@@ -5,7 +5,7 @@ cask 'openarena' do
   # download.tuxfamily.org/openarena was verified as official when first introduced to the cask
   url "https://download.tuxfamily.org/openarena/rel/#{version.before_comma.no_dots}/openarena-#{version.before_comma}.zip"
   name 'OpenArena'
-  homepage 'http://openarena.ws/smfnews.php'
+  homepage 'https://openarena.ws/smfnews.php'
 
   app "openarena-#{version.before_comma}/OpenArena #{version.before_comma} #{version.after_comma}.app"
 

--- a/Casks/web-sharing.rb
+++ b/Casks/web-sharing.rb
@@ -2,7 +2,7 @@ cask 'web-sharing' do
   version '1.0'
   sha256 '54115af3de0b36f25b42834e52704490f0a4a85aed3a77e5b46a1a4e61592097'
 
-  url "http://dl.clickontyler.com/web-sharing/websharing_#{version}.zip"
+  url "https://dl.clickontyler.com/web-sharing/websharing_#{version}.zip"
   name 'Web Sharing'
   homepage 'https://clickontyler.com/web-sharing-mountain-lion/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

---
The `adventure` issue is due to a server mis-configuration that broke the Sparkle feed in HTTPS mode, while HTTP got also redirected to HTTPS, so it's only fixable server-side. I've sent an email to the maintainer a few days ago about it.

```terminal
1 file inspected, no offenses detected
==> Downloading https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/190
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'adobe-acrobat-reader'.
audit for adobe-acrobat-reader: passed

1 file inspected, no offenses detected
==> Downloading https://www.lobotomo.com/products/downloads/Adventure.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'adventure'.
audit for adventure: failed
 - The URL https://www.lobotomo.com/products/Adventure/profileInfo.php is not reachable (HTTP status code 500)
Error: audit failed for casks: adventure

1 file inspected, no offenses detected
==> Downloading https://www.riverdark.net/atlantis/downloads/Atlantis-0.9.9.4.dm
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'atlantis'.
audit for atlantis: passed

1 file inspected, no offenses detected
==> Downloading https://files.gokgs.com/javaBin/cgoban.dmg
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'cgoban', skipping verification.
audit for cgoban: passed

1 file inspected, no offenses detected
==> Downloading https://dl.clickontyler.com/commandq/commandq_1.0.4.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'commandq'.
audit for commandq: passed

1 file inspected, no offenses detected
==> Downloading https://downloads.factorcode.org/releases/0.98/factor-macosx-x86
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'factor'.
audit for factor: passed

1 file inspected, no offenses detected
==> Downloading https://www.lobotomo.com/products/downloads/IPSecuritas%204.9.1.
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'ipsecuritas'.
audit for ipsecuritas: passed

1 file inspected, no offenses detected
==> Downloading https://download.tuxfamily.org/openarena/rel/088/openarena-0.8.8
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'openarena'.
audit for openarena: passed

1 file inspected, no offenses detected
==> Downloading https://dl.clickontyler.com/web-sharing/websharing_1.0.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'web-sharing'.
audit for web-sharing: passed
```