### PR TITLE
Update reunion from 12.0.0.190924 to 12.0.0.191105

### DIFF
--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -1,6 +1,6 @@
 cask 'reunion' do
-  version '12.0.0.190924'
-  sha256 '729de26b38a0f97990378795a4f372f70880dafa4864da91d7c7e018b88497bf'
+  version '12.0.0.191105'
+  sha256 '54c6dca89e32cf80c3751cb2d516a6ed5ed3cdc249c2c0cbec8b7e041797e918'
 
   url "https://store.leisterpro.com/updates/reunion#{version.major}/Reunion-#{version.dots_to_hyphens}.zip"
   appcast "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.