### PR TITLE
Update scummvm from 2.1.0 to 2.5.1

### DIFF
--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -1,6 +1,6 @@
 cask 'scummvm' do
   version '2.5.1'
-  sha256 'f73856ed6925c8d8be2e9cb05875a0b273c8caa7f529b7202cce1573db5a0e03'
+  sha256 '628add60fdedf2cb5c255b601109f9487e1a789e37145064fc4523ab2bacd52b'
 
   url "https://scummvm.org/frs/scummvm/#{version.major_minor_patch}/scummvm-#{version}-macosx.dmg"
   appcast 'https://www.scummvm.org/appcasts/macosx/release.xml'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -1,6 +1,6 @@
 cask 'scummvm' do
-  version '2.1.0'
-  sha256 'c82f8a1c20a555c2dc4fee6854afffe33815a7d1bee58fe13052ff52b41a98f8'
+  version '2.5.1'
+  sha256 '270d7ce916bfb375b208cfac6ee77604a8fc2a39d1ad2d068e7c7973f43e2839'
 
   url "https://scummvm.org/frs/scummvm/#{version.major_minor_patch}/scummvm-#{version}-macosx.dmg"
   appcast 'https://www.scummvm.org/appcasts/macosx/release.xml'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -1,6 +1,6 @@
 cask 'scummvm' do
   version '2.5.1'
-  sha256 '270d7ce916bfb375b208cfac6ee77604a8fc2a39d1ad2d068e7c7973f43e2839'
+  sha256 'f73856ed6925c8d8be2e9cb05875a0b273c8caa7f529b7202cce1573db5a0e03'
 
   url "https://scummvm.org/frs/scummvm/#{version.major_minor_patch}/scummvm-#{version}-macosx.dmg"
   appcast 'https://www.scummvm.org/appcasts/macosx/release.xml'

--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -2,7 +2,7 @@ cask 'scummvm' do
   version '2.5.1'
   sha256 '628add60fdedf2cb5c255b601109f9487e1a789e37145064fc4523ab2bacd52b'
 
-  url "https://scummvm.org/frs/scummvm/#{version.major_minor_patch}/scummvm-#{version}-macosx.dmg"
+  url "https://scummvm.org/frs/scummvm/#{version}/scummvm-#{version}-macosx.dmg"
   appcast 'https://www.scummvm.org/appcasts/macosx/release.xml'
   name 'ScummVM'
   homepage 'https://www.scummvm.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.