### PR TITLE
Update banking-4 from 7.2.0,7222 to 7.2.1,7259

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.2.0,7222'
-  sha256 '28e59fc89edf76101b8e41085fc92d256b95e42835cd013223ef4865a31b08cd'
+  version '7.2.1,7259'
+  sha256 '5dbf6515cf5b944b36df3db0038512f2528e03f9cb0cab2c0e2f82630de3f70a'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.