### PR TITLE
Update prudent from 55.0.2883.87,initial to 55.0.2883.87,12

### DIFF
--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -1,6 +1,6 @@
 cask 'prudent' do
-  version '55.0.2883.87,initial'
-  sha256 '128c50e2c4e00c71e35212f23b74b93d6256d219d05ffed55079369310950d8f'
+  version '55.0.2883.87,12'
+  sha256 'de9d5e55735010113e05e259a61f1aa5ca92112d76386131ac1bdd36907168f9'
 
   # github.com/PrudentMe/main was verified as official when first introduced to the cask
   url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"

--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -4,7 +4,8 @@ cask 'prudent' do
 
   # github.com/PrudentMe/main was verified as official when first introduced to the cask
   url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"
-  appcast 'https://github.com/PrudentMe/main/releases.atom'
+  appcast 'https://github.com/PrudentMe/main/releases.atom',
+          configuration: version.after_comma
   name 'Prudent'
   homepage 'https://prudent.me/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.