### PR TITLE
Update vanilla from 1.1.3,33:1567125972 to 1.2.2,40

### DIFF
--- a/Casks/vanilla.rb
+++ b/Casks/vanilla.rb
@@ -2,7 +2,6 @@ cask 'vanilla' do
   version '1.2.2,40'
   sha256 '6ed84c99dde08aa95ddc4cf4e68d5091a70212fc817b216f7793ece767e9c751'
 
-  # devmate.com/net.matthewpalmer.Vanilla was verified as official when first introduced to the cask
   url "https://macrelease.matthewpalmer.net/distribution/appcasts/Vanilla-#{version.after_comma}.dmg"
   appcast 'https://updates.devmate.com/net.matthewpalmer.Vanilla.xml'
   name 'Vanilla'

--- a/Casks/vanilla.rb
+++ b/Casks/vanilla.rb
@@ -1,9 +1,9 @@
 cask 'vanilla' do
-  version '1.1.3,33:1567125972'
-  sha256 '18a06d1b329673026764f23b75412a2033e0dcc6f476014c756fda974d3ed9c1'
+  version '1.2.2,40'
+  sha256 '6ed84c99dde08aa95ddc4cf4e68d5091a70212fc817b216f7793ece767e9c751'
 
   # devmate.com/net.matthewpalmer.Vanilla was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/net.matthewpalmer.Vanilla/#{version.after_comma.before_colon}/#{version.after_colon}/Vanilla-#{version.after_comma.before_colon}.zip"
+  url "https://macrelease.matthewpalmer.net/distribution/appcasts/Vanilla-#{version.after_comma}.dmg"
   appcast 'https://updates.devmate.com/net.matthewpalmer.Vanilla.xml'
   name 'Vanilla'
   homepage 'https://matthewpalmer.net/vanilla/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.