### PR TITLE
Update intel-haxm from 7.5.2 to 7.5.4

### DIFF
--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -1,6 +1,6 @@
 cask 'intel-haxm' do
-  version '7.5.2'
-  sha256 '20914a1dfac8f4ca7a6a9bf77998f7aa4075384fa88c883e3eb6666661821b81'
+  version '7.5.4'
+  sha256 'e5d2e07274e512ad2e6a17bb57476a122d336c741d1baf6b1c0e51929e787515'
 
   # github.com/intel/haxm was verified as official when first introduced to the cask
   url "https://github.com/intel/haxm/releases/download/v#{version}/haxm-macosx_v#{version.dots_to_underscores}.zip"

--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -15,13 +15,13 @@ cask 'intel-haxm' do
                       sudo:       true,
                     }
 
-  uninstall pkg:    'com.intel.kext.haxm.*',
-            script: {
-                      sudo:         true,
-                      must_succeed: true,
-                      executable:   'silent_install.sh',
-                      args:         ['-u'],
-                    }
+  uninstall pkgutil: 'com.intel.kext.haxm.*',
+            script:  {
+                       sudo:         true,
+                       must_succeed: true,
+                       executable:   'silent_install.sh',
+                       args:         ['-u'],
+                     }
 
   caveats do
     license 'https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager-end-user-license-agreement-macosx'

--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -15,7 +15,8 @@ cask 'intel-haxm' do
                       sudo:       true,
                     }
 
-  uninstall script: {
+  uninstall pkg:    'com.intel.kext.haxm.*',
+            script: {
                       sudo:         true,
                       must_succeed: true,
                       executable:   'silent_install.sh',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.