### PR TITLE
Update mosaic from 1.2.4 to 1.2.5

### DIFF
--- a/Casks/mosaic.rb
+++ b/Casks/mosaic.rb
@@ -1,6 +1,6 @@
 cask 'mosaic' do
-  version '1.2.4'
-  sha256 '105b2628a85cf67632c445a1280181d7ff7793c6df3c4e89b7c8b7ffc06f43ad'
+  version '1.2.5'
+  sha256 '9f2b9ef539e08b5f1bd8d4cc81186bd49dff20e09de3deeab312f1534a5de94a'
 
   url "https://lightpillar.com/appdata/mosaic/archive/Mosaic_#{version.dots_to_underscores}.pkg"
   appcast 'https://lightpillar.com/appdata/mosaic/features/version-history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.