### PR TITLE
Update kode54-cog from 0.08,242c0b947 to 0.08,38d1dee84

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,242c0b947'
-  sha256 '62df972b224c295ad3f97da2e8df8f17387c9fdd79b493f3f9c322664239bc78'
+  version '0..8,38d1dee84'
+  sha256 '3b02e6e351990dbeecb49b483595a80533125ed804d8cd8a4778765f2585b274'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"

--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,5 +1,5 @@
 cask 'kode54-cog' do
-  version '0..8,38d1dee84'
+  version '0.08,38d1dee84'
   sha256 '3b02e6e351990dbeecb49b483595a80533125ed804d8cd8a4778765f2585b274'
 
   # losno.co/cog was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.