### PR TITLE
Update segger-embedded-studio-for-arm from 4.30b to 4.30c

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.30b'
-  sha256 '1fc20120faa58991c556f5f0b528accf6b0d1fd76185019c505529dfda430cd0'
+  version '4.30c'
+  sha256 '152cfbed1ce8c3c73acc9b8ac382c15da11cf4c3b5b15807a451e7ee81ae774e'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.