### PR TITLE
Add manpage stanze to mpv.rb

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -12,6 +12,7 @@ cask 'mpv' do
 
   app 'mpv.app'
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"
+  manpage 'documentation/man/mpv.1'
 
   zap trash: [
                '~/.config/mpv',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

As per mpv-player/mpv#7116, I have now added the man page through the manpage stanza after noticing the stanza made it to release.

This does not change anything else.