### PR TITLE
Update haskell-for-mac from 1.6.1,1482.1545510880 to 1.7.0,1525.1572470003

### DIFF
--- a/Casks/haskell-for-mac.rb
+++ b/Casks/haskell-for-mac.rb
@@ -1,6 +1,6 @@
 cask 'haskell-for-mac' do
-  version '1.6.1,1482.1545510880'
-  sha256 'be546ebae7df2492b7c8a203916ff74c92367b24d4ec00f75d89134b8f71e14f'
+  version '1.7.0,1525.1572470003'
+  sha256 'a8298a709d9fd9da700a4228377a2533cdbd8a4e7406ca84772b5e064649d72d'
 
   # dl.devmate.com/com.haskellformac.Haskell.basic was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.haskellformac.Haskell.basic/#{version.after_comma.major}/#{version.after_comma.minor}/Haskell%E2%80%94FunctionalProgrammingLab-#{version.after_comma.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.