### PR TITLE
Update netron from 3.5.6 to 3.5.7

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.5.6'
-  sha256 'f11f5156ad6333bafd24edfea2ade3dbe8a06b17a5e3304207fabadbf8d270cd'
+  version '3.5.7'
+  sha256 '98e932a041a40ac80b05915437fb7545c8b8596e8ba26d0b481bd35df2c4e95d'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.