### PR TITLE
Update lunar from 2.9.1 to 2.9.3

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.9.1'
-  sha256 '00976d6f18baffc7b1507be3b5eaddd2a73517d2185d1fe42dd2bc493df98aa5'
+  version '2.9.3'
+  sha256 '9fc20c3f86fbfb13dfa90dd0bc8a14afa33ad37b54cb49150bd272b32dd80bca'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.