### PR TITLE
Update munki from 3.6.2.3776 to 3.6.4.3786

### DIFF
--- a/Casks/munki.rb
+++ b/Casks/munki.rb
@@ -1,6 +1,6 @@
 cask 'munki' do
-  version '3.6.2.3776'
-  sha256 '65868859ff75ca078fe466c5387095374bbb337737f6745ad68cd3db8c8d36e2'
+  version '3.6.4.3786'
+  sha256 'c20826da7df6dd7c9b3404e1c348523a5f04b760413dfd7a2b632cb861025d0d'
 
   # github.com/munki/munki was verified as official when first introduced to the cask
   url "https://github.com/munki/munki/releases/download/v#{version.major_minor_patch}/munkitools-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.