### PR TITLE
Update ticktick version from 3.3.00,117 to 3.3.00,119 and set auto-up…

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,12 +1,14 @@
 cask 'ticktick' do
-  version '3.3.00,117'
-  sha256 '366ea616e6d99f64260e6f2a92a74984ad48133416211ee00201763bc5f0da9b'
+  version '3.3.00,119'
+  sha256 '7ae6a1bf2129f242b7d4625e07c6437ec629a0ec289aec0468edeeca0cda95b1'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.ticktick.com/static/getApp/download?type=mac'
   name 'TickTick'
   homepage 'https://www.ticktick.com/home'
+
+  auto_updates true
 
   app 'TickTick.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).