### PR TITLE
Update filepane from 1.10.4,1532767525 to 1.10.5,1570653522

### DIFF
--- a/Casks/filepane.rb
+++ b/Casks/filepane.rb
@@ -1,6 +1,6 @@
 cask 'filepane' do
-  version '1.10.4,1532767525'
-  sha256 'ba910ad4340027725a1a94aec40bf6fea0ba3cbbd03a3a1e1e2de052b790d4fe'
+  version '1.10.5,1570653522'
+  sha256 '2b8d75610f10bed81857b6503e61bbfb2246368abe2a20788de242a28acb74e7'
 
   # dl.devmate.com/com.mymixapps.FilePane was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mymixapps.FilePane/#{version.before_comma}/#{version.after_comma}/FilePane-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.