### PR TITLE
Update keycastr from 0.9.7 to 0.9.8

### DIFF
--- a/Casks/keycastr.rb
+++ b/Casks/keycastr.rb
@@ -1,6 +1,6 @@
 cask 'keycastr' do
-  version '0.9.7'
-  sha256 '20f68c2581c6dbfce2f24931c7dc4d85aed0072a138272bbf6565828d6ff753a'
+  version '0.9.8'
+  sha256 'd21f944e45dfe8e5cc2f8d60f45c97b93be0583ecd9e0145689d3fa2bcd231e6'
 
   url "https://github.com/keycastr/keycastr/releases/download/v#{version}/KeyCastr.app.zip"
   appcast 'https://github.com/keycastr/keycastr/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.