### PR TITLE
Update kode54-cog from 0.08,754b5f126 to 0.08,258a88464

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,754b5f126'
-  sha256 '4de49819ae8637ac770cbd70eb38c9abd51c90254bc4c8f057dda1c322d6dff3'
+  version '0.08,258a88464'
+  sha256 '55656f1225f14509752a5d5b20bd652d289b22625a1fe284235466075874e078'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.