### PR TITLE
Update unity from 2019.2.9f1,ebce4d76e6e8 to 2019.2.10f1,923acd2d43aa

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.9f1,ebce4d76e6e8'
-  sha256 '7def2ca0f997281ebceec55f5208ae0150fc04b5a73a4c2171c66cf9b83f6405'
+  version '2019.2.10f1,923acd2d43aa'
+  sha256 'a2c9bcc422453891c27b6bc146c8d6f8cb923a7b86792a3a5154cf10e26488a5'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.