### PR TITLE
Add Kinza.app v5.0.0

### DIFF
--- a/Casks/kinza.rb
+++ b/Casks/kinza.rb
@@ -4,8 +4,9 @@ cask 'kinza' do
 
   # d7s9ygw7nxr46.cloudfront.net was verified as official when first introduced to the cask
   url "https://d7s9ygw7nxr46.cloudfront.net/mac/kinza_#{version}.dmg"
+  appcast 'https://www.kinza.jp/en/download/thankyou/mac/'
   name 'Kinza'
-  homepage 'https://www.kinza.jp/'
+  homepage 'https://www.kinza.jp/en/'
 
   app 'Kinza.app'
 end

--- a/Casks/kinza.rb
+++ b/Casks/kinza.rb
@@ -1,0 +1,11 @@
+cask 'kinza' do
+  version '5.0.0'
+  sha256 '73306617236d40d2318e5662359126bbf0e3f026c106c7a1ff45739e8e931250'
+
+  # d7s9ygw7nxr46.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d7s9ygw7nxr46.cloudfront.net/mac/kinza_#{version}.dmg"
+  name 'Kinza'
+  homepage 'https://www.kinza.jp/'
+
+  app 'Kinza.app'
+end


### PR DESCRIPTION
<p align="center">
<a href="https://www.kinza.jp/"><img src="https://user-images.githubusercontent.com/10376491/69816013-2d9d5c00-11bd-11ea-8088-869b6fc7f5f9.png" /></a>
</p>

<h1 align="center">Evolving with users' voices</h3>

[Kinza](https://www.kinza.jp) is a Chromium-based Japanese web browser born in the halls of Nihonbashi in Chūō, the heart of Tokyo, Japan. Since the 16th-century Edo period, Nihonbashi has been one of Tokyo's burgeoning economic districts in education, business, and finance as the location of the Tokugawa shogunate's gold and silver mints ([Ginza](https://en.wikipedia.org/wiki/Ginza)) and the current location of the head office of the modern Bank of Japan. Kinza is inspired by the deep history of Nihonbashi through its desire to give the community of the Internet a gold-standard web experience and zeal to evolve through the voices of its users.

*From Dayz Inc., the developers of Kinza:*
> Many internet users maintain the web browser pre-installed on their PCs, while experienced users abandon it for more extensive browsers such as Google Chrome and Firefox. However, web browsers can be developed more flexibly depending on how they are used. That is why Kinza evolves with users' voices. For example, Mouse Gesture and Super Drag have been developed to reflect users' voices. We believe that our mission is to give shape to the best for users and present the appeal of web browsers by Kinza.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

--- 

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

At first, the `generate_task_token` script suggested `applicationkinza` as the Cask token. I figured that wouldn't work 🤷‍♂️. After creating the cask, I tested again and the script correctly proposed `kinza`. I wasn't able to reproduce the first case again, but things should be fine now.

Thank you!