### PR TITLE
Update freesmug-chromium from 77.0.3865.90 to 77.0.3865.120

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '77.0.3865.90'
-  sha256 'c75f726f73bc3acbb6abfb9f1445bb2df0ba6dfb840f9a5fe85042eac4299100'
+  version '77.0.3865.120'
+  sha256 'a0240fc93f341d672d3bbcb5479c2b3567f57bec906d576b88c3dadaffb7cd10'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.