### PR TITLE
Update beatunes from 5.2.1 to 5.2.2

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,6 +1,6 @@
 cask 'beatunes' do
-  version '5.2.1'
-  sha256 'dbb9971c9cdb88557f271ce1748603e941c612f7184eda9e70064ea317829ec2'
+  version '5.2.2'
+  sha256 'd3e2e102898c651722e6c11c66b7da3d4e63af0942638ef2475904aef52c2f57'
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   appcast 'https://www.beatunes.com/en/beatunes-download.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.