### PR TITLE
Update yate from 5.0.1.2 to 5.0.1.3

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '5.0.1.2'
-  sha256 '8c08cbb467f3f088dd0116333b07ef43461d4ed25eb43dce938daae54b26f1ae'
+  version '5.0.1.3'
+  sha256 'b56ec68760832e4d9392e7e84b8f541ff24ae7e30abed093ab25f4eb9ac33739'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.