### PR TITLE
Update stretchly from 0.20.1 to 0.21.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,6 +1,6 @@
 cask 'stretchly' do
-  version '0.20.1'
-  sha256 '1c51f0aeb01bde477c23c7f9908e14729a6661fff78060f3bdda22b9e4609ea5'
+  version '0.21.0'
+  sha256 '3bddd917ccc53d18ab35f7faf5b80e28c934c062831f92f4a71fcdc223bcd02b'
 
   # github.com/hovancik/stretchly was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.