### PR TITLE
Update alt-tab from 1.9.5 to 1.9.6

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.9.5'
-  sha256 '9d519024c1d960480f428feaaa311ec925a9ff63de0963755c4ff5bbc3e71834'
+  version '1.9.6'
+  sha256 '6418e03c5d0d4418318c0861f33b909887015eace54ec6f68174dd020691cc93'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.