### PR TITLE
Update pages-data-merge.rb

### DIFF
--- a/Casks/pages-data-merge.rb
+++ b/Casks/pages-data-merge.rb
@@ -2,7 +2,7 @@ cask 'pages-data-merge' do
   version :latest
   sha256 :no_check
 
-  url 'https://iworkautomation.com/pages/PagesDataMergeApp.zip',
+  url 'https://iworkautomation.com/pages/PagesDataMergeAppMojave.zip',
       user_agent: :fake
   name 'Pages Data Merge'
   homepage 'https://iworkautomation.com/pages/script-tags-data-merge.html'

--- a/Casks/pages-data-merge.rb
+++ b/Casks/pages-data-merge.rb
@@ -7,5 +7,5 @@ cask 'pages-data-merge' do
   name 'Pages Data Merge'
   homepage 'https://iworkautomation.com/pages/script-tags-data-merge.html'
 
-  app 'PagesDataMergeApp/Pages Data Merge.app'
+  app 'Pages Data Merge.app'
 end


### PR DESCRIPTION
change to the 'mojave' url. WARNING: this is officially declared as 'beta' on the homepage, but it might still be better as the current version won't run on 2/3 of our officially supported macOS versions.