### PR TITLE
Update toggl from 7.4.1034 to 7.4.1036

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.1034'
-  sha256 'eae0804589e73556ffdf45f64b9673e0227440ca9f2de6c009ae2ba6a3789ba3'
+  version '7.4.1036'
+  sha256 '45461031b0aa58bba6c4990606cbd71e8a0583d33bc87ab01443ac4bc6723e6e'
 
   # github.com/toggl-open-source/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.