### PR TITLE
Update timeular from 2.3.5 to 2.4.0

### DIFF
--- a/Casks/timeular.rb
+++ b/Casks/timeular.rb
@@ -1,6 +1,6 @@
 cask 'timeular' do
-  version '2.3.5'
-  sha256 '49a9d71d8739042ffaaa5aa1c6ef3f1523786f225f2658b1883b909fba6aa77b'
+  version '2.4.0'
+  sha256 '9b78c28b7da5b6b7bfa0bfeffd83f707f0dcb516ca1378afd3a486a830e722c7'
 
   # timeular-desktop-packages.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://timeular-desktop-packages.s3.amazonaws.com/mac/production/Timeular-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.