### PR TITLE
Update navicat-for-sql-server from 15.0.3 to 15.0.4

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.3'
-  sha256 '69aebf183f97010ba1eff6e8564d6871951595f81c958adf3f2e1fc37db638c2'
+  version '15.0.4'
+  sha256 'ed462c247e0ef150335cce624956082a37067744e582960fcf07b5d6073758bc'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.