### PR TITLE
Update chronosync from 4.9.5 to 4.9.6

### DIFF
--- a/Casks/chronosync.rb
+++ b/Casks/chronosync.rb
@@ -1,6 +1,6 @@
 cask 'chronosync' do
-  version '4.9.5'
-  sha256 '4baaefbeaddbe1e4fd3bbfdbe51d1b4decda433dd224f2020af123e0198bd747'
+  version '4.9.6'
+  sha256 '43245b3a610ce48b8c06927dea3608109369a79349ba2c39f52d492dc88f9fee'
 
   url 'https://downloads.econtechnologies.com/CS4_Download.dmg'
   appcast "https://www.econtechnologies.com/UC/updatecheck.php?prod=ChronoSync&vers=#{version.major_minor}.0&lang=en&plat=mac&os=10.14.1&hw=i64&req=1"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.