### PR TITLE
Update popo from 3.0.4 to 3.0.5

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
-  version '3.0.4'
-  sha256 '039df27d52e9b9910991aa218859a09255f56a0098fa648a8e97a0a9ea607adb'
+  version '3.0.5'
+  sha256 '4d94f26a6fec8e953fc9a2e66772192f584a4bcbf7b7b64a6f0b72ecb9a80c47'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores.before_comma}.dmg"
   appcast 'http://popo.netease.com/'

--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -2,8 +2,9 @@ cask 'popo' do
   version '3.0.5'
   sha256 '4d94f26a6fec8e953fc9a2e66772192f584a4bcbf7b7b64a6f0b72ecb9a80c47'
 
-  url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores.before_comma}.dmg"
-  appcast 'http://popo.netease.com/'
+  url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
+  appcast 'http://popo.netease.com/',
+          configuration: version.dots_to_underscores
   name 'NetEase POPO'
   homepage 'http://popo.netease.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.