### PR TITLE
Update ibackup-viewer from 4.1570 to 4.1580

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1570'
-  sha256 'cffacc4fb89dc07fb4b6f45f313fa37ee523dd374d934086b4cfc710fbe855cc'
+  version '4.1580'
+  sha256 'e7f4d272ef7c06e2d8f6a7dd8b47bbb72df36235271d24e54853cadf111d4f85'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.