### PR TITLE
Update aimersoft-video-converter-ultimate from 11.5.0.6,747 to 11.5.1.8

### DIFF
--- a/Casks/aimersoft-video-converter-ultimate.rb
+++ b/Casks/aimersoft-video-converter-ultimate.rb
@@ -1,8 +1,8 @@
 cask 'aimersoft-video-converter-ultimate' do
-  version '11.5.0.6,747'
-  sha256 '993af05a983f0d86a754884d8273905fe8abcf5b425928a44d8302901b17cd0a'
+  version '11.5.1.8'
+  sha256 'ff65948c7e3b2d81099f805f0ab93df764ef201f6d5b54f2299ce2e7718c69a4'
 
-  url "http://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full#{version.after_comma}.dmg"
+  url 'http://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full747.dmg'
   name 'Aimersoft Video Converter Ultimate'
   homepage 'https://www.aimersoft.com/mac-video-converter-ultimate.html'
 

--- a/Casks/aimersoft-video-converter-ultimate.rb
+++ b/Casks/aimersoft-video-converter-ultimate.rb
@@ -4,7 +4,7 @@ cask 'aimersoft-video-converter-ultimate' do
 
   url 'http://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full747.dmg'
   name 'Aimersoft Video Converter Ultimate'
-  homepage 'https://www.aimersoft.com/mac-video-converter-ultimate.html'
+  homepage 'https://www.aimersoft.com/video-converter-ultimate.html'
 
   app 'Aimersoft Video Converter Ultimate.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.