### PR TITLE
Update kext-updater from 3.2.1 to 3.2.2

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,6 +1,6 @@
 cask 'kext-updater' do
-  version '3.2.1'
-  sha256 '4e72435a2c79c1c0a58a5e861da0fe2382b85beb5c2d680966943883aeaa980f'
+  version '3.2.2'
+  sha256 '17eb79942ac4151e98f8e990b6fe3f81bf9996aa67e47124e5c885b8a74bd63b'
 
   url 'https://update.kextupdater.de/kextupdater/Kext%20Updater.zip'
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.