### PR TITLE
Update thingsmacsandboxhelper from 3.16 to 3.18

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -1,6 +1,6 @@
 cask 'thingsmacsandboxhelper' do
-  version '3.16'
-  sha256 '8b9b19ffb406823124bdf60acd0107764d9f5a3e8a98c71f0bd6feb06b38b5d8'
+  version '3.18'
+  sha256 '157c23c55c08dd14b244ee075e3d89684b7359e284198590ba8b091512ed7fb6'
 
   # culturedcode.cachefly.net was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.