### PR TITLE
Update ipfs from 0.9.7 to 0.10.1

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -1,6 +1,6 @@
 cask 'ipfs' do
-  version '0.9.7'
-  sha256 '8bc019d6fdc0189571b7a0384ee2321cf8b6ed206c400813c32530520a75ef26'
+  version '0.10.1'
+  sha256 '957da49b502d71e0eef096db60cc7737d666c7db67a32ed08b458387bbc88b15'
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/ipfs-desktop-#{version}.dmg"
   appcast 'https://github.com/ipfs-shipyard/ipfs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] brew cask audit --download {{cask_file}} is error-free.
- [x] brew cask style --fix {{cask_file}} left no offenses.
- [x] The commit message includes the cask’s name and version.