### PR TITLE
Add rrcc v0.8.7 (RoboRock vacuum cleaner controller)

### DIFF
--- a/Casks/rrcc.rb
+++ b/Casks/rrcc.rb
@@ -9,8 +9,5 @@ cask 'rrcc' do
 
   app 'rrcc.app'
 
-  zap trash: [
-               '~/Library/Saved Application State/com.yourcompany.rrcc.savedState',
-               # Probably more?
-             ]
+  zap trash: '~/Library/Saved Application State/com.yourcompany.rrcc.savedState'
 end

--- a/Casks/rrcc.rb
+++ b/Casks/rrcc.rb
@@ -1,0 +1,16 @@
+cask 'rrcc' do
+  version '0.8.7'
+  sha256 '66b181d17acb4477a148d8759d517da078ff9cead3f6a5ff3e0feed439a2dcec'
+
+  url "https://github.com/LazyT/rrcc/releases/download/#{version}/rrcc-#{version.no_dots}.dmg"
+  appcast 'https://github.com/LazyT/rrcc/releases.atom'
+  name 'RoboRock Control Center'
+  homepage 'https://github.com/LazyT/rrcc'
+
+  app 'rrcc.app'
+
+  zap trash: [
+               '~/Library/Saved Application State/com.yourcompany.rrcc.savedState',
+               # Probably more?
+             ]
+end


### PR DESCRIPTION
Roborock control center for Xiaomi/Roborock cleaners, 170 stars on Github: https://github.com/LazyT/rrcc

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. — doesn't work for me but I've followed the style closely
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
