### PR TITLE
Update thedesk from 18.11.4 to 20.0.1

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '18.11.4'
-  sha256 'ba0b853c811471905d9f259e91e5fc8152b86c1ce58418ee402c18cd3ac57fac'
+  version '20.0.1'
+  sha256 '3783737b425ab27cc189365d5842c4b1da1f483a9148f4fdcae746981fee2d60'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.