### PR TITLE
Update pdf-expert from 2.4.29,641 to 2.4.30,649

### DIFF
--- a/Casks/pdf-expert.rb
+++ b/Casks/pdf-expert.rb
@@ -1,6 +1,6 @@
 cask 'pdf-expert' do
-  version '2.4.29,641'
-  sha256 'e61de5665f471a8ad8a5a0b9e9775573c358e17e765cffcdc354358ad290a536'
+  version '2.4.30,649'
+  sha256 'd5e2df03a36ad00db98947552cd00ee01dedabe314026b21adcd8c50f8b3a014'
 
   # d1ke680phyeohy.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1ke680phyeohy.cloudfront.net/versions/#{version.after_comma}/PDFExpert.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.