### PR TITLE
Update macupdater from 1.4.18 to 1.4.18,6420

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,8 +1,8 @@
 cask 'macupdater' do
-  version '1.4.18'
+  version '1.4.18,6420'
   sha256 'e73049ab156381849effe405d7974c066deb1b095b7d78b5a2499e198db2744d'
 
-  url "https://www.corecode.io/downloads/macupdater_#{version}.dmg"
+  url "https://www.corecode.io/downloads/macupdater_#{version.before_comma}.dmg"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'
   name 'MacUpdater'
   homepage 'https://www.corecode.io/macupdater/index.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.