### PR TITLE
Update devonthink from 3.0 to 3.0.1

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -4,7 +4,7 @@ cask 'devonthink' do
 
   # s3.amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_#{version.major}.dmg.zip"
-  appcast 'https://api.devontechnologies.com/1/apps/sparkle/sparkle.php?id=217255'
+  appcast "https://www.devontechnologies.com/Sparkle/DEVONthink#{version.major}.xml"
   name 'DEVONthink'
   homepage 'https://www.devontechnologies.com/apps/devonthink/'
 

--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,6 +1,6 @@
 cask 'devonthink' do
-  version '3.0'
-  sha256 'b525e33a3352dae6e9a4e8b1b32588752906c6a915fe528f240cb0b1d1e2d3fa'
+  version '3.0.1'
+  sha256 'f6333d0e62884765b30f80dfe9a6e02b02c48bc7b6f10914aca4595cb0eb7608'
 
   # s3.amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_#{version.major}.dmg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.