### PR TITLE
Update hostbuddy from 2.2.3,20_12 to 2.2.4,20_13

### DIFF
--- a/Casks/hostbuddy.rb
+++ b/Casks/hostbuddy.rb
@@ -1,6 +1,6 @@
 cask 'hostbuddy' do
-  version '2.2.3,20_12'
-  sha256 '13371a8b03df1035043421fb695aae945ca2e751266cfc35f422c51b0c5d8873'
+  version '2.2.4,20_13'
+  sha256 '613c9eb8972d2bbfb53fda0b16b033d6d668e4de9f8667ecbe1bf0337dcab41a'
 
   # downloads-clickonideas.netdna-ssl.com/hostbuddy was verified as official when first introduced to the cask
   url "https://downloads-clickonideas.netdna-ssl.com/hostbuddy/hostbuddy#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.