### PR TITLE
Update fiji

### DIFF
--- a/Casks/fiji.rb
+++ b/Casks/fiji.rb
@@ -3,7 +3,7 @@ cask 'fiji' do
   sha256 :no_check
 
   # downloads.imagej.net/fiji was verified as official when first introduced to the cask
-  url 'https://downloads.imagej.net/fiji/latest/fiji-macosx.dmg'
+  url 'https://downloads.imagej.net/fiji/latest/fiji-macosx.zip'
   name 'Fiji'
   homepage 'https://fiji.sc/'
 


### PR DESCRIPTION
The download is unversioned, but the .dmg package has not been updated in two years. It ships with old Java which cannot be updated from within Fiji.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] The commit message includes the cask’s name and version.