### PR TITLE
Update station from 1.58.1 to 1.58.2

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.58.1'
-  sha256 '891c08480520d3455b7d7a21748bd44a18e8e74c1ae0c0f105a2e59e41b8ea01'
+  version '1.58.2'
+  sha256 'a492f2c24d63f1cdb304891765cca3a20afa38237a75eab659f37464ad1e0bc8'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.