### PR TITLE
Update ivideonclient from 6.8.1 to 6.8.2

### DIFF
--- a/Casks/ivideonclient.rb
+++ b/Casks/ivideonclient.rb
@@ -1,6 +1,6 @@
 cask 'ivideonclient' do
-  version '6.8.1'
-  sha256 '970959428ed0d55c61db81617e36c65fce5b3ad0c80dd10dd16d2ed358458bef'
+  version '6.8.2'
+  sha256 'e5f66164183c1375797f602228f75b798403d186cc224afd53885b539e0f6de3'
 
   # updates.iv-cdn.com was verified as official when first introduced to the cask
   url "https://updates.iv-cdn.com/bundles/ivideon_client/#{version}/IvideonClient_#{version}_macosx-x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.