### PR TITLE
Update mp3tag from 2.97 to 2.98

### DIFF
--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -1,8 +1,8 @@
 cask 'mp3tag' do
-  version '2.97'
-  sha256 'd1fd2e60bcdf18f70edf339bb2b7c3e76c31e69cd7c71d46fa570fc0cdc9a819'
+  version '2.98'
+  sha256 '3c433aece61a531e9d0521157921719ba83fac099fa832d0046395108f5271cf'
 
-  url "https://download.mp3tag.de/mp3tagv#{version.no_dots}-macOS-Wine.zip"
+  url 'http://download.mp3tag.de/mp3tagv298-macOS-Wine.zip'
   appcast 'https://www.mp3tag.de/en/mac-osx.html'
   name 'MP3TAG'
   homepage 'https://www.mp3tag.de/en/'

--- a/Casks/mp3tag.rb
+++ b/Casks/mp3tag.rb
@@ -2,7 +2,7 @@ cask 'mp3tag' do
   version '2.98'
   sha256 '3c433aece61a531e9d0521157921719ba83fac099fa832d0046395108f5271cf'
 
-  url 'http://download.mp3tag.de/mp3tagv298-macOS-Wine.zip'
+  url "https://download.mp3tag.de/mp3tagv#{version.no_dots}-macOS-Wine.zip"
   appcast 'https://www.mp3tag.de/en/mac-osx.html'
   name 'MP3TAG'
   homepage 'https://www.mp3tag.de/en/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.