### PR TITLE
Update origin from 10.5.51.32258 to 10.5.55.33574

### DIFF
--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -1,6 +1,6 @@
 cask 'origin' do
-  version '10.5.51.32258'
-  sha256 '684bd48df0ce0543d465b46b3dea09a1ec45b584f0cdb98773a05d7776a7fd16'
+  version '10.5.55.33574'
+  sha256 '76a157e5126c513504a5f8e05fe651d87b3fa2f602296dc31b8f770e2ca8572e'
 
   # origin-a.akamaihd.net was verified as official when first introduced to the cask
   url "https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/OriginUpdate_#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.