### PR TITLE
Update screenflick from 2.7.43 to 2.7.44

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,6 +1,6 @@
 cask 'screenflick' do
-  version '2.7.43'
-  sha256 '12a9279f46044c19c5e5cc12e64d4010be5095b7f6da52d29abaf1c8ad9fedf3'
+  version '2.7.44'
+  sha256 '982b3282b8ee8c915805d8e561d1c731a005bc7d100216c98cee38c2decc3bd8'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.