### PR TITLE
Update java from 13,33:5b8a42f3905b406298b72d750b6919f6 to 13.0.1,9:cec27d702aa74d5a8630c65ae61e4305

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     export TRAVIS_BUILD_DIR="${TAP_DIR}"
     builtin cd "${TAP_DIR}"
 
-script: brew cask ci
+script: brew cask ci -vd
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     export TRAVIS_BUILD_DIR="${TAP_DIR}"
     builtin cd "${TAP_DIR}"
 
-script: brew cask ci -vd
+script: brew cask ci
 
 notifications:
   email: false

--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,6 +1,6 @@
 cask 'java' do
-  version '13,33:5b8a42f3905b406298b72d750b6919f6'
-  sha256 '1a9c096630a0e4f27ce61ac9e477378b8581c537568186d4afd0b416a7e9dd68'
+  version '13.0.1,9:cec27d702aa74d5a8630c65ae61e4305'
+  sha256 '593c5c9dc0978db21b06d6219dc8584b76a59c79d57e6ec1b28ad0d848a7713f'
 
   url "https://download.java.net/java/GA/jdk#{version.before_comma}/#{version.after_colon}/#{version.after_comma.before_colon}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Java Development Kit'

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -244,6 +244,7 @@ module Cask
               yield != false
             rescue => e
               $stderr.puts e.message
+              $stderr.puts e.backtrace
               false
             end
           end

--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -104,7 +104,10 @@ module Cask
           check = Check.new
 
           overall_success &= step "brew cask install #{cask.token}", "install" do
-            Installer.new(cask, verbose: true).zap if was_installed
+            if was_installed
+              old_cask = CaskLoader.load(cask.installed_caskfile)
+              Installer.new(old_cask, verbose: true).zap
+            end
 
             check.before
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.