### PR TITLE
Update lmms from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/lmms.rb
+++ b/Casks/lmms.rb
@@ -1,6 +1,6 @@
 cask 'lmms' do
-  version '1.2.0'
-  sha256 'e258aa298b0bdab3b7be88933a83f24bddf39ac62ffaa1c20ecc5927b313bfbf'
+  version '1.2.1'
+  sha256 '157cca82f617e18edbfa3f9f9f91b4d44df048d4f865721bf46f4854f13495e9'
 
   # github.com/LMMS/lmms was verified as official when first introduced to the cask
   url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}-mac10.13.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.