### PR TITLE
Update sourcetree from 4.0_229 to 4.0_232

### DIFF
--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -12,8 +12,8 @@ cask 'sourcetree' do
     # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
     url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"
   else
-    version '4.0_229'
-    sha256 '654c12cb4a2c0d29c7d3ae0b4337bb28aa4bed7945167e8a42103c752e2eab5b'
+    version '4.0_232'
+    sha256 '626e3e88bb4656d26c6faafec442250e9fc221dd0037b0078b8e2776899285f1'
 
     # atlassian.com/software/sourcetree was verified as official when first introduced to the cask
     url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.