### PR TITLE
Update wiznote from 2.7.8,2019-10-17 to 2.7.9,2019-10-21

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.7.8,2019-10-17'
-  sha256 'e4af518847c6400416cd367833f1add767a0bc997d924acbda8094cc6854abcc'
+  version '2.7.9,2019-10-21'
+  sha256 'd9f089534ff54bce5af36f6caea347a15c94f78d320fffd5fe438ed2da5ad5d4'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://url.wiz.cn/u/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.