### PR TITLE
Update lingon-x from 7.4.4 to 7.4.5

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.5'
     sha256 'b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8'
   else
-    version '7.4.4'
-    sha256 '8a885e430297f57ae39ad764abf788a96fa1df4574ab2d656a9ebbc2962e7337'
+    version '7.4.5'
+    sha256 'c283192e6c5940b4c463533b092790bcd946d75bf1d4c489e133142177974305'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.