### PR TITLE
Update understand from 5.1.1005 to 5.1.1006

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1005'
-  sha256 '51858a876799ff347bd6a92a3ff7332bd5f3c9bb17bbea8847173d753780a353'
+  version '5.1.1006'
+  sha256 'e2e9c022d3e094a7f7123d7ded5d1f630b1e3e2486440b3f99004412b30f7193'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/build-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.