### PR TITLE
Update dcp-o-matic-player from 2.14.14 to 2.14.15

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.14'
-  sha256 '0943d70a82cc8492f88f1098e8ff47b4ee09e1767b81648c54ab4ad9fdea1d51'
+  version '2.14.15'
+  sha256 'c257ce614c26b2e6a8eb622934be9b2111bae0291400ee1558cbec7c3784dbd9'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.