### PR TITLE
Update iconjar from 2.1,37075 to 2.1.1,37078

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,6 +1,6 @@
 cask 'iconjar' do
-  version '2.1,37075'
-  sha256 'fc8bfd0da4e52dd9b962df00fa9e936db4ae3fc8bed7a18486842d4f450fc5b0'
+  version '2.1.1,37078'
+  sha256 '8cd6eec040ef970568416650b95ffa0fbb40a7d477d19d534d865d1ec4b2685e'
 
   url "https://geticonjar.com/releases/IconJar.app.#{version.after_comma}.zip"
   appcast 'https://geticonjar.com/releases/stable.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.