### PR TITLE
Update ableton-live-suite from 10.1.4 to 10.1.5

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite' do
-  version '10.1.4'
-  sha256 '8962eab69f8600501d5002b051668ea1ddde3c3febb44d02253da5064364a62b'
+  version '10.1.5'
+  sha256 'a5bdf073fd74e34307d3aa14aa2f26d49e104865547079651d94282a57a9fd30'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.