### PR TITLE
Update ableton-live-lite from 10.1.1 to 10.1.2

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '10.1.1'
-  sha256 '4fe9ded48ce12b370cc3b4225ab947c3ef7cabf7ff97f07d7a4af6a1e5cf0c5d'
+  version '10.1.2'
+  sha256 '67a4d70d4ce3b3d2de5499c40cddece8d8641b9ca105b11cd4a3734de5f2f1f9'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.