### PR TITLE
Update syncovery from 8.55a to 8.57a

### DIFF
--- a/Casks/syncovery.rb
+++ b/Casks/syncovery.rb
@@ -1,6 +1,6 @@
 cask 'syncovery' do
-  version '8.55a'
-  sha256 '48b715b60cf96fa07497cde36967cb0dd2e994a89b31280ab2e57441c7db825a'
+  version '8.57a'
+  sha256 '89394d64da46594f953f25fab807b1ee6917fa7f17a1dd51f5edcc5a3627930f'
 
   url "https://www.syncovery.com/release/SyncoveryMac#{version}.dmg"
   appcast 'https://www.syncovery.com/download/mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.