### PR TITLE
Update neo4j from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,7 +1,7 @@
 cask 'neo4j' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '1.2.2'
-  sha256 '9b86c08825275410be47937eef0f02e994c81c12e0cbe3a4242b0af28d1372f7'
+  version '1.2.3'
+  sha256 'eb14ee9d6aa9eb1f9c9e66590ea2a6ebcdb0ff3d7b92fc842a542bf163d75e2c'
 
   url "https://neo4j.com/artifact.php?name=neo4j-desktop-offline-#{version}.dmg"
   appcast 'https://neo4j.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.