### PR TITLE
Update fsnotes from 4.0.6 to 4.0.7

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.0.6'
-  sha256 '31ec5677f4670d67c23613106eb9a4b11e53e74dcf420db3e054849f33c261f6'
+  version '4.0.7'
+  sha256 'a2a9c4d9576401a36694dd01e805d89f14afd9da894ee6441a52049647dafc81'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.