### PR TITLE
Update qownnotes from 19.11.19,b4904-170147 to 19.11.20,b4915-114408

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.19,b4904-170147'
-  sha256 '8d4c8d55d6048b544738fda8284f636f701e2dd748f74ddbe3b87105eef144d7'
+  version '19.11.20,b4915-114408'
+  sha256 '1dbe771981cf960fed35aa02c3f089fcb2e7523497dc591683eb84ac6351ce94'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.