### PR TITLE
Update wpsoffice from 1.6.0(2399) to 1.6.1(2429)

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
-  version '1.6.0(2399)'
-  sha256 'b9167573878a04f40c500837e3b6c4f786a355e7d40776c5392e158562c47cb9'
+  version '1.6.1(2429)'
+  sha256 'fe65131ce6155553548616b7983112b0e52ea8a620b66e0ab94ef073154fb76b'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
   url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.major_minor_patch}/WPS_Office_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.