### PR TITLE
Update alfaview from 7.50429 to 7.51964

### DIFF
--- a/Casks/alfaview.rb
+++ b/Casks/alfaview.rb
@@ -1,6 +1,6 @@
 cask 'alfaview' do
-  version '7.50429'
-  sha256 'd483f079f09eec8e1b7913a638a494c1b88bea08ccb5a8a6f1c2ff98733fd09a'
+  version '7.51964'
+  sha256 'ce45be5b71abb4f46289d2909cc725aec7d285ec85e41963611c78f49c3b2697'
 
   url "https://assets.alfaview.com/stable/mac/alfaview-mac-production-#{version}.dmg"
   appcast 'https://alfaview.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.