### PR TITLE
Update dcp-o-matic-batch-converter from 2.14.10 to 2.14.11

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.14.10'
-  sha256 '4fd29a186511330481d19af23e5af90d39c674996ea88367c1994653669dc1d4'
+  version '2.14.11'
+  sha256 '48f102041ed388aa87d804593bc73525ae8864f3341f8a49c06e1203dc1a6986'
 
   url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.