### PR TITLE
Update cisdem-data-recovery from 5.7.0 to 6.0.0

### DIFF
--- a/Casks/cisdem-data-recovery.rb
+++ b/Casks/cisdem-data-recovery.rb
@@ -1,6 +1,6 @@
 cask 'cisdem-data-recovery' do
-  version '5.7.0'
-  sha256 'cf9115653d16889874e393ed8ec3fce08e7b7098549baa2ad78ca77716bf7e5c'
+  version '6.0.0'
+  sha256 '6e43692c0533b14591d60de527b7f6432a8bad0e861318b38f89b9a264232427'
 
   url 'http://download.cisdem.com/cisdem-datarecovery.dmg'
   appcast 'https://www.cisdem.com/data-recovery-mac/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.