### PR TITLE
Update plex-media-server from 1.18.1.1973-0f4abfbcc to 1.18.1.2019-c186313fe

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.18.1.1973-0f4abfbcc'
-  sha256 'b6803a8ffb62182853e30f66414b7078266625497dfbccbcd40fcd7dbe810fe7'
+  version '1.18.1.2019-c186313fe'
+  sha256 'bea00ee9ea1285c4d51749372d0aa09330bd2a0a8e5c31c3d98726ab210eb200'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.