### PR TITLE
Update photosweeper-x from 3.4.3 to 3.5.0

### DIFF
--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,6 +1,6 @@
 cask 'photosweeper-x' do
-  version '3.4.3'
-  sha256 '331acd6799fbd81ddcfba762a6826d87ad50e625d6b539f12c5948e790dd38a0'
+  version '3.5.0'
+  sha256 '219449a640233f67c1b111636c0a29018c5525d44929d19605b366c79e128e30'
 
   url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
   appcast 'https://overmacs.com/photosweeper/updates/photosweeper_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.