### PR TITLE
Update thebrain from 10.0.65.0 to 10.0.66.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,6 +1,6 @@
 cask 'thebrain' do
-  version '10.0.65.0'
-  sha256 '481cd71a820ef52e3c3b5e9352ce71d8091ffd11e868a789b3e7ff1116ff0d03'
+  version '10.0.66.0'
+  sha256 '2a9a7b6f08a2694e2ee94e4dd7217a4aaf7b53042557fd77b6b304909f3d1383'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.