### PR TITLE
Update qownnotes from 19.11.23,b4959-160643 to 19.12.0,b4974-073640

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.11.23,b4959-160643'
-  sha256 '29867e80503b1b62effe11e9d15f1a7ab5da18cf6c4813a39915168b5d620a7a'
+  version '19.12.0,b4974-073640'
+  sha256 'efd58497a5224d73bf527ec952b3344c60ca84a708e6c4acd8b18d9948bcc052'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.