### PR TITLE
Update fman from 1.6.7 to 1.6.8

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.6.7'
-  sha256 '863b72e5938fdf67302d6bde6ae93803263f211ae7f5dc2b5ad9ed4c64daf88e'
+  version '1.6.8'
+  sha256 '1620e19aaa9311bf8ee6f047fbc55558590a22e6c80b44315c74f89b8c7091e0'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.