### PR TITLE
Update pock from 0.6 to 0.6.1

### DIFF
--- a/Casks/pock.rb
+++ b/Casks/pock.rb
@@ -1,6 +1,6 @@
 cask 'pock' do
-  version '0.6'
-  sha256 '94040d127d3d4476d541c40eb96ba9cb4ccaa5bb1b9e7a36c8da5779ecda9b8d'
+  version '0.6.1'
+  sha256 '2050a4f9ef39ef2fd5bf912ae4f1bb0a2737f685b76a056249cca5e3ed17bbff'
 
   url "https://pock.dev/download.php?file=pock_#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/pigigaldi/Pock/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.