### PR TITLE
Update enpass from 6.2.0,537 to 6.3.0,575

### DIFF
--- a/Casks/enpass.rb
+++ b/Casks/enpass.rb
@@ -1,6 +1,6 @@
 cask 'enpass' do
-  version '6.2.0,537'
-  sha256 '91859dafdf4a956a24c6f06632d88e04d344690e8cf340feedc95380763b30e1'
+  version '6.3.0,575'
+  sha256 'e6bf3d8856af634a02dda188d761554402c4e1521acb98a7196ca7e3284d777a'
 
   url "https://dl.enpass.io/stable/mac/package/#{version.after_comma}/Enpass.pkg"
   appcast 'https://rest.enpass.io/enpass/alert/?format=json&language=en%7Cen&os=osx%7C10.14&package=in.sinew.Enpass-Desktop.App&version=0.0.0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.