### PR TITLE
Update photozoom-pro from 7 to 8

### DIFF
--- a/Casks/photozoom-pro.rb
+++ b/Casks/photozoom-pro.rb
@@ -1,5 +1,5 @@
 cask 'photozoom-pro' do
-  version '7'
+  version '8'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.benvista.com/photozoompro#{version}/download/mac",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.