### PR TITLE
Update alt-tab from 1.4.6 to 1.4.7

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.4.6'
-  sha256 '5dbb441bea27ac38ec38f246b31f5c18b63ceef1a4bcced6b08a6a8bef3ec1be'
+  version '1.4.7'
+  sha256 '88c40c907487f40b83dd8ea5b98ad88d851b7f0369e23b904920298129113491'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.