### PR TITLE
Allow to use Maccy 0.5.1 on High Sierra

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -7,7 +7,7 @@ cask 'maccy' do
   name 'Maccy'
   homepage 'https://github.com/p0deje/Maccy'
 
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :high_sierra'
 
   app 'Maccy.app'
 end


### PR DESCRIPTION
This particular version added support for High Sierra.
See https://github.com/p0deje/Maccy/releases/tag/0.5.1.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
