### PR TITLE
Update macupdater from 1.4.18 to 1.5.0

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.4.18'
-  sha256 'e73049ab156381849effe405d7974c066deb1b095b7d78b5a2499e198db2744d'
+  version '1.5.0'
+  sha256 '6c35d8a815e3716449eebbc67bc9994791157d586e99e1e33699ea5db6d674e9'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.dmg"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.