### PR TITLE
Update microsoft-office from 16.30.19101301 to 16.31.19111002

### DIFF
--- a/Casks/microsoft-office.rb
+++ b/Casks/microsoft-office.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-office' do
-  version '16.30.19101301'
-  sha256 '9eee9de31663bc46552dd39183ba13347baaee6871e8dbad218e0817eebcd031'
+  version '16.31.19111002'
+  sha256 'd2dc6ab56d33ae603c85006a36f1b87bccdc5d0af5cc0a2ec656a7e0c2157899'
 
   # officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Office_#{version}_Installer.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.