### PR TITLE
Bump Gimp.app to 2.10.14

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -1,6 +1,6 @@
 cask 'gimp' do
-  version '2.10.12'
-  sha256 '8b964ad3dbbe31d0fa48fb834aa4c17fc0eb81becbc4595a57b04e3d4fc6efeb'
+  version '2.10.14'
+  sha256 '60631e39a1042c38cc281bc3213a76be109fb909b9671fb03c55cf5cf31ea632'
 
   url "https://download.gimp.org/pub/gimp/v#{version.major_minor}/osx/gimp-#{version}-x86_64.dmg"
   appcast 'https://download.gimp.org/pub/gimp/stable/osx/'


### PR DESCRIPTION
Add Catalina support as well as features, patches, and bugfixes:

```
Basic out-of-canvas pixels viewing and editing
Optional editing of layers with disabled visibility
Foreground Select tool: new Grayscale Preview Mode
Newly added Normal Map filter
27 old filters ported to use GEGL buffers
HEIF, TIFF, and PDF support improvements
Better loading of corrupted XCF files
Grayscale workflows order of magnitude faster
macOS Catalina compatibility
45 bugfixes, 22 translation updates
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).