### PR TITLE
Update find-any-file from 2.0 to 2.1.1

### DIFF
--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -1,10 +1,10 @@
 cask 'find-any-file' do
-  version '2.0'
-  sha256 '7aa7379e7d3f86d0a924d20fbd26ffab857178f5159c9a11b1bef0e0a08b5697'
+  version '2.1.1'
+  sha256 '5e444bcb16f89bbb44ded8da6f84d494d081ef07d8949ac2287ac80d1cc2a585'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/files.tempel.org/FindAnyFile_#{version}.zip"
-  appcast 'https://apps.tempel.org/FindAnyFile/appcast.xml'
+  appcast 'http://findanyfile.app/appcast2.php'
   name 'Find Any File'
   homepage 'https://apps.tempel.org/FindAnyFile/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.