### PR TITLE
Update tiled from 1.2.5 to 1.3.0

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,6 +1,6 @@
 cask 'tiled' do
-  version '1.2.5'
-  sha256 'bcb43f2942cd9d5f7bd331076c18fc5c968b113cb1253ccc7dcea0951cbf72b1'
+  version '1.3.0'
+  sha256 '825c0abd208f9a827693d940b3a8176696510ae97185ad2b166dbdb748517db5'
 
   # github.com/bjorn/tiled was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/Tiled-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.