### PR TITLE
Update hotswitch from 1.18 to 1.19

### DIFF
--- a/Casks/hotswitch.rb
+++ b/Casks/hotswitch.rb
@@ -1,6 +1,6 @@
 cask 'hotswitch' do
-  version '1.18'
-  sha256 'ebaf2b6e73446a4a70077a451d7ed0a9f14bf8aa75b9f67f74347a65d31e6db0'
+  version '1.19'
+  sha256 '4e341d025a1951270fcd0ee363f821c5a026b9eb5a1d592e25a955afe497b256'
 
   url 'https://oniatsu.github.io/HotSwitch/release/zip/HotSwitch.zip'
   appcast 'https://github.com/oniatsu/HotSwitch/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.