### PR TITLE
Update chromium from 696687 to 707633

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '696687'
-  sha256 'd83f8e63edbe6262e8ae0db9e3a1c8a85f11d0043c76d790d335ae4fe6885aa7'
+  version '707633'
+  sha256 '22bc4cfc638cc4a57843b81d4a7a95484443bd151be79c05f569a1feee6f727e'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.