### PR TITLE
Update macs-fan-control from 1.5.1.7 to 1.5.2.8

### DIFF
--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -10,7 +10,7 @@ cask 'macs-fan-control' do
   homepage 'https://www.crystalidea.com/macs-fan-control'
 
   auto_updates true
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :mojave'
 
   app 'Macs Fan Control.app'
 

--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -1,6 +1,6 @@
 cask 'macs-fan-control' do
-  version '1.5.1.7'
-  sha256 '29c9d84611c7b67bbf134db8e3899f27f515ddd1521424f6a5cddbb34714d4db'
+  version '1.5.2.8'
+  sha256 'f5666cbe2591aa152507ad55a9209664a226b51c7568f59a0f3d3ff72f3f8b32'
 
   # github.com/crystalidea/macs-fan-control was verified as official when first introduced to the cask
   url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version.major_minor_patch}/macsfancontrol.zip"
@@ -10,7 +10,7 @@ cask 'macs-fan-control' do
   homepage 'https://www.crystalidea.com/macs-fan-control'
 
   auto_updates true
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :sierra'
 
   app 'Macs Fan Control.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.