### PR TITLE
Update download url in  duplicate-annihilator-for-photos.rb

### DIFF
--- a/Casks/duplicate-annihilator-for-photos.rb
+++ b/Casks/duplicate-annihilator-for-photos.rb
@@ -3,7 +3,7 @@ cask 'duplicate-annihilator-for-photos' do
   sha256 :no_check
 
   url 'https://brattoo.com/propaganda/downloadDap.php'
-  name 'Duplicate Annihilator'
+  name 'Duplicate Annihilator for Photos'
   homepage 'https://brattoo.com/propaganda/'
 
   app 'Duplicate Annihilator for Photos.app'

--- a/Casks/duplicate-annihilator-for-photos.rb
+++ b/Casks/duplicate-annihilator-for-photos.rb
@@ -1,4 +1,4 @@
-cask 'duplicate-annihilator' do
+cask 'duplicate-annihilator-for-photos' do
   version :latest
   sha256 :no_check
 
@@ -6,5 +6,5 @@ cask 'duplicate-annihilator' do
   name 'Duplicate Annihilator'
   homepage 'https://brattoo.com/propaganda/'
 
-  app 'Duplicate Annihilator.app'
+  app 'Duplicate Annihilator for Photos.app'
 end

--- a/Casks/duplicate-annihilator.rb
+++ b/Casks/duplicate-annihilator.rb
@@ -2,7 +2,7 @@ cask 'duplicate-annihilator' do
   version :latest
   sha256 :no_check
 
-  url 'https://brattoo.com/propaganda/downloadDa.php'
+  url 'https://brattoo.com/propaganda/downloadDap.php'
   name 'Duplicate Annihilator'
   homepage 'https://brattoo.com/propaganda/'
 


### PR DESCRIPTION
Duplicate annihilator is now Duplicate annihilator-for-photos and was upgraded to 4.0
-> https://brattoo.com/propaganda/