### PR TITLE
Update graphicconverter from 11.1,4132 to 11.1.1,4163

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,6 +1,6 @@
 cask 'graphicconverter' do
-  version '11.1,4132'
-  sha256 'fdafcabd95497d8d02ae9a906119b59f7a38c429bf7e49dbc880296a776405e1'
+  version '11.1.1,4163'
+  sha256 'c117c62293da46d7ae4f23c203ee32590f588b7879e4893ed01442672b67e756'
 
   # lemkesoft.info was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.