### PR TITLE
Update reaper from 5.98.500 to 5.98.600

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,6 +1,6 @@
 cask 'reaper' do
-  version '5.98.500'
-  sha256 'd719f8225a7382e0da8ea29e384fdcccb9e653a499af2f7d541a3b6dfb8a9f92'
+  version '5.98.600'
+  sha256 '15edab8f69707a417680318c58da8cd4024e2b09ea76042c8b0391baaa444229'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.