### PR TITLE
Update plex-media-server from 1.18.2.2029-36236cc4c to 1.18.2.2041-3d469cb32

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.18.2.2029-36236cc4c'
-  sha256 'aa5076cb02b9846a082464d34c28536a53898f4620880d7b9dd2d88e6ed44281'
+  version '1.18.2.2041-3d469cb32'
+  sha256 '350123c67a6142d202fda2034c7855a40d0bc10285a9cc3f3a31d84c9efbeb3a'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.