### PR TITLE
Update sound-siphon from 3.1.3 to 3.2.1,5876

### DIFF
--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -3,7 +3,7 @@ cask 'sound-siphon' do
   sha256 'a3e28bdb4e848b43a84834ad1c07db3ddfc6c4970cd1624f7fa6133531971619'
 
   # staticz.net was verified as official when first introduced to the cask
-  url "http://staticz.com/download/#{version.after_comma}/"
+  url "https://staticz.com/download/#{version.after_comma}/"
   appcast "http://staticz.net/updates/soundsiphon#{version.major}.rss"
   name 'SoundSiphon'
   homepage 'https://staticz.com/soundsiphon/'

--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -1,9 +1,9 @@
 cask 'sound-siphon' do
-  version '3.1.3'
-  sha256 'ca0630f918cf98b5cf8e648d88ca73a8e042bba1f8140cf3a0593f577879f38a'
+  version '3.2.1,5876'
+  sha256 'a3e28bdb4e848b43a84834ad1c07db3ddfc6c4970cd1624f7fa6133531971619'
 
   # staticz.net was verified as official when first introduced to the cask
-  url "http://staticz.net/downloads/SoundSiphon_#{version}.dmg"
+  url "http://staticz.com/download/#{version.after_comma}/"
   appcast "http://staticz.net/updates/soundsiphon#{version.major}.rss"
   name 'SoundSiphon'
   homepage 'https://staticz.com/soundsiphon/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.