### PR TITLE
Update angry-ip-scanner from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -1,6 +1,6 @@
 cask 'angry-ip-scanner' do
-  version '3.6.1'
-  sha256 '00d223d61d1569d44bfe81805359f94c15c9549473762016605287c31733bae6'
+  version '3.6.2'
+  sha256 '5f36bb51a099a20c72d69123aa5b17558fa78ba37b5d340b8db9877e4055ad0e'
 
   # github.com/angryip/ipscan was verified as official when first introduced to the cask
   url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.