### PR TITLE
Update filemaker-pro-advanced from 18.0.2.209 to 18.0.3.317

### DIFF
--- a/Casks/filemaker-pro-advanced.rb
+++ b/Casks/filemaker-pro-advanced.rb
@@ -3,6 +3,7 @@ cask 'filemaker-pro-advanced' do
   sha256 '4eba410556271b6a60eaed58450e2539b10281698ba854c96ab10c564040eda0'
 
   url "https://fmdl.filemaker.com/esd/fmpa_#{version}.dmg"
+  appcast 'https://www.filemaker.com/redirects/ss.txt'
   name 'FileMaker Pro Advanced'
   homepage 'https://www.filemaker.com/'
 

--- a/Casks/filemaker-pro-advanced.rb
+++ b/Casks/filemaker-pro-advanced.rb
@@ -1,6 +1,6 @@
 cask 'filemaker-pro-advanced' do
-  version '18.0.2.209'
-  sha256 '8915757ec0c99361fb9690d68e027be485cd4081aaa72178699a4669eafb7348'
+  version '18.0.3.317'
+  sha256 '4eba410556271b6a60eaed58450e2539b10281698ba854c96ab10c564040eda0'
 
   url "https://fmdl.filemaker.com/esd/fmpa_#{version}.dmg"
   name 'FileMaker Pro Advanced'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.