### PR TITLE
Update qfinder-pro from 7.1.1.0527 to 7.1.2.1008

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,6 +1,6 @@
 cask 'qfinder-pro' do
-  version '7.1.1.0527'
-  sha256 '47f0d0236c6ee37dde6b4fba889d879341d523460100a3b82489d0eb427ff223'
+  version '7.1.2.1008'
+  sha256 'f8c7deb5b99d39636ad488bc61910b439885b4cc5e4280f424817c44a93cbed6'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://update.qnap.com/SoftwareRelease.xml&splitter_1=Mac_for_QT&index_1=1&splitter_2=downloadURL&index_2=1'

--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -12,5 +12,9 @@ cask 'qfinder-pro' do
   uninstall pkgutil: [
                        'qnap.com.qfinder.*',
                        'qnap.com.Qfinder',
+                     ],
+            delete:  [
+                       '/Applications/Qfinder Pro.app',
+                       '/Applications/Qfinder Pro.app/Contents/Resources/Qfinder Pro.app',
                      ]
 end

--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -13,8 +13,5 @@ cask 'qfinder-pro' do
                        'qnap.com.qfinder.*',
                        'qnap.com.Qfinder',
                      ],
-            delete:  [
-                       '/Applications/Qfinder Pro.app',
-                       '/Applications/Qfinder Pro.app/Contents/Resources/Qfinder Pro.app',
-                     ]
+            delete:  '/Applications/Qfinder Pro.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.