### PR TITLE
Update fork from 1.0.85.2 to 1.0.86

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,6 +1,6 @@
 cask 'fork' do
-  version '1.0.85.2'
-  sha256 '73830ab29877b7eebb0704101bcbe8e7d6f6a5e4dd672bf5beea98f98347ba2a'
+  version '1.0.86'
+  sha256 '0cff1383fffba679a6613d327fe2f8e9877dea3799808fafb6c99f718aeff911'
 
   # forkapp.ams3.cdn.digitaloceanspaces.com/mac was verified as official when first introduced to the cask
   url "https://forkapp.ams3.cdn.digitaloceanspaces.com/mac/Fork-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.