### PR TITLE
Update vimr from 0.28.0-328 to 0.29.0-329

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,6 +1,6 @@
 cask 'vimr' do
-  version '0.28.0-328'
-  sha256 'd4f94ddf4b04e37de516ccce2d7a9507e23c83d8c01e367a13cccb8da8128733'
+  version '0.29.0-329'
+  sha256 '2282c15c8b2886640148fdd34070786e817bdbfc399ad98b3fd18f8220f73a5a'
 
   # github.com/qvacua/vimr was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.