### PR TITLE
Update keeweb from 1.12.1 to 1.12.2

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.12.1'
-  sha256 'e63e8658bba517c0b01fcf3c435569467b79207c99fb50900841a626ce780eaa'
+  version '1.12.2'
+  sha256 'c7839d437fecf842c79d762a9f3f6c4a9b6fd459de38c1c6c50144f5f09443b1'
 
   # github.com/keeweb/keeweb was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.