### PR TITLE
Update tower from 3.6.0-205,1262a183 to 3.6.0,205:1262a183

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,9 +1,9 @@
 cask 'tower' do
-  version '3.6.0-205,1262a183'
+  version '3.6.0,205:1262a183'
   sha256 '704998cdd473860d2e90eaaa774c4c9011a54712f844b8d658670e8cd12dd8cd'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.before_comma}.zip"
+  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.after_comma.before_colon}-#{version.after_colon}/Tower-#{version.before_comma}-#{version.after_comma.before_colon}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable"
   name 'Tower'
   homepage 'https://www.git-tower.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.