### PR TITLE
Update 1password-cli to - 0.7.1  (build #70101)

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask '1password-cli' do
-  version '0.7.0'
-  sha256 '39d5a52b6da02dd889c57214e8a3fae9d0ec885c52dffe79de1c08b2338bd103'
+  version '0.7.1'
+  sha256 '4708c3cc7f1ff1381be246cd47d798565087eaaeca7b042764fc7ca0a2f5901c'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"


### PR DESCRIPTION
0.7.1  (build #70101) – released 2019-10-29 - https://app-updates.agilebits.com/product_history/CLI

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

