### PR TITLE
Update softraid from 5.7.5 to 5.8

### DIFF
--- a/Casks/softraid.rb
+++ b/Casks/softraid.rb
@@ -1,9 +1,9 @@
 cask 'softraid' do
-  version '5.7.5'
-  sha256 '2d3914eadf524fc7e272ad50ffd3b742ded45b6c3757a452e8278a87d9ffdf1a'
+  version '5.8'
+  sha256 'ec5e4771e20a0a2d218c1c1d46b225148dc6465e6ceb556815404a08ce63348e'
 
   # download.owcdigital.com/softraid was verified as official when first introduced to the cask
-  url "https://download.owcdigital.com/softraid/mac/#{version.major}/softraid/SoftRAID_#{version}.dmg"
+  url "https://download.owcdigital.com/softraid/mac/#{version.major}/softraid/SoftRAID%20#{version}.dmg"
   appcast 'https://www.softraid.com/pages/support/download_latest_version.html'
   name 'SoftRAID'
   homepage 'https://www.softraid.com/'

--- a/Casks/softraid.rb
+++ b/Casks/softraid.rb
@@ -9,5 +9,4 @@ cask 'softraid' do
   homepage 'https://www.softraid.com/'
 
   app "SoftRAID #{version}/SoftRAID #{version}.app"
-  app "SoftRAID #{version}/SoftRAID Easy Setup.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.