### PR TITLE
Update nosqlbooster-for-mongodb from 5.2.5 to 5.2.6

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '5.2.5'
-  sha256 '36202f898bb34f8d83164a622c4679a6ca87c5f1247430c886f91da495eca1fc'
+  version '5.2.6'
+  sha256 '1af659f91a4846480561b7b3f4acba419adac7bff3c41c69da76f8338cf2b743'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   appcast 'https://nosqlbooster.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.