### PR TITLE
Update keycastr from 0.9.6 to 0.9.7

### DIFF
--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -1,6 +1,6 @@
 cask 'keycastr' do
-  version '0.9.6'
-  sha256 '1d4c3c0ab46a7573d0372958ef5f210a1d69616acaa6fba3c00ebd6c044c0e5b'
+  version '0.9.7'
+  sha256 '20f68c2581c6dbfce2f24931c7dc4d85aed0072a138272bbf6565828d6ff753a'
 
   url "https://github.com/keycastr/keycastr/releases/download/v#{version}/KeyCastr.app.zip"
   appcast 'https://github.com/keycastr/keycastr/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.