### PR TITLE
Update jami from 20191025.1939 to 20191028.1657

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20191025.1939'
-  sha256 '739716c56fdd244770014db05b63e2f5726f89621383648a7d3b89790346c29c'
+  version '20191028.1657'
+  sha256 'fb83c8078c2e41ac312b584ab1f0b1fb831e1574243026ad1fe1f0fd83ac6de7'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.