### PR TITLE
Update downie from 3.9,2099 to 3.9.1,3005

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.9,2099'
-  sha256 '211651f96f41c6a54fe980f92157dde081458b0e06e5f0c033262bb5a0fc8759'
+  version '3.9.1,3005'
+  sha256 'c6664f67fd8dfe0e116ba016a0992191025f37ca58fd07bb709c2adcd02fd794'
 
   url "https://trial.charliemonroe.net/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/downie/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.