### PR TITLE
Update monitorcontrol from 1.7.0 to 1.7.1

### DIFF
--- a/Casks/monitorcontrol.rb
+++ b/Casks/monitorcontrol.rb
@@ -1,6 +1,6 @@
 cask 'monitorcontrol' do
-  version '1.7.0'
-  sha256 '8577bfc1d7d187acaa913a36c8854d095eaa66949a827c4d7fbe1468f2e9382a'
+  version '1.7.1'
+  sha256 'c2102be6604e9f7e9e3261d9c77c0ade251d028e776f8c58fb567a81cce20768'
 
   url "https://github.com/the0neyouseek/MonitorControl/releases/download/v#{version}/MonitorControl.#{version}.dmg"
   appcast 'https://github.com/the0neyouseek/MonitorControl/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.