### PR TITLE
Update skim from 1.5.3 to 1.5.4

### DIFF
--- a/Casks/skim.rb
+++ b/Casks/skim.rb
@@ -1,6 +1,6 @@
 cask 'skim' do
-  version '1.5.3'
-  sha256 '5d71c6f77022263d0ee21ea16b1849cbb730388e68fbb2018c537b5993d24ef1'
+  version '1.5.4'
+  sha256 'fa6ce575bc8edbfb50325feea2d2a0e3a48b5f946b5e73eb1a8d08c09c187962'
 
   # downloads.sourceforge.net/skim-app was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/skim-app/Skim/Skim-#{version}/Skim-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.