### PR TITLE
Update gisto from 1.12.11 to 1.12.12

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.12.11'
-  sha256 '79604a4ded5ca068e606bdbfa785b0d682b7d1c07e071ffb681674859b3f6d3e'
+  version '1.12.12'
+  sha256 '785146c2450089c012b3c7ac4d219ba4b5cf6acf03ff7ec306cf1da2a12e72e6'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.