### PR TITLE
Update cyberduck from 7.1.0.31395 to 7.1.1.31577

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,6 +1,6 @@
 cask 'cyberduck' do
-  version '7.1.0.31395'
-  sha256 '5b72569c594d416050e801eed72316225100d3004fb1b528d072fa8185529e14'
+  version '7.1.1.31577'
+  sha256 '7efababe66d5e972a31cbc545a8533135a9be0046ded09fb9a40d8f88dac7aa7'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.