### PR TITLE
Update navicat-premium from 12.1.25 to 12.1.26

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '12.1.25'
-  sha256 'ca79231978300815f1ba8bc33db4da5dc8f3f6aaf53680e943bb9980cc1e92a9'
+  version '12.1.26'
+  sha256 'a5d4c5695067b38aff458b3545e7b4942dc407cd4926d61710aff5cb78f77ab6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20Premium&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.