### PR TITLE
Update mindjet-mindmanager from 12.1.183 to 12.1.190

### DIFF
--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -1,6 +1,6 @@
 cask 'mindjet-mindmanager' do
-  version '12.1.183'
-  sha256 '716287e692bbba2c14ba7d5efae3be6148d4b0c62bb57af7195caaec5fc25fa9'
+  version '12.1.190'
+  sha256 '06a68a50fda70bf9d270a9a02ad69441e359b4a0eb63b8217610f08e1998048a'
 
   url "https://download.mindjet.com/Mindjet_MindManager_Mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.mindjet.com/latest-release-notes-mac-english',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.