### PR TITLE
Update dcp-o-matic-player from 2.14.16 to 2.14.17

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.16'
-  sha256 'fd19e77d2df861d333b9af8ad541171708daf5d4f1d1cbf9c5abbe934689fa0b'
+  version '2.14.17'
+  sha256 '5a68c965b6024e01cfd3f204a9d93f3272591448493d48122da72959c18d8575'
 
   url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.