### PR TITLE
Fix sha256 in p4v version 19.2-1856742

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -1,6 +1,6 @@
 cask 'p4v' do
   version '19.2-1856742'
-  sha256 'e87b9319e4ade57e43164376ad18f749347402693adfa03d851fa2b574e70b7d'
+  sha256 '48a51d075bfb2e82f1f6d48df3ae641239839fb6a7cb3b98242081f0bdc4f380'
 
   url "https://cdist2.perforce.com/perforce/r#{version.major_minor}/bin.macosx1013x86_64/P4V.dmg"
   appcast 'https://www.perforce.com/perforce/doc.current/user/p4vnotes.txt'


### PR DESCRIPTION
when try to install p4v cask get error about incorrect checksum

```
brew cask install p4v
==> Downloading https://cdist2.perforce.com/perforce/r19.2/bin.macosx1013x86_64/
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'p4v'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
Error: Checksum for Cask 'p4v' does not match.
Expected: e87b9319e4ade57e43164376ad18f749347402693adfa03d851fa2b574e70b7d
  Actual: 48a51d075bfb2e82f1f6d48df3ae641239839fb6a7cb3b98242081f0bdc4f380
    File: /Users/santiagovasquez/Library/Caches/Homebrew/downloads/76791874e5a0ec452888d7634ee83c15d3825a678b36eb752495f92c4aae1b55--P4V.dmg
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/master/doc/reporting_bugs/checksum_does_not_match_error.md
```

tried to fix following https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask but got an error related to security when pushing fix to origin, so I made change manually and opened this PR