### PR TITLE
Update onepile from 2.0-1092 to 2.1-1100

### DIFF
--- a/Casks/onepile.rb
+++ b/Casks/onepile.rb
@@ -1,6 +1,6 @@
 cask 'onepile' do
-  version '2.0-1092'
-  sha256 '8deb9355b80cc8ddc14797db98bdb917bae07fb2c92d785e797e19f6a8a30b32'
+  version '2.1-1100'
+  sha256 '7254482f2b5f32f102dec936eda2d9910d4df632b7cebf98111c1f3a6265492d'
 
   url "https://onepile.app/update/macos/OnePile-#{version}.zip"
   appcast 'https://onepile.app/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.