### PR TITLE
Update gpxsee from 7.15 to 7.17

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.15'
-  sha256 '0abbefd3ec8417f690dfdbd7797809c23c53b1813853a1d07837e44fffc41ad0'
+  version '7.17'
+  sha256 '6a269a5273bbcac6e79602b729c2199859c503ee20ddbf34fd7797c581393775'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.