### PR TITLE
Update screens from 4.6.11 to 4.7,25494:1571154585

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,9 +1,9 @@
 cask 'screens' do
-  version '4.6.11'
-  sha256 '1156fe32dd27239466d2910c07c4ad2142b0d70d4f55e2edb0dfa96ccc42930e'
+  version '4.7,25494:1571154585'
+  sha256 '79a0403f6c7d5719faf92edfd194ef6812523595f3f83c02e76cf54eeea83b0c'
 
   # dl.devmate.com/com.edovia.screens4.mac was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.edovia.screens4.mac/Screens4.dmg'
+  url "https://dl.devmate.com/com.edovia.screens4.mac/#{version.after_comma.before_colon}/#{version.after_colon}/Screens#{version.major}-#{version.after_comma.before_colon}.zip"
   appcast "https://updates.devmate.com/com.edovia.screens#{version.major}.mac.xml"
   name 'Screens'
   homepage 'https://edovia.com/screens-mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.