### PR TITLE
Update mission-control-plus from 1.12 to 1.13

### DIFF
--- a/Casks/mission-control-plus.rb
+++ b/Casks/mission-control-plus.rb
@@ -1,9 +1,9 @@
 cask 'mission-control-plus' do
-  version '1.12'
-  sha256 'f72c46afed7c3bc0c2fe521443fc8c70d299d730356589ed35a525ccb058a5b3'
+  version '1.13'
+  sha256 'cc56395c2d836ae141f6da7e0db4f84a01375d6097b9b11b5fc5707fc8ed6b24'
 
   # github.com/ronyfadel/MissionControlPlusReleases was verified as official when first introduced to the cask
-  url "https://github.com/ronyfadel/MissionControlPlusReleases/releases/download/v#{version}/Mission_Control_Plus.zip"
+  url "https://github.com/ronyfadel/MissionControlPlusReleases/releases/download/#{version}/Mission.Control.Plus.tgz"
   appcast 'https://github.com/ronyfadel/MissionControlPlusReleases/releases.atom'
   name 'Mission Control Plus'
   homepage 'https://fadel.io/MissionControlPlus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.