### PR TITLE
Update commander-one from 2.3 to 2.4

### DIFF
--- a/Casks/commander-one.rb
+++ b/Casks/commander-one.rb
@@ -1,9 +1,10 @@
 cask 'commander-one' do
-  version '2.3'
-  sha256 '1e48e509a62f24fa058158d86b0e563f9ec5c3b09dda1c04eac8030cf11f619f'
+  version '2.4'
+  sha256 'dbb9c82ef5c471577ca1ae80cc175b2df43ce01a85c0d68fc2b9af80f9959a42'
 
-  url 'https://cdn.eltima.com/download/commander.dmg'
-  appcast 'https://cdn.eltima.com/download/commander-update/settings.xml'
+  # cdn.electronic.us was verified as official when first introduced to the cask
+  url 'https://cdn.electronic.us/products/commander/mac/download/commander.dmg'
+  appcast 'https://cdn.electronic.us/products/commander/mac/update/settings.xml'
   name 'Commander One'
   homepage 'https://mac.eltima.com/file-manager.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.