### PR TITLE
Update kodelife from 0.8.6.101 to 0.8.7.105

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,6 +1,6 @@
 cask 'kodelife' do
-  version '0.8.6.101'
-  sha256 '41075265832c171c7e45ea5733ea1a3d3e8170e5874828752e77c0966f540e0c'
+  version '0.8.7.105'
+  sha256 '1b3568538672a4afa0c1399b000cf8301b4b207b5633e2a0d83de586b2cd3bb8'
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-macos.zip"
   appcast 'https://hexler.net/pub/kodelife/appcast.hex'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.