### PR TITLE
Update virtualhostx from 8.7.12,80_61 to 8.7.13,80_62

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '8.7.12,80_61'
-  sha256 '4db714e733f56d215071eab54b0f2dfbb6b44b9fcda53c37ac698268f0d401be'
+  version '8.7.13,80_62'
+  sha256 'd5dbb0dbbb7e4c5c6d13da6fd538358a717944dbd962273ac47796ae6c963c77'
 
   # downloads-clickonideas.netdna-ssl.com/virtualhostx was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/virtualhostx/virtualhostx#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.