### PR TITLE
Update axe-edit-iii from 1.03.07 to 1.03.08

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.03.07'
-  sha256 '431fab8eae0de37e0a8c482efd88500f9dbdda22c38648da299f3bfae7f347ef'
+  version '1.03.08'
+  sha256 '8dae2aff9487b73463bc9ce840f829960e344f7f1ff522acbcff5f2ae21e8718'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.