### PR TITLE
Update thonny from 3.2.3 to 3.2.4

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,6 +1,6 @@
 cask 'thonny' do
-  version '3.2.3'
-  sha256 'def7e5898208b47ad8590a3c1a0870477ed7c5662199770b16c05c642062519c'
+  version '3.2.4'
+  sha256 '60b271e3a5f29f2e72500e4280b67fe8684f6bfc18ee09f73de56070d975b999'
 
   # github.com/thonny/thonny/releases/download was verified as official when first introduced to the cask
   url "https://github.com/thonny/thonny/releases/download/v#{version}/thonny-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.