### PR TITLE
parse_electron_builder_appcast: support s3 buckets without a channel

### DIFF
--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -21,8 +21,9 @@ def parse(app_path)
   when "s3"
     bucket = data["bucket"]
     channel = data["channel"]
+    region = data["region"]
 
-    return "https://s3-us-west-2.amazonaws.com/#{bucket}/desktop/latest-mac.yml" if channel.nil?
+    return "https://s3-#{region}.amazonaws.com/#{bucket}/desktop/latest-mac.yml" if channel.nil?
     return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
 end
 

--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -13,11 +13,11 @@ def parse(app_path)
   case data["provider"]
   when "generic"
     url = data["url"]
-    return "#{url}/latest-mac.yml"
+    "#{url}/latest-mac.yml"
   when "github"
     owner = data["owner"]
     repo = data["repo"]
-    return "https://github.com/#{owner}/#{repo}/releases.atom"
+    "https://github.com/#{owner}/#{repo}/releases.atom"
   when "s3"
     bucket = data["bucket"]
     channel = data["channel"]
@@ -28,7 +28,7 @@ def parse(app_path)
       return "https://s3-#{region}.amazonaws.com/#{bucket}/#{path}/latest-mac.yml"
     end
 
-    return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
+    "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
   end
 end
 

--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -29,6 +29,7 @@ def parse(app_path)
     end
 
     return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
+  end
 end
 
 ###

--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -25,7 +25,7 @@ def parse(app_path)
     if channel.nil?
       region = data["region"]
       path = data["path"].sub(%r{^/(.*)/$}, '\1')
-      return "https://s3-#{region}.amazonaws.com/#{bucket}/#{path}/latest-mac.yml" if channel.nil?
+      return "https://s3-#{region}.amazonaws.com/#{bucket}/#{path}/latest-mac.yml"
     end
 
     return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"

--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -13,16 +13,17 @@ def parse(app_path)
   case data["provider"]
   when "generic"
     url = data["url"]
-    puts "#{url}/latest-mac.yml"
+    return "#{url}/latest-mac.yml"
   when "github"
     owner = data["owner"]
     repo = data["repo"]
-    puts "https://github.com/#{owner}/#{repo}/releases.atom"
+    return "https://github.com/#{owner}/#{repo}/releases.atom"
   when "s3"
     bucket = data["bucket"]
     channel = data["channel"]
-    puts "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
-  end
+
+    return "https://s3-us-west-2.amazonaws.com/#{bucket}/desktop/latest-mac.yml" if channel.nil?
+    return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
 end
 
 ###
@@ -42,4 +43,4 @@ unless ARGV.length == 1
   exit 1
 end
 
-parse(ARGV[0])
+puts parse(ARGV[0])

--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -22,13 +22,11 @@ def parse(app_path)
     bucket = data["bucket"]
     channel = data["channel"]
 
-    if channel.nil?
-      region = data["region"]
-      path = data["path"].sub(%r{^/(.*)/$}, '\1')
-      return "https://s3-#{region}.amazonaws.com/#{bucket}/#{path}/latest-mac.yml"
-    end
+    return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml" if channel
 
-    "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
+    region = data["region"]
+    path = data["path"].sub(%r{^/(.*)/$}, '\1')
+    "https://s3-#{region}.amazonaws.com/#{bucket}/#{path}/latest-mac.yml"
   end
 end
 

--- a/developer/bin/parse_electron_builder_appcast
+++ b/developer/bin/parse_electron_builder_appcast
@@ -21,9 +21,13 @@ def parse(app_path)
   when "s3"
     bucket = data["bucket"]
     channel = data["channel"]
-    region = data["region"]
 
-    return "https://s3-#{region}.amazonaws.com/#{bucket}/desktop/latest-mac.yml" if channel.nil?
+    if channel.nil?
+      region = data["region"]
+      path = data["path"].sub(%r{^/(.*)/$}, '\1')
+      return "https://s3-#{region}.amazonaws.com/#{bucket}/#{path}/latest-mac.yml" if channel.nil?
+    end
+
     return "https://#{bucket}.s3.amazon-aws.yml/#{channel}/latest-mac.yml"
 end
 


### PR DESCRIPTION
Made the function `return` for cleaner code when exiting early.

Refs https://github.com/Homebrew/homebrew-cask/pull/71098#issuecomment-544175447.