### PR TITLE
Update hiarcs-chess-explorer from 1.9.3.0 to 1.9.4

### DIFF
--- a/Casks/hiarcs-chess-explorer.rb
+++ b/Casks/hiarcs-chess-explorer.rb
@@ -1,6 +1,6 @@
 cask 'hiarcs-chess-explorer' do
-  version '1.9.3.0'
-  sha256 '1ce7544fbdf3afa53a760d263f57bfc82b1f5b8cf77480b25c3dbedb74080aed'
+  version '1.9.4'
+  sha256 'eaf7627801ca4cc2351fef58bb313353eca2a51d894e28df2b627dd011856a7f'
 
   url "http://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
   appcast 'http://www.hiarcs.com/hce/mac-v120.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.