### PR TITLE
Update gingko from 2.4.3 to 2.4.4

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,6 +1,6 @@
 cask 'gingko' do
-  version '2.4.3'
-  sha256 'e10f35c4f71bcf9eb283b0b941e834f39a5b96e3d0e4c3fb52981712319f5031'
+  version '2.4.4'
+  sha256 '0a026b497cb65f507902d6bac3315373fe69e355a9b72527ec6a726155a1825a'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/Gingko-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.