### PR TITLE
Update softmaker-freeoffice from 2018,971 to 2018,973

### DIFF
--- a/Casks/softmaker-freeoffice.rb
+++ b/Casks/softmaker-freeoffice.rb
@@ -1,6 +1,6 @@
 cask 'softmaker-freeoffice' do
-  version '2018,971'
-  sha256 'f3cd377dadb5143da35cd35201d3f376250177d2dde475c2f4abbeb9e3135f9d'
+  version '2018,973'
+  sha256 'b0e25f30e14eff0e6b12fa1a6317f47b0ae6e56a363d676ee215ab4a788e4993'
 
   # softmaker.net was verified as official when first introduced to the cask
   url "https://www.softmaker.net/down/softmaker-freeoffice-#{version.before_comma}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.