### PR TITLE
Update love from 11.2 to 11.3

### DIFF
--- a/Casks/love.rb
+++ b/Casks/love.rb
@@ -1,6 +1,6 @@
 cask 'love' do
-  version '11.2'
-  sha256 '770286edc8cdab6abb7a522d05bb488ed2433dc5a76f6aca7b2ed54d7c5d4dd8'
+  version '11.3'
+  sha256 '65b0cf09e6be1a63251ec212ebf54c748e0115692d8bd1d116297279449a1ae5'
 
   # bitbucket.org/rude/love was verified as official when first introduced to the cask
   url "https://bitbucket.org/rude/love/downloads/love-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.