### PR TITLE
Set auto_updates true for keyboard-maestro 9.0.4

### DIFF
--- a/Casks/keyboard-maestro.rb
+++ b/Casks/keyboard-maestro.rb
@@ -8,9 +8,8 @@ cask 'keyboard-maestro' do
   name 'Keyboard Maestro'
   homepage 'https://www.keyboardmaestro.com/main/'
 
-  depends_on macos: '>= :yosemite'
-
   auto_updates true
+  depends_on macos: '>= :yosemite'
 
   app 'Keyboard Maestro.app'
 

--- a/Casks/keyboard-maestro.rb
+++ b/Casks/keyboard-maestro.rb
@@ -10,6 +10,8 @@ cask 'keyboard-maestro' do
 
   depends_on macos: '>= :yosemite'
 
+  auto_updates true
+
   app 'Keyboard Maestro.app'
 
   zap trash: [


### PR DESCRIPTION
I have used auto update to get to the latest version of this app without updating via homebrew cask. Here is a screenshot of the app and its auto-update menu item on the latest version:

![Screen Shot 2019-12-09 at 3 29 46 PM](https://user-images.githubusercontent.com/13492015/70419819-db035000-1a98-11ea-8185-a61728998c99.png)

After making all changes to the cask:

- [x] `brew cask audit --download keyboard-maestro` is error-free.
- [x] `brew cask style --fix keyboard-maestro` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).