### PR TITLE
Fixed spelling mistake in microsoft-office 16.30.19101301

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -9,9 +9,9 @@ cask 'microsoft-office' do
 
   auto_updates true
   conflicts_with cask: [
-                         'microsot-word',
-                         'microsot-excel',
-                         'microsot-powerpoint',
+                         'microsoft-word',
+                         'microsoft-excel',
+                         'microsoft-powerpoint',
                          'onedrive',
                        ]
   depends_on macos: '>= :sierra'


### PR DESCRIPTION
From microsot to microsoft

No change of the software or the version, just fixed a spelling mistake in the Formula.
cask: 'microsoft-office' 
version: '16.30.19101301'

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).