### PR TITLE
Update android-studio from 3.5.1.0,191.5900203 to 3.5.2.0,191.5977832

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '3.5.1.0,191.5900203'
-  sha256 'fdbf79636691b2b20d9541061435d8eed7855951170ed7f479723059a8b215ef'
+  version '3.5.2.0,191.5977832'
+  sha256 'd7574c724a8c87af6244e1873c60b5a27d5df7c4fdbf7cc65a659aacc6e44d75'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.