### PR TITLE
Update selfcontrol from 2.3 to 2.3.1

### DIFF
--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -1,6 +1,6 @@
 cask 'selfcontrol' do
-  version '2.3'
-  sha256 '10f55e3bbe21444760227699f1467ea4653f61791dfba7f4b3e92bf76bf87e18'
+  version '2.3.1'
+  sha256 '91cbc81725bfdc9f3fce17f8b9857b90c4fc920541c23dba5b4e974683a0a0cf'
 
   url "https://downloads.selfcontrolapp.com/SelfControl-#{version}.zip"
   appcast 'https://selfcontrolapp.com/SelfControlAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.