### PR TITLE
Update unity-ios-support-for-editor from 2019.2.8f1,ff5b465c8d13 to 2019.2.9f1,ebce4d76e6e8

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.2.8f1,ff5b465c8d13'
-  sha256 'cfe3d131d04d34f8a1703ab74a4b6137ed27fe3c9bdce7e65a01346056c68411'
+  version '2019.2.9f1,ebce4d76e6e8'
+  sha256 'f951d3335f3f88da3dbf7fcc15d6f209eab75e7ddcbbdc1b5d2a35d3ab99bf0f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.