### PR TITLE
Update skype from 8.54.0.85 to 8.54.0.91

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.54.0.85'
-  sha256 '014f94e6c7b057dcc6d0abba730c7e87615dc4d632a44538d5b9fe94dd1df854'
+  version '8.54.0.91'
+  sha256 '820d6769e5988253f358632d1c292db57167715af08ca5fd0a6c005a6de848a2'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.