### PR TITLE
Update lastpass from 4.37.0 to 4.38.0

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.37.0'
-  sha256 '66d6359fab75c9f04355b64f20bc8437c4c4b8679d57e4627fb0127b50c85e5c'
+  version '4.38.0'
+  sha256 'cc42b5d5e04c58c8f554bf5b694a4457e787d2c4db1a586d7a76345b620e760c'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

And also resolve #73320 