### PR TITLE
Update dcp-o-matic-encode-server from 2.14.16 to 2.14.17

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.16'
-  sha256 '526560ae45731cdf45ab54441879d2c75a217bbe94300ae92b40d85015e5a8b5'
+  version '2.14.17'
+  sha256 'af34d80f3b0a61373b77c79f7e969b89464915f6cdd1ae57313c306aa413eb89'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.