### PR TITLE
Update unity-linux-support-for-editor from 2019.2.6f1,fe82a0e88406 to 2019.2.8f1,ff5b465c8d13

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.6f1,fe82a0e88406'
-  sha256 'ce6bcf478c55b59bda9ec4bb774575c2e5c474c49ec4f306e450a5befdc73630'
+  version '2019.2.8f1,ff5b465c8d13'
+  sha256 '4475a6ff876e4384677a21360977ce7af3305a41d72931835545676e14cc6c7b'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.