### PR TITLE
Update netron from 3.4.0 to 3.4.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.4.0'
-  sha256 'fe4cae8ed134cee2ccd9cb053d1520b9ec2f65938376ef655fcae797e73035b5'
+  version '3.4.1'
+  sha256 'def26ddec18ab6d4ee8e8337c15a28df1c0a4f3316093990f7245373ed2df4bc'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.