### PR TITLE
Update kode54-cog from 0.08,86681e972 to 0.08,61c6cf328

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '0.08,86681e972'
-  sha256 '659054d25af3aef1548da0caa39c9973328dc8dabc5966b99988e9b393260690'
+  version '0.08,61c6cf328'
+  sha256 '2dcedaa2ca313ef23c33468d9c0a8d9241cd323d4bc5bb03146a258585229706'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.