### PR TITLE
Update mission-control-plus from 1.11 to 1.12

### DIFF
--- a/Casks/mission-control-plus.rb
+++ b/Casks/mission-control-plus.rb
@@ -1,6 +1,6 @@
 cask 'mission-control-plus' do
-  version '1.11'
-  sha256 '6575889e11d06c659fcd090e5a9084f0452509e1419ae9bc847ea4233f26e811'
+  version '1.12'
+  sha256 'f72c46afed7c3bc0c2fe521443fc8c70d299d730356589ed35a525ccb058a5b3'
 
   # github.com/ronyfadel/MissionControlPlusReleases was verified as official when first introduced to the cask
   url "https://github.com/ronyfadel/MissionControlPlusReleases/releases/download/v#{version}/Mission_Control_Plus.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.