### PR TITLE
Update freecad 0.19_pre,18353

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
   version '0.19_pre,18353'
-  sha256 '4ae884e74454d58a50550c7da2caa7339c9344afa651fb7817cfea4dc3761e86'
+  sha256 'abf7a7216497b6aa4135ae60038e70234e5e731b9085f4196c63e7e18b2c5af4'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
Somehow, the `sha` has changed to [`abf7a7216497b6aa4135ae60038e70234e5e731b9085f4196c63e7e18b2c5af4`](https://github.com/FreeCAD/FreeCAD/releases/download/0.19_pre/FreeCAD_0.19-18353-OSX-x86_64-conda-Qt5-Py3.dmg-SHA256.txt) breaking #70078

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
