### PR TITLE
Update tribler from 7.3.0 to 7.3.1

### DIFF
--- a/Casks/tribler.rb
+++ b/Casks/tribler.rb
@@ -1,6 +1,6 @@
 cask 'tribler' do
-  version '7.3.0'
-  sha256 '97e7d22d9276ffdcb8f41e9a80395015b7594be2dddba76a589e81bfb4ca9fce'
+  version '7.3.1'
+  sha256 '73fb80b1a1855bfed680be9d8415b91fa6a3e6dab4f37d1b298410e68a55cee9'
 
   # github.com/Tribler/tribler was verified as official when first introduced to the cask
   url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.