### PR TITLE
Update browserosaurus from 6.5.2 to 6.6.1

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '6.5.2'
-  sha256 '2721aba87a8d66606ac7b56b8c40dbd81105612c86288eb956fe69670b13d976'
+  version '6.6.1'
+  sha256 '12f889a8837866e81eb8abd62e5386ec5c93c245709bc36e797a3a02e87b58a4'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.