### PR TITLE
Add a fork of Rclone Browser v1.7.0

### DIFF
--- a/Casks/kapitainsky-rclone-browser.rb
+++ b/Casks/kapitainsky-rclone-browser.rb
@@ -4,7 +4,7 @@ cask 'kapitainsky-rclone-browser' do
 
   url "https://github.com/kapitainsky/RcloneBrowser/releases/download/#{version.before_comma}/rclone-browser-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://github.com/kapitainsky/RcloneBrowser/releases.atom'
-  name 'Rclone Browser (kapitainsky fork)'
+  name 'Rclone Browser'
   homepage 'https://github.com/kapitainsky/RcloneBrowser'
 
   depends_on formula: 'rclone'

--- a/Casks/kapitainsky-rclone-browser.rb
+++ b/Casks/kapitainsky-rclone-browser.rb
@@ -1,0 +1,13 @@
+cask 'kapitainsky-rclone-browser' do
+  version '1.7.0,f0dc81f'
+  sha256 'e2b94030f05b30f1075b884375c40df45afafb4bb2941367db2ed245fb88065b'
+
+  url "https://github.com/kapitainsky/RcloneBrowser/releases/download/#{version.before_comma}/rclone-browser-#{version.before_comma}-#{version.after_comma}.dmg"
+  appcast 'https://github.com/kapitainsky/RcloneBrowser/releases.atom'
+  name 'Rclone Browser (kapitainsky fork)'
+  homepage 'https://github.com/kapitainsky/RcloneBrowser'
+
+  depends_on formula: 'rclone'
+
+  app 'Rclone Browser.app'
+end


### PR DESCRIPTION
The existing rclone-browser cask is no longer maintained and does not work with the latest version of rclone. This fork of Rclone Browser is actively maintained and works.

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version]

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].


