### PR TITLE
Update flipper from 0.27.0 to 0.28.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.27.0'
-  sha256 'c20bfaf56a19bccfe5cf4ccb32fbd1e02a1da5a3eb109dd19757bcecc06b849e'
+  version '0.28.0'
+  sha256 'bfe6408aff789cf6edaa5575362e0523d0e3de2280c638df4b07288d264a50c2'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.