### PR TITLE
Update jump from 8.4.7 to 8.4.8

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.4.7'
-  sha256 '7ba7fdf0c2858fd263f19c5fa3a41adf48a0ab69b7ea058cfc32a1287adb632d'
+  version '8.4.8'
+  sha256 'cc1f0f7b5c3b279bb6b94a2b2d49e5ea73f9ca27b790668cfd3493c6e16b0051'
 
   url "https://mirror.jumpdesktop.com/downloads/JumpDesktopMac-#{version}.zip"
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.