### PR TITLE
Update shift from 4.0.2 to 4.0.4

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,6 +1,6 @@
 cask 'shift' do
-  version '4.0.2'
-  sha256 '84fa20c49de9c8ecd63a68404ef1e824e67067ae5bd6a2c2a5b942576ee66c75'
+  version '4.0.4'
+  sha256 '87e3b94288ef28bfce062ceeb5cc4e76f7ce0b403571af77ade2ab219e414648'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"
   appcast 'https://tryshift.com/download/?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.