### PR TITLE
Update eiskaltdcpp from 2.2.10-631-macOS10.12 to 2.2.10-644-macOS10.12

### DIFF
--- a/Casks/eiskaltdcpp.rb
+++ b/Casks/eiskaltdcpp.rb
@@ -1,6 +1,6 @@
 cask 'eiskaltdcpp' do
-  version '2.2.10-631-macOS10.12'
-  sha256 '36708cc72ad9ffb36ac2cfcf42348f4a7bff72ebfb65df80825af934924e9f41'
+  version '2.2.10-644-macOS10.12'
+  sha256 '701f1f2d62c084114244350a831f880b0aaa4fbed3021ec159c4a066b7fa6ea1'
 
   url "https://downloads.sourceforge.net/eiskaltdcpp/EiskaltDC++-#{version}-x86_64.dmg"
   appcast 'https://sourceforge.net/projects/eiskaltdcpp/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.