### PR TITLE
Update eve-launcher from 1580296 to 1583250

### DIFF
--- a/Casks/eve-launcher.rb
+++ b/Casks/eve-launcher.rb
@@ -1,6 +1,6 @@
 cask 'eve-launcher' do
-  version '1580296'
-  sha256 'a85ae33c687152d13f76d580c9299dce105732e4d04509bf638ead76da2a823f'
+  version '1583250'
+  sha256 'b500d407f87de6388fc896ae5de866fc0ccc62c7152b9c0d37eb16a90d3ce133'
 
   url "https://binaries.eveonline.com/EveLauncher-#{version}.dmg"
   appcast 'https://launcher.eveonline.com/launcherVersions.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.