### PR TITLE
Set auto_updates for sf-symbols

### DIFF
--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -6,6 +6,7 @@ cask 'sf-symbols' do
   name 'SF Symbols'
   homepage 'https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/'
 
+  auto_updates true
   depends_on macos: '>= :mojave'
 
   pkg 'SF Symbols.pkg'


### PR DESCRIPTION
SF-Symbols now auto-updates via macOS Software Updates.
As Apple doesn't provide a versioned download link, I left the version on `:latest`. Should I change that to the version displayed in the app?

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
