### PR TITLE
Update dmm-player from 2.0.1 to 2.0.3

### DIFF
--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -1,6 +1,6 @@
 cask 'dmm-player' do
-  version '2.0.1'
-  sha256 '7c8119625c36afef95ae6a4e7ea0e8f0449ded7b872d89ebaae9000c91f50c6e'
+  version '2.0.3'
+  sha256 'a630e615494f071f4eca389819ec0912107dd2f200d84a3d32703fa1d2d0ca9c'
 
   url "http://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name 'DMM Player'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.