### PR TITLE
Update navicat-data-modeler-essentials from 2.1.21 to 3.0.3

### DIFF
--- a/Casks/navicat-data-modeler-essentials.rb
+++ b/Casks/navicat-data-modeler-essentials.rb
@@ -1,9 +1,9 @@
 cask 'navicat-data-modeler-essentials' do
-  version '2.1.21'
-  sha256 'abd7a616f3514c601610636bea7882ed067a1c0808031a9d4d94ae467ba9237c'
+  version '3.0.3'
+  sha256 '3628ce3e73711e24c9162bc890a453de39b2883fa5a59dc8c4b394274b4acdd8'
 
-  url "http://download.navicat.com/download/modeleress0#{version.major_minor.no_dots}_en.dmg"
-  appcast 'https://www.navicat.com/updater/modeler_v2/sysProfileInfo.php?appName=Navicat%20Data%20Modeler%20Essentials'
+  url "http://download3.navicat.com/updater/modeler0#{version.major_minor.no_dots}_ess_mac_en.zip"
+  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Data%20Modeler%20Essentials&appLang=en'
   name 'Navicat Data Modeler Essentials'
   homepage 'https://www.navicat.com/en/products/navicat-data-modeler'
 

--- a/Casks/navicat-data-modeler-essentials.rb
+++ b/Casks/navicat-data-modeler-essentials.rb
@@ -3,7 +3,7 @@ cask 'navicat-data-modeler-essentials' do
   sha256 '3628ce3e73711e24c9162bc890a453de39b2883fa5a59dc8c4b394274b4acdd8'
 
   url "http://download3.navicat.com/updater/modeler0#{version.major_minor.no_dots}_ess_mac_en.zip"
-  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Data%20Modeler%20Essentials&appLang=en'
+  appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Data%20Modeler%20Essentials'
   name 'Navicat Data Modeler Essentials'
   homepage 'https://www.navicat.com/en/products/navicat-data-modeler'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.