### PR TITLE
Update mudlet from 4.1.2 to 4.2.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '4.1.2'
-  sha256 '469da0feffb98059f17b20f4fa37401914647d33c0d313d0f4b8d836cf754f5b'
+  version '4.2.0'
+  sha256 '615fab9473cc0752bac0dfae33e29f80ce8ba9d74fc28275aa0c24906a1b67ff'
 
   url "https://www.mudlet.org/wp-content/files/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.