### PR TITLE
Update golly from 3.2 to 3.3

### DIFF
--- a/Casks/golly.rb
+++ b/Casks/golly.rb
@@ -1,6 +1,6 @@
 cask 'golly' do
-  version '3.2'
-  sha256 '71c66136ef81d336ed0fc94a5f5a4d650e3727d99fe1f00c6036b8dc99eee8db'
+  version '3.3'
+  sha256 '3641940d1bd102573a546320c814e847f8fe4f0e6602ab055362d0b85d1e7cd9'
 
   # downloads.sourceforge.net/golly was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/golly/golly/golly-#{version}/Golly-#{version}-Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.