### PR TITLE
Update abstract from 86.0.0 to 86.1.0

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '86.0.0'
-  sha256 '2fddc6e046d78df5257ce74556d6ec5ca4a2abe29eee556b72f77094a12ad83c'
+  version '86.1.0'
+  sha256 '3316453983a4308672a868a09d9906fc82ef59959b74374206ff5924bf183fbb'
 
   url "https://downloads.goabstract.com/Abstract-#{version}.dmg"
   appcast 'https://www.goabstract.com/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.