### PR TITLE
Update deezer from 4.17.21 to 4.18.0

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.17.21'
-  sha256 '69bf314b037177dd4f5be81b4d39a0267f78c084d5b91f4298bd954f643252ab'
+  version '4.18.0'
+  sha256 'f5f5a11d3fa220ee4387aa7306aa66d5158748b0f7a116ac50716eafdc14a91a'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.