### PR TITLE
Update android-platform-tools from 29.0.4 to 29.0.5

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,6 +1,6 @@
 cask 'android-platform-tools' do
-  version '29.0.4'
-  sha256 '0138d738eeb96a48a0b04894e502d4b4ef802cb8cf446a61838fb7c2a386a532'
+  version '29.0.5'
+  sha256 'f4a671ab24845f26cb4b579079e2cc3a58c9931e07ae2fca1c83ffebdf773cc1'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.