### PR TITLE
Update cisdem-document-reader from 4.3.0 to 4.4.0

### DIFF
--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-document-reader' do
-  version '4.3.0'
-  sha256 '705b5828d38525ac41433606a8d63f67311e0c6c583ae581af401c97f8d30884'
+  version '4.4.0'
+  sha256 'dc3207fe688bb3f07ba806ddf0ffe5743ac51ff135cf08cc09b50de58aaa00b1'
 
   url 'http://download.cisdem.com/cisdem-documentreader.dmg'
   appcast 'https://www.cisdem.com/document-reader-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.