### PR TITLE
Update balenaetcher from 1.5.59 to 1.5.60

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.59'
-  sha256 '7d61984c744ed95b6fc09012b8862cdf28e3d03de70fab0a08582875814f8158'
+  version '1.5.60'
+  sha256 '2bd42b3247890f833377bed5f2401b120c0cdbedfbe98dca7df452b442a8b35e'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.