### PR TITLE
Update rocket-chat from 2.16.2 to 2.17.0

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask 'rocket-chat' do
-  version '2.16.2'
-  sha256 '789da06588130b177f5053b188f9f7c479fa2aeb2c2f440c4505335435642b75'
+  version '2.17.0'
+  sha256 '0caaa89df3edd58f5144a8c8e13a7e0d388b7060c7581785b68cd3deb508f4dd'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.