### PR TITLE
Update snagit from 2020 to 2020.0.1

### DIFF
--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -1,5 +1,5 @@
 cask 'snagit' do
-  version '2020'
+  version '2020.0.1'
   sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://download.techsmith.com/snagitmac/releases/Snagit.dmg'

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -8,5 +8,5 @@ cask 'snagit' do
 
   depends_on macos: '>= :sierra'
 
-  app "Snagit 2020.app"
+  app 'Snagit 2020.app'
 end

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -8,5 +8,5 @@ cask 'snagit' do
 
   depends_on macos: '>= :sierra'
 
-  app 'Snagit 2020.app'
+  app "Snagit #(version.major}.app"
 end

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -8,5 +8,5 @@ cask 'snagit' do
 
   depends_on macos: '>= :sierra'
 
-  app "Snagit #{version}.app"
+  app "Snagit 2020.app"
 end

--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -8,5 +8,5 @@ cask 'snagit' do
 
   depends_on macos: '>= :sierra'
 
-  app "Snagit #(version.major}.app"
+  app "Snagit #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.