### PR TITLE
Update audirvana from 3.5.21 to 3.5.22

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.21'
-  sha256 '4eac1565ddf8fddcfcc922a00c5a38a3fba3cc51526354e17f828ee3283d13e7'
+  version '3.5.22'
+  sha256 '7ea305ef800e71b3b88886395ff477d7b9bc9138e1fc7508fd040eab88b6de51'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
