### PR TITLE
Update media-converter from 2.0.8 to 2.0.9

### DIFF
--- a/Casks/media-converter.rb
+++ b/Casks/media-converter.rb
@@ -1,6 +1,6 @@
 cask 'media-converter' do
-  version '2.0.8'
-  sha256 '84ada045ec04250699c9b7fa0b4a01ce292d8b977c4ee3715b9f05fdc5c4596e'
+  version '2.0.9'
+  sha256 'c796f68cad26f795de4a9202584ce26a5ce1a2884d1c1e6865dd1903353f8612'
 
   # downloads.sourceforge.net/media-converter was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/media-converter/media-converter/#{version}/media-converter-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.