### PR TITLE
Update quicken from 5.13.2,513.30554.100 to 5.13.3,513.30586.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.13.2,513.30554.100'
-  sha256 '8faa493ee8f5aee61aff1c49c5ce533040c2f1da633e1e9c77359ca4f3c5b792'
+  version '5.13.3,513.30586.100'
+  sha256 '1772db7c44d1969367ea54b2e99878aa0019251381eab383af60e3d001b6dd1d'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.