### PR TITLE
Update robofont from 3.2 to 3.3

### DIFF
--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -1,6 +1,6 @@
 cask 'robofont' do
-  version '3.2'
-  sha256 '75cd586f08d6b17eb74f5a309f0df26ad745ba7ccb6355e1b1e94d7a0d067cfd'
+  version '3.3'
+  sha256 '2ee6460201abe754710188c0a18ff725af1599c49d38ffa6ca5828f33bd04683'
 
   # static.typemytype.com/robofont was verified as official when first introduced to the cask
   url 'https://static.typemytype.com/robofont/RoboFont.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.