### PR TITLE
gimp.rb: updated folders to be deleted via zap

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -15,8 +15,8 @@ cask 'gimp' do
   end
 
   zap trash: [
-               '~/Library/Preferences/org.gnome.gimp.plist',
+               "~/Library/Preferences/org.gimp.gimp-#{version.major_minor}:.plist",
                '~/Library/Application Support/Gimp',
-               '~/Library/Saved Application State/org.gnome.gimp.savedState',
+               "~/Library/Saved Application State/org.gimp.gimp-#{version.major_minor}:.savedState",
              ]
 end


### PR DESCRIPTION
At some point between gimp 2.8 and 2.10 they changed their application domain from `org.gnome.gimp` to `org.gimp.gimp`. Also, even if a little bit strange, the `.plist` and `.savedState` files have a colon/slash after the version number.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).