### PR TITLE
Update openra from 20190314 to 20191117

### DIFF
--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -1,6 +1,6 @@
 cask 'openra' do
-  version '20190314'
-  sha256 '47991698799dfc15e65641317293fa5503efbe02703aa8c570b838cfc3649693'
+  version '20191117'
+  sha256 'ff5fafd5a3233c562d6a7515b15938d461815d36373bc1e23d46642d465ab1b6'
 
   # github.com/OpenRA/OpenRA was verified as official when first introduced to the cask
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.