### PR TITLE
Update pagico from 9.0.3050 to 9.0.3055

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '9.0.3050'
-  sha256 '32c63b76a95464b72bdbeb6dcdeb7c12a47d1bb00eba9f625a844827cd499916'
+  version '9.0.3055'
+  sha256 'c03f90e89921e8daab70cfcf58a8f6e7101b4de43a78e2013a609b8d6095c082'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast "https://www.pagico.com/api/pagico#{version.major}.mac.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.