### PR TITLE
Update kite from 0.20191029.0 to 0.20191031.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191029.0'
-  sha256 'd504510207d3a0cc885142ebf415e54db991ff6de194547c97fafd14eaabe214'
+  version '0.20191031.0'
+  sha256 '70e94c8000d648a8c3f66d38ec758a6f99fa97d35eeef9c8c13414000beea6b4'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.