### PR TITLE
Update neteasemusic.rb from 2.3.0_814,b2a5:20191015153044 to ?? (2.3.1_824,605533604/4f60:201911523186)

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,9 +1,9 @@
 cask 'neteasemusic' do
-  version '2.3.1_824,605533604/4f60:201911523186'
+  version '2.3.1_824,605533604.4f60.201911523186'
   sha256 '4860316e46904594ed2ccb96fc451bb4d49ee7de01be7c64069980d50edac989'
 
   # d1.music.126.net was verified as official when first introduced to the cask
-  url "http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/#{version.after_comma.before_colon}/#{version.after_colon}/NeteaseMusic_#{version.before_comma}_web.dmg",
+  url "http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/#{version.after_comma.major}/#{version.after_comma.minor}/#{version.after_comma.patch}/NeteaseMusic_#{version.before_comma}_web.dmg",
       user_agent: :fake
   appcast 'https://music.163.com/api/mac/appcast.xml'
   name 'NetEase cloud music'

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -3,7 +3,7 @@ cask 'neteasemusic' do
   sha256 '4860316e46904594ed2ccb96fc451bb4d49ee7de01be7c64069980d50edac989'
 
   # d1.music.126.net was verified as official when first introduced to the cask
-  url "http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/605533604/4f60/201911523186/NeteaseMusic_#{version.before_comma}_web.dmg",
+  url "https://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/605533604/4f60/201911523186/NeteaseMusic_#{version.before_comma}_web.dmg",
       user_agent: :fake
   appcast 'https://music.163.com/api/mac/appcast.xml'
   name 'NetEase cloud music'

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,9 +1,9 @@
 cask 'neteasemusic' do
-  version '2.3.1_824,605533604.4f60.201911523186'
+  version '2.3.1_824'
   sha256 '4860316e46904594ed2ccb96fc451bb4d49ee7de01be7c64069980d50edac989'
 
   # d1.music.126.net was verified as official when first introduced to the cask
-  url "http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/#{version.after_comma.major}/#{version.after_comma.minor}/#{version.after_comma.patch}/NeteaseMusic_#{version.before_comma}_web.dmg",
+  url "http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/605533604/4f60/201911523186/NeteaseMusic_#{version.before_comma}_web.dmg",
       user_agent: :fake
   appcast 'https://music.163.com/api/mac/appcast.xml'
   name 'NetEase cloud music'

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,9 +1,9 @@
 cask 'neteasemusic' do
-  version '2.3.0_814,b2a5:20191015153044'
-  sha256 '3e90d78f5798a759862f7412b194d2624626a25afc9e046cfff27cc6fb75989e'
+  version '2.3.1_824,605533604/4f60:201911523186'
+  sha256 '4860316e46904594ed2ccb96fc451bb4d49ee7de01be7c64069980d50edac989'
 
   # d1.music.126.net was verified as official when first introduced to the cask
-  url "https://d1.music.126.net/dmusic/#{version.after_comma.before_colon}/#{version.after_colon}/NeteaseMusic_#{version.before_comma}_web.dmg",
+  url "http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/#{version.after_comma.before_colon}/#{version.after_colon}/NeteaseMusic_#{version.before_comma}_web.dmg",
       user_agent: :fake
   appcast 'https://music.163.com/api/mac/appcast.xml'
   name 'NetEase cloud music'


### PR DESCRIPTION
hey @vitorgalvao - could you please have a look on this?
The problem is that the feed download has now 4 changing parts instead of 3
this is the new download:
http://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/605533604/4f60/201911523186/NeteaseMusic_2.3.1_824_web.dmg
(from https://music.163.com/api/mac/appcast.xml)
thanks