### PR TITLE
Update unity-android-support-for-editor from 2019.2.12f1,b1a7e1fb4fa5 to 2019.2.13f1,e20f6c7e5017

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.2.12f1,b1a7e1fb4fa5'
-  sha256 'b1f3741c7b1367c7c1c5d744410486dcd2bf06086342e36cdf51e3e49b26b910'
+  version '2019.2.13f1,e20f6c7e5017'
+  sha256 'f053c86b18c5998b036082f948db9a7966d9e72ab0ac4a56af0f4bb7bac6a5f6'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.