### PR TITLE
Update melodics from 2.1.3628 to 2.1.3679

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3628'
-  sha256 'a80d8583b9e04560a8b3c4cab4c43f6dc3c47330fe085a14920cac8e8eab27b7'
+  version '2.1.3679'
+  sha256 '06efdfe7cdd400d1dc44ba6ab8f7409550b74f5e53bc03adf627b28bb582a738'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.