### PR TITLE
Update alt-tab to 1.0.12 and add depends_on mojave

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,11 +1,13 @@
 cask 'alt-tab' do
-  version '1.0.11'
-  sha256 'ea686d83929bb043b0de9d776d93b07f21a2218f2b9b822342e47954b23b3580'
+  version '1.0.12'
+  sha256 '0785737a0ca5d4e2562754483da11a4ac1220effef38d78617e9aa375da6ffef'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/alt-tab-macos.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'
   name 'alt-tab'
   homepage 'https://github.com/lwouis/alt-tab-macos'
+
+  depends_on macos: '>= :mojave'
 
   app 'alt-tab-macos.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

OSX dependency based on on this issue in the projects repo
https://github.com/lwouis/alt-tab-macos/issues/27