### PR TITLE
Update dissenter-browser from 0.68.131,5d3f93a29dd49a5b1d9fc27f:5d8287329001ac55509c6aa0 to 0.69.135,5d3f93a29dd49a5b1d9fc27f:5da5f347bcf95235c499fb7c

### DIFF
--- a/Casks/dissenter-browser.rb
+++ b/Casks/dissenter-browser.rb
@@ -1,6 +1,6 @@
 cask 'dissenter-browser' do
-  version '0.68.131,5d3f93a29dd49a5b1d9fc27f:5d8287329001ac55509c6aa0'
-  sha256 '540f1446253de671dae6a36ae9c50a21d035d81cd848116fb0a4f0a204b6423f'
+  version '0.69.135,5d3f93a29dd49a5b1d9fc27f:5da5f347bcf95235c499fb7c'
+  sha256 '854ffbd5c16e16836ec8bb210d157c38f4522c5cfc78c2f025f4db9433bac618'
 
   # apps.gab.com was verified as official when first introduced to the cask
   url "https://apps.gab.com/application/#{version.after_comma.before_colon}/resource/#{version.after_colon}/content"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.