### PR TITLE
Update gingko from 2.4.2 to 2.4.3

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,6 +1,6 @@
 cask 'gingko' do
-  version '2.4.2'
-  sha256 'c8542d6123aad025e70ed26875e2504e7ad607ee06f4086b790602431f78344e'
+  version '2.4.3'
+  sha256 'e10f35c4f71bcf9eb283b0b941e834f39a5b96e3d0e4c3fb52981712319f5031'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/Gingko-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.