### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.12f1,b1a7e1fb4fa5 to 2019.2.13f1,e20f6c7e5017

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.12f1,b1a7e1fb4fa5'
-  sha256 '92cd3efe82c2279b044a1856b028c18f78804dd9f5a1a0daf81bd98cd35b8618'
+  version '2019.2.13f1,e20f6c7e5017'
+  sha256 'f8a514f914ecbc4a93e7acd926067c5e1872caf89d771b63ded7837feb3f804a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.