### PR TITLE
Update archi from 4.6.0,201911 to 4.6.0,2019111111

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,5 +1,5 @@
 cask 'archi' do
-  version '4.6.0,201911'
+  version '4.6.0,2019111111'
   sha256 '761a1f37af04fc2dc1bb8d9d250f2c4251a08c47ed4893c13fe087800e029030'
 
   url "https://www.archimatetool.com/downloads/#{version.after_comma}/Archi-Mac-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.