### PR TITLE
Update bitshares from 3.1.19061,8.1 to 3.1.19061,8.5

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,6 +1,6 @@
 cask 'bitshares' do
-  version '3.1.19061,8.1'
-  sha256 '6fa5bc3ae5765f2085024784422fd0ce0ac1b071c8e01a79dc80a77d1add689e'
+  version '3.1.19061,8.5'
+  sha256 'e4a6b6520bee314ac9635b78d2baaf13b11521a39e7e3dae4575087f6c3256bb'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version.before_comma}#{version.after_comma}/BitShares-#{version.before_comma}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.