### PR TITLE
Update one-switch from 1.7.1 to 1.8

### DIFF
--- a/Casks/one-switch.rb
+++ b/Casks/one-switch.rb
@@ -1,6 +1,6 @@
 cask 'one-switch' do
-  version '1.7.1'
-  sha256 'c2127c94c26d606dfdee632fe1cc833be9586d58a4be78ab61f36892abfcd205'
+  version '1.8'
+  sha256 'd75e2c50f947dc735ab52627909d55c951079efa8dde0cc67a80c98fedafab1b'
 
   # dl.devmate.com/studio.fireball.OneSwitch was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/studio.fireball.OneSwitch/OneSwitch.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.