### PR TITLE
Update trilium-notes from 0.36.2 to 0.36.3

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.36.2'
-  sha256 '645e1f07c69cc81a2b4a067d7e0425fcfe8203c43b63872700ccf640078af30b'
+  version '0.36.3'
+  sha256 'a95761a9f317623ac2330b4610c697aabb3787d2938a7b56b6d6ff474b530675'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.