### PR TITLE
Update mailspring from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/mailspring.rb
+++ b/Casks/mailspring.rb
@@ -1,6 +1,6 @@
 cask 'mailspring' do
-  version '1.7.1'
-  sha256 'e54e515fe9ab552c5787c71431354faea9bf3a17cd44848ef44735ac5db555bf'
+  version '1.7.2'
+  sha256 '9c1ff33dd9b8597cdffb9518a9725d8f409855bccedba1639913f2d1a5d7a853'
 
   # github.com/Foundry376/Mailspring was verified as official when first introduced to the cask
   url "https://github.com/Foundry376/Mailspring/releases/download/#{version}/Mailspring.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.