### PR TITLE
Update qownnotes from 19.11.6,b4768-174233 to 19.11.7,b4776-165013

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.6,b4768-174233'
-  sha256 '30b9646ebfbba49b41922b81f685c9be98aae5ca6509036769019b4801b8f417'
+  version '19.11.7,b4776-165013'
+  sha256 'c284e750d759891b4eddedcc358ed7eaa6fb5b0a7853e8c35506be15b41af01d'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.