### PR TITLE
Update protopie from 4.0.5 to 4.1.0

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '4.0.5'
-  sha256 'cf7b4a0eff06ffeb9941b995563d4f4831c09e01e5d92cd640f7b45b830418f4'
+  version '4.1.0'
+  sha256 '2eee2e56a9b6574a7939dacea175c62e592ae972fa10d5feb143a13092cd9276'
 
   url "http://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.