### PR TITLE
Update menumeters from 2.0.0 to 2.0.2

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,6 +1,6 @@
 cask 'menumeters' do
-  version '2.0.0'
-  sha256 '6bbc68c215e70e686378d031aed7f3c35c98f68daf50a5ada53b0d7edf9158eb'
+  version '2.0.2'
+  sha256 '95572ea7b04c2284d4c258afc209432183b36c4aafd082bd4a03aa1e43a4d5f4'
 
   url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version.major_minor_patch}.zip"
   appcast 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.