### PR TITLE
Update ishowu-instant from 1.2.11 to 1.3.0

### DIFF
--- a/Casks/ishowu-instant.rb
+++ b/Casks/ishowu-instant.rb
@@ -1,6 +1,6 @@
 cask 'ishowu-instant' do
-  version '1.2.11'
-  sha256 '7429c2d8a9c7ecdf67b2bb00dc1319836f2114281e6906f9432cb522f2b0765b'
+  version '1.3.0'
+  sha256 '6a17a8c2f127397841826b27dfcae9887c454d098ba951e07257635f5bb7ac15'
 
   url "https://www.shinywhitebox.com/downloads/instant/iShowU_Instant_#{version}.dmg"
   appcast 'https://www.shinywhitebox.com/store/appcast.php?p=14'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.