### PR TITLE
Update boom-3d from 1.3.2,1566975454 to 1.3.3,1571300754

### DIFF
--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -1,6 +1,6 @@
 cask 'boom-3d' do
-  version '1.3.2,1566975454'
-  sha256 'f83d719b9af08a666e88cb9560d787d1f408aed12ab66da458afa94cb4e5c546'
+  version '1.3.3,1571300754'
+  sha256 'd65bd4bd1c146b8c9bd061f35c4e64b8e1d29c6796f6db0bc42a8b9e2f16741a'
 
   # devmate.com/com.globaldelight.Boom3D was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.globaldelight.Boom3D/#{version.before_comma}/#{version.after_comma}/Boom3D-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.