### PR TITLE
Update extraterm from 0.47.0 to 0.48.0

### DIFF
--- a/Casks/extraterm.rb
+++ b/Casks/extraterm.rb
@@ -1,6 +1,6 @@
 cask 'extraterm' do
-  version '0.47.0'
-  sha256 'a598217188c50dd6cd44f3c3b6f532d386e781f254ff8f4b7dfa88db55ebbf34'
+  version '0.48.0'
+  sha256 '14260b7c7aebd3c05f5eeca4ce3e2c65280eb466e159d724919cd7424eaf36e4'
 
   # github.com/sedwards2009/extraterm was verified as official when first introduced to the cask
   url "https://github.com/sedwards2009/extraterm/releases/download/v#{version}/extraterm-#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.