### PR TITLE
Update nomachine from 6.8.1_1 to 6.8.2_1

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '6.8.1_1'
-  sha256 '82ac992238afa52ec12182298bc3ac8e17cb5e0eddff6ed75d953cf9ea5df02b'
+  version '6.8.2_1'
+  sha256 '72326d10545f372d99d7ebed7b97e3154abd46d41a4a0bfb2131273389d591f0'
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   appcast 'https://www.nomachine.com/download/download&id=7'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.