### PR TITLE
Update qladdict to 1.2.5

### DIFF
--- a/Casks/qladdict.rb
+++ b/Casks/qladdict.rb
@@ -1,5 +1,5 @@
 cask 'qladdict' do
-  version '1.2.4'
+  version '1.2.5'
   sha256 '2af44d8392f75616c7852f37e627b674d561306328351331cb592ac93ea244cd'
 
   url "https://github.com/tattali/QLAddict/releases/download/#{version}/QLAddict.qlgenerator.#{version}.zip"

--- a/Casks/qladdict.rb
+++ b/Casks/qladdict.rb
@@ -1,6 +1,6 @@
 cask 'qladdict' do
   version '1.2.5'
-  sha256 '2af44d8392f75616c7852f37e627b674d561306328351331cb592ac93ea244cd'
+  sha256 '912fc99e78919712bfff5ef9b9ce2c655d798306251b3eaa4a00e4f1cb1690bb'
 
   url "https://github.com/tattali/QLAddict/releases/download/#{version}/QLAddict.qlgenerator.#{version}.zip"
   appcast 'https://github.com/tattali/QLAddict/releases.atom'


### PR DESCRIPTION
The formula points to this [file](https://github.com/tattali/QLAddict/releases/download/1.2.5/QLAddict.qlgenerator.1.2.5.zip)
[Release 1.2.5 page](https://github.com/tattali/QLAddict/releases/tag/1.2.5)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
