### PR TITLE
Update version in macs-fan-control.rb from 1.5.1 to 1.5.1.7

### DIFF
--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -1,10 +1,11 @@
 cask 'macs-fan-control' do
   version '1.5.1.7'
-  sha256 'ac93dc9020e31d199caa550f3ab7b892afd6ddd5d94b3a0794f0cd44d9e5bd7c'
+  sha256 '29c9d84611c7b67bbf134db8e3899f27f515ddd1521424f6a5cddbb34714d4db'
 
   # github.com/crystalidea/macs-fan-control was verified as official when first introduced to the cask
   url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version.major_minor_patch}/macsfancontrol.zip"
-  appcast 'https://github.com/crystalidea/macs-fan-control/releases.atom'
+  appcast 'https://github.com/crystalidea/macs-fan-control/releases.atom',
+          configuration version.major_minor_patch
   name 'Macs Fan Control'
   homepage 'https://www.crystalidea.com/macs-fan-control'
 

--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -1,9 +1,9 @@
 cask 'macs-fan-control' do
-  version '1.5.1'
+  version '1.5.1.7'
   sha256 'ac93dc9020e31d199caa550f3ab7b892afd6ddd5d94b3a0794f0cd44d9e5bd7c'
 
   # github.com/crystalidea/macs-fan-control was verified as official when first introduced to the cask
-  url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version}/macsfancontrol.zip"
+  url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version.major_minor_patch}/macsfancontrol.zip"
   appcast 'https://github.com/crystalidea/macs-fan-control/releases.atom'
   name 'Macs Fan Control'
   homepage 'https://www.crystalidea.com/macs-fan-control'

--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -5,7 +5,7 @@ cask 'macs-fan-control' do
   # github.com/crystalidea/macs-fan-control was verified as official when first introduced to the cask
   url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version.major_minor_patch}/macsfancontrol.zip"
   appcast 'https://github.com/crystalidea/macs-fan-control/releases.atom',
-          configuration version.major_minor_patch
+          configuration: version.major_minor_patch
   name 'Macs Fan Control'
   homepage 'https://www.crystalidea.com/macs-fan-control'
 


### PR DESCRIPTION
would it be possible to take the full version notation for this cask?
there often just a change in the last number 