### PR TITLE
Update cacher from 2.20.2 to 2.21.0

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.20.2'
-  sha256 'f93555081233babd21f77d8c1c5cc1334fed8fe332ca5a8c7b172a9c54751404'
+  version '2.21.0'
+  sha256 'fc1e651e36868ae480201c938816528efad8516104014ac345abc2ef350aef8a'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.