### PR TITLE
Add MQTT Explorer v0.3.5

### DIFF
--- a/Casks/mqtt-explorer.rb
+++ b/Casks/mqtt-explorer.rb
@@ -1,0 +1,19 @@
+cask 'mqtt-explorer' do
+  version '0.3.5'
+  sha256 '4322a9127c3ce9025d33afa3ff91e76e8873fff260493a112eadc4769c027778'
+
+  url "https://github.com/thomasnordquist/MQTT-Explorer/releases/download/v#{version}/MQTT-Explorer-#{version}-mac.zip"
+  appcast 'https://github.com/thomasnordquist/MQTT-Explorer/releases.atom'
+  name 'MQTT Explorer'
+  homepage 'https://mqtt-explorer.com'
+
+  app 'MQTT Explorer.app'
+
+  uninstall quit: 'de.t7n.apps.mqtt-explorer'
+
+  zap trash: [
+        '~/Library/Containers/de.t7n.apps.mqtt-explorer',
+        '~/Library/Group Containers/*.de.t7n.apps.mqtt-explorer',
+        '~/Library/Application Scripts/de.t7n.apps.mqtt-explorer',
+    ]
+end

--- a/Casks/mqtt-explorer.rb
+++ b/Casks/mqtt-explorer.rb
@@ -2,18 +2,19 @@ cask 'mqtt-explorer' do
   version '0.3.5'
   sha256 '4322a9127c3ce9025d33afa3ff91e76e8873fff260493a112eadc4769c027778'
 
+  # github.com/thomasnordquist/MQTT-Explorer was verified as official when first introduced to the cask
   url "https://github.com/thomasnordquist/MQTT-Explorer/releases/download/v#{version}/MQTT-Explorer-#{version}-mac.zip"
   appcast 'https://github.com/thomasnordquist/MQTT-Explorer/releases.atom'
   name 'MQTT Explorer'
-  homepage 'https://mqtt-explorer.com'
+  homepage 'https://mqtt-explorer.com/'
 
   app 'MQTT Explorer.app'
 
   uninstall quit: 'de.t7n.apps.mqtt-explorer'
 
   zap trash: [
-        '~/Library/Containers/de.t7n.apps.mqtt-explorer',
-        '~/Library/Group Containers/*.de.t7n.apps.mqtt-explorer',
-        '~/Library/Application Scripts/de.t7n.apps.mqtt-explorer',
-    ]
+               '~/Library/Containers/de.t7n.apps.mqtt-explorer',
+               '~/Library/Group Containers/*.de.t7n.apps.mqtt-explorer',
+               '~/Library/Application Scripts/de.t7n.apps.mqtt-explorer',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

I wasn't able to get the `syntax` check to run successfully.

```
> brew cask style --fix mqtt-explorer --verbose --debug
/Users/sdoran/.gem/ruby/2.6.0/bin/bundle install
Error: failed to run `/Users/sdoran/.gem/ruby/2.6.0/bin/bundle install`!
Error: Kernel.exit
/usr/local/Homebrew/Library/Homebrew/utils.rb:124:in `exit'
/usr/local/Homebrew/Library/Homebrew/utils.rb:124:in `odie'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:31:in `odie_if_defined'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:100:in `install_bundler_gems!'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/style.rb:13:in `rubocop'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/style.rb:54:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/abstract_command.rb:36:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:92:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:158:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:123:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:9:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:102:in `<main>'
```

This seems similar to issues #43898 and #48997.
