### PR TITLE
Update stoplight-studio from 1.4.1 to 1.4.2

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.4.1'
-  sha256 'f5b97a158c48cc136d0ba04589db518c84cc9cefa364eac287e6a9ec59722538'
+  version '1.4.2'
+  sha256 '3436d9da8ee20dfbf2a69fe641c92214dabd2546935e8a5bc03c21d95e0fe7a7'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.