### PR TITLE
Update kap from 3.0.0 to 3.0.1

### DIFF
--- a/Casks/kap.rb
+++ b/Casks/kap.rb
@@ -1,6 +1,6 @@
 cask 'kap' do
-  version '3.0.0'
-  sha256 '4564f5af42a9d6eb3b8a8865e30d64a0f208742501a02a7139253029ab24742f'
+  version '3.0.1'
+  sha256 '0db24a0c05d74f1c5484be0eedbb5fb20a97c6d663fc78a64b1ae686de3f0235'
 
   # github.com/wulkano/kap was verified as official when first introduced to the cask
   url "https://github.com/wulkano/kap/releases/download/v#{version.major_minor_patch}/Kap-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.