### PR TITLE
Update hiarcs-chess-explorer from 1.9.4 to 1.9.4a

### DIFF
--- a/Casks/hiarcs-chess-explorer.rb
+++ b/Casks/hiarcs-chess-explorer.rb
@@ -1,6 +1,6 @@
 cask 'hiarcs-chess-explorer' do
-  version '1.9.4'
-  sha256 'eaf7627801ca4cc2351fef58bb313353eca2a51d894e28df2b627dd011856a7f'
+  version '1.9.4a'
+  sha256 '5dbeb42d597d93f24c89690f7d1a7a32bff9e8dfe38ec4ba396b4e3140c68db0'
 
   url "http://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
   appcast 'http://www.hiarcs.com/hce/mac-v120.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.