### PR TITLE
Update typeface from 2.6.0 to 2.6.1

### DIFF
--- a/Casks/typeface.rb
+++ b/Casks/typeface.rb
@@ -1,6 +1,6 @@
 cask 'typeface' do
-  version '2.6.0'
-  sha256 '104bd9cf08f627bd5cd9b3752bc49740757bc961e8beb341b80747aac9654c5b'
+  version '2.6.1'
+  sha256 'fa78fa3dfe5bf1594702f04f6bc566088fa403646101f16378930dc3a952347f'
 
   url 'https://dcdn.typefaceapp.com/latest'
   appcast 'https://dcdn.typefaceapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.