### PR TITLE
Update balenaetcher from 1.5.63 to 1.5.64

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.63'
-  sha256 '59f98032491f131210609257571cfe490cac980a97b306f745c40fe69b7e3bde'
+  version '1.5.64'
+  sha256 '348554b9a5bbd24257b3c9e1a77214b6aaa09cdf21c9d43eb7f26d02cc40bd45'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.