### PR TITLE
Update 4k-stogram from 2.8.1.1970 to 2.8.2.2000

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask '4k-stogram' do
-  version '2.8.1.1970'
-  sha256 '92c3fe4b0e46f62083c4deccdbfa7b9be6305a6eada0eabdea9617c7b40d7441'
+  version '2.8.2.2000'
+  sha256 'd298cbdf03ee7c767d877cd4f70d33762c344bdf3ce36a9d8f554aeec15b0503'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.