### PR TITLE
Update flash-player-debugger-ppapi from 32.0.0.255 to 32.0.0.270

### DIFF
--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-ppapi' do
-  version '32.0.0.255'
-  sha256 '049b1ed4c3b30e34755b94a3df94fc253c756984caf84158d06119a1227a5146'
+  version '32.0.0.270'
+  sha256 '84aa853adb071f550937ff67c408417adc486817eb8a0c2c585a0ef4c62060fa'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.