### PR TITLE
Update axe-edit-iii from 1.03.09 to 1.03.10

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.03.09'
-  sha256 '9750571f18f8f9aa13d98adc36fa9f6a7e6f49727274eef41448c65db85bb994'
+  version '1.03.10'
+  sha256 'd6bea394107c69ef687e2fbe5f00d36d46cd2f2d6dd91fab5fd431aac8ef494e'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.