### PR TITLE
Update qt3dstudio from 2.4.0 to 2.5.0

### DIFF
--- a/Casks/qt3dstudio.rb
+++ b/Casks/qt3dstudio.rb
@@ -1,6 +1,6 @@
 cask 'qt3dstudio' do
-  version '2.4.0'
-  sha256 '5f5fdf827564ea45209c755a232642b63a24ce459d7c06714aa6edf49604d977'
+  version '2.5.0'
+  sha256 '904c6c092ad3ed588bbe47e55f949facf5250abacc6167dc48ac47fc4ee80b22'
 
   url "https://download.qt.io/official_releases/qt3dstudio/#{version.major_minor}/qt-3dstudio-opensource-mac-x64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qt3dstudio/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.