### PR TITLE
Update hotswitch from 1.17,2018-03-12,21-19-19 to 1.18

### DIFF
--- a/Casks/hotswitch.rb
+++ b/Casks/hotswitch.rb
@@ -1,6 +1,6 @@
 cask 'hotswitch' do
-  version '1.17,2018-03-12,21-19-19'
-  sha256 'ad137876ac51d165e65464adcf08f1e5eced76af880aef3aeb7a7987a12b9d40'
+  version '1.18'
+  sha256 'ebaf2b6e73446a4a70077a451d7ed0a9f14bf8aa75b9f67f74347a65d31e6db0'
 
   url 'https://oniatsu.github.io/HotSwitch/release/zip/HotSwitch.zip'
   appcast 'https://github.com/oniatsu/HotSwitch/releases.atom'

--- a/Casks/hotswitch.rb
+++ b/Casks/hotswitch.rb
@@ -7,5 +7,5 @@ cask 'hotswitch' do
   name 'HotSwitch'
   homepage 'https://oniatsu.github.io/HotSwitch/'
 
-  app "HotSwitch #{version.after_comma.before_comma} #{version.after_comma.after_comma}/HotSwitch.app"
+  app "HotSwitch.app"
 end

--- a/Casks/hotswitch.rb
+++ b/Casks/hotswitch.rb
@@ -7,5 +7,5 @@ cask 'hotswitch' do
   name 'HotSwitch'
   homepage 'https://oniatsu.github.io/HotSwitch/'
 
-  app "HotSwitch.app"
+  app 'HotSwitch.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.