### PR TITLE
Update preform from 3.1.2,1502 to 3.2.0,1539

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.1.2,1502'
-  sha256 '8b2bc4de8daee8446a1cc4d5e94c56e8190b08d10742f10cdd07d5829eda9894'
+  version '3.2.0,1539'
+  sha256 '0c4a362fbf15d3bba0231dd4f9f3daacb82d3618c9b66a1d73a11f5f18beaf30'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.