### PR TITLE
Update wordpresscom from 4.5.0 to 4.6.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '4.5.0'
-  sha256 '891146c4afb602f046b255fa86860ec0a4084044a956e84de0c3133994b5b309'
+  version '4.6.0'
+  sha256 '99b514df700db3d0630d4288324eb4f8f035ae58f23b8e5be9cc0b20e2cea776'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.