### PR TITLE
Update powerphotos from 1.7.2 to 1.7.3

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -16,8 +16,8 @@ cask 'powerphotos' do
     sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.7.2'
-    sha256 '78ba704362bfac12f8f9d07f68eb38417076cade61afe707dc719cb6e127abd5'
+    version '1.7.3'
+    sha256 '2aa91eaa5c8ca0283f7862f53400c37f55fbad136b805a6764fcce0c2aadacb9'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.