### PR TITLE
Update understand from 5.1.996 to 5.1.997

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.996'
-  sha256 '13698578b9585fa5fa7ab97df780f132768679229d4f87055296c7cab053b329'
+  version '5.1.997'
+  sha256 '852a7f800aca1c258ae9386577b1ee821bc40f80a2eb79d237c03e4029698b89'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.