### PR TITLE
Update piezo from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/piezo.rb
+++ b/Casks/piezo.rb
@@ -1,6 +1,6 @@
 cask 'piezo' do
-  version '1.6.1'
-  sha256 '36a264ae1b68cf2c73bcaff1fd1f7af52cafc31210ac8a03029faa17e5394db5'
+  version '1.6.2'
+  sha256 'd27f3baa4200576f7405f3832bbdfffbba58b38c25a0288a675bf6a221d6e079'
 
   url 'https://rogueamoeba.com/piezo/download/Piezo.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.Piezo&system=10146'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.