### PR TITLE
Update mailplane from 4.1.4,4753 to 4.2,4779

### DIFF
--- a/Casks/mailplane.rb
+++ b/Casks/mailplane.rb
@@ -1,6 +1,6 @@
 cask 'mailplane' do
-  version '4.1.4,4753'
-  sha256 '250ebb35e8d36c2aa1a3476c7465fb4f74d13a819752bedca35cb4719e1c4840'
+  version '4.2,4779'
+  sha256 '40b931771b9dae13a3a0a921b511978662823b2fc54d8c731adde74f2568d579'
 
   url "https://update.mailplaneapp.com/builds/Mailplane_#{version.major}_#{version.after_comma}.tbz"
   appcast "https://update.mailplaneapp.com/appcast.php?rqsr=1&osVersion=10.14.1&appVersion=#{version.after_comma}&shortVersionString=#{version.before_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.