### PR TITLE
Update qiyimedia from 20191031,5.15.6-180 to 20191121,5.16.11-188

### DIFF
--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -1,6 +1,6 @@
 cask 'qiyimedia' do
-  version '20191031,5.15.6-180'
-  sha256 '0efaffab6679e033fd17c48beb9336e1ea1a8b96352790b0520c0816d856744d'
+  version '20191121,5.16.11-188'
+  sha256 '4da0e67f7bc1391ee1d0b120da1bce96de1f80c52eaea65947300af69f045bc7'
 
   url 'https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_000.dmg',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.