### PR TITLE
Update find-any-file from 1.9.3 to 1.9.4

### DIFF
--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -1,6 +1,6 @@
 cask 'find-any-file' do
-  version '1.9.3'
-  sha256 '43a756641076388ff2080fcb0aa4e12d6619503b8daada99c0a20a6025cfba01'
+  version '1.9.4'
+  sha256 '16cd8f8ecd4d20f5aa56ecbe71a73ab864842f6411d59425abe77d24c6017b8d'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/files.tempel.org/FindAnyFile_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.