### PR TITLE
Update sqlpro-for-postgres from 2019.09.06 to 2019.45

### DIFF
--- a/Casks/sqlpro-for-postgres.rb
+++ b/Casks/sqlpro-for-postgres.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-postgres' do
-  version '2019.09.06'
-  sha256 '4475355a6e03aab3a6f953056d7ead28b1a047977211ed6b839b7a3c2030bafe'
+  version '2019.45'
+  sha256 'b4256b90c130b8db198985f716fca51a153c9653dbe8a3d8b25d100542f8c2b4'
 
   # d3fwkemdw8spx3.cloudfront.net/postgres was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/postgres/SQLProPostgres.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.