### PR TITLE
Update nvidia-geforce-now from 2.0.15.63,81BAD9 to 2.0.15.67,9A2E8D

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.15.63,81BAD9'
-  sha256 '633859cc41b56e97cd795a722fc685149417ed34cecfa99cc358c9d2d441e306'
+  version '2.0.15.67,9A2E8D'
+  sha256 '513079dac33c860a36f0b564a01e153b8ea1d6a481c83f2a4d2c36abe8c6d7f1'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.