### PR TITLE
Update 4k-video-downloader from 4.10.0.3230 to 4.10.1.3240

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.10.0.3230'
-  sha256 '502b210e92746af1a980c3380ee2e651a9d451f831b27621e0991bc2cb974eec'
+  version '4.10.1.3240'
+  sha256 '61e6e7f6626474aeb08aea244f61e792fc1b4fbbc9e440ef89908f51299f10c9'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.