### PR TITLE
wine-stable: allow to be installed on Catalina

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -13,7 +13,6 @@ cask 'wine-stable' do
                             'wine-staging',
                           ]
   depends_on x11: true
-  depends_on macos: '<= :mojave'
 
   pkg "winehq-stable-#{version}.pkg",
       choices: [


### PR DESCRIPTION
`wine-*` packages _do_ work on Catalina,
if launched via `wine64` to execute 64-bit Windows binaries. It 
means it makes sense to still allow them to be installed on Catalina.

Ref: https://github.com/Homebrew/homebrew-core/pull/46556#issuecomment-552922357
