### PR TITLE
Update compositor from 1.13.0 to 1.14.0

### DIFF
--- a/Casks/compositor.rb
+++ b/Casks/compositor.rb
@@ -1,6 +1,6 @@
 cask 'compositor' do
-  version '1.13.0'
-  sha256 'c90cef90026a5743a92c7ac57a332b2842bba63b15d1e3872e7c1989f3c0c104'
+  version '1.14.0'
+  sha256 '9ede6513b3ff29d229a697f4cd3da445017c99e0221d744d506904be08c5a7b9'
 
   url "https://compositorapp.com/updates/Compositor_#{version}.zip"
   appcast 'https://compositorapp.com/updates/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.