### PR TITLE
Update joplin from 1.0.173 to 1.0.174

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.173'
-  sha256 '21abb98a4cc46a2c759c49dbf946139faa88152c1531e8fe1c6a9b80806fbf8d'
+  version '1.0.174'
+  sha256 '3dd33c4b1b6cbccd9f3536c362d28eef21c74760811b2be27196cf9be691a2f9'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.