### PR TITLE
Update jameica from 2.8.5 to 2.8.6

### DIFF
--- a/Casks/jameica.rb
+++ b/Casks/jameica.rb
@@ -1,6 +1,6 @@
 cask 'jameica' do
-  version '2.8.5'
-  sha256 '398aa78e1c319ae774464e6674536c7b46c8f5b6db264a084a48247f3b49a6a3'
+  version '2.8.6'
+  sha256 'da61520246d924892c9664bfc40aad2892a5b27bebdbb5d339edad302faae5f3'
 
   url "https://www.willuhn.de/products/jameica/releases/current/jameica/jameica-macos64-#{version}.zip"
   name 'Jameica'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.