### PR TITLE
Update magiccap from 2.0.0 to 2.0.2

### DIFF
--- a/Casks/magiccap.rb
+++ b/Casks/magiccap.rb
@@ -1,6 +1,6 @@
 cask 'magiccap' do
-  version '2.0.0'
-  sha256 '8cebb0061062e03e54a71ff120a6c658a41bbf8952aadfd2945fd76808dc2cb6'
+  version '2.0.2'
+  sha256 '1c0f53f57fd1a950db284f639b407a9f479a1d44f90fe67e48360369f6c39d39'
 
   # github.com/magiccap/MagicCap was verified as official when first introduced to the cask
   url "https://github.com/magiccap/MagicCap/releases/download/v#{version}/magiccap-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.