### PR TITLE
Update stoplight-studio from 1.3.0 to 1.4.0

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,9 +1,9 @@
 cask 'stoplight-studio' do
-  version '1.3.0'
-  sha256 '09e31311112c397dad26ad2045cfca8d9350b0c2a11ab8355e9520a6aaf69bc7'
+  version '1.4.0'
+  sha256 '2121f4f71930ae97b9a49d73cf53f6e6db3afa129d8f7408cc800a44b10693f7'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
-  url "https://github.com/stoplightio/studio/releases/download/v#{version}/Stoplight-Studio-#{version}.dmg"
+  url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"
   appcast 'https://github.com/stoplightio/studio/releases.atom'
   name 'Stoplight Studio'
   homepage 'https://stoplight.io/studio/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.