### PR TITLE
Update operadriver from 2.40 to 77.0.3865.120

### DIFF
--- a/Casks/operadriver.rb
+++ b/Casks/operadriver.rb
@@ -1,6 +1,6 @@
 cask 'operadriver' do
-  version '2.40'
-  sha256 '4ef7291b3aae0463d4155fb6938c72e3132684871d0e5fe7eb2c47931662eb3a'
+  version '77.0.3865.120'
+  sha256 '77cc8a242ca21b3c445abaf81de7c0d79816dbaadce1460bb161ecf945070418'
 
   url "https://github.com/operasoftware/operachromiumdriver/releases/download/v.#{version}/operadriver_mac64.zip"
   appcast 'https://github.com/operasoftware/operachromiumdriver/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.