### PR TITLE
Update wiznote from 2.7.9,2019-10-21 to 2.8.0,2019-11-11

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.7.9,2019-10-21'
-  sha256 'd9f089534ff54bce5af36f6caea347a15c94f78d320fffd5fe438ed2da5ad5d4'
+  version '2.8.0,2019-11-11'
+  sha256 '14de8ac137eb2e961ce360e464c02985128745ae81992a8d58f28dfeea28d7e3'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://url.wiz.cn/u/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.