### PR TITLE
Update cloudapp from 5.4.2.1871 to 5.5.0.1878

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,6 +1,6 @@
 cask 'cloudapp' do
-  version '5.4.2.1871'
-  sha256 'd10a603a9d5aff49cb72b5c7dac1f54af39c5cb9756f1233832984660fc1be2b'
+  version '5.5.0.1878'
+  sha256 '16daf5982a44e31c5a91ab1413d9c9c3331324d3a4f517d539227a50290bb3b4'
 
   url "http://downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://d2plwz9jdz9z5d.cloudfront.net/mac/latest/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.