### PR TITLE
Add yandex-cloud-cli 0.41.1

### DIFF
--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -1,0 +1,11 @@
+cask 'yandex-cloud-cli' do
+  version '0.41.1'
+  sha256 '5a61097604d3b8d2d402d7d8fe878860399e7e8795c901bd01032e47586264c9'
+
+  # yandexcloud.net was verified as official when first introduced to the cask
+  url "https://storage.yandexcloud.net/yandexcloud-yc/release/#{version}/darwin/amd64/yc"
+  name 'Yandex Cloud CLI'
+  homepage 'https://cloud.yandex.com/docs/cli/'
+
+  binary 'yc'
+end

--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -2,7 +2,7 @@ cask 'yandex-cloud-cli' do
   version '0.41.1'
   sha256 '5a61097604d3b8d2d402d7d8fe878860399e7e8795c901bd01032e47586264c9'
 
-  # yandexcloud.net was verified as official when first introduced to the cask
+  # yandexcloud.net/yandexcloud-yc was verified as official when first introduced to the cask
   url "https://storage.yandexcloud.net/yandexcloud-yc/release/#{version}/darwin/amd64/yc"
   name 'Yandex Cloud CLI'
   homepage 'https://cloud.yandex.com/docs/cli/'


### PR DESCRIPTION
Add cask for Yandex Cloud CLI (analogues to `google-cloud-sdk` cask). Yandex is one of the largest cloud providers in Russia and Eastern Europe.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
- [x] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
