### PR TITLE
Update arq-cloud-backup from 1.3.2.1 to 1.4

### DIFF
--- a/Casks/arq-cloud-backup.rb
+++ b/Casks/arq-cloud-backup.rb
@@ -1,6 +1,6 @@
 cask 'arq-cloud-backup' do
-  version '1.3.2.1'
-  sha256 'bc14aa4a852657aabe37e05112ea0aa13066afb7d1267705e2345ea1501f3d74'
+  version '1.4'
+  sha256 '883b9d6696b5d5022eb2e06cd6617107e7839c024d7fcc44a55e6065712cee81'
 
   url 'https://www.arqbackup.com/download/arqcloudbackup/ArqCloudBackup.dmg'
   appcast 'https://www.arqbackup.com/download/arqcloudbackup/arqcloudbackup_release_notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.