### PR TITLE
Rename x-lite to bria-solo and update from 5.8.1_102009 to 6.0.1_102001

### DIFF
--- a/Casks/bria-solo.rb
+++ b/Casks/bria-solo.rb
@@ -1,4 +1,4 @@
-cask 'x-lite' do
+cask 'bria-solo' do
   version '6.0.1_102001'
   sha256 'd327f8518f8c4aa16e67f3c557fe4985c158d448f889f87f0bf1858a6ae95ea0'
 

--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -1,4 +1,4 @@
-cask 'bria-solo' do
+cask 'bria' do
   version '6.0.1_102001'
   sha256 'd327f8518f8c4aa16e67f3c557fe4985c158d448f889f87f0bf1858a6ae95ea0'
 

--- a/Casks/x-lite.rb
+++ b/Casks/x-lite.rb
@@ -1,12 +1,11 @@
 cask 'x-lite' do
-  version '5.8.1_102009'
-  sha256 '046573027c8823844fa4b9392ef245026950dba5aa084fdb44095241c0ef674c'
+  version '6.0.1_102001'
+  sha256 'd327f8518f8c4aa16e67f3c557fe4985c158d448f889f87f0bf1858a6ae95ea0'
 
-  # counterpath.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://counterpath.s3.amazonaws.com/downloads/X-Lite_#{version}.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.counterpath.com/XLiteForMac'
-  name 'X-Lite'
-  homepage 'https://www.counterpath.com/x-lite/'
+  url "https://secure.counterpath.com/Downloads/Bria_#{version}.dmg"
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://solo.softphone.com/downloads/bria-for-mac'
+  name 'Bria'
+  homepage 'https://www.counterpath.com/bria-solo/'
 
-  app 'X-Lite.app'
+  app 'Bria.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.