### PR TITLE
Update craftmanager from 1.0.88 to 1.0.89

### DIFF
--- a/Casks/craftmanager.rb
+++ b/Casks/craftmanager.rb
@@ -1,6 +1,6 @@
 cask 'craftmanager' do
-  version '1.0.88'
-  sha256 'fa49e98529bca9027113da97467671aa6035837a322284d2a9908b6c6afce663'
+  version '1.0.89'
+  sha256 'ca4ae7658fab74716ee8e3448c8c2b265701f270caa69ffacc389aa2714094c8'
 
   url 'https://craft-assets.invisionapp.com/CraftManager/production/CraftManager.zip'
   appcast 'https://craft-assets.invisionapp.com/CraftManager/production/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.