### PR TITLE
Update horos from 3.3.5 to 4.0.0

### DIFF
--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -6,8 +6,8 @@ cask 'horos' do
     version '2.0.2'
     sha256 '5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08'
   else
-    version '3.3.5'
-    sha256 'e99716ee2939fc16cbe06fd04dfc6945fa0dbbf713c9db9bd53189d473ff9544'
+    version '4.0.0'
+    sha256 'fc23124feefc181488a36482a1f63e34a50b02e2c85897c2027f850c5f0242bb'
   end
 
   url "https://horosproject.org/horos-content/Horos#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.