### PR TITLE
Update netron from 3.5.1 to 3.5.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.5.1'
-  sha256 '307eb4f42c74a36f24ce5f53d44c272657a91fa9c3510c9a604a93d52de876cd'
+  version '3.5.2'
+  sha256 'b5b6a0abc14ab519849523eacfcc63d45dd3449431f6ae43553e3f286b2e68ba'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.