### PR TITLE
Update github from 2.2.0-2beb5d52 to 2.2.1-6f192f11

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,6 +1,6 @@
 cask 'github' do
-  version '2.2.0-2beb5d52'
-  sha256 '00519871868158feeef79a5e8ab0a5bf332d618532450ff7e1c9b5a8d1153455'
+  version '2.2.1-6f192f11'
+  sha256 '10b7d64760511e854d71ccb9d1a375304f5f3a6fb6aa7992f2129348e1ca9cf0'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.