### PR TITLE
Update fritzing

### DIFF
--- a/Casks/fritzing.rb
+++ b/Casks/fritzing.rb
@@ -1,28 +1,17 @@
 cask 'fritzing' do
-  version '0.9.3b'
-  sha256 'a057ed849b842540b98a68ab2cb996e22b482278706dd2f8da21d1bccf70513f'
+  version '0.9.4,a1ffcea08814801903b1a9515b18cf97067968ae:498'
 
-  url "https://fritzing.org/download/#{version}/mac-os-x-105/Fritzing#{version}.dmg"
+  if MacOS.version >= '10.14'
+    url "https://fritzing.org/download/#{version.before_comma}/mac-os-x-1014/fritzing-#{version.after_comma.before_colon}-master-#{version.after_colon}.mojave.10.2.dmg"
+    sha256 '51f23f1677a8da07f3ceb4b0405caa30ab8f46269e0336bca56689a98f0c6049'
+  elsif MacOS.version <= '10.13'
+    url "https://fritzing.org/download/#{version.before_comma}/mac-os-x-1013/fritzing-#{version.after_comma.before_colon}-master-#{version.after_colon}.high_sierra.10.1.dmg"
+    sha256 '51f23f1677a8da07f3ceb4b0405caa30ab8f46269e0336bca56689a98f0c6049'
+  end
+
   appcast 'https://github.com/fritzing/fritzing-app/releases.atom'
   name 'Fritzing'
   homepage 'https://fritzing.org/home/'
 
   app 'Fritzing.app'
-
-  caveats <<~EOS
-    There's a known issue with Fritzing 0.9.3b, causing it to corrupt its own
-    parts-library on first-launch. To avoid this, you must launch Fritzing
-    *from the command-line* for the first time:
-
-      $ #{appdir}/Fritzing.app/Contents/MacOS/Fritzing
-
-    Once open, you'll need to explicitly update the parts-library:
-
-      Help → Check for updates...
-
-    Thereafter, at least until the next time you want to update the
-    parts-library, you can safely launch it from the Finder.
-
-    See: https://github.com/fritzing/fritzing-app/issues/3308 for more.
-  EOS
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.