### PR TITLE
Update yate from 5.0.1.1 to 5.0.1.2

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '5.0.1.1'
-  sha256 'bd56bd1ec5ea3366d9c39232b14a9cf5582d5f698c9930baa4e300a4c6ac4cd7'
+  version '5.0.1.2'
+  sha256 '8c08cbb467f3f088dd0116333b07ef43461d4ed25eb43dce938daae54b26f1ae'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.