### PR TITLE
Update knockknock from 2.0.5 to 2.1.0

### DIFF
--- a/Casks/knockknock.rb
+++ b/Casks/knockknock.rb
@@ -1,6 +1,6 @@
 cask 'knockknock' do
-  version '2.0.5'
-  sha256 '060ec9e03fd63c310a9f71e55eb7aad8f2185283ffc495be9690b2f58c2da7c6'
+  version '2.1.0'
+  sha256 '8595f196f9233f8016bf0dfd5f7814e7e61a48073245ca4a853a6a8e53c5a2e1'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/KnockKnock_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.