### PR TITLE
Update swinsian from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/swinsian.rb
+++ b/Casks/swinsian.rb
@@ -1,6 +1,6 @@
 cask 'swinsian' do
-  version '2.2.0'
-  sha256 'ef6cb1e95f557989df60e44cb0afde9377940010ceccebf26eae573840f4c977'
+  version '2.2.1'
+  sha256 '11127c3102303064b3669be11f73a92f3a44d977513180e93a631e0abf4c1165'
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   appcast 'https://www.swinsian.com/sparkle/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.