### PR TITLE
Update panoply from 4.10.9 to 4.10.10

### DIFF
--- a/Casks/panoply.rb
+++ b/Casks/panoply.rb
@@ -1,6 +1,6 @@
 cask 'panoply' do
-  version '4.10.9'
-  sha256 '226d9aaa1194e106876d1304e7dde15ff2981c75330d32493527a55b5ef27fca'
+  version '4.10.10'
+  sha256 '6a347c2755650ce2e284270bc5734f75c4b89caf4d5f9b0b4287717517330d1f'
 
   url "https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-#{version}.dmg"
   appcast 'https://www.giss.nasa.gov/tools/panoply/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.