### PR TITLE
Update universal-media-server from 9.0.0 to 9.0.1

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,6 +1,6 @@
 cask 'universal-media-server' do
-  version '9.0.0'
-  sha256 '4d7d0464247b82fb8f91e27a50b26d40112443b093ab4a07d406dbebffec4872'
+  version '9.0.1'
+  sha256 '61a087061bc43c44a70e2eb43025b018dfca2e9d0277e5824dd514eede87e20c'
 
   # github.com/UniversalMediaServer/UniversalMediaServer was verified as official when first introduced to the cask
   url "https://github.com/UniversalMediaServer/UniversalMediaServer/releases/download/#{version}/UMS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.