### PR TITLE
Update comictagger from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/comictagger.rb
+++ b/Casks/comictagger.rb
@@ -1,6 +1,6 @@
 cask 'comictagger' do
-  version '1.2.2'
-  sha256 '93d541490994e8dd6ad88c7179bffff607211c21c9c127e43e5dab3090c2b164'
+  version '1.2.3'
+  sha256 'c42168aa74167ea41c5ece2bd5001b091fab6a6878e7ccc6c988876bb1494d1c'
 
   url "https://github.com/davide-romanini/comictagger/releases/download/#{version}/ComicTagger-#{version}-osx-10.12.6-x86_64.app.zip"
   appcast 'https://github.com/davide-romanini/comictagger/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.