### PR TITLE
Update capture-one from 12.1.4 to 13.0.1.19,20.0.1

### DIFF
--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,13 +1,13 @@
 cask 'capture-one' do
-  version '12.1.4'
-  sha256 '8bcd5e25336e2766fa11a12dc499393e223f8f17ae3c7f6db413cc89c047265d'
+  version '13.0.0.186,20'
+  sha256 '776676d221676d0a79e0f7fa5a7a8c7b772e2b84efce8719177a0ae24261e67c'
 
-  url "https://downloads.phaseone.com/d972230a-e941-47ca-a751-35f57a3f2d94/International/CaptureOne12.Mac.#{version}.dmg"
-  appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version}"
-  name 'Capture One'
+  url "https://downloads.phaseone.com/374dd05f-e8c7-499d-a703-9a7dca20d5b7/International/CaptureOne#{version.after_comma}.Mac.#{version.after_comma}.0.0.dmg"
+  appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.major}"
+  name "Capture One #{version.after_comma}.app"
   homepage 'https://www.phaseone.com/en/Capture-One.aspx'
 
   depends_on macos: '>= :sierra'
 
-  app "Capture One #{version.major}.app"
+  app "Capture One #{version.after_comma}.app"
 end

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -4,7 +4,7 @@ cask 'capture-one' do
 
   url "https://downloads.phaseone.com/374dd05f-e8c7-499d-a703-9a7dca20d5b7/International/CaptureOne#{version.after_comma}.Mac.#{version.after_comma}.0.0.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.major}"
-  name "Capture One #{version.after_comma}.app"
+  name 'Capture One'
   homepage 'https://www.captureone.com/en/'
 
   depends_on macos: '>= :high_sierra'

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -5,9 +5,9 @@ cask 'capture-one' do
   url "https://downloads.phaseone.com/374dd05f-e8c7-499d-a703-9a7dca20d5b7/International/CaptureOne#{version.after_comma}.Mac.#{version.after_comma}.0.0.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.major}"
   name "Capture One #{version.after_comma}.app"
-  homepage 'https://www.phaseone.com/en/Capture-One.aspx'
+  homepage 'https://www.captureone.com/en/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   app "Capture One #{version.after_comma}.app"
 end

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,6 +1,6 @@
 cask 'capture-one' do
   version '13.0.1.19,20.0.1'
-  sha256 '776676d221676d0a79e0f7fa5a7a8c7b772e2b84efce8719177a0ae24261e67c'
+  sha256 'a880db69e7032a5878f95fc4003cce3d94d366bc93cfae91a0fed2deeadfe0c4'
 
   # phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International was verified as official when first introduced to the cask
   url "https://downloads.phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International/CaptureOne#{version.after_comma.major}.Mac.#{version.after_comma}.dmg"

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -1,13 +1,13 @@
 cask 'capture-one' do
-  version '13.0.0.186,20'
+  version '13.0.1.19,20.0.1'
   sha256 '776676d221676d0a79e0f7fa5a7a8c7b772e2b84efce8719177a0ae24261e67c'
 
-  url "https://downloads.phaseone.com/374dd05f-e8c7-499d-a703-9a7dca20d5b7/International/CaptureOne#{version.after_comma}.Mac.#{version.after_comma}.0.0.dmg"
+  url "https://downloads.phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International/CaptureOne#{version.after_comma.major}.Mac.#{version.after_comma}.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.major}"
   name 'Capture One'
   homepage 'https://www.captureone.com/en/'
 
   depends_on macos: '>= :high_sierra'
 
-  app "Capture One #{version.after_comma}.app"
+  app "Capture One #{version.after_comma.major}.app"
 end

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -2,6 +2,7 @@ cask 'capture-one' do
   version '13.0.1.19,20.0.1'
   sha256 '776676d221676d0a79e0f7fa5a7a8c7b772e2b84efce8719177a0ae24261e67c'
 
+  # phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International was verified as official when first introduced to the cask
   url "https://downloads.phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International/CaptureOne#{version.after_comma.major}.Mac.#{version.after_comma}.dmg"
   appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.major}"
   name 'Capture One'

--- a/Casks/capture-one.rb
+++ b/Casks/capture-one.rb
@@ -4,7 +4,7 @@ cask 'capture-one' do
 
   # phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International was verified as official when first introduced to the cask
   url "https://downloads.phaseone.com/a9562498-f874-404e-842d-9f5cc8a05efd/International/CaptureOne#{version.after_comma.major}.Mac.#{version.after_comma}.dmg"
-  appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.major}"
+  appcast "https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=#{version.after_comma.major}"
   name 'Capture One'
   homepage 'https://www.captureone.com/en/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.