### PR TITLE
Update zotero from 5.0.76 to 5.0.77

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.76'
-  sha256 '5cfeab499f7e127fd3dccc717e197b82f59e1265ae7dbf1afb551a6961ea5510'
+  version '5.0.77'
+  sha256 '7e1dc037baba1ddd876f84f3cf8f0256a16c45453c5ba6721175a4d45f43c623'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.