### PR TITLE
Update free-ruler from 2.0.1 to 2.0.3

### DIFF
--- a/Casks/free-ruler.rb
+++ b/Casks/free-ruler.rb
@@ -1,6 +1,6 @@
 cask 'free-ruler' do
-  version '2.0.1'
-  sha256 '0ec0b4d62b7b9be17412d00d3eb045e4f574d6b0e1f725ad569740a983249685'
+  version '2.0.3'
+  sha256 'aa428907c113e249a6baedb329e788b10d6db67d9f9117c3986780d2c592da9d'
 
   # github.com/pascalpp/FreeRuler was verified as official when first introduced to the cask
   url "https://github.com/pascalpp/FreeRuler/releases/download/v#{version}/free-ruler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.