### PR TITLE
Update grafx from 2.6.2492,41 to 2.72768,46

### DIFF
--- a/Casks/grafx.rb
+++ b/Casks/grafx.rb
@@ -1,6 +1,6 @@
 cask 'grafx' do
-  version '2.6.2492,41'
-  sha256 '31658ed8983ac3ed7778e2fd0b6dfc5e1abc4c1302c5bc77a4dc584cd7c7efb5'
+  version '2.72768,46'
+  sha256 '7206f7feed0d754c8c17b54ee2bb830fe6fc88bc987a555794e5986893a81c1c'
 
   url "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{version.after_comma}"
   appcast "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.