### PR TITLE
Update unity-windows-support-for-editor from 2019.2.10f1,923acd2d43aa to 2019.2.11f1,5f859a4cfee5

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.10f1,923acd2d43aa'
-  sha256 '3b6a0a5dbdfb98aa4368d68be4d3317e2c6457247d5ced227f1c581983caca28'
+  version '2019.2.11f1,5f859a4cfee5'
+  sha256 '150fc5b49719ea3ba04ad194a1dcc293821fabe505b767a5c960a94fec3c0ed7'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.