### PR TITLE
Update middleclick from 1.0 to 2.4.5

### DIFF
--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -2,7 +2,6 @@ cask 'middleclick' do
   version '2.4.5'
   sha256 '0cf66ff60029b449155ccc008cf64fe3ba3abadfa37035c416bdb58e31ea1d0c'
 
-  # github.com was verified as official when first introduced to the cask
   url "https://github.com/DaFuqtor/MiddleClick/releases/download/#{version}/MiddleClick.zip"
   appcast 'https://github.com/DaFuqtor/MiddleClick/releases.atom'
   name 'MiddleClick'

--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,16 +1,17 @@
 cask 'middleclick' do
-  version '1.0'
-  sha256 'a83a329493b9140cb73b418ddfa2e921555fc7706a11d8ec2ba13c4016392aca'
+  version '2.4.5'
+  sha256 '0cf66ff60029b449155ccc008cf64fe3ba3abadfa37035c416bdb58e31ea1d0c'
 
   # github.com was verified as official when first introduced to the cask
-  url 'https://github.com/cl3m/MiddleClick/releases/download/mojave/MiddleClick_Mojave.zip'
-  appcast 'https://github.com/cl3m/MiddleClick/releases.atom'
+  url "https://github.com/DaFuqtor/MiddleClick/releases/download/#{version}/MiddleClick.zip"
+  appcast 'https://github.com/DaFuqtor/MiddleClick/releases.atom'
   name 'MiddleClick'
-  homepage 'https://rouge41.com/labs/'
+  homepage 'https://github.com/DaFuqtor/MiddleClick'
 
   app 'MiddleClick.app'
 
-  caveats do
-    discontinued
-  end
+  uninstall login_item: 'MiddleClick',
+            quit:       'com.rouge41.middleClick'
+
+  zap trash: '~/Library/Preferences/com.rouge41.middleClick.plist'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

> The previous version of the application is no longer maintained, the author of the application pointed this out in [his repository](//github.com/cl3m/MiddleClick) and gave a link to [my fork](//github.com/DaFuqtor/MiddleClick-Catalina).
