### PR TITLE
Update browserosaurus from 8.0.1 to 8.1.0

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '8.0.1'
-  sha256 '86dc12e7d5720077d1e9c4b41614550af7ce8fb8c81fb518954924d6536ff504'
+  version '8.1.0'
+  sha256 'f7594a0735ab66db1a73332afa711701975fb6dab537ba227d3b96c9538a3640'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"

--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -7,6 +7,7 @@ cask 'browserosaurus' do
   appcast 'https://github.com/will-stone/browserosaurus/releases.atom'
   name 'Browserosaurus'
   homepage 'https://will-stone.github.io/browserosaurus/'
+  auto_updates true
 
   app 'Browserosaurus.app'
 end

--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -7,6 +7,7 @@ cask 'browserosaurus' do
   appcast 'https://github.com/will-stone/browserosaurus/releases.atom'
   name 'Browserosaurus'
   homepage 'https://will-stone.github.io/browserosaurus/'
+
   auto_updates true
 
   app 'Browserosaurus.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.