### PR TITLE
Update latexit from 2.13.2 to 2.13.3

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,6 +1,6 @@
 cask 'latexit' do
-  version '2.13.2'
-  sha256 '46f5c9c45ce74e65627ef54cba3031bc2991ad7c78e046947c5812f23ead85db'
+  version '2.13.3'
+  sha256 '35535573684f55a3ef9346b3d4f00392c967b0f4119c02b87048a8717e6abe6c'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.