### PR TITLE
Update roblox from 0.406.0.351423,c9625b3036514c13 to 0.407.0.353595,510ae7995e4847a5

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.406.0.351423,c9625b3036514c13'
-  sha256 '3f1d84114d0c819d1587426ad44079682efdecfe91bcec6c2b2dfc083020e090'
+  version '0.407.0.353595,510ae7995e4847a5'
+  sha256 'acdf1f2d772c6783c95cb34bcacd088a6a3a60d403f64e9bf9cea53ed9d5d92b'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.