### PR TITLE
Update bettertouchtool from 3.206 to 3.207

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.206'
-    sha256 '81a762711d1413e22c61ffac8d1fe25d6de50a92a61fc0a8d2b7a0753d71e143'
+    version '3.207'
+    sha256 'bb7ae78131890539807e348362ebf6599e7a853a428686534a351cde1aad2fc2'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.