### PR TITLE
Update simplenote from 1.8.0 to 1.9.1

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,6 +1,6 @@
 cask 'simplenote' do
-  version '1.8.0'
-  sha256 'd5d6a9c7ff29702bbfc725b77f78eb3a4be57697c3863680aefffe02c0c844ef'
+  version '1.9.1'
+  sha256 '04221435fdc40d1fc1ced0f3ca9ac0417e4cd262c4f06a01ea737435a087df1f'
 
   url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.dmg"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.