### PR TITLE
Update acslogo from 1.5.1 to 1.6

### DIFF
--- a/Casks/acslogo.rb
+++ b/Casks/acslogo.rb
@@ -1,6 +1,6 @@
 cask 'acslogo' do
-  version '1.5.1'
-  sha256 'fcdab9679a9cc783d4b7912d611442faa1fe1293497c4cb649f6808a58d27082'
+  version '1.6'
+  sha256 '467e4ff74265308de2262dc46d88f15841618c6fab4b4b761f32191214123a1c'
 
   url "https://www.alancsmith.co.uk/logo/ACSLogo#{version.no_dots}.dmg"
   appcast 'https://www.alancsmith.co.uk/logo/release.html'

--- a/Casks/acslogo.rb
+++ b/Casks/acslogo.rb
@@ -7,5 +7,5 @@ cask 'acslogo' do
   name 'ACSLogo'
   homepage 'https://www.alancsmith.co.uk/logo/'
 
-  app 'ACSLogo/ACSLogo.app'
+  app 'ACSLogo.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.