### PR TITLE
Update vcv-rack from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/vcv-rack.rb
+++ b/Casks/vcv-rack.rb
@@ -1,6 +1,6 @@
 cask 'vcv-rack' do
-  version '1.1.5'
-  sha256 '45b2d3c7c5a10c87f2662bdecd75311c78ac60291fb0b73e6d7ec90d67e6abbf'
+  version '1.1.6'
+  sha256 '79078ca77dff41beab2247cadf22d1a9d4112b3981f8a4084923b75519664a50'
 
   url "https://vcvrack.com/downloads/Rack-#{version}-mac.zip"
   appcast 'https://github.com/VCVRack/Rack/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.