### PR TITLE
Update studio-3t from 2019.5.1 to 2019.6.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2019.5.1'
-  sha256 '383e32005abaae8517f1cf25c1450350497789a038e683d1a5380328935dc1b3'
+  version '2019.6.0'
+  sha256 'bd75fa718bb76db0d1b44e3ea2f39bcd8e1fd8f6d97e4ff069ced71bfb3e36c9'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.