### PR TITLE
Update Maccy 0.5.1 cask to use its new homepage

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -2,10 +2,11 @@ cask 'maccy' do
   version '0.5.1'
   sha256 'ad71007a32378ee9b07caed6b67e9ae9c7bc53b9bdfaba59b30f139cbb1dd994'
 
+  # github.com/p0deje/Maccy was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"
   appcast 'https://github.com/p0deje/Maccy/releases.atom'
   name 'Maccy'
-  homepage 'https://github.com/p0deje/Maccy'
+  homepage 'https://maccy.app/'
 
   depends_on macos: '>= :mojave'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).