### PR TITLE
Update activedock from 266,1573645440 to 406,1574340678

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '266,1573645440'
-  sha256 '9c5bf95d388cc339624596b5ed20b9f6ab0bb779b6b1220d69e81fa7b5d541a9'
+  version '406,1574340678'
+  sha256 'cb99e88a534c30a7b639daa31f65a0c2a38e32c10d78dd48710b0653bc4a253a'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.