### PR TITLE
Add caveats to yandex-cloud-cli 0.42.0 regarding docker-credential-yc

### DIFF
--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -8,4 +8,11 @@ cask 'yandex-cloud-cli' do
   homepage 'https://cloud.yandex.com/docs/cli/'
 
   binary 'yc'
+
+  caveats <<~EOS
+    To install Docker Credential helper run:
+
+      yc components post-update
+      mv '#{staged_path}/docker-credential-yc' '/usr/local/bin'
+  EOS
 end


### PR DESCRIPTION
Following the discussion with @vitorgalvao in https://github.com/Homebrew/homebrew-cask/pull/71588, this PR adds caveats explaining to the user how additional `docker-credential-yc` utility can be installed which is needed for some functionality.

Automated install isn't feasible as of right now due to Gatekeeper issues on macOS Catalina.

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version].