### PR TITLE
Update blueharvest from 7.1.2 to 7.2.0

### DIFF
--- a/Casks/blueharvest.rb
+++ b/Casks/blueharvest.rb
@@ -1,6 +1,6 @@
 cask 'blueharvest' do
-  version '7.1.2'
-  sha256 '5927e73627abf098e511063b42bd1b4473acb05889ce2b619ccab8eb7f78c324'
+  version '7.2.0'
+  sha256 '5ac6ff545f65a1240e96ab86ba801d2ad0a338871825e96c435ca8e373a51e0a'
 
   url "https://zeroonetwenty.com/downloads/BlueHarvest#{version.no_dots}.dmg"
   appcast 'https://cp37.ezyreg.com/~zeroonet/downloads/versioninfo/sparkle/blueharvest6.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.