### PR TITLE
Update wireshark from 3.0.5 to 3.0.6

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,6 +1,6 @@
 cask 'wireshark' do
-  version '3.0.5'
-  sha256 '21bffc033dfbee74d30c6209dfa7ed57107cb7dd9d394fee579a333cddb746e6'
+  version '3.0.6'
+  sha256 '186970a1e0b610f23cb59314feaa3ce3eeb89b7c39bb5c34b4549910f1782f04'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.wireshark.org/download.html&splitter_1=stable&index_1=1&splitter_2=development&index_2=0'
@@ -10,7 +10,9 @@ cask 'wireshark' do
   conflicts_with cask: 'wireshark-chmodbpf'
   depends_on macos: '>= :sierra'
 
-  pkg "Wireshark #{version} Intel 64.pkg"
+  app 'Wireshark.app'
+  pkg 'Install ChmodBPF.pkg'
+  pkg 'Add Wireshark to the system path.pkg'
 
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
@@ -18,21 +20,7 @@ cask 'wireshark' do
   end
 
   uninstall pkgutil:   'org.wireshark.*',
-            launchctl: 'org.wireshark.ChmodBPF',
-            delete:    [
-                         '/private/etc/manpaths.d/Wireshark',
-                         '/private/etc/paths.d/Wireshark',
-                         '/usr/local/bin/capinfos',
-                         '/usr/local/bin/dftest',
-                         '/usr/local/bin/dumpcap',
-                         '/usr/local/bin/editcap',
-                         '/usr/local/bin/mergecap',
-                         '/usr/local/bin/randpkt',
-                         '/usr/local/bin/rawshark',
-                         '/usr/local/bin/text2pcap',
-                         '/usr/local/bin/tshark',
-                         '/usr/local/bin/wireshark',
-                       ]
+            launchctl: 'org.wireshark.ChmodBPF'
 
   zap trash: '~/Library/Saved Application State/org.wireshark.Wireshark.savedState'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.