### PR TITLE
Update shift from 4.0.4 to 4.0.5

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,6 +1,6 @@
 cask 'shift' do
-  version '4.0.4'
-  sha256 '87e3b94288ef28bfce062ceeb5cc4e76f7ce0b403571af77ade2ab219e414648'
+  version '4.0.5'
+  sha256 'e63a810bd693c30c10bfd738d475c0cf9d687fa4312f5b607b3896c53a670c57'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"
   appcast 'https://tryshift.com/download/?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.