### PR TITLE
Update unity-windows-support-for-editor from 2019.2.12f1,b1a7e1fb4fa5 to 2019.2.13f1,e20f6c7e5017

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.12f1,b1a7e1fb4fa5'
-  sha256 '425503b338eeffb0c90c7b69fb97c7dd1d6dffa5e317325521d4ff4b9d487fd0'
+  version '2019.2.13f1,e20f6c7e5017'
+  sha256 'ed36451ffdff075030510c3441cb49170e572c70b0d5e36d69cfad9a438d5dcc'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.