### PR TITLE
Update kindle-comic-converter from 5.5.1 to 5.5.2

### DIFF
--- a/Casks/kindle-comic-converter.rb
+++ b/Casks/kindle-comic-converter.rb
@@ -1,6 +1,6 @@
 cask 'kindle-comic-converter' do
-  version '5.5.1'
-  sha256 '4fea22c4db0c7953050e0dedfb97007af1dd30470360e39373e1cadcedc5bcce'
+  version '5.5.2'
+  sha256 '73d3f7ab9fc3e1e3dee62a83848fb52bba62f45fef56063466a0ac9c9f57513a'
 
   url "https://kcc.iosphe.re/OSX/KindleComicConverter_osx_#{version}.dmg"
   appcast 'https://github.com/ciromattia/kcc/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.