### PR TITLE
Update papers from 3.4.20,579 to 3.4.21,581

### DIFF
--- a/Casks/papers.rb
+++ b/Casks/papers.rb
@@ -1,6 +1,6 @@
 cask 'papers' do
-  version '3.4.20,579'
-  sha256 '48882e7852cd60ee42356e16fc297bbbe4f49c6a01f8a4a9127cfd10e45ff775'
+  version '3.4.21,581'
+  sha256 '04833ef8294a9b112b7bde5de82b9e0bc98a50ae575fcafcb7bba15181007f90'
 
   # appcaster.papersapp.com/apps/mac/production/download was verified as official when first introduced to the cask
   url "https://appcaster.papersapp.com/apps/mac/production/download/#{version.after_comma}/papers_#{version.before_comma.no_dots}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.