### PR TITLE
Update marvel from 8.5 to 8.5.1

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.5'
-  sha256 'd3391b68b6aadb8938779b718a7409a14d958af9769f548e54dd607cc0e7bdfa'
+  version '8.5.1'
+  sha256 'fe2349371771f4d4f49239c6d742590c7516f48494b736514a2381349b1b63f4'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.