### PR TITLE
Update capture-one from 12.1.3 to 12.1.4

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,8 +1,8 @@
 cask 'capture-one' do
-  version '12.1.3'
-  sha256 '120174eeef6fcdc90d8d1cccdcd7b03203febb622b4743c3b5776e5698eb4333'
+  version '12.1.4'
+  sha256 '8bcd5e25336e2766fa11a12dc499393e223f8f17ae3c7f6db413cc89c047265d'
 
-  url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne.Mac.#{version}.dmg"
+  url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne12.Mac.#{version}.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version}"
   name 'Capture One'
   homepage 'https://www.phaseone.com/en/Capture-One.aspx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.