### PR TITLE
Update spek.rb, add the withmorten/spek-alternative forked version

### DIFF
--- a/Casks/spek.rb
+++ b/Casks/spek.rb
@@ -1,14 +1,20 @@
 cask 'spek' do
-  version '0.8.3'
-  sha256 '648ffe37a4605d76b8d63ca677503ba63338b84c5df73961d9a5335ff144cc54'
+  if MacOS.version <= :sierra
+    version '0.8.3'
+    sha256 '648ffe37a4605d76b8d63ca677503ba63338b84c5df73961d9a5335ff144cc54'
+    # github.com/alexkay/spek was verified as official when first introduced to the cask
+    url "https://github.com/alexkay/spek/releases/download/v#{version}/spek-#{version}.dmg"
+    appcast 'https://github.com/alexkay/spek/releases.atom'
+  else
+    version '0.8.2.3'
+    sha256 '6426c4c34ac8bcb2fa1020cb295e3c105ca912c853cbbe84d1d196a32bba361b'
+    # The original author may suspend maintenance, here using the withmorten/spek-alternative forked version
+    url "https://github.com/withmorten/spek-alternative/releases/download/#{version}/spek-alternative-#{version}.dmg"
+    appcast 'https://github.com/withmorten/spek-alternative/releases.atom'
+  end
 
-  # github.com/alexkay/spek was verified as official when first introduced to the cask
-  url "https://github.com/alexkay/spek/releases/download/v#{version}/spek-#{version}.dmg"
-  appcast 'https://github.com/alexkay/spek/releases.atom'
   name 'Spek'
   homepage 'http://spek.cc/'
-
-  depends_on macos: '<= :sierra'
 
   app 'Spek.app'
 end


### PR DESCRIPTION
The original author may suspend maintenance, here add the [withmorten/spek-alternative](https://github.com/withmorten/spek-alternative) forked version for Mojave.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
