### PR TITLE
Update station from 1.52.1 to 1.52.2

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.52.1'
-  sha256 '7d78c53e8c56de578c8fbf22d6fdd8446992e00b326715627d58252ae8c40ae5'
+  version '1.52.2'
+  sha256 '717a8f0247076ca34cf93da52fe310d9eb867e1aaa0c117eef4e68898e8d63ec'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.