### PR TITLE
Update zeplin from 2.7,751 to 2.7.1,762

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,5 +1,5 @@
 cask 'zeplin' do
-  version '2.7,751'
+  version '2.7.1,762'
   sha256 'f8ca773eece8496098bd087590c8c0749691ae299a84aaae48c73ab7817ef30f'
 
   url 'https://api.zeplin.io/urls/download-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.