### PR TITLE
Add OpenWebStart 0.5.0

### DIFF
--- a/Casks/openwebstart.rb
+++ b/Casks/openwebstart.rb
@@ -2,8 +2,8 @@ cask 'openwebstart' do
   version '0.5.0'
   sha256 'a6c7ff4c2171a32c0d5bb4fe71743d5fa84f3b8458c16d292191aebdd1476a99'
 
-  # github.com was verified as official when first introduced to the cask
-  url 'https://github.com/karakun/OpenWebStart/releases/download/v0.5.0/OpenWebStart_macos_0_5_0.dmg'
+  # github.com/karakun/OpenWebStart was verified as official when first introduced to the cask
+  url "https://github.com/karakun/OpenWebStart/releases/download/v#{version}/OpenWebStart_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/karakun/OpenWebStart/releases.atom'
   name 'OpenWebStart'
   homepage 'https://openwebstart.com/'

--- a/Casks/openwebstart.rb
+++ b/Casks/openwebstart.rb
@@ -1,0 +1,22 @@
+cask 'openwebstart' do
+  version '0.5.0'
+  sha256 'a6c7ff4c2171a32c0d5bb4fe71743d5fa84f3b8458c16d292191aebdd1476a99'
+
+  # github.com was verified as official when first introduced to the cask
+  url 'https://github.com/karakun/OpenWebStart/releases/download/v0.5.0/OpenWebStart_macos_0_5_0.dmg'
+  appcast 'https://github.com/karakun/OpenWebStart/releases.atom'
+  name 'OpenWebStart'
+  homepage 'https://openwebstart.com/'
+
+  installer script: {
+                      executable: 'OpenWebStart Installer.app/Contents/MacOS/JavaApplicationStub',
+                      args:       ['-q'],
+                      sudo:       true,
+                    }
+
+  uninstall script: {
+                      executable: '/Applications/OpenWebStart/OpenWebStart Uninstaller.app/Contents/MacOS/JavaApplicationStub',
+                      args:       ['-q'],
+                      sudo:       true,
+                    }
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version] 
**Exception: no stable version**


Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference]. 
**Exception: Exact Application bundle name is 'OpenWebStart javaws.app' - dropping the javaws here in the spirit of the guideline around dropping terms like 'Launcher' javaws is the name of the well-known jre webstart launcher executable and also because the app is widely known as OpenWebStart**
- [x] `brew cask install {{cask_file}}` worked successfully.
**Exception: No code signature**
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256