### PR TITLE
Update boxcryptor from 2.30.1004 to 2.31.1006

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,6 +1,6 @@
 cask 'boxcryptor' do
-  version '2.30.1004'
-  sha256 'cccea52e3ac7c1e4957dc0136c4564d224005bd39bfeaf46f6774b541603e4e6'
+  version '2.31.1006'
+  sha256 'fd08f59a8bd00f2be167d22493a7f53556b67ad281ed3d4281aa461a608abb77'
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.boxcryptor.com/l/download-macosx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.