### PR TITLE
Update dashlane from 6.1944.0.25701 to 6.1948.0.27265

### DIFF
--- a/Casks/dashlane.rb
+++ b/Casks/dashlane.rb
@@ -1,6 +1,6 @@
 cask 'dashlane' do
-  version '6.1944.0.25701'
-  sha256 'efbd11bced3d091dda77b3696a8dbe5e7d2fcb261e378aff7a9032d679687d81'
+  version '6.1948.0.27265'
+  sha256 '42c4fa7884f9f0ef45c61a1693191dc8832644882e877932dba3c60b098ea59c'
 
   # d3mfqat9ni8wb5.cloudfront.net/releases was verified as official when first introduced to the cask
   url "https://d3mfqat9ni8wb5.cloudfront.net/releases/#{version.major_minor_patch}/#{version}/release/Dashlane.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.