### PR TITLE
Update paste from 2.5.2,7 to 2.5.3,8

### DIFF
--- a/Casks/paste.rb
+++ b/Casks/paste.rb
@@ -1,6 +1,6 @@
 cask 'paste' do
-  version '2.5.2,7'
-  sha256 '6a95be2b3eacb42930d271bb7676e2b0c2c5b1b2079ef840ea90b7e72030c6b0'
+  version '2.5.3,8'
+  sha256 '7283aa7ab57ff9d7fa05b12d961080357956a6dd9a8047293926aa6c8ed38924'
 
   # rink.hockeyapp.net/api/2/apps/d6efdf44318a43ebb2130e89477625c8 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/d6efdf44318a43ebb2130e89477625c8/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.