### PR TITLE
Revert "Update ultimate from 3.0.11.1025 to 3.0.11.1028"

### DIFF
--- a/Casks/ultimate.rb
+++ b/Casks/ultimate.rb
@@ -1,5 +1,5 @@
 cask 'ultimate' do
-  version '3.0.11.1028'
+  version '3.0.11.1025'
   sha256 'cffb891540b4b338a1ac32e15a16eb3f44129983657f45bb0872105bd6029700'
 
   url 'https://download.epubor.com/epubor_ultimate.zip'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#71836
the SHA didn't change and the app contains still v 3.0.11.1025