### PR TITLE
Update tropy from 1.5.4 to 1.6.0

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.5.4'
-  sha256 '7655dec6751c99896ba4af8ee067d2ad806b80fe863eccd87aabcbff3e712ca5'
+  version '1.6.0'
+  sha256 '2c061c7dc96f79d45039034f639d9143cb7903a6450faf0fe54c6696d6a0cbc9'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.