### PR TITLE
Local: Remove VirtualBox, update homepage

### DIFF
--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -7,9 +7,7 @@ cask 'local' do
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://local-by-flywheel-flywheel.netdna-ssl.com/latest/mac',
           configuration: version.dots_to_hyphens
   name 'Local by Flywheel'
-  homepage 'https://local.getflywheel.com/'
-
-  depends_on cask: 'virtualbox'
+  homepage 'https://localbyflywheel.com/'
 
   app 'Local.app'
 


### PR DESCRIPTION
With Local version 5 ("Local Lightning") VirtualBox requirement has been dropped as explained on [Flywheel's support site](https://getflywheel.com/wordpress-support/migrating-from-local-by-flywheel-to-local/). All the required applications run directly on the host OS and are bundled with the application.

Furthermore, `https://local.getflywheel.com/` redirects to `https://localbyflywheel.com/`.

----

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
