### PR TITLE
Update unity-lumin-support-for-editor from 2019.2.11f1,5f859a4cfee5 to 2019.2.12f1,b1a7e1fb4fa5

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.2.11f1,5f859a4cfee5'
-  sha256 '61c84d5baf0c526612f5c94adf398f99e3413154533265204c1c6d75be78b373'
+  version '2019.2.12f1,b1a7e1fb4fa5'
+  sha256 '8b37a3024c73ce5816a51b4b42bad1b3ffc0251fde2e0a1a6e5a64f5918c17bb'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.