### PR TITLE
Update 4k-stogram from 2.7.3.1805 to 2.8.0.1950

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask '4k-stogram' do
-  version '2.7.3.1805'
-  sha256 '8ade355bd9697cdcb1ef8fe16a8493f1c37f28b44a3d266eac725ba0431cda48'
+  version '2.8.0.1950'
+  sha256 'e9502ef69803533cda36c6619378b993b7321c35f2f1b2a1a2b737a3874bbaca'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.