### PR TITLE
Update kext-updater from 3.1.8 to 3.1.9

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,6 +1,6 @@
 cask 'kext-updater' do
-  version '3.1.8'
-  sha256 'b79bc7847b30e06326be6f3f3658b1ebf85d5f0e75513504bc6827faae370a1d'
+  version '3.1.9'
+  sha256 'c8f21ddc5bd2887cfc10cf37f744dc8298126eea6089a002bdfeeba7d976dc07'
 
   url 'https://update.kextupdater.de/kextupdater/Kext%20Updater.zip'
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.