### PR TITLE
Update glyphs from 2.6.3,1269 to 2.6.3,1270

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.3,1269'
-  sha256 'fce5f4b1bfbef515b6e0808b5d422daf2136bbcba4533b987f6947d3e417fd1b'
+  version '2.6.3,1270'
+  sha256 'bdde0d0886a50e3698fb85817bb4cebe60260b59b8226874a481fa4d5b175226'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.