### PR TITLE
Update openrct2 from 0.2.3 to 0.2.4

### DIFF
--- a/Casks/openrct2.rb
+++ b/Casks/openrct2.rb
@@ -1,9 +1,9 @@
 cask 'openrct2' do
-  version '0.2.3'
-  sha256 'a44489657804ba580b2e6fe524b40376b002c4cd952aa9cf8b2860c5d5705685'
+  version '0.2.4'
+  sha256 '81b43d1c787df643092332e64b3ce5a1b18ffde75af637c5fc802a710ebade2e'
 
   # github.com/OpenRCT2/OpenRCT2 was verified as official when first introduced to the cask
-  url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x64.zip"
+  url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86_64.zip"
   appcast 'https://github.com/OpenRCT2/OpenRCT2/releases.atom'
   name 'OpenRCT2'
   homepage 'https://openrct2.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.