### PR TITLE
Update plex-media-player from 2.45.0.1028-45edbf41 to 2.46.0.1031-6dc7c723

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.45.0.1028-45edbf41'
-  sha256 '6a9fb148b0ccb03ef322e8fd61b914bf6a511c1fd109ec5d0892be41554da293'
+  version '2.46.0.1031-6dc7c723'
+  sha256 '1cb57278445ab79904b746148c50bafa2417deced8b784243c945dd492f26f31'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.