### PR TITLE
Update marvel from 8.5.4 to 8.5.6

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.5.4'
-  sha256 '6d820bc52eb76aecd001b1bececd8b9711730b867c6709cd9e1be17533b6deb6'
+  version '8.5.6'
+  sha256 'c8b46bec4ba7974edac61654160865b0cad3ccded007f776d2d9d2ebfe5af7ea'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.