### PR TITLE
Update c0re100-qbittorrent from 4.1.8.4 to 4.1.9.1

### DIFF
--- a/Casks/c0re100-qbittorrent.rb
+++ b/Casks/c0re100-qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'c0re100-qbittorrent' do
-  version '4.1.8.4'
-  sha256 '88fa763518729c6d3d897e14282df4054cd95a2ddce41d4cc7e7df242d94df91'
+  version '4.1.9.1'
+  sha256 '68256ef2c161cac7919d27c62a0d419609e16cae862713549e2aad75e596d169'
 
   url "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-#{version}/qBittorrent-#{version}.dmg"
   appcast 'https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
