### PR TITLE
Update whatsapp from 0.3.4679 to 0.3.4941

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'whatsapp' do
-  version '0.3.4679'
-  sha256 '2ae0a2e201e0ec466569f46ad0339f97a6c74d92229b8cd44e0a21e63441daf3'
+  version '0.3.4941'
+  sha256 'e96b70b4728401b3fa1db7691086138501c84e297146f505acfeba9c12974864'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.