### PR TITLE
mysqlworkbench.rb: updated zap folders

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -13,10 +13,8 @@ cask 'mysqlworkbench' do
 
   zap trash: [
                '~/Library/Application Support/MySQL/Workbench',
-               '~/Library/Preferences/com.oracle.mysql.workbench.plist',
-               '~/Library/Preferences/com.oracle.MySQLWorkbench.plist',
-               '~/Library/Saved Application State/com.oracle.mysql.workbench.savedState',
-               '~/Library/Saved Application State/com.oracle.MySQLWorkbench.savedState',
-               '~/Library/Caches/com.oracle.mysql.workbench',
+               '~/Library/Preferences/com.oracle.workbench.MySQLWorkbench.plist',
+               '~/Library/Caches/com.oracle.workbench.MySQLWorkbench',
+               '~/Library/Saved Application State/com.oracle.workbench.MySQLWorkbench.savedState',
              ]
 end


### PR DESCRIPTION
The previously listed folders didn't match the current files/folders anymore.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
