### PR TITLE
Update stereo-tool from 9.35 to 9.37

### DIFF
--- a/Casks/stereo-tool.rb
+++ b/Casks/stereo-tool.rb
@@ -1,6 +1,6 @@
 cask 'stereo-tool' do
-  version '9.35'
-  sha256 'db3e369592f07206d6a28903434787a03fd3195c36ccd2a14c38ed8d2d3396ff'
+  version '9.37'
+  sha256 '3dca564359eb7626086f96d62c3b706c4db78205f6b0e3080b2de7bcb6c62db5'
 
   url 'https://www.stereotool.com/download/ThimeoStereoTool-Installer.dmg'
   appcast 'https://www.stereotool.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.