### PR TITLE
Update trilium-notes from 0.37.3 to 0.37.4

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.37.3'
-  sha256 '963d70a6a8bc2ff5675ec5ed49112e0b1803ca0bce3951ac2edb1876748c7627'
+  version '0.37.4'
+  sha256 '62bb1eb445664d1e442e7d70bc78c913893fc417bbf3aa588ef376a3e7b583f3'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.