### PR TITLE
Add shim script for Inkscape v1.0beta1 CLI

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -16,6 +16,18 @@ cask 'inkscape' do
 
     url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}_OEMhoXK.dmg"
 
+    # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+    shimscript = "#{staged_path}/inkscape.wrapper.sh"
+
+    binary shimscript, target: 'inkscape'
+
+    preflight do
+      IO.write shimscript, <<~EOS
+        #!/bin/sh
+        cd '#{staged_path}/Inkscape.app/' && ./Contents/MacOS/Inkscape "$@"
+      EOS
+    end
+
     zap trash: '~/Library/Application Support/Inkscape'
   end
 

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -24,7 +24,7 @@ cask 'inkscape' do
     preflight do
       IO.write shimscript, <<~EOS
         #!/bin/sh
-        cd '#{staged_path}/Inkscape.app/' && ./Contents/MacOS/Inkscape "$@"
+        exec '#{staged_path}/Inkscape.app/Contents/MacOS/Inkscape' "$@"
       EOS
     end
 


### PR DESCRIPTION
The location of the Inkscape command-line tools has changed between v0.9
and v1.0, and symlinking the scripts will no longer work (see
https://wiki.inkscape.org/wiki/index.php/Mac_OS_X#Inkscape_command_line).

To resolve this, this commit adds a shim script to run the Inkscape
scripts from the correct working directory (according to the official
shim script guidance https://github.com/Homebrew/homebrew-cask/issues/18809).

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
