### PR TITLE
Update dcp-o-matic-kdm-creator from 2.14.14 to 2.14.15

### DIFF
--- a/Casks/dcp-o-matic-kdm-creator.rb
+++ b/Casks/dcp-o-matic-kdm-creator.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-kdm-creator' do
-  version '2.14.14'
-  sha256 '9edb66bcc0abb4a1aa7f01b630d4ad6ca32ef099edc89eaf0d0261e89f0ae267'
+  version '2.14.15'
+  sha256 '80880d4bf33cce4b0c326819a7c15d19d5d3a5a2737081f5f11d7932242eda96'
 
   url "https://dcpomatic.com/dl.php?id=osx-kdm&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.