### PR TITLE
Update sqlpro-for-mysql from 2019.09.12 to 2019.48

### DIFF
--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -1,9 +1,9 @@
 cask 'sqlpro-for-mysql' do
-  version '2019.09.12'
-  sha256 '8d25777bd146561b37657b7f54890ed1b73595485f7d4753d13c11a34e14242a'
+  version '2019.48'
+  sha256 'a426db6970e3a1bf272509c0b4b7996fd9728636bf02fc1ad4f175f6782f1d38'
 
   # d3fwkemdw8spx3.cloudfront.net/mysql was verified as official when first introduced to the cask
-  url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.app.zip"
+  url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.mysqlui.com/download.php'
   name 'SQLPro for MySQL'
   homepage 'https://www.mysqlui.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.