### PR TITLE
Update amazon-music from 7.8.4,20191014:194547a7a5 to 7.8.5,20191109:02490370af

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask 'amazon-music' do
-  version '7.8.4,20191014:194547a7a5'
-  sha256 '2907563115b2d367f77cac66f40abd12f830734001eaee688a34cb371a9c2089'
+  version '7.8.5,20191109:02490370af'
+  sha256 '9f864b10a3b6ebcd2ad8bef9510436d346c05756bdd55ee1220848f89afa5f67'
 
   # ssl-images-amazon.com/images was verified as official when first introduced to the cask
   url "https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/#{version.after_comma.before_colon}/#{version.after_colon}/AmazonMusicInstaller.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.