### PR TITLE
Update scrutiny from 9.3.3 to 9.3.4

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '9.3.3'
-  sha256 '676a147890f1e8d947058d5ee02ccef032899c05aec64e48ffe932f790170545'
+  version '9.3.4'
+  sha256 'd74b3b814eff5e787872dabb1dd3b01d5ac52c407f267253c4bd2949d15add4c'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.