### PR TITLE
Update clamxav from 3.0.12_8001 to 3.0.14_8208

### DIFF
--- a/Casks/clamxav.rb
+++ b/Casks/clamxav.rb
@@ -1,6 +1,6 @@
 cask 'clamxav' do
-  version '3.0.12_8001'
-  sha256 '72837502a46260bd7db91b1c259ad64f71787bfba0bc0a99d3a109f3bcc75aaf'
+  version '3.0.14_8208'
+  sha256 'd829a9af263f264efe490f2ab8ed06bf937fbee553165a5f164bd9640bdedb47'
 
   url "https://cdn.clamxav.com/ClamXAVdownloads/ClamXAV_#{version}.zip"
   appcast "https://www.clamxav.com/sparkle/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.