### PR TITLE
Update metabase from 0.33.5.1 to 0.33.6.0

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.33.5.1'
-  sha256 '4c53a18b92bb55e88fff1551b9bdc1e083eb8fce3081d6d4af3a88539ac486f0'
+  version '0.33.6.0'
+  sha256 'cbb66145f7b6d8705983601a519346525305a99275dcc2ea6399bd362752a5e7'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.