### PR TITLE
Update qownnotes from 19.10.1,b4589-102239 to 19.10.2,b4595-164629

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.10.1,b4589-102239'
-  sha256 '617940c70645f05f0a72f4798a72a87e5ff1ac96f7d50c2fe17e07b8dddbe8cb'
+  version '19.10.2,b4595-164629'
+  sha256 '664df9f7f8a41dc323a9ae516818138754c5a2951f964fb811cb4838228d9d51'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.