### PR TITLE
Update fsnotes from 4.0.0 to 4.0.2

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.0.0'
-  sha256 '85cef272236a844d73b524ef25ab210261bd3ea6348ccaaa3ff14731bfdf1a0b'
+  version '4.0.2'
+  sha256 'dbb072a8e4ace877d5f5552530ea7c24aa9ab55a6dad5e1e34447b1cbdb6ae75'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.