### PR TITLE
Update gns3 from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.2.0'
-  sha256 '97d24a2a54cfc8548f5d70343734a7f8818899bb59853706cc1d930aa971d3bc'
+  version '2.2.1'
+  sha256 '428adf9b8134e7de5a096cbb755e5fc5fef35acbb52f62a452402c58e11ad9c5'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.