### PR TITLE
Update curio from 13011.4 to 13020.7

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '13011.4'
-  sha256 '86215b58e47644e80ec95aeb71fc066a27d7dd517ff40827c771740d9f31791f'
+  version '13020.7'
+  sha256 '329c22433455cc72ed48dc181248ad1e95a3e33ab8fd9e87c572b70da97296a7'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio13HLwLK2C84LaKptcz.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.