### PR TITLE
Update smooze from 1.8.5 to 1.8.6

### DIFF
--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -1,5 +1,5 @@
 cask 'smooze' do
-  version '1.8.5'
+  version '1.8.6'
   sha256 'cdeb8b4559b74bb7a51fd13e46eeecfdef99d386e1b32581f5053ab7a49eb179'
 
   url 'https://smooze.co/updates/Smooze.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.