### PR TITLE
Update workflowy from 1.3.4-4580 to 1.3.4-4613

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.4-4580'
-  sha256 '42fde90c893c841eacea75ec4748368a29570f157f8ba717dee5917059d13d1f'
+  version '1.3.4-4613'
+  sha256 'da7acf69cee8c51ed7ec15bbf12a162712079ea8191559d5be01a9c5bca9cb41'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.