### PR TITLE
Update tnefs-enough from 3.7 to 3.8

### DIFF
--- a/Casks/tnefs-enough.rb
+++ b/Casks/tnefs-enough.rb
@@ -1,6 +1,6 @@
 cask 'tnefs-enough' do
-  version '3.7'
-  sha256 'fd8f0fa03b03fa0307a74694abed29e797b13e844d4d435c21f588fef5bb5d79'
+  version '3.8'
+  sha256 '9b067dc9f8397f3128b6b35b56bca93ce79f0daf677d7c786ae85f9050a12909'
 
   url "https://www.joshjacob.com/mac-development/TNEF#{version}.dmg"
   appcast 'https://www.joshjacob.com/mac-development/tnef.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.