### PR TITLE
Update kstars from 3.3.6 to 3.3.8

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask 'kstars' do
-  version '3.3.6'
-  sha256 'b998cd6a30e6375871fb0eb5d3c29c1a055bfc172541b0192bec909dc1c1a7b7'
+  version '3.3.8'
+  sha256 '141b0b695399afff0b56b9cc2dc1bdc1c03a323092267003a1205bbe2b6198d9'
 
   # indilib.org/jdownloads/kstars was verified as official when first introduced to the cask
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.