### PR TITLE
Update get-iplayer-automator from 1.16.1.b20191008001 to 1.17,20191130002

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.17.b20191130002'
+  version '1.17,b20191130002'
   sha256 '44128ad80e31ed21c0cd1580041f4dec51ecc7b72e7383a9e0ce8f6bbde20be5'
 
-  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor}/Get.iPlayer.Automator.v#{version.major_minor}.#{version.patch}.zip"
+  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.before_comma}/Get.iPlayer.Automator.v#{version.before_comma}.#{version.after_comma}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          configuration: version.major_minor
+          configuration: version.before_comma
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 

--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.17,20191130002'
+  version '1.17.b20191130002'
   sha256 '44128ad80e31ed21c0cd1580041f4dec51ecc7b72e7383a9e0ce8f6bbde20be5'
 
-  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.before_comma}/Get.iPlayer.Automator.v#{version.before_comma}.b#{version.after_comma}.zip"
+  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor}/Get.iPlayer.Automator.v#{version.major_minor}.b#{version.patch}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          configuration: version.before_comma
+          configuration: version.major_minor
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 

--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -2,7 +2,7 @@ cask 'get-iplayer-automator' do
   version '1.17.b20191130002'
   sha256 '44128ad80e31ed21c0cd1580041f4dec51ecc7b72e7383a9e0ce8f6bbde20be5'
 
-  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor}/Get.iPlayer.Automator.v#{version.major_minor}.b#{version.patch}.zip"
+  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor}/Get.iPlayer.Automator.v#{version.major_minor}.#{version.patch}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
           configuration: version.major_minor
   name 'Get iPlayer Automator'

--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,10 +1,10 @@
 cask 'get-iplayer-automator' do
-  version '1.16.1.b20191008001'
-  sha256 '616702b1830f30ff34dea6b0d5adf1fee4f06f676ee0326597f587dec32112bd'
+  version '1.17,20191130002'
+  sha256 '44128ad80e31ed21c0cd1580041f4dec51ecc7b72e7383a9e0ce8f6bbde20be5'
 
-  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.major_minor_patch}/Get.iPlayer.Automator.v#{version}.zip"
+  url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.before_comma}/Get.iPlayer.Automator.v#{version.before_comma}.b#{version.after_comma}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',
-          configuration: version.major_minor_patch
+          configuration: version.before_comma
   name 'Get iPlayer Automator'
   homepage 'https://github.com/Ascoware/get-iplayer-automator'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.