### PR TITLE
Update liteide from 36.1 to 36.2

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,9 +1,9 @@
 cask 'liteide' do
-  version '36.1'
-  sha256 'f9094b6f0732cd2b99f3f3501555e46249b3420703ef82b02150a34f5df6d023'
+  version '36.2'
+  sha256 '9c23c2a4f75f04689aa19189aced081e36148efb7ae3fb1ec9d863198528e012'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
-  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.9.5.zip"
+  url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.12.5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom'
   name 'LiteIDE'
   homepage 'http://liteide.org/'

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -8,5 +8,5 @@ cask 'liteide' do
   name 'LiteIDE'
   homepage 'http://liteide.org/'
 
-  app 'LiteIDE.app'
+  app 'liteide/LiteIDE.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.