### PR TITLE
Update stoplight-studio from 1.1.4 to 1.1.5

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.1.4'
-  sha256 '00c0e52eb56a29157ed53b1eafd45446b03709be74b2944e50759b1ee3740eba'
+  version '1.1.5'
+  sha256 '335c8ee0fdccae679a502d5e69382d957e735079186057f4d49c3473d756df15'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/Stoplight-Studio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.