### PR TITLE
Update flash-player-debugger-npapi from 32.0.0.270 to 32.0.0.293

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-npapi' do
-  version '32.0.0.270'
-  sha256 'e7b060d2d463a07dbe759e874124ea5316ec71cc1a689e8cfac2cc163b2c9b48'
+  version '32.0.0.293'
+  sha256 'ec8d42fdc522fe8e4754a1f7212ad4e9cd5a583de70a7f41b60d8731f170b561'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.