### PR TITLE
diffmerge#4.2.1.1013: switch to dmg to support Mac OS Catalina

### DIFF
--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -6,9 +6,10 @@ cask 'diffmerge' do
   name 'DiffMerge'
   homepage 'https://www.sourcegear.com/diffmerge/'
 
+  dmg_folder = 'Extras'
   app 'DiffMerge.app'
-  artifact 'Extras/diffmerge.sh', target: 'diffmerge'
-  artifact 'Extras/diffmerge.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/diffmerge.1"
+  binary "#{dmg_folder}/diffmerge.sh", target: 'diffmerge'
+  artifact "#{dmg_folder}/diffmerge.1", target: "#{HOMEBREW_PREFIX}/share/man/man1/diffmerge.1"
 
   zap trash: [
                '~/Library/Preferences/com.sourcegear.DiffMerge.plist',

--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -1,14 +1,14 @@
 cask 'diffmerge' do
   version '4.2.1.1013'
-  sha256 '1f19897513fb7af8fc7d3b40643bd6dee80e401c7245a0ed774e8211fd48e388'
+  sha256 '59efeede7beb69a5b3bf3126787f73930984b3b423094500fe73623656f66d43'
 
-  url "http://download.sourcegear.com/DiffMerge/#{version.sub(%r{\.\d+$}, '')}/DiffMerge.#{version}.intel.stable.pkg"
+  url "http://download.sourcegear.com/DiffMerge/#{version.sub(%r{\.\d+$}, '')}/DiffMerge.#{version}.intel.stable.dmg"
   name 'DiffMerge'
   homepage 'https://www.sourcegear.com/diffmerge/'
 
-  pkg "DiffMerge.#{version}.intel.stable.pkg"
-
-  uninstall pkgutil: 'com.sourcegear.DiffMerge'
+  app 'DiffMerge.app'
+  artifact 'Extras/diffmerge.sh', target: "#{HOMEBREW_PREFIX}/bin/diffmerge"
+  artifact 'Extras/diffmerge.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/diffmerge.1"
 
   zap trash: [
                '~/Library/Preferences/com.sourcegear.DiffMerge.plist',

--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -7,7 +7,7 @@ cask 'diffmerge' do
   homepage 'https://www.sourcegear.com/diffmerge/'
 
   app 'DiffMerge.app'
-  artifact 'Extras/diffmerge.sh', target: "#{HOMEBREW_PREFIX}/bin/diffmerge"
+  artifact 'Extras/diffmerge.sh', target: 'diffmerge'
   artifact 'Extras/diffmerge.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/diffmerge.1"
 
   zap trash: [

--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -6,10 +6,9 @@ cask 'diffmerge' do
   name 'DiffMerge'
   homepage 'https://www.sourcegear.com/diffmerge/'
 
-  dmg_folder = 'Extras'
   app 'DiffMerge.app'
-  binary "#{dmg_folder}/diffmerge.sh", target: 'diffmerge'
-  artifact "#{dmg_folder}/diffmerge.1", target: "#{HOMEBREW_PREFIX}/share/man/man1/diffmerge.1"
+  binary 'Extras/diffmerge.sh', target: 'diffmerge'
+  artifact 'Extras/diffmerge.1', target: "#{HOMEBREW_PREFIX}/share/man/man1/diffmerge.1"
 
   zap trash: [
                '~/Library/Preferences/com.sourcegear.DiffMerge.plist',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md

Closes https://github.com/Homebrew/homebrew-cask/issues/70792.