### PR TITLE
Update iglance from 1.4.0 to 1.4.1

### DIFF
--- a/Casks/iglance.rb
+++ b/Casks/iglance.rb
@@ -1,6 +1,6 @@
 cask 'iglance' do
-  version '1.4.0'
-  sha256 '071f56b0f3288e5a5d3b1de540611da51c22a56e753c3b4e0708b4597453d9f8'
+  version '1.4.1'
+  sha256 '51c352393c1dc4421d287cfef8b45ef44ea60e9f0ff0645ceda84507f6781f76'
 
   url "https://github.com/iglance/iglance/releases/download/v#{version}/iGlance.dmg"
   appcast 'https://github.com/iglance/iglance/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.