### PR TITLE
Update preference-manager from 4.4.3.0 to 4.4.4.0

### DIFF
--- a/Casks/preference-manager.rb
+++ b/Casks/preference-manager.rb
@@ -1,6 +1,6 @@
 cask 'preference-manager' do
-  version '4.4.3.0'
-  sha256 '4920d80e09bf5e492a930896068352c4f08b3764ce723b7c13000e8b1d04ae15'
+  version '4.4.4.0'
+  sha256 'cee73faea96e0a83666ec070c49d302d53c9a23010c6a3579c0ee8da3af35d30'
 
   url "https://www.digitalrebellion.com/download/prefman?version=#{version.no_dots}"
   appcast 'https://www.digitalrebellion.com/prefman/changelog',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.