### PR TITLE
Update atext from 2.34.1 to 2.35

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,6 +1,6 @@
 cask 'atext' do
-  version '2.34.1'
-  sha256 'f055dbd0b4309a7b5f0d97f01e2896aec1b34ea2d8f838967710bec9e7a4db31'
+  version '2.35'
+  sha256 'ecb9f38d83c6eed71eee22ec39d4a415b21d398438583d06b8723b0fef44add2'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'
   appcast 'https://www.trankynam.com/atext/aText-Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.