### PR TITLE
Update mirrorop from 2.5.0.52 to 2.5.1.61

### DIFF
--- a/Casks/mirrorop.rb
+++ b/Casks/mirrorop.rb
@@ -1,6 +1,6 @@
 cask 'mirrorop' do
-  version '2.5.0.52'
-  sha256 '00583d9f5e282fcd32cc0d940c9eec24aea5aeb34793d274a4cf0df28de924b8'
+  version '2.5.1.61'
+  sha256 'a6b0c38e5e78a5b1eaddcc59522a6270614c1806a7012f326a6397b364df26b7'
 
   url "https://www.barco.com/services/website/en/TdeFiles/Download?FileNumber=R33050100&TdeType=3&MajorVersion=#{version.major}&MinorVersion=#{version.minor}&PatchVersion=#{version.patch}&BuildVersion=#{version.split('.')[-1]}"
   appcast 'https://www.barco.com/en/support/software/R33050100'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.