### PR TITLE
Update fliqlo from 1.7.2 to 1.8

### DIFF
--- a/Casks/fliqlo.rb
+++ b/Casks/fliqlo.rb
@@ -1,6 +1,6 @@
 cask 'fliqlo' do
-  version '1.7.2'
-  sha256 '20f81b5a06966cf729bcb065d151a6f89958b34d6339e6ea1bd7221b12bdd6ae'
+  version '1.8'
+  sha256 'f5ef7c842a5e45229737cfd38712225b4edc5b5c15879254d00932cf2dde5710'
 
   url "https://fliqlo.com/download/Fliqlo%20#{version}.dmg",
       referer: 'https://fliqlo.com/#about'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.