### PR TITLE
Update blitz from 1.3.5 to 1.3.7

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.3.5'
-  sha256 '7182d5b72396bca988396bb31c6a2a7fad4ea31a6f31b0cc7da4e52c66b1d3bc'
+  version '1.3.7'
+  sha256 'b67c397aec46abcfda31e770924585620d2973e9b6d26bb1df2175c5c22ab0f2'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.