### PR TITLE
Update navicat-for-sqlite from 12.1.27 to 15.0.3

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,9 +1,9 @@
 cask 'navicat-for-sqlite' do
-  version '12.1.27'
-  sha256 'db180d5450114d22b1dc9e0ae49257383f1bc43c7487030e5bf1da908e7af70d'
+  version '15.0.3'
+  sha256 'a5648641e1a55b9307ac590b8e7635b3913fd19c85e9f403ef585a8bcf46ee60'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
-  appcast 'https://www.navicat.com/updater/v120/sysProfileInfo.php?appName=Navicat%20for%20SQLite&appLang=en'
+  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'
   name 'Navicat for SQLite'
   homepage 'https://www.navicat.com/products/navicat-for-sqlite'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.