### PR TITLE
Update mysql-shell from 8.0.17 to 8.0.18

### DIFF
--- a/Casks/mysql-shell.rb
+++ b/Casks/mysql-shell.rb
@@ -1,6 +1,6 @@
 cask 'mysql-shell' do
-  version '8.0.17'
-  sha256 '1a527b42a1e60f263e8c8653754e7d3ea6833be3fac96377645a552a3c47d49d'
+  version '8.0.18'
+  sha256 '23676e36670ae4753583344e012066782d09c7df3ed11d2611d604c85d91693d'
 
   url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version}-macos10.14-x86-64bit.dmg"
   name 'MySQL Shell'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.