### PR TITLE
Update molotov from 4.1.1 to 4.2.1

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,6 +1,6 @@
 cask 'molotov' do
-  version '4.1.1'
-  sha256 'a00de03f2e78fff49ee18e409b27d5f6dfbf905fa21817e2b6f262e9f47d425e'
+  version '4.2.1'
+  sha256 'd03d7390c59cc735e5a6c5ff443b661ffa07f9b409d7d1f02a1b69c85c4e5768'
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-v#{version}.dmg"
   appcast 'https://desktop-auto-upgrade.molotov.tv/mac/manifest.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.