### PR TITLE
Update netron from 3.4.8 to 3.4.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.4.8'
-  sha256 '229d20da3c8463d9372f1052c3063b111208e52af14a7f57ed63588de2e278cf'
+  version '3.4.9'
+  sha256 '43173e4a513697bf793829c0fe26a12be31a5b3679516b346ad95748c7785115'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.