### PR TITLE
Update local from 5.0.6 to 5.0.7

### DIFF
--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -1,6 +1,6 @@
 cask 'local' do
-  version '5.0.6'
-  sha256 'ae2b8d7567ebd0cfebe274222dc95b7603515266f9477a0cac8695cddee12bb5'
+  version '5.0.7'
+  sha256 '9da001589453643dcef9c8ee46c163a97749d37ddf32ffa567810c8c8281931d'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-#{version.dots_to_hyphens}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.