### PR TITLE
add auto_updates true to lastpass 4.33.5

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -7,6 +7,7 @@ cask 'lastpass' do
   name 'LastPass'
   homepage 'https://www.lastpass.com/'
 
+  auto_updates true
   depends_on macos: '>= :sierra'
 
   app 'LastPass.app'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


The most recent few versions of lastpass have had an auto update prompt