### PR TITLE
Update virtualbox install

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -9,7 +9,29 @@ cask 'virtualbox' do
 
   conflicts_with cask: 'virtualbox-beta'
 
-  pkg 'VirtualBox.pkg'
+  pkg 'VirtualBox.pkg',
+      choices: [
+                 {
+                   'choiceIdentifier' => 'choiceVBoxKEXTs',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'choiceVBox',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'choiceVBoxCLI',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+                 {
+                   'choiceIdentifier' => 'choiceOSXFuseCore',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 0,
+                 },
+               ]
 
   postflight do
     # If VirtualBox is installed before `/usr/local/lib/pkgconfig` is created by Homebrew, it creates it itself with incorrect permissions that break other packages
@@ -22,17 +44,18 @@ cask 'virtualbox' do
                        args:       ['--unattended'],
                        sudo:       true,
                      },
-            pkgutil: 'org.virtualbox.pkg.*'
+            pkgutil: 'org.virtualbox.pkg.*',
+            delete:  '/usr/local/bin/vboximg-mount'
 
   zap trash: [
                '/Library/Application Support/VirtualBox',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.virtualbox.app.virtualbox.sfl*',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.virtualbox.app.virtualboxvm.sfl*',
-               '~/Library/VirtualBox',
                '~/Library/Preferences/org.virtualbox.app.VirtualBox.plist',
                '~/Library/Preferences/org.virtualbox.app.VirtualBoxVM.plist',
                '~/Library/Saved Application State/org.virtualbox.app.VirtualBox.savedState',
                '~/Library/Saved Application State/org.virtualbox.app.VirtualBoxVM.savedState',
+               '~/Library/VirtualBox',
              ],
       rmdir: '~/VirtualBox VMs'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
____
Starting with 6.0 `virtualbox` installs an older and conflicting pkg that is provided by `osxfuse`, if `osxfuse` is already installed it is silently overwritten by the `virtualbox` installer.

Conflicting pkg: `com.github.osxfuse.pkg.Core`

Version currently installed by:
- `virtualbox` 3.8.2
- `osxfuse` 3.10.3

This disables the installation of the conflicting package by `virtualbox`, which is an option when installing manually.

![virtualbox](https://user-images.githubusercontent.com/26216252/69109846-9f421f80-0ac4-11ea-80d9-59c9b469c7e9.png)

I'm not really sure if the features in `virtualbox` that need `osxfuse` are widely used or not, it might end up needing a `caveat` to install `osxfuse` or an explicit `depends_on cask: osxfuse`.

Also adds a single binary in `/usr/local/bin` to the uninstall as is isn't removed by `pkgutil` or the uninstall script.