### PR TITLE
Update katalon-studio from 7.0.7 to 7.0.8

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.0.7'
-  sha256 '2a18541e351d244bb1081174ef61715c4ffa269ca0287342557498681c000707'
+  version '7.0.8'
+  sha256 'a824b969dd326188528372039406ca3d9bd3728414bbc08fca5b4b9468082d8e'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.