### PR TITLE
Update luyten from 0.5.4 to 0.5.4,0.5.4_Rebuilt_with_Latest_depenencies

### DIFF
--- a/Casks/luyten.rb
+++ b/Casks/luyten.rb
@@ -1,9 +1,9 @@
 cask 'luyten' do
-  version '0.5.4'
-  sha256 'c7191d822d6a9ab08e383c7038acf0aaf3885e332fdaf204c14b3c550a28120a'
+  version '0.5.4,0.5.4_Rebuilt_with_Latest_depenencies'
+  sha256 '7f48f8b75991c1c039cfb901440fa05dd3cf18e2219e39cf19f86aaf551a097e'
 
   # github.com/deathmarine/Luyten was verified as official when first introduced to the cask
-  url "https://github.com/deathmarine/Luyten/releases/download/v#{version}/luyten-OSX-#{version}.zip"
+  url "https://github.com/deathmarine/Luyten/releases/download/v#{version.after_comma}/luyten-OSX-#{version.before_comma}.zip"
   appcast 'https://github.com/deathmarine/Luyten/releases.atom'
   name 'Luyten'
   homepage 'https://deathmarine.github.io/Luyten/'

--- a/Casks/luyten.rb
+++ b/Casks/luyten.rb
@@ -1,9 +1,9 @@
 cask 'luyten' do
-  version '0.5.4,0.5.4_Rebuilt_with_Latest_depenencies'
+  version '0.5.4'
   sha256 '7f48f8b75991c1c039cfb901440fa05dd3cf18e2219e39cf19f86aaf551a097e'
 
   # github.com/deathmarine/Luyten was verified as official when first introduced to the cask
-  url "https://github.com/deathmarine/Luyten/releases/download/v#{version.after_comma}/luyten-OSX-#{version.before_comma}.zip"
+  url "https://github.com/deathmarine/Luyten/releases/download/v#{version}_Rebuilt_with_Latest_depenencies/luyten-OSX-#{version}.zip"
   appcast 'https://github.com/deathmarine/Luyten/releases.atom'
   name 'Luyten'
   homepage 'https://deathmarine.github.io/Luyten/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.