### PR TITLE
Update workflowy from 1.3.4-4640 to 1.3.5-4650

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.4-4640'
-  sha256 '8aa9c8381240fa8437e7a17d54456db487d97669dc6d083b60026adc56bd3588'
+  version '1.3.5-4650'
+  sha256 '64466d21247f98c16effcc2c6407eedf9cad2d49c23fe79c0e7b0b63c67fa92a'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.