### PR TITLE
Update cacher from 2.21.0 to 2.21.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.21.0'
-  sha256 'fc1e651e36868ae480201c938816528efad8516104014ac345abc2ef350aef8a'
+  version '2.21.1'
+  sha256 '8758970499d90019f1f3e49486af95b2ca17988d1f84f0fb7376bfe552a6f1cc'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.