### PR TITLE
Update marvel from 8.5.3 to 8.5.4

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.5.3'
-  sha256 '340cd61295a588a29f19b0a24e7672bc506b84a02563f354fa6a9c3eea4bc74d'
+  version '8.5.4'
+  sha256 '6d820bc52eb76aecd001b1bececd8b9711730b867c6709cd9e1be17533b6deb6'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.