### PR TITLE
Update freecad from 0.18.3,16131 to 0.19,18353

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,9 +1,9 @@
 cask 'freecad' do
-  version '0.19,18353'
+  version '0.19_pre,18353'
   sha256 '4ae884e74454d58a50550c7da2caa7339c9344afa651fb7817cfea4dc3761e86'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}_pre/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"
   appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom'
   name 'FreeCAD'
   homepage 'https://www.freecadweb.org/'

--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,9 +1,9 @@
 cask 'freecad' do
-  version '0.18.3,16131'
-  sha256 '8f3e4503e42c1579bd12e537f68ecf91f7c3515e2944b7124db0e155815f71c4'
+  version '0.19,18353'
+  sha256 '4ae884e74454d58a50550c7da2caa7339c9344afa651fb7817cfea4dc3761e86'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}_pre/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"
   appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom'
   name 'FreeCAD'
   homepage 'https://www.freecadweb.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The current version (0.18.3,16131) won't download because they have pulled the macOS release of 0.18.3. The [0.18.3 release page](https://github.com/FreeCAD/FreeCAD/releases/0.18.3) says:

> NOTE: For OSX it is recommended to use the 0.19_dev builds. https://github.com/FreeCAD/FreeCAD/releases/tag/0.19_pre
> FreeCAD 0.19.x has been ported to QT5.9 and QTWebEngine which solves some OSX specific issues.

Because 0.19 is still tagged `0.19_pre`, I had to manually edit `url` and insert the `_pre` bit.