### PR TITLE
Update keybase from 4.7.2-20191026044208,6fc2e969b4 to 5.0.0-20191114182642,f73f97dac6

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,6 +1,6 @@
 cask 'keybase' do
-  version '4.7.2-20191026044208,6fc2e969b4'
-  sha256 'ec9fc20f80995ac674616df7b9cda3aaf41d8d6494d1d57eb432f351b773c024'
+  version '5.0.0-20191114182642,f73f97dac6'
+  sha256 'b94a3fd4b1059b90cfa91cc9b4939c9c3efe8d4758396c920e06e7c7b8018af1'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.