### PR TITLE
Update alt-tab to 1.4.3 and add depends_on mojave

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,11 +1,13 @@
 cask 'alt-tab' do
-  version '1.0.11'
-  sha256 'ea686d83929bb043b0de9d776d93b07f21a2218f2b9b822342e47954b23b3580'
+  version '1.4.5'
+  sha256 'a10be9f85ed2450b4e38c5f1e8773270f8c523e7fe12b153e81abfa2f431f1ba'
 
-  url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/alt-tab-macos.zip"
+  url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'
   name 'alt-tab'
   homepage 'https://github.com/lwouis/alt-tab-macos'
 
-  app 'alt-tab-macos.app'
+  depends_on macos: '>= :mojave'
+
+  app 'AltTab.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The app name was also changed from alt-tab to AltTab so the token should be alttab but i wanted to do it in a different PR