### PR TITLE
Update cctalk from 7.6.0.10 to 7.6.1.11

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask 'cctalk' do
-  version '7.6.0.10'
-  sha256 '066f09812da123545371cc0c37a690ae7f9842a975fffdb88ae47780595cdd79'
+  version '7.6.1.11'
+  sha256 'bab460c7e06161b72f63a7a569c04e7ba930ebcc1f32a2b85137ddc364476878'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "https://cc.hjfile.cn//#{version}/8/1/103/#{version}.dmg"
+  url "http://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.