### PR TITLE
Update manictime from 2.0.25 to 2.0.26

### DIFF
--- a/Casks/manictime.rb
+++ b/Casks/manictime.rb
@@ -1,6 +1,6 @@
 cask 'manictime' do
-  version '2.0.25'
-  sha256 'd1eb51fff19cce62801d7d150ea68b100978180ab0d511d30346d044ed7639f2'
+  version '2.0.26'
+  sha256 '484295bf0f59eeffb4ad415a3fcab21bf1be65354e2be83dfdbdfa89a739d06f'
 
   url "https://cdn.manictime.com/setup/mac/ManicTime-v#{version}.dmg"
   appcast 'https://www.manictime.com/mac/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.