### PR TITLE
Update qownnotes from 19.11.7,b4776-165013 to 19.11.9,b4792-193817

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.7,b4776-165013'
-  sha256 'c284e750d759891b4eddedcc358ed7eaa6fb5b0a7853e8c35506be15b41af01d'
+  version '19.11.9,b4792-193817'
+  sha256 'bbf75fb90d8799efa4ea8a109af2d87c7d31e126d92ebabb017007939587f9c8'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.