### PR TITLE
Update iexplorer from 4.3.6,168 to 4.3.7,169

### DIFF
--- a/Casks/iexplorer.rb
+++ b/Casks/iexplorer.rb
@@ -1,6 +1,6 @@
 cask 'iexplorer' do
-  version '4.3.6,168'
-  sha256 'df15787591d3c195d23da5daf76a8992b06d6914793279d479022372251699f8'
+  version '4.3.7,169'
+  sha256 '82eeb70aac3dcd9f2d647cf83c91937a1dd52c2b304d6afd4fc83a577e48f4b0'
 
   url "https://assets.macroplant.com/download/#{version.after_comma}/iExplorer-#{version.before_comma}.dmg"
   appcast "https://macroplant.com/iexplorer/mac/v#{version.major}/appcast"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.