### PR TITLE
Update audirvana from 3.5.26 to 3.5.28

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.27'
-  sha256 '0cc3d13b6664bcd8bf5a89cc48c503f1c2374d399283fbb1495e389db0b215f0'
+  version '3.5.28'
+  sha256 'a3a3864cc9ace6f7fa22b2767aa45c570304b0df33a270c5c3729959f2ed5d01'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"

--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.26'
-  sha256 '1915af25a5184d631d1f9951da834f9e13e43b52986206a50d90e81c1b8b09af'
+  version '3.5.27'
+  sha256 '0cc3d13b6664bcd8bf5a89cc48c503f1c2374d399283fbb1495e389db0b215f0'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
