### PR TITLE
Update abstract from 85.1.1 to 86.0.0

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '85.1.1'
-  sha256 '491cfe75f87f28ca324ebff2405b3d74195b332aa2d4ee3c05bee923978a6351'
+  version '86.0.0'
+  sha256 '2fddc6e046d78df5257ce74556d6ec5ca4a2abe29eee556b72f77094a12ad83c'
 
   url "https://downloads.goabstract.com/Abstract-#{version}.dmg"
   appcast 'https://www.goabstract.com/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.