### PR TITLE
Update use-engine from 2.1.6 to 2.2.0 and set depends_on mac to >= yosemite

### DIFF
--- a/Casks/use-engine.rb
+++ b/Casks/use-engine.rb
@@ -1,13 +1,13 @@
 cask 'use-engine' do
-  version '2.1.6'
-  sha256 '7508037123d06a4f0e10c3c53a4e19aadb865e7351f61fe151433ea63994cebc'
+  version '2.2.0'
+  sha256 'ff3c5f9f3063260ad15485e50ed4ee7b1d9992e58a0d4bcd20f266e49c8c6785'
 
   url "https://repository.use-together.com/stable/use-engine/macos/#{version.major}.x/#{version}/use-engine.dmg"
   name 'USE Engine'
   homepage 'https://www.use-together.com/'
 
   auto_updates true
-  depends_on macos: '>= :mavericks'
+  depends_on macos: '>= :yosemite'
 
   app 'USE Engine.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).