### PR TITLE
Update cisdem-pdf-converter-ocr from 7.4.0 to 7.5.0

### DIFF
--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-pdf-converter-ocr' do
-  version '7.4.0'
-  sha256 '759861d1d975d6193e6656a1389b4f73c612c8595d8f1c20b77a09ae5644eec7'
+  version '7.5.0'
+  sha256 'dabdd364beb742094ceabfd153fe160cc070a79f8e87e2c41aec80b5a5158f21'
 
   url 'http://download.cisdem.com/cisdem-pdfconverterocr.dmg'
   appcast 'https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.