### PR TITLE
Add checkra1n cask

### DIFF
--- a/Casks/checkra1n.rb
+++ b/Casks/checkra1n.rb
@@ -1,6 +1,6 @@
 cask 'checkra1n' do
-  version '0.9'
-  sha256 '4d63520f02d29eb91046ce0bb0a5849ed5599fc4684038954e18bc9d622febdb'
+  version '0.9.1'
+  sha256 'dec472b249315a44a7a8caed016eaff2802a8b8d969d2fd299602a3af75ce3a0'
 
   url "https://checkra.in/assets/downloads/macos/#{sha256}/checkra1n%20beta%20#{version}.dmg"
   name 'checkra1n'

--- a/Casks/checkra1n.rb
+++ b/Casks/checkra1n.rb
@@ -3,6 +3,7 @@ cask 'checkra1n' do
   sha256 'dec472b249315a44a7a8caed016eaff2802a8b8d969d2fd299602a3af75ce3a0'
 
   url "https://checkra.in/assets/downloads/macos/#{sha256}/checkra1n%20beta%20#{version}.dmg"
+  appcast 'https://checkra.in/'
   name 'checkra1n'
   homepage 'https://checkra.in/'
 

--- a/Casks/checkra1n.rb
+++ b/Casks/checkra1n.rb
@@ -1,0 +1,10 @@
+cask 'checkra1n' do
+  version '0.9'
+  sha256 '4d63520f02d29eb91046ce0bb0a5849ed5599fc4684038954e18bc9d622febdb'
+
+  url "https://checkra.in/assets/downloads/macos/#{sha256}/checkra1n%20beta%20#{version}.dmg"
+  name 'checkra1n'
+  homepage 'https://checkra.in/'
+
+  app 'checkra1n.app'
+end


### PR DESCRIPTION
This adds the [checkra1n jailbreak utility](https://checkra.in/) (currently in [early beta preview](https://checkra.in/#important-information)) as a cask.

Right now, there is no uninstall stanza.

- [x] `brew cask audit --download checkra1n` is error-free.
- [x] `brew cask style --fix checkra1n` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] Named the cask according to the [token reference].
- [x] `brew cask install checkra1n` worked successfully.
- [x] `brew cask uninstall checkra1n` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
