### PR TITLE
Update pagico from 9.0.3060 to 9.0.3063

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '9.0.3060'
-  sha256 '5720a15304ad2bac302330ad63501c4e83674c6dee4cab1956deb03018043c91'
+  version '9.0.3063'
+  sha256 'ef65ac17dc7e420c6fa072d7474cb7e57ade28122359f6b6c9d1bcd5b013a206'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast "https://www.pagico.com/api/pagico#{version.major}.mac.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.