### PR TITLE
Update openemu from 2.0.9.1 to 2.1

### DIFF
--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -3,8 +3,8 @@ cask 'openemu' do
     version '1.0.4'
     sha256 'c9c3abc2acea4ed4c1e2b62fd6868feae1719251428a79803d9aa8a0de4474ef'
   else
-    version '2.0.9.1'
-    sha256 'c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790'
+    version '2.1'
+    sha256 'f9933541cdc19c9b75874548e223633d423716bdd2b42c93d4c91695fe1eac1e'
   end
 
   # github.com/OpenEmu/OpenEmu was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.