### PR TITLE
Update runway from 0.9.25 to 0.10.0

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.9.25'
-  sha256 'bbd6b39e1d1225b4897fd68b03a17c73792c1dc1c03571ccc8d952b7ec2de438'
+  version '0.10.0'
+  sha256 '96579f206ca980ba7cac6c48a7b4eedea694f995c972e24f7b2575fd320e5fd1'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.