### PR TITLE
Update activedock from 406,1574340678 to 460,1574458848

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '406,1574340678'
-  sha256 'cb99e88a534c30a7b639daa31f65a0c2a38e32c10d78dd48710b0653bc4a253a'
+  version '460,1574458848'
+  sha256 '1d6f03f60705579740f99e28b9296f9bc2a17422e7aeeccf1ac05ec13b5f765f'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.