### PR TITLE
Update lunar from 2.9.8 to 2.9.9

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,6 +1,6 @@
 cask 'lunar' do
-  version '2.9.8'
-  sha256 'aa788569235ec504684a6a604c38ddca249bc3a2f6cc1026b72eb39fadef1fd9'
+  version '2.9.9'
+  sha256 '8d9e3ce200cc9b8fdbbc90f880a2d456b1541d90ce59aeefa8b46809fb90d5bf'
 
   # github.com/alin23/Lunar was verified as official when first introduced to the cask
   url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.