### PR TITLE
Update fsnotes from 4.0.7 to 4.0.8

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.0.7'
-  sha256 'a2a9c4d9576401a36694dd01e805d89f14afd9da894ee6441a52049647dafc81'
+  version '4.0.8'
+  sha256 'b35b87ad732a3d76d85cba830b3aacdc4443f15009371dd0f6a9418da566cb12'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.