### PR TITLE
Update brave-browser from 0.70.122 to 0.70.123

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '0.70.122'
-  sha256 '505ab84699bd3c27778d9cfed045447646cb7c35d6f9b5649a12c2396a60673f'
+  version '0.70.123'
+  sha256 'ab7a54354d666fab420d0e1264710773bf70c34a33918f07760b7c16e3091df2'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.