### PR TITLE
Update oracle-jdk-javadoc from 13,33:5b8a42f3905b406298b72d750b6919f6 to 13.0.1,9:cec27d702aa74d5a8630c65ae61e4305

### DIFF
--- a/Casks/oracle-jdk-javadoc.rb
+++ b/Casks/oracle-jdk-javadoc.rb
@@ -1,6 +1,6 @@
 cask 'oracle-jdk-javadoc' do
-  version '13,33:5b8a42f3905b406298b72d750b6919f6'
-  sha256 '8e9848af68ee227438661cfb73740de94e11755234432ceae04f86a04b1c7e15'
+  version '13.0.1,9:cec27d702aa74d5a8630c65ae61e4305'
+  sha256 '9603c0b8fe0bbf68115e6ccf70d386bc1036295a66783362a76bcc2c78e0c3d7'
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.