### PR TITLE
Update omnidb from 2.16.0 to 2.17.0

### DIFF
--- a/Casks/omnidb.rb
+++ b/Casks/omnidb.rb
@@ -1,6 +1,6 @@
 cask 'omnidb' do
-  version '2.16.0'
-  sha256 '4b5a861162564d2d4c0fbd656d9f372897d83dd61c0bfaa4842da22b4af744f3'
+  version '2.17.0'
+  sha256 '8fdd482d45d1b2d4d330074d94238d91cc91242239a3ebb62ccc3319bacd5d16'
 
   url "https://omnidb.org/dist/#{version}/omnidb-app_#{version}-mac.dmg"
   appcast 'https://github.com/OmniDB/OmniDB/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.