### PR TITLE
Update atext from 2.35 to 2.35.1

### DIFF
--- a/Casks/atext.rb
+++ b/Casks/atext.rb
@@ -1,5 +1,5 @@
 cask 'atext' do
-  version '2.35'
+  version '2.35.1'
   sha256 'd85a2f6cdc2eb221b92b4a3384123ac87ebe8c054b4ab15fa43bca5c578fe44e'
 
   url 'https://www.trankynam.com/atext/downloads/aText.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.