### PR TITLE
Update webrecorder-player from 1.7.0 to 1.8.0

### DIFF
--- a/Casks/webrecorder-player.rb
+++ b/Casks/webrecorder-player.rb
@@ -1,6 +1,6 @@
 cask 'webrecorder-player' do
-  version '1.7.0'
-  sha256 'f8b89442479a9ecda4b5cd02926bc8f852113946f41822eef3703180bb0d89e3'
+  version '1.8.0'
+  sha256 'c7ecc7b19c31814a15a1dc5bff41ac899b239877d5968b057b0946b250aedd3a'
 
   url "https://github.com/webrecorder/webrecorder-player/releases/download/v#{version}/webrecorder-player-#{version}.dmg"
   appcast 'https://github.com/webrecorder/webrecorder-player/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.