### PR TITLE
Update screentray from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/screentray.rb
+++ b/Casks/screentray.rb
@@ -1,6 +1,6 @@
 cask 'screentray' do
-  version '1.6.0'
-  sha256 '7806c0d81bf714bbd30753398f55af49ac33b09bb79ac7a0495249dffed38474'
+  version '1.7.0'
+  sha256 '60b39581c9b240ff9f7ca7d5bc20cf6a1310fd05186a9e96d6ba44d68b723fe6'
 
   # github.com/DSnopov/screentray-distribution was verified as official when first introduced to the cask
   url "https://github.com/DSnopov/screentray-distribution/releases/download/v#{version}/ScreenTray-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.