### PR TITLE
Update postbird from 0.8.2 to 0.8.3

### DIFF
--- a/Casks/postbird.rb
+++ b/Casks/postbird.rb
@@ -1,6 +1,6 @@
 cask 'postbird' do
-  version '0.8.2'
-  sha256 'ef8d979c256e9d5308c6beee0805adb63ef1d7862da05b2f96c7489c6bec8848'
+  version '0.8.3'
+  sha256 '19f5ebcb620b480ae2652526c30724fc53ca90862db343226a3eae37ce91f3ff'
 
   url "https://github.com/Paxa/postbird/releases/download/#{version}/Postbird-#{version}.dmg"
   appcast 'https://github.com/Paxa/postbird/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.