### PR TITLE
Update material-colors from 2.0.0 to 2.0.1

### DIFF
--- a/Casks/material-colors.rb
+++ b/Casks/material-colors.rb
@@ -1,6 +1,6 @@
 cask 'material-colors' do
-  version '2.0.0'
-  sha256 'a764f8af33499a96d46e3e79fe2e4594eb0ccff6217cff0920d9b44982a0f8be'
+  version '2.0.1'
+  sha256 'fbe1791d7193ad9f7d235b8daf4304fa391b7543bb6591b393519211499aebfa'
 
   url "https://github.com/romannurik/MaterialColorsApp/releases/download/v#{version}/MaterialColors-#{version}.zip"
   appcast 'https://github.com/romannurik/MaterialColorsApp/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.