### PR TITLE
Update kite from 0.20191119.0 to 0.20191120.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191119.0'
-  sha256 '34f8a96d87a27d42784c2e412b024608ec96484add2d5d48de939a097e72aa98'
+  version '0.20191120.0'
+  sha256 '5542ab5bccfbce154e9a5530b6164f1f9979f508515353a4ff5291028bc317d0'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.