### PR TITLE
Update dashlane from 6.1937.0.23216 to 6.1942.0.24426

### DIFF
--- a/Casks/dashlane.rb
+++ b/Casks/dashlane.rb
@@ -1,6 +1,6 @@
 cask 'dashlane' do
-  version '6.1937.0.23216'
-  sha256 'c0b3b98c67dba41da1296d2090ff0972d2f57a7952bbf8a336263484a548e835'
+  version '6.1942.0.24426'
+  sha256 'c5b37fe0c36d42014a8fde4ce4334833fbf5d6815b37cc2df732dd90a6aaae24'
 
   # d3mfqat9ni8wb5.cloudfront.net/releases was verified as official when first introduced to the cask
   url "https://d3mfqat9ni8wb5.cloudfront.net/releases/#{version.major_minor_patch}/#{version}/release/Dashlane.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.