### PR TITLE
Update musicbrainz-picard from 2.2.2 to 2.2.3

### DIFF
--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -1,6 +1,6 @@
 cask 'musicbrainz-picard' do
-  version '2.2.2'
-  sha256 '747e8ebaaf96dc33435bf72b588046a2a491404f6fb46278320e9aaa63bcfeae'
+  version '2.2.3'
+  sha256 'a64e6d1736da86f96022a6f4a9445496750849ee8eaa83472bd2dddc69888b86'
 
   # musicbrainz.osuosl.org/pub/ was verified as official when first introduced to the cask
   url "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz.Picard.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.