### PR TITLE
Update feishu from 3.10.6 to 3.11.4

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,6 +1,6 @@
 cask 'feishu' do
-  version '3.10.6'
-  sha256 'bccdaba097fbfa77762fb381e6599c8df446258fff30075a4cad05a95323e5aa'
+  version '3.11.4'
+  sha256 'a0ad32fc1a06268956d653e36f202e8866614a59a4d0dc3e34b0b2aa9a3e4541'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.