### PR TITLE
Update dropdmg from 3.5.8 to 3.5.9

### DIFF
--- a/Casks/dropdmg.rb
+++ b/Casks/dropdmg.rb
@@ -1,6 +1,6 @@
 cask 'dropdmg' do
-  version '3.5.8'
-  sha256 '1b137bca48a0af0cc6a58e0ad0e33e84c54afd756c3eab39843cb3f50004bf96'
+  version '3.5.9'
+  sha256 '3e84c0a84f9413ff3dc3a173e007bf7b736c1811a2ce799b0e1ad15903d60b3f'
 
   url "https://c-command.com/downloads/DropDMG-#{version}.dmg"
   appcast 'https://c-command.com/dropdmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.