### PR TITLE
Update ibackup-viewer from 4.1581 to 4.1582

### DIFF
--- a/Casks/ibackup-viewer.rb
+++ b/Casks/ibackup-viewer.rb
@@ -1,6 +1,6 @@
 cask 'ibackup-viewer' do
-  version '4.1581'
-  sha256 'cb5120c3619d3883f304cc2a8a8912b2f66abcfb9c96cde9a96cf07ce1a36fef'
+  version '4.1582'
+  sha256 '2ce0e8f93bc6e505ecb6d128b158c77556790091835d6cb56f7ef00e7176da48'
 
   url 'https://www.imactools.com/download/iBackupViewer.dmg'
   appcast 'https://www.imactools.com/update/ibackupviewer.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.