### PR TITLE
Update gingko from 2.4.4 to 2.4.5

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,6 +1,6 @@
 cask 'gingko' do
-  version '2.4.4'
-  sha256 '0a026b497cb65f507902d6bac3315373fe69e355a9b72527ec6a726155a1825a'
+  version '2.4.5'
+  sha256 '892bd882da397db1291fe48bbd6746bdd0bf096e451d561a6045a0187a6bcbed'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/Gingko-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.