### PR TITLE
Update vagrant-manager from 2.7.0 to 2.7.1

### DIFF
--- a/Casks/vagrant-manager.rb
+++ b/Casks/vagrant-manager.rb
@@ -1,9 +1,9 @@
 cask 'vagrant-manager' do
-  version '2.7.0'
-  sha256 'e2bc635e7e0f2ddca1fde8279a775f3ca8615144dff71a2b0b0f4d3b0f640936'
+  version '2.7.1'
+  sha256 'ad10795f36a2c0977ec8e278082f1f66624cc3b16f837dc72c0f1c063fefb4de'
 
   # github.com/lanayotech/vagrant-manager was verified as official when first introduced to the cask
-  url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/Vagrant.Manager-#{version}.dmg"
+  url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
   appcast 'https://github.com/lanayotech/vagrant-manager/releases.atom'
   name 'Vagrant Manager'
   homepage 'http://vagrantmanager.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.