### PR TITLE
Update airmedia from 3.1.12 to 3.1.29

### DIFF
--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -2,7 +2,7 @@ cask 'airmedia' do
   version '3.1.29'
   sha256 '809d193a9f71494734be57b3bebc2912f284acd88f4bc408486ef6fb6951522d'
 
-  url "https://www.crestron.com/getmedia/751a3c59-a9a8-49b8-ac28-4989da4dc2e1/airmedia_osx_#{version}_guest"
+  url "https://www.crestron.com/Crestron/media/Crestron/WidenResources/Web%20Miscellaneous/airmedia_osx_#{version.dots_to_underscores}_guest.zip"
   appcast 'https://www.crestron.com/en-US/Products/Featured-Solutions/Airmedia'
   name 'Crestron AirMedia'
   homepage 'https://www.crestron.com/microsites/airmedia-mobile-wireless-hd-presentations'

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -1,5 +1,5 @@
 cask 'airmedia' do
-  version '3.1.12'
+  version '3.1.29'
   sha256 '809d193a9f71494734be57b3bebc2912f284acd88f4bc408486ef6fb6951522d'
 
   url "https://www.crestron.com/getmedia/751a3c59-a9a8-49b8-ac28-4989da4dc2e1/airmedia_osx_#{version}_guest"

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -1,6 +1,6 @@
 cask 'airmedia' do
   version '3.1.29'
-  sha256 '809d193a9f71494734be57b3bebc2912f284acd88f4bc408486ef6fb6951522d'
+  sha256 '95585254f8d82e16229af9f89da0806f0c5ff8f927d2b21efcdeefd88b912b52'
 
   url "https://www.crestron.com/Crestron/media/Crestron/WidenResources/Web%20Miscellaneous/airmedia_osx_#{version.dots_to_underscores}_guest.zip"
   appcast 'https://www.crestron.com/en-US/Products/Featured-Solutions/Airmedia'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.