### PR TITLE
Update qownnotes from 19.10.8,b4630-132021 to 19.10.10,b4637-123303

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.10.8,b4630-132021'
-  sha256 '4c46e59ac126316b1794f3e2d68eff8b59a494f47daffaa8929c54b493ec6e51'
+  version '19.10.10,b4637-123303'
+  sha256 '8b204ae0228098c54249c64adda45dd2d5289c55fb32596a79e28a08e88f70cf'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.