### PR TITLE
Update alt-tab from 1.11.0 to 1.11.3

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.11.0'
-  sha256 '8bc397a461193d0006077c58ee5b4b7b0fbd434a1f660e429c7a0daed16f7a2f'
+  version '1.11.3'
+  sha256 'f9968b4b0ba63879b8135d5c23d1a509ffe6edf2ffdc7da1a9724d1a8702dd5f'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.