### PR TITLE
Update mendeley-reference-manager from 2.15.0 to 2.16.0

### DIFF
--- a/Casks/mendeley-reference-manager.rb
+++ b/Casks/mendeley-reference-manager.rb
@@ -1,6 +1,6 @@
 cask 'mendeley-reference-manager' do
-  version '2.15.0'
-  sha256 '004fc765bc9539170e7f14fdce386593bc2caa3742de51577b775c6d2ed81025'
+  version '2.16.0'
+  sha256 '53612db726c41690e3d0c935149a735e8895aec9fa6341ac9bcc622fccebf96f'
 
   url "https://static.mendeley.com/bin/desktop/mendeley-reference-manager-#{version}.dmg"
   appcast 'https://static.mendeley.com/bin/desktop/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.