### PR TITLE
Update qownnotes from 19.11.3,b4732-173105 to 19.11.4,b4741-175631

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.3,b4732-173105'
-  sha256 'e1407fe5f133311634f9a25ab135a178bb5e216602af2c95ed7cd563e5ba5c11'
+  version '19.11.4,b4741-175631'
+  sha256 'dea8bff0071551564f379974046ed7b30baa454d785bdaa5c0d7681394cad219'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.