### PR TITLE
Update gogs from 0.11.86 to 0.11.91

### DIFF
--- a/Casks/gogs.rb
+++ b/Casks/gogs.rb
@@ -1,6 +1,6 @@
 cask 'gogs' do
-  version '0.11.86'
-  sha256 '0f7b1800e7004d7ce99eb59eb3487efe1a198e5aa2a77d79cf7f29378600143a'
+  version '0.11.91'
+  sha256 '1480a489aa853d01b0f6c9c2fb0aa19b61b5847bcd0cae1f2d8db6833f79b29d'
 
   # github.com/gogs/gogs was verified as official when first introduced to the cask
   url "https://github.com/gogs/gogs/releases/download/v#{version}/darwin_amd64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.