### PR TITLE
Update tuple from 0.53.0,2019-11-04-6350aa0b to 0.53.1,2019-11-07-110631ac

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.53.0,2019-11-04-6350aa0b'
-  sha256 '52647664c168eded3f15cd41e801388d8fbb9f140339ba3b6e8f2d14259c8d96'
+  version '0.53.1,2019-11-07-110631ac'
+  sha256 'be4bb99757e08bb7e2d5193d89effcf3dfbdc8a5ef075c6d383b0c5032ecf020'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.