### PR TITLE
Update smoothscroll from 1.3.6 to 1.3.8

### DIFF
--- a/Casks/smoothscroll.rb
+++ b/Casks/smoothscroll.rb
@@ -1,6 +1,6 @@
 cask 'smoothscroll' do
-  version '1.3.6'
-  sha256 '07e7810de40ab7341da293895838420c4bedb1deb049f2247dd7eb07a6433c56'
+  version '1.3.8'
+  sha256 'add1d28409c6884adf085fc1b2e319c5772bb3cb82264baca3b7080f48ebe3e6'
 
   url 'https://www.smoothscroll.net/mac/download/SmoothScroll.app.zip'
   appcast 'https://updater.smoothscroll.net/mac/updater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.