### PR TITLE
Update opensong from 2.2.7,2.2.3-1075 to 3.0.0

### DIFF
--- a/Casks/opensong.rb
+++ b/Casks/opensong.rb
@@ -1,9 +1,9 @@
 cask 'opensong' do
-  version '2.2.7,2.2.3-1075'
-  sha256 'b347c7c9e1c5a152e943e3e06e0bbf50b43ea41680bae75aa191764b00f50181'
+  version '3.0.0'
+  sha256 'a9ef4384eea2dcf99e7e7f296be86b93a11228c3d75a9c21ede2846eb961dffd'
 
   # sourceforge.net/opensong was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/opensong/OpenSong/V#{version.before_comma}/OpenSongOSX-V#{version.after_comma}.dmg"
+  url "https://downloads.sourceforge.net/opensong/OpenSong/V#{version}/OpenSongOSX-V#{version}.dmg"
   appcast 'https://sourceforge.net/projects/opensong/rss'
   name 'OpenSong'
   homepage 'http://www.opensong.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.