### PR TITLE
Update teamdrive from 4.6.7.2415 to 4.6.8.2441

### DIFF
--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -1,9 +1,9 @@
 cask 'teamdrive' do
-  version '4.6.7.2415'
-  sha256 'e5cf9dc14066e895a59ff70672c84cb34fe1f3a1f7836bffad3675124c9450f9'
+  version '4.6.8.2441'
+  sha256 'ea699840e05e47dda4b4d522978bf49374bfada0072e6185e59b3780cc3d1ecc'
 
   # s3-eu-west-1.amazonaws.com/s3download.teamdrive.net was verified as official when first introduced to the cask
-  url "https://s3-eu-west-1.amazonaws.com/s3download.teamdrive.net/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.14.2/Install-TeamDrive-#{version}_TMDR.dmg"
+  url "https://s3-eu-west-1.amazonaws.com/s3download.teamdrive.net/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.14.6/Install-TeamDrive-#{version}_TMDR.dmg"
   appcast 'https://teamdrive.com/en/downloads/'
   name 'TeamDrive'
   homepage 'https://www.teamdrive.com/'

--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -4,7 +4,8 @@ cask 'teamdrive' do
 
   # s3-eu-west-1.amazonaws.com/s3download.teamdrive.net was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/s3download.teamdrive.net/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.14.6/Install-TeamDrive-#{version}_TMDR.dmg"
-  appcast 'https://teamdrive.com/en/downloads/'
+  appcast 'https://teamdrive.com/en/downloads/',
+          configuration: "#{version.major_minor}.#{version.split('.').last}"
   name 'TeamDrive'
   homepage 'https://www.teamdrive.com/'
 

--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -4,8 +4,7 @@ cask 'teamdrive' do
 
   # s3-eu-west-1.amazonaws.com/s3download.teamdrive.net was verified as official when first introduced to the cask
   url "https://s3-eu-west-1.amazonaws.com/s3download.teamdrive.net/#{version.major_minor}.#{version.split('.').last}/TMDR/mac-10.14.6/Install-TeamDrive-#{version}_TMDR.dmg"
-  appcast 'https://teamdrive.com/en/downloads/',
-          configuration: "#{version.major_minor}.#{version.split('.').last}"
+  appcast 'https://teamdrive.com/en/downloads/'
   name 'TeamDrive'
   homepage 'https://www.teamdrive.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.