### PR TITLE
Update path-finder from 9.0.1 to 9.0.2

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '9.0.1'
-  sha256 'b53cb65f41423f7c79fa0e37fdd15926b15c600617c04ad4cfb1580ceca7d48b'
+  version '9.0.2'
+  sha256 '06e0090f6a7a630e2c638aa69e78f0a397eb486aa8baee7df3bb44ef16da9beb'
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.