### PR TITLE
Update daedalus from 0.15.0,3.1.0:8276 to 0.15.1,3.1.0:8695

### DIFF
--- a/Casks/daedalus.rb
+++ b/Casks/daedalus.rb
@@ -1,6 +1,6 @@
 cask 'daedalus' do
-  version '0.15.0,3.1.0:8276'
-  sha256 '21d0f47e45e9b6f6f4f35cb8375ccb74bae28d74c189f923fd65e9432dcd9198'
+  version '0.15.1,3.1.0:8695'
+  sha256 '26746a905bcbca4fc9f88add86a64f3bba69fae051b82308b2437f04f2011478'
 
   # github.com/input-output-hk/daedalus was verified as official when first introduced to the cask
   url "https://github.com/input-output-hk/daedalus/releases/download/#{version.before_comma}/daedalus-#{version.before_comma}-cardano-sl-#{version.after_comma.before_colon}-mainnet-macos-#{version.after_comma.after_colon}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.