### PR TITLE
Update jami from 20191110.0956 to 20191112.1050

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20191110.0956'
-  sha256 '095b9303e0cc09fbde5d70724765fbafe3af5268818810f37388ec85df8ad2d3'
+  version '20191112.1050'
+  sha256 '63002b9d1c705d1ba92a7997e599c9b17ec9349371d93831b4e7f5addfb5727a'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.