### PR TITLE
Update cisdem-pdfmanagerultimate from 2.5.0 to 3.2.0

### DIFF
--- a/Casks/cisdem-pdfmanagerultimate.rb
+++ b/Casks/cisdem-pdfmanagerultimate.rb
@@ -1,5 +1,5 @@
 cask 'cisdem-pdfmanagerultimate' do
-  version '2.5.0'
+  version '3.2.0'
   sha256 '572ed99e8ea18474a0dfe7fd42e0fe704e40607f12a979ada704054fc81d05de'
 
   url 'https://www.cisdem.com/download/cisdem-pdfmanagerultimate.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.