### PR TITLE
Update gyazmail from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/gyazmail.rb
+++ b/Casks/gyazmail.rb
@@ -1,6 +1,6 @@
 cask 'gyazmail' do
-  version '1.6.1'
-  sha256 'af351cd431bfa7628074a0baad3fa4ab63bbbf4dff4e4d45df46f9e5055ae71e'
+  version '1.6.2'
+  sha256 '4d23d0de517aa1558515a7fce4eb6c6ffc1de55538b697c9033a21c1f4218e34'
 
   url "http://gyazsquare.com/gyazmail/GyazMail-#{version.no_dots}.dmg"
   appcast 'http://gyazsquare.com/gyazmail/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.