### PR TITLE
Update pdfpenpro from 1111.3,1570056557 to 1112.1,1571281353

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1111.3,1570056557'
-  sha256 '7df020bca156d3bc40dcfe9e96555754b4a36ef76233ba6b5d1cf38fc4befe0c'
+  version '1112.1,1571281353'
+  sha256 'b5940d2ed97624100cb32fd7fb18e79afe1df7e9bba3eb93ea0d178c46607820'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.