### PR TITLE
Update malus from 0.7.3,1573013349 to 0.7.5

### DIFF
--- a/Casks/malus.rb
+++ b/Casks/malus.rb
@@ -1,9 +1,9 @@
 cask 'malus' do
-  version '0.7.3,1573013349'
-  sha256 'c242d33141d6f7e509a35c416be24ca87847ac1fe7313ccc223aed0ffbed7184'
+  version '0.7.5'
+  sha256 '45b6bf151202d2838616c166d9145290cdd630f8cff0c71edcdfc5d4ef630769'
 
   # malusfile.com was verified as official when first introduced to the cask
-  url "https://malusfile.com/uploads/Malus-#{version.before_comma}-#{version.after_comma}.dmg"
+  url "https://malusfile.com/downloads/Malus-mac-#{version}.dmg"
   appcast 'https://api.getmalus.com/api/checkDesktopUpdate?type=mac'
   name 'Malus'
   homepage 'https://getmalus.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.