### PR TITLE
Update flash-player-debugger from 32.0.0.255 to 32.0.0.270

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger' do
-  version '32.0.0.255'
-  sha256 'eb8a0cbf13ac049c422f14a078ca9f97120a8b17dabb74280b1211805bd6bf8c'
+  version '32.0.0.270'
+  sha256 'cff53930d6534c6aff439dfce59fc546cccc53c85d352e72675b73e3b10f289c'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.