### PR TITLE
Update livechat from 3.6.5 to 9.0.6

### DIFF
--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -3,7 +3,7 @@ cask 'livechat' do
   sha256 '55b8bc5793f7dc0aa220ff6e4df61ebb7d8102b42374b62d7821f032eef10668'
 
   url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
-  appcast 'https://rink.hockeyapp.net/api/2/apps/e64c8a48eb174b2fab6afdbd4ff76d31.rss'
+  appcast 'https://s3.amazonaws.com/dal-livechat-main-web/download/Mac/latest-mac.yml'
   name 'LiveChat'
   homepage 'https://www.livechatinc.com/'
 

--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -1,6 +1,6 @@
 cask 'livechat' do
-  version '3.6.5'
-  sha256 'a807030bf49acaec1e35c4e74a3e1912c73f03cd6502cac280798a6bee0a446e'
+  version '9.0.6'
+  sha256 '55b8bc5793f7dc0aa220ff6e4df61ebb7d8102b42374b62d7821f032eef10668'
 
   url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
   appcast 'https://rink.hockeyapp.net/api/2/apps/e64c8a48eb174b2fab6afdbd4ff76d31.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.