### PR TITLE
geekbench: version 5 dropped support for macOS <= Sierra

### DIFF
--- a/Casks/geekbench.rb
+++ b/Casks/geekbench.rb
@@ -2,7 +2,7 @@ cask 'geekbench' do
   if MacOS.version <= :mavericks
     version '3.4.2'
     sha256 '05e1b977a46648d38cf6c641be7ef34722200d0168a10d4372fca771ffa24e28'
-  elsif MacOS.version <= :mavericks
+  elsif MacOS.version <= :sierra
     version '4.4.2'
     sha256 '3c46e630a28a0752afd702fc1cd379edd2420001be22302c932e61751284c0cc'
   else


### PR DESCRIPTION
This change is required so that version 4 is installed on machines
where version 5 would not run.

Fixes a regression introduced in b66a69b39d235108b18d5062d31c4053d015e000.