### PR TITLE
Update wire from 3.10.3133 to 3.10.3215

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,6 +1,6 @@
 cask 'wire' do
-  version '3.10.3133'
-  sha256 'a98fba19c4ae390da74829da77a32fad2ceed9cfe40c16d5b838323fa84b0f35'
+  version '3.10.3215'
+  sha256 '8a27781f576dc760be07c8a369587f1ca11830cf597327a7b82dcce49f1bf579'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
   url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.