### PR TITLE
Update memory from 2019.24 to 2019.25

### DIFF
--- a/Casks/memory.rb
+++ b/Casks/memory.rb
@@ -1,6 +1,6 @@
 cask 'memory' do
-  version '2019.24'
-  sha256 '81f397af082399577acec3dfc46243a6bead056c679e2fffe9b04994e7da3fc9'
+  version '2019.25'
+  sha256 '63c32b6ca8e2b4e7d2ef4c67343663113f65afb25316364a623a90f64f0f3217'
 
   # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.