### PR TITLE
Update neo4j from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,7 +1,7 @@
 cask 'neo4j' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '1.2.1'
-  sha256 'feb633c5e1ea23de6e4c5fa30b6e15475cdf6e051518129b435a85c1800c27c7'
+  version '1.2.2'
+  sha256 '9b86c08825275410be47937eef0f02e994c81c12e0cbe3a4242b0af28d1372f7'
 
   url "https://neo4j.com/artifact.php?name=neo4j-desktop-offline-#{version}.dmg"
   appcast 'https://neo4j.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.