### PR TITLE
Update usb-overdrive from 3.4 to 4.0.1

### DIFF
--- a/Casks/usb-overdrive.rb
+++ b/Casks/usb-overdrive.rb
@@ -1,6 +1,6 @@
 cask 'usb-overdrive' do
-  version '3.4'
-  sha256 '8dd426c9bb2ab048269189acea143df9e77bbe106747f2a2d505d75e4079b340'
+  version '4.0.1'
+  sha256 'fbd41aa72c814a57646058378c5022fcbf529f9d371e597a1be2a63dbd451856'
 
   url "https://www.usboverdrive.com/download/USB-Overdrive-#{version.no_dots}.dmg"
   name 'USB Overdrive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.