### PR TITLE
Update fontlab from 6.1.4,7044 to 7.0.0.7264

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,11 +1,12 @@
 cask 'fontlab' do
-  version '7.0.0.7264'
-  sha256 '1347268c8e5c28d38a02c6b55f299d93159da24e2d5fa339e24211e8bbce3029'
+  version '7.0.7264'
+  sha256 '761fec570778e5b1aea1eb640a15a6da563a3c80120ca5484b412b726b4cc30b'
 
-  url "https://download.fontlab.com/fontlab-#{version.major}/upd-mac.php"
-  appcast 'https://download.fontlab.com/fontlab-vi/appcast-mac.xml'
+  # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://fontlab.s3.amazonaws.com/fontlab#{version.major}/#{version.patch}/FontLab-#{version.major}-Mac-Install-#{version.patch}.dmg"
+  appcast "https://download.fontlab.com/fontlab-#{version.major}/appcast-mac.xml"
   name 'Fontlab'
   homepage 'https://www.fontlab.com/font-editor/fontlab/'
 
-  app 'FontLab VI.app'
+  app "FontLab #{version.major}.app"
 end

--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -3,7 +3,7 @@ cask 'fontlab' do
   sha256 '761fec570778e5b1aea1eb640a15a6da563a3c80120ca5484b412b726b4cc30b'
 
   # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://fontlab.s3.amazonaws.com/fontlab#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"
+  url "https://fontlab.s3.amazonaws.com/fontlab-#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"
   appcast "https://download.fontlab.com/fontlab-#{version.major}/appcast-mac.xml"
   name 'Fontlab'
   homepage 'https://www.fontlab.com/font-editor/fontlab/'

--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,11 +1,11 @@
 cask 'fontlab' do
-  version '6.1.4,7044'
-  sha256 'cc04ff57dbd51915f41e69811254b1fba0bf6900ac04a015b5dd4c7efc3ca588'
+  version '7.0.0.7264'
+  sha256 '1347268c8e5c28d38a02c6b55f299d93159da24e2d5fa339e24211e8bbce3029'
 
-  url "https://download.fontlab.com/fontlab-vi/downloads/FontLab-VI-Mac-Install-#{version.after_comma}.dmg"
+  url "https://download.fontlab.com/fontlab-#{version.major}/upd-mac.php"
   appcast 'https://download.fontlab.com/fontlab-vi/appcast-mac.xml'
   name 'Fontlab'
-  homepage 'https://www.fontlab.com/font-editor/fontlab-vi'
+  homepage 'https://www.fontlab.com/font-editor/fontlab/'
 
   app 'FontLab VI.app'
 end

--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,9 +1,9 @@
 cask 'fontlab' do
-  version '7.0.7264'
+  version '7.0.0.7264'
   sha256 '761fec570778e5b1aea1eb640a15a6da563a3c80120ca5484b412b726b4cc30b'
 
   # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://fontlab.s3.amazonaws.com/fontlab#{version.major}/#{version.patch}/FontLab-#{version.major}-Mac-Install-#{version.patch}.dmg"
+  url "https://fontlab.s3.amazonaws.com/fontlab#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"
   appcast "https://download.fontlab.com/fontlab-#{version.major}/appcast-mac.xml"
   name 'Fontlab'
   homepage 'https://www.fontlab.com/font-editor/fontlab/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.