### PR TITLE
Update acquia-dev from 2.2019.06.06 to 2.2019.10.18

### DIFF
--- a/Casks/acquia-dev.rb
+++ b/Casks/acquia-dev.rb
@@ -1,6 +1,6 @@
 cask 'acquia-dev' do
-  version '2.2019.06.06'
-  sha256 '27caf4ac1cc89314a2f89f1d463a784d224d7950792a46735bb3dc6ffa18f47f'
+  version '2.2019.10.18'
+  sha256 'ddd7c6c12f582e5909eb44ce7a59566fba844fcc8359dd50260172b49ad74c4a'
 
   url "https://dev.acquia.com/sites/default/files/file/#{version.minor_patch.dots_to_hyphens}/AcquiaDevDesktop-#{version.dots_to_hyphens}.dmg"
   appcast 'https://dev.acquia.com/downloads',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.