### PR TITLE
Update battlescribe from 2.03.02 to 2.03.03

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.02'
-  sha256 'e5e1cebc3592ef8e02f1186292c3a91f58f159929078aabb95cea5695d5470e9'
+  version '2.03.03'
+  sha256 '62a6903aa5a9a45c34c269f5851e36e69a9115f11c869ddd1feb5a48ddc21e3e'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.