### PR TITLE
Update quicken from 5.12.5,512.29294.100 to 5.13.1,513.30543.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.12.5,512.29294.100'
-  sha256 '5ae66aaa2f835f36461250ed47267c984ee70cafd4b792e2fb5d2c7781d4fe98'
+  version '5.13.1,513.30543.100'
+  sha256 '544446cc50c5b5087124491efc66dff4124575d159af428db4d7de0ef4582eb0'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.