### PR TITLE
Update wickrme from 5.40.9 to 5.40.11

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.40.9'
-  sha256 '6be8e0211900d51db02e8631032d2363a6a5107ca4a7027ecdb27354a1e4ab3d'
+  version '5.40.11'
+  sha256 '4a4ef31f5486c39035d99a898740eaa0d2675bfdc24c9cd01277e2eaf66b7b72'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.