### PR TITLE
Update diskmaker-x for catalina

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,5 +1,4 @@
 cask 'diskmaker-x' do
-
   if MacOS.version == :catalina
     sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
     version '9.0.b1'

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,7 +1,13 @@
 cask 'diskmaker-x' do
-  version '8.0.3'
-  sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
-
+  
+  if MacOS.version == :catalina
+    sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
+    version '9.0.b1'
+  else    
+    sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
+    version '8.0.3'
+  end
+  
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -3,12 +3,12 @@ cask 'diskmaker-x' do
     version '8.0.3'
     sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
 
-    app "DiskMaker X #{version.major} for macOS Mojave.app"p"
+    app "DiskMaker X #{version.major} for macOS Mojave.app"
   else
     version '9.0.b1'
     sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
 
-    app "DiskMaker X #{version.major} for macOS Catalina.ap
+    app "DiskMaker X #{version.major} for macOS Catalina.app"
   end
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,14 +1,14 @@
 cask 'diskmaker-x' do
   if MacOS.version <= :mojave
-    version '9.0.b1'
-    sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
-
-    app "DiskMaker X #{version.major} for macOS Catalina.app"
-  else
     version '8.0.3'
     sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
 
-    app "DiskMaker X #{version.major} for macOS Mojave.app"
+    app "DiskMaker X #{version.major} for macOS Mojave.app"p"
+  else
+    version '9.0.b1'
+    sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
+
+    app "DiskMaker X #{version.major} for macOS Catalina.ap
   end
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,10 +1,12 @@
 cask 'diskmaker-x' do
-  if MacOS.version == :catalina
+  if MacOS.version <= :mojave
     sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
     version '9.0.b1'
+    app "DiskMaker X #{version.major} for macOS Catalina.app"
   else
     sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
     version '8.0.3'
+    app "DiskMaker X #{version.major} for macOS Mojave.app"
   end
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
@@ -12,5 +14,4 @@ cask 'diskmaker-x' do
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
 
-  app "DiskMaker X #{version.major} for macOS Mojave.app"
 end

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,11 +1,13 @@
 cask 'diskmaker-x' do
   if MacOS.version <= :mojave
-    sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
     version '9.0.b1'
+    sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
+
     app "DiskMaker X #{version.major} for macOS Catalina.app"
   else
-    sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
     version '8.0.3'
+    sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
+
     app "DiskMaker X #{version.major} for macOS Mojave.app"
   end
 

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -1,13 +1,13 @@
 cask 'diskmaker-x' do
-  
+
   if MacOS.version == :catalina
     sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
     version '9.0.b1'
-  else    
+  else
     sha256 '79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7'
     version '8.0.3'
   end
-  
+
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -13,5 +13,4 @@ cask 'diskmaker-x' do
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
-
 end


### PR DESCRIPTION
Adding as discussed a fallback strategy for mojave.

After making all changes to the cask:

- [ x] `brew cask audit --download {{cask_file}}` is error-free.
- [ x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x] The commit message includes the cask’s name and version.
- [ x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).