### PR TITLE
Update path-finder from 9.0.2 to 9.0.3

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '9.0.2'
-  sha256 '06e0090f6a7a630e2c638aa69e78f0a397eb486aa8baee7df3bb44ef16da9beb'
+  version '9.0.3'
+  sha256 '21a47587872a38bc430d4a68bf8f64133f5d142ba8962192381008e87406257c'
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.