### PR TITLE
Update xrg from 2.6.0 to 2.7.0

### DIFF
--- a/Casks/xrg.rb
+++ b/Casks/xrg.rb
@@ -1,6 +1,6 @@
 cask 'xrg' do
-  version '2.6.0'
-  sha256 '682f0ccea561b6362d5eeb9e25bf1f611f223137908c692769f518ebda861f9b'
+  version '2.7.0'
+  sha256 '2772d6eea11429c4bbd74e3fa1f4a5acb04d35d80afdb10634292f0f5a465ded'
 
   url "https://download.gauchosoft.com/xrg/XRG-release-#{version}.zip"
   appcast 'https://gauchosoft.com/Products/XRG/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.