### PR TITLE
Update malwarebytes from 4.0.27.3069 to 4.0.30.3073

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '4.0.27.3069'
-  sha256 'cc7996e73e81d8522d0caafab86c8e8493544f8bae4295d424396e01757f74c2'
+  version '4.0.30.3073'
+  sha256 'b4b3bed354204143de83af2fb44a7df1f2990e08039be8157877789cf83f0d1d'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.