### PR TITLE
Update slack from 4.1.0 to 4.1.2

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -1,6 +1,6 @@
 cask 'slack' do
-  version '4.1.0'
-  sha256 'b9c563bbd6db83d15c49e2566d1887af11a8a54260a2d55df75c5c1c4a3eb757'
+  version '4.1.2'
+  sha256 '49586996f04c36bcb945ed95e53456e04d64ccd263070dd7508e3aa53f1cd74d'
 
   # downloads.slack-edge.com was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/mac_releases/Slack-#{version}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.