### PR TITLE
Update ableton-live-lite from 10.1.3 to 10.1.4

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '10.1.3'
-  sha256 '81cc914eb710a9c8597c73c2063abd154b421849e56f90c630f1c41786d441a5'
+  version '10.1.4'
+  sha256 '54f20eda463a3291904da9ddeceb167ce99c32f386a0e3d8dc7923f8dc9b93cd'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.