### PR TITLE
Add mysqlworkbench version 6.3.10 for High Sierra users

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -1,13 +1,18 @@
 cask 'mysqlworkbench' do
-  version '8.0.18'
-  sha256 '965f85163d1723be26c1f0c74c5b1cd908fac79e02c00fa371c217c9a3bf09ae'
+  if MacOS.version <= :high_sierra
+    version '6.3.10'
+    sha256 '29857bf84bebb7c4442ce147e44602d00f8c001e3c09b3a6e3af356767e08d2c'
+  else
+    version '8.0.18'
+    sha256 '965f85163d1723be26c1f0c74c5b1cd908fac79e02c00fa371c217c9a3bf09ae'
+  end
 
   url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   appcast 'https://dev.mysql.com/downloads/workbench/'
   name 'MySQL Workbench'
   homepage 'https://www.mysql.com/products/workbench/'
 
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :high_sierra'
 
   app 'MySQLWorkbench.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.