### PR TITLE
Update flock from 2.2.327 to 2.2.314

### DIFF
--- a/Casks/flock.rb
+++ b/Casks/flock.rb
@@ -1,6 +1,6 @@
 cask 'flock' do
-  version '2.2.327'
-  sha256 'bf8f42bf10bc0b2915bc2972fb24c88d6a412f03a5a0b5f735ff0518cf38730f'
+  version '2.2.314'
+  sha256 'a9b72fd763cfede7d67336b238164eef56053a3e1100415d0668d7ed0c3b89b3'
 
   # flock.co was verified as official when first introduced to the cask
   url "https://updates.flock.co/fl_mac_electron/Flock-macOS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.