### PR TITLE
Update meta from 1.9.4 to 1.9.5

### DIFF
--- a/Casks/meta.rb
+++ b/Casks/meta.rb
@@ -1,6 +1,6 @@
 cask 'meta' do
-  version '1.9.4'
-  sha256 '6579b209beb859e065df2d2dcbc8a686e699bec6db221926bf72da0454b946ad'
+  version '1.9.5'
+  sha256 '0d7a5e08a20a5f6911f1d195719a20d287ce129ba824b2216fc9d18d9f626e21'
 
   url "https://www.nightbirdsevolve.com/meta/updates/bin/Meta%20#{version}.zip"
   appcast 'https://www.nightbirdsevolve.com/meta/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.