### PR TITLE
Update kiwi-for-g-suite from 2.0.26v to 2.0.27v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask 'kiwi-for-g-suite' do
-  version '2.0.26v'
-  sha256 'e371a1c461126478e36bc7a08a0459c6cbaa9ab91376684c561aa2b341dd98e7'
+  version '2.0.27v'
+  sha256 '5cc37e233e3c47f156cc4450e4edcd081853523c0ce6ce6a314320e829096b86'
 
   # kiwiforgsuite.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.