### PR TITLE
secure URLs

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -3,7 +3,7 @@ cask 'cctalk' do
   sha256 'bab460c7e06161b72f63a7a569c04e7ba930ebcc1f32a2b85137ddc364476878'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "http://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
+  url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'

--- a/Casks/find-any-file.rb
+++ b/Casks/find-any-file.rb
@@ -4,7 +4,7 @@ cask 'find-any-file' do
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/files.tempel.org/FindAnyFile_#{version}.zip"
-  appcast 'http://findanyfile.app/appcast2.php'
+  appcast 'https://findanyfile.app/appcast2.php'
   name 'Find Any File'
   homepage 'https://apps.tempel.org/FindAnyFile/'
 

--- a/Casks/hiarcs-chess-explorer.rb
+++ b/Casks/hiarcs-chess-explorer.rb
@@ -2,10 +2,10 @@ cask 'hiarcs-chess-explorer' do
   version '1.9.4a'
   sha256 '5dbeb42d597d93f24c89690f7d1a7a32bff9e8dfe38ec4ba396b4e3140c68db0'
 
-  url "http://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
-  appcast 'http://www.hiarcs.com/hce/mac-v120.htm'
+  url "https://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
+  appcast 'https://www.hiarcs.com/hce/mac-v120.htm'
   name '(Deep) HIARCS Chess Explorer'
-  homepage 'http://www.hiarcs.com/mac-chess-explorer.htm'
+  homepage 'https://www.hiarcs.com/mac-chess-explorer.htm'
 
   pkg "HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
 

--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -3,7 +3,7 @@ cask 'livechat' do
   sha256 '34a4941b7429e094770d55dd864de0a4d795c8e875aa36344921e89d36d94d06'
 
   url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
-  appcast 'https://s3.amazonaws.com/dal-livechat-main-web/download/Mac/latest-mac.yml'
+  appcast 'https://dal-livechat-main-web.s3.amazonaws.com/download/Mac/latest-mac.yml'
   name 'LiveChat'
   homepage 'https://www.livechatinc.com/'
 

--- a/Casks/my-image-garden.rb
+++ b/Casks/my-image-garden.rb
@@ -3,7 +3,7 @@ cask 'my-image-garden' do
   sha256 '9942141cc5a46bec2e29ffe87cc679ca5de51f008c4182b48f666b61ad3285bb'
 
   # c-wss.com was verified as official when first introduced to the cask
-  url "http://gdlp01.c-wss.com/gds/3/0200004873/08/mmig-mac-#{version.dots_to_underscores}-ea11.dmg"
+  url "https://gdlp01.c-wss.com/gds/3/0200004873/08/mmig-mac-#{version.dots_to_underscores}-ea11.dmg"
   name 'Canon My Image Garden'
   homepage 'https://support-asia.canon-asia.com/?personal'
 

--- a/Casks/opendnsupdater.rb
+++ b/Casks/opendnsupdater.rb
@@ -3,7 +3,7 @@ cask 'opendnsupdater' do
   sha256 '3e5def08fd366a0d4d651a8bd7cf0a1274f8dd67f8c7a55842b3c4126492a15b'
 
   url 'https://www.opendns.com/download/mac/'
-  appcast 'http://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.opendns.com/download/mac/'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.opendns.com/download/mac/'
   name 'OpenDNS Updater'
   homepage 'https://support.opendns.com/hc/en-us/articles/227987867'
 

--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -2,7 +2,7 @@ cask 'protopie' do
   version '4.1.3'
   sha256 '354eb173607e613ea6cb670104eb93727eea24dc9907d945e42f70caec3b5c13'
 
-  url "http://release.protopie.io/ProtoPie-#{version}.dmg"
+  url "https://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'
   name 'ProtoPie'
   homepage 'https://www.protopie.io/'

--- a/Casks/qdslrdashboard.rb
+++ b/Casks/qdslrdashboard.rb
@@ -4,11 +4,11 @@ cask 'qdslrdashboard' do
   if MacOS.version <= :mavericks
     sha256 '1d643430dc7aa7f25254846eef43e35ee15d2f365526058665c145269042affe'
     # files.lrtimelapse.com/dslrdashboard was verified as official when first introduced to the cask
-    url "http://files.lrtimelapse.com/dslrdashboard/V#{version}/qDslrDashboard_V#{version}_macOS_preMojave.dmg"
+    url "https://files.lrtimelapse.com/dslrdashboard/V#{version}/qDslrDashboard_V#{version}_macOS_preMojave.dmg"
   else
     sha256 '349e0fb9532c92120b9d89790e984fc251d14c5373bfddef4d96f0ff05af26b7'
     # files.lrtimelapse.com/dslrdashboard was verified as official when first introduced to the cask
-    url "http://files.lrtimelapse.com/dslrdashboard/V#{version}/qDslrDashboard_V#{version}_macOS.dmg"
+    url "https://files.lrtimelapse.com/dslrdashboard/V#{version}/qDslrDashboard_V#{version}_macOS.dmg"
   end
 
   appcast 'https://dslrdashboard.info/downloads/'

--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -6,7 +6,7 @@ cask 'recents' do
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b'
   name 'Recents'
-  homepage 'http://recentsapp.com/'
+  homepage 'https://recentsapp.com/'
 
   depends_on macos: '>= :high_sierra'
 

--- a/Casks/session-manager-plugin.rb
+++ b/Casks/session-manager-plugin.rb
@@ -2,8 +2,8 @@ cask 'session-manager-plugin' do
   version :latest
   sha256 :no_check
 
-  # s3.amazonaws.com/session-manager-downloads was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip'
+  # session-manager-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://session-manager-downloads.s3.amazonaws.com/plugin/latest/mac/sessionmanager-bundle.zip'
   name 'Session Manager Plugin for the AWS CLI'
   homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
 

--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -4,7 +4,7 @@ cask 'timely' do
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://app.timelyapp.com/download/mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://app.timelyapp.com/download/mac'
   name 'Timely'
   homepage 'https://timelyapp.com/'
 

--- a/Casks/weiyun.rb
+++ b/Casks/weiyun.rb
@@ -3,7 +3,7 @@ cask 'weiyun' do
   sha256 '65f3996fea7da1c80a0abd433a3f109b3985d5143e67ed9aa79b0ac54e9e0055'
 
   # dldir1.qq.com/weiyun was verified as official when first introduced to the cask
-  url "http://dldir1.qq.com/weiyun/Weiyun_Mac_#{version}.dmg"
+  url "https://dldir1.qq.com/weiyun/Weiyun_Mac_#{version}.dmg"
   appcast 'https://qzonestyle.gtimg.cn/qzone/qzactStatics/configSystem/data/65/config1.js'
   name 'weiyun'
   homepage 'https://www.weiyun.com/'

--- a/Casks/xctu.rb
+++ b/Casks/xctu.rb
@@ -2,7 +2,7 @@ cask 'xctu' do
   version :latest
   sha256 :no_check
 
-  url 'http://ftp1.digi.com/support/utilities/40003027_W.zip'
+  url 'https://ftp1.digi.com/support/utilities/40003027_W.zip'
   name 'XCTU'
   homepage 'https://www.digi.com/products/embedded-systems/digi-xbee-tools/xctu'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
1 file inspected, no offenses detected
==> Downloading https://cc.hjfile.cn/cc/7.6.1.11/8/1/103/7.6.1.11.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cctalk'.
audit for cctalk: passed

1 file inspected, no offenses detected
==> Downloading https://s3.amazonaws.com/files.tempel.org/FindAnyFile_2.1.1.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'find-any-file'.
audit for find-any-file: passed

1 file inspected, no offenses detected
==> Downloading https://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v1.9.
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'hiarcs-chess-explorer'.
audit for hiarcs-chess-explorer: passed

1 file inspected, no offenses detected
==> Downloading https://www.livechatinc.com/download/Mac/LiveChat.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'livechat'.
audit for livechat: passed

1 file inspected, no offenses detected
==> Downloading https://gdlp01.c-wss.com/gds/3/0200004873/08/mmig-mac-3_6_3-ea11
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'my-image-garden'.
audit for my-image-garden: passed

1 file inspected, no offenses detected
==> Downloading https://www.opendns.com/download/mac/
==> Downloading from https://s3-us-west-1.amazonaws.com/opendns-downloads/OpenDN
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'opendnsupdater'.
audit for opendnsupdater: passed

1 file inspected, no offenses detected
==> Downloading https://release.protopie.io/ProtoPie-4.1.3.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'protopie'.
audit for protopie: passed

1 file inspected, no offenses detected
==> Downloading https://files.lrtimelapse.com/dslrdashboard/V3.5.9/qDslrDashboar
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'qdslrdashboard'.
audit for qdslrdashboard: passed

1 file inspected, no offenses detected
==> Downloading https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/4867?format=zip
==> Downloading from https://cdn.hockeyapp.net/production/app/builds/045/295/530/original/7bcd2148a71ee3090cb927b451da124c/Recents.zip?Expires=15
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'recents'.
audit for recents: passed

1 file inspected, no offenses detected
==> Downloading https://session-manager-downloads.s3.amazonaws.com/plugin/latest
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'session-manager-plugin', skipping veri
audit for session-manager-plugin: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/Timely/desktop-releases/releases/download/dar
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'timely'.
audit for timely: passed

1 file inspected, no offenses detected
==> Downloading https://dldir1.qq.com/weiyun/Weiyun_Mac_3.0.3.396_465df4.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'weiyun'.
audit for weiyun: passed

1 file inspected, no offenses detected
==> Downloading https://ftp1.digi.com/support/utilities/40003027_W.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'xctu', skipping verification.
audit for xctu: passed
```
