### PR TITLE
Update cinch from 1.2.3 to 1.2.4

### DIFF
--- a/Casks/cinch.rb
+++ b/Casks/cinch.rb
@@ -1,6 +1,6 @@
 cask 'cinch' do
-  version '1.2.3'
-  sha256 '62589f8f7d08e537dcadea97a4cb35243db2b8a63efc25a21317814f732c5c11'
+  version '1.2.4'
+  sha256 '68afff19aaff4885e803733df74cfc87fe6529ec57107d21bddcb00d61dd14a0'
 
   url "https://www.irradiatedsoftware.com/downloads/Cinch_#{version}.zip"
   appcast 'https://www.irradiatedsoftware.com/updates/profiles/cinch.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.