### PR TITLE
Update jalbum from 19.0.0 to 19.1

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,8 +1,8 @@
 cask 'jalbum' do
-  version '19.0.0'
-  sha256 '865064c3df9b4845c2c7d57a26b862a51ce3b66debf8edc85a692fc351a2f6ac'
+  version '19.1'
+  sha256 '0038c2cd01757058d2f3e7e03f11cc937a580ac8bbc70af0653eb08036890dd9'
 
-  url "https://download.jalbum.net/download/#{version.major}/MacOSX/jAlbum.dmg"
+  url "https://download.jalbum.net/download/#{version}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',
           configuration: version.major_minor.chomp('.0')
   name 'jAlbum'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.