### PR TITLE
Update osxfuse: Remove outdated conflict

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -9,7 +9,6 @@ cask 'osxfuse' do
   homepage 'https://osxfuse.github.io/'
 
   auto_updates true
-  conflicts_with cask: 'osxfuse-dev'
 
   pkg "Extras/FUSE for macOS #{version}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Remove conflict with deleted cask osxfuse-dev (Homebrew/homebrew-cask-versions#8122)