### PR TITLE
Update melodics from 2.1.3758 to 2.1.3764

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3758'
-  sha256 '0bcf80e93458f29255585c477b72f472ab0916d1db4e309e1d8479a70c77405e'
+  version '2.1.3764'
+  sha256 'ec5efa5246406def1e4d74b5a5229dc496e2cc030096d8dedeaba781e1506529'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.