### PR TITLE
Add Autodesk Fusion 360 v2.0.6516

### DIFF
--- a/Casks/autodesk-fusion-360.rb
+++ b/Casks/autodesk-fusion-360.rb
@@ -1,0 +1,28 @@
+cask 'autodesk-fusion-360' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Client%20Downloader.dmg'
+  name 'Autodesk Fusion 360'
+  homepage 'https://www.autodesk.com/products/fusion-360'
+
+  installer script: 'Right-click > Open to Install.app/Contents/MacOS/Fusion 360 Client Downloader'
+
+  uninstall quit:   [
+                      'com.autodesk.fusion360',
+                      'com.autodesk.dls.streamer.scriptapp.Autodesk-Fusion-360',
+                    ],
+            script: {
+                      executable: "#{staged_path}/Right-click > Open to Install.app/Contents/MacOS/streamer",
+                      args:       [
+                                    '--process', 'uninstall',
+                                    '--appid', '73e72ada57b7480280f7a6f4a289729f',
+                                    '--stream', 'production',
+                                    '--quiet'
+                                  ],
+                    },
+            delete: [
+                      '~/Applications/Autodesk Fusion 360.app',
+                      '~/Applications/Remove Autodesk Fusion 360.app',
+                    ]
+end

--- a/Casks/autodesk-fusion360.rb
+++ b/Casks/autodesk-fusion360.rb
@@ -1,4 +1,5 @@
-cask 'autodesk-fusion-360' do
+cask 'autodesk-fusion360' do
+  # note: "360" is not a version number, but an intrinsic part of the product name
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference]. — no. Suggested by script: `autodesk-fusion`. Actual software name: `Autodesk Fusion 360`
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask. — There's a dead one from 4 years ago: https://github.com/Homebrew/homebrew-cask/pull/10387
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


## Rationale:

Installer is graphical, but non-interactive, and it returns after installation is done:
<img width="972" alt="sshot 2019-10-28 в 23 39 39" src="https://user-images.githubusercontent.com/1821846/67717587-d5254400-f9ef-11e9-9812-b3f5d71789cd.png">

Non-interactive uninstaller is a bit tricky.

Here's the contents of the installer script `Right-click > Open to Install.app/Contents/MacOS/Fusion 360 Client Downloader`

```bash
#!/bin/sh

function execute() {
   (...)   
    "$(dirname "$0")/streamer" "${args[@]}"
}

execute "73e72ada57b7480280f7a6f4a289729f" "production" "https://dl.appstreaming.autodesk.com/production/" "${@}"
```

And the uninstaller, `~/Applications/Remove Autodesk Fusion 360.app/Contents/MacOS/Remove Autodesk Fusion 360`:
```bash
#!/bin/sh

STREAMERSDIR="$HOME/Library/Application Support/Autodesk/webdeploy/meta/streamer"

for ver in $(ls "${STREAMERSDIR}" | sort -r); do
    STREAMERPATH="${STREAMERSDIR}/${ver}/streamer"
    if [ -x "$STREAMERPATH" ]; then
        break
    fi
    STREAMERPATH=""
done

if [ -n "$STREAMERPATH" ]; then
    "$STREAMERPATH" -p uninstall -a 73e72ada57b7480280f7a6f4a289729f  -s production
fi
```

`streamer` «Deploys and updates an Autodesk 360 Applications»

It has a nice command-line help, and `--quiet` means "Signal that the process should be executed quietly without a graphical user interface."

There are 2 instances of `streamer` after installation: one in installer, one in `/Library/Application Support/Autodesk/webdeploy/meta/streamer`. The second one is auto-updating (I guess), so it would be safer to use it for `uninstall:` stanza.

...But it looks complicated and a bit unsafe:

```ruby
executable: Dir.glob("#{ENV['HOME']}/Library/Application Support/Autodesk/webdeploy/meta/streamer/*/streamer").first,
```

Also script may be modified to install app system-wide, in /Applications instead of ~/Applications.

Any feedback welcomed.