### PR TITLE
Update hammerspoon from 0.9.75 to 0.9.76

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -3,8 +3,8 @@ cask 'hammerspoon' do
     version '0.9.46'
     sha256 '20f7e81624b6f007d6fdd8944cab3d9ba48c36fd0b4f1405a590526b5d4859bc'
   else
-    version '0.9.75'
-    sha256 '7372a490ed82f5735b5c77abfb1fc0cb87f7ea362f23c9b343feb16e764dd078'
+    version '0.9.76'
+    sha256 'abb99822ae13001486d7190c4988b60e784e2a23273a9b31cfbe39c58495d5e4'
   end
 
   # github.com/Hammerspoon/hammerspoon was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.