### PR TITLE
Update prefs-editor from 1.2.4 to 1.2.5

### DIFF
--- a/Casks/prefs-editor.rb
+++ b/Casks/prefs-editor.rb
@@ -1,6 +1,6 @@
 cask 'prefs-editor' do
-  version '1.2.4'
-  sha256 '50a9ae754f06390db1838553b2c276fa60fad84be800de195ca2c7a5fc3cd23b'
+  version '1.2.5'
+  sha256 '1d59f2094fab451d8d669aa5490a8dadc4d5f534f78f10dbefa1cb4eed7f3a45'
 
   url "https://files.tempel.org/Various/OSX_Prefs_Editor/PrefsEditor-#{version}_64bit.zip"
   appcast 'https://apps.tempel.org/PrefsEditor/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.