### PR TITLE
Update kode54-cog from 0.08,0a9c7693d to 0.08,09777d455

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,0a9c7693d'
-  sha256 '6825d54e7c4b488481c2c884a8415f74335ade6d4b8b802a46871b6f0f14fa54'
+  version '0.08,09777d455'
+  sha256 '9022218156e1c844a9953526601a1d264f317c13cf361c4da2387e2949ef0f76'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.