### PR TITLE
Update logitech-presentation from 1.52.95 to 1.54.84

### DIFF
--- a/Casks/logitech-presentation.rb
+++ b/Casks/logitech-presentation.rb
@@ -1,6 +1,6 @@
 cask 'logitech-presentation' do
-  version '1.52.95'
-  sha256 '1d814eab908bb541e48f90fcd1af320e9ccc2aa98091e71b7c39e43642a80ac6'
+  version '1.54.84'
+  sha256 '3b6a52b3b0f4ee036101239bd6a28c61a04dccf22b6dbf272f2d17920d2462e2'
 
   # download01.logi.com/web/ftp/pub/techsupport/presentation was verified as official when first introduced to the cask
   url "https://download01.logi.com/web/ftp/pub/techsupport/presentation/LogiPresentation_#{version.major_minor_patch}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.