### PR TITLE
Update unity-android-support-for-editor from 2019.2.6f1,fe82a0e88406 to 2019.2.8f1,ff5b465c8d13

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.2.6f1,fe82a0e88406'
-  sha256 '984c7c254658a7237dac850e78cfab62000a5a982c21af5460877d53851aed5c'
+  version '2019.2.8f1,ff5b465c8d13'
+  sha256 'b89a4687c3765b0b1a2a051e2b706cc68f29dd8d096576a0f87a8e3229b8949e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.