### PR TITLE
Update plex-media-server from 1.18.0.1944-f2cae8d6b to 1.18.1.1973-0f4abfbcc

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.18.0.1944-f2cae8d6b'
-  sha256 'f392aa17d6002a6159773393959cce3aced995062420a19132f95390a675cc21'
+  version '1.18.1.1973-0f4abfbcc'
+  sha256 'b6803a8ffb62182853e30f66414b7078266625497dfbccbcd40fcd7dbe810fe7'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.