### PR TITLE
Update epoch-flip-clock from 0.0.4 to 0.0.5

### DIFF
--- a/Casks/epoch-flip-clock.rb
+++ b/Casks/epoch-flip-clock.rb
@@ -1,6 +1,6 @@
 cask 'epoch-flip-clock' do
-  version '0.0.4'
-  sha256 '7a9fe06209a140ea86a6a37263e3476ce9080bc274d27b815e373a3f8352c45d'
+  version '0.0.5'
+  sha256 '90fa0ace6b13b47a12dc89a56c33d9add1140fecbd6bdd0c905d396fa093b02d'
 
   url "https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver/releases/download/#{version}/Epoch.Flip.Clock.#{version}.saver.zip"
   appcast 'https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.