### PR TITLE
Update eloston-chromium from 77.0.3865.120-1 to 78.0.3904.97-1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,6 +1,6 @@
 cask 'eloston-chromium' do
-  version '77.0.3865.120-1'
-  sha256 '3197d136d6648eac6806e5b951788498b1cf5af9b57ff9629c522fb537f33119'
+  version '78.0.3904.97-1'
+  sha256 '48257a5bf449e37c6f8d3381bc704f566f86c86f1669346f313556e8fe8ce4e1'
 
   # github.com/kramred/ungoogled-chromium-binaries was verified as official when first introduced to the cask
   url "https://github.com/kramred/ungoogled-chromium-binaries/releases/download/#{version}/ungoogled-chromium_#{version}.1_macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.