### PR TITLE
Update qutebrowser from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,6 @@
 cask 'qutebrowser' do
-  version '1.8.1'
-  sha256 'cdc19ecd10ceba3fa7b898b5fa30ff06d4ef263b2532552a2aaa221a3efaaa44'
+  version '1.8.2'
+  sha256 'b13161b7e7aed12add2a2c4fb94d3d7ac73d656f22aef77fce3cd4e88aefc002'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.