### PR TITLE
Update arrayfire from 3.6.1 to 3.6.4

### DIFF
--- a/Casks/arrayfire.rb
+++ b/Casks/arrayfire.rb
@@ -1,6 +1,6 @@
 cask 'arrayfire' do
-  version '3.6.1'
-  sha256 '4afa07262d4c48a682c13901dd09ad2aadfe988212379c2ed78cc9c45049a5d0'
+  version '3.6.4'
+  sha256 '7ca7f9280fd7bda18fa78275c9d4ce2ea3885307afb29e5b8793711394fd9995'
 
   # arrayfire.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://arrayfire.s3.amazonaws.com/#{version}/ArrayFire-v#{version}_OSX_x86_64.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.