### PR TITLE
Update mongodb-compass-isolated-edition from 1.19.12 to 1.19.13

### DIFF
--- a/Casks/mongodb-compass-isolated-edition.rb
+++ b/Casks/mongodb-compass-isolated-edition.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-isolated-edition' do
-  version '1.19.12'
-  sha256 'c6d8aac98a313db4b2f6d7f2f75632b75de743ead7db24d18ebb1f2c13573c17'
+  version '1.19.13'
+  sha256 '5978944f20ba526174f7cb3038a8aaf71c951b2f5f32cf7cc55e1250b4131d51'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-isolated-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.