### PR TITLE
Update snapndrag from 4.3.1 to 4.3.2

### DIFF
--- a/Casks/snapndrag.rb
+++ b/Casks/snapndrag.rb
@@ -1,6 +1,6 @@
 cask 'snapndrag' do
-  version '4.3.1'
-  sha256 'e643cd47fbc3ffbe2ef98f22987ad0e8588d090e017717164a7e14fec9a838da'
+  version '4.3.2'
+  sha256 'af579ee0d779416923df403c35da15df4a7720a70a3599fa5c677a5971833a62'
 
   url "https://yellowmug.com/download/SnapNDrag_#{version}.dmg"
   appcast 'https://yellowmug.com/snapndrag/appcast-1014.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.