### PR TITLE
Update dungeon-crawl-stone-soup-tiles from 0.23.2 to 0.24.0

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.23.2'
-  sha256 '6ba47351b14a57be65d3c631013d6ed828c9badaf07956f4b3ff2d0461ed4f9a'
+  version '0.24.0'
+  sha256 'f95146f701d5412b73fdd7d0369e16fc3158ce70d3892ed603e953266bbe2d68'
 
   url "https://crawl.develz.org/release/#{version.major_minor}/stone_soup-#{version}-tiles-macosx.zip"
   appcast 'https://github.com/crawl/crawl/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.