### PR TITLE
Update clashx from 1.16.4 to 1.16.5

### DIFF
--- a/Casks/clashx.rb
+++ b/Casks/clashx.rb
@@ -1,6 +1,6 @@
 cask 'clashx' do
-  version '1.16.4'
-  sha256 '67773b413f65224f2ab535257abae0d206bd226001ae98513bcdf904a0dcf562'
+  version '1.16.5'
+  sha256 '024dbce379b4a3624ba49a3a64be73e7d2d7ed180e59e1fceb8313796ee1b9ac'
 
   url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   appcast 'https://github.com/yichengchen/clashX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.