### PR TITLE
Update ezip from 1.7.5 to 1.7.6

### DIFF
--- a/Casks/ezip.rb
+++ b/Casks/ezip.rb
@@ -1,6 +1,6 @@
 cask 'ezip' do
-  version '1.7.5'
-  sha256 '21b137cb41f561b0438d792680c8be3ae0dcb1a4fae949a5c7f4d09050dd9e1a'
+  version '1.7.6'
+  sha256 '04e341600948e6cb06356fa948432090f2aaee263d6b94825d8a9892f29a9c50'
 
   url "https://cdn.awehunt.com/ezip/release/eZip_V#{version}.dmg"
   appcast 'https://ezip.awehunt.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.