### PR TITLE
Update diskcatalogmaker from 7.5.7 to 7.5.8

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.5.7'
-  sha256 '347ddba77d0f91ac8993ddd47daab60df942c90d2ad0d7861ae12ed16a3b21c9'
+  version '7.5.8'
+  sha256 '05550dc9cb750207ce2939c504ffa945fe397c963f2bb924ecf97b6e68093965'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.