### PR TITLE
Update graphicconverter from 11.0.1,4059 to 11.1,4132

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,6 +1,6 @@
 cask 'graphicconverter' do
-  version '11.0.1,4059'
-  sha256 'b869c73fa0727718e171b54a6247bc8c442e56ddda63d1850c92a28da4e349d0'
+  version '11.1,4132'
+  sha256 'fdafcabd95497d8d02ae9a906119b59f7a38c429bf7e49dbc880296a776405e1'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.