### PR TITLE
Update netron from 3.3.9 to 3.4.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.3.9'
-  sha256 'ab95a1a12a29940b14b089db0cc18457df283065abb9993ee1c4f6c63a7eff5e'
+  version '3.4.0'
+  sha256 'fe4cae8ed134cee2ccd9cb053d1520b9ec2f65938376ef655fcae797e73035b5'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.