### PR TITLE
Update insync from 3.0.22.40446 to 3.0.23.40579

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '3.0.22.40446'
-  sha256 '47c7c3b4577d2be8d2c11648495cfa6e2b9de285c283506570ba8c623d6f1e42'
+  version '3.0.23.40579'
+  sha256 '1efe026ebf4a3967a1c8d7a56d7d147165ce4d3037238c7f87fe57afb054d2d7'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   appcast 'https://www.insynchq.com/downloads?start=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.