### PR TITLE
Update amazon-music from 7.8.5,20191109:02490370af to 7.8.6,20191112:0935336bdb

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask 'amazon-music' do
-  version '7.8.5,20191109:02490370af'
-  sha256 '9f864b10a3b6ebcd2ad8bef9510436d346c05756bdd55ee1220848f89afa5f67'
+  version '7.8.6,20191112:0935336bdb'
+  sha256 'e7848561f2c6f24483f6cd5d3988656c58c3196f26cdfdd4c263a6d91c06589a'
 
   # ssl-images-amazon.com/images was verified as official when first introduced to the cask
   url "https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/#{version.after_comma.before_colon}/#{version.after_colon}/AmazonMusicInstaller.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.