### PR TITLE
Update twist from 1.6.18,6719 to 1.6.19,6773

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.6.18,6719'
-  sha256 '9fa80be6f9baf41f9cbc1849d138c0aa98b56c2b845be931008b59db863d11f2'
+  version '1.6.19,6773'
+  sha256 '80ee874519eb9691f5b5b1c1a61aaf2c91a96f549ff55a4bc436f760054304d5'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.