### PR TITLE
Update roblox from 0.411.0.363394,a91076f95db04dcb to 0.412.0.365788,3383b43641344761

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.411.0.363394,a91076f95db04dcb'
-  sha256 '7f3f0e9e1d9c2f320b752459ba9bbb6e3581503d855b6070fd21d6c6be34e075'
+  version '0.412.0.365788,3383b43641344761'
+  sha256 '8e3a9ea94365f4b3f176150958973f860973fb5ddc5d417006de7bf1cfb2c4da'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.