### PR TITLE
Update unity from 2019.2.6f1,fe82a0e88406 to 2019.2.8f1,ff5b465c8d13

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.6f1,fe82a0e88406'
-  sha256 '96ec98f235ea32e73141b56c2dfe6d4f43551cd4657d55b019019c89a89637a9'
+  version '2019.2.8f1,ff5b465c8d13'
+  sha256 'a1da7f145fcebbf30e6b7671be507b7983510beb568c93213e7d195e0fc1ed51'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.