### PR TITLE
Remove macOS Catalina support from PlayOnMac

### DIFF
--- a/Casks/playonmac.rb
+++ b/Casks/playonmac.rb
@@ -7,5 +7,15 @@ cask 'playonmac' do
   name 'PlayOnMac'
   homepage 'https://www.playonmac.com/en'
 
+  # PlayOnMac doesn't work on Catalina, see https://www.playonmac.com/en/topic-16558-macOS_Catalina_When_will_PlayOnMac_be_ready.html#m65029
+  depends_on macos: [
+                      :mavericks,
+                      :yosemite,
+                      :el_capitan,
+                      :sierra,
+                      :high_sierra,
+                      :mojave,
+                    ]
+
   app 'PlayOnMac.app'
 end

--- a/Casks/playonmac.rb
+++ b/Casks/playonmac.rb
@@ -8,14 +8,7 @@ cask 'playonmac' do
   homepage 'https://www.playonmac.com/en'
 
   # PlayOnMac doesn't work on Catalina, see https://www.playonmac.com/en/topic-16558-macOS_Catalina_When_will_PlayOnMac_be_ready.html#m65029
-  depends_on macos: [
-                      :mavericks,
-                      :yosemite,
-                      :el_capitan,
-                      :sierra,
-                      :high_sierra,
-                      :mojave,
-                    ]
+  depends_on macos: '<= :mojave'
 
   app 'PlayOnMac.app'
 end


### PR DESCRIPTION
[macOS Catalina drops support for 32-bit apps][1], and PlayOnMac is currently waiting on [compatibility between wine and Catalina][2] to move to 64-bit.

Until then PlayOnMac does not start on macOS Catalina. There is an issue on GitHub tracking this at https://github.com/PhoenicisOrg/phoenicis-winebuild/issues/26.

[1]: https://support.apple.com/en-us/HT208436
[2]: https://www.playonmac.com/en/topic-16558-macOS_Catalina_When_will_PlayOnMac_be_ready.html#m65029

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download Casks/playonmac.rb` is error-free.
- [x] `brew cask style --fix Casks/playonmac.rb` reports no offenses.
- [x] The commit message includes the cask’s name ~and version~.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
