### PR TITLE
Update waterfox from 56.2.14 to 2019.10

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,9 +1,9 @@
 cask 'waterfox' do
-  version '56.2.14'
-  sha256 'c9df511b7a9474a123f2eba456332744e9bdd8ef0a9fae464441932a6f655bd0'
+  version '2019.10'
+  sha256 '69ff0aca4cd0e58fe583c3807e002f3e5fc460e6de8a5a41413bb50785cfb8b9'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20#{version}%20Setup.dmg"
+  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Current%20#{version}%20Setup.dmg"
   appcast 'https://www.waterfox.net/releases/'
   name 'Waterfox'
   homepage 'https://www.waterfox.net/'

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -3,7 +3,7 @@ cask 'waterfox' do
   sha256 '69ff0aca4cd0e58fe583c3807e002f3e5fc460e6de8a5a41413bb50785cfb8b9'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Current%20#{version}%20Setup.dmg"
+  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Classic%20#{version}%20Setup.dmg"
   appcast 'https://www.waterfox.net/releases/'
   name 'Waterfox'
   homepage 'https://www.waterfox.net/'

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
   version '2019.10'
-  sha256 '69ff0aca4cd0e58fe583c3807e002f3e5fc460e6de8a5a41413bb50785cfb8b9'
+  sha256 'ed30fba5843f041aec9cc5393f5049df05b5c8773423daf7c3806819cb505171'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Classic%20#{version}%20Setup.dmg"

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -8,7 +8,7 @@ cask 'waterfox' do
   name 'Waterfox'
   homepage 'https://www.waterfox.net/'
 
-  app 'Waterfox.app'
+  app 'Waterfox Classic.app'
 
   zap trash: [
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.waterfox.sfl*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.