### PR TITLE
Update anydo from 4.2.53 to 4.2.54

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.53'
-  sha256 '1de99ff5845bc62a33879ea5731e80eaceb174177dbc67b2c528e68c6b422142'
+  version '4.2.54'
+  sha256 'e4f31950396d496580293e6ea8b4c25e583271636fd2057235fd3048a40f544f'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.