### PR TITLE
Update trilium-notes from 0.37.5 to 0.37.6

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.37.5'
-  sha256 '0863e3ee0c6393f09d2677b3c7b1fbdced93c4a4240bd19059f2e4af0b36b1b5'
+  version '0.37.6'
+  sha256 'abf6349ce5ef79455169e8820033aceb103289dcbff8879bb8c0d79a2c7295c7'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.