### PR TITLE
Update kite from 0.20191015.0 to 0.20191022.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191015.0'
-  sha256 'bc88f2d89bf851dca39cb1907c23f431e8c4440f0ea17b35cd2b0c753653eeb9'
+  version '0.20191022.0'
+  sha256 '75fad20b6d8f79407efbc7786e4a4c577f008241540962e262182a815232d19f'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.