### PR TITLE
Update activedock from 260,1570615354 to 263,1570798654

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '260,1570615354'
-  sha256 '44dc120b8e28dd860ebad7df67320b77ed5135d39690eae5d71a05d49b4546d8'
+  version '263,1570798654'
+  sha256 '2bff0d0151e11d0ab8ec9e4d0d6a326d9508ba883f22839c4507fa04bd1bcae2'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.