### PR TITLE
Update archi from 4.6.0 to 4.6.0,201911

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,8 +1,8 @@
 cask 'archi' do
-  version '4.6.0'
-  sha256 '2cc75122d6e1fb9ce9cf99488aeb041c07cec0df237e9bd496f6f8dc4cf66cbc'
+  version '4.6.0,201911'
+  sha256 '761a1f37af04fc2dc1bb8d9d250f2c4251a08c47ed4893c13fe087800e029030'
 
-  url "https://www.archimatetool.com/downloads/#{version.no_dots}/Archi-Mac-#{version}.zip"
+  url "https://www.archimatetool.com/downloads/#{version.after_comma}/Archi-Mac-#{version.before_comma}.zip"
   appcast 'https://github.com/archimatetool/archi/releases.atom'
   name 'Archi'
   homepage 'https://www.archimatetool.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.