### PR TITLE
Update unity-lumin-support-for-editor from 2019.2.12f1,b1a7e1fb4fa5 to 2019.2.13f1,e20f6c7e5017

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.2.12f1,b1a7e1fb4fa5'
-  sha256 '8b37a3024c73ce5816a51b4b42bad1b3ffc0251fde2e0a1a6e5a64f5918c17bb'
+  version '2019.2.13f1,e20f6c7e5017'
+  sha256 'bf158ffa0f88183f3b4dd743c0fcb0127f762bf2668fb0bf00a1566207d24a53'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.