### PR TITLE
Update freedom from 2.2.2 to 2.2.3

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,6 +1,6 @@
 cask 'freedom' do
-  version '2.2.2'
-  sha256 '418563e6a43ae7415452b3b6ed37ea243c10c559a3fce93cfcaf0ea2e206193c'
+  version '2.2.3'
+  sha256 'd753dc72c3c59e3ee6bb8a90f3a0aa2c1daebe325df1cd26e70fb36fe7816ff3'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.