### PR TITLE
Update anydo from 4.2.50 to 4.2.51

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.50'
-  sha256 '1fd2b027d00a2a5c5f997c0bb2aaa0b518465d3db188775663b76e1a281b7ac2'
+  version '4.2.51'
+  sha256 'b7d65e11f9f0e5e0a30644ca34e196622c2e3f17786d0a48ab47999ac9f7c7e4'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.