### PR TITLE
Update cacher from 2.21.3 to 2.21.4

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.21.3'
-  sha256 '609d88fb5f611b8a41e8630692ee40db9c735c52abca4f8d11bcc3cfdfcb9f6d'
+  version '2.21.4'
+  sha256 '914b54cc769c13cc52c92fe2d05773d9b55d61bbd4b48aa9822754a0ffb36a22'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.