### PR TITLE
Update vivaldi from 2.8.1664.44 to 2.9.1705.31

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.8.1664.44'
-  sha256 'e27080800d4844c97c4fe3707766e1b9c2a1f0a8e2dcecf1c5221d2142228124'
+  version '2.9.1705.31'
+  sha256 'd33adf4a5ca2f4c7b46074500b62a76e92d8ce7e15fb86215f6bac19230e67f5'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.