### PR TITLE
Update tg-pro from 2.44 to 2.45

### DIFF
--- a/Casks/tg-pro.rb
+++ b/Casks/tg-pro.rb
@@ -1,6 +1,6 @@
 cask 'tg-pro' do
-  version '2.44'
-  sha256 '6817830142377c30d97a8f6fdbbf8bd5f783abd10a70b2468a602446d71949f4'
+  version '2.45'
+  sha256 '0d7408f07fa7f9f9d0727239aaacbf42b0928ff75c68177848c380be1fcc580c'
 
   url "https://www.tunabellysoftware.com/resources/TG%20Pro%20#{version}.dmg"
   appcast 'https://www.tunabellysoftware.com/resources/sparkle/tgpro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.