### PR TITLE
Update geneious-prime from 2020.0.2 to 2020.0.3

### DIFF
--- a/Casks/geneious-prime.rb
+++ b/Casks/geneious-prime.rb
@@ -1,6 +1,6 @@
 cask 'geneious-prime' do
-  version '2020.0.2'
-  sha256 '79e33b4f4b91c90c673a7d0cf3ab9d44db5c26f835c2ca8ed62d477f0a78a352'
+  version '2020.0.3'
+  sha256 'a343bf8829f9741f2b93d510c7506ebac69ac984bd0f40a8f084866eef529ff5'
 
   url "https://assets.geneious.com/installers/geneious/release/Geneious_Prime_mac64_#{version.dots_to_underscores}_with_jre.dmg"
   appcast 'https://www.geneious.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.