### PR TITLE
Update appcast in  jubler.rb

### DIFF
--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -4,7 +4,7 @@ cask 'jubler' do
 
   # sourceforge.net/jubler was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jubler/Jubler-#{version}.dmg"
-  appcast 'https://sourceforge.net/projects/jubler/rss'
+  appcast 'https://www.jubler.org/changelog.html'
   name 'Jubler'
   homepage 'https://www.jubler.org/'
 


### PR DESCRIPTION
the rss feed does not contain the version number anymore - changed it to the changelog
https://www.jubler.org/changelog.html