### PR TITLE
Add IpePresenter 7.2.13

### DIFF
--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -4,9 +4,9 @@ cask 'ipepresenter' do
 
   # bintray.com/otfried was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"
-  appcast 'http://ipe.otfried.org/'
+  appcast 'http://ipepresenter.otfried.org'
   name 'IpePresenter'
-  homepage 'http://ipe.otfried.org/'
+  homepage 'http://ipepresenter.otfried.org'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -4,9 +4,9 @@ cask 'ipepresenter' do
 
   # bintray.com/otfried was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"
-  appcast 'http://ipepresenter.otfried.org'
+  appcast 'http://ipepresenter.otfried.org/'
   name 'IpePresenter'
-  homepage 'http://ipepresenter.otfried.org'
+  homepage 'http://ipepresenter.otfried.org/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -1,0 +1,14 @@
+cask 'ipepresenter' do
+  version '7.2.13'
+  sha256 'ad10ad1afbef8ef9a632a48976534623a3af3a23536765674142d15d10d1c3ce'
+
+  # bintray.com/otfried was verified as official when first introduced to the cask
+  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"
+  appcast 'http://ipe.otfried.org/'
+  name 'IpePresenter'
+  homepage 'http://ipe.otfried.org/'
+
+  depends_on macos: '>= :yosemite'
+
+  app 'IpePresenter.app'
+end


### PR DESCRIPTION
Ipe and IpePresenter are now two separate installs -- see 

https://github.com/Homebrew/homebrew-cask/pull/71526

and 

https://github.com/Homebrew/homebrew-cask/pull/70306