### PR TITLE
Update slite from 1.1.6 to 1.1.7

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.1.6'
-  sha256 'cdbb52e9b5f699fa2cdd1f5e685048fa4e6f07b8efe723eb7c85f16d3392594d'
+  version '1.1.7'
+  sha256 '713da1ffdc07284d27ac3be1775ea50648a748fae060382a19e1ba115aa59ba3'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.