### PR TITLE
Update itubedownloader from 6.5.8 to 6.5.9

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,6 +1,6 @@
 cask 'itubedownloader' do
-  version '6.5.8'
-  sha256 'ee28060d871911e37ede2e637c33697faf1ed62cd001f69ae08ec94396a0d6b4'
+  version '6.5.9'
+  sha256 'c5334262b5f975f7d0eb4e9c6e666d6d2a8a53ab71a035ea04d468e15c95a27d'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask
   url 'https://dl.devmate.com/com.AlphaSoft.iTubeDownloader/iTubeDownloader.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.