### PR TITLE
Update wechatwebdevtools from 1.02.1907300 to 1.02.1910120

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,8 +1,8 @@
 cask 'wechatwebdevtools' do
-  version '1.02.1907300'
-  sha256 '37b73bd3782ca6174a2382039ce883b4a0fcd58dc7d070d938138cf63878eccd'
+  version '1.02.1910120'
+  sha256 '407d53fa744529b3ab40c0a754bea446bf0b2a0ac04a39fa5f93eddec9c934b3'
 
-  url "https://dldir1.qq.com/WechatWebDev/#{version.major}.2.0/20#{version.patch}/wechat_devtools_#{version}.dmg"
+  url "https://dldir1.qq.com/WechatWebDev/nightly/p-ae42ee2cde4d42ee80ac60b35f183a99/wechat_devtools_#{version}.dmg"
   appcast 'https://developers.weixin.qq.com/miniprogram/dev/devtools/stable.html'
   name 'wechat web devtools'
   name '微信web开发者工具'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.