### PR TITLE
Update blitz from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.5.0'
-  sha256 'ad5e9203399f960ec290398be4ea58553938df04b1c9b4ac8c8dd08463822973'
+  version '1.5.1'
+  sha256 'f019b1c160a8c58928998d123e1131f5392abdbe6745d78804789662e5ed21b6'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.