### PR TITLE
Upgrade Standard ML of New Jersey to v110.94

### DIFF
--- a/Casks/smlnj.rb
+++ b/Casks/smlnj.rb
@@ -1,15 +1,15 @@
 cask 'smlnj' do
-  version '110.91'
-  sha256 '8476fe570b13f722b9b81182590144ccb770495a5534fa77600a7c592028568a'
+  version '110.94'
+  sha256 '8af582d4fc2e1bb425dd4925696d3c56b687baeb50ffc16362a1a46fa495f27b'
 
   # smlnj.cs.uchicago.edu was verified as official when first introduced to the cask
-  url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-x86-#{version}.pkg"
+  url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-amd64-#{version}.pkg"
   name 'Standard ML of New Jersey'
   homepage 'https://www.smlnj.org/'
 
-  pkg "smlnj-x86-#{version}.pkg"
+  pkg "smlnj-amd64-#{version}.pkg"
 
-  uninstall pkgutil: 'org.smlnj.x86.pkg'
+  uninstall pkgutil: 'org.smlnj.amd64.pkg'
 
   caveats do
     path_environment_variable '/usr/local/smlnj/bin'


### PR DESCRIPTION
With Catalina and 64-bit release of smlnj, we switch to amd64 version of
the package.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
