### PR TITLE
Update blitz from 1.3.19 to 1.4.2

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.3.19'
-  sha256 '05fabb20f942a600a2203da4aff990f62c6267a5dcb7d96a76fdb42164c79bfb'
+  version '1.4.2'
+  sha256 'c61475b422965e6148ff309b8a48091fdf948a069ce20b322be164ca49d0c04e'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.