### PR TITLE
Update elan-avfx from 5.7 to 5.8

### DIFF
--- a/Casks/elan-avfx.rb
+++ b/Casks/elan-avfx.rb
@@ -1,8 +1,8 @@
 cask 'elan-avfx' do
-  version '5.7'
-  sha256 '258d7390e8985ad603b9239ae39fe32285a1d7a78a70f242e3fa1ff4ed79c930'
+  version '5.8'
+  sha256 '35e89961de320dc0db5812c4ea1cd65be77a4667cb03bb7bc60603770edf70aa'
 
-  url "https://www.mpi.nl/tools/elan/ELAN_#{version.dots_to_hyphens}-AVFX_mac.zip"
+  url "https://www.mpi.nl/tools/elan/ELAN_#{version.dots_to_hyphens}_mac.zip"
   appcast 'https://tla.mpi.nl/tools/tla-tools/elan/release-notes/'
   name 'ELAN'
   homepage 'https://tla.mpi.nl/tools/tla-tools/elan/'

--- a/Casks/elan-avfx.rb
+++ b/Casks/elan-avfx.rb
@@ -1,6 +1,6 @@
 cask 'elan-avfx' do
   version '5.8'
-  sha256 '35e89961de320dc0db5812c4ea1cd65be77a4667cb03bb7bc60603770edf70aa'
+  sha256 '91153961b6ba6ad148bd5021967568e7dcbc2416b709e0c8681163e89f270d7d'
 
   url "https://www.mpi.nl/tools/elan/ELAN_#{version.dots_to_hyphens}_mac.zip"
   appcast 'https://tla.mpi.nl/tools/tla-tools/elan/release-notes/'

--- a/Casks/elan.rb
+++ b/Casks/elan.rb
@@ -1,4 +1,4 @@
-cask 'elan-avfx' do
+cask 'elan' do
   version '5.8'
   sha256 '91153961b6ba6ad148bd5021967568e7dcbc2416b709e0c8681163e89f270d7d'
 
@@ -9,5 +9,5 @@ cask 'elan-avfx' do
 
   depends_on macos: '>= :high_sierra'
 
-  app "ELAN_#{version}-AVFX.app"
+  app "ELAN_#{version}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.