### PR TITLE
Update atlantis from 0.9.9.6 to 0.9.9.7

### DIFF
--- a/Casks/atlantis.rb
+++ b/Casks/atlantis.rb
@@ -1,6 +1,6 @@
 cask 'atlantis' do
-  version '0.9.9.6'
-  sha256 'c3e38e71061426b5b112487e1274b36110fe6e4723069101112f237e75e09131'
+  version '0.9.9.7'
+  sha256 '64a5066991c50c32426e539d10b4bc89db5af435bd86fedf7938d4a19907fe76'
 
   url "https://www.riverdark.net/atlantis/downloads/Atlantis-#{version}.zip"
   appcast 'https://www.riverdark.net/atlantis/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.