### PR TITLE
Update browserosaurus from 7.0.0 to 8.0.1

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '7.0.0'
-  sha256 '31b40b5595c6cb9bdb15c9aee55fb666942d1f5b75e2127acbf56abe813bb825'
+  version '8.0.1'
+  sha256 '86dc12e7d5720077d1e9c4b41614550af7ce8fb8c81fb518954924d6536ff504'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.