### PR TITLE
Update tidepool-uploader from 2.23.0 to 2.23.1

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.23.0'
-  sha256 '633e3285ad3f9081d84f410b334cdccf1354689e9ed1bc32272adfb24c1f7e50'
+  version '2.23.1'
+  sha256 '54b8bdb44e2debd826ba15bd81cd471ceb1ae6bc656816fc2742189bd30370c7'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.