### PR TITLE
Update deezer from 4.17.1 to 4.17.21

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.17.1'
-  sha256 'fd1769c4e978e5d3c5a370f3ec1e030ba77b32d22b2c8d029eea2218ea1ac1e8'
+  version '4.17.21'
+  sha256 '69bf314b037177dd4f5be81b4d39a0267f78c084d5b91f4298bd954f643252ab'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.