### PR TITLE
Update Mattermost cask to v4.3.1

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
-  version '4.3.0'
-  sha256 '9dcf760e98edce0c5ac13fc4b2c5a10094ac3311456157b62c4064d1b00933a8'
+  version '4.3.1'
+  sha256 'c9b40c55725337c116b7fe3694a20243fdcc55b32cb0539e50fc56efb2aa7981'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
   appcast 'https://github.com/mattermost/desktop/releases.atom'

--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
-  version '4.2.3'
-  sha256 'bde028f596ac3bc20ecfd04693ffe497b7e9979babd3436c2438500afecfa732'
+  version '4.3.0'
+  sha256 '9dcf760e98edce0c5ac13fc4b2c5a10094ac3311456157b62c4064d1b00933a8'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
   appcast 'https://github.com/mattermost/desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
