### PR TITLE
Update data-rescue from 5.0.10 to 5.0.11

### DIFF
--- a/Casks/data-rescue.rb
+++ b/Casks/data-rescue.rb
@@ -1,6 +1,6 @@
 cask 'data-rescue' do
-  version '5.0.10'
-  sha256 'f4862181dc3e411a7197b74d6b1eace4ca3674691cfe08acd65f127ef87862c5'
+  version '5.0.11'
+  sha256 '04025ee898a72c68b809e9722a197dd395b4e1100a9b5b2aafc35fe704749c87'
 
   url "https://downloads.prosofteng.com/dr/Data_Rescue_#{version}.dmg"
   appcast "https://www.prosofteng.com/resources/dr#{version.major}/dr#{version.major}_updates_mac.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.