### PR TITLE
Update spamsieve from 2.9.37 to 2.9.38

### DIFF
--- a/Casks/spamsieve.rb
+++ b/Casks/spamsieve.rb
@@ -1,6 +1,6 @@
 cask 'spamsieve' do
-  version '2.9.37'
-  sha256 '86b4ccb2cb4ced10d10c750e6c6d91ef25d53961be138fbc4c4c7f1bade81532'
+  version '2.9.38'
+  sha256 '2769625a211512d09d561d7adbd7bee9dae4b56563165c3958125ebed24b08c2'
 
   url "https://c-command.com/downloads/SpamSieve-#{version}.dmg"
   appcast 'https://c-command.com/spamsieve/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.