### PR TITLE
Update trilium-notes from 0.36.4 to 0.36.5

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.36.4'
-  sha256 'aed0cc98625390b6fa29dca485f10671cb41eb728d860ff9506aa653f601c35d'
+  version '0.36.5'
+  sha256 '49fd53dd53a67200a54d4911571870fb36039cbf6b0ba945c0c908b856125ba8'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.