### PR TITLE
Update path-finder from 9.0.4 to 9.0.5

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '9.0.4'
-  sha256 '5e0a69fbb0d342efe32d837696a53a14b42f54522923f3510f12158557ef017e'
+  version '9.0.5'
+  sha256 'ce66c0c469a9af7003db87767192d114a02175e7553a6e7dc4ad55eb500dbfeb'
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.