### PR TITLE
Update xiami from 7.5.4,32d5c7d0853b57e32e1d64af3db2e8de to 7.5.6,dd3237c0a4dd99385ddbc853f23c5fd8

### DIFF
--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -1,6 +1,6 @@
 cask 'xiami' do
-  version '7.5.4,32d5c7d0853b57e32e1d64af3db2e8de'
-  sha256 'be516f4c7ff3028096e6d1533d1ad45f7101924ec761e9dd88a1b1f1a30c4ba6'
+  version '7.5.6,dd3237c0a4dd99385ddbc853f23c5fd8'
+  sha256 '6a5576f2c53d42a1c61f1ddc9503486d039aa6ed0388246ea53aec9b32a8338c'
 
   url "https://files.xiami.com/webh5/files/xiamiMac/#{version.after_comma}.xiamimac#{version.before_comma.dots_to_hyphens}.zip"
   appcast 'https://g.alicdn.com/music/desktop-app/XiamiMac.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.