### PR TITLE
Update boinc from 7.16.3 to 7.14.2

### DIFF
--- a/Casks/boinc.rb
+++ b/Casks/boinc.rb
@@ -1,9 +1,9 @@
 cask 'boinc' do
-  version '7.16.3'
-  sha256 '72cad84c0daa854d0c4ca8ddfa5b772cfaf0d15ef3e38a2e982ba6e53e1a3b28'
+  version '7.14.2'
+  sha256 '0160f9e7f89a94a7b201f9cea2626ff0c6ae96e8e84e46927d1e605b0e25a7ff'
 
   url "https://boinc.berkeley.edu/dl/boinc_#{version}_macOSX_x86_64.zip"
-  appcast 'https://boinc.berkeley.edu/dl/?C=M;O=D'
+  appcast 'https://boinc.berkeley.edu/download.php'
   name 'Berkeley Open Infrastructure for Network Computing'
   name 'BOINC'
   homepage 'https://boinc.berkeley.edu/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.