### PR TITLE
Update understand from 5.1.1003 to 5.1.1004

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1003'
-  sha256 '7018d561294d895eb09eeded0a0116613d92cf1e1db92da3b3bc8b66b56426fd'
+  version '5.1.1004'
+  sha256 '54fae5a9a92ed3e3019fd896eb2c2fbc98a7b5c8d9e0b5d380225f2a29731769'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.