### PR TITLE
Update unity-ios-support-for-editor from 2019.2.12f1,b1a7e1fb4fa5 to 2019.2.13f1,e20f6c7e5017

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.2.12f1,b1a7e1fb4fa5'
-  sha256 'bab43d72a2b9808ed3c50ade2455b665f245d432d37dbaefef66eb10db9d4330'
+  version '2019.2.13f1,e20f6c7e5017'
+  sha256 'fa5116274a85d547fe7e9a5d3d0549d549b24be5c442360783fc72e2a601c95f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.