### PR TITLE
Update navicat-for-postgresql from 12.1.27 to 15.0.3

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,9 +1,9 @@
 cask 'navicat-for-postgresql' do
-  version '12.1.27'
-  sha256 'fd18095c4bafa512334ebd1f1e4bef9b4eb185a088456071a08661e114e3f85a'
+  version '15.0.3'
+  sha256 '8a3ef451a7bdd529692f1dd32675bfc0422bf3482bd99581c09c570a2735a933'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
-  appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20PostgreSQL&appLang=en'
+  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'
   name 'Navicat for PostgreSQL'
   homepage 'https://www.navicat.com/products/navicat-for-postgresql'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.