### PR TITLE
Update electron from 7.0.0 to 7.0.1

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '7.0.0'
-  sha256 '2c21408071b8b25ef602a9687c763bb0785c9d17fac476ecff413bc7f23c5b95'
+  version '7.0.1'
+  sha256 '16a2855b0a281117af153a46aa390caae2da1cda3d6197bff82b31425796b72e'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.