### PR TITLE
Update get-iplayer-automator from 1.15.1.b20190331001 to 1.16.1.b20191008001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -3,7 +3,8 @@ cask 'get-iplayer-automator' do
   sha256 '616702b1830f30ff34dea6b0d5adf1fee4f06f676ee0326597f587dec32112bd'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
-  appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom'
+  appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
+          configuration: version.major_minor_patch
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 

--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,6 +1,6 @@
 cask 'get-iplayer-automator' do
-  version '1.15.1.b20190331001'
-  sha256 '97e02c14bc9b0cdd96cbdd01c507b574874759c8081d7752cdc0c6bcde6fdefc'
+  version '1.16.1.b20191008001'
+  sha256 '616702b1830f30ff34dea6b0d5adf1fee4f06f676ee0326597f587dec32112bd'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.