### PR TITLE
Update miditrail from 1.2.6,71183 to 1.3.1,71899

### DIFF
--- a/Casks/miditrail.rb
+++ b/Casks/miditrail.rb
@@ -1,6 +1,6 @@
 cask 'miditrail' do
-  version '1.2.6,71183'
-  sha256 '37ab9b7689ba2cb0be9991a2b2cfd21972176b00c06ac667a3de6e7459c186f6'
+  version '1.3.1,71899'
+  sha256 '17d561bafa46413a721215b7df5a5442cf131acfd868309a5c8bcb37a14f1286'
 
   # dl.osdn.jp/miditrail was verified as official when first introduced to the cask
   url "http://dl.osdn.jp/miditrail/#{version.after_comma}/MIDITrail-Ver.#{version.before_comma}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.