### PR TITLE
Update ticktick from 3.2.60,113 to 3.2.61,116

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.2.60,113'
-  sha256 'c5b93ad9d1e605554918275b75840dd689efc4ffcd678862cbbb35945f0fa31c'
+  version '3.2.61,116'
+  sha256 'a1d94b052aff7b7bcc0829203945a78ba81b9168b1e4cbed9ac51299cedcceaa'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.