### PR TITLE
Update superproductivity from 2.13.13 to 2.13.14

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '2.13.13'
-  sha256 '105ab0c5618aadb266176d05acdb22266886e95448bb15133575c3e5d9d2e87c'
+  version '2.13.14'
+  sha256 '9a0560fe8fa775049e820e823274bf68e97dba1dee1a3a080e0a5fec9a6dee40'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.