### PR TITLE
Update mate-translate from 6.0.2,1555331041 to 6.1.0,1570524082

### DIFF
--- a/Casks/mate-translate.rb
+++ b/Casks/mate-translate.rb
@@ -1,6 +1,6 @@
 cask 'mate-translate' do
-  version '6.0.2,1555331041'
-  sha256 '71fe9c4285faf55da7ab0456a1c20f6426cb8561bef4b0102d7df281abc4c65e'
+  version '6.1.0,1570524082'
+  sha256 '3a346f7fe69726152863b639ea83f72720ab6dff2d1a14fb0b1549595ac4f02f'
 
   # dl.devmate.com/com.twopeoplesoftware.InstantTranslate-nomas was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.twopeoplesoftware.InstantTranslate-nomas/#{version.before_comma}/#{version.after_comma}/InstantTranslate-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.