### PR TITLE
Include Yosemite Specific Build of Launchpad Manager

### DIFF
--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,8 +1,8 @@
 cask 'launchpad-manager' do
 
   if MacOS.version = :yosemite
-    version '1.0.10'
-    sha256 '88b37120c0ae022309573c4d2587a6ec85df7895773bca0fd3b5ba6cd86461a6'
+    version :latest
+    sha256 :no_check
 
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
 

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,6 +1,6 @@
 cask 'launchpad-manager' do
 
-  if MacOS.version = :yosemite
+  if MacOS.version <= :yosemite
     version :latest
     sha256 :no_check
 

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,18 +1,14 @@
 cask 'launchpad-manager' do
-
   if MacOS.version <= :yosemite
-    version :latest
     sha256 :no_check
-
     url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
 
   else
-    version :latest
     sha256 :no_check
-
     url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
   end
 
+  version :latest
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'
 

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,14 +1,13 @@
 cask 'launchpad-manager' do
-  if MacOS.version <= :yosemite
-    sha256 :no_check
-    url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
+  version :latest
+  sha256 :no_check
 
+  if MacOS.version <= :yosemite
+    url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
   else
-    sha256 :no_check
     url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
   end
 
-  version :latest
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'
 

--- a/Casks/launchpad-manager.rb
+++ b/Casks/launchpad-manager.rb
@@ -1,8 +1,18 @@
 cask 'launchpad-manager' do
-  version :latest
-  sha256 :no_check
 
-  url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
+  if MacOS.version = :yosemite
+    version '1.0.10'
+    sha256 '88b37120c0ae022309573c4d2587a6ec85df7895773bca0fd3b5ba6cd86461a6'
+
+    url 'http://launchpadmanager.com/download_yosemite.php/LaunchpadManagerYosemite.dmg'
+
+  else
+    version :latest
+    sha256 :no_check
+
+    url 'http://launchpadmanager.com/download.php/LaunchpadManager.dmg'
+  end
+
   name 'Launchpad Manager'
   homepage 'http://launchpadmanager.com/'
 


### PR DESCRIPTION
This adds a Yosemite-specific build of Launchpad Manager for people using an older version of macOS. This will fix the issue that @ikurek reported here: https://github.com/Homebrew/homebrew-cask/pull/71883#issuecomment-549757566 . 

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256