### PR TITLE
Update smlnj from 110.94 to 110.95

### DIFF
--- a/Casks/smlnj.rb
+++ b/Casks/smlnj.rb
@@ -1,6 +1,6 @@
 cask 'smlnj' do
-  version '110.94'
-  sha256 '07d4b3b6d36e387bc1fa1e1a6732e3ba947217c91199170e2562e441d7a09651'
+  version '110.95'
+  sha256 '3df3f31f3882ca1ac0755573a649212873ef2b2ec4ccbb939904b59732018976'
 
   # smlnj.cs.uchicago.edu was verified as official when first introduced to the cask
   url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-amd64-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.