### PR TITLE
Update linear from 1.3.0 to 1.5

### DIFF
--- a/Casks/linear.rb
+++ b/Casks/linear.rb
@@ -1,6 +1,6 @@
 cask 'linear' do
-  version '1.3.0'
-  sha256 'f93d9115e5173375b529c836cf6727936f40cd364b12314c42dc80564444ca10'
+  version '1.5'
+  sha256 'a449b498e552fcc9de0f42a360f894d26e1796ce44ab1dc150fc87acab10a9c2'
 
   # github.com/mikaa123/linear was verified as official when first introduced to the cask
   url "https://github.com/mikaa123/linear/releases/download/#{version}/linear.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.