### PR TITLE
Update reaper from 5.98.400 to 5.98.500

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,6 +1,6 @@
 cask 'reaper' do
-  version '5.98.400'
-  sha256 'ebc28a5db6ed2939a54761dd9bcf158544a50d9202f50ab53a8cd5ea3dc0bbf8'
+  version '5.98.500'
+  sha256 'd719f8225a7382e0da8ea29e384fdcccb9e653a499af2f7d541a3b6dfb8a9f92'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.