### PR TITLE
Update colorsnapper from 1.5.1 to 1.6.0

### DIFF
--- a/Casks/colorsnapper.rb
+++ b/Casks/colorsnapper.rb
@@ -1,6 +1,6 @@
 cask 'colorsnapper' do
-  version '1.5.1'
-  sha256 '7e14a69e521153d9aa6fb8c75932b52e1ddb0f60b00178123fc0636b32010016'
+  version '1.6.0'
+  sha256 '3a1c3c98201554a67e141cade48cd6508c2ffb0af2c6c441fa53e1d3761871b4'
 
   # cs2-binaries.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://cs2-binaries.s3.amazonaws.com/ColorSnapper2-#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.