### PR TITLE
Update bluegriffon from 3.0.1 to 3.1

### DIFF
--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -1,6 +1,6 @@
 cask 'bluegriffon' do
-  version '3.0.1'
-  sha256 'b1fd87e24890d9d7f227da4051e384e327e418c80112f94fe376985697f7f1d9'
+  version '3.1'
+  sha256 '651f0c089adfbb988870b09f0101ca021de218af4bb138011f196c4630312412'
 
   url "http://bluegriffon.org/freshmeat/#{version}/bluegriffon-#{version}.mac-x86_64.dmg"
   appcast 'http://bluegriffon.org/freshmeat/?C=M;O=D'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.