### PR TITLE
Update navicat-for-sqlite from 12.1.25 to 12.1.27

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.25'
-  sha256 '305faa2677f032e5db07299bbe46542ed34af8bd5a67ca8849353523757d16df'
+  version '12.1.27'
+  sha256 'db180d5450114d22b1dc9e0ae49257383f1bc43c7487030e5bf1da908e7af70d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.