### PR TITLE
Update airy from 3.11,242 to 3.11,245

### DIFF
--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -1,5 +1,5 @@
 cask 'airy' do
-  version '3.11,242'
+  version '3.11,245'
   sha256 '505327f3f4aac5f7949600549d76fab06c209c9e3365abaab97c419d5dc15173'
 
   url 'https://cdn.eltima.com/download/airy.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.