### PR TITLE
Update livechat from 9.0.6 to 9.0.7

### DIFF
--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -1,6 +1,6 @@
 cask 'livechat' do
-  version '9.0.6'
-  sha256 '55b8bc5793f7dc0aa220ff6e4df61ebb7d8102b42374b62d7821f032eef10668'
+  version '9.0.7'
+  sha256 '34a4941b7429e094770d55dd864de0a4d795c8e875aa36344921e89d36d94d06'
 
   url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
   appcast 'https://s3.amazonaws.com/dal-livechat-main-web/download/Mac/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.