### PR TITLE
Update omnioutliner from 5.4.2(n) to 5.5

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,8 +1,8 @@
 cask 'omnioutliner' do
-  version '5.4.2(n)'
-  sha256 'a9364dcf2ee97a871a881530785fa54d269f5e95298e2e4d2e979c70b6365395'
+  version '5.5'
+  sha256 '19a552e1a8f92cbb598044c27dd358bd51e77aebf8fdbd3b9a7ece3690a2d89f'
 
-  url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniOutliner-#{version}.dmg"
+  url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
   appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniOutliner#{version.major}"
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -7,7 +7,7 @@ cask 'omnioutliner' do
   name 'OmniOutliner'
   homepage 'https://www.omnigroup.com/omnioutliner/'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :mojave'
 
   app 'OmniOutliner.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.