### PR TITLE
secure/fix URLs

### DIFF
--- a/Casks/appdelete.rb
+++ b/Casks/appdelete.rb
@@ -2,10 +2,10 @@ cask 'appdelete' do
   version '4.3.3'
   sha256 'ac7ce8a55ad74eed68d79ccf69284a1174bf74a2a376f73c63e51ca8c4687547'
 
-  url 'http://www.reggieashworth.com/downloads/AppDelete.dmg'
-  appcast "http://www.reggieashworth.com/AD#{version.major}Appcast.xml"
+  url 'https://www.reggieashworth.com/downloads/AppDelete.dmg'
+  appcast "https://www.reggieashworth.com/AD#{version.major}Appcast.xml"
   name 'AppDelete'
-  homepage 'http://www.reggieashworth.com/appdelete'
+  homepage 'https://www.reggieashworth.com/appdelete.html'
 
   auto_updates true
 

--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -3,7 +3,7 @@ cask 'cctalk' do
   sha256 '066f09812da123545371cc0c37a690ae7f9842a975fffdb88ae47780595cdd79'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "http://cc.hjfile.cn//#{version}/8/1/103/#{version}.dmg"
+  url "https://cc.hjfile.cn//#{version}/8/1/103/#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/openrefine.rb
+++ b/Casks/openrefine.rb
@@ -6,7 +6,7 @@ cask 'openrefine' do
   url "https://github.com/OpenRefine/OpenRefine/releases/download/#{version}/openrefine-mac-#{version}.dmg"
   appcast 'https://github.com/OpenRefine/OpenRefine/releases.atom'
   name 'OpenRefine'
-  homepage 'http://openrefine.org/'
+  homepage 'https://openrefine.org/'
 
   app 'OpenRefine.app'
 end

--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -5,7 +5,7 @@ cask 'ukelele' do
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_#{version}&filename=Ukelele_#{version}.dmg"
   appcast 'https://www.dropbox.com/s/vi51g5jig3etaum/Ukelele_appcast.xml?dl=1'
   name 'Ukelele'
-  homepage 'https://scripts.sil.org/ukelele'
+  homepage 'https://software.sil.org/ukelele/'
 
   app 'Ukelele.app'
 

--- a/Casks/usb-overdrive.rb
+++ b/Casks/usb-overdrive.rb
@@ -2,9 +2,9 @@ cask 'usb-overdrive' do
   version '3.4'
   sha256 '8dd426c9bb2ab048269189acea143df9e77bbe106747f2a2d505d75e4079b340'
 
-  url "http://www.usboverdrive.com/download/USB-Overdrive-#{version.no_dots}.dmg"
+  url "https://www.usboverdrive.com/download/USB-Overdrive-#{version.no_dots}.dmg"
   name 'USB Overdrive'
-  homepage 'http://www.usboverdrive.com/'
+  homepage 'https://www.usboverdrive.com/'
 
   pkg 'Install USB Overdrive.pkg'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```console
1 file inspected, no offenses detected
==> Downloading https://www.reggieashworth.com/downloads/AppDelete.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'appdelete'.
audit for appdelete: passed

1 file inspected, no offenses detected
==> Downloading https://cc.hjfile.cn//7.6.0.10/8/1/103/7.6.0.10.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cctalk'.
audit for cctalk: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/OpenRefine/OpenRefine/releases/download/3.2/o
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'openrefine'.
audit for openrefine: passed

1 file inspected, no offenses detected
==> Downloading https://scripts.sil.org/cms/scripts/render_download.php?format=f
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'ukelele'.
audit for ukelele: passed

1 file inspected, no offenses detected
==> Downloading https://www.usboverdrive.com/download/USB-Overdrive-34.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'usb-overdrive'.
audit for usb-overdrive: passed
```