### PR TITLE
Update gzdoom from 4.2.3 to 4.2.4

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '4.2.3'
-  sha256 '386f4d2f42dd3a849faf237ecbbaddc05df191b4e3e1a8307379846305ea3949'
+  version '4.2.4'
+  sha256 'adea4dd67b8ae9f450b5c5b233d18cfcb1ca4fa8314880c8ba8f84d85ad436cf'
 
   # github.com/coelckers/gzdoom was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.