### PR TITLE
Update subler from 1.5.19 to 1.5.20

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask 'subler' do
-  version '1.5.19'
-  sha256 '0f6c7f2e67c643d2f44e167f2ef6a8398a969bda97e4f02adba47bab22efb460'
+  version '1.5.20'
+  sha256 'da66ea0e06b07d354e773a3675c7cdf46a3a3d993a9af140c636292a584d56d3'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.