### PR TITLE
Update yandex-disk from 1.3.8,30 to 3.1.9,30

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
-  version '1.3.8,30'
-  sha256 'd8ecadecc3aaf8a3b920173fc8e9d45951cbe4707e941fbbf2d371e376d70e0f'
+  version '3.1.9,30'
+  sha256 '86dde43923b697ad8b9e663238c3928814aa3ff67ccc51993060ab9e2c144bcf'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.after_comma}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.