### PR TITLE
Update zotero from 5.0.74 to 5.0.75

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.74'
-  sha256 'b32e12d717265510dd54b564875ba837737a469de03ba4913eeba41fa7087a98'
+  version '5.0.75'
+  sha256 'de71b6fd42560a13ac67a21f9087cd18caadd5785abf7fd347d84e7591cb7208'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.