### PR TITLE
Update devonthink from 3.0.1 to 3.0.2

### DIFF
--- a/Casks/devonthink.rb
+++ b/Casks/devonthink.rb
@@ -1,6 +1,6 @@
 cask 'devonthink' do
-  version '3.0.1'
-  sha256 'f6333d0e62884765b30f80dfe9a6e02b02c48bc7b6f10914aca4595cb0eb7608'
+  version '3.0.2'
+  sha256 '922ebe623aa7fb66c928a0e316de63ccae36a9bdb508e16077e6227aaca34db5'
 
   # s3.amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonthink/#{version}/DEVONthink_#{version.major}.dmg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.