### PR TITLE
Update swinsian from 2.1.15 to 2.2.0

### DIFF
--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,6 +1,6 @@
 cask 'swinsian' do
-  version '2.1.15'
-  sha256 '76987c0a2437f10c67b30e7fffc9b3e768a8c9e373fa16c98d4b8f8fa01979bb'
+  version '2.2.0'
+  sha256 'ef6cb1e95f557989df60e44cb0afde9377940010ceccebf26eae573840f4c977'
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.