### PR TITLE
Update kite from 0.20191125.0 to 0.20191127.2

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191125.0'
-  sha256 'ce0c6ee2b6083291e0f4119bb13c22cccb07ec7af1ec382350b4729f83dc3ecb'
+  version '0.20191127.2'
+  sha256 'c584af8fba84c9da28e3b84ff270b6003fd4e9d488a30b20759825908516a66e'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.