### PR TITLE
Update kite from 0.20191202.0 to 0.20191203.2

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191202.0'
-  sha256 'dd4ef6a8cd82ab8d92a633eb008b13022fd9e5cdf86ef82bb8040d90e97d6ef3'
+  version '0.20191203.2'
+  sha256 '8326ee27e85e9c7b64859f2f45ce92ba06bedaaa1b332565ba37f27f823261b0'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.