### PR TITLE
Update bitrix24 from 7.0.95 to 8.1.0.44

### DIFF
--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -1,9 +1,9 @@
 cask 'bitrix24' do
   # note: "24" is not a version number, but an intrinsic part of the product name
   version '8.1.0.44'
-  sha256 '7149942929882b1a00c7b65e652249807e0dc03c4078416778c0fe665584a3e7'
-
-  url 'https://dl.bitrix24.com/b24/bitrix24_desktop.dmg'
+  sha256 '4494265baf3a9927d929131274f7f75d1b05f9bb3c6f1a81ecb7882288a7ca7d'
+  
+  url "https://dl.bitrix24.com/b24/bitrix24_desktop_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.bitrix24.com/osx_version.php'
   name 'Bitrix24'
   homepage 'https://www.bitrix24.com/apps/mobile-and-desktop-apps.php#desktop_app'

--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -2,7 +2,7 @@ cask 'bitrix24' do
   # note: "24" is not a version number, but an intrinsic part of the product name
   version '8.1.0.44'
   sha256 '4494265baf3a9927d929131274f7f75d1b05f9bb3c6f1a81ecb7882288a7ca7d'
-  
+
   url "https://dl.bitrix24.com/b24/bitrix24_desktop_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.bitrix24.com/osx_version.php'
   name 'Bitrix24'

--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -1,6 +1,6 @@
 cask 'bitrix24' do
   # note: "24" is not a version number, but an intrinsic part of the product name
-  version '7.0.95'
+  version '8.1.0.44'
   sha256 '7149942929882b1a00c7b65e652249807e0dc03c4078416778c0fe665584a3e7'
 
   url 'https://dl.bitrix24.com/b24/bitrix24_desktop.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.