### PR TITLE
Update lrtimelapse from 5.3.1 to 5.3.2

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -7,7 +7,7 @@ cask 'lrtimelapse' do
   name 'LRTimelapse'
   homepage 'https://lrtimelapse.com/'
 
-  pkg 'LRTimelapse Installer.pkg'
+  pkg 'LRTimelapse  Installer.pkg'
 
   uninstall script:  'Uninstall LRTimelapse.command',
             pkgutil: [

--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,6 +1,6 @@
 cask 'lrtimelapse' do
-  version '5.3.1'
-  sha256 '62fb8bd9fe38de42789b4ec0fc4fa3bae87c76e53433913488d15bfe85face0a'
+  version '5.3.2'
+  sha256 'dabbad9d6bb1c0bd6e934a10f20bea0212289bef16320a171564465bee43ab10'
 
   url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/"
   appcast 'https://lrtimelapse.com/download/'

--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -7,7 +7,7 @@ cask 'lrtimelapse' do
   name 'LRTimelapse'
   homepage 'https://lrtimelapse.com/'
 
-  pkg "LRTimelapse #{version} Installer.pkg"
+  pkg 'LRTimelapse Installer.pkg'
 
   uninstall script:  'Uninstall LRTimelapse.command',
             pkgutil: [


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.