### PR TITLE
Update deepl from 1.2.0 to 1.3.0

### DIFF
--- a/Casks/deepl.rb
+++ b/Casks/deepl.rb
@@ -1,6 +1,6 @@
 cask 'deepl' do
-  version '1.2.0'
-  sha256 '31d4809da03661d0c89ae32aae2c9277307b8a2d8329c59e6fd10ceba0b072f7'
+  version '1.3.0'
+  sha256 'b96de40392fa89c4e5445c7bb891eb54f10ebafd7a7a0d746f896bc03034f906'
 
   url "https://www.deepl.com/macos/download/LpsA0EG5frbfX8p5/DeepL#{version.no_dots}.zip"
   name 'DeepL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.