### PR TITLE
Update browserosaurus from 8.1.1 to 8.1.2

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '8.1.1'
-  sha256 '4ee610ea10bc46e2630acdd1359b5ff5215dca5bbd96f583b89fc213fbd447a6'
+  version '8.1.2'
+  sha256 'f146ee016adc238bb076d5326b4c29c5f52d476fb2d19e39d79bf3b455158bb6'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.