### PR TITLE
Update preform from 3.2.0,1539 to 3.2.1,1600

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,9 +1,9 @@
 cask 'preform' do
-  version '3.2.0,1539'
-  sha256 '0c4a362fbf15d3bba0231dd4f9f3daacb82d3618c9b66a1d73a11f5f18beaf30'
+  version '3.2.1,1600'
+  sha256 'c13e7573ed7f1de6e2715a99dbde78f52a45593ab432c1f3d1dd17dc694aeeed'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"
+  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://formlabs.com/download-preform-mac/'
   name 'PreForm'
   homepage 'https://formlabs.com/tools/preform/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.