### PR TITLE
Update evolve-ip-uc-one from 22.2.0.1359 to 22.6.3.88

### DIFF
--- a/Casks/evolve-ip-uc-one.rb
+++ b/Casks/evolve-ip-uc-one.rb
@@ -1,5 +1,5 @@
 cask 'evolve-ip-uc-one' do
-  version '22.2.0.1359'
+  version '22.6.3.88'
   sha256 '2cf8d3019de5bb74816898a3678d4824a984f099c10ada764bf1d0d41f414712'
 
   url 'https://www.voip.evolveip.net/dms/bc/pc/uc-one-mac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.