### PR TITLE
Update coteditor from 3.8.6 to 3.8.7

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -6,8 +6,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.8.6'
-    sha256 'a3ca3b0bd7952140fd18ad7ea1f72513e53bc093304cbd32e7d7cac682c4b97e'
+    version '3.8.7'
+    sha256 '0db7c7c980d11823a7ceb86628339f643d6bd518448f44954129a2d87039b922'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.