### PR TITLE
Update tastyworks from 1.0.16 to 1.3.0

### DIFF
--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -3,7 +3,8 @@ cask 'tastyworks' do
   sha256 '73ce5e43a8455c7e93abcc6bddcea3cfd13ad90ab5893eefd7d0e1fd31512e54'
 
   url "https://download.tastyworks.com/desktop-#{version.major}.x.x/#{version}/tastyworks-#{version}.dmg"
-  appcast 'https://tastyworks.com/technology.html'
+  appcast 'https://tastyworks.freshdesk.com/support/solutions/articles/43000435186-recent-release-notes',
+          configuration: version.major_minor
   name 'tastyworks'
   homepage 'https://tastyworks.com/'
 

--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -1,6 +1,6 @@
 cask 'tastyworks' do
-  version '1.0.16'
-  sha256 'd2c16129f6031da04c2402dee449ddeaa64ae3766df22fd50e7917314c8d61f7'
+  version '1.3.0'
+  sha256 '73ce5e43a8455c7e93abcc6bddcea3cfd13ad90ab5893eefd7d0e1fd31512e54'
 
   url "https://download.tastyworks.com/desktop-#{version.major}.x.x/#{version}/tastyworks-#{version}.dmg"
   appcast 'https://tastyworks.com/technology.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.