### PR TITLE
Update protonmail-bridge from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/protonmail-bridge.rb
+++ b/Casks/protonmail-bridge.rb
@@ -1,6 +1,6 @@
 cask 'protonmail-bridge' do
-  version '1.2.2'
-  sha256 '99de8fa3edb4a82347bb5220d6a912b09b298122b5395753cdf47f9061e8bd17'
+  version '1.2.3'
+  sha256 '81a7d219b74ddd89d14604174bbc7aad1f767975b6cf783efe642eda8acd295d'
 
   url 'https://protonmail.com/download/Bridge-Installer.dmg'
   appcast 'https://protonmail.com/download/current_version_darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.