### PR TITLE
Update melodics from 2.1.3551 to 2.1.3610

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3551'
-  sha256 '7b9d0c573d0bc73bb1a4c74e758bfa9e8ce16d4cdf3347629a72a9b3b53f0313'
+  version '2.1.3610'
+  sha256 '5cb948fecb0fbb542667f54af99cb33acfdb3c7618ff097cff2592daff2e72d6'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.