### PR TITLE
Update zoomus from 4.5.5416.0929 to 4.5.5452.1010

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.5.5416.0929'
-  sha256 'd794a90f5300ac34c4e21f3d2157b84beabfb89691aff13b6913bf320280d15f'
+  version '4.5.5452.1010'
+  sha256 '064c3c04914a49a06b7c5b3d1658b93ead17e9773220ddf303cfc28923201924'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://zoom.us/client/latest/Zoom.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.