### PR TITLE
Update alt-tab from 1.4.7 to 1.5.1

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.4.7'
-  sha256 '88c40c907487f40b83dd8ea5b98ad88d851b7f0369e23b904920298129113491'
+  version '1.5.1'
+  sha256 '80d37bf3f6d0384b34376aa87bd20377c087fc56388b83c9fe9d4964b16ede70'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.