### PR TITLE
Update resolume-arena from 7.0.5,66948 to 7.0.5,67036

### DIFF
--- a/Casks/resolume-arena.rb
+++ b/Casks/resolume-arena.rb
@@ -1,6 +1,6 @@
 cask 'resolume-arena' do
-  version '7.0.5,66948'
-  sha256 '002663dcf0cc234df67b013780f1a8db0d4d04305fb655c8a2a86dc3306a5ba2'
+  version '7.0.5,67036'
+  sha256 '84785bc2aa2f11819a1bcf9da4a544cdfea27c52eb17808cb95c3dfe7b7cc335'
 
   url "https://resolume.com/download/Resolume_Arena_#{version.major_minor_patch.dots_to_underscores}_rev_#{version.after_comma}_Installer.dmg"
   appcast 'https://resolume.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.