### PR TITLE
Update cycling74-max from 8.1.0_190924 to 8.1.1_191112

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '8.1.0_190924'
-  sha256 'f1b3d793a1fca62f65d965db14c22b8df85c01d4f9b7813aff437980f8d06644'
+  version '8.1.1_191112'
+  sha256 '95bf87c7f57ff0a4381189dc911755e195482ab0820f6d2e279262afa43a2134'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.