### PR TITLE
Update icq from 3.0.24385 to 3.0.24905

### DIFF
--- a/Casks/icq.rb
+++ b/Casks/icq.rb
@@ -1,5 +1,5 @@
 cask 'icq' do
-  version '3.0.24385'
+  version '3.0.24905'
   sha256 '0cd6532b87c38b082711891f8f1908f51c3031d6606ab9bc59c3f08e43ab9254'
 
   # mra.mail.ru/icq_mac3_update was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.