### PR TITLE
Update gisto from 1.12.12 to 1.12.13

### DIFF
--- a/Casks/biscuit.rb
+++ b/Casks/biscuit.rb
@@ -1,0 +1,17 @@
+cask 'biscuit' do
+  version '1.2.0'
+  sha256 '93b6c59ce972d8bb2ef2b23606171470013f1d01038963a026c4034820e19927'
+
+  # github.com/agata/dl.biscuit was verified as official when first introduced to the cask
+  url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}.dmg"
+  appcast 'https://github.com/agata/dl.biscuit/releases.atom'
+  name 'biscuit'
+  homepage 'https://eatbiscuit.com/'
+
+  app 'Biscuit.app'
+
+  zap trash: [
+               '~/Library/Application Support/Biscuit',
+               '~/Library/Preferences/com.eatbiscuit.biscuit.plist',
+             ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.