### PR TITLE
Update bluegriffon from 3.0.1 to 3.1

### DIFF
--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -7,5 +7,7 @@ cask 'bluegriffon' do
   name 'BlueGriffon'
   homepage 'http://bluegriffon.org/'
 
+  depends_on macos: '>= :high_sierra'
+
   app 'BlueGriffon.app'
 end

--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -1,6 +1,6 @@
 cask 'bluegriffon' do
-  version '3.0.1'
-  sha256 'c62f0af91ee7544c3f83f7a598638dad5e344ef6ce743e18b7d337a37e359580'
+  version '3.1'
+  sha256 'cf457ac89447c8a54e0fbc1c13b995286e9b9143cee104fe3f3777a80f540a35'
 
   url "http://bluegriffon.org/freshmeat/#{version}/bluegriffon-#{version}.mac-x86_64.dmg"
   appcast 'http://bluegriffon.org/freshmeat/?C=M;O=D'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.