### PR TITLE
Update subethaedit from 5.1 to 5.1.1

### DIFF
--- a/Casks/subethaedit.rb
+++ b/Casks/subethaedit.rb
@@ -1,6 +1,6 @@
 cask 'subethaedit' do
-  version '5.1'
-  sha256 '0b41e835a64d358a159467c7c9fc14b50295e1973cb54cf4944b4ad561f1b1ec'
+  version '5.1.1'
+  sha256 'a7dd83d16e212124a8100fa264671b1b4859660f2b0c7e8a4d828ab85d64e8e6'
 
   url "https://subethaedit.net/Releases/SubEthaEdit-#{version}.zip"
   appcast 'https://subethaedit.net/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.