### PR TITLE
Update dcp-o-matic-encode-server from 2.14.10 to 2.14.11

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.10'
-  sha256 '1a9454ee430a15ea9891a059eb5957cb32753b6e324736807f3f728ef35f6f6f'
+  version '2.14.11'
+  sha256 'b8fbd56f3c8749ff9b69f8276d68fbd44399928fbfcbf997a0a50ad133977ad4'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.