### PR TITLE
Update kite from 0.20191120.0 to 0.20191121.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191120.0'
-  sha256 '5542ab5bccfbce154e9a5530b6164f1f9979f508515353a4ff5291028bc317d0'
+  version '0.20191121.0'
+  sha256 '0a7eeb0d119632d24a77836c4251b2aeab3ab0e56ffe007c4fa3048b55f5eab9'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.