### PR TITLE
Update eagle from 9.5.1 to 9.5.2

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,6 +1,6 @@
 cask 'eagle' do
-  version '9.5.1'
-  sha256 '3a9bb291ea87309a01d414e7eb0d86373f97cf7cb3eaf626c88762777f26bca2'
+  version '9.5.2'
+  sha256 '499848f67b0930dfe21eccfd0f984ba3ffc74a793c625e7d45457e7d505fd2dc'
 
   url "https://trial2.autodesk.com/NET17SWDLD/2017/EGLPRM/ESD/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.autodesk.com/eagle-download-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.