### PR TITLE
Update simply-fortran from 3.6.3116 to 3.7.3131

### DIFF
--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -1,6 +1,6 @@
 cask 'simply-fortran' do
-  version '3.6.3116'
-  sha256 '9c3a9d94f76fdc55d724ed3f87e4798508665cddb730aeaf496b0c3b98bf6b65'
+  version '3.7.3131'
+  sha256 '4c106a3366b9ecdc156beb474aeb3c3be74a1dbc9a6cada7e0e996b20066b5cb'
 
   # download.approximatrix.com/simplyfortran was verified as official when first introduced to the cask
   url "http://download.approximatrix.com/simplyfortran/#{version.major_minor}/simplyfortran-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.