### PR TITLE
Add `auto_updates` flag to sip 2.2.2

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -12,6 +12,7 @@ cask 'sip' do
   name 'Sip'
   homepage 'https://sipapp.io/'
 
+  auto_updates true
   depends_on macos: '>= :sierra'
 
   app 'Sip.app'


### PR DESCRIPTION
Sip has its own update mechanism:
<img width="662" alt="Screenshot 2019-11-24 at 22 19 55" src="https://user-images.githubusercontent.com/13354491/69500044-b344b180-0f08-11ea-92ae-0319dff0cae5.png">

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).