### PR TITLE
Update anydo from 4.2.47 to 4.2.48

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.47'
-  sha256 'ba73bde4a7e247e54b2b084b128cac0b49fa72f3e50bc35c2d721f7b9fb1442a'
+  version '4.2.48'
+  sha256 '624363ab60cf8210f74aacede65f2d11540a1834bb4d22795eb05d438563214f'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.