### PR TITLE
Revert "Update molotov from 4.1.1 to 4.2.0"

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '4.2.0'
-  sha256 'c6ad99a9b2c439b46057ba107f5d65047546df7d1e87923302a9c8709ef343ab'
+  version '4.1.1'
+  sha256 'a00de03f2e78fff49ee18e409b27d5f6dfbf905fa21817e2b6f262e9f47d425e'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   appcast 'https://desktop-auto-upgrade.molotov.tv/mac/manifest.json'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#72142

Seems like the update to 4.2.0 has been remove from molotov website (see https://www.molotov.tv/download) not sure why. 

Current version is stil 4.1.1.