### PR TITLE
Update kiwi-for-g-suite from 2.0.24v to 2.0.25v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask 'kiwi-for-g-suite' do
-  version '2.0.24v'
-  sha256 '31609e63dd031395b8684655b786620e4e882f0e63dca5c36c6189a365bdbb9a'
+  version '2.0.25v'
+  sha256 'fb46c48fd308985c54d6c439441ca41d788234eb3df7833dbe4b7f94c079684d'
 
   # kiwiforgsuite.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.