### PR TITLE
Update thedesk from 20.0.1 to 20.0.2

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '20.0.1'
-  sha256 '3783737b425ab27cc189365d5842c4b1da1f483a9148f4fdcae746981fee2d60'
+  version '20.0.2'
+  sha256 '87cf00538a9fb7d9a67132d139d752f91a146d403313c5e4f679f5d9bad743ca'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.