### PR TITLE
Update brave-browser from 0.69.135 to 0.70.121

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.69.135'
-  sha256 '7d6fb2a7fe3ddeb85f8c0f89041f81a3bb8e01010c26926b77c00b8dc780c302'
+  version '0.70.121'
+  sha256 'd0d8ec9a0d14ce3f238fb574d6d1910aca498f8d32da3b9bfe70ba8e2b1bd75a'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.