### PR TITLE
Update gpg-suite-pinentry from 2019.1 to 2019.2

### DIFF
--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -1,6 +1,6 @@
 cask 'gpg-suite-pinentry' do
-  version '2019.1'
-  sha256 'f85e15cfb01543ad6e09dd46e921c248dba10d2dbafa1449c234979ef5a3728f'
+  version '2019.2'
+  sha256 '98e26e3dc2fadc3563ef1add6bc2cdaefa986462aeae256a20e894e16118a179'
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast 'https://gpgtools.org/releases/gka/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.