### PR TITLE
Update thonny from 3.2.1 to 3.2.3

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,6 +1,6 @@
 cask 'thonny' do
-  version '3.2.1'
-  sha256 '922c277c9f1ffee142d717dce7d698a72da1f5bca80636078ee7a0e536d32038'
+  version '3.2.3'
+  sha256 'def7e5898208b47ad8590a3c1a0870477ed7c5662199770b16c05c642062519c'
 
   # github.com/thonny/thonny/releases/download was verified as official when first introduced to the cask
   url "https://github.com/thonny/thonny/releases/download/v#{version}/thonny-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.