### PR TITLE
Update rambox from 0.6.9 to 0.7.0

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,6 +1,6 @@
 cask 'rambox' do
-  version '0.6.9'
-  sha256 '6d943e6a44d50923c2d932a3bc7fd5a01c2b6aadb60cc035b3760e8bc11dfa8b'
+  version '0.7.0'
+  sha256 '6fd38c416bb62ce785ae24c7fa87b57078079724063dbbf869e37bf020205887'
 
   # github.com/ramboxapp/community-edition was verified as official when first introduced to the cask
   url "https://github.com/ramboxapp/community-edition/releases/download/#{version}/Rambox-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.