### PR TITLE
Update coconutbattery from 3.8.1 to 3.8.2

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -9,8 +9,8 @@ cask 'coconutbattery' do
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
   else
     version '3.8.2'
-    sha256 '0a09dc05d1c498eeed67a05e1aacb9fa3634c0e40af76c666d5f167660f4856b'
-    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
+    sha256 'e73fb1710498d9370f1a49e73baf979d25864a65742ce7bdcd07577238189f63'
+    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.delete('.')}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml'
   end
 

--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -8,8 +8,8 @@ cask 'coconutbattery' do
     sha256 '8e289fb4a75cb117fc1d7861020c9ab2384b09dfd18f066c7fadfc9d42c3ac56'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
   else
-    version '3.8.1'
-    sha256 '43c1f73ee1e8247428ad2994f5fb7885e191f96f2593b02eceee43e9028a49e4'
+    version '3.8.2'
+    sha256 '0a09dc05d1c498eeed67a05e1aacb9fa3634c0e40af76c666d5f167660f4856b'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.