### PR TITLE
Update unity-windows-support-for-editor from 2019.2.14f1,49dd4e9fa428 to 2019.2.15f1,dcb72c2e9334

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.14f1,49dd4e9fa428'
-  sha256 'af48b9f7d2ce821631b16e99a2f5ac952e8938e2566b422292dee11789e98bf7'
+  version '2019.2.15f1,dcb72c2e9334'
+  sha256 'df753a60e601d63030fb8ba59e80f93109a94c90dcc38d37500e28918c182009'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.