### PR TITLE
Update marvin from 1.48.1 to 1.49.0

### DIFF
--- a/Casks/marvin.rb
+++ b/Casks/marvin.rb
@@ -1,6 +1,6 @@
 cask 'marvin' do
-  version '1.48.1'
-  sha256 '4321c51bae3244144196dbc2486a9b7e0c59cc1cdbef36af95d0d7e0eb537089'
+  version '1.49.0'
+  sha256 '90e75c8b396fccd9f1de7aa056a0c3c2db7c33424f87055be7a00c58f5c4d659'
 
   # amazingmarvin.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://amazingmarvin.s3.amazonaws.com/Marvin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.