### PR TITLE
Update kekadefaultapp from 1.1.5-rc.1,1.0.0-r.6 to 1.1.22,1.0.1-r.7

### DIFF
--- a/Casks/kekadefaultapp.rb
+++ b/Casks/kekadefaultapp.rb
@@ -1,8 +1,8 @@
 cask 'kekadefaultapp' do
-  version '1.1.5-rc.1,1.0.0-r.6'
-  sha256 'f28224e980afe89af5ee05cf3fa4162fa622554050b0646246597a006960d81d'
+  version '1.1.22,1.0.1-r.7'
+  sha256 '64a9ba60d5fdf7e8e72b21e9bdec0c2804b07f83599de61368f2ecebdcb65eb1'
 
-  url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}/KekaDefaultApp-#{version.after_comma}.zip"
+  url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}/KekaDefaultApp.v#{version.after_comma}.zip"
   appcast 'https://github.com/aonez/Keka/releases.atom'
   name 'KekaDefaultApp'
   homepage 'https://github.com/aonez/Keka/wiki/Default-application'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.