### PR TITLE
Update stella from 6.0.1 to 6.0.2

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,6 +1,6 @@
 cask 'stella' do
-  version '6.0.1'
-  sha256 '177773f4b2b1227cd09dd61dd77b222ea3e4d606136425c8c249d0791b6d1da4'
+  version '6.0.2'
+  sha256 'a161d7ac4fa1b70d9029a401a35f900887217f686a51b1663b60d924f0f24439'
 
   # github.com/stella-emu/stella was verified as official when first introduced to the cask
   url "https://github.com/stella-emu/stella/releases/download/#{version}/Stella-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.