### PR TITLE
Update Launchpad Manager Versioning

### DIFF
--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,6 +1,6 @@
 cask 'launchpad-manager' do
-  version '1.3.11'
-  sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'
+  version :latest
+  sha256 :no_check
 
   url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
   name 'Launchpad Manager'

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,16 +1,8 @@
 cask 'launchpad-manager' do
-  if MacOS.version <= :mavericks
-    version '1.3.11'
-    sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'
+  version '1.3.11'
+  sha256 'f686a9a332663a003e9fabd32a1d44fc98debda15225368f1e8aef181955bc72'
 
-    url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
-  else
-    version '1.0.10'
-    sha256 '88b37120c0ae022309573c4d2587a6ec85df7895773bca0fd3b5ba6cd86461a6'
-
-    url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
-  end
-
+  url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'
 


### PR DESCRIPTION
When macOS Yosemite was released, Launchpad Manager released a new version `1.0.10` at a special url for Yosemite users: http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg. It was the latest version available at the time, so logic was added to the Cask to ensure that any macOS version newer than Mavericks used the Yosemite-specific download link to get `1.0.10`, and any older macOS versions used the existing download link to get the existing, older version at http://launchpadmanager.com/download.php/LaunchpadManager.dmg.

Now that new versions of both macOS and Launchpad Manager have been released, the macOS specific versions are no longer necessary and the outdated logic causes users on macOS Catalina (or anything past Mavericks) to download the (now older) Yosemite version `1.0.10` instead of the latest `1.3.11` that's now available. I've removed this logic so now Catalina users (or really, anyone past Mavericks) will retrieve the correct version rather than the Yosemite-specific outdated version.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
