### PR TITLE
Update yandex-cloud-cli 0.42.0 to install docker-credential-yc

### DIFF
--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -7,5 +7,12 @@ cask 'yandex-cloud-cli' do
   name 'Yandex Cloud CLI'
   homepage 'https://cloud.yandex.com/docs/cli/'
 
+  installer script: {
+                      executable: "#{staged_path}/yc",
+                      args:       ['components', 'post-update'],
+                    }
+  binary 'docker-credential-yc'
   binary 'yc'
+
+  uninstall delete: "#{staged_path}/docker-credential-yc"
 end

--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -13,6 +13,4 @@ cask 'yandex-cloud-cli' do
                     }
   binary 'docker-credential-yc'
   binary 'yc'
-
-  uninstall delete: "#{staged_path}/docker-credential-yc"
 end


### PR DESCRIPTION
Invoke installer during cask install to add second binary.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).