### PR TITLE
Update thebrain from 10.0.64.0 to 10.0.65.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,6 +1,6 @@
 cask 'thebrain' do
-  version '10.0.64.0'
-  sha256 '63eb56cc8175cef3eeea1c7086cc1e3c9129c41dea5e65955a9ab124b4f509ac'
+  version '10.0.65.0'
+  sha256 '481cd71a820ef52e3c3b5e9352ce71d8091ffd11e868a789b3e7ff1116ff0d03'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.