### PR TITLE
Update clover-configurator from 5.6.0.0 to 5.6.1.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.6.0.0'
-  sha256 '9df774ce26ef084807d916fc76cb5091891db13f9f0cfe945eec241581622ea0'
+  version '5.6.1.0'
+  sha256 'f026ea023bac469fbf5c9902c8a71be6365037e4da611c89abace246604a9adb'
 
   url 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/builds-data-ccg/CCG.zip'
   appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.