### PR TITLE
Update onepile from 2.2-1106 to 2.3-1120

### DIFF
--- a/Casks/onepile.rb
+++ b/Casks/onepile.rb
@@ -1,6 +1,6 @@
 cask 'onepile' do
-  version '2.2-1106'
-  sha256 '8554a14a87ea476e1b596147a80ac92a91cf14eb0de948079597e7d48705b316'
+  version '2.3-1120'
+  sha256 'b88e38120bfb124cfe2ba7faa73384757c4c137dc1760617e67a8ecdadaa0fee'
 
   url "https://onepile.app/update/macos/OnePile-#{version}.zip"
   appcast 'https://onepile.app/sparklecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.