### PR TITLE
Update tagspaces from 3.2.3 to 3.2.5

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask 'tagspaces' do
-  version '3.2.3'
-  sha256 '5d661143d7831e12ec2ef454d83532da05fd3fc7e81f546e581ae12c38e74a1c'
+  version '3.2.5'
+  sha256 '370104e2c94e468a1c0e60674010c7ad3f7c87f5b6b8ea3905092294a2659d13'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.