### PR TITLE
Update unity-linux-support-for-editor from 2019.2.8f1,ff5b465c8d13 to 2019.2.9f1,ebce4d76e6e8

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.8f1,ff5b465c8d13'
-  sha256 '4475a6ff876e4384677a21360977ce7af3305a41d72931835545676e14cc6c7b'
+  version '2019.2.9f1,ebce4d76e6e8'
+  sha256 'aaf7cef31ddde43f04369118fabf07e4d9613640909b744416f30b16f5c0284a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.