### PR TITLE
Update airtame from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '3.6.0'
-  sha256 '682f6d259244566ab7e892051637df537301d26746f1e5846914d1d836428be1'
+  version '3.6.1'
+  sha256 '1ed7013a174da6964bdc180f4a851c330701f7a93ecc1bfb7e4ec7d00d70be3f'
 
   url "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.