### PR TITLE
Update miktex-console from 2.9.7230-1 to 2.9.7250-1

### DIFF
--- a/Casks/miktex-console.rb
+++ b/Casks/miktex-console.rb
@@ -1,6 +1,6 @@
 cask 'miktex-console' do
-  version '2.9.7230-1'
-  sha256 'eb55ebe17075516377c45885f2528323deb0176f5e9aaa8092cff77a1f42ff85'
+  version '2.9.7250-1'
+  sha256 'bae786c68a2c9873392047e8330384db5ce13bc52751c7bcc152b5c2416a3ce5'
 
   url "https://miktex.org/download/ctan/systems/win32/miktex/setup/darwin-x86_64/miktex-#{version}-darwin-x86_64.dmg"
   appcast 'https://miktex.org/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.