### PR TITLE
Sets auto_updates to true for ivpn version 2.10.8

### DIFF
--- a/Casks/ivpn.rb
+++ b/Casks/ivpn.rb
@@ -7,6 +7,8 @@ cask 'ivpn' do
   name 'IVPN'
   homepage 'https://www.ivpn.net/apps-macos'
 
+  auto_updates true
+
   app 'IVPN.app'
 
   uninstall_preflight do


### PR DESCRIPTION
I have used auto update to get to the latest version of this app without updating via homebrew cask. Here is a screenshot of the app and its auto-update menu item on the latest version:

![Screen Shot 2019-12-05 at 12 09 26 PM](https://user-images.githubusercontent.com/1747920/70257778-fe589300-1758-11ea-97f2-6a92e86690a9.png)


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
