### PR TITLE
Update ringcentral from 19.2.2 to 19.3.0

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '19.2.2'
-  sha256 'd1a8c7a42b567b8b566ad2378826faacef2aaeaf49ccd39a3b931b63765d55c4'
+  version '19.3.0'
+  sha256 '77db1037fe8c6255153f39921394bddc6ee74bad20c4ca415a7e1b7533e3ab16'
 
   url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads.ringcentral.com/sp/RingCentralForMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.