### PR TITLE
Update qownnotes from 19.11.15,b4884-182626 to 19.11.16,b4892-191823

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.15,b4884-182626'
-  sha256 'b3f22f1dc562476efe779d44d431391034826010bccddb734e3c842840365695'
+  version '19.11.16,b4892-191823'
+  sha256 '1a9e4b1e31357b175d64c15814ec1d0571621942fa2d4b3b90428ab29b28b878'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.