### PR TITLE
Update selfcontrol from 2.2.2 to 2.3

### DIFF
--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -1,6 +1,6 @@
 cask 'selfcontrol' do
-  version '2.2.2'
-  sha256 '2cf92f8f142d630ed8cf77308599fa00fd610ec9fbafafcea27773974afdd4e1'
+  version '2.3'
+  sha256 '10f55e3bbe21444760227699f1467ea4653f61791dfba7f4b3e92bf76bf87e18'
 
   url "https://downloads.selfcontrolapp.com/SelfControl-#{version}.zip"
   appcast 'https://selfcontrolapp.com/SelfControlAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.