### PR TITLE
Update chromium from 713968 to 715308

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '713968'
-  sha256 'c6510b85ea2e329150c6d17d800cb0dcf754365d787f714b61383629bb59f908'
+  version '715308'
+  sha256 '237d7529796fdc9640d56d3f4713724d9e7423ff352440637d2e564795ff5c0a'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.