### PR TITLE
Update kinza from 5.0.0 to 5.0.1

### DIFF
--- a/Casks/kinza.rb
+++ b/Casks/kinza.rb
@@ -1,6 +1,6 @@
 cask 'kinza' do
-  version '5.0.0'
-  sha256 '73306617236d40d2318e5662359126bbf0e3f026c106c7a1ff45739e8e931250'
+  version '5.0.1'
+  sha256 '2bbcd7c6312e024fe7e316e58757e5119d9897180f29c088e2958ee446926853'
 
   # d7s9ygw7nxr46.cloudfront.net was verified as official when first introduced to the cask
   url "https://d7s9ygw7nxr46.cloudfront.net/mac/kinza_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.