### PR TITLE
Update qownnotes from 19.12.1,b4995-173009 to 19.12.2,b5006-155152

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.1,b4995-173009'
-  sha256 '8fa8454d2b8c8f6b3cd3284d10f5dd49a53621966c9673dce0a2df46c63324a0'
+  version '19.12.2,b5006-155152'
+  sha256 '023b90d222e831c977fc9fbb18e587ada9a6011e0e16c9558891a6af92cd1110'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.