### PR TITLE
Updated TablePlus build to 276.

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '2.10.2,272'
-  sha256 'ee4f23b286f5407704d01c9b84eab0084eaa95fc90e234b5f85ca0a46a34edc3'
+  version '2.11,276'
+  sha256 '1704360e2bc97bec96b7606de80b93d415b917894996e71f68b1753ee2f5fc2c'
 
   # tableplus-osx-builds.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).