### PR TITLE
Update frhelper from 3.9.2,2019-10-08 to 3.9.3,2019-10-13

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,5 +1,5 @@
 cask 'frhelper' do
-  version '3.9.3,2019-10-13'
+  version '3.9.3,2019-10-14'
   sha256 'bc0e4369c0ce482a42f138d7ea347d5e261cd522e8f21f06a6548ac147541a7e'
 
   # static.frdic.com was verified as official when first introduced to the cask

--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,5 +1,5 @@
 cask 'frhelper' do
-  version '3.9.2,2019-10-08'
+  version '3.9.3,2019-10-13'
   sha256 'bc0e4369c0ce482a42f138d7ea347d5e261cd522e8f21f06a6548ac147541a7e'
 
   # static.frdic.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.