### PR TITLE
Update visicut from 1.8-105-g369693d4 to 1.8-107-g0e7ccc95

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask 'visicut' do
-  version '1.8-105-g369693d4'
-  sha256 'eea73ba174a18def77db323a760f8f92d72004261ba18b104fa3944861c29d53'
+  version '1.8-107-g0e7ccc95'
+  sha256 'f72f5632d9dbec568207693f2caf69094e2644447a549cd0916792ad019a1a10'
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast 'https://download.visicut.org'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.