### PR TITLE
Update diskmaker-x from 9.0b1 to 9.0

### DIFF
--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -5,8 +5,8 @@ cask 'diskmaker-x' do
 
     app "DiskMaker X #{version.major} for macOS Mojave.app"
   else
-    version '9.0b1'
-    sha256 '9946b75cafed3f9e71cbe09c45cac7db66a4a17a2bb61c76f6e006822d077d52'
+    version '9'
+    sha256 '96845cd375543401b822fb4e17d2ecc300fcb621f56afcdad613ae11c9afddce'
 
     app "DiskMaker X #{version.major} for macOS Catalina.app"
   end

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -11,7 +11,7 @@ cask 'diskmaker-x' do
     app "DiskMaker X #{version.major} for macOS Catalina.app"
   end
 
-  url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.no_dots}.dmg"
+  url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.major}.dmg"
   appcast 'https://diskmakerx.com/feed/'
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -5,7 +5,7 @@ cask 'diskmaker-x' do
 
     app "DiskMaker X #{version.major} for macOS Mojave.app"
   else
-    version '9'
+    version '9.0'
     sha256 '96845cd375543401b822fb4e17d2ecc300fcb621f56afcdad613ae11c9afddce'
 
     app "DiskMaker X #{version.major} for macOS Catalina.app"

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -12,7 +12,8 @@ cask 'diskmaker-x' do
   end
 
   url "https://diskmakerx.com/downloads/DiskMaker_X_#{version.major}.dmg"
-  appcast 'https://diskmakerx.com/feed/'
+  appcast 'https://diskmakerx.com/feed/',
+          configuration: version.major
   name 'DiskMaker X'
   homepage 'https://diskmakerx.com/'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.