### PR TITLE
Update rightfont from 5.7.0 to 5.8.0

### DIFF
--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -1,6 +1,6 @@
 cask 'rightfont' do
-  version '5.7.0'
-  sha256 '2bdd97933bf83366c732b4ff165e15f031cb5ef1a0dda6692dce2e70ba353276'
+  version '5.8.0'
+  sha256 'c16b63dd775e2e85d60f905eee5ec93b1e02033c551c56a38c827bd78883e1f3'
 
   url 'https://rightfontapp.com/update/rightfont.zip'
   appcast "https://rightfontapp.com/update/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.