### PR TITLE
Update paw from 3.1.8 to 3.1.9

### DIFF
--- a/Casks/paw.rb
+++ b/Casks/paw.rb
@@ -1,6 +1,6 @@
 cask 'paw' do
-  version '3.1.8'
-  sha256 '1eca10c6b71d54f961f9942341a159cc172153c4634241971e6c49c117d8c452'
+  version '3.1.9'
+  sha256 'a2d52e1052e0062f1d0301dc147dd7b7e10f18cd0bd613bbb98aeb3b48578f2b'
 
   url "https://cdn-builds.paw.cloud/paw/Paw-#{version}.zip"
   appcast 'https://paw.cloud/api/v2/updates/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.