### PR TITLE
Update sage from 8.8,10.14.5 to 8.9,10.14.6

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,6 +1,6 @@
 cask 'sage' do
-  version '8.8,10.14.5'
-  sha256 'c0d7a633cf94231be48f1eb5a5b7de22befb5646eaa8b3e4a13b784f892b6ad6'
+  version '8.9,10.14.6'
+  sha256 '48dfbd697eaadb77913f8a57e01444e45826bdfeabf5e27ba1bc215c4cbd1764'
 
   # mirrors.mit.edu/sage/osx/intel was verified as official when first introduced to the cask
   url "https://mirrors.mit.edu/sage/osx/intel/sage-#{version.before_comma}-OSX_#{version.after_comma}-x86_64.app.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.