### PR TITLE
Update arq from 5.16.2 to 5.17.1

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '5.16.2'
-  sha256 'f953be8d47e937e3dffe23111b838aa6d871ef6b61eb4807dfee558b2d61395a'
+  version '5.17.1'
+  sha256 'f8468091b8d2a977bd64f9a7c1f3a05b10cafe73b3aaf9ec13764f75b90da489'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version}.zip"
   appcast "https://www.arqbackup.com/download/arqbackup/arq#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.