### PR TITLE
Update postgres from 2.3.1 to 2.3.2

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,6 +1,6 @@
 cask 'postgres' do
-  version '2.3.1'
-  sha256 'a668643a9ebf9d5ff488a4cf3fc51b0d5605756b7d6b8e39f16da7ac87f8171e'
+  version '2.3.2'
+  sha256 '7be264a1c456a1a7f4df16b39a05c2a3b932773da57e590731b780672de35124'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}-10-11-12.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.