### PR TITLE
Update tinderbox from 8.1.0 to 8.1.1

### DIFF
--- a/Casks/tinderbox.rb
+++ b/Casks/tinderbox.rb
@@ -4,8 +4,8 @@ cask 'tinderbox' do
     sha256 '765a6245d25f9c2185802f36caa1f620f276637b884260fffa74bf639670e211'
     app 'TinderboxSix.app'
   else
-    version '8.1.0'
-    sha256 '8f77d8ead2f6b3c5e4b3f581cec90262e67c8a6558261704b8d13f2f4259c15f'
+    version '8.1.1'
+    sha256 '8048b496a55a4b54a6b42cd132d8998a98f6fbee7cb86906b0c903513eb40b8f'
     app "Tinderbox #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.