### PR TITLE
Update hedgewars from 0.9.22 to 1.0.0

### DIFF
--- a/Casks/hedgewars.rb
+++ b/Casks/hedgewars.rb
@@ -1,11 +1,6 @@
 cask 'hedgewars' do
-  if MacOS.version <= :el_capitan
-    version '0.9.22'
-    sha256 'adc0b6dd3b47de115e85db1cb72841836444c0ebc77caee8139bfd6561e28fe8'
-  else
-    version '0.9.23'
-    sha256 '2a5fbfa005ec6aeea172270397025c17a2c117224dd21db5214b8cbbeade411b'
-  end
+  version '1.0.0'
+  sha256 '5a0bdd9bc4cb7beea03b95a2549c1cf994ea8646f6621f5353dd22d79c757404'
 
   url "https://www.hedgewars.org/download/releases/Hedgewars-#{version}.dmg"
   appcast 'https://www.hedgewars.org/download/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.