### PR TITLE
Update coderunner from 3.0.1 to 3.1

### DIFF
--- a/Casks/coderunner.rb
+++ b/Casks/coderunner.rb
@@ -1,9 +1,8 @@
 cask 'coderunner' do
-  version '3.0.1'
-  sha256 '31976c2551102eb07c3c20b578664a0697a92299c53a4956bc7353c7440a81fa'
+  version '3.1'
+  sha256 'c85ee95a52af5986a0279a8191feff3f0c7d9f86b0f8030779b48b6a33541bee'
 
-  # dktfof1z89xc1.cloudfront.net was verified as official when first introduced to the cask
-  url "https://dktfof1z89xc1.cloudfront.net/CodeRunner-#{version}.zip"
+  url "https://coderunnerapp.com/download/update/CodeRunner-#{version}.zip"
   appcast 'https://coderunnerapp.com/appcast.xml'
   name 'CodeRunner'
   homepage 'https://coderunnerapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.