### PR TITLE
Update hazel from 4.4 to 4.4.1

### DIFF
--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -1,6 +1,6 @@
 cask 'hazel' do
-  version '4.4'
-  sha256 '7a47118a26b651874d9cf066dbc2d1109281d8fe516b6c9b3cb746165a7a782a'
+  version '4.4.1'
+  sha256 '0a6ba80403e0696013412bd80f308a8db5a31ec56416a834200a99c3d93f35d1'
 
   # s3.amazonaws.com/Noodlesoft was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Noodlesoft/Hazel-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.