### PR TITLE
Update qownnotes from 19.11.12,b4859-162627 to 19.11.13,b4866-165318

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.12,b4859-162627'
-  sha256 'ad0b2c1d2998d7f05267d789ecc03fbd97cb608a827f1680e4bb7c17ef5601b8'
+  version '19.11.13,b4866-165318'
+  sha256 '20c10112cb4e9e2ffb4cec68ddf2dcfdc0931b5457b419f47376ec51e09a8425'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.