### PR TITLE
Update grandtotal from 6.0.1 to 6.0.2

### DIFF
--- a/Casks/grandtotal.rb
+++ b/Casks/grandtotal.rb
@@ -1,6 +1,6 @@
 cask 'grandtotal' do
-  version '6.0.1'
-  sha256 'ee1a42104af254290139451f78d00f9210117022bedbd150ba48dc6848344a75'
+  version '6.0.2'
+  sha256 'dfd904a27ea6608bb615e5433608804f6d0744777d3bd3419f221bbcb6c775a4'
 
   url "https://mediaatelier.com/GrandTotal#{version.major}/GrandTotal_#{version}.zip"
   appcast "https://mediaatelier.com/GrandTotal#{version.major}/feed.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.