### PR TITLE
Update cd-to-iterm from 2.6.0 to 3.0

### DIFF
--- a/Casks/cd-to-iterm.rb
+++ b/Casks/cd-to-iterm.rb
@@ -1,8 +1,8 @@
 cask 'cd-to-iterm' do
-  version '2.6.0'
-  sha256 'a92def521d332a373f655a41338d0ec18dfaa6e24eb9ec2ca6df281398db3d46'
+  version '3.0'
+  sha256 'ced82da81b9b3448280b5c465c6649c93a876895de0142a396efca489c7b59b6'
 
-  url "https://github.com/jbtule/cdto/releases/download/#{version.dots_to_underscores}/cdto_#{version.major_minor.dots_to_underscores}.zip"
+  url "https://github.com/jbtule/cdto/releases/download/v#{version}/cdto_#{version.major_minor.dots_to_underscores}.zip"
   appcast 'https://github.com/jbtule/cdto/releases.atom'
   name 'cd to'
   homepage 'https://github.com/jbtule/cdto'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.