### PR TITLE
Update runway from 0.9.22 to 0.9.24

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.9.22'
-  sha256 'ad92bebfac1d66c9f303a36158ecde98012a0b815eaf8d5b84f6fbc88cf19fc5'
+  version '0.9.24'
+  sha256 '0d30e2d0eb949dff828acc9e2d4339f7498e7911f7023b9c4e4ada058f5ba02a'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.