### PR TITLE
Update navicat-for-mariadb from 12.1.25 to 12.1.27

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '12.1.25'
-  sha256 'adc3c9cdd0c0bfc4617119dc57933b9c829d86e37d74950d2e6ea283bec1ace5'
+  version '12.1.27'
+  sha256 '5c466e9142c19796e3f9c710c1bb9f13ce61162ebad006a5c975dd13ef42bdb6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.