### PR TITLE
Update bluej from 4.2.1 to 4.2.2

### DIFF
--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -1,6 +1,6 @@
 cask 'bluej' do
-  version '4.2.1'
-  sha256 '666d08e2a1c7986328bcdafd9885553cefd9e5974ac26705a3645a2037598d79'
+  version '4.2.2'
+  sha256 '37ae5c8c575ac3ee88f6890a7555ae38662f339622528987986a6ae335310311'
 
   url "https://www.bluej.org/download/files/BlueJ-mac-#{version.no_dots}.zip"
   appcast 'https://www.bluej.org'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.