### PR TITLE
Update navicat-for-mysql from 12.1.27 to 15.0.3

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,9 +1,9 @@
 cask 'navicat-for-mysql' do
-  version '12.1.27'
-  sha256 'ea969a9d837eaf4d79df3df736fdbd70a273ef29e50a58c27b804d940711c28f'
+  version '15.0.3'
+  sha256 'b63f7df88d48484743e33e34a11e1d199f8fa9f564b1de478d9894bf530a8919'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
-  appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20MySQL&appLang=en'
+  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MySQL&appLang=en'
   name 'Navicat for MySQL'
   homepage 'https://www.navicat.com/products/navicat-for-mysql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.