### PR TITLE
Update lbry from 0.36.0 to 0.36.1

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.36.0'
-  sha256 '09ce936b1b13c05bc89a5b39950086cdade2881c4afaf2a961affa8c9eecf034'
+  version '0.36.1'
+  sha256 'bfc943a8c6631e513bbfa8cfb1da22bc8d07a8297b16f291be4d2a43a5eb960c'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.