### PR TITLE
Update drawbot from 3.120 to 3.121

### DIFF
--- a/Casks/drawbot.rb
+++ b/Casks/drawbot.rb
@@ -1,6 +1,6 @@
 cask 'drawbot' do
-  version '3.120'
-  sha256 '3c4367befaac968b47b71320e20132f1b0761e2830c13465004268ea446deed4'
+  version '3.121'
+  sha256 '68b8327fcacf21db7d37374a389fe5609d87eac6e6df01993b0effffef95aa71'
 
   # typemytype.com/drawBot was verified as official when first introduced to the cask
   url 'https://static.typemytype.com/drawBot/DrawBot.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.