### PR TITLE
Update proxyman from 1.9.1 to 1.9.2

### DIFF
--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -1,6 +1,6 @@
 cask 'proxyman' do
-  version '1.9.1'
-  sha256 '7376e9ff691f87477e7f96f7433e4f25e813696fcdb38dd34b934429fe9d9147'
+  version '1.9.2'
+  sha256 'a7cf630b188e263ba4067f0522385a460ac38f6dad2ce2a307a6c984b5a2acac'
 
   # github.com/ProxymanApp/Proxyman was verified as official when first introduced to the cask
   url "https://github.com/ProxymanApp/Proxyman/releases/download/#{version}/Proxyman_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.