### PR TITLE
Update keeweb from 1.11.10 to 1.12.1

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.11.10'
-  sha256 'b42d991deaac0963d1d85efdafc1e89c2407d677817b853cb76bfe43ca570172'
+  version '1.12.1'
+  sha256 'e63e8658bba517c0b01fcf3c435569467b79207c99fb50900841a626ce780eaa'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.