### PR TITLE
Update radarr from 0.2.0.1358 to 0.2.0.1450

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,6 +1,6 @@
 cask 'radarr' do
-  version '0.2.0.1358'
-  sha256 '0cf9d05c8e971e834a591fef60f1a6f3e685a2999751cb118a537c118d5f5466'
+  version '0.2.0.1450'
+  sha256 '6891cd4e087c2c49fdf1ddc0fcb07c6ecc2f8267b18f32e804117333248a3acc'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.