### PR TITLE
Update anydo from 4.2.46 to 4.2.47

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.46'
-  sha256 'cf2874c2d3160d280e021baed8b39b30ac5bbd22a96834c55246a84cc967008d'
+  version '4.2.47'
+  sha256 'ba73bde4a7e247e54b2b084b128cac0b49fa72f3e50bc35c2d721f7b9fb1442a'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.