### PR TITLE
Update kite from 0.20191011.1 to 0.20191015.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191011.1'
-  sha256 '71301ee039adb7aa91a155d5712db33af46d2b251ccae818b00b87684e1db117'
+  version '0.20191015.0'
+  sha256 'bc88f2d89bf851dca39cb1907c23f431e8c4440f0ea17b35cd2b0c753653eeb9'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.