### PR TITLE
Update path-finder from 9.0 to 9.0.1

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '9.0'
-  sha256 '334607bf8500158665e267cfcf3fcb4628f0407687884ffc6fdb32d86a436f82'
+  version '9.0.1'
+  sha256 'b53cb65f41423f7c79fa0e37fdd15926b15c600617c04ad4cfb1580ceca7d48b'
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.