### PR TITLE
Update qownnotes from 19.10.10,b4637-123303 to 19.10.12,b4694-175731

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.10.10,b4637-123303'
-  sha256 '8b204ae0228098c54249c64adda45dd2d5289c55fb32596a79e28a08e88f70cf'
+  version '19.10.12,b4694-175731'
+  sha256 '0f69c5c3fc4036085fa130cc19058a79373ab11db9e09911ff296cd3c08dd9ef'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.