### PR TITLE
Update pencil from 3.0.4 to 3.1.0.ga

### DIFF
--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -1,6 +1,6 @@
 cask 'pencil' do
-  version '3.0.4'
-  sha256 '3ca99c293be804067c95db77a7248531ede321d0c9a436bac0a34c57a192088f'
+  version '3.1.0.ga'
+  sha256 '5369787a801a470179a86ba60407b33e647f826b1a8b001b62e4f81a6bb0629d'
 
   url "https://pencil.evolus.vn/dl/V#{version}/Pencil-#{version}.dmg"
   appcast 'https://github.com/evolus/pencil/releases.atom'

--- a/Casks/pencil.rb
+++ b/Casks/pencil.rb
@@ -3,7 +3,8 @@ cask 'pencil' do
   sha256 '5369787a801a470179a86ba60407b33e647f826b1a8b001b62e4f81a6bb0629d'
 
   url "https://pencil.evolus.vn/dl/V#{version}/Pencil-#{version}.dmg"
-  appcast 'https://github.com/evolus/pencil/releases.atom'
+  appcast 'https://github.com/evolus/pencil/releases.atom',
+          configuration: version.major_minor_patch
   name 'Pencil'
   homepage 'https://pencil.evolus.vn/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.