### PR TITLE
Update latexit from 2.13.3 to 2.13.4

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,6 +1,6 @@
 cask 'latexit' do
-  version '2.13.3'
-  sha256 '35535573684f55a3ef9346b3d4f00392c967b0f4119c02b87048a8717e6abe6c'
+  version '2.13.4'
+  sha256 '11acd8c7925607c4177022ad1d459bcf63e52f4f346ee76ea50f2c3975cbc12c'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.