### PR TITLE
Update lastpass from 4.33.5 to 4.34.0

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.33.5'
-  sha256 'ab4f444472cc6afc47e7177e0abf07f4d728c75793e5cc11f64406f0c951956d'
+  version '4.34.0'
+  sha256 '3f649f740455d7fc3185bb6e1e9f2cd98acbfe78f937651d82daeed51ae23eea'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.