### PR TITLE
Update netlogo from 6.1.0 to 6.1.1

### DIFF
--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -1,6 +1,6 @@
 cask 'netlogo' do
-  version '6.1.0'
-  sha256 '4a074f0edcc4e977e08eb72ca4f02a8eb45cb7cffaf3ad33df56029658ba41d1'
+  version '6.1.1'
+  sha256 'cf733a599aaf2f1603af501ed48867fdf3f3d9b7c73439d5afb8681396a6fd99'
 
   url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}.dmg"
   appcast 'https://ccl.northwestern.edu/netlogo/oldversions.shtml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.