### PR TITLE
Update unity-download-assistant from 2019.2.6f1,fe82a0e88406 to 2019.2.8f1,ff5b465c8d13

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.2.6f1,fe82a0e88406'
-  sha256 '962a4f2c71c2713e4a9cf33741abe55f92a71b4ee88d57da8deff19c91bb8123'
+  version '2019.2.8f1,ff5b465c8d13'
+  sha256 'aeaefa169399a683f531c6eb35dfc601a6a287902e681864b12f46cd1c8d22db'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.