### PR TITLE
Update dashcam-viewer from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/dashcam-viewer.rb
+++ b/Casks/dashcam-viewer.rb
@@ -1,6 +1,6 @@
 cask 'dashcam-viewer' do
-  version '3.3.1'
-  sha256 '3a956382fe4962ebc961d4ec509959fcc6c5b602117c3186df71a93ffa5923e8'
+  version '3.3.2'
+  sha256 'd2b51036aed654eb7a267009d7df7c31f6b38961eeb8c21fe8f6b9669e9025bb'
 
   # filedn.com/l2s8TAtm4VASBX72ds0zYD8/dcv was verified as official when first introduced to the cask
   url "https://filedn.com/l2s8TAtm4VASBX72ds0zYD8/dcv/Dashcam_Viewer_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.