### PR TITLE
Update grafx from 2.6.2477,40 to 2.6.2492,41

### DIFF
--- a/Casks/grafx.rb
+++ b/Casks/grafx.rb
@@ -1,6 +1,6 @@
 cask 'grafx' do
   version '2.6.2492,41'
-  sha256 '37c22dcffe51ec6d0ee07369d4b85d489dcc60075eb69b66aceaca8dfe0e5b0a'
+  sha256 '31658ed8983ac3ed7778e2fd0b6dfc5e1abc4c1302c5bc77a4dc584cd7c7efb5'
 
   url "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{version.after_comma}"
   appcast "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads"

--- a/Casks/grafx.rb
+++ b/Casks/grafx.rb
@@ -1,6 +1,6 @@
 cask 'grafx' do
-  version '2.6.2477,40'
-  sha256 '54857b80cc0f81c5a4170e7c78fdadd132c5f077d351b86c689dc45078ea6ec0'
+  version '2.6.2492'
+  sha256 '37c22dcffe51ec6d0ee07369d4b85d489dcc60075eb69b66aceaca8dfe0e5b0a'
 
   url "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{version.after_comma}"
   appcast "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads"

--- a/Casks/grafx.rb
+++ b/Casks/grafx.rb
@@ -1,5 +1,5 @@
 cask 'grafx' do
-  version '2.6.2492'
+  version '2.6.2492,41'
   sha256 '37c22dcffe51ec6d0ee07369d4b85d489dcc60075eb69b66aceaca8dfe0e5b0a'
 
   url "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.