### PR TITLE
Update multitouch from 1.16 to 1.1.6.2

### DIFF
--- a/Casks/multitouch.rb
+++ b/Casks/multitouch.rb
@@ -1,6 +1,6 @@
 cask 'multitouch' do
-  version '1.16'
-  sha256 '3f8502f09e79215958f7523f40e9c9f6e13eade1f0090501de07cda62151e620'
+  version '1.1.6.2'
+  sha256 'ab1e88af2850fb242d231d63425e592319df4768e4068978004004d7521c975c'
 
   url "https://multitouch.app/downloads/multitouch#{version}.dmg"
   appcast 'https://www.multitouch.app/downloads/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.