### PR TITLE
Update fontexplorer-x-pro from 6.0.9 to 7.0.0

### DIFF
--- a/Casks/fontexplorer-x-pro.rb
+++ b/Casks/fontexplorer-x-pro.rb
@@ -1,6 +1,6 @@
 cask 'fontexplorer-x-pro' do
-  version '6.0.9'
-  sha256 'c4a8dadcfdba2961e05c363c3c95a6297121f2f613d1eb3f565935391088b865'
+  version '7.0.0'
+  sha256 '5bda8425468f98efb8db458358df9abc6096a0f2dbdfa41afad177d9823e32a5'
 
   url "https://fast.fontexplorerx.com/FontExplorerXPro#{version.no_dots}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://fex.linotype.com/download/mac/FontExplorerXPro.dmg',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.