### PR TITLE
Fix liteicon 3.9 and 4.1 supported OS versions

### DIFF
--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -2,7 +2,7 @@ cask 'liteicon' do
   if MacOS.version <= :sierra
     version '3.7.1'
     sha256 'b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432'
-  elsif MacOS.version == :high_sierra
+  elsif MacOS.version <= :high_sierra
     version '3.9'
     sha256 'd185503d1c6cbbc6f770517853bd9ef08dc620f4e7ce3de913251a57e4d450d9'
   else

--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -2,7 +2,7 @@ cask 'liteicon' do
   if MacOS.version <= :sierra
     version '3.7.1'
     sha256 'b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432'
-  elsif MacOS.version <= :mojave
+  elsif MacOS.version == :high_sierra
     version '3.9'
     sha256 'd185503d1c6cbbc6f770517853bd9ef08dc620f4e7ce3de913251a57e4d450d9'
   else


### PR DESCRIPTION
LiteIcon 4.1 (introduced in #71038), introduced Mojave support into post-4.0 versions, making 3.9 useful exclusively for High Sierra.  The conditions for versions and hashes have been updated accordingly.

OS version compatibility is detailed on FreeMacSoft's [website](https://freemacsoft.net/liteicon/).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. (sorta)
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).