### PR TITLE
Update aerial from 1.6.2 to 1.6.3

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.6.2'
-  sha256 '7e7f938cd1aa4e1d40ed24938f34b88d694b1487424e74775a766c248658eff9'
+  version '1.6.3'
+  sha256 '6ef5550aa80703d48098af74ce878fa97e0f52f354c1d96d5defc51008df2fb8'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.