### PR TITLE
Update betaflight-configurator from 10.5.1 to 10.6.0

### DIFF
--- a/Casks/betaflight-configurator.rb
+++ b/Casks/betaflight-configurator.rb
@@ -1,6 +1,6 @@
 cask 'betaflight-configurator' do
-  version '10.5.1'
-  sha256 '6ee33a722fa5d86e369676ecea4968a347fe5df923052ecc469ae70ab7e582c7'
+  version '10.6.0'
+  sha256 '2e5e1a7d305e5a645d6707463f107c9b009e4682116af0be2c3bc0faa86345ab'
 
   url "https://github.com/betaflight/betaflight-configurator/releases/download/#{version}/betaflight-configurator_#{version}_macOS.dmg"
   appcast 'https://github.com/betaflight/betaflight-configurator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.