### PR TITLE
Update google-chrome from 78.0.3904.70 to 78.0.3904.87

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,6 +1,6 @@
 cask 'google-chrome' do
-  version '78.0.3904.70'
-  sha256 '7388736a55e921535b6754a9a5cb0e50ec816dd83a06caf56cfb54e7998ab4a7'
+  version '78.0.3904.87'
+  sha256 '82c1a6f9e83935f1d371319cd320bc381a5332ee1496187ac9720d923c86f4c8'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
   appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.