### PR TITLE
Update lunar from 2.9.0 to 2.9.1

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.9.0'
-  sha256 'a2f432287e40056456aa96f0b0047163370b7b8470c1c0b3547efe2ba33aa14c'
+  version '2.9.1'
+  sha256 '00976d6f18baffc7b1507be3b5eaddd2a73517d2185d1fe42dd2bc493df98aa5'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.