### PR TITLE
Update kode54-cog from 0.08,09777d455 to 0.08,6847f1bcb

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,09777d455'
-  sha256 '9022218156e1c844a9953526601a1d264f317c13cf361c4da2387e2949ef0f76'
+  version '0.08,6847f1bcb'
+  sha256 'aa804f8e4435fb8182cfb542402ad5cd2398b0d7fde17b48b6d75098edf2a37d'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.