### PR TITLE
Update navicat-for-mysql from 15.0.3 to 15.0.4

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '15.0.3'
-  sha256 'b63f7df88d48484743e33e34a11e1d199f8fa9f564b1de478d9894bf530a8919'
+  version '15.0.4'
+  sha256 '6a0ec2a51804b68010d38a0c48f7415e95f58a6d0800487c3c8e425dbe560ad1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.