### PR TITLE
Update katalon-studio from 6.3.3 to 7.0.1

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '6.3.3'
-  sha256 '41f05ca5350cd6e0a77dafd6a0e8a84cab6d2026827dadcf0f4daf194ba832e6'
+  version '7.0.1'
+  sha256 '1809541574f8747e41fad4f0bd54b17bb25705b3c8babcee765f6528dff2f598'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.