### PR TITLE
Update gb-studio from 1.1.0 to 1.2.0

### DIFF
--- a/Casks/gb-studio.rb
+++ b/Casks/gb-studio.rb
@@ -1,9 +1,9 @@
 cask 'gb-studio' do
-  version '1.1.0'
-  sha256 '86ff5ae6a9f8955da7c06e839b480c5e37f06f422375997e0a27063c849e6e65'
+  version '1.2.0'
+  sha256 '0bdb91223edca531af3af09044975aa100977ce00ca2615c560f42025550a92b'
 
   # github.com/chrismaltby/gb-studio was verified as official when first introduced to the cask
-  url "https://github.com/chrismaltby/gb-studio/releases/download/v#{version}/GB.Studio-darwin-x64-#{version}.zip"
+  url "https://github.com/chrismaltby/gb-studio/releases/download/v#{version}/GB-Studio-Mac-#{version}.zip"
   appcast 'https://github.com/chrismaltby/gb-studio/releases.atom'
   name 'GB Studio'
   homepage 'https://www.gbstudio.dev/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.