### PR TITLE
Update kiwi-for-g-suite from 2.0.29v to 2.0.30v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask 'kiwi-for-g-suite' do
-  version '2.0.29v'
-  sha256 'e5562ca1dca044c3061ff30b53597c1577bbc291a259f9d9e77f224f8448f11d'
+  version '2.0.30v'
+  sha256 'b5ba3c92dea325b38771bd65bb445d26a1c216e0141d6bde5de9c79c57eaaed4'
 
   # kiwiforgsuite.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.