### PR TITLE
Update unity-windows-support-for-editor from 2019.2.6f1,fe82a0e88406 to 2019.2.8f1,ff5b465c8d13

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.6f1,fe82a0e88406'
-  sha256 '6785cc016c998f734e7a0d69fcef3b45c0b0f6799a978df4136bb1d400d36315'
+  version '2019.2.8f1,ff5b465c8d13'
+  sha256 '5ef4974f453dc2df45cbe45d01acf21bd4c42bc0d85dba81ef8b3d6c3c08102e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.