### PR TITLE
Update downie from 3.8.5,2065 to 3.8.6,2069

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.8.5,2065'
-  sha256 '64053c4162d3c921bb55d40f183ee4bea5bdabd3b7aed5dcba9c376790f2abf0'
+  version '3.8.6,2069'
+  sha256 'aae7aa07806f7c7673e27ff53025b2669a59702c30fc9231d7d47e35f9ff1753'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.