### PR TITLE
Update ableton-live-intro from 10.1.3 to 10.1.4

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-intro' do
-  version '10.1.3'
-  sha256 '0fbbd090cf4b8391f76719fe618535f7c690d624110e1983a5ec6e4fa751b42d'
+  version '10.1.4'
+  sha256 '78cb697c8025cdabe08c261d09b63ad468a7f0bc19c864ea076f9fc4259d5db4'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.