### PR TITLE
Update displaycal from 3.8.7.1 to 3.8.8.0

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,6 +1,6 @@
 cask 'displaycal' do
-  version '3.8.7.1'
-  sha256 '500f424f7e59d9fd63cfe1e0e0c554c52f95c6820a5d0f117551b28ff2fac9f6'
+  version '3.8.8.0'
+  sha256 '738ec1bbd56fd254b397de30014ac23ae64713b00b9f4a1a5446d7e19c9cc52e'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.