### PR TITLE
Update birdfont from 3.30.6 to 3.31.0

### DIFF
--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -3,8 +3,8 @@ cask 'birdfont' do
     version '2.19.4'
     sha256 '013d9c42c2252b57079453bd27e4c18dbbc09eda55563ff1516fd079c0499f76'
   else
-    version '3.30.6'
-    sha256 '2ade922f34d0e119d51be16c60ef2be3198188cff289b3bcaa657485eefc687c'
+    version '3.31.0'
+    sha256 '0879898b3c248167cc9f4c8ede47a576130adb4eb2a7e3231f617b1e3dc091e2'
   end
 
   url "https://birdfont.org/download/birdfont-#{version}-free.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.