### PR TITLE
Update browserosaurus from 8.1.0 to 8.1.1

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '8.1.0'
-  sha256 'f7594a0735ab66db1a73332afa711701975fb6dab537ba227d3b96c9538a3640'
+  version '8.1.1'
+  sha256 '4ee610ea10bc46e2630acdd1359b5ff5215dca5bbd96f583b89fc213fbd447a6'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.