### PR TITLE
Update firecamp from 0.6.7 to 0.6.9

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask 'firecamp' do
-  version '0.6.7'
-  sha256 '984322a9f32c0afd0f443df5cf2699ebd6500b05bfa46df7c0f4e01520a58032'
+  version '0.6.9'
+  sha256 '66c9bf83ab403d1dd39ec844e947232ec6b4d3751bd87b54051eaf1f0c5f476b'
 
   # firecamp.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.