### PR TITLE
Update notable from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.8.1'
-  sha256 '406a72e4ac9a235c36cafc4724b75e36c91de0c4570d560b088504d28207468d'
+  version '1.8.2'
+  sha256 '9b02f93804bab4ed8f9c694cbc0aaa86fff03b3eae85f1adb92d76e25b8cb029'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.