### PR TITLE
Update hubstaff from 1.5.2,1629 to 1.5.4,1728

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.5.2,1629'
-  sha256 '99c35d5f28adebba9782a02ff4c10130be27785b5c6021f3a4ae7f4c4c163b77'
+  version '1.5.4,1728'
+  sha256 '597a8fd886e1c1fbc0e4135f47e37f950daf9e804af48babd985688007ed6fd3'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.