### PR TITLE
Update igetter from 2.9.6 to 2.9.7

### DIFF
--- a/Casks/igetter.rb
+++ b/Casks/igetter.rb
@@ -1,6 +1,6 @@
 cask 'igetter' do
-  version '2.9.6'
-  sha256 '31acb5393debc5fbb26a8d7a8ff1acf64144422ec127393dbc1a7329d9669a14'
+  version '2.9.7'
+  sha256 'b085f89873005bd6c9055e6b7641738009229a8e83e0719be2206ec7ab037cc5'
 
   url "https://www.igetter.net/search/downloads/iGetter#{version}.dmg"
   appcast 'https://www.igetter.net/downloads.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.