### PR TITLE
Update nosql-workbench-for-amazon-dynamodb from 0.3.0 to 0.3.1

### DIFF
--- a/Casks/nosql-workbench-for-amazon-dynamodb.rb
+++ b/Casks/nosql-workbench-for-amazon-dynamodb.rb
@@ -4,9 +4,9 @@ cask 'nosql-workbench-for-amazon-dynamodb' do
 
   # nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com/NoSQL+Workbench+for+Amazon+DynamoDB+(Preview)-mac-#{version}.dmg"
-  appcast 'https://docs.aws.amazon.com/en_pv/amazondynamodb/latest/developerguide/workbench.settingup.partial.html'
+  appcast 'https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.settingup.html'
   name 'NoSQL Workbench for Amazon DynamoDB'
-  homepage 'https://docs.aws.amazon.com/en_pv/amazondynamodb/latest/developerguide/workbench.html'
+  homepage 'https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html'
 
   app 'NoSQL Workbench for Amazon DynamoDB (Preview).app'
 end

--- a/Casks/nosql-workbench-for-amazon-dynamodb.rb
+++ b/Casks/nosql-workbench-for-amazon-dynamodb.rb
@@ -1,6 +1,6 @@
 cask 'nosql-workbench-for-amazon-dynamodb' do
-  version '0.3.0'
-  sha256 '8cf0d7eac9d73a1f5c761dcfe22e617cc384c5d27a49c80d0258070d548201fe'
+  version '0.3.1'
+  sha256 '16b71734e87f3feefbb8955cb7d47a8b24e7bdb1fdcbd7cb8092683888975e55'
 
   # nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com/NoSQL+Workbench+for+Amazon+DynamoDB+(Preview)-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Ref: https://github.com/Homebrew/homebrew-cask/pull/72481