### PR TITLE
Update transmission-remote-gui from 5.17.0 to 5.18.0

### DIFF
--- a/Casks/transmission-remote-gui.rb
+++ b/Casks/transmission-remote-gui.rb
@@ -1,6 +1,6 @@
 cask 'transmission-remote-gui' do
-  version '5.17.0'
-  sha256 'c3c8addabc1fe3f4c395b7843abd5d05c64c484cc45541c13cef4050546f6b6a'
+  version '5.18.0'
+  sha256 'fe32f0cdd5c8f9777bace0eceb92d6b269a2b20210f4cc0552112861ddead759'
 
   url "https://github.com/transmission-remote-gui/transgui/releases/download/v#{version}/transgui-#{version}.dmg"
   appcast 'https://github.com/transmission-remote-gui/transgui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.