### PR TITLE
Update name-mangler from 3.5 to 3.6

### DIFF
--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -1,6 +1,6 @@
 cask 'name-mangler' do
-  version '3.5'
-  sha256 '2f896e219820beade8e0f9bd9cd337cf3a59a35aaf1aabdec5a2a64ca9897943'
+  version '3.6'
+  sha256 '920089b29f13e7a2036898b7dd720367698e92c1bbbb2b417bdad06a0c3e2cfa'
 
   url 'https://manytricks.com/download/namemangler'
   appcast 'https://manytricks.com/namemangler/appcast/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.