### PR TITLE
Update dissenter-browser from 0.69.135,5d3f93a29dd49a5b1d9fc27f:5da5f347bcf95235c499fb7c to 0.70.122,5d3f93a29dd49a5b1d9fc27f:5dbd49e3fa229c690746a809

### DIFF
--- a/Casks/dissenter-browser.rb
+++ b/Casks/dissenter-browser.rb
@@ -1,6 +1,6 @@
 cask 'dissenter-browser' do
-  version '0.69.135,5d3f93a29dd49a5b1d9fc27f:5da5f347bcf95235c499fb7c'
-  sha256 '854ffbd5c16e16836ec8bb210d157c38f4522c5cfc78c2f025f4db9433bac618'
+  version '0.70.122,5d3f93a29dd49a5b1d9fc27f:5dbd49e3fa229c690746a809'
+  sha256 '40e2d60a090eee0500debab488323d25b27c24e09c8d0353325678f3f5f59768'
 
   # apps.gab.com was verified as official when first introduced to the cask
   url "https://apps.gab.com/application/#{version.after_comma.before_colon}/resource/#{version.after_colon}/content"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.