### PR TITLE
Update remotix-agent from 1.2.7 to 1.2.9

### DIFF
--- a/Casks/remotix-agent.rb
+++ b/Casks/remotix-agent.rb
@@ -1,6 +1,6 @@
 cask 'remotix-agent' do
-  version '1.2.7'
-  sha256 '83072b682fd00ef1a83fa6354db16cc7a39eb7040eeb0bf84025723af1a3be5d'
+  version '1.2.9'
+  sha256 '2b76536a853462f3d60fc7e243fe2a64f904b47c2a7935d123f890a93f9cacf6'
 
   url 'https://downloads.remotixcloud.com/agent-mac/RemotixAgent.pkg'
   name 'Remotix Agent'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.