### PR TITLE
Update browserosaurus from 6.6.1 to 6.7.0

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '6.6.1'
-  sha256 '12f889a8837866e81eb8abd62e5386ec5c93c245709bc36e797a3a02e87b58a4'
+  version '6.7.0'
+  sha256 'fad7fe4be779025d8bfe2d34aa59c69415ba21b54669b2e268b19eeafcbc1e2c'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.