### PR TITLE
Update omnifocus from 3.4.2 to 3.4.3

### DIFF
--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -16,8 +16,8 @@ cask 'omnifocus' do
     sha256 '8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0'
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
   else
-    version '3.4.2'
-    sha256 '3492aad2f19e8e0963f29a7ece9fd72b548086bd4c6dea50d8c764ba76894158'
+    version '3.4.3'
+    sha256 'cc87a81d82cd03eaee3bb80850d6d19f7a5aeae4d16d107cee4bf6fd77fbf6af'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniFocus-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.