### PR TITLE
Update wavesurfer from 1.8.8p5 to 1.8.8p6

### DIFF
--- a/Casks/wavesurfer.rb
+++ b/Casks/wavesurfer.rb
@@ -1,8 +1,8 @@
 cask 'wavesurfer' do
-  version '1.8.8p5'
-  sha256 'f14765e4b5ee015c9199081de75934900c55358af8925e8debc345023b91aa96'
+  version '1.8.8p6'
+  sha256 '612cede095ffd6eee9b53bf29246ad8af778753cba907300db42770e4631e56a'
 
-  url "https://downloads.sourceforge.net/wavesurfer/wavesurfer-#{version}-osx-i386.dmg"
+  url "https://downloads.sourceforge.net/wavesurfer/wavesurfer-#{version}-macos.dmg"
   appcast 'https://sourceforge.net/projects/wavesurfer/rss'
   name 'WaveSurfer'
   homepage 'https://sourceforge.net/projects/wavesurfer/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.