### PR TITLE
Update adoptopenjdk from 13,33 to 13.0.1,9

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,6 +1,6 @@
 cask 'adoptopenjdk' do
-  version '13,33'
-  sha256 'f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f'
+  version '13.0.1,9'
+  sha256 '9c82de98ce9bc2353bcf314d85366c9a2c572db034e10a71aa47e804e13748c1'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.