### PR TITLE
Update magiccap from 2.1.0 to 2.1.1

### DIFF
--- a/Casks/magiccap.rb
+++ b/Casks/magiccap.rb
@@ -1,6 +1,6 @@
 cask 'magiccap' do
-  version '2.1.0'
-  sha256 '8b4d81751515f458d2d2044da45bbc9858d09777e194ec76f5ea987f26cbc45b'
+  version '2.1.1'
+  sha256 'f5a1e6ae19fb676556e0ce9994ce4a6e41627f6c7c248b8f298144bf08c0a4dd'
 
   # github.com/magiccap/MagicCap was verified as official when first introduced to the cask
   url "https://github.com/magiccap/MagicCap/releases/download/v#{version}/magiccap-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.