### PR TITLE
Improve installation for prince

### DIFF
--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -3,17 +3,18 @@ cask 'prince' do
   sha256 'd7940c2f60b1e9657db1deb1144b2496cc34c728f650c36b24d6885b964e9aed'
 
   url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
+  appcast 'https://www.princexml.com/download/'
   name 'Prince'
   homepage 'https://www.princexml.com/'
 
-  installer script: "prince-#{version}-macosx/install.sh"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/prince-#{version}-macosx/prince.wrapper.sh"
+  binary shimscript, target: 'prince'
 
-  uninstall delete: [
-                      '/usr/local/bin/prince',
-                      '/usr/local/lib/prince',
-                    ]
-
-  caveats do
-    files_in_usr_local
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{staged_path}/prince-#{version}-macosx/lib/prince/bin/prince' --prefix '#{staged_path}/prince-#{version}-macosx/lib/prince' "$@"
+    EOS
   end
 end


### PR DESCRIPTION
Previously, this cask delegated to a bundled installation script that does the following:
- Ask for a prefix location
- Copy its files wholesale to that location
- Create a shim script that calls the binary with an added `--prefix` option
- Set permissions on the files

As Cask can manage all of that, the installation script is skipped and Cask is instructed on having a similar outcome.

There is however a problem in the Catalina update, Gatekeeper flat out refuses to launch the executable -even from the terminal- as it has the quarantine bit set and is not signed. Should I remove the quarantine bit in a `postflight` script, or leave it as-is?

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
> It doesn't include the version as there's no change to it
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).