### PR TITLE
Update wiznote from 2.7.6,2019-07-26 to 2.7.8,2019-10-17

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.7.6,2019-07-26'
-  sha256 '453441c23b5a5a73cc65c92ad44e7211a03e7407ca53ae305533e0d8c5702ab3'
+  version '2.7.8,2019-10-17'
+  sha256 'e4af518847c6400416cd367833f1add767a0bc997d924acbda8094cc6854abcc'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://url.wiz.cn/u/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.