### PR TITLE
Update zoc from 7.24.3 to 7.24.5

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.24.3'
-  sha256 '88964adf25081a896db64b8d7825c2d0de3440dc7143e2246ad42631a621b3bc'
+  version '7.24.5'
+  sha256 'e6b13e1e7ccffe117b2445c1f83e585976cb16cb04b474f7ea8b6d4f5540ed36'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.