### PR TITLE
Update wickrme from 5.41.14 to 5.42.15

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.41.14'
-  sha256 '4fae5e120b77129421be90ee8767a990ed6a0b97a4395c60450d49585984a7cd'
+  version '5.42.15'
+  sha256 '7cf4349b9f97facd2e9257178ad018d5f359d17bb127a4ea90092a1604ebda4d'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.