### PR TITLE
Update milanote from 1.5.1 to 1.5.2

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.5.1'
-  sha256 '101a5ad54a779fc94fdc3b274b025e8e4997cab6408ab979524231a3f2b1ceab'
+  version '1.5.2'
+  sha256 '1f9ed0a50386679298f28acb8db8c8f4bcf882e8292e698138f0fe9fbb5ce6e3'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.