### PR TITLE
Update marvel from 8.5.6 to 8.5.7

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '8.5.6'
-  sha256 'c8b46bec4ba7974edac61654160865b0cad3ccded007f776d2d9d2ebfe5af7ea'
+  version '8.5.7'
+  sha256 '1061b27ac2520e41485516b2c730105aab06c641104966e1b1f10cd36e020f5d'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.