### PR TITLE
Update garagesale from 8.0.3 to 8.0.4

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,6 +1,6 @@
 cask 'garagesale' do
-  version '8.0.3'
-  sha256 '17e739513616c955d164ba05b5ec8edb016e2103c0db0d23508ec5864ca6ab81'
+  version '8.0.4'
+  sha256 'd0d07fd6dbc64dd9f4d1182dee75e57cfa201a7a8ae4a7930cb906e8bc5cfa00'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   appcast 'https://www.iwascoding.com/GarageSale/Downloads.html#VersionHistory'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.