### PR TITLE
Update developerexcuses from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/developerexcuses.rb
+++ b/Casks/developerexcuses.rb
@@ -1,6 +1,6 @@
 cask 'developerexcuses' do
-  version '2.1.1'
-  sha256 '8d22c91c6932ef353a12eba734fe265fa68b058f31db14358ff098a06f01bddd'
+  version '2.1.2'
+  sha256 '9e2b0d8aa60b6538d289213b5d84e6ec897f119ed782ec15551cd24b4d29450f'
 
   url "https://github.com/kimar/DeveloperExcuses/releases/download/#{version}/DeveloperExcuses.saver.zip"
   appcast 'https://github.com/kimar/DeveloperExcuses/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.