### PR TITLE
Update melodics from 2.1.3764 to 2.1.3807

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3764'
-  sha256 'ec5efa5246406def1e4d74b5a5229dc496e2cc030096d8dedeaba781e1506529'
+  version '2.1.3807'
+  sha256 '4078dcd083e27445adb659d7227e85c9ba9fdf10b872e67e83da1a46ffea2af9'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.