### PR TITLE
Update acorn from 6.5.2 to 6.5.3

### DIFF
--- a/Casks/acorn.rb
+++ b/Casks/acorn.rb
@@ -1,6 +1,6 @@
 cask 'acorn' do
-  version '6.5.2'
-  sha256 '44f4254fc7dd852e5f6c421e84cbb34696161e7d896b9813b5bbf2d459a00084'
+  version '6.5.3'
+  sha256 '11dd7f576c20becd12bd15392e1805b7862b15803aac0933ed69b2a315b923c0'
 
   url "https://flyingmeat.com/download/Acorn-#{version}.zip"
   appcast "https://www.flyingmeat.com/download/acorn#{version.major}update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.