### PR TITLE
Update avocode from 4.1.0 to 4.2.0

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.1.0'
-  sha256 '7390af391840f7a1821cdc8b6cc65193e1d39c8dd3c62f9c7d5ed2dcdebfdc63'
+  version '4.2.0'
+  sha256 '9f3e96399f65bcf28252d1ed38a07e20ee5eb71230ade0d9de69baad40f93c41'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.