### PR TITLE
Update kite from 0.20191007.1 to 0.20191011.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191007.1'
-  sha256 'b6817a840325cc8a08a0c2afcac036554e6f7c3d20758a437d3953d8e37ec4f3'
+  version '0.20191011.1'
+  sha256 '71301ee039adb7aa91a155d5712db33af46d2b251ccae818b00b87684e1db117'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.