### PR TITLE
Update menumeters from 1.9.8 to 2.0.0

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,9 +1,9 @@
 cask 'menumeters' do
-  version '1.9.9'
-  sha256 'ee34d38ead45a13d77b81b7c949d6a157d671e4a385b46d207c4a4cac25dfba2'
+  version '2.0.0'
+  sha256 '6bbc68c215e70e686378d031aed7f3c35c98f68daf50a5ada53b0d7edf9158eb'
 
   # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
-  url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version.major_minor_patch}.zip"
+  url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version.major_minor_patch}.zip"
   appcast 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml'
   name 'MenuMeters for El Capitan (and later)'
   homepage 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'

--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,16 +1,25 @@
 cask 'menumeters' do
-  version '1.9.8'
-  sha256 '7e034975be0d7eac033f0d4fcaf8725d435280411358d50a9828ce62f8bc1cca'
+  version '1.9.9'
+  sha256 'ee34d38ead45a13d77b81b7c949d6a157d671e4a385b46d207c4a4cac25dfba2'
 
   # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
   url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version.major_minor_patch}.zip"
-  appcast 'https://github.com/yujitach/MenuMeters/releases.atom'
+  appcast 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml'
   name 'MenuMeters for El Capitan (and later)'
   homepage 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'
 
+  auto_updates true
   depends_on macos: '>= :el_capitan'
 
-  prefpane 'MenuMeters.prefPane'
+  app 'MenuMeters.app'
 
-  zap trash: '~/Library/Preferences/com.ragingmenace.MenuMeters.plist'
+  uninstall login_item: 'MenuMeters',
+            quit:       'com.yujitach.MenuMeters'
+
+  zap trash: [
+               '~/Library/Caches/com.yujitach.MenuMeters',
+               '~/Library/PreferencesPanes/MenuMeters.prefPane',
+               '~/Library/Preferences/com.ragingmenace.MenuMeters.plist',
+               '~/Library/Preferences/com.yujitach.MenuMeters.plist',
+             ]
 end

--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -2,7 +2,6 @@ cask 'menumeters' do
   version '2.0.0'
   sha256 '6bbc68c215e70e686378d031aed7f3c35c98f68daf50a5ada53b0d7edf9158eb'
 
-  # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
   url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version.major_minor_patch}.zip"
   appcast 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml'
   name 'MenuMeters for El Capitan (and later)'

--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -13,8 +13,7 @@ cask 'menumeters' do
 
   app 'MenuMeters.app'
 
-  uninstall login_item: 'MenuMeters',
-            quit:       'com.yujitach.MenuMeters'
+  uninstall quit: 'com.yujitach.MenuMeters'
 
   zap trash: [
                '~/Library/Caches/com.yujitach.MenuMeters',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
The developer updated from a Preference Pane to an App with Sparkle autoupdates.