### PR TITLE
Update paraview from 5.6.2 to 5.7.0

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -2,8 +2,7 @@ cask 'paraview' do
   version '5.7.0'
   sha256 '41cae3522c9f6188aa94b4cfed10624cdce8b426171f03b3246b44c26d036f1d'
 
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-64bit.dmg",
-      user_agent: :fake
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-Python2.7-64bit.dmg"
   appcast 'https://www.paraview.org/files/listing.txt'
   name 'ParaView'
   homepage 'https://www.paraview.org/'

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,6 +1,6 @@
 cask 'paraview' do
-  version '5.6.2'
-  sha256 '9cbc9ff9b10625ccd38fd018d3e5b0424c5d394b1b57ff9d1faec182efd6101a'
+  version '5.7.0'
+  sha256 '41cae3522c9f6188aa94b4cfed10624cdce8b426171f03b3246b44c26d036f1d'
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-64bit.dmg",
       user_agent: :fake

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -3,7 +3,7 @@ cask 'paraview' do
   sha256 '41cae3522c9f6188aa94b4cfed10624cdce8b426171f03b3246b44c26d036f1d'
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-Python2.7-64bit.dmg"
-      user_agent: :fake  
+      user_agent: :fake
   appcast 'https://www.paraview.org/files/listing.txt'
   name 'ParaView'
   homepage 'https://www.paraview.org/'

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -3,6 +3,7 @@ cask 'paraview' do
   sha256 '41cae3522c9f6188aa94b4cfed10624cdce8b426171f03b3246b44c26d036f1d'
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-Python2.7-64bit.dmg"
+      user_agent: :fake  
   appcast 'https://www.paraview.org/files/listing.txt'
   name 'ParaView'
   homepage 'https://www.paraview.org/'

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -2,7 +2,7 @@ cask 'paraview' do
   version '5.7.0'
   sha256 '41cae3522c9f6188aa94b4cfed10624cdce8b426171f03b3246b44c26d036f1d'
 
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-Python2.7-64bit.dmg"
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-Python2.7-64bit.dmg",
       user_agent: :fake
   appcast 'https://www.paraview.org/files/listing.txt'
   name 'ParaView'

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,6 +1,6 @@
 cask 'paraview' do
   version '5.7.0'
-  sha256 '41cae3522c9f6188aa94b4cfed10624cdce8b426171f03b3246b44c26d036f1d'
+  sha256 '7d81ea4a26ba7cd9528bac748cabbbb5511858981ed33dee79f2d82a32194dca'
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.12-Python2.7-64bit.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.