### PR TITLE
Update ukelele from 3.3 to 3.4.0

### DIFF
--- a/Casks/ukelele.rb
+++ b/Casks/ukelele.rb
@@ -1,6 +1,6 @@
 cask 'ukelele' do
-  version '3.3'
-  sha256 '5991dc6dedd991134cf813fd84fa6d8586e5d387cef119d49dd7ab63011635e6'
+  version '3.4.0'
+  sha256 '38b42254b780bbba3e4d3e2fac2a6bb0df8e273b1a1a29e6508b36e2178a019b'
 
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Ukelele_#{version}&filename=Ukelele_#{version}.dmg"
   appcast 'https://www.dropbox.com/s/vi51g5jig3etaum/Ukelele_appcast.xml?dl=1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.