### PR TITLE
Update vitamin-r from 3.10 to 3.11

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -3,8 +3,8 @@ cask 'vitamin-r' do
     version '2.58'
     sha256 'c6c631430b44359aa022d9ca5ca6e98dbdf7258f2ceae0353f344a035682661e'
   else
-    version '3.10'
-    sha256 'a86d898d6f2f5fec6b704ac4865a9914da4db72ddbf880e45d7c75a3104638ee'
+    version '3.11'
+    sha256 'cac26478a53c14a5dd64105206c3d64b4eb6c58beb94f63ea6844b2c634283e3'
   end
 
   url "https://www.publicspace.net/download/signedVitamin#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.