### PR TITLE
oclint: Coexist peacefully with brewed GCCs

### DIFF
--- a/Casks/oclint.rb
+++ b/Casks/oclint.rb
@@ -13,5 +13,5 @@ cask 'oclint' do
   binary "oclint-#{version.before_comma}/bin/oclint-xcodebuild"
   binary "oclint-#{version.before_comma}/lib/oclint", target: "#{HOMEBREW_PREFIX}/lib/oclint"
   binary "oclint-#{version.before_comma}/lib/clang", target: "#{HOMEBREW_PREFIX}/lib/clang"
-  binary "oclint-#{version.before_comma}/include/c++", target: "#{HOMEBREW_PREFIX}/include/c++"
+  binary "oclint-#{version.before_comma}/include/c++/v1", target: "#{HOMEBREW_PREFIX}/include/c++/v1"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name ~~and version~~.
      __I am not bumping the version so I only included the name. Let me know if I should amend my commit__
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

N/A

## Details

`brew cask reinstall oclint` fails when brewed GCCs are on the system, and, likewise, linking gcc fails when oclint is installed. For a long time `oclint` was installed by default on Travis-CI's macOS instances which prevented installing and testing with GCC.

By linking `/usr/local/include/c++/v1` instead of `/usr/local/include/c++` this prevents this conflict from ocuring.

```shell
$ brew cask reinstall oclint
==> Downloading https://github.com/oclint/oclint/releases/download/v0.13.1/oclint-0.13.1-x86_64-darwin-17.4.0.tar.gz
Already downloaded: /Users/ibeekman/Library/Caches/Homebrew/downloads/9ab8b95a2c2879f63f7a61902a73500c46da030a06e9a11b7a14a7984d3787b2--oclint-0.13.1-x86_64-darwin-17.4.0.tar.gz
==> Verifying SHA-256 checksum for Cask 'oclint'.
==> Uninstalling Cask oclint
==> Unlinking Binary '/usr/local/bin/oclint'.
==> Unlinking Binary '/usr/local/bin/oclint-json-compilation-database'.
==> Unlinking Binary '/usr/local/bin/oclint-xcodebuild'.
==> Unlinking Binary '/usr/local/lib/oclint'.
==> Unlinking Binary '/usr/local/lib/clang'.
==> Purging files for version 0.13.1,17.4.0 of Cask oclint
==> Installing Cask oclint
==> Linking Binary 'oclint' to '/usr/local/bin/oclint'.
==> Linking Binary 'oclint-json-compilation-database' to '/usr/local/bin/oclint-json-compilation-database'.
==> Linking Binary 'oclint-xcodebuild' to '/usr/local/bin/oclint-xcodebuild'.
==> Linking Binary 'oclint' to '/usr/local/lib/oclint'.
==> Linking Binary 'clang' to '/usr/local/lib/clang'.
==> Unlinking Binary '/usr/local/lib/clang'.
==> Unlinking Binary '/usr/local/lib/oclint'.
==> Unlinking Binary '/usr/local/bin/oclint-xcodebuild'.
==> Unlinking Binary '/usr/local/bin/oclint-json-compilation-database'.
==> Unlinking Binary '/usr/local/bin/oclint'.
==> Purging files for version 0.13.1,17.4.0 of Cask oclint
Error: It seems there is already a Binary at '/usr/local/include/c++'; not linking.
```

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
