### PR TITLE
Update pyfa from 2.12.0 to 2.12.1

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.12.0'
-  sha256 '3b646e74828a454e09ce09b1b7022a9748a2b72c434c7212d917581ad5c267df'
+  version '2.12.1'
+  sha256 '1639953736df0f6de5bae779d22eaba906ccbb41eee951c5c25de9955d4a4a8b'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.