### PR TITLE
Update shadowsocksx-ng from 1.9.2 to 1.9.3

### DIFF
--- a/Casks/shadowsocksx-ng.rb
+++ b/Casks/shadowsocksx-ng.rb
@@ -1,8 +1,8 @@
 cask 'shadowsocksx-ng' do
-  version '1.9.2'
-  sha256 'e0cbd1a6f4b70c45d716cc218d8e4125773b32ab31244a940d9144bd40b82b7e'
+  version '1.9.3'
+  sha256 '6c9d99daa154b66ee06091bcbe88173c09e4babae21627f6557a22f51e2b11ee'
 
-  url "https://github.com/shadowsocks/ShadowsocksX-NG/releases/download/v#{version}/ShadowsocksX-NG.app.#{version}.zip"
+  url "https://github.com/shadowsocks/ShadowsocksX-NG/releases/download/v#{version}/ShadowsocksX-NG.#{version}.zip"
   appcast 'https://github.com/shadowsocks/ShadowsocksX-NG/releases.atom'
   name 'ShadowsocksX-NG'
   homepage 'https://github.com/shadowsocks/ShadowsocksX-NG/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.