### PR TITLE
Update clip-studio-paint from 1.9.4 to 1.9.5

### DIFF
--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -1,6 +1,6 @@
 cask 'clip-studio-paint' do
-  version '1.9.4'
-  sha256 '65ed5e08806814438401938f949fb1ebacbb00ea34e405b09ec9e0442dc751b6'
+  version '1.9.5'
+  sha256 'b9f0c537a6eb7b4134971f03a2fe8f3afdee4d195ca121cb3a75cd7fa27f34be'
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
   appcast 'https://www.clipstudio.net/en/dl'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.