### PR TITLE
Update miktex-console from 2.9.7050-1 to 2.9.7230-1

### DIFF
--- a/Casks/miktex-console.rb
+++ b/Casks/miktex-console.rb
@@ -1,6 +1,6 @@
 cask 'miktex-console' do
-  version '2.9.7050-1'
-  sha256 '46689b9de8bf158d6c74a17ecdcacc418e8303bc47988228fa395c660d41a9fa'
+  version '2.9.7230-1'
+  sha256 'eb55ebe17075516377c45885f2528323deb0176f5e9aaa8092cff77a1f42ff85'
 
   url "https://miktex.org/download/ctan/systems/win32/miktex/setup/darwin-x86_64/miktex-#{version}-darwin-x86_64.dmg"
   appcast 'https://miktex.org/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.