### PR TITLE
Update diskmaker-x to a catalina supported version 9.0.b1

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,11 +1,11 @@
 cask 'diskmaker-x' do
-  version '8.0.3'
-  sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
-
+  version '9.0.b1'
+  sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
+  
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
 
-  app "DiskMaker X #{version.major} for macOS Mojave.app"
+  app "DiskMaker X #{version.major} for macOS Catalina.app"
 end

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,7 +1,7 @@
 cask 'diskmaker-x' do
   version '9.0.b1'
   sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
-  
+
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'


### PR DESCRIPTION

After making all changes to the cask:

- [ x] `brew cask audit --download {{cask_file}}` is error-free.
- [ x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x] The commit message includes the cask’s name and version.
- [ x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).