### PR TITLE
Update dropshare from 5.5,5125 to 5.6,5128

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,6 +1,6 @@
 cask 'dropshare' do
-  version '5.5,5125'
-  sha256 'ea075ceafe5e4f0729d3060e6ed620a652179290589fe16df4e8b7d23d0d5ff5'
+  version '5.6,5128'
+  sha256 '23bbe1e64965bb7cfd07511c0b05e7ed125eef8e9283e3fee9ed634487ac6704'
 
   # d2wvuuix8c9e48.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.