### PR TITLE
update wechat version 2.3.27.18

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,6 +1,6 @@
 cask 'wechat' do
-  version '2.3.27.17'
-  sha256 '512ac9e5910c9475f9c2f5e9ebc254b9183aa3c2d7446523e2f26f000d457ffe'
+  version '2.3.27.18'
+  sha256 '721185cdcb7bd4672252a7660d5ba8d582e380007482ea340eee4cd401cb7c9f'
 
   url 'https://dldir1.qq.com/weixin/mac/WeChatMac.dmg'
   appcast 'https://dldir1.qq.com/weixin/mac/mac-release.xml'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).