### PR TITLE
Update electron-cash from 4.0.10 to 4.0.11

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.10'
-  sha256 '8e2bd667a9681ec896f080d00e5d5655c00e52291561bf8dedb481c10fc69a29'
+  version '4.0.11'
+  sha256 'ab90d13ac2c8fcb7d934f6881d1de54e5d5a27918f2d2e8c9843b34128849bfc'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/Electron-Cash/Electron-Cash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.