### PR TITLE
Update vitamin-r from 3.11 to 3.12

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -3,8 +3,8 @@ cask 'vitamin-r' do
     version '2.58'
     sha256 'c6c631430b44359aa022d9ca5ca6e98dbdf7258f2ceae0353f344a035682661e'
   else
-    version '3.11'
-    sha256 'cac26478a53c14a5dd64105206c3d64b4eb6c58beb94f63ea6844b2c634283e3'
+    version '3.12'
+    sha256 '0fc2e4c0e5006d4e53e6b7358d30fb5d6a73b286acd94a3fc559a275123b6115'
   end
 
   url "https://www.publicspace.net/download/signedVitamin#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.