### PR TITLE
Update typeface from 2.5.0 to 2.6.0

### DIFF
--- a/Casks/typeface.rb
+++ b/Casks/typeface.rb
@@ -1,6 +1,6 @@
 cask 'typeface' do
-  version '2.5.0'
-  sha256 '6583316df269eaee8431606ed7ff8e454fb610e2053f4b3af131c81cd3f559e0'
+  version '2.6.0'
+  sha256 '104bd9cf08f627bd5cd9b3752bc49740757bc961e8beb341b80747aac9654c5b'
 
   url 'https://dcdn.typefaceapp.com/latest'
   appcast 'https://dcdn.typefaceapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.