### PR TITLE
Update resolume-arena from 7.0.3,66005 to 7.0.4,66626

### DIFF
--- a/Casks/resolume-arena.rb
+++ b/Casks/resolume-arena.rb
@@ -1,6 +1,6 @@
 cask 'resolume-arena' do
-  version '7.0.3,66005'
-  sha256 '548a92e6f5e55fea1b16efc84a28e296c0c92a72a12243c134a3afd89951977f'
+  version '7.0.4,66626'
+  sha256 '55a693c3e71acd40dc39e41d8c6588285f838d30fd17dabe4b0b14c509bdfaab'
 
   url "https://resolume.com/download/Resolume_Arena_#{version.major_minor_patch.dots_to_underscores}_rev_#{version.after_comma}_Installer.dmg"
   appcast 'https://resolume.com/download/'
@@ -9,7 +9,11 @@ cask 'resolume-arena' do
 
   pkg 'Resolume Arena Installer.pkg'
 
-  uninstall pkgutil:   'com.resolume.pkg.ResolumeArena.*',
+  uninstall pkgutil:   [
+                         'com.resolume.pkg.ResolumeArena.*',
+                         'com.resolume.pkg.ResolumeDXV',
+                         'com.resolume.pkg.ResolumeQuickLook',
+                       ],
             delete:    "/Applications/Resolume Arena #{version.major}",
             signal:    ['TERM', 'com.resolume.arena'],
             launchctl: 'com.resolume.arena'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.