### PR TITLE
Update garagebuy from 3.3 to 3.3.1

### DIFF
--- a/Casks/garagebuy.rb
+++ b/Casks/garagebuy.rb
@@ -1,6 +1,6 @@
 cask 'garagebuy' do
-  version '3.3'
-  sha256 '57409fe84cc308fd78fe01101939bd517641e57454bf757a07b47950ce5fdcca'
+  version '3.3.1'
+  sha256 'a1e6f7f105655d1a773755c450a0a062aa5509407a3d5ed02fb5aa2756bdabe9'
 
   # iwascoding.de was verified as official when first introduced to the cask
   url "https://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.