### PR TITLE
Update bisq from 1.1.7 to 1.2.1

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '1.1.7'
-  sha256 'ef92e10897b0a4dfd83d2b24c4b18376a2341069f24d73b72db4bcc7ce197576'
+  version '1.2.1'
+  sha256 'ca31d9fa10ce7977ee6aa7f9d10ddd1b6fa05e908862fbc1d201865b12ddff22'
 
   # github.com/bisq-network/bisq was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.