### PR TITLE
Update ableton-live from 10.1.2 to 10.1.3

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live' do
-  version '10.1.2'
-  sha256 '45a48dc708fa8bcc7c28d8ef15cf807e94d2e17687e4988440d26cf5adbef0e5'
+  version '10.1.3'
+  sha256 '9e0766d403e4381b653c257e22b6ae47e108ddb61f345b57d4d2573efb807efa'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.