### PR TITLE
Update lingo from 9.1 to 9.2

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,6 +1,6 @@
 cask 'lingo' do
-  version '9.1'
-  sha256 '9ed550e0034a0ca0beb57fb0f89d5c85c244e131030c5e9dca2121081499409a'
+  version '9.2'
+  sha256 '71df09330848d0c2fcf090c5f67336642df5b216356a603ce042e45517014ad4'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask
   url 'https://nounproject.s3.amazonaws.com/lingo/Lingo.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.