### PR TITLE
Update understand from 5.1.1007 to 5.1.1008

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1007'
-  sha256 '6662fbcf9774cb2d9fb127dd7b562ee52affd73cb13c177606147305f98a068c'
+  version '5.1.1008'
+  sha256 'd0cc84e115d45aec72dcabb1ff7e61b14c9c68ee6cfd53ba08b006926d8d7dac'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.