### PR TITLE
Update wechatwork from 2.8.15.2071 to 2.8.16.2005

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.15.2071'
-  sha256 '98774d7f6a24b3419640ae3169b938ed5da70c0f73796f08bea4e773e9dad1c0'
+  version '2.8.16.2005'
+  sha256 'c7e1313f831da6c725dfdc7784c18ba6f1a968bdc53fd2c38c3def3acc7ed02a'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.