### PR TITLE
Update thedesk from 18.10.1 to 18.11.0

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.10.1'
-  sha256 'a648cf19736f29ea0d56882b1c32bbc594fa6e0641ca443088e2bdf1f7e5f652'
+  version '18.11.0'
+  sha256 '048ba05c0401b49ec8eaf37ad29562e556a8bb3ffc9bb8318fa55b2ea37395ef'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.