### PR TITLE
Update omnigraffle from 7.11.3 to 7.11.4

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -4,8 +4,8 @@ cask 'omnigraffle' do
     sha256 'ab463ea6c12d49c4104d3814ac3280d0359072702d4751f5074f644fc79de0c6'
     url "https://downloads.omnigroup.com/software/Archive/MacOSX/10.12/OmniGraffle-#{version}.dmg"
   else
-    version '7.11.3'
-    sha256 '9903a70a0837f7ecba5b9175db9705d8aa83290f5a2307c670aba301470fb108'
+    version '7.11.4'
+    sha256 '9896de28b72cd56de89c75294453095ea144262761b9f372acf2e64a1145f56d'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.