### PR TITLE
Update igv from 2.6.3 to 2.7.0

### DIFF
--- a/Casks/igv.rb
+++ b/Casks/igv.rb
@@ -1,6 +1,6 @@
 cask 'igv' do
-  version '2.6.3'
-  sha256 '9dff406ecebc9312278eb22b3e14250ee4e0d3f8a70c401f73877a00ba2f0fa7'
+  version '2.7.0'
+  sha256 '58c59a706760615bff52d2e97e7256b8245601d5241faf9d0e55f5d9144d0cce'
 
   url "https://data.broadinstitute.org/igv/projects/downloads/#{version.major_minor}/IGV_#{version}.app.zip"
   appcast 'https://data.broadinstitute.org/igv/projects/downloads/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.