### PR TITLE
Update airparrot from 2.8.0 to 2.8.1

### DIFF
--- a/Casks/airparrot.rb
+++ b/Casks/airparrot.rb
@@ -1,6 +1,6 @@
 cask 'airparrot' do
-  version '2.8.0'
-  sha256 '3ec8e83c5a029d926cdfb16c4015c72996911826ca39ca4a39eed41c2e7aeb1e'
+  version '2.8.1'
+  sha256 'e4507e8b12377ef5669a37cc10130a9b69f6decca34fa9c6ac98a83d35fb2523'
 
   url "https://download.airsquirrels.com/AirParrot#{version.major}/Mac/AirParrot-#{version}.dmg"
   appcast "https://updates.airsquirrels.com/AirParrot#{version.major}/Mac/AirParrot#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.