### PR TITLE
Update mountain-duck from 3.2.1.15003 to 3.2.3.15107

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,6 +1,6 @@
 cask 'mountain-duck' do
-  version '3.2.1.15003'
-  sha256 '00abf2d58f15d579018744ca48df4c1f19345cdf146debbd6b86a1e48b46f8d7'
+  version '3.2.3.15107'
+  sha256 '502b196c36488c251c3242ce4dc96821f4cb92f3fad42c361bac5030a975914f'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast "https://version.mountainduck.io/#{version.major}/macos/changelog.rss"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.