### PR TITLE
Update freesmug-chromium from 78.0.3904.97 to 78.0.3904.108

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '78.0.3904.97'
-  sha256 '7c90c63714a983e1d2277f40a1f3ce1e90f245c1b1a8bacc6e9308ed328d552b'
+  version '78.0.3904.108'
+  sha256 '4f2e0bd62cab6c5493f5670a3b6947dc8d82a93b4cb9eb0dd1f837ec4380ba5d'
 
   # sourceforge.net/osxportableapps was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.