### PR TITLE
Update permute from 3.3.7,2208 to 3.3.8,2211

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.3.7,2208'
-  sha256 '0a4c6d957c60e4cce0ae0d5cb38e9cae0dbf3223dc1e7b06173f460c34409dd3'
+  version '3.3.8,2211'
+  sha256 '26b53cb5fe5295dae3c57214ae19ead0342a8b4ff814bedd47f7465df052d05b'
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.