### PR TITLE
Update powerphotos from 1.7.3 to 1.7.4

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -16,8 +16,8 @@ cask 'powerphotos' do
     sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.7.3'
-    sha256 '9debaa2e292a05767b017953b4fb1e900705d7380d4b462ac6a37d1a8fa73421'
+    version '1.7.4'
+    sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 

--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -17,7 +17,7 @@ cask 'powerphotos' do
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
     version '1.7.4'
-    sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
+    sha256 'e69e49edbfbb8ed76911b4f13a8132763bc9bacbd6cb5b1567a0e3572dfffbbe'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.