### PR TITLE
Update gns3 from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.2.1'
-  sha256 '428adf9b8134e7de5a096cbb755e5fc5fef35acbb52f62a452402c58e11ad9c5'
+  version '2.2.2'
+  sha256 'b2ee3e7657204b53d7b7ec8196c23e4c58192fcdf4dccb002ee82da4c2690837'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.