### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.11f1,5f859a4cfee5 to 2019.2.12f1,b1a7e1fb4fa5

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.11f1,5f859a4cfee5'
-  sha256 'f098649efbc6226db60dfb9c6b5f4e391af0a43e1f851be78c64e519018e6ebd'
+  version '2019.2.12f1,b1a7e1fb4fa5'
+  sha256 '92cd3efe82c2279b044a1856b028c18f78804dd9f5a1a0daf81bd98cd35b8618'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.