### PR TITLE
Update toggl from 7.4.1022 to 7.4.1023

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.1022'
-  sha256 'd80ba540b4302ba3228b590121a2c87fbc67a2dea5a4bc073b46e121235826e4'
+  version '7.4.1023'
+  sha256 'cd87582ece7538f6d1b8731a794e97b2d38df60f206ace0796b9c532a5b9e3c3'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.