### PR TITLE
Update gingko from 2.4.1 to 2.4.2

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,6 +1,6 @@
 cask 'gingko' do
-  version '2.4.1'
-  sha256 'f68e14a5fcf2a6bc676c4b8c91a95d9a32ec1ce83a7ac5ce20dc483f7ae58c36'
+  version '2.4.2'
+  sha256 'c8542d6123aad025e70ed26875e2504e7ad607ee06f4086b790602431f78344e'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/Gingko-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.