### PR TITLE
GitHub Actions: updates for data generation

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate:
+    if: github.repository == 'Homebrew/homebrew-cask'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -22,7 +22,7 @@ jobs:
 
           export PATH="$(brew --repo)/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH"
 
-          git clone git@github.com:Homebrew/formulae.brew.sh
+          git clone --depth=1 git@github.com:Homebrew/formulae.brew.sh
           cd formulae.brew.sh
 
           # setup analytics


### PR DESCRIPTION
1. Perform a shallow clone when fetching Homebrew/formulae.brew.sh, as is currently done in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/generate_formulae.brew.sh_data.yml#L25).
2. Ensure we're running off the original homebrew-cask repo and not a fork, as suggested in Homebrew/homebrew-core#44809.