### PR TITLE
Update cacher from 2.22.1 to 2.22.3

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.22.1'
-  sha256 '835d760fce8ccc53463769daf184780141a168c317f606db6413a419aad8663a'
+  version '2.22.3'
+  sha256 '3ab0be4b58d30bc25e87bcba00d4531141a9fce6b1674061e1a8d502ea8cda80'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.