### PR TITLE
Update openbazaar from 2.3.5 to 2.3.6

### DIFF
--- a/Casks/openbazaar.rb
+++ b/Casks/openbazaar.rb
@@ -1,6 +1,6 @@
 cask 'openbazaar' do
-  version '2.3.5'
-  sha256 'ab137cf1ae0dc4973b2efd221b5b89b3fb9ebd4edfb2894210b5c2abe043ab11'
+  version '2.3.6'
+  sha256 'd7f8e909476b0a5196738d589256cdac2b05f4eb68dbd0ef4ee7365fd76051cc'
 
   # github.com/OpenBazaar/openbazaar-desktop was verified as official when first introduced to the cask
   url "https://github.com/OpenBazaar/openbazaar-desktop/releases/download/v#{version}/OpenBazaar#{version.major}-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.