### PR TITLE
Update slite from 1.1.4 to 1.1.5

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.1.4'
-  sha256 '4cc5b8c613bcf8c58fc16d03b55cb9bc942904fe712683f229eb4241e53f305b'
+  version '1.1.5'
+  sha256 'cbfea4e1f378b94e26c107c2c53cb96edfc462df29a515c1bd0c73fd2ce76037'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.