### PR TITLE
Update chiaki from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/chiaki.rb
+++ b/Casks/chiaki.rb
@@ -1,6 +1,6 @@
 cask 'chiaki' do
-  version '1.1.0'
-  sha256 'aac4e37835f25738988decd47f525a876331f182cf3e806be91eea2260c0e273'
+  version '1.1.1'
+  sha256 '40436df719ffa22841185ed7caedf881a42956c1ec84bea5f582314131b0df9f'
 
   url "https://github.com/thestr4ng3r/chiaki/releases/download/v#{version}/Chiaki-v#{version}-macOS-x86_64.dmg"
   appcast 'https://github.com/thestr4ng3r/chiaki/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.