### PR TITLE
Update private-internet-access from 1.6-03756 to 1.6.1-03773

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -1,6 +1,6 @@
 cask 'private-internet-access' do
-  version '1.6-03756'
-  sha256 'eb33f68f207b2bb955dbbc95b680795e2a0df70b2ffc9d5e630c997e9a0fba01'
+  version '1.6.1-03773'
+  sha256 'f88aa6c124af7ca13c8d386857f28e4e68a28235d80169823315138de93ad1fb'
 
   url "https://installers.privateinternetaccess.com/download/pia-macos-#{version}.zip"
   appcast 'https://www.privateinternetaccess.com/pages/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.