### PR TITLE
Update macs-fan-control depends_on

### DIFF
--- a/Casks/macs-fan-control.rb
+++ b/Casks/macs-fan-control.rb
@@ -10,7 +10,7 @@ cask 'macs-fan-control' do
   homepage 'https://www.crystalidea.com/macs-fan-control'
 
   auto_updates true
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :sierra'
 
   app 'Macs Fan Control.app'
 


### PR DESCRIPTION
according to the releasenotes for 1.5.2, the minimum system has been lowered again