### PR TITLE
Update pokerstars.rb

### DIFF
--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -28,7 +28,7 @@ cask 'pokerstars' do
 
   url "https://www.pokerstars#{language[2]}/PokerStars#{language[1]}.app.zip"
   name 'PokerStars'
-  homepage "https://www.pokerstars#{language[0]}"
+  homepage "https://www.pokerstars#{language[0]}/"
 
   container nested: "PokerStars#{language[1]}/PokerStars#{language[1]}.dmg"
 


### PR DESCRIPTION
Fails cask style check for missing forward slash.

== /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/pokerstars.rb ==
C: 31: 12: 'https://www.pokerstars#{language[0]}' must have a slash after the domain.

1 file inspected, 1 offense detected
Error: Style check failed.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
