### PR TITLE
Update liclipse from 5.3.0,c0dcsho551y0brr to 6.0.0,ve32xytlixmlg3x

### DIFF
--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -1,6 +1,6 @@
 cask 'liclipse' do
-  version '5.3.0,c0dcsho551y0brr'
-  sha256 '6c1c342018cf8f76c84bcce82536ccfc4100fe9d05aeb4a67f5dcadf810ec08b'
+  version '6.0.0,ve32xytlixmlg3x'
+  sha256 'd26d250e9edecf99108e3e37e07014f8a4347d74d9dce583c2ac1481ec3c94c3'
 
   # mediafire.com/file was verified as official when first introduced to the cask
   url "https://www.mediafire.com/file/#{version.after_comma}/liclipse_#{version.before_comma}_macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.