### PR TITLE
Update sqleditor from 3.5.5 to 3.6.2

### DIFF
--- a/Casks/sqleditor.rb
+++ b/Casks/sqleditor.rb
@@ -1,6 +1,6 @@
 cask 'sqleditor' do
-  version '3.5.5'
-  sha256 'baed5180887d88151cb4f09a9f73f327118fc7f335a0fba117a3bee8dc4b1bb5'
+  version '3.6.2'
+  sha256 'd6d4696079e8297749acaaf9a0ccaeaa31df9061f569191ec6de88dd86cee3a4'
 
   url "https://www.malcolmhardie.com/sqleditor/releases/#{version}/SQLEditor-#{version.dots_to_hyphens}.zip"
   appcast 'https://www.malcolmhardie.com/sqleditor/appcast/sq2release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.