### PR TITLE
Update flirc from 3.24.0 to 3.24.2

### DIFF
--- a/Casks/flirc.rb
+++ b/Casks/flirc.rb
@@ -1,6 +1,6 @@
 cask 'flirc' do
-  version '3.24.0'
-  sha256 'fc4996cc47f9e72cc25cff984e5f9c3dbf6bd7103fa78b423b6d5ad8f0510067'
+  version '3.24.2'
+  sha256 'e8163616146448e1541c554d47c3325428fe1d0db143f8aad8ccd9661a75f34a'
 
   url "https://flirc.tv/software/flirc-usb/GUI/release/mac/Flirc-#{version}.dmg"
   appcast 'https://flirc.tv/software/release/gui/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.