### PR TITLE
Update tastyworks from 1.0.15 to 1.0.16

### DIFF
--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -1,6 +1,6 @@
 cask 'tastyworks' do
-  version '1.0.15'
-  sha256 'c540eac3c09937f7e6a7ff6c98a897d28445df7f8fbf0521ceab198c3d59e397'
+  version '1.0.16'
+  sha256 'd2c16129f6031da04c2402dee449ddeaa64ae3766df22fd50e7917314c8d61f7'
 
   url "https://download.tastyworks.com/desktop-#{version.major}.x.x/#{version}/tastyworks-#{version}.dmg"
   appcast 'https://tastyworks.com/technology.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.