### PR TITLE
Update garagesale from 7.0.20 to 8.0

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,6 +1,6 @@
 cask 'garagesale' do
-  version '7.0.20'
-  sha256 '90caedc5d7d040a98c4f14f9d31af0850d1cd9c9e8ab587476b3ae6dca34b809'
+  version '8.0'
+  sha256 'd57014d1cdcbc848a7716cf64fc2e865a9f97cca8e962930729cb9815abcbe7f'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   appcast "https://www.iwascoding.com/cgi-bin/version_check.cgi?APPLICATION=GarageSale&APP_BUNDLE_VERSION=#{version.major}00"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.