### PR TITLE
Update Pext to 0.27

### DIFF
--- a/Casks/pext.rb
+++ b/Casks/pext.rb
@@ -1,6 +1,6 @@
 cask 'pext' do
-  version '0.26'
-  sha256 '65748c1360eddb694a6af2793f440db4235b4431fcb00302f395ee209ee9ebe2'
+  version '0.27'
+  sha256 '10d9797be8bd9a7aa4430aace8f324dd330bc883617a5a8944ea954a1ed9c176'
 
   # github.com/Pext/Pext was verified as official when first introduced to the cask
   url "https://github.com/Pext/Pext/releases/download/v#{version}/Pext-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free. - Can't test, not on macOS currently
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. - Can't test, not on macOS currently
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).