### PR TITLE
Update protonvpn from 1.5.5 to 1.5.6

### DIFF
--- a/Casks/protonvpn.rb
+++ b/Casks/protonvpn.rb
@@ -1,6 +1,6 @@
 cask 'protonvpn' do
-  version '1.5.5'
-  sha256 '6bf0df3e1d42e95f97a5b94000bc7f5454fe8144a021d00deb3dffe686179c50'
+  version '1.5.6'
+  sha256 'f75056bb2bb4862a90914f30b7c759ef5b9f2f80d804d212e1ce323a77385e89'
 
   url "https://protonvpn.com/download/ProtonVPN_mac_v#{version}.dmg"
   appcast 'https://protonvpn.com/download/macos-update2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.