### PR TITLE
Update wpsoffice from 1.8.0,2797 to 1.8.1,2821

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,9 +1,9 @@
 cask 'wpsoffice' do
-  version '1.8.0,2797'
-  sha256 '43995f09cce5663d1cd126706a5bbe53be5240e5e5014689dc6a3f305cf008e0'
+  version '1.8.1,2821'
+  sha256 'fb69d6798354138073134f0ba345ad19ea69f25731bcbe60f0c1c5536c718399'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
-  url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}_#{version.after_comma}.dmg"
+  url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}(#{version.after_comma}).dmg"
   appcast 'https://www.wps.cn/product/wpsmac/'
   name 'WPS Office'
   homepage 'https://www.wps.cn/product/wpsmac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.