### PR TITLE
Update Musescore from 3.3 to 3.3.1

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,16 +1,16 @@
 cask 'musescore' do
-  version '3.3.0'
-  sha256 '227325d1bac5ec6cf2256fbe29fd731a7b874de252c48d11ac41c9337a23e445'
+  version '3.3.1'
+  sha256 '09a4340b16448c0bd063da45b89b76c48dd2485f5266a28d51ef6fc5ed832d91'
 
   # github.com/musescore/MuseScore was verified as official when first introduced to the cask
-  url "https://github.com/musescore/MuseScore/releases/download/v#{version.major_minor}/MuseScore-#{version}.dmg"
+  url "https://github.com/musescore/MuseScore/releases/download/v#{version}/MuseScore-#{version}.dmg"
   appcast 'https://github.com/musescore/MuseScore/releases.atom'
   name 'MuseScore'
   homepage 'https://musescore.org/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :yosemite'
 
-  app "MuseScore #{version.major_minor}.app"
+  app "MuseScore #{version.major}.app"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/mscore.wrapper.sh"
   binary shimscript, target: 'mscore'
@@ -18,7 +18,7 @@ cask 'musescore' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{appdir}/MuseScore #{version.major_minor}.app/Contents/MacOS/mscore' "$@"
+      exec '#{appdir}/MuseScore #{version.major}.app/Contents/MacOS/mscore' "$@"
     EOS
   end
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I also updated OS minimum version, as website specifies [macOS 10.10 or higher](https://musescore.org/en/download)

