### PR TITLE
Update studio-3t from 2019.6.0 to 2019.6.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2019.6.0'
-  sha256 'bd75fa718bb76db0d1b44e3ea2f39bcd8e1fd8f6d97e4ff069ced71bfb3e36c9'
+  version '2019.6.1'
+  sha256 'f9a5513d2174a6364b470a35cf1bbea7197e4c7f78b00edd7a80793a2a99238d'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.