### PR TITLE
Update lockrattler from 4.23,2019.10 to 4.24,2019.10

### DIFF
--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -1,6 +1,6 @@
 cask 'lockrattler' do
-  version '4.23,2019.10'
-  sha256 '898ee89f217f86cf635451f2f003269df7cece48cd30862ba4e89da0917158a0'
+  version '4.24,2019.10'
+  sha256 '60c348faaf58f69e4128b96e6221884fdcbc68eb7c3286e1ea68152ed4c76d87'
 
   # eclecticlightdotcom.files.wordpress.com was verified as official when first introduced to the cask
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.after_comma.major}/#{version.after_comma.minor}/lockrattler#{version.before_comma.no_dots}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.