### PR TITLE
Update couleurs from 1.2 to 1.2.1

### DIFF
--- a/Casks/couleurs.rb
+++ b/Casks/couleurs.rb
@@ -1,6 +1,6 @@
 cask 'couleurs' do
-  version '1.2'
-  sha256 '59d725b0bbe7f7f2744b8b372006f0ec26c9b2300ea76139bed49ce8bb5824b2'
+  version '1.2.1'
+  sha256 '32d1b1898e9791c8137edc746c9f7ef508a12194669aae567719f58be2c8a876'
 
   url "https://couleursapp.com/couleurs-#{version}.zip"
   appcast 'https://couleursapp.com/updates/releases.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.