### PR TITLE
Update neofinder from 7.4.1 to 7.5

### DIFF
--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,6 +1,6 @@
 cask 'neofinder' do
-  version '7.4.1'
-  sha256 'fc6355078341b87dff5aba92d5ebbfb974515df8634aca1d7ae17ef052e0c6e3'
+  version '7.5'
+  sha256 '80e874d591af8d11969bca3d6376440b26801747c7a6fe592dce6feb86684eed'
 
   # wfs-apps.de was verified as official when first introduced to the cask
   url "https://www.wfs-apps.de/updates/neofinder.#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.