### PR TITLE
Update lingo from 9.4 to 10.0

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,6 +1,6 @@
 cask 'lingo' do
-  version '9.4'
-  sha256 'ac699a35c0bd882198be646a412c42fb87881d3ea005156314d00151c0e31f78'
+  version '10.0'
+  sha256 'bc16c02a73b23ac3c9889d1dd524eb125b0826b621ff6298fcf3023d94e1f903'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask
   url 'https://nounproject.s3.amazonaws.com/lingo/Lingo.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.