### PR TITLE
Upgrade Scribus to 1.5.5 devel branch for Catalina (fixed)

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,10 +1,20 @@
 cask 'scribus' do
-  version '1.4.8'
-  sha256 '9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5'
+  if MacOS.version <= :mojave
+    version '1.4.8'
+    sha256 '9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5'
 
-  # sourceforge.net/scribus was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
-  appcast 'https://www.scribus.net/downloads/stable-branch/'
+    # sourceforge.net/scribus was verified as official when first introduced to the cask
+    url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
+    appcast 'https://www.scribus.net/downloads/stable-branch/'
+  else
+    version '1.5.5'
+    sha256 '42426b1bf21a1eafc5e5c442e81ca77cec65b83751c8fdcd4f9b258c47063f3b'
+
+    # sourceforge.net/scribus-devel was verified as official when first introduced to the cask
+    url "https://downloads.sourceforge.net/scribus/scribus-devel/#{version}/scribus-#{version}.dmg"
+    appcast 'https://www.scribus.net/downloads/unstable-branch/'
+  end
+
   name 'Scribus'
   homepage 'https://www.scribus.net/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
