### PR TITLE
Update hstracker from 1.6.7 to 1.6.9

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.7'
-  sha256 '3bcf9e64d97f6b0579d241459a4e70ab8763f4c0d9d153ef6b15d380728350e2'
+  version '1.6.9'
+  sha256 'd09ce3b582cec0d4ab60a150790cbff3c09595a58cfc5ff2445e1a08d062ae03'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.