### PR TITLE
Update dcp-o-matic from 2.14.15 to 2.14.16

### DIFF
--- a/Casks/dcp-o-matic.rb
+++ b/Casks/dcp-o-matic.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic' do
-  version '2.14.15'
-  sha256 'cc25ed31cdc01f2610e9a5011616c2fb3433b7daeb572fab5bb22719a5113f2b'
+  version '2.14.16'
+  sha256 '6b139bcb2fbff7bb64c9dc888948df8eff20698d45f94031617e898d8b894afa'
 
   url "https://dcpomatic.com/dl.php?id=osx-main&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.