### PR TITLE
Update zoomus from 4.5.5735.1105 to 4.5.5757.1110

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.5.5735.1105'
-  sha256 '5f1134214c368831cfd206b0e789416d4c6aa3860b959221f8eef1aec7c0f8cc'
+  version '4.5.5757.1110'
+  sha256 '294ef17ef2f199a861a92d67f2f278baa88997d5ba5e3293b2004f8a4098ec53'
 
   url "https://www.zoom.us/client/#{version}/zoomusInstaller.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://zoom.us/client/latest/Zoom.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.