### PR TITLE
Update frhelper from 3.9.1 to 3.9.2

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,6 +1,6 @@
 cask 'frhelper' do
-  version '3.9.1'
-  sha256 'cb6825c62657f4c8d229294d1239fedc804850d4a5832bd126c8745489b79591'
+  version '3.9.2'
+  sha256 '85c5bb80abdf63b5623ac6561b14e5ed7e439ec9848d36798e66988bf84c793a'
 
   # static.frdic.com was verified as official when first introduced to the cask
   url 'https://static.frdic.com/pkg/fhmac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.