### PR TITLE
Update orange from 3.23.0 to 3.23.1

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,6 +1,6 @@
 cask 'orange' do
-  version '3.23.0'
-  sha256 'e53f73fe4b0bcb7339430e5a67c5e43136d9a20a6cafe74d4d127746ac3d7789'
+  version '3.23.1'
+  sha256 'c9225f9bd53a7c475fe134602dd270599f3d01cd9c0fbe19ee6f7203dad3464b'
 
   url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://service.biolab.si/download/orange?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.