### PR TITLE
Update battlescribe from 2.03.01 to 2.03.02

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.01'
-  sha256 '35756e8af8103f21dff69192108f54e019049730221b9d04e299697521c33f4e'
+  version '2.03.02'
+  sha256 'e5e1cebc3592ef8e02f1186292c3a91f58f159929078aabb95cea5695d5470e9'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.