### PR TITLE
Update tableau-public from 2019.3.1 to 2019-4-0

### DIFF
--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,5 +1,5 @@
 cask 'tableau-public' do
-  version '2019-4-0'
+  version '2019.4.0'
   sha256 'a9720cad769e8c5d2d592b7d4cf37f8b8290ebaa180e856cdfa86e93ef6d137b'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"

--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,6 +1,6 @@
 cask 'tableau-public' do
-  version '2019.3.1'
-  sha256 'e48134a1a8d966df317a533301163c82bbba17e81748cdf3121b5c13eabc71cd'
+  version '2019-4-0'
+  sha256 'a9720cad769e8c5d2d592b7d4cf37f8b8290ebaa180e856cdfa86e93ef6d137b'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.