### PR TITLE
Update loginputmac from 2.2.7 to 2.2.8

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '2.2.7'
-  sha256 '47e8b37bc01bba06db5695301f21e001d07fcd0297e0f452abc0492f73d6e5f3'
+  version '2.2.8'
+  sha256 '9f5b65efdee6b404c32e0a01633f0635e112f95b337f4d057d39071f8ad746b7'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.