### PR TITLE
Update pacifist from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/pacifist.rb
+++ b/Casks/pacifist.rb
@@ -1,6 +1,6 @@
 cask 'pacifist' do
-  version '3.6.1'
-  sha256 'a884c8c0d16ca159bf7f90064247d7c00f4ebbd54ac86028bb57c0cbf666cf2a'
+  version '3.6.2'
+  sha256 'e8bd4595462e2cb6f900705ef69fdc9f044aea1e2759e347c3e9667c757fd6af'
 
   url "https://www.charlessoft.com/pacifist_download/Pacifist_#{version}.dmg"
   appcast 'https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.