### PR TITLE
Update crunch from 3.0.1 to 4.0.0

### DIFF
--- a/Casks/crunch.rb
+++ b/Casks/crunch.rb
@@ -1,6 +1,6 @@
 cask 'crunch' do
-  version '3.0.1'
-  sha256 'af380230c6d83a097a9e537bf5f01136190294e6cb41d44da1b604eec7915766'
+  version '4.0.0'
+  sha256 '6969fcb91e5a93b9d9e604cca2e6a98b6ebdcc7dde0c53803c25d379d3e4e729'
 
   url "https://github.com/chrissimpkins/Crunch/releases/download/v#{version}/Crunch-Installer.dmg"
   appcast 'https://github.com/chrissimpkins/Crunch/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.