### PR TITLE
Update blitz from 1.4.11 to 1.5.0

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.4.11'
-  sha256 'aa73a2fd52403b510825d47922db0a5623763d5fdcc16ce00fb0b5ee2afad982'
+  version '1.5.0'
+  sha256 'ad5e9203399f960ec290398be4ea58553938df04b1c9b4ac8c8dd08463822973'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.