### PR TITLE
Update jami from 20191128.2156 to 20191206.1121

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20191128.2156'
-  sha256 '1cf53ff37173f0bee8a9ccdb615bd01e1e0862c9dd6c26b2b739e147e43fa577'
+  version '20191206.1121'
+  sha256 '7103ea57730d50a82c6210f28ff8de453672d67e1d218b95de0fb99b3a6104b5'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.