### PR TITLE
Update moom from 3.2.16 to 3.2.17

### DIFF
--- a/Casks/moom.rb
+++ b/Casks/moom.rb
@@ -1,6 +1,6 @@
 cask 'moom' do
-  version '3.2.16'
-  sha256 'a77230b7b7e81d7a35a8663713ff0f6519baa49759fc56fb3b3bbbc5e3670054'
+  version '3.2.17'
+  sha256 'c6bb33f478721dade0531ebf5fd0c9cd63d8b6d48b34afdc849d6c94a201aebd'
 
   url "https://manytricks.com/download/_do_not_hotlink_/moom#{version.no_dots}.dmg"
   appcast 'https://manytricks.com/moom/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.