### PR TITLE
Update ringcentral from 19.3.2 to 19.3.4

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '19.3.2'
-  sha256 '4bb84b822082e0a8cbeac4f512fefebf9bcceb6b7e3565aa351eddfc354753a9'
+  version '19.3.4'
+  sha256 'd45d945fc9e6e723a989901ef9e4f7e33c9245b8e3b23d36b3623c2bc6fc1fc3'
 
   url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads.ringcentral.com/sp/RingCentralForMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.