### PR TITLE
bbedit 13.0 not compatible with pre Mojave macOS

### DIFF
--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -2,10 +2,17 @@ cask 'bbedit' do
   if MacOS.version <= :el_capitan
     version '12.1.6'
     sha256 '23b9fc6ef5c03cbcab041566503c556d5baf56b2ec18f551e6f0e9e6b48dc690'
+  elsif MacOS.version <= :sierra
+    version '12.6.7'
+    sha256 'd0647c864268b187343bd95bfcf490d6a2388579b1f8fce64a289c65341b1144'
+  elsif MacOS.version <= :high_sierra
+    version '12.6.7'
+    sha256 'd0647c864268b187343bd95bfcf490d6a2388579b1f8fce64a289c65341b1144'
   else
     version '13.0'
     sha256 '38126aa393fd6cafdc91903bbca50d0555f06f7c0f08161c6ab110206ecaada3'
   end
+  # Version 13.0 requires macOS 10.14.2. elsif for Sierra and High Sierra to download last compatible versions.
   # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml'

--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -2,9 +2,6 @@ cask 'bbedit' do
   if MacOS.version <= :el_capitan
     version '12.1.6'
     sha256 '23b9fc6ef5c03cbcab041566503c556d5baf56b2ec18f551e6f0e9e6b48dc690'
-  elsif MacOS.version <= :sierra
-    version '12.6.7'
-    sha256 'd0647c864268b187343bd95bfcf490d6a2388579b1f8fce64a289c65341b1144'
   elsif MacOS.version <= :high_sierra
     version '12.6.7'
     sha256 'd0647c864268b187343bd95bfcf490d6a2388579b1f8fce64a289c65341b1144'
@@ -12,7 +9,6 @@ cask 'bbedit' do
     version '13.0'
     sha256 '38126aa393fd6cafdc91903bbca50d0555f06f7c0f08161c6ab110206ecaada3'
   end
-  # Version 13.0 requires macOS 10.14.2. elsif for Sierra and High Sierra to download last compatible versions.
   # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/BBEdit_#{version}.dmg"
   appcast 'https://versioncheck.barebones.com/BBEdit.xml'


### PR DESCRIPTION
Added two elsif to make sure the last compatible version, 12.6.7, will be downloaded for Sierra and High Sierra.

Note: BBEdit 12.1.6 requires macOS 10.11.6 or later, BBEdit 12.6.7 requires macOS 10.12.6 or later, and BBEdit 13.0 requires macOS 10.14.2 or later. Is there a way to specify minor version numbers?

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
