### PR TITLE
Update prudent from 55.0.2883.87,12 to 55.0.2883.87,14

### DIFF
--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -1,6 +1,6 @@
 cask 'prudent' do
-  version '55.0.2883.87,12'
-  sha256 'de9d5e55735010113e05e259a61f1aa5ca92112d76386131ac1bdd36907168f9'
+  version '55.0.2883.87,14'
+  sha256 '7d14c3427abd289b6fd09a9f30f27d3925a02ad831879e7568068144ce3a8c43'
 
   # github.com/PrudentMe/main was verified as official when first introduced to the cask
   url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.