### PR TITLE
Update kode54-cog from 0.08,1dceedaa5 to 0.08,0f93b0c7b

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,5 +1,5 @@
 cask 'kode54-cog' do
-  version '0.089,0f93b0c7b'
+  version '0.08,0f93b0c7b'
   sha256 'e97b8b4bf60d1706acd683cce5211471916f6fff257b668bb348cd9a4f41ed38'
 
   # losno.co/cog was verified as official when first introduced to the cask

--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,1dceedaa5'
-  sha256 '3054a006462ed797033eb7dfc02f928af8f6e39e93c5a032cee33f8cec301840'
+  version '0.089,0f93b0c7b'
+  sha256 'e97b8b4bf60d1706acd683cce5211471916f6fff257b668bb348cd9a4f41ed38'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.