### PR TITLE
Update cd-to-terminal from 2.6.0 to 3.0

### DIFF
--- a/Casks/cd-to-terminal.rb
+++ b/Casks/cd-to-terminal.rb
@@ -1,22 +1,19 @@
 cask 'cd-to-terminal' do
-  version '2.6.0'
-  sha256 'a92def521d332a373f655a41338d0ec18dfaa6e24eb9ec2ca6df281398db3d46'
+  version '3.0'
+  sha256 'ced82da81b9b3448280b5c465c6649c93a876895de0142a396efca489c7b59b6'
 
-  url "https://github.com/jbtule/cdto/releases/download/#{version.dots_to_underscores}/cdto_#{version.major_minor.dots_to_underscores}.zip"
+  url "https://github.com/jbtule/cdto/releases/download/v#{version}/cdto_#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/jbtule/cdto/releases.atom'
   name 'cd to'
   homepage 'https://github.com/jbtule/cdto'
 
-  # Renamed to avoid conflict with cd-to-iterm.
-  app "cdto_#{version.major_minor.dots_to_underscores}/terminal/cd to.app", target: 'cd to terminal.app'
+  app 'cd to ....app'
 
   caveats <<~EOS
     To complete installation:
     1. Open the the Applications folder in finder.
-    2. Drag "cd to.app" onto the Finder toolbar while holding down the command(⌘) and option(⌥) keys.
+    2. Drag "cd to ....app" onto the Finder toolbar while holding down the command(⌘) and option(⌥) keys.
 
     To use, just click on the new button and instantly opens a new Terminal.app window.
-
-    Only "cd to.app" for Terminal.app has been added to the Applications folder. The iTerm and x11_term versions are also staged.
   EOS
 end

--- a/Casks/cd-to.rb
+++ b/Casks/cd-to.rb
@@ -1,4 +1,4 @@
-cask 'cd-to-terminal' do
+cask 'cd-to' do
   version '3.0'
   sha256 'ced82da81b9b3448280b5c465c6649c93a876895de0142a396efca489c7b59b6'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.