### PR TITLE
Update memory from 2019.27 to 2019.28

### DIFF
--- a/Casks/memory.rb
+++ b/Casks/memory.rb
@@ -1,6 +1,6 @@
 cask 'memory' do
-  version '2019.27'
-  sha256 'a214301998ec652d780e9062812868536d0b9b4de7e98532c30b559350c233db'
+  version '2019.28'
+  sha256 'a7015c41e992879e9a2ffb49daff9262e7955c7c1dde01faccff47cb0eaa0c09'
 
   # timelytimetracking.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://timelytimetracking.s3.amazonaws.com/mac_tracker/Memory%20Tracker%20by%20Timely.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.