### PR TITLE
Crunch 3.0.1: Remove libpng/little-cms2 dependencies

### DIFF
--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -7,10 +7,5 @@ cask 'crunch' do
   name 'Crunch'
   homepage 'https://github.com/chrissimpkins/Crunch'
 
-  depends_on formula: [
-                        'libpng',
-                        'little-cms2',
-                      ]
-
   app 'Crunch.app'
 end


### PR DESCRIPTION
The dependencies are no longer required after
the release of v2.0.0

ref: https://github.com/chrissimpkins/Crunch/issues/22
ref: https://github.com/chrissimpkins/Crunch/issues/23

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).