### PR TITLE
Update netron from 3.5.2 to 3.5.3

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.5.2'
-  sha256 'b5b6a0abc14ab519849523eacfcc63d45dd3449431f6ae43553e3f286b2e68ba'
+  version '3.5.3'
+  sha256 '3677235e7a9032354c32f7a44156ee3a1babb057dce38af94c318bbe8149e646'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.