### PR TITLE
Update altair-graphql-client from 2.3.6 to 2.3.7

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.3.6'
-  sha256 '99fde6e3e7a45a3e9c5d942af57443bbb53d4eae9733d7142acd6c3b2d4962fa'
+  version '2.3.7'
+  sha256 '1a84a8abe305f87dcc8919fb5e01a6a1b3f0ffb35e840056b172a0e2b99dac20'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair_#{version}_mac.zip"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.