### PR TITLE
Update roblox from 0.405.0.348052,5236228c56b848cc to 0.406.0.351423,c9625b3036514c13

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.405.0.348052,5236228c56b848cc'
-  sha256 '2df0c41bbfdc08f0fc4ee75d7466588e435e76a9c11fd3c2ff794af2526dfa79'
+  version '0.406.0.351423,c9625b3036514c13'
+  sha256 '3f1d84114d0c819d1587426ad44079682efdecfe91bcec6c2b2dfc083020e090'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.