### PR TITLE
Update thunderbird from 68.1.2 to 68.2.0

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,83 +1,83 @@
 cask 'thunderbird' do
-  version '68.1.2'
+  version '68.2.0'
 
   language 'cs' do
-    sha256 '4d5bd71e1a5a681b45de8c03c2cdeb29e6da385b10b1e72c5dee0f7ab73f2b29'
+    sha256 '2c4a184362fc2e3eff946b7489f4b2498ec143e21baa12617295e59ba329a1a6'
     'cs'
   end
 
   language 'de' do
-    sha256 '196742cec19685e3384f99222d74378fc8a8742fa2207da1e35cbe5c29712c4f'
+    sha256 '734b91d07a3fb4db2ec24eba69c3f2209f33008c1685fe168dfd5426acbe481a'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '3629ec9360d9d97b646d72586ec9590dc12af2afcfeb4c8754e4bf0f4895a09f'
+    sha256 '6699b9eb5bafd332ea30e9283b70b0112fbb0d40aea36d6b26685f6a80c0eb24'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '7b35fe87e8a9c2a150d9521999a330ec24654b819dcfa756c59c701864d9c6f9'
+    sha256 '7f7c922dc1c1bb47cf76389e27d733bcbb90c4d6ef4b603177409ab24c92a1fc'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '7d6ae64c56d770ec42378f3eaaef4d73ad9839f297a02c0e5e0372951a60b1bf'
+    sha256 '6202886d7eee095bfe30359bbb3a3727c1a4311e962aa99fd6c51e436b647c04'
     'fr'
   end
 
   language 'gl' do
-    sha256 '1e080bc10b561bcabc3559ce43d89b783d15058742872820e3b15d84df244354'
+    sha256 'fa503f526dacb4e18cacead86271c3c70d0f66bcba372f30d774a672ee638218'
     'gl'
   end
 
   language 'it' do
-    sha256 '33ec392b4c0c121905be19e1ff2f3045b84eed48100884361cac45dafd69c942'
+    sha256 '5537fffe12fc3a7b94fd6a7ec634a99d63760fd704264ca16d2484558c57ec49'
     'it'
   end
 
   language 'ja' do
-    sha256 'c9cd154d081dc14220e73a962ec120ed6868fa914c0ce33823c033c38c1b61de'
+    sha256 '374d9c5ea61632a4888052696902851d156b01a6a22dfadeae45382de716fee6'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'a75f6fc32b79e36f069c1bfa5437c8d9fe8c6a23c94e8adf8194f37f3219a03d'
+    sha256 '97e92eaef8f0c57830c1d35a0d2f2db8180ead77807a114ef497ed2d52e7994b'
     'nl'
   end
 
   language 'pl' do
-    sha256 'dd5597d55d6adea89dde2978f60be3fa82ae8dd9d4868127e9ea03e5a19a782b'
+    sha256 '367d607333904f7552574f14f027c159a96e8086945a2d600da28d79b7942e8d'
     'pl'
   end
 
   language 'pt' do
-    sha256 '5126c0e24b0247a6d78d990a5311ff99719068778f3080b24580554aa621c89d'
+    sha256 '12b584b2e5ae76117ca02002311035d15dc9972ec4f4e138b674637b731d46e1'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '092f367e3105e8a376558d10b6e65a1515519cb19f2413b5cae03ade990c5944'
+    sha256 '4fea89eff0d1a540ba22932a1ead9b72272c21c6ab88028ba08ac22d36e8c53f'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '9fb9772e5751a29f4c5bf996c608bc992a6874e199ae3cf8ca884bf08ba117ab'
+    sha256 'c0dcfad208f0dbedf91207c0be9165a3144586e692a7c3812b1526f50110ad5e'
     'ru'
   end
 
   language 'uk' do
-    sha256 'e5f61ec04afd9ecd41694276f8845eadbd3c93cbc73ede7e84a818c62572531c'
+    sha256 '2639bc77b8d315a7ef032ee89709a69a51d2989cb2297103fee0a8dbd5d9248b'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '86b08509c0c83d31c87795828d126eb71e29e50a4ae310feecd8e4b2dd00cfd9'
+    sha256 '7599abd91831a98b85d90ca71afe00d6689f75bcac3695132c14de7dc175842c'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '7e9a67bf79df4e46a66db3306fd73a8087a60a996beb3ada032bc54981cbbfaa'
+    sha256 'e15a9d46eb012b7b12bd383939387591bf56ef7097d4fb7b71032d864cdb2041'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
