### PR TITLE
Update thedesk from 18.11.3 to 18.11.4

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.11.3'
-  sha256 '21dcf120ea7bd23d406a281e4ca4b45e010229f3f0730558b20151246f8cdc7e'
+  version '18.11.4'
+  sha256 'ba0b853c811471905d9f259e91e5fc8152b86c1ce58418ee402c18cd3ac57fac'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.