### PR TITLE
Update browserosaurus from 6.5.0 to 6.5.1

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '6.5.0'
-  sha256 '75ff642a302b2bbf8d19025770f97995525e56098c2ca92fbc110c2db7a9ee27'
+  version '6.5.1'
+  sha256 '27bca7220072673014e63d9bb66817bc3fbeb33fc67ba3795a55a771af924f1b'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.