### PR TITLE
Update blitz from 1.3.10 to 1.3.11

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.3.10'
-  sha256 'e90b9d7ab5d2742a121f9ea2bf714b72f12a3813dec8accf3223754e61f57a8a'
+  version '1.3.11'
+  sha256 '29029591f80059159801e9fc0ddd972173ad3b3968f2a80462a14bc9ac884fbb'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.