### PR TITLE
Update viscosity from 1.8.2 to 1.8.3

### DIFF
--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,6 +1,6 @@
 cask 'viscosity' do
-  version '1.8.2'
-  sha256 '9eb08d31c514a86840b9b4158261415fc31f9df52c3b4946d7424d648e29c253'
+  version '1.8.3'
+  sha256 '6cda9fd9cba6780e43b55deec075d8fb484f6a9c0404f61165b6849cc253b021'
 
   url "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%20#{version}.dmg"
   appcast 'https://swupdate.sparklabs.com/appcast/mac/release/viscosity/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.