### PR TITLE
Update manico from 2.6 to 2.6.1

### DIFF
--- a/Casks/manico.rb
+++ b/Casks/manico.rb
@@ -1,6 +1,6 @@
 cask 'manico' do
-  version '2.6'
-  sha256 '9caca1926989bcebe7b768923a69b990ce48b92122bcea6029a6b8adfa63b4d5'
+  version '2.6.1'
+  sha256 '78b6a79357a5a505d564654ccdf43b51332ac0427d61ef5485b0004430ac6f78'
 
   url "https://manico.im/static/Manico_#{version}.dmg"
   appcast 'https://manico.im/static/manico-official-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.