### PR TITLE
Update skim from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -1,6 +1,6 @@
 cask 'skim' do
-  version '1.5.2'
-  sha256 '9edef70d3f1611caab2c5d40a2a08ae4ad834c163c494a379db93ea6aeb68b44'
+  version '1.5.3'
+  sha256 '5d71c6f77022263d0ee21ea16b1849cbb730388e68fbb2018c537b5993d24ef1'
 
   # downloads.sourceforge.net/skim-app was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/skim-app/Skim/Skim-#{version}/Skim-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.