### PR TITLE
Update filepane from 1.10.5,1570653522 to 1.10.6,1573342847

### DIFF
--- a/Casks/filepane.rb
+++ b/Casks/filepane.rb
@@ -1,6 +1,6 @@
 cask 'filepane' do
-  version '1.10.5,1570653522'
-  sha256 '2b8d75610f10bed81857b6503e61bbfb2246368abe2a20788de242a28acb74e7'
+  version '1.10.6,1573342847'
+  sha256 'bfb5c593bd1a859ce5217c594f91274ace03893385d5272b805313f4db27d59d'
 
   # dl.devmate.com/com.mymixapps.FilePane was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mymixapps.FilePane/#{version.before_comma}/#{version.after_comma}/FilePane-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.