### PR TITLE
Update retroarch from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask 'retroarch' do
-  version '1.8.0'
-  sha256 '46fe601b23ce80a5908965e6d94cba75a5f0b0fe392397c2d79a4f1c826312a7'
+  version '1.8.1'
+  sha256 '819cfa685fbec93b8fdf73d2e49e07949703a7f6919da5675ec47eee338b6f60'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   appcast 'https://buildbot.libretro.com/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.