### PR TITLE
Update qobuz from 5.1.0-b003 to 5.3.0-b005

### DIFF
--- a/Casks/qobuz.rb
+++ b/Casks/qobuz.rb
@@ -1,6 +1,6 @@
 cask 'qobuz' do
-  version '5.1.0-b003'
-  sha256 'bf5c0a6a47c56b5192c07d120d4849feb4e02406d463cded8f771e0689210c6d'
+  version '5.3.0-b005'
+  sha256 '05b2a312c9ddeaaf6ed1ceabca02b420cc250b8d9ad07eced86c3d159b6f10b1'
 
   url "https://desktop.qobuz.com/releases/darwin/x64/elCapitan_sierra/#{version}/Qobuz.dmg"
   name 'Qobuz'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.