### PR TITLE
Update openemu 2.1 to 2.1.1

### DIFF
--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -7,7 +7,7 @@ cask 'openemu' do
     sha256 'c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790'
   else
     version '2.1.1'
-    sha256 'c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790'
+    sha256 '444b03c190399d91960fd64c95258714638669870db26d0681354999809927e4'
   end
 
   # github.com/OpenEmu/OpenEmu was verified as official when first introduced to the cask

--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -6,8 +6,8 @@ cask 'openemu' do
     version '2.0.9.1'
     sha256 'c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790'
   else
-    version '2.1'
-    sha256 'f9933541cdc19c9b75874548e223633d423716bdd2b42c93d4c91695fe1eac1e'
+    version '2.1.1'
+    sha256 'c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790'
   end
 
   # github.com/OpenEmu/OpenEmu was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.