### PR TITLE
Update kode54-cog from 0.08,389a70155 to 0.08,242c0b947

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,389a70155'
-  sha256 'da0c0e2b071b81519e98a1bbe60b7b78d51c783df55d286a2ab278d87d1465a3'
+  version '0.08,242c0b947'
+  sha256 '62df972b224c295ad3f97da2e8df8f17387c9fdd79b493f3f9c322664239bc78'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.