### PR TITLE
Update coteditor from 3.8.4 to 3.8.5

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -6,8 +6,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.8.4'
-    sha256 '101a0d440a931c50a08962f7ddd5b30be714ccef0e3d80f32c8e55f0cc1355c4'
+    version '3.8.5'
+    sha256 '59dc997d2f35fa8c9cbe77f5b2059fd6beda4443ffe0d28c6ffb945dc4763da5'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.