### PR TITLE
Updated yacreader.rb to latest version 9.6.2

### DIFF
--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -2,6 +2,7 @@ cask 'yacreader' do
   version '9.6.2'
   sha256 '92152f17b4ff072c3463ae045da5d232c2f59cb77267a0eeebb8af5de7d29214'
 
+  # github.com/YACReader/yacreader was verified as official when first introduced to the cask
   url "https://github.com/YACReader/yacreader/releases/download/#{version}/YACReader-#{version}.1909283.MacOSX-Intel.dmg"
   appcast 'https://github.com/YACReader/yacreader/releases.atom'
   name 'YACReader'

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -4,7 +4,8 @@ cask 'yacreader' do
 
   # github.com/YACReader/yacreader was verified as official when first introduced to the cask
   url "https://github.com/YACReader/yacreader/releases/download/#{version.major_minor_patch}/YACReader-#{version}.MacOSX-Intel.dmg"
-  appcast 'https://github.com/YACReader/yacreader/releases.atom'
+  appcast 'https://github.com/YACReader/yacreader/releases.atom',
+          configuration: version.major_minor_patch
   name 'YACReader'
   homepage 'https://www.yacreader.com/'
 

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -1,9 +1,9 @@
 cask 'yacreader' do
-  version '9.6.2'
+  version '9.6.2.1909283'
   sha256 '92152f17b4ff072c3463ae045da5d232c2f59cb77267a0eeebb8af5de7d29214'
 
   # github.com/YACReader/yacreader was verified as official when first introduced to the cask
-  url "https://github.com/YACReader/yacreader/releases/download/#{version}/YACReader-#{version}.1909283.MacOSX-Intel.dmg"
+  url "https://github.com/YACReader/yacreader/releases/download/#{version.major_minor_patch}/YACReader-#{version}.MacOSX-Intel.dmg"
   appcast 'https://github.com/YACReader/yacreader/releases.atom'
   name 'YACReader'
   homepage 'https://www.yacreader.com/'

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -1,9 +1,8 @@
 cask 'yacreader' do
-  version '9.5.0'
-  sha256 'c7b3a9e8f385bdc9bdfb29e754503c64ae1f3703f4bbfcb381feb46659b28491'
+  version '9.6.2'
+  sha256 '92152f17b4ff072c3463ae045da5d232c2f59cb77267a0eeebb8af5de7d29214'
 
-  # bitbucket.org/luisangelsm/yacreader was verified as official when first introduced to the cask
-  url "https://bitbucket.org/luisangelsm/yacreader/downloads/YACReader-#{version}-MacOSX-Intel.dmg"
+  url "https://github.com/YACReader/yacreader/releases/download/#{version}/YACReader-#{version}.1909283.MacOSX-Intel.dmg"
   appcast 'https://github.com/YACReader/yacreader/releases.atom'
   name 'YACReader'
   homepage 'https://www.yacreader.com/'


### PR DESCRIPTION
changed URL to github since development has moved there and https://www.yacreader.com/ also has links to download from github.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
