### PR TITLE
Update metabase from 0.33.5.0 to 0.33.5.1

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,5 +1,5 @@
 cask 'metabase' do
-  version '0.33.5.0'
+  version '0.33.5.1'
   sha256 '4c53a18b92bb55e88fff1551b9bdc1e083eb8fce3081d6d4af3a88539ac486f0'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.