### PR TITLE
Update isubtitle from 3.2.3 to 3.3

### DIFF
--- a/Casks/isubtitle.rb
+++ b/Casks/isubtitle.rb
@@ -1,6 +1,6 @@
 cask 'isubtitle' do
-  version '3.2.3'
-  sha256 '3af9d4c0199720b9cccbd85ae2527565ea45ada176669cfee6f6d6f48cc39bbc'
+  version '3.3'
+  sha256 '4ba3046f1d1e6f1a23827e2e0b6407716cc3208a2cf7a5234f1f285563ee3a31'
 
   url "https://www.bitfield.se/isubtitle#{version.major}/download/iSubtitle_#{version}.zip"
   appcast "https://www.bitfield.se/isubtitle#{version.major}/changelog.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.