### PR TITLE
Update bitshares from 3.1.19061,8.5 to 3.1.191011

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,9 +1,9 @@
 cask 'bitshares' do
-  version '3.1.19061,8.5'
-  sha256 'e4a6b6520bee314ac9635b78d2baaf13b11521a39e7e3dae4575087f6c3256bb'
+  version '3.1.191011'
+  sha256 '34394912ad29512220480a3c3a1eff2c309beb9e1b9bac1050ece40987ce8b2f'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
-  url "https://github.com/bitshares/bitshares-ui/releases/download/#{version.before_comma}#{version.after_comma}/BitShares-#{version.before_comma}-#{version.after_comma}.dmg"
+  url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}-mac.zip"
   appcast 'https://github.com/bitshares/bitshares-ui/releases.atom'
   name 'BitShares'
   homepage 'https://bitshares.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.