### PR TITLE
Update docker from 2.1.0.4,39773 to 2.1.0.5,40693

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -3,8 +3,8 @@ cask 'docker' do
     version '18.06.1-ce-mac73,26764'
     sha256 '3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5'
   else
-    version '2.1.0.4,39773'
-    sha256 '545379f00641b267fc28d95237c99b185e868e6b2368c597d73d03f7e2d1e319'
+    version '2.1.0.5,40693'
+    sha256 '8f7098e72a672d3523ac3791096e14315a49c53da985ed8ba5156b2349ec1bda'
   end
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.