### PR TITLE
Update dosbox-x from 0.82.22,20190930195458 to 0.82.23,20191031192846

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.22,20190930195458'
-  sha256 '96f90ba7b5bad6f9633b22e1dc94c5daeb2b0cf7acb9258f512bf67ee43cc842'
+  version '0.82.23,20191031192846'
+  sha256 '545a0e7091573e0992b997a33e8b748b778858678fa6107f6ecd3225a3ecd4a1'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.