### PR TITLE
Upgrade fre:ac from 1.1-alpha-20190423 to 1.1-alpha-20190423a

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -3,7 +3,7 @@ cask 'freac' do
   sha256 'f6cbe820d0c8c114064b1282ea45e256a95df0c4433483043477cfe77c3627f5'
 
   # github.com/enzo1982/freac was verified as official when first introduced to the cask
-  url "https://github.com/enzo1982/freac/releases/download/v#{version.sub(/a$/, '')}/freac-#{version}-macosx.dmg"
+  url "https://github.com/enzo1982/freac/releases/download/v#{version.chomp('a')}/freac-#{version}-macosx.dmg"
   appcast 'https://github.com/enzo1982/freac/releases.atom'
   name 'fre:ac'
   homepage 'https://www.freac.org/'

--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,9 +1,9 @@
 cask 'freac' do
-  version '1.1-alpha-20190423'
-  sha256 'ce10882ca82198ec84397ab3a2d1fb3292dd9272ab59db2e22226cf09cab2739'
+  version '1.1-alpha-20190423a'
+  sha256 'f6cbe820d0c8c114064b1282ea45e256a95df0c4433483043477cfe77c3627f5'
 
   # github.com/enzo1982/freac was verified as official when first introduced to the cask
-  url "https://github.com/enzo1982/freac/releases/download/v#{version}/freac-#{version}-macosx.dmg"
+  url 'https://github.com/enzo1982/freac/releases/download/v1.1-alpha-20190423/freac-1.1-alpha-20190423a-macosx.dmg'
   appcast 'https://github.com/enzo1982/freac/releases.atom'
   name 'fre:ac'
   homepage 'https://www.freac.org/'

--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -3,7 +3,7 @@ cask 'freac' do
   sha256 'f6cbe820d0c8c114064b1282ea45e256a95df0c4433483043477cfe77c3627f5'
 
   # github.com/enzo1982/freac was verified as official when first introduced to the cask
-  url 'https://github.com/enzo1982/freac/releases/download/v1.1-alpha-20190423/freac-1.1-alpha-20190423a-macosx.dmg'
+  url "https://github.com/enzo1982/freac/releases/download/v#{version.sub(/a$/, '')}/freac-#{version}-macosx.dmg"
   appcast 'https://github.com/enzo1982/freac/releases.atom'
   name 'fre:ac'
   homepage 'https://www.freac.org/'


### PR DESCRIPTION
Fixes compatibility issue with macOS Catalina.