### PR TITLE
Update dust3d from 1.0.0-beta.26 to 1.0.0-beta.27

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-beta.26'
-  sha256 '4dd19a2bc802f2543a41b43c8af406a1090e91b6b831a58ad9369bf3b1f48795'
+  version '1.0.0-beta.27'
+  sha256 'fb44d8271f911b9f8027450a936cfbe6c4f2c0b4e14a45c45f23d8bb3e91679f'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.