### PR TITLE
Update onepile from 2.1-1100 to 2.2-1106

### DIFF
--- a/Casks/onepile.rb
+++ b/Casks/onepile.rb
@@ -1,6 +1,6 @@
 cask 'onepile' do
-  version '2.1-1100'
-  sha256 '7254482f2b5f32f102dec936eda2d9910d4df632b7cebf98111c1f3a6265492d'
+  version '2.2-1106'
+  sha256 '8554a14a87ea476e1b596147a80ac92a91cf14eb0de948079597e7d48705b316'
 
   url "https://onepile.app/update/macos/OnePile-#{version}.zip"
   appcast 'https://onepile.app/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.