### PR TITLE
Update qownnotes from 19.11.22,b4948-172055 to 19.11.23,b4959-160643

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.22,b4948-172055'
-  sha256 'ce730e0b487d78e863c2daecad904f8d98e707603314a492e6276b4ceda2f960'
+  version '19.11.23,b4959-160643'
+  sha256 '29867e80503b1b62effe11e9d15f1a7ab5da18cf6c4813a39915168b5d620a7a'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.