### PR TITLE
Update simplenote from 1.10.0 to 1.11.0

### DIFF
--- a/Casks/simplenote.rb
+++ b/Casks/simplenote.rb
@@ -1,6 +1,6 @@
 cask 'simplenote' do
-  version '1.10.0'
-  sha256 'af397b64cc5921d5783eb377868b178822e72cf5d1d850ece5006f7cfe8a4c33'
+  version '1.11.0'
+  sha256 '7179414aec19cf100c7d45b1aef449070236eee896684a4f08767d768dd5ea7d'
 
   url "https://github.com/Automattic/simplenote-electron/releases/download/v#{version}/Simplenote-macOS-#{version}.dmg"
   appcast 'https://github.com/Automattic/simplenote-electron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.