### PR TITLE
Update second-life-viewer from 6.3.2.530962 to 6.3.3.531811

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.3.2.530962'
-  sha256 'b0f53ea8647dce7add48b86078143199b48a019fc580077047b7e52f24ce17a4'
+  version '6.3.3.531811'
+  sha256 '34c1cc5922cb00d8bb63bf70238e75a6014180b258a27a54a14d0978c30c9c73'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.