### PR TITLE
Update vscodium from 1.39.0 to 1.39.1

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.39.0'
-  sha256 'cd0291761675941a5ecffbb79e07d583466fa485eb6004d025158482644b5946'
+  version '1.39.1'
+  sha256 '701cb2379908aea4f99ed99f62ae223f93af10ed8f73d72c9c43887931a0ba33'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.