### PR TITLE
Update navicat-premium-essentials from 12.1.25 to 12.1.27

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '12.1.25'
-  sha256 '35bfe7013426b350a2a3b98e959fc728d3c879cc6915799676119dd0ebbd5709'
+  version '12.1.27'
+  sha256 '41f15116c7c186c93a93157436e9e1ed48c7d839bfb7447a7974e718ae498b5d'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20Premium%20Essentials&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.