### PR TITLE
Update 4k-slideshow-maker from 1.7.1.978 to 1.8.1.1029

### DIFF
--- a/Casks/4k-slideshow-maker.rb
+++ b/Casks/4k-slideshow-maker.rb
@@ -1,6 +1,6 @@
 cask '4k-slideshow-maker' do
-  version '1.7.1.978'
-  sha256 'e1fcf1b3ef7303c09431541d79cd52580037448e4ca22553ec33587c295d984f'
+  version '1.8.1.1029'
+  sha256 'c3a1d2af0d5247c09e9bfb2c1ec55ab78d06cff9c84c080e513684433655c85d'
 
   url "https://dl.4kdownload.com/app/4kslideshowmaker_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.