### PR TITLE
netxms-console version updated to 3.1.242

### DIFF
--- a/Casks/netxms-console.rb
+++ b/Casks/netxms-console.rb
@@ -1,6 +1,6 @@
 cask 'netxms-console' do
-  version '3.0.2329'
-  sha256 '0ce973e2df8edaa4c72c7b102888364d21ff943f2da340b2ba1e696109487d7f'
+  version '3.1.242'
+  sha256 '57968fe224f0883af0a649f379e55456477a26a7816cdb8a8bafe1276d12bf36'
 
   url "https://netxms.org/download/releases/#{version.major_minor}/nxmc-#{version}.dmg"
   appcast "https://netxms.org/download/releases/#{version.major_minor}/"


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
