### PR TITLE
Update electron from 7.1.2 to 7.1.3

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '7.1.2'
-  sha256 '8f09c4f27e3ac6bd8bcc02e1a89fce4dab555cb114ccb5eec304bdeb3efc055d'
+  version '7.1.4'
+  sha256 'fd37d03c28436d0d5a87c8c9218716b3815c86803880a108113792b921ec979d'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.