### PR TITLE
Update toggl from 7.4.1036 to 7.4.1041

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.1036'
-  sha256 '45461031b0aa58bba6c4990606cbd71e8a0583d33bc87ab01443ac4bc6723e6e'
+  version '7.4.1041'
+  sha256 'd0ce836cab3ded5265f24472e64bc4232a66bf1da1935a5e60f8b1aaa3c04f4a'
 
   # github.com/toggl-open-source/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.