### PR TITLE
Update SciHubEVA from v3.2.1 to v3.2.2

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -1,6 +1,6 @@
 cask 'scihubeva' do
-  version 'v3.2.1'
-  sha256 '30caed6892906b3f04379150fe4af45eb5b25c40ae3ca37888cd4a0a116b2003'
+  version 'v3.2.2'
+  sha256 '7803fb54a5dbcd20b5c3a59aaad20ede4ce9061a7f392e4b7de34989f02f1275'
 
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast 'https://github.com/leovan/SciHubEVA/releases.atom'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).