### PR TITLE
Update trilium-notes from 0.35.2 to 0.36.2

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.35.2'
-  sha256 'eea17a5013ab3cdc01b63c7ea4452826d4f174a66a1f03c118d140fce615a5be'
+  version '0.36.2'
+  sha256 '645e1f07c69cc81a2b4a067d7e0425fcfe8203c43b63872700ccf640078af30b'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.