### PR TITLE
Update nvidia-geforce-now from 2.0.14.93,ADDE2E to 2.0.15.45,540049

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.14.93,ADDE2E'
-  sha256 'c70fecd98ab176c83b0e9c36b2aa5e494b8cd82d6864108dccb9906034abb883'
+  version '2.0.15.45,540049'
+  sha256 '4f5bb27f873806c51bef5c112985e33156cc33a247618554badb316788e68a59'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.