### PR TITLE
Update virtualhostx from 2019.04,1003 to 2019.05,1004

### DIFF
--- a/Casks/virtualhostx.rb
+++ b/Casks/virtualhostx.rb
@@ -1,6 +1,6 @@
 cask 'virtualhostx' do
-  version '2019.04,1003'
-  sha256 'df7a9d5ef1846883582ba4b79a96cfb362ea76a51ecdf9bf9ad61185509981b1'
+  version '2019.05,1004'
+  sha256 'e6a27c766c9f4ddff965f78dae2b573d85be319108bfe74ba8ba5111d23c7737'
 
   url "https://download.clickontyler.com/virtualhostx/virtualhostxpro_#{version.after_comma}.zip"
   appcast 'https://shine.clickontyler.com/appcast.php?id=45'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.