### PR TITLE
Update fantastical from 2.5.10 to 2.5.11

### DIFF
--- a/Casks/fantastical.rb
+++ b/Casks/fantastical.rb
@@ -1,6 +1,6 @@
 cask 'fantastical' do
-  version '2.5.10'
-  sha256 '46772c5c24a1761c3ddae7b2f16def2fdf2577366e059c647c7112b4a0ad4fd9'
+  version '2.5.11'
+  sha256 'b5c4f7b97c254cc787c2dc6c7b76af732e3b3f0e5b7ce3e5a5071a50b711a1f2'
 
   url "http://cdn.flexibits.com/Fantastical_#{version}.zip"
   appcast "https://flexibits.com/fantastical/appcast#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.