### PR TITLE
pr_template: remove appcast item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,11 +15,9 @@ Additionally, if **adding a new cask**:
 - [ ] Checked there are no [open pull requests] for the same cask.
 - [ ] Checked the cask was not [already refused].
 - [ ] Checked the cask is submitted to [the correct repo].
-- [ ] Attempted to find an [appcast].
 
 [token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
 [open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
 [already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
 [the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
 [version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
-[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md


### PR DESCRIPTION
@core-code It was worth a try, but it didn’t work. Even experienced contributors are failing to add the most obvious appcasts. I’m not sure where the problem lies so I don’t have a fix.

I usually catch the new submissions and I’m taking care to always find an appcast, so might as well remove the item from the template.