### PR TITLE
Update vivaldi from 2.8.1664.43 to 2.8.1664.44

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.8.1664.43'
-  sha256 'd76ce2caf3047d9e86b413a6e6717419ce883ad64002f7fe6b12993eb1fe6072'
+  version '2.8.1664.44'
+  sha256 'e27080800d4844c97c4fe3707766e1b9c2a1f0a8e2dcecf1c5221d2142228124'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.