### PR TITLE
Update archi from 4.5.1 to 4.6.0

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,6 +1,6 @@
 cask 'archi' do
-  version '4.5.1'
-  sha256 '32c705fec35a3ff8384bb13da93545fbb1104f78488309c6a4851c0f963d68c3'
+  version '4.6.0'
+  sha256 '2cc75122d6e1fb9ce9cf99488aeb041c07cec0df237e9bd496f6f8dc4cf66cbc'
 
   url "https://www.archimatetool.com/downloads/#{version.no_dots}/Archi-Mac-#{version}.zip"
   appcast 'https://github.com/archimatetool/archi/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.