### PR TITLE
Update navicat-for-oracle from 12.1.25 to 12.1.26

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '12.1.25'
-  sha256 'b0a51aa78ba2294ffcce1b5e741b5676efe2b50a4b9570a8abc56ebb5f08c15d'
+  version '12.1.26'
+  sha256 '665a00f7be7963be9a194008f8212fcd4cf47a0ef31da7d8f58f7ac4f8948e01'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.