### PR TITLE
Update tiled from 1.2.4 to 1.2.5

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,6 +1,6 @@
 cask 'tiled' do
-  version '1.2.4'
-  sha256 'c4135c514774e3543fffa56210e15f4005d0bf0a9f24e300519dd85b5468d7f5'
+  version '1.2.5'
+  sha256 'bcb43f2942cd9d5f7bd331076c18fc5c968b113cb1253ccc7dcea0951cbf72b1'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/Tiled-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.