### PR TITLE
Update mongodb-compass-readonly from 1.19.12 to 1.19.13

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.19.12'
-  sha256 '35a62501ac5004b187940e705699eb677cbe08fbd3c9370d416f5be5874f23fb'
+  version '1.19.13'
+  sha256 'c65e1da52b0acfa426573f23b224a60d88d02d58036075824cdf258154af1cd6'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.