### PR TITLE
Update cask 'readcube' from 2.1.0 to 4.0.0

### DIFF
--- a/Casks/readcube.rb
+++ b/Casks/readcube.rb
@@ -1,14 +1,19 @@
 cask 'readcube' do
-  version '2.1.0'
-  sha256 'cb3e54f08f57051252c70b9b45cb8cc2f001769a3ae25a5f5789abe55269eea4'
+  version '4.0.0'
+  sha256 '8c63a193ced25c92db168e415b3a537efb828c86bd62b7615bc95508d3532801'
 
-  url "https://download.readcube.com/desktop/#{version}/ReadCubeSetup.zip"
-  name 'ReadCube'
-  homepage 'https://www.readcube.com/'
+  url "https://download.readcube.com/app/Install%20Papers.pkg"
+  name 'ReadCube Papers'
+  homepage 'https://www.papersapp.com/'
 
-  installer manual: 'Install ReadCube.app'
+  pkg 'Install Papers.pkg'
 
-  uninstall delete: '/Applications/ReadCube.app'
+  uninstall pkgutil: 'com.papersapp.PapersInstaller'
 
-  zap trash: '~/Library/Preferences/com.readcube.Desktop/'
+  zap trash: [
+               "~/Library/Preferences/com.ReadCube.Papers.plist",
+               "~/Library/Caches/com.ReadCube.Papers.ShipIt",
+               "~/Library/Saved Application State/com.ReadCube.Papers.savedState",
+               "~/Library/Caches/com.ReadCube.Papers",
+             ]
 end

--- a/Casks/readcube.rb
+++ b/Casks/readcube.rb
@@ -2,7 +2,8 @@ cask 'readcube' do
   version '4.0.0'
   sha256 '8c63a193ced25c92db168e415b3a537efb828c86bd62b7615bc95508d3532801'
 
-  url "https://download.readcube.com/app/Install%20Papers.pkg"
+  # download.readcube.com was verified as official when first introduced to the cask
+  url 'https://download.readcube.com/app/Install%20Papers.pkg'
   name 'ReadCube Papers'
   homepage 'https://www.papersapp.com/'
 
@@ -11,9 +12,9 @@ cask 'readcube' do
   uninstall pkgutil: 'com.papersapp.PapersInstaller'
 
   zap trash: [
-               "~/Library/Preferences/com.ReadCube.Papers.plist",
-               "~/Library/Caches/com.ReadCube.Papers.ShipIt",
-               "~/Library/Saved Application State/com.ReadCube.Papers.savedState",
-               "~/Library/Caches/com.ReadCube.Papers",
+               '~/Library/Preferences/com.ReadCube.Papers.plist',
+               '~/Library/Caches/com.ReadCube.Papers.ShipIt',
+               '~/Library/Saved Application State/com.ReadCube.Papers.savedState',
+               '~/Library/Caches/com.ReadCube.Papers',
              ]
 end

--- a/Casks/readcube.rb
+++ b/Casks/readcube.rb
@@ -2,10 +2,9 @@ cask 'readcube' do
   version '4.0.0'
   sha256 '8c63a193ced25c92db168e415b3a537efb828c86bd62b7615bc95508d3532801'
 
-  # download.readcube.com was verified as official when first introduced to the cask
   url 'https://download.readcube.com/app/Install%20Papers.pkg'
   name 'ReadCube Papers'
-  homepage 'https://www.papersapp.com/'
+  homepage 'https://www.readcube.com/home'
 
   pkg 'Install Papers.pkg'
 


### PR DESCRIPTION
The last change of this cask was #41478, a long time ago.
1. Their homepage has been moved to https://www.readcube.com/home, and the product homepage is https://www.papersapp.com.
2. The product has been renamed to "ReadCube Papers", as can be seen on their homepage:
![image](https://user-images.githubusercontent.com/25192197/69695610-f9397b00-10aa-11ea-9edd-3a20c3a9a5f3.png) and [support page](https://readcubesupport.freshdesk.com/support/home).
![image](https://user-images.githubusercontent.com/25192197/69695682-2d14a080-10ab-11ea-8c02-7b873027f36b.png)
3. The download link has been moved to https://www.papersapp.com/download/, which will download a `Install Papers.pkg` (I guess because it is a preview version). I cannot see the exact version from the link, nor can I tell the appcast. I got the version after I install it (do not install the helper, it will auto-update and restart, the next time you start will see the version to be 4.0.3).
![before adding a helper](https://user-images.githubusercontent.com/25192197/69695884-e70c0c80-10ab-11ea-8b00-0650a884ce15.png)
4. I update the "zap trash" using the info given by `CleanMyMac.app`.
5. The relation with [`papers.rb`](https://github.com/ran-dall/homebrew-cask/blob/bd007995e0a102447b9118a5b3458bfc2ffcfe42/Casks/papers.rb). They will abandon that app as I remember. I guess they are transferring from one app to another so that the names are in a mess. But I think the app that was actually installed in 4.0.0, is the same app as before: They share the same logo. The current app has the name `Papers.app`, while in the past, it was `ReadCube.app`.
![image](https://user-images.githubusercontent.com/25192197/69696228-0ce5e100-10ad-11ea-80ae-bdf9704b1923.png)



After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256