### PR TITLE
Update gifox from 010601.03 to 2.0.0,020000.07

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -4,7 +4,7 @@ cask 'gifox' do
 
   # d3si16icyi9iar.cloudfront.net/gifox was verified as official when first introduced to the cask
   url "https://d3si16icyi9iar.cloudfront.net/gifox/#{version.after_comma}.dmg"
-  appcast 'https://api.gifox.io/appcast?prereleases=false'
+  appcast 'https://d3si16icyi9iar.cloudfront.net/gifox/appcast.xml'
   name 'gifox'
   homepage 'https://gifox.io/'
 

--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -1,22 +1,22 @@
 cask 'gifox' do
-  version '010601.03'
-  sha256 'b0dea197c7c0f1533de4ca2d0402247780bc0463eecdfd8dfa3928f81e5399a9'
+  version '2.0.0,020000.07'
+  sha256 '0b4a8984a6f46ae5583675d44144b9741a9f50d8ecd23a76371683c0b9cf5226'
 
-  # d1hsvn1xu03mmy.cloudfront.net/gifox was verified as official when first introduced to the cask
-  url "https://d1hsvn1xu03mmy.cloudfront.net/gifox/#{version}.dmg"
-  appcast 'https://d1hsvn1xu03mmy.cloudfront.net/gifox/appcast.xml'
+  # d3si16icyi9iar.cloudfront.net/gifox was verified as official when first introduced to the cask
+  url "https://d3si16icyi9iar.cloudfront.net/gifox/#{version.after_comma}.dmg"
+  appcast 'https://gifox.io/sparkle?prereleases=false'
   name 'gifox'
   homepage 'https://gifox.io/'
 
   app 'Gifox.app'
 
-  uninstall launchctl: 'com.gifox.gifox.agent',
-            quit:      'com.gifox.gifox'
+  uninstall launchctl: "com.gifox.gifox#{version.major}.agent",
+            quit:      "com.gifox.gifox#{version.major}"
 
   zap trash: [
-               '~/Library/Application Support/Gifox',
-               '~/Library/Caches/com.gifox.gifox',
-               '~/Library/Cookies/com.gifox.gifox.binarycookies',
-               '~/Library/Preferences/com.gifox.gifox.plist',
+               "~/Library/Application Support/Gifox #{version.major}",
+               "~/Library/Caches/com.gifox.gifox#{version.major}",
+               "~/Library/Cookies/com.gifox.gifox#{version.major}.binarycookies",
+               "~/Library/Preferences/com.gifox.gifox#{version.major}.plist",
              ]
 end

--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -4,7 +4,7 @@ cask 'gifox' do
 
   # d3si16icyi9iar.cloudfront.net/gifox was verified as official when first introduced to the cask
   url "https://d3si16icyi9iar.cloudfront.net/gifox/#{version.after_comma}.dmg"
-  appcast 'https://gifox.io/sparkle?prereleases=false'
+  appcast 'https://api.gifox.io/appcast?prereleases=false'
   name 'gifox'
   homepage 'https://gifox.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.