### PR TITLE
Update pagico from 9.0.3057 to 9.0.3060

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '9.0.3057'
-  sha256 'e370d491d9428af9dadb0a98a9ebd663e6096aed0283aa2477afdd4a7b7559bd'
+  version '9.0.3060'
+  sha256 '5720a15304ad2bac302330ad63501c4e83674c6dee4cab1956deb03018043c91'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast "https://www.pagico.com/api/pagico#{version.major}.mac.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.