### PR TITLE
Update phoenix-slides from 1.4.4 to 1.4.5

### DIFF
--- a/Casks/phoenix-slides.rb
+++ b/Casks/phoenix-slides.rb
@@ -1,6 +1,6 @@
 cask 'phoenix-slides' do
-  version '1.4.4'
-  sha256 'f27bb747a822e8b39eae81a6fe426692624d209cf7a50b98bdd5331bd451fdb9'
+  version '1.4.5'
+  sha256 '78c491f543abaef0da62fc892433d9698f6f5badd98210d0ac4c4865d289cdd6'
 
   # github.com/gobbledegook/creevey was verified as official when first introduced to the cask
   url "https://github.com/gobbledegook/creevey/releases/download/v#{version}/phoenix-slides-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.