### PR TITLE
Update material-colors from 1.1.0 to 2.0.0

### DIFF
--- a/Casks/material-colors.rb
+++ b/Casks/material-colors.rb
@@ -1,6 +1,6 @@
 cask 'material-colors' do
-  version '1.1.0'
-  sha256 '61a23327f723f61b714b1718a7e30cc6f3c5bcee2b2103074354244a76e029d8'
+  version '2.0.0'
+  sha256 'a764f8af33499a96d46e3e79fe2e4594eb0ccff6217cff0920d9b44982a0f8be'
 
   url "https://github.com/romannurik/MaterialColorsApp/releases/download/v#{version}/MaterialColors-#{version}.zip"
   appcast 'https://github.com/romannurik/MaterialColorsApp/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.