### PR TITLE
Update whatsapp from 0.3.4941 to 0.3.5148

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'whatsapp' do
-  version '0.3.4941'
-  sha256 'e96b70b4728401b3fa1db7691086138501c84e297146f505acfeba9c12974864'
+  version '0.3.5148'
+  sha256 'bdad9abe2e0d80c2597e3dd85db97c46bb9603213eee4d72a159dda3c4f51ff4'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.