### PR TITLE
Update dcp-o-matic-encode-server from 2.14.14 to 2.14.15

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.14'
-  sha256 'ff7034ebd881eac24d9fd07308ae0a5d2daadd34bdb005d318fad86252084a74'
+  version '2.14.15'
+  sha256 'f115a435080d2d163653d2669e97730611c046d41e55a55b03bb9b38150dc05c'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.