### PR TITLE
Updated version number of Vidyo from 3.6.14.0003 to 3.6.18.0009

### DIFF
--- a/Casks/vidyo.rb
+++ b/Casks/vidyo.rb
@@ -1,6 +1,6 @@
 cask 'vidyo' do
-  version '3.6.14.0003'
-  sha256 'd99548771c014636876cb5cca8bcbf9ca6f0800855cde8ba25aeffce636cceb1'
+  version '3.6.18.0009'
+  sha256 '6f1d1dcc8e707befc07e3f251ecad007e027016f4203b71396c45384b9a1dd5e'
 
   url "https://client-downloads.vidyocloud.com/VidyoDesktopInstaller-macosx-TAG_VD_#{version.dots_to_underscores}.dmg"
   name 'Vidyo'


### PR DESCRIPTION
Updated version number which adds necessary support for macOS Catalina

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
