### PR TITLE
Update slite from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.1.5'
-  sha256 'cbfea4e1f378b94e26c107c2c53cb96edfc462df29a515c1bd0c73fd2ce76037'
+  version '1.1.6'
+  sha256 'cdbb52e9b5f699fa2cdd1f5e685048fa4e6f07b8efe723eb7c85f16d3392594d'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.