### PR TITLE
Update wechatwork from 2.8.17.2012 to 2.8.19.2003

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.17.2012'
-  sha256 '3b626997358cd49dc35615b848a3e89563b8b7e645307e60256053dc899f6677'
+  version '2.8.19.2003'
+  sha256 '3f4cfb929e45703fd93c945d70eb46c4c4af287833cc146fe7821c57d5cba1e7'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.