### PR TITLE
Update runway from 0.10.5 to 0.10.8

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.10.5'
-  sha256 'f9b6742cdcbb9ca042bc74f1f1a8dca94114c041a6ad0d31a6912bbb6df0e254'
+  version '0.10.8'
+  sha256 '122479a86e1eb20adf44b5a29f84896d8dcbad094fb93c35611d415a1de4d534'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.