### PR TITLE
Update mudlet from 4.2.0 to 4.2.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '4.2.0'
-  sha256 '615fab9473cc0752bac0dfae33e29f80ce8ba9d74fc28275aa0c24906a1b67ff'
+  version '4.2.1'
+  sha256 'b939a058fa5bc5631fcce7d413dd15606c333f3920c5a1a6efb1eb2ed7b54293'
 
   url "https://www.mudlet.org/wp-content/files/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.