### PR TITLE
Update path-finder from 8.6 to 9.0

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,5 +1,5 @@
 cask 'path-finder' do
-  version '8.6'
+  version '9.0'
   sha256 'b64666967c550b61d804a198cd9acf379a72cc4897559aec5db541cc9412e1f3'
 
   url 'https://get.cocoatech.com/PF8.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.