### PR TITLE
Update dcp-o-matic-encode-server from 2.14.13 to 2.14.14

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.13'
-  sha256 '1fd6f93185a45efe08c067eef77c2a3078ddd0ef642eeba03473930abbe5d06d'
+  version '2.14.14'
+  sha256 'ff7034ebd881eac24d9fd07308ae0a5d2daadd34bdb005d318fad86252084a74'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.