### PR TITLE
Update kite from 0.20191205.0 to 0.20191205.2

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191205.0'
-  sha256 '6b9ed6bdf234199cec669956241bb45a4841eb95e1f55bccb54204c9bf193474'
+  version '0.20191205.2'
+  sha256 'abdce3f7ae86069d748e6a6402ffc41fd5d6994b0190685ab12c198ba1218c04'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.