### PR TITLE
Update runway from 0.10.2 to 0.10.3

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.10.2'
-  sha256 'eb037083e5268245a1e2408dadbeee38e88f15f27d5d2d7424906391f4993371'
+  version '0.10.3'
+  sha256 'c532d6718d34b2655fddf0f0d79163d9b43dd417c1b1a5f801c277c6f8765104'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.