### PR TITLE
Update clipgrab from 3.8.5 to 3.8.6

### DIFF
--- a/Casks/clipgrab.rb
+++ b/Casks/clipgrab.rb
@@ -1,6 +1,6 @@
 cask 'clipgrab' do
-  version '3.8.5'
-  sha256 '53227ad63233d6e5e6b371e0606b1ca3d6b9f840a3d61f296bf91d92ee85e831'
+  version '3.8.6'
+  sha256 '6517d9c5e32e6e3258b46d1aeb4fa7b82d540069357a7adc4ce5a2a6058e3699'
 
   url "https://download.clipgrab.org/ClipGrab-#{version}.dmg"
   appcast 'https://clipgrab.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.