### PR TITLE
Update hstracker from 1.6.4 to 1.6.6

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.4'
-  sha256 'ae52214c2dbd4cf3478e074a17d0c49abbd1ef636874ef95e87c1435591d3274'
+  version '1.6.6'
+  sha256 'de4af6dd3790784345ec25da82976589fc9db7286b5014730bd6a2daddb15ce5'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.