### PR TITLE
Update cacher from 2.20.0 to 2.20.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.20.0'
-  sha256 '20d902fe39990209a6f29018f0830921dcd87d824a1181813fe1e74e42f67bb8'
+  version '2.20.1'
+  sha256 '349ad10083d793160f9f5f62c5c2e6906af92e45195259a0f7bc5d37ef253e52'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.