### PR TITLE
Update unity-lumin-support-for-editor from 2019.2.14f1,49dd4e9fa428 to 2019.2.15f1,dcb72c2e9334

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.2.14f1,49dd4e9fa428'
-  sha256 'e93b1d02a061fe142b3e3a3e8788bc7c8aeda8383d64735a3a8ba2e8c85596be'
+  version '2019.2.15f1,dcb72c2e9334'
+  sha256 '480c360bc63246b69da137ed6ec63e3f2d6d36ed8311de6f093221b976c8c8d5'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.