### PR TITLE
Update superproductivity from 2.13.9 to 2.13.12

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.13.9'
-  sha256 'f6f45697215f3ca5eef8feba55c0aeec59f3ccd723d676577b2421d00dd962f2'
+  version '2.13.12'
+  sha256 '125d4c528a1186c65d0f03dcfdf310f57f307704f0392d7ed4a06858888db2b1'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.