### PR TITLE
Update curio from 13020.7 to 13020.9

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '13020.7'
-  sha256 '329c22433455cc72ed48dc181248ad1e95a3e33ab8fd9e87c572b70da97296a7'
+  version '13020.9'
+  sha256 '09b500dcfa6e2bb1ff93c0ac6eacd83dbd8ad23f611ba1ec93f3fdff8888c003'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio13HLwLK2C84LaKptcz.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.