### PR TITLE
Update qiyimedia from 20190912,5.13.11 to 20191014,5.14.11

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '20190912,5.13.11'
-  sha256 'ac546972d444c41403f709a11286bde2e32a1a55734ba79e5d16b844b2f8e988'
+  version '20191014,5.14.11'
+  sha256 'd9a8c09fd7b5f039d6e600ef755a6aa5c592ee15af7b52824f8b3c8c01bec02b'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.