### PR TITLE
Update lingo from 9.2 to 9.4 + update appcast

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -4,7 +4,7 @@ cask 'lingo' do
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask
   url 'https://nounproject.s3.amazonaws.com/lingo/Lingo.dmg'
-  appcast 'https://rink.hockeyapp.net/api/2/apps/7d71478daf6447bda4094e216e97b0cf'
+  appcast 'https://www.lingoapp.com/mac/appcast'
   name 'Lingo'
   homepage 'https://www.lingoapp.com/'
 

--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,6 +1,6 @@
 cask 'lingo' do
-  version '9.2'
-  sha256 'ef642bf866093fa5719aeca4fe2b79d83e525dd9dbfb1d7f0835dbfa2e6ae201'
+  version '9.4'
+  sha256 'ac699a35c0bd882198be646a412c42fb87881d3ea005156314d00151c0e31f78'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask
   url 'https://nounproject.s3.amazonaws.com/lingo/Lingo.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.