### PR TITLE
Update diskmaker-x from 9.0.b1 to 9.0b1

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -5,7 +5,7 @@ cask 'diskmaker-x' do
 
     app "DiskMaker X #{version.major} for macOS Mojave.app"
   else
-    version '9.0.b1'
+    version '9.0b1'
     sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
 
     app "DiskMaker X #{version.major} for macOS Catalina.app"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.