### PR TITLE
Update augur from 1.16.4 to 1.16.5

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.16.4'
-  sha256 '0841eede1d41a00465c31b65b74d8ad52bfd640c8ced9c473456b95e0e3a73e7'
+  version '1.16.5'
+  sha256 '0860f41a6c8e558f86fa5430eb0c0a03e09053ce5ebefd5025d30d8e7ea16f40'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.