### PR TITLE
Update imazing from 2.10.3,11461:1569604829 to 2.10.4,11513:1572452886

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.10.3,11461:1569604829'
-  sha256 'dd4e9bf6542c129967f01198a47de55d7d1be566c32c8e43a775f8329a491cfe'
+  version '2.10.4,11513:1572452886'
+  sha256 '1fc27b8758b536eff1cdb0b7d949d42bd0f84e818b79cc979987ebab86f89995'
 
   # dl.devmate.com/com.DigiDNA.iMazing2Mac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.DigiDNA.iMazing2Mac/#{version.after_comma.before_colon}/#{version.after_colon}/iMazing#{version.major}forMac-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.