### PR TITLE
Update springtoolsuite from 4.4.0.RELEASE,4.13.0 to 4.4.1.RELEASE,4.13.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask 'springtoolsuite' do
-  version '4.4.0.RELEASE,4.13.0'
-  sha256 'f8ca0eaefabd3f1229f4a440094716b7df4f3ea78bdba19fb9c38e572939fecc'
+  version '4.4.1.RELEASE,4.13.0'
+  sha256 '87e7bf2abd89620f810c00c3ffa6f667ae5f471e285b3b5da766ff30a0aab808'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.