### PR TITLE
Add nuclear.app v0.5.1

### DIFF
--- a/Casks/nuclear.rb
+++ b/Casks/nuclear.rb
@@ -1,0 +1,12 @@
+cask 'nuclear' do
+  version '0.5.1'
+  sha256 'c2bad0a3d3f29250f1b40102acda588c798c3a198c3c454f9593afbce4271477'
+
+  # github.com/nukeop/nuclear was verified as official when first introduced to the cask
+  url "https://github.com/nukeop/nuclear/releases/download/v#{version}/nuclear-7e3bac.dmg"
+  appcast 'https://github.com/nukeop/nuclear/releases.atom'
+  name 'Nuclear'
+  homepage 'https://nuclear.js.org/'
+
+  app 'nuclear.app'
+end


### PR DESCRIPTION
Ref: https://github.com/nukeop/nuclear/issues/67

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Was not able to check style locally due to nokogiri failing to build.

After making all changes to the cask:

- [x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x ] The commit message includes the cask’s name and version.
- [x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x ] Named the cask according to the [token reference].
- [x ] `brew cask install {{cask_file}}` worked successfully.
- [x ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x ] Checked there are no [open pull requests] for the same cask.
- [x ] Checked the cask was not [already refused].
- [x ] Checked the cask is submitted to [the correct repo].
- [x ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
