### PR TITLE
Update qownnotes from 19.11.2,b4723-114722 to 19.11.3,b4732-173105

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.2,b4723-114722'
-  sha256 'f13ba256382d61f75a5a697e6cd4c2d48be0975386cd30c9b454aaa413583956'
+  version '19.11.3,b4732-173105'
+  sha256 'e1407fe5f133311634f9a25ab135a178bb5e216602af2c95ed7cd563e5ba5c11'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.