### PR TITLE
Update inboard from 1.1.4-421 to 1.1.5-431

### DIFF
--- a/Casks/inboard.rb
+++ b/Casks/inboard.rb
@@ -1,6 +1,6 @@
 cask 'inboard' do
-  version '1.1.4-421'
-  sha256 '79a91ed1f899d360b2f2bafce22abce1902e9e402b893adf8b06cac4c7fd4476'
+  version '1.1.5-431'
+  sha256 'b7ec8f738aaf3f0a707fbfc432bfd58b5fe6bb6b880e80102e37c71492966a5b'
 
   url "https://inboardapp.com/trial/Inboard-#{version}.zip"
   appcast 'https://inboardapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.