### PR TITLE
Update lehreroffice from 2019.11.5 to 2019.12.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.11.5'
-  sha256 '8e567088eb5522ef8191959721f4f5437cad11ab8bd35421e1a9f99656a31bb6'
+  version '2019.12.0'
+  sha256 'b243ddb5f15e39b50e198a35e59c3a6c9a1dbfa4d7273d84a30618350da274da'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.