### PR TITLE
Update omegat from 4.3.0 to 4.3.1

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,9 +1,9 @@
 cask 'omegat' do
-  version '4.3.0'
-  sha256 '0beccd1bcc4633e65f4ed272aaf946c95b17e5d343b39a90a7b742f2768b065b'
+  version '4.3.1'
+  sha256 '2e427d9fd8008a88877aeaa0e634f3d4ff8cbd51bb11e48314535940fc43c0a5'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}/OmegaT_#{version}_Mac_Signed.zip"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}/OmegaT_#{version}_Mac_Notarized.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard'
   name 'OmegaT'
   homepage 'https://omegat.org/'

--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -8,7 +8,7 @@ cask 'omegat' do
   name 'OmegaT'
   homepage 'https://omegat.org/'
 
-  app "OmegaT_#{version}_Mac_Signed/OmegaT.app"
+  app "OmegaT_#{version}_Mac_Notarized/OmegaT.app"
 
   caveats do
     depends_on_java '8+'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.