### PR TITLE
Update vimediamanager.rb from 0.7a19 to 0.7a20 + url change

### DIFF
--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -2,7 +2,7 @@ cask 'vimediamanager' do
   version '0.7a20'
   sha256 'd8a1a6f938cbc8c77ad92e063fd2bc0899ea9170b3f7f5273630668038383db9'
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{vesion.minor.gsub(/[a-z]/, '')}.dmg"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{version.minor.gsub(/[a-z]/, '')}.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'

--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -2,7 +2,7 @@ cask 'vimediamanager' do
   version '0.7a20'
   sha256 'd8a1a6f938cbc8c77ad92e063fd2bc0899ea9170b3f7f5273630668038383db9'
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{version.minor.gsub(%r{[a-z]}, '')}.dmg"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{version.split('.')[-1].gsub(%r{[a-z]}, '')}.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'

--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -2,7 +2,7 @@ cask 'vimediamanager' do
   version '0.7a20'
   sha256 'd8a1a6f938cbc8c77ad92e063fd2bc0899ea9170b3f7f5273630668038383db9'
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v720.dmg"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{vesion.minor.gsub(/[a-z]/, '')}.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'

--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -2,7 +2,7 @@ cask 'vimediamanager' do
   version '0.7a20'
   sha256 'd8a1a6f938cbc8c77ad92e063fd2bc0899ea9170b3f7f5273630668038383db9'
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{version.minor.gsub(/[a-z]/, '')}.dmg"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v#{version.minor.gsub(%r{[a-z]}, '')}.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'

--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -1,8 +1,8 @@
 cask 'vimediamanager' do
-  version '0.7a19'
-  sha256 '066d1adfdeea8e3bcb20ce8197f9521bd09a3a080e6b5d490d4b2765de8c1130'
+  version '0.7a20'
+  sha256 'd8a1a6f938cbc8c77ad92e063fd2bc0899ea9170b3f7f5273630668038383db9'
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager.v#{version}.dmg"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v720.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom'
   name 'ViMediaManager'
   homepage 'https://github.com/vidalvanbergen/ViMediaManager'


### PR DESCRIPTION
hey @vitorgalvao - do you perhaps have an idea how to solve the new url notation?
`url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager-v720.dmg"`