### PR TITLE
Update tidepool-uploader from 2.20.0 to 2.21.0

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.20.0'
-  sha256 '37fd4fa915af3e0f6ba30cbab355a22b2aa4597c9e71bfe12b42936b3542994e'
+  version '2.21.0'
+  sha256 '8d1986bad8193656d2241c733465261f30f5ee53af51a4d9b1d55a256a171384'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.