### PR TITLE
Update wiznote from 2.8.0,2019-11-11 to 2.8.1,2019-11-11

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,5 +1,5 @@
 cask 'wiznote' do
-  version '2.8.0,2019-11-11'
+  version '2.8.1,2019-11-11'
   sha256 '14de8ac137eb2e961ce360e464c02985128745ae81992a8d58f28dfeea28d7e3'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.