### PR TITLE
Update macpilot from 11.0.3 to 11.0.4

### DIFF
--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -1,6 +1,6 @@
 cask 'macpilot' do
-  version '11.0.3'
-  sha256 '6acabff3dc9eddebd4043bdc41c495d7f621233349a40660a127d69cf1676a07'
+  version '11.0.4'
+  sha256 '2db7806f18c7634d192e939b6520af09c75f9cd295bd4d03533f44bffcb9a239'
 
   url 'http://mirror.koingosw.com/products/macpilot/download/macpilot.dmg'
   appcast 'https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.