### PR TITLE
Update stoplight-studio from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.6.1'
-  sha256 'a8ca9232d07841c789efeede39772c15ad696f0d8eefe902abf0af4c8609951e'
+  version '1.6.2'
+  sha256 'b07010e3a42000ba4c8a6f55241a386cc94844a01c5e0db890268c9cc40ad5b2'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.