### PR TITLE
Update vmware-horizon-client from 5.2.0-14625369,CART20FQ3 to 5.2.1-14979452,CART20FQ3

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -1,6 +1,6 @@
 cask 'vmware-horizon-client' do
-  version '5.2.0-14625369,CART20FQ3'
-  sha256 '0446c8ab2faca9a6e7c80adf1d27e3493d9630748edcc35f8972320bd46885c9'
+  version '5.2.1-14979452,CART20FQ3'
+  sha256 '8de6487d87b5aa43bf46cf124b608ec556f34c915e186ef71ef2e2f423e5ead9'
 
   url "https://download3.vmware.com/software/view/viewclients/#{version.after_comma}/VMware-Horizon-Client-#{version.before_comma}.dmg"
   appcast 'https://docs.vmware.com/en/VMware-Horizon-Client-for-Mac/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.