### PR TITLE
Update navicat-for-sql-server from 12.1.27 to 15.0.3

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,9 +1,9 @@
 cask 'navicat-for-sql-server' do
-  version '12.1.27'
-  sha256 'ad85600d2eda1ee0d8cb4b12ad2a9acaded98dcfe4125688400d28651f6deea3'
+  version '15.0.3'
+  sha256 '69aebf183f97010ba1eff6e8564d6871951595f81c958adf3f2e1fc37db638c2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
-  appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQL%20Server&appLang=en'
+  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'
   name 'Navicat for SQL Server'
   homepage 'https://www.navicat.com/products/navicat-for-sqlserver'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.