### PR TITLE
Update wordpresscom from 4.4.0 to 4.4.1

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '4.4.0'
-  sha256 'ccea3f3701a55c0520ca756cb8537f92400539268a20b5295ec44abed5078638'
+  version '4.4.1'
+  sha256 '6f86aa1301ff725e5d44ad0267d70acfe199c8728e33ebf471bb75de5c707421'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.