### PR TITLE
Update jubler from 6.0.2 to 7.0.0-alpha1

### DIFF
--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -1,16 +1,12 @@
 cask 'jubler' do
-  version '6.0.2'
-  sha256 'd0d01cf027c745a2aaf3f88c1e00f003e1dacae8108564ebe8f158dfa8c2630c'
+  version '7.0.0-alpha1'
+  sha256 'a3028e4a9a3a345b5f6d8bca6fa6d56527fe5a8721bb9f3ff10417d42096aa85'
 
-  # sourceforge.net/jubler was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/jubler/Jubler-#{version}.dmg"
-  appcast 'https://sourceforge.net/projects/jubler/rss'
+  # github.com/teras/Jubler was verified as official when first introduced to the cask
+  url "https://github.com/teras/Jubler/releases/download/v#{version}/Jubler-#{version}.dmg"
+  appcast 'https://github.com/teras/Jubler/releases.atom'
   name 'Jubler'
   homepage 'https://www.jubler.org/'
 
   app 'Jubler.app'
-
-  caveats do
-    depends_on_java
-  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.