### PR TITLE
Update trilium-notes from 0.35.1 to 0.35.2

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.35.1'
-  sha256 'a3df74299669eacf9c7d8d4896362f458636da0c4a60a5d00901f0f2a2ae13c7'
+  version '0.35.2'
+  sha256 'eea17a5013ab3cdc01b63c7ea4452826d4f174a66a1f03c118d140fce615a5be'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.