### PR TITLE
Update bbedit from 13.0 to 13.0.1

### DIFF
--- a/Casks/bbedit.rb
+++ b/Casks/bbedit.rb
@@ -6,8 +6,8 @@ cask 'bbedit' do
     version '12.6.7'
     sha256 'd0647c864268b187343bd95bfcf490d6a2388579b1f8fce64a289c65341b1144'
   else
-    version '13.0'
-    sha256 '38126aa393fd6cafdc91903bbca50d0555f06f7c0f08161c6ab110206ecaada3'
+    version '13.0.1'
+    sha256 'cb330230cbf1795cf79ed7f0ea44a9155007a1a3d753f24ed4a0184897265fd5'
   end
   # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/BBEdit_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.