### PR TITLE
Update archiver from 3.0.7 to 3.0.8

### DIFF
--- a/Casks/archiver.rb
+++ b/Casks/archiver.rb
@@ -1,6 +1,6 @@
 cask 'archiver' do
-  version '3.0.7'
-  sha256 '86cbb5fb2c3680b87b911bc642d0bdb6ea495dd11e00323ffcc271d5f863c6c0'
+  version '3.0.8'
+  sha256 '3652f413c8ac70c0509a8318f3a65752f621dbb87e323df5ac87b999fde2c98b'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Archiver-#{version.major}/Archiver-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.