### PR TITLE
Update freecad from 0.18.3,16131 to 0.18.4,16146

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
-  version '0.18.3,16131'
-  sha256 '23d495ec3e34d54704d8d8b7688ef88ecd6876bf1b08e407f48149635e7225b6'
+  version '0.18.4,16146'
+  sha256 'db54a6b6c1190a204333d241f3d7af36027f8299409345a096c431c22a0f5814'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.