### PR TITLE
Update code-notes from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/code-notes.rb
+++ b/Casks/code-notes.rb
@@ -1,6 +1,6 @@
 cask 'code-notes' do
-  version '1.2.2'
-  sha256 'b76f29fe200028b4cd8ab9fd4031ec8599236c760ac023e942445fd05e721ef4'
+  version '1.2.3'
+  sha256 '54294a1ac2854cadac4d62e2bd52ea8e7dcdccba5917c314215abc816e9d661a'
 
   # github.com/lauthieb/code-notes was verified as official when first introduced to the cask
   url "https://github.com/lauthieb/code-notes/releases/download/#{version}/code-notes-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.