### PR TITLE
iina: Remove conflict with deleted cask iina-beta

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -8,10 +8,7 @@ cask 'iina' do
   homepage 'https://iina.io/'
 
   auto_updates true
-  conflicts_with cask: [
-                         'iina-beta',
-                         'iina-nightly',
-                       ]
+  conflicts_with cask: 'iina-nightly'
   depends_on macos: '>= :el_capitan'
 
   app 'IINA.app'


### PR DESCRIPTION
The cask `iina-beta` was removed in Homebrew/homebrew-cask-versions#8108. This PR removes the conflict with the removed cask from `iina`.