### PR TITLE
Update ableton-live-standard from 10.1.3 to 10.1.4

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard' do
-  version '10.1.3'
-  sha256 'a38a739385d6945a0815d3cfd0ac56926fbd213482b63d76f5521242e97ffa67'
+  version '10.1.4'
+  sha256 'fb5a8eac14e70e562d7c16519855a56d1d2afc5b79a7a4b226011f5323aba453'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.