### PR TITLE
Add `auto_updates` flag to swish 1.2.1

### DIFF
--- a/Casks/swish.rb
+++ b/Casks/swish.rb
@@ -7,6 +7,7 @@ cask 'swish' do
   name 'Swish'
   homepage 'https://highlyopinionated.co/swish/'
 
+  auto_updates true
   depends_on macos: '>= :high_sierra'
 
   app 'Swish.app'


### PR DESCRIPTION
Swish has its own update mechanism:
<img width="912" alt="Screenshot 2019-11-24 at 22 18 18" src="https://user-images.githubusercontent.com/13354491/69500002-7a0c4180-0f08-11ea-8ff9-c7a2b82de139.png">

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).