### PR TITLE
Bump 1password-cli from 0.7.1 to 0.8.0

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,14 +1,16 @@
 cask '1password-cli' do
-  version '0.7.1'
-  sha256 '4708c3cc7f1ff1381be246cd47d798565087eaaeca7b042764fc7ca0a2f5901c'
+  version '0.8.0'
+  sha256 '50e340049867df058ee9dc08bc0b722c93e0e9e463238bbe2042f09793d6642b'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
-  url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.zip"
+  url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.pkg"
   appcast 'https://app-updates.agilebits.com/product_history/CLI'
   name '1Password CLI'
   homepage 'https://support.1password.com/command-line/'
 
-  binary 'op'
+  pkg "op_darwin_amd64_v#{version}.pkg"
+
+  uninstall pkgutil: 'com.1password.op'
 
   zap trash: '~/.op'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).