### PR TITLE
Update popclip from 2019.9.1 to 2019.10

### DIFF
--- a/Casks/popclip.rb
+++ b/Casks/popclip.rb
@@ -1,6 +1,6 @@
 cask 'popclip' do
-  version '2019.9.1'
-  sha256 '4dccb918097bc8c61a23054257a54b581446eae7987162ea99581afbebf73a8c'
+  version '2019.10'
+  sha256 '052cb6d24d1060fcc133837603c8d48bc937f3c0d9ad34eea6f695aedffb50e4'
 
   url "https://pilotmoon.com/downloads/PopClip-#{version}.zip"
   appcast 'https://softwareupdate.pilotmoon.com/update/popclip/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.