### PR TITLE
Update reaper.rb from 5.99.0 to 6.0 + add mojave case

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -5,7 +5,6 @@ cask 'reaper' do
     sha256 '589977a587aa510d7430308b09383551ab32506e7a1150e38ecff533ee4fc71b'
 
     url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
-
   else
     sha256 '49a17c631faa079cda2664e9fb0fd353cbd9e56c83f407202ddacd19e2363f32'
 

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,10 +1,18 @@
 cask 'reaper' do
-  version '5.99.0'
-  sha256 '8e069381c9cd1ea03cbe64fb4c9ff902220c1b73321c7e84f214792a8b01eb7d'
+  version '6.0'
 
-  url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots.sub(%r{0*$}, '')}_x86_64.dmg"
-  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',
-          configuration: "#{version.major}.#{version.minor}#{version.patch.sub(%r{0*$}, '')}"
+  if MacOS.version <= :mojave
+    sha256 '589977a587aa510d7430308b09383551ab32506e7a1150e38ecff533ee4fc71b'
+
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
+
+  else
+    sha256 '49a17c631faa079cda2664e9fb0fd353cbd9e56c83f407202ddacd19e2363f32'
+
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64_catalina.dmg"
+  end
+
+  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 


### PR DESCRIPTION
there is a slight difference between the catalina and the mojave download - i think we should add this two cases (?) (https://www.reaper.fm/download.php)