### PR TITLE
Update ring from 2.3.0 to 2.4.0

### DIFF
--- a/Casks/ring.rb
+++ b/Casks/ring.rb
@@ -1,6 +1,6 @@
 cask 'ring' do
-  version '2.3.0'
-  sha256 '1b2147deca9c7cbfc3bbcf8c4269455bc15bd3302c9aa0241ae95afb9aab3f3c'
+  version '2.4.0'
+  sha256 'f378d0f31a353fab104dade54313cf91c4e7a5063392b350476356c42277c1fb'
 
   # ring-mac-app-assets.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ring-mac-app-assets.s3.amazonaws.com/production/Ring_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.