### PR TITLE
Add zap for Maccy 0.5.1 to remove login item and preferences plist

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -10,4 +10,7 @@ cask 'maccy' do
   depends_on macos: '>= :mojave'
 
   app 'Maccy.app'
+
+  zap login_item: 'Maccy',
+      trash:      '~/Library/Preferences/org.p0deje.Maccy.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew cask zap {{cask_file}}` worked successfully.