### PR TITLE
Update opendns-updater from 3.0 to 3.1

### DIFF
--- a/Casks/opendns-updater.rb
+++ b/Casks/opendns-updater.rb
@@ -1,9 +1,9 @@
 cask 'opendns-updater' do
-  version '3.0'
-  sha256 '64ad7b55cc8a62739815a806c077df0751ecbbc6c4a71c01792c2f71dc7fd8cc'
+  version '3.1'
+  sha256 '3e5def08fd366a0d4d651a8bd7cf0a1274f8dd67f8c7a55842b3c4126492a15b'
 
   url 'https://www.opendns.com/download/mac/'
-  appcast 'https://opendnsupdate.appspot.com/macupdatecheck/ipupdater/AppCast.xml'
+  appcast 'http://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.opendns.com/download/mac/'
   name 'OpenDNS Updater'
   homepage 'https://support.opendns.com/hc/en-us/articles/227987867'
 

--- a/Casks/opendns-updater.rb
+++ b/Casks/opendns-updater.rb
@@ -7,5 +7,5 @@ cask 'opendns-updater' do
   name 'OpenDNS Updater'
   homepage 'https://support.opendns.com/hc/en-us/articles/227987867'
 
-  app 'OpenDNS Updater.app'
+  app 'OpenDNSUpdater.app'
 end

--- a/Casks/opendnsupdater.rb
+++ b/Casks/opendnsupdater.rb
@@ -1,4 +1,4 @@
-cask 'opendns-updater' do
+cask 'opendnsupdater' do
   version '3.1'
   sha256 '3e5def08fd366a0d4d651a8bd7cf0a1274f8dd67f8c7a55842b3c4126492a15b'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.