### PR TITLE
Update touchosc-bridge from 1.4.0.1 to 1.5.0

### DIFF
--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-bridge' do
   version '1.5.0'
-  sha256 'a5a4b5d78733b682d61952959a96fadc74019158166f74d5dfac65e2f76b59fa'
+  sha256 '53ce1e920e05b844c3fa2bb1e891fec2b8de9e4917ec0fa01feecfcb772cd767'
 
   url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-macos.zip" 
   appcast 'https://hexler.net/software/touchosc'

--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-bridge' do
-  version '1.4.0.1'
-  sha256 '7911ad9284aafb1ddd337af333d445de7ae57df5ca9b134bdf6881139a8795f4'
+  version '1.5.0'
+  sha256 'a5a4b5d78733b682d61952959a96fadc74019158166f74d5dfac65e2f76b59fa'
 
   url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-osx.zip"
   appcast 'https://hexler.net/software/touchosc'

--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -2,7 +2,7 @@ cask 'touchosc-bridge' do
   version '1.5.0'
   sha256 '53ce1e920e05b844c3fa2bb1e891fec2b8de9e4917ec0fa01feecfcb772cd767'
 
-  url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-macos.zip" 
+  url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-macos.zip"
   appcast 'https://hexler.net/software/touchosc'
   name 'TouchOSC Bridge'
   homepage 'https://hexler.net/software/touchosc'

--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -2,7 +2,7 @@ cask 'touchosc-bridge' do
   version '1.5.0'
   sha256 'a5a4b5d78733b682d61952959a96fadc74019158166f74d5dfac65e2f76b59fa'
 
-  url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-osx.zip"
+  url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-macos.zip" 
   appcast 'https://hexler.net/software/touchosc'
   name 'TouchOSC Bridge'
   homepage 'https://hexler.net/software/touchosc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.