### PR TITLE
Update imaging-edge from 2.0.0_1908a,RXbW3ux0HM to 201_1910a,BlN9wc3nG4

### DIFF
--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,6 +1,6 @@
 cask 'imaging-edge' do
-  version '2.0.0_1908a,RXbW3ux0HM'
-  sha256 '0faf40d6acf2e867b250b58d15d8291580115135e20a48c67a9749f321edcf17'
+  version '201_1910a,BlN9wc3nG4'
+  sha256 '983afe3863bc2307c693bb335b05bd3794eb59736435f5fcbf9d236329e58efa'
 
   # ids.update.sony.net/IDC was verified as official when first introduced to the cask
   url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma.no_dots}.dmg"

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,5 +1,5 @@
 cask 'imaging-edge' do
-  version '201_1910a,BlN9wc3nG4'
+  version '2.0.1_1910a,BlN9wc3nG4'
   sha256 '983afe3863bc2307c693bb335b05bd3794eb59736435f5fcbf9d236329e58efa'
 
   # ids.update.sony.net/IDC was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.