### PR TITLE
Update gpxsee from 7.14 to 7.15

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.14'
-  sha256 '55cfea3b2c63bc6e8de48f77bbd1f71294b64e9b1327ef95871ddba2f2282fc5'
+  version '7.15'
+  sha256 '0abbefd3ec8417f690dfdbd7797809c23c53b1813853a1d07837e44fffc41ad0'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.