### PR TITLE
Update pock from 0.6.2 to 0.6.3

### DIFF
--- a/Casks/pock.rb
+++ b/Casks/pock.rb
@@ -1,6 +1,6 @@
 cask 'pock' do
-  version '0.6.2'
-  sha256 'bfc2ffd38860a9f3f5c05487a636894507def118572875d58e481f041429f9d7'
+  version '0.6.3'
+  sha256 '04aa9968c048ce45313b61688c3a083093d381221ff2a7cd833f9364339c943d'
 
   url "https://pock.dev/download.php?file=pock_#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/pigigaldi/Pock/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.