### PR TITLE
Update bluestacks from 4.130.1.2809,bed43ee634f0a39bab766bd697cc09ab to 4.130.11.2802,39e0d097d6504e901d1fa5103cca7fd9

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -1,6 +1,6 @@
 cask 'bluestacks' do
-  version '4.130.1.2809,bed43ee634f0a39bab766bd697cc09ab'
-  sha256 '76c1eb38d04a6634ee2ff1967b7d774047f982e81091cdb03aa647699cf923cd'
+  version '4.130.11.2802,39e0d097d6504e901d1fa5103cca7fd9'
+  sha256 '18bee3b446e42bbb4616110c5d838144667f75e733c085b330e9e9a8f8f75f65'
 
   url "https://cdn3.bluestacks.com/downloads/mac/bgp64_mac/#{version.before_comma}/#{version.after_comma}/x64/BlueStacksInstaller_#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://cloud.bluestacks.com/api/getdownloadnow?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.