### PR TITLE
Update eloston-chromium from 77.0.3865.90-1 to 77.0.3865.120-1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,6 +1,6 @@
 cask 'eloston-chromium' do
-  version '77.0.3865.90-1'
-  sha256 '234a5224886593d93b238557b1ee972bf5ac5a9195bedce6109f74056fcf4009'
+  version '77.0.3865.120-1'
+  sha256 '3197d136d6648eac6806e5b951788498b1cf5af9b57ff9629c522fb537f33119'
 
   # github.com/kramred/ungoogled-chromium-binaries was verified as official when first introduced to the cask
   url "https://github.com/kramred/ungoogled-chromium-binaries/releases/download/#{version}/ungoogled-chromium_#{version}.1_macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.