### PR TITLE
Update freesmug-chromium from 78.0.3904.87 to 78.0.3904.97

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '78.0.3904.87'
-  sha256 'c83d011f2ffd7b99a35a4d364ca75666370e6774954e351a4838c2e54d45f18f'
+  version '78.0.3904.97'
+  sha256 '7c90c63714a983e1d2277f40a1f3ce1e90f245c1b1a8bacc6e9308ed328d552b'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.