### PR TITLE
Update holavpn from 1.0.24 to 1.0.25

### DIFF
--- a/Casks/holavpn.rb
+++ b/Casks/holavpn.rb
@@ -1,6 +1,6 @@
 cask 'holavpn' do
-  version '1.0.24'
-  sha256 '5502448c404cc661897fae0fcca40ee503d7644314bd84db0486c13af057ee77'
+  version '1.0.25'
+  sha256 'a8f2468919174684210773ae01cc375feec8b83ccebfbd547c6bd230f2fd9b5f'
 
   url "https://cdn4.hola.org/static/HolaVPN-#{version}.dmg"
   appcast 'https://hola.org/macos_vpn_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.