### PR TITLE
Update xld from 2018.10.19 to 2019.10.04

### DIFF
--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -4,7 +4,8 @@ cask 'xld' do
 
   # sourceforge.net/xld was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/xld/xld-#{version.no_dots}.dmg"
-  appcast 'https://svn.code.sf.net/p/xld/code/appcast/xld-appcast_e.xml'
+  appcast 'https://svn.code.sf.net/p/xld/code/appcast/xld-appcast_e.xml',
+          configuration: version.no_dots
   name 'X Lossless Decoder'
   name 'XLD'
   homepage 'https://tmkk.undo.jp/xld/index_e.html'

--- a/Casks/xld.rb
+++ b/Casks/xld.rb
@@ -1,6 +1,6 @@
 cask 'xld' do
-  version '2018.10.19'
-  sha256 '3f49f4c1669b6c9f1ae7f6e1919526bc539971ce8b1a880ac581da3bb3f84b2c'
+  version '2019.10.04'
+  sha256 '6fedfede1f54d691b69f0d6dc5477062c57fe6c48b7f86624a47eb1b58a1e4ef'
 
   # sourceforge.net/xld was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/xld/xld-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.