### PR TITLE
Update clover-configurator from 5.6.2.0 to 5.7.0.0

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.6.2.0'
-  sha256 'ab6c6792bc28601d97f829e3d9b47508b7453fd660ed9b49d930b0e92387ba76'
+  version '5.7.0.0'
+  sha256 '7d4cbf65e835541922d0411fa856835a78e642ee05e7573d69e63fe902e299f9'
 
   url 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/builds-data-ccg/CCG.zip'
   appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.