### PR TITLE
Update stamp from 4.15.1 to 4.15.2

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.15.1'
-  sha256 'b3b30a67e14782be5d354bf76d3210081c3c4f14f4b7a322d96893e6ef4b0378'
+  version '4.15.2'
+  sha256 '9fb6b1dfc0551106e21bf2e04a6b3859f3494cdb18f5486813c98027e48fdce4'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/STAMP#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.