### PR TITLE
Update favro from 1.0.34 to 1.0.36

### DIFF
--- a/Casks/favro.rb
+++ b/Casks/favro.rb
@@ -1,6 +1,6 @@
 cask 'favro' do
-  version '1.0.34'
-  sha256 'ed4cba5eea735cf113fb82b97a7068faaee7ba05c3f77f33b93e9e994c47bff0'
+  version '1.0.36'
+  sha256 'cb42e7f8bcb998d005645b22b200e38f21d9b92ca697662226f298477191eed6'
 
   url "https://download.favro.com/FavroDesktop/macOS/x64/Favro-#{version}.dmg"
   appcast 'https://download.favro.com/FavroDesktop/macOS/x64/Latest.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.