### PR TITLE
Update openrct2 from 0.0.7 to 0.2.3

### DIFF
--- a/Casks/openrct2.rb
+++ b/Casks/openrct2.rb
@@ -1,11 +1,12 @@
 cask 'openrct2' do
-  version '0.0.7'
-  sha256 'e99bbb2c02b501ec0f322947b35e025897bb54d380f855dacdc6bb472f1e4520'
+  version '0.2.3'
+  sha256 'a44489657804ba580b2e6fe524b40376b002c4cd952aa9cf8b2860c5d5705685'
 
-  url "https://github.com/LRFLEW/OpenRCT2Launcher/releases/download/v#{version}/OpenRCT2Launcher-macos.zip"
-  appcast 'https://github.com/LRFLEW/OpenRCT2Launcher/releases.atom'
-  name 'OpenRCT2 Launcher'
-  homepage 'https://github.com/LRFLEW/OpenRCT2Launcher'
+  # github.com/OpenRCT2/OpenRCT2 was verified as official when first introduced to the cask
+  url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x64.zip"
+  appcast 'https://github.com/OpenRCT2/OpenRCT2/releases.atom'
+  name 'OpenRCT2'
+  homepage 'https://openrct2.io/'
 
   app 'OpenRCT2.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.