### PR TITLE
Update veracrypt from 1.24 to 1.24,hotfix1

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,9 +1,9 @@
 cask 'veracrypt' do
-  version '1.24'
+  version '1.24,hotfix1'
   sha256 '5515766ebac14dcc3e397f0afd24f31f998a4a3c69571ea40b990772fede679c'
 
   # launchpad.net/veracrypt/trunk was verified as official when first introduced to the cask
-  url "https://launchpad.net/veracrypt/trunk/#{version}-hotfix1/+download/VeraCrypt_#{version}-Hotfix1.dmg"
+  url "https://launchpad.net/veracrypt/trunk/#{version.before_comma}-hotfix1/+download/VeraCrypt_#{version.before_comma}-Hotfix1.dmg"
   appcast 'https://github.com/veracrypt/VeraCrypt/releases.atom'
   name 'VeraCrypt'
   homepage 'https://www.veracrypt.fr/'

--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,9 +1,9 @@
 cask 'veracrypt' do
-  version '1.24,hotfix1'
+  version '1.24-Hotfix1'
   sha256 '5515766ebac14dcc3e397f0afd24f31f998a4a3c69571ea40b990772fede679c'
 
   # launchpad.net/veracrypt/trunk was verified as official when first introduced to the cask
-  url "https://launchpad.net/veracrypt/trunk/#{version.before_comma}-hotfix1/+download/VeraCrypt_#{version.before_comma}-Hotfix1.dmg"
+  url "https://launchpad.net/veracrypt/trunk/#{version.major_minor}-hotfix1/+download/VeraCrypt_#{version}.dmg"
   appcast 'https://github.com/veracrypt/VeraCrypt/releases.atom'
   name 'VeraCrypt'
   homepage 'https://www.veracrypt.fr/'

--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -3,7 +3,7 @@ cask 'veracrypt' do
   sha256 '5515766ebac14dcc3e397f0afd24f31f998a4a3c69571ea40b990772fede679c'
 
   # launchpad.net/veracrypt/trunk was verified as official when first introduced to the cask
-  url "https://launchpad.net/veracrypt/trunk/#{version.major_minor}-hotfix1/+download/VeraCrypt_#{version}.dmg"
+  url "https://launchpad.net/veracrypt/trunk/#{version.downcase}/+download/VeraCrypt_#{version}.dmg"
   appcast 'https://github.com/veracrypt/VeraCrypt/releases.atom'
   name 'VeraCrypt'
   homepage 'https://www.veracrypt.fr/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.