### PR TITLE
Update textmate from 2.0 to 2.0.3

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -1,6 +1,6 @@
 cask 'textmate' do
-  version '2.0'
-  sha256 'e3e9c8825bb561476d3b89280fcccacf1a98c0b62fa7b271fc4216941e0c7d24'
+  version '2.0.3'
+  sha256 'a2a3221995d11da1fb4e9b7a4c5d9a3d8774ce0c476d515b44480a3982ccc13e'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.