### PR TITLE
Update lunar from 2.9.6 to 2.9.7

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.9.6'
-  sha256 '656bbf5dcbae44133c478066dd92a29416a8f0ac795f9a156916cc2f21fbf526'
+  version '2.9.7'
+  sha256 '92abe6d8271a160985f6031b56f361e70a572b725d930009abc52fbc39525ae2'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.