### PR TITLE
Update qownnotes from 19.11.0,b4712-161224 to 19.11.2,b4723-114722

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.0,b4712-161224'
-  sha256 '9b67ae695687c3d8038d9760f8f246fc2c71e6dfc93a2159f2a7d06607c38e50'
+  version '19.11.2,b4723-114722'
+  sha256 'f13ba256382d61f75a5a697e6cd4c2d48be0975386cd30c9b454aaa413583956'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.