### PR TITLE
Add Flic version 1.1.3

### DIFF
--- a/Casks/flic.rb
+++ b/Casks/flic.rb
@@ -7,5 +7,5 @@ cask 'flic' do
   appcast 'FlicMac Developer Distribution '
   homepage 'https://flic.io/mac-app'
 
-  app "FlicMac Developer Distribution #{version.after_comma}/"
+  app "FlicMac Developer Distribution #{version.after_comma}/Flic.app"
 end

--- a/Casks/flic.rb
+++ b/Casks/flic.rb
@@ -1,13 +1,11 @@
 cask 'flic' do
-  version '1.1.3'
+  version '1.1.3,2018-09-11 13-14-23'
   sha256 '400b1aed904b527b049af26c61aca234a6812e7f3d366ecb471a5b8fe6646ae1'
 
-  url "https://s3.amazonaws.com/misc-scl-cdn/Flic.#{version}.zip"
-  name 'Flic'
+  # misc-scl-cdn.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://misc-scl-cdn.s3.amazonaws.com/Flic.#{version.before_comma}.zip"
+  appcast 'FlicMac Developer Distribution '
   homepage 'https://flic.io/mac-app'
 
-  # The application is located in an directory with seems to be named after the
-  # build date and is therefor not predictable
-  app "#{Dir.glob('#{appdir}/FlicMac Developer Distribution */Flic.app')[0]}"
-
+  app "FlicMac Developer Distribution #{version.after_comma}/"
 end

--- a/Casks/flic.rb
+++ b/Casks/flic.rb
@@ -1,0 +1,13 @@
+cask 'flic' do
+  version '1.1.3'
+  sha256 '400b1aed904b527b049af26c61aca234a6812e7f3d366ecb471a5b8fe6646ae1'
+
+  url "https://s3.amazonaws.com/misc-scl-cdn/Flic.#{version}.zip"
+  name 'Flic'
+  homepage 'https://flic.io/mac-app'
+
+  # The application is located in an directory with seems to be named after the
+  # build date and is therefor not predictable
+  app "#{Dir.glob('#{appdir}/FlicMac Developer Distribution */Flic.app')[0]}"
+
+end

--- a/Casks/flic.rb
+++ b/Casks/flic.rb
@@ -4,7 +4,8 @@ cask 'flic' do
 
   # misc-scl-cdn.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://misc-scl-cdn.s3.amazonaws.com/Flic.#{version.before_comma}.zip"
-  appcast 'FlicMac Developer Distribution '
+  appcast 'https://flic.io/mac-app'
+  name 'FlicMac Developer Distribution'
   homepage 'https://flic.io/mac-app'
 
   app "FlicMac Developer Distribution #{version.after_comma}/Flic.app"


### PR DESCRIPTION
Not sure if the globbing in  app stanza is allowed but I couldn't find a better
way to work around that the developers seems to name the archive directory
by build date which make is very hard to predict.

Ruby isn't my language of choice so it might be better ways to solve it aswell…

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
