### PR TITLE
Update pagico from 8.18.2426 to 8.18.2427

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '8.18.2426'
-  sha256 '74fa60570ce79169c11c6deef2e463960094fe33166a9bf2439f342cc4e849a4'
+  version '8.18.2427'
+  sha256 '4d852f807f09812d3deb52c202ae81fedb46e8944a67bf65999682680e0b893a'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast "https://www.pagico.com/api/pagico#{version.major}.mac.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.