### PR TITLE
Update find-any-file from 1.9.4 to 2.0

### DIFF
--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -1,6 +1,6 @@
 cask 'find-any-file' do
-  version '1.9.4'
-  sha256 '16cd8f8ecd4d20f5aa56ecbe71a73ab864842f6411d59425abe77d24c6017b8d'
+  version '2.0'
+  sha256 '7aa7379e7d3f86d0a924d20fbd26ffab857178f5159c9a11b1bef0e0a08b5697'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/files.tempel.org/FindAnyFile_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.