### PR TITLE
Update jaxx-liberty from 2.3.1 to 2.3.2

### DIFF
--- a/Casks/jaxx-liberty.rb
+++ b/Casks/jaxx-liberty.rb
@@ -1,6 +1,6 @@
 cask 'jaxx-liberty' do
-  version '2.3.1'
-  sha256 'ac967f288660d74922f8b3a20d483690a19ef3349b973082fb37ffa91231297d'
+  version '2.3.2'
+  sha256 '943b4fcdd9f909bfbec6758af2bea3dcdbc402f76e92feabf4659ce3ee811164'
 
   url "https://download-liberty.jaxx.io/Jaxx.Liberty-#{version}.dmg"
   appcast 'https://jaxx.io/downloads.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.