### PR TITLE
Update dcp-o-matic-player from 2.14.10 to 2.14.11

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.10'
-  sha256 'ef4f64af0d24c2f7a54b7f2b30acff621d1b56a4524a06fce7ddfdee34646090'
+  version '2.14.11'
+  sha256 '5bac5ef3040cbe2b318d947aae1cf31c0fe121a8fa0398f7210a7ce3a626347d'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.