### PR TITLE
Update dmm-player from 2.0.5 to 2.0.6

### DIFF
--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -1,6 +1,6 @@
 cask 'dmm-player' do
-  version '2.0.5'
-  sha256 '8605f5e38d014d49d93a062d5bb2c7f15184947d7eaa6ad6e732476930c8318d'
+  version '2.0.6'
+  sha256 'a0749012c7dbd3df86a2c40a5543c943c4328fc12f4f4594798a794f57d40ca1'
 
   url "http://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name 'DMM Player'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.