### PR TITLE
Update gargoyle from 2011.1 to 2019.1

### DIFF
--- a/Casks/gargoyle.rb
+++ b/Casks/gargoyle.rb
@@ -1,8 +1,8 @@
 cask 'gargoyle' do
-  version '2011.1'
-  sha256 '4e830ad3feec78d623ce5c13ce14f440f9769d302ac46604afc4b9785baa038c'
+  version '2019.1'
+  sha256 '239cd26ba6063a302c6cd12d8241cff0f2837f31ce89f9dc2718e4dcd4cfecc7'
 
-  url "https://github.com/garglk/garglk/releases/download/stable-#{version}/gargoyle-#{version}-mac.dmg"
+  url "https://github.com/garglk/garglk/releases/download/#{version}/gargoyle-#{version}-mac-nota.dmg"
   appcast 'https://github.com/garglk/garglk/releases.atom'
   name 'Gargoyle'
   homepage 'https://github.com/garglk/garglk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.