### PR TITLE
Update navicat-for-sql-server from 12.1.25 to 12.1.27

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.25'
-  sha256 '17eef9fb9b95476bbb9ed7ff8acdf25cebf0514a656fbf65b8db1bdcba587db5'
+  version '12.1.27'
+  sha256 'ad85600d2eda1ee0d8cb4b12ad2a9acaded98dcfe4125688400d28651f6deea3'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.