### PR TITLE
Update timely from 1.0.7 to 1.0.8

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,6 +1,6 @@
 cask 'timely' do
-  version '1.0.7'
-  sha256 '205b90d8d4f52fde074c7152facb8ca79f45414f246291b896908974a71c3673'
+  version '1.0.8'
+  sha256 '59170f4c7bde38a3c5bf1fd22db7d68ffc21eb7fd3305a3e68ecdbf8de449aad'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.