### PR TITLE
Update cevelop from 1.12.1-201907101456 to 1.13.0-201910070714

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,6 +1,6 @@
 cask 'cevelop' do
-  version '1.12.1-201907101456'
-  sha256 '4d1e4737a5ff1373e213d57472c29d270b02edee30e5821dd61fbd3b7bf1945a'
+  version '1.13.0-201910070714'
+  sha256 '00d71ac7a20a4e61598355080ec5faf4b957895eb60dbd62a4dfa59cbc061f64'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.