### PR TITLE
secure (and fix) URLs

### DIFF
--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -2,9 +2,9 @@ cask 'dwarf-fortress' do
   version '0.44.12'
   sha256 '218d53199f7eb9f58c035e3a5d44d882f1b69e07ef63f98a6590d61a6fc8a6d5'
 
-  url "http://www.bay12games.com/dwarves/df_#{version.minor}_#{version.patch}_osx.tar.bz2"
+  url "https://www.bay12games.com/dwarves/df_#{version.minor}_#{version.patch}_osx.tar.bz2"
   name 'Dwarf Fortress'
-  homepage 'http://www.bay12games.com/dwarves/'
+  homepage 'https://www.bay12games.com/dwarves/'
 
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/df_osx/df.wrapper.sh"

--- a/Casks/grisbi.rb
+++ b/Casks/grisbi.rb
@@ -3,10 +3,10 @@ cask 'grisbi' do
   sha256 '89df854060d0445713e7bd02f99f952bd0fa7286a7102d32b2c40609f433d1cd'
 
   # sourceforge.net/grisbi was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/grisbi/grisbi%20stable/#{version.major_minor}.x/Grisbi-#{version}.dmg"
+  url "https://downloads.sourceforge.net/grisbi/grisbi%20stable/#{version.major_minor}.x/#{version.major_minor_patch}/Grisbi-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/grisbi/rss?path=/grisbi%20stable'
   name 'Grisbi'
-  homepage 'http://www.grisbi.org/'
+  homepage 'https://www.grisbi.org/'
 
   app 'Grisbi.app'
 end

--- a/Casks/pandora.rb
+++ b/Casks/pandora.rb
@@ -2,8 +2,8 @@ cask 'pandora' do
   version '15.0.1'
   sha256 '2342782b5b0effa9cf1a1f8e81f7e1a80d30dcfea6826bb3c50d3eaa22126be6'
 
-  # s3-us-west-2.amazonaws.com/p-desktop-app was verified as official when first introduced to the cask
-  url "https://s3-us-west-2.amazonaws.com/p-desktop-app/releases/Pandora-#{version}.dmg"
+  # p-desktop-app.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://p-desktop-app.s3.amazonaws.com/releases/Pandora-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://pdora.co/desktop_mac_download'
   name 'Pandora'
   homepage 'https://www.pandora.com/desktop'

--- a/Casks/sdrdx.rb
+++ b/Casks/sdrdx.rb
@@ -2,9 +2,9 @@ cask 'sdrdx' do
   version :latest
   sha256 :no_check
 
-  url 'http://fyngyrz.com/SdrDx-AA7AS-Light.zip'
+  url 'https://fyngyrz.com/SdrDx-AA7AS-Light.zip'
   name 'SdrDx'
-  homepage 'http://fyngyrz.com/?p=915'
+  homepage 'https://fyngyrz.com/?p=915'
 
   app 'SdrDx.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
==> Downloading https://www.bay12games.com/dwarves/df_44_12_osx.tar.bz2
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'dwarf-fortress'.
audit for dwarf-fortress: passed

1 file inspected, no offenses detected
==> Downloading https://downloads.sourceforge.net/grisbi/grisbi%20stable/1.2.x/1
==> Downloading from https://netcologne.dl.sourceforge.net/project/grisbi/grisbi
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'grisbi'.
audit for grisbi: passed

1 file inspected, no offenses detected
==> Downloading https://p-desktop-app.s3.amazonaws.com/releases/Pandora-15.0.1.d
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'pandora'.
audit for pandora: passed

1 file inspected, no offenses detected
==> Downloading https://fyngyrz.com/SdrDx-AA7AS-Light.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'sdrdx', skipping verification.
audit for sdrdx: passed
```