### PR TITLE
Update snowflake-snowsql from 1.1.84 to 1.1.85

### DIFF
--- a/Casks/snowflake-snowsql.rb
+++ b/Casks/snowflake-snowsql.rb
@@ -1,6 +1,6 @@
 cask 'snowflake-snowsql' do
-  version '1.1.84'
-  sha256 '9ab879bed19bdeb99dd0d6aaad3cd03e61c2cd9004f653f54450375f59d758ec'
+  version '1.1.85'
+  sha256 '865d280cc92d52dc04c7a938d05806832e9bf1a9786cdf3413e3a92aed031487'
 
   # sfc-snowsql-updates.s3.us-west-2.amazonaws.com was verified as official when first introduced to the cask
   url "https://sfc-snowsql-updates.s3.us-west-2.amazonaws.com/bootstrap/#{version.major_minor}/darwin_x86_64/snowsql-#{version}-darwin_x86_64.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.