### PR TITLE
Update cacher from 2.19.4 to 2.20.0

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.19.4'
-  sha256 '0d847995e02b68d73cc69f218de415980954379dd7f50d24385814ab5b67ffa7'
+  version '2.20.0'
+  sha256 '20d902fe39990209a6f29018f0830921dcd87d824a1181813fe1e74e42f67bb8'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.