### PR TITLE
Update devonagent from 3.11.2 to 3.11.3

### DIFF
--- a/Casks/devonagent.rb
+++ b/Casks/devonagent.rb
@@ -1,6 +1,6 @@
 cask 'devonagent' do
-  version '3.11.2'
-  sha256 'cb9817ec4b0f8f79da18f8e14e6a1c2ea9f3158e95875e3fcd4d82dcbefebd0a'
+  version '3.11.3'
+  sha256 'f5b50eb92ffda9791b159e38b8d3725ef7a3e9307a441da0b1f5931921703808'
 
   # s3.amazonaws.com/DTWebsiteSupport was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/DTWebsiteSupport/download/devonagent/#{version}/DEVONagent_Pro.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.