### PR TITLE
Update powerphotos from 1.7.5 to 1.7.6

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -16,8 +16,8 @@ cask 'powerphotos' do
     sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.7.5'
-    sha256 '8d02de327d137fd22a7ed9162ae756545132d10332567e87434c1648d024538f'
+    version '1.7.6'
+    sha256 '337879541a11f63d8e0f1c6690ec69e769a04936d30a1a795ccc821e4b69328f'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.