### PR TITLE
Update fontbase from 2.10.2 to 2.10.3

### DIFF
--- a/Casks/fontbase.rb
+++ b/Casks/fontbase.rb
@@ -1,6 +1,6 @@
 cask 'fontbase' do
-  version '2.10.2'
-  sha256 '3829985f2ee91d2eb420f2fe0ea088c9ef6eaaf1895b0a490198fde78a49b6bd'
+  version '2.10.3'
+  sha256 'afb1fc07643747ed156bf5afc276055c70785a8655bb8bcdb0eda94abd95516d'
 
   url "https://releases.fontba.se/mac/FontBase-#{version}.dmg"
   appcast 'https://releases.fontba.se/mac/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.