### PR TITLE
Update buttercup from 1.17.2 to 1.17.3

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.17.2'
-  sha256 '2906259f9d21fcb4facc210cf7454c6cce0bdaad904e52ff9a0303e0e3d78599'
+  version '1.17.3'
+  sha256 '8bb83ef5b68e79078c6363c9b1a16ed3f8f7913192246f0e8349adf55fe98459'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.