### PR TITLE
Update exodus from 19.10.24 to 19.11.8

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '19.10.24'
-  sha256 '3635edcd5bee28970baa8478d8c535fc72990928c0053f34034c7046bce02c20'
+  version '19.11.8'
+  sha256 '5d661298d8809af575bb4c168e6e65173a5b17874106ecab4bdcbd86bebc7bed'
 
   # exodusbin.azureedge.net was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.