### PR TITLE
Update electron from 7.0.1 to 7.1.1

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '7.0.1'
-  sha256 '16a2855b0a281117af153a46aa390caae2da1cda3d6197bff82b31425796b72e'
+  version '7.1.1'
+  sha256 '07a08e7ea34cea607d6af7fb911dc50bb0c4133fe2e774b1ca97f4ab164239e0'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.