### PR TITLE
Update movist-pro from 2.2.11 to 2.2.12

### DIFF
--- a/Casks/movist-pro.rb
+++ b/Casks/movist-pro.rb
@@ -1,6 +1,6 @@
 cask 'movist-pro' do
-  version '2.2.11'
-  sha256 'a00fe42122b262b64ceb4d7dc0fd47fa400fd1e75e3b42d6e9d37f62fbfe51a4'
+  version '2.2.12'
+  sha256 'a35b80a2ec752a324230b18aaf117b539dc1ecd67301a4dca8cc26c77dd47b27'
 
   # d2uukrxj8lf22z.cloudfront.net was verified as official when first introduced to the cask
   url 'https://d2uukrxj8lf22z.cloudfront.net/MovistPro.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.