### PR TITLE
Update sqlitemanager from 4.8.3 to 4.8.4

### DIFF
--- a/Casks/sqlitemanager.rb
+++ b/Casks/sqlitemanager.rb
@@ -1,6 +1,6 @@
 cask 'sqlitemanager' do
-  version '4.8.3'
-  sha256 '0e0e99490f45e6145efde46ddc32dd1e131248b024824254579dc7985426793e'
+  version '4.8.4'
+  sha256 '83725f041913ae9a09301ec2eb1c6e8d07b47596b1412297f0372346ebbeba02'
 
   url 'https://www.sqlabs.com/download/SQLiteManager.zip'
   appcast 'https://www.sqlabs.com/sqlitemanager_version'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.