### PR TITLE
Update katalon-studio from 7.0.6 to 7.0.7

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.0.6'
-  sha256 '9787e33b90a094e83f7819ee9d3fa28d1fa31d4e5fb2b43a1049ee12eddb57cf'
+  version '7.0.7'
+  sha256 '2a18541e351d244bb1081174ef61715c4ffa269ca0287342557498681c000707'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.