### PR TITLE
Update parallels-client from 17.0.1-21472 to 17.0.1-21481

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,6 +1,6 @@
 cask 'parallels-client' do
-  version '17.0.1-21472'
-  sha256 '2540ef40ae7f262ef8ff3b4c3193c3dd83ca9ef2bbcc9a48cccd91703d9764e8'
+  version '17.0.1-21481'
+  sha256 '7d7e0503009443292b43c897e14380a1e458391b878c33c3deba4b2d1fa94c3c'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
   appcast "https://download.parallels.com/ras/v#{version.major}/RAS%20Client%20for%20Mac%20Changelog.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.