### PR TITLE
Update alt-tab from 1.4.5 to 1.4.6

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.4.5'
-  sha256 'a10be9f85ed2450b4e38c5f1e8773270f8c523e7fe12b153e81abfa2f431f1ba'
+  version '1.4.6'
+  sha256 '5dbb441bea27ac38ec38f246b31f5c18b63ceef1a4bcced6b08a6a8bef3ec1be'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.