### PR TITLE
Update appium from 1.13.0 to 1.15.0-1

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,6 +1,6 @@
 cask 'appium' do
-  version '1.13.0'
-  sha256 'eae60a13682708da31b00f07d0728de448e354e5feb145d5602fba3335cb87da'
+  version '1.15.0-1'
+  sha256 '2f894dc5c3e5141086f663a98e94dd6b3cccd9120922658dc5ff0165255aaabb'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
   url "https://github.com/appium/appium-desktop/releases/download/v#{version}/Appium-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.