### PR TITLE
Update altair-graphql-client from 2.3.5 to 2.3.6

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,9 +1,9 @@
 cask 'altair-graphql-client' do
-  version '2.3.5'
-  sha256 'd6fe8401fb45011b14adac5c240cecad64c7fc2be6c9f93b4af45b8e4652dd0a'
+  version '2.3.6'
+  sha256 '99fde6e3e7a45a3e9c5d942af57443bbb53d4eae9733d7142acd6c3b2d4962fa'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
-  url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair-electron_#{version}_mac.zip"
+  url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair_#{version}_mac.zip"
   appcast 'https://github.com/imolorhe/altair/releases.atom'
   name 'Altair GraphQL Client'
   homepage 'https://altair.sirmuel.design/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.