### PR TITLE
Update provisionql from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -1,6 +1,6 @@
 cask 'provisionql' do
-  version '1.6.0'
-  sha256 'eb4646ca2f082f15755fb93b2b1ab70d62b439dd657917667a8a921c0fa437d2'
+  version '1.6.1'
+  sha256 '3b545d71bbf2afc50719204071ffb57bc5b782881ace153807bea060b5300b27'
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
   appcast 'https://github.com/ealeksandrov/ProvisionQL/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.