### PR TITLE
Add support for LiteIcon v4.0 on Catalina

### DIFF
--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -2,6 +2,9 @@ cask 'liteicon' do
   if MacOS.version <= :sierra
     version '3.7.1'
     sha256 'b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432'
+  elsif MacOS.version == :catalina
+    version '4.0'
+    sha256 '9953f02a9a09c57214ca3a0afc3099032b6e152aa1206e9ffce636571d3d88b8'
   else
     version '3.9'
     sha256 'd185503d1c6cbbc6f770517853bd9ef08dc620f4e7ce3de913251a57e4d450d9'

--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -2,12 +2,12 @@ cask 'liteicon' do
   if MacOS.version <= :sierra
     version '3.7.1'
     sha256 'b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432'
-  elsif MacOS.version == :catalina
-    version '4.0'
-    sha256 '9953f02a9a09c57214ca3a0afc3099032b6e152aa1206e9ffce636571d3d88b8'
-  else
+  elsif MacOS.version <= :mojave
     version '3.9'
     sha256 'd185503d1c6cbbc6f770517853bd9ef08dc620f4e7ce3de913251a57e4d450d9'
+  else
+    version '4.0'
+    sha256 '9953f02a9a09c57214ca3a0afc3099032b6e152aa1206e9ffce636571d3d88b8'
   end
 
   url "https://www.freemacsoft.net/downloads/LiteIcon_#{version}.zip"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).