### PR TITLE
Update command-tab-plus from 1.97,337:1570546404 to 1.98,342:1571924100

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.97,337:1570546404'
-  sha256 '06369b01aa170aff3b85ab350c8bfe0060403bea0d6cf23290ca8ff3c7812e8c'
+  version '1.98,342:1571924100'
+  sha256 '1ff74d1948266d5c0a8ee2b407dc82d396adc0406b2a56bea07c8fc836676b1b'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.