### PR TITLE
Update reaper from 5.98.600 to 5.98.700

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,6 +1,6 @@
 cask 'reaper' do
-  version '5.98.600'
-  sha256 '15edab8f69707a417680318c58da8cd4024e2b09ea76042c8b0391baaa444229'
+  version '5.98.700'
+  sha256 '49185a83634f030691838d77948b5fafb590fd8d36b53684f66afff34e35455b'
 
   url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.