### PR TITLE
Update screens from 4.7.1,25512 to 4.7.2,25530

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,6 +1,6 @@
 cask 'screens' do
-  version '4.7.1,25512'
-  sha256 '8cf340f8785869b8be7de199990ba52cb2a4104ab8e3141969d59d0434ece0ed'
+  version '4.7.2,25530'
+  sha256 'bdf45d57e11f78e5288a39c0f17735e09d032ea165c810ead740b8265f30d54f'
 
   url "https://updates.edovia.com/com.edovia.screens#{version.major}.mac/Screens_#{version.before_comma}b#{version.after_comma}.zip"
   appcast "https://updates.edovia.com/com.edovia.screens#{version.major}.mac/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.