### PR TITLE
Update tunnelbear from 3.9.5 to 3.9.7

### DIFF
--- a/Casks/tunnelbear.rb
+++ b/Casks/tunnelbear.rb
@@ -1,6 +1,6 @@
 cask 'tunnelbear' do
-  version '3.9.5'
-  sha256 '8e09fc6ae52411e5d8f88ee66be7689a474bb07303a6f487fd369fc894f23d73'
+  version '3.9.7'
+  sha256 'df039bf4123b5d42ce16286564ca1e81f6ad68d86703447e430e9aacb56f5404'
 
   # tunnelbear.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tunnelbear.s3.amazonaws.com/downloads/mac/TunnelBear-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.