### PR TITLE
Update ocenaudio from 3.7.4 to 3.7.5

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,7 +2,7 @@ cask 'ocenaudio' do
   version '3.7.5'
 
   if MacOS.version <= :high_sierra
-    sha256 'a20b4a2b87ede0e11cb05616eb46028fecea8f46df63665fd0b3d5d76d789ce4'
+    sha256 'fc90419e8f82ae0156aaf11a0c4055e04df02cf67822c6f309c1e8774e3bd522'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,12 +1,12 @@
 cask 'ocenaudio' do
-  version '3.7.4'
+  version '3.7.5'
 
   if MacOS.version <= :high_sierra
     sha256 'a20b4a2b87ede0e11cb05616eb46028fecea8f46df63665fd0b3d5d76d789ce4'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 '303d78a55aab37428ee369d656253c5e904adfa6880758aaafbe3e239ec7dcf3'
+    sha256 '52373afa3400f2c4133b9927f01d157619ba658dec9ab917d1db34a4d6ce06a2'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.