### PR TITLE
Update simpholders from 3.0.9,2275 to 3.0.10,2277

### DIFF
--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -1,6 +1,6 @@
 cask 'simpholders' do
-  version '3.0.9,2275'
-  sha256 'd7a59876543eb47d4678b3c0f6d1c0647373b4a7b8d4f52d02430f40ef524fe7'
+  version '3.0.10,2277'
+  sha256 'edcfb7b1c78873755487640615960980f2c13ae56a565f67c55d30ad1657f134'
 
   url "https://simpholders.com/site/assets/files/#{version.after_comma}/simpholders_#{version.before_comma.dots_to_underscores}.dmg"
   appcast 'https://simpholders.com/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.