### PR TITLE
Update rectangle from 0.10 to 0.12

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -1,6 +1,6 @@
 cask 'rectangle' do
-  version '0.10'
-  sha256 'dfb07b50854a8821b93f32b1a64c67a8d8500c5f7b6c8a5530e8beb3cab4b8d6'
+  version '0.12'
+  sha256 '98b7d8b6cedecd11de29696a833b410c306564c23d34953822c85c2178c3dcf1'
 
   # github.com/rxhanson/Rectangle/releases/download/v was verified as official when first introduced to the cask
   url "https://github.com/rxhanson/Rectangle/releases/download/v#{version}/Rectangle#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.