### PR TITLE
Update alt-tab from 1.12.2 to 1.14.2

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.12.2'
-  sha256 '6e5a22ca0131f7a10c60b518045029bf92392f371168ae64bbb8ae393eacb6bd'
+  version '1.14.2'
+  sha256 '609085cd86c2383862a2a77bfb83fea6db3cb31d9b0246420463f0ba56c9e31d'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.