### PR TITLE
Update mockuuups-studio from 2.1.0 to 2.2.1

### DIFF
--- a/Casks/mockuuups-studio.rb
+++ b/Casks/mockuuups-studio.rb
@@ -1,6 +1,6 @@
 cask 'mockuuups-studio' do
-  version '2.1.0'
-  sha256 'bfc3449815f36fafa62a12bbc2c077ee6c8bb6937ff629ce8a15eab567bf3d08'
+  version '2.2.0'
+  sha256 '2d542ca9f9e162f20a6df2a39b26d62a8e9570968279a2960da61b68c7c26447'
 
   # mockuuups.com was verified as official when first introduced to the cask
   url "https://binaries.mockuuups.com/Mockuuups%20Studio-#{version}-mac.zip"

--- a/Casks/mockuuups-studio.rb
+++ b/Casks/mockuuups-studio.rb
@@ -1,5 +1,5 @@
 cask 'mockuuups-studio' do
-  version '2.2.0'
+  version '2.2.1'
   sha256 '2d542ca9f9e162f20a6df2a39b26d62a8e9570968279a2960da61b68c7c26447'
 
   # mockuuups.com was verified as official when first introduced to the cask

--- a/Casks/mockuuups-studio.rb
+++ b/Casks/mockuuups-studio.rb
@@ -1,6 +1,6 @@
 cask 'mockuuups-studio' do
   version '2.2.1'
-  sha256 '2d542ca9f9e162f20a6df2a39b26d62a8e9570968279a2960da61b68c7c26447'
+  sha256 '1ccdc2cb96b2aea8c320f7df7c2d322b0195a3c11c3d7a0916e24221349b9a55'
 
   # mockuuups.com was verified as official when first introduced to the cask
   url "https://binaries.mockuuups.com/Mockuuups%20Studio-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.