### PR TITLE
Update kekadefaultapp from 1.1.1,1.0.0-r.6 to 1.1.5-rc.1,1.0.0-r.6

### DIFF
--- a/Casks/kekadefaultapp.rb
+++ b/Casks/kekadefaultapp.rb
@@ -1,6 +1,6 @@
 cask 'kekadefaultapp' do
-  version '1.1.1,1.0.0-r.6'
-  sha256 '45b4072395aea8cdb6827b193ab8520097ac939f3ab9da6728394c8a666096b8'
+  version '1.1.5-rc.1,1.0.0-r.6'
+  sha256 'f28224e980afe89af5ee05cf3fa4162fa622554050b0646246597a006960d81d'
 
   url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}/KekaDefaultApp-#{version.after_comma}.zip"
   appcast 'https://github.com/aonez/Keka/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

--
Although the version string of the containing release notes it as a non-stable release, the [wiki](https://github.com/aonez/Keka/wiki/Default-application) links to this release. Keka itself is already at 1.1.21 by now, and the KekaDefaultApp artifact hasn't been updated since, it seems.