### PR TITLE
Update josm from 15390 to 15492

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask 'josm' do
-  version '15390'
-  sha256 'f9ccfaf5f376d873aab28c8adfbcae317af58a18b78a011ace3d154c1849f56f'
+  version '15492'
+  sha256 '712014ce299166a55dd765d431f63c7b61c0e775df9d2c5d318223dd24b89896'
 
   url "https://josm.openstreetmap.de/download/macosx/josm-macosx-#{version}.zip"
   appcast 'https://josm.openstreetmap.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.