### PR TITLE
Update simpholders from 3.0.6,2245 to 3.0.7,2269

### DIFF
--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -1,6 +1,6 @@
 cask 'simpholders' do
-  version '3.0.6,2245'
-  sha256 'bb69e1f185d17edbb24e3b1f1f2981e2344388c478308d75a2b1c129246cddd8'
+  version '3.0.7,2269'
+  sha256 '30a146ab6999a58a44a1e3d910caf9a7afe68c2ce1ac5a4cf8af21ddd0909dcb'
 
   url "https://simpholders.com/site/assets/files/#{version.after_comma}/simpholders_#{version.before_comma.dots_to_underscores}.dmg"
   appcast 'https://simpholders.com/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.