### PR TITLE
Update krita from 4.2.6 to 4.2.7.1

### DIFF
--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -1,6 +1,6 @@
 cask 'krita' do
-  version '4.2.6'
-  sha256 '77497f4d61338ecb7544817b5c2fcd0755e5efad1fcb7dedf0356f6aba229baa'
+  version '4.2.7.1'
+  sha256 'ebf37150a449eb9977d1bafb40f1cbb59a5e14278a646fd80273a1300cd0bd11'
 
   # kde.org/stable/krita was verified as official when first introduced to the cask
   url "https://download.kde.org/stable/krita/#{version.major_minor_patch}/krita-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.