### PR TITLE
Update script-debugger from 7.0.8-7A80 to 7.0.9-7A94

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,6 +1,6 @@
 cask 'script-debugger' do
-  version '7.0.8-7A80'
-  sha256 'fbb80e8690c0fbd3873649579022ce885896c8b9806763ed5283b4541e52236f'
+  version '7.0.9-7A94'
+  sha256 'd0490db4c993ad9288da86c86b729dd72f4d1396b9d076f5abc1c423df7aaa2e'
 
   # s3.amazonaws.com/latenightsw.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.