### PR TITLE
Update lulu from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/lulu.rb
+++ b/Casks/lulu.rb
@@ -1,6 +1,6 @@
 cask 'lulu' do
-  version '1.2.1'
-  sha256 'a51b73c1fc3e4e11bbccffed0d1d70b4fc06a6f4774af06b254f8a82c0e4c1d5'
+  version '1.2.2'
+  sha256 '3c443bc2e847d7ff3ab12b3869b89ac6e87603496583e51e351ef68c4d123b78'
 
   # bitbucket.org/objective-see was verified as official when first introduced to the cask
   url "https://bitbucket.org/objective-see/deploy/downloads/LuLu_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.