### PR TITLE
Update vuescan from 9.7.08 to 9.7.09

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
   version '9.7.09'
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 '572e0efba66110c56a2315ebc42e56eaa663c316787c5724955b2993b23c42d5'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'

--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,5 +1,5 @@
 cask 'vuescan' do
-  version '9.7.08'
+  version '9.7.09'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.