### PR TITLE
Update banking-4 from 7.2.1,7259 to 7.2.2,7272

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.2.1,7259'
-  sha256 '5dbf6515cf5b944b36df3db0038512f2528e03f9cb0cab2c0e2f82630de3f70a'
+  version '7.2.2,7272'
+  sha256 '331ddc867919a0a6474ed9969d1e1a886e33b4601d94004337fbd4a968cf35f2'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.