### PR TITLE
Update netron from 3.5.3 to 3.5.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.5.3'
-  sha256 '3677235e7a9032354c32f7a44156ee3a1babb057dce38af94c318bbe8149e646'
+  version '3.5.4'
+  sha256 'abf10ba6765530a4e3ee14174aa5abae52b69efca2fb995dfcec5b507c923fb1'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.