### PR TITLE
Update splice from 3.5.7 to 3.5.8

### DIFF
--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -1,6 +1,6 @@
 cask 'splice' do
-  version '3.5.7'
-  sha256 'b84b9b81ed0bad1f254feec70b75424d5f11f4da66022245ac5d5314c250eb49'
+  version '3.5.8'
+  sha256 '23b71584acf477536f9a6cd123ddb18ddd50da45b0e28ab3d52c41833fe27d89'
 
   # splicedesktop.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://splicedesktop.s3.amazonaws.com/darwin/stable/Splice.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.