### PR TITLE
Update praat from 6.1.05 to 6.1.06

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.1.05'
-  sha256 '5014db3cc3254e23282b9e5f1389833625c82de43affdbff2623bcddf0eeaaa0'
+  version '6.1.06'
+  sha256 '25d483b1d0b12e11502c4d4939df95ecc16d8bfba640dee574dc858f1394de23'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.