### PR TITLE
Update 4k-stogram from 2.8.0.1950 to 2.8.1.1970

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask '4k-stogram' do
-  version '2.8.0.1950'
-  sha256 'e9502ef69803533cda36c6619378b993b7321c35f2f1b2a1a2b737a3874bbaca'
+  version '2.8.1.1970'
+  sha256 '92c3fe4b0e46f62083c4deccdbfa7b9be6305a6eada0eabdea9617c7b40d7441'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.