### PR TITLE
Update iris from 1.1.6 to 1.2.0

### DIFF
--- a/Casks/iris.rb
+++ b/Casks/iris.rb
@@ -1,9 +1,9 @@
 cask 'iris' do
-  version '1.1.6'
-  sha256 'f241b98649690ca88bb81bd474480f159ae423bb4116fc0281a27c870b24275e'
+  version '1.2.0'
+  sha256 'dec14c8768aab69c343ec173e4b7cca2c9966d6b5425a1fb3a198b3704a21359'
 
-  # raw.githubusercontent.com/danielng01/Iris-Builds was verified as official when first introduced to the cask
-  url "https://raw.githubusercontent.com/danielng01/Iris-Builds/master/OSX/Iris-#{version}-OSX.zip"
+  # raw.githubusercontent.com/danielng01/product-builds was verified as official when first introduced to the cask
+  url "https://raw.githubusercontent.com/danielng01/product-builds/master/Iris/macOS/Iris-#{version}-OSX.zip"
   appcast 'https://iristech.co/iris/'
   name 'Iris'
   homepage 'https://iristech.co/iris/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.