### PR TITLE
Update viscosity from 1.8 to 1.8.1

### DIFF
--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,6 +1,6 @@
 cask 'viscosity' do
-  version '1.8'
-  sha256 '581c52d50ac7fc2c254199e121106f254d697be65d735ac28d830af67273cb7e'
+  version '1.8.1'
+  sha256 '7733254c8b6a3614818528d6f0b6411856a629966b1b9681d554dda663c0d48f'
 
   url "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%20#{version}.dmg"
   appcast 'https://swupdate.sparklabs.com/appcast/mac/release/viscosity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.