### PR TITLE
Update garagesale from 8.0.5 to 8.0.6

### DIFF
--- a/Casks/garagesale.rb
+++ b/Casks/garagesale.rb
@@ -1,6 +1,6 @@
 cask 'garagesale' do
-  version '8.0.5'
-  sha256 'e65654afce4e3e6c3cf0bcefd16a2ef3beccb3cbdf6c4bf845177eac09f67a71'
+  version '8.0.6'
+  sha256 'bc409ce760a3b93be94a71477e1aec2e36a9540150f39a1309897ab8c1d89efe'
 
   url "https://downloads.iwascoding.com/downloads/GarageSale_#{version}.dmg"
   appcast 'https://www.iwascoding.com/GarageSale/Downloads.html#VersionHistory'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.