### PR TITLE
Update cocoscreator from 2.2.0_20191017 to 2.2.1_20191204

### DIFF
--- a/Casks/cocoscreator.rb
+++ b/Casks/cocoscreator.rb
@@ -1,6 +1,6 @@
 cask 'cocoscreator' do
-  version '2.2.0_20191017'
-  sha256 '6e0b7832290d66e9e808e716aec0172816f010cbf641fd6adc0583188bb7ba6c'
+  version '2.2.1_20191204'
+  sha256 '666168356ccc952f7eda793713a2e60607421b77c3aaee7334f3c58712dbbd0c'
 
   url "https://digitalocean.cocos2d-x.org/CocosCreator/v#{version.split('_')[0]}/CocosCreator_v#{version}_mac.dmg"
   appcast 'https://cocos2d-x.org/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.