### PR TITLE
Update outline from 3.21.5 to 3.22.0

### DIFF
--- a/Casks/outline.rb
+++ b/Casks/outline.rb
@@ -1,6 +1,6 @@
 cask 'outline' do
-  version '3.21.5'
-  sha256 '0c8137bb7f668d44e860d1fb968051738f2d610ebbe2ce551daa55aeed7a7f9e'
+  version '3.22.0'
+  sha256 '17ca1633a6b1a66f8e2f2eba708129f7b7be4239a1a585ee7e2738de00e14dc1'
 
   url "http://static.outline.ws/versions/Outline_#{version}.zip"
   appcast 'https://gorillized.s3.amazonaws.com/versions/update_channel.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.