### PR TITLE
Update qutebrowser from 1.8.2 to 1.8.3

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,6 @@
 cask 'qutebrowser' do
-  version '1.8.2'
-  sha256 'b13161b7e7aed12add2a2c4fb94d3d7ac73d656f22aef77fce3cd4e88aefc002'
+  version '1.8.3'
+  sha256 '547fe56e784771033c7d16b19327d49cb79509309de78c3ee5bf54fb976abcd6'
 
   # github.com/qutebrowser/qutebrowser was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.