### PR TITLE
Update quakespasm from 0.93.1 to 0.93.2

### DIFF
--- a/Casks/quakespasm.rb
+++ b/Casks/quakespasm.rb
@@ -1,6 +1,6 @@
 cask 'quakespasm' do
-  version '0.93.1'
-  sha256 '7cbeba17619779717b76bb366a938d96f094c4eabd9fef008c61dd3c2e806c9a'
+  version '0.93.2'
+  sha256 'e7d0d2d970a899ad3f54943f1d16e2cc210f29347c5d669dbd8988ea4531f797'
 
   # downloads.sourceforge.net/quakespasm was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/quakespasm/Mac/QuakeSpasm-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.