### PR TITLE
Update studio-3t from 2019.6.1 to 2019.7.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2019.6.1'
-  sha256 'f9a5513d2174a6364b470a35cf1bbea7197e4c7f78b00edd7a80793a2a99238d'
+  version '2019.7.0'
+  sha256 '0ef25d3b22a4ec9f82ef5b1ce02017f749dda348584a7e7cbdb14a564e1cfe95'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.