### PR TITLE
Update buttercup from 1.18.0 to 1.18.1

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.18.0'
-  sha256 'e6994c4e3bfdf59526d4f2e1ed4daa8af6ea1467b78eccbc6f8a11699c78b5b1'
+  version '1.18.1'
+  sha256 'a42431e000dd00e423a9de12b045399b3e3f4550082545c8b47e4361bed266c4'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.