### PR TITLE
Update ableton-live from 10.1.1 to 10.1.2

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live' do
-  version '10.1.1'
-  sha256 'bd3330b0872de294bf92bd852a02f2f66340b5419a7ef2e343bdeed2cf517534'
+  version '10.1.2'
+  sha256 '45a48dc708fa8bcc7c28d8ef15cf807e94d2e17687e4988440d26cf5adbef0e5'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.