### PR TITLE
Update amazon-workspaces from 2.5.9 to 2.5.11

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,6 +1,6 @@
 cask 'amazon-workspaces' do
-  version '2.5.9'
-  sha256 '215c762adc7fcc35cb161604a74f25f0b7ac9e94f9c9727c4945349826b1bcfe'
+  version '2.5.11'
+  sha256 'd217cceaecb28cb8d2c4f99f2f84c0aa4696f91dfb779c2cacf0c51e1b93c6a1'
 
   # d2td7dqidlhjx7.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.