### PR TITLE
Update unity-lumin-support-for-editor from 2019.2.13f1,e20f6c7e5017 to 2019.2.14f1,49dd4e9fa428

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.2.13f1,e20f6c7e5017'
-  sha256 'bf158ffa0f88183f3b4dd743c0fcb0127f762bf2668fb0bf00a1566207d24a53'
+  version '2019.2.14f1,49dd4e9fa428'
+  sha256 'e93b1d02a061fe142b3e3a3e8788bc7c8aeda8383d64735a3a8ba2e8c85596be'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.