### PR TITLE
Update netron from 3.4.9 to 3.5.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.4.9'
-  sha256 '43173e4a513697bf793829c0fe26a12be31a5b3679516b346ad95748c7785115'
+  version '3.5.0'
+  sha256 '7b450b7d67151dc0e1f94a8bff351f9db04d623357b51d3af118902cfe4daa13'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.