### PR TITLE
Update audio-hijack from 3.5.7 to 3.6.0

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -1,6 +1,6 @@
 cask 'audio-hijack' do
-  version '3.5.7'
-  sha256 '12bbfb98c7973aca3956f1ed0018ea43e2da3926ad12363dbec9711bfc87a0fb'
+  version '3.6.0'
+  sha256 '107e6cbec991a2a1808cdc7348b5bcb8d40967dc79ccb777fea9aeb9730f26eb'
 
   url 'https://rogueamoeba.com/audiohijack/download/AudioHijack.zip'
   appcast 'https://www.rogueamoeba.com/audiohijack/releasenotes.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.