### PR TITLE
Update thedesk from 18.11.0 to 18.11.1

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.11.0'
-  sha256 '048ba05c0401b49ec8eaf37ad29562e556a8bb3ffc9bb8318fa55b2ea37395ef'
+  version '18.11.1'
+  sha256 '789c52ea75efdc521a5b8ccfe0617fab9dcdd9b01f9868c3ffa261c423c83f40'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.