### PR TITLE
Update navicat-for-postgresql from 15.0.3 to 15.0.4

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.3'
-  sha256 '8a3ef451a7bdd529692f1dd32675bfc0422bf3482bd99581c09c570a2735a933'
+  version '15.0.4'
+  sha256 '56f5d7baf57445c3fe51f256a3c447f38064f024ef8bd2548ed07c506ab4815d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.