### PR TITLE
Update namechanger from 3.4.2 to 3.4.3

### DIFF
--- a/Casks/namechanger.rb
+++ b/Casks/namechanger.rb
@@ -1,6 +1,6 @@
 cask 'namechanger' do
-  version '3.4.2'
-  sha256 '9da44a88bcb4ba10fc918671bd11237df8fea2469d3fb34bdf311435c0cf7ed3'
+  version '3.4.3'
+  sha256 '27ca369e1c355b2f7683caf709db7c180a8dfeeed3bbd72db55db54889a70ac4'
 
   url "https://www.mrrsoftware.com/Downloads/NameChanger/Updates/NameChanger-#{version.dots_to_underscores}.zip"
   appcast 'https://mrrsoftware.com/Downloads/NameChanger/Updates/NameChangerSoftwareUpdates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.