### PR TITLE
Update bluegriffon 3.1 minimum OS requirement

### DIFF
--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -7,7 +7,7 @@ cask 'bluegriffon' do
   name 'BlueGriffon'
   homepage 'http://bluegriffon.org/'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :yosemite'
 
   app 'BlueGriffon.app'
 end


### PR DESCRIPTION
As per Blue griffon's official site (http://bluegriffon.org/) , the minimum MacOS should be 10.10.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).