### PR TITLE
Update mendeley-reference-manager from 2.14.0 to 2.15.0

### DIFF
--- a/Casks/mendeley-reference-manager.rb
+++ b/Casks/mendeley-reference-manager.rb
@@ -1,6 +1,6 @@
 cask 'mendeley-reference-manager' do
-  version '2.14.0'
-  sha256 '45f80eb0b3046e04407023c1f64b001d7ea60e46b4971437767d13d60a204500'
+  version '2.15.0'
+  sha256 '004fc765bc9539170e7f14fdce386593bc2caa3742de51577b775c6d2ed81025'
 
   url "https://static.mendeley.com/bin/desktop/mendeley-reference-manager-#{version}.dmg"
   appcast 'https://static.mendeley.com/bin/desktop/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.