### PR TITLE
Update activedock from 265,1573476246 to 266,1573645440

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '265,1573476246'
-  sha256 '50e4ce9e2261c5e1787be07e08d4ed01172f2fcf7bf656473f07a9cc73179bfd'
+  version '266,1573645440'
+  sha256 '9c5bf95d388cc339624596b5ed20b9f6ab0bb779b6b1220d69e81fa7b5d541a9'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.