### PR TITLE
Update energybar from 1.6.19169 to 1.7.19321

### DIFF
--- a/Casks/energybar.rb
+++ b/Casks/energybar.rb
@@ -1,6 +1,6 @@
 cask 'energybar' do
-  version '1.6.19169'
-  sha256 '573b040a27da32842581b22f9a31920c78a8661a277b9a7bf8ae8e64e3b9212f'
+  version '1.7.19321'
+  sha256 '96c06a93d5916001306af401046295926bf38996d767365c199131e068d85627'
 
   url "https://github.com/billziss-gh/EnergyBar/releases/download/v#{version.major_minor}/EnergyBar-#{version}.zip"
   appcast 'https://github.com/billziss-gh/EnergyBar/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.