### PR TITLE
Revert "Delete impactor.rb (#72491)"

### DIFF
--- a/Casks/impactor.rb
+++ b/Casks/impactor.rb
@@ -1,0 +1,12 @@
+cask 'impactor' do
+  version '0.9.52'
+  sha256 '9db548074424473c5804d1118d27cd4f052db8b53b3e7c3261c1a903f521cbf1'
+
+  # cache.saurik.com/impactor was verified as official when first introduced to the cask
+  url "https://cache.saurik.com/impactor/mac/Impactor_#{version}.dmg"
+  appcast 'https://cydia.saurik.com/api/appcast/1'
+  name 'Impactor'
+  homepage 'http://www.cydiaimpactor.com/'
+
+  app 'Impactor.app'
+end


### PR DESCRIPTION
This reverts commit 76e8b4119666a7bd80f30d3cfb790f4b076ed7b1.

Revert the following pull request: #72491 

> This is a false positive. And not just that but whomever made that comment i'll quote in a moment is very misinformed
> 
> > is an old jailbreaking tool to sideload things into your iOS device
> 
> Impactor is only a sideloading tool, not a jailbreaking tool. Also, it's not that old, it came out like 3 or 4 years ago.
> 
> > I don't know if it's even maintained anymore
> 
> All you need to do is some simple research, it's constantly updated, saurik literally tweeted about it a few days ago.
> 
> > as Cydia kinda went defunct
> 
> No it didn't. Cydia still gets updates, although it's not on the hands of saurik anymore.
> 
> > BUT, I would argue that it probably doesn't have any legitimate purposes anymore
> 
> That's a stupid thing to say considering a ton of people use Impactor all the time (well maybe not right now as a server-side change by Apple broke it, but you get the point)

~https://github.com/Homebrew/homebrew-cask/pull/72491#issuecomment-557908163