### PR TITLE
Update maccy from 0.5.1 to 0.6.0

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask 'maccy' do
-  version '0.5.1'
-  sha256 'ad71007a32378ee9b07caed6b67e9ae9c7bc53b9bdfaba59b30f139cbb1dd994'
+  version '0.6.0'
+  sha256 '57e9eb2f49bafe64be412e0f8dd29340ff69e8707e803ddcd480dd26d4670fe1'
 
   # github.com/p0deje/Maccy was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.