### PR TITLE
Update drawbot from 3.121 to 3.122

### DIFF
--- a/Casks/drawbot.rb
+++ b/Casks/drawbot.rb
@@ -1,6 +1,6 @@
 cask 'drawbot' do
-  version '3.121'
-  sha256 '68b8327fcacf21db7d37374a389fe5609d87eac6e6df01993b0effffef95aa71'
+  version '3.122'
+  sha256 '9cdb142da6f4585384bf624ff06d29a184d84aa80987b060587f14eda7273582'
 
   # typemytype.com/drawBot was verified as official when first introduced to the cask
   url 'https://static.typemytype.com/drawBot/DrawBot.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.