### PR TITLE
Update tastyworks from 0.41.0 to 1.0.15

### DIFF
--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -1,8 +1,8 @@
 cask 'tastyworks' do
-  version '0.41.0'
-  sha256 '953862888ee31ed993d6e8cad8b12a817de30c94b82c0324c8cae58d1b938920'
+  version '1.0.15'
+  sha256 'c540eac3c09937f7e6a7ff6c98a897d28445df7f8fbf0521ceab198c3d59e397'
 
-  url "https://download.tastyworks.com/desktop/#{version}/tastyworks-#{version}.dmg"
+  url "https://download.tastyworks.com/desktop-#{version.major}.x.x/#{version}/tastyworks-#{version}.dmg"
   appcast 'https://tastyworks.com/technology.html'
   name 'tastyworks'
   homepage 'https://tastyworks.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.