### PR TITLE
Update hands-off from 4.3.0 to 4.4.0

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '4.3.0'
-  sha256 '836da734a43d5434b25fca893ed58363c79af288b2c7d57785cb132e6a534a2f'
+  version '4.4.0'
+  sha256 'a4aa07a33ca903723ecda64c6b28d7dcdee183a94a03fb2f86c38a53b94f40e2'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.