### PR TITLE
Update anydo from 4.2.49 to 4.2.50

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.49'
-  sha256 '16c1ff093a6a62bb04dc92b09e92e1edfb0913c472f7d0423a44d7fae25ca1ea'
+  version '4.2.50'
+  sha256 '1fd2b027d00a2a5c5f997c0bb2aaa0b518465d3db188775663b76e1a281b7ac2'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.