### PR TITLE
Update upwork from 5.3.3.800,zh8y1qe7l33a9ip6 to 5.3.3.848,ciy2bosj7ts6feza

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,6 +1,6 @@
 cask 'upwork' do
-  version '5.3.3.800,zh8y1qe7l33a9ip6'
-  sha256 '519a935fa430ea36a54ea89ebb815aed27d34913beabbd5ae8a4b5e10437cb4b'
+  version '5.3.3.848,ciy2bosj7ts6feza'
+  sha256 '6cba593f4140ddaa55e9a1c38d7f2c3ed87242a25dd9c8b0489654220791719b'
 
   url "https://updates-desktopapp.upwork.com/binaries/v#{version.before_comma.dots_to_underscores}_#{version.after_comma}/Upwork.dmg"
   name 'Upwork'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.