### PR TITLE
Update lunar from 2.9.3 to 2.9.4

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.9.3'
-  sha256 '9fc20c3f86fbfb13dfa90dd0bc8a14afa33ad37b54cb49150bd272b32dd80bca'
+  version '2.9.4'
+  sha256 '8c176f3420d65dc614196b8af33adf8b4d94c5169d920956cb1f23c117329627'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.