### PR TITLE
Update pdfpenpro from 1110.2,1562632601 to 1111.3,1570056557

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1110.2,1562632601'
-  sha256 '7cfa2436fa7d17f1bf0d5b24e6a6bc3717dfbfd78260540a55576d4f10a601c0'
+  version '1111.3,1570056557'
+  sha256 '7df020bca156d3bc40dcfe9e96555754b4a36ef76233ba6b5d1cf38fc4befe0c'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.