### PR TITLE
Update melodics from 2.1.3862 to 2.1.3888

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3862'
-  sha256 'dbaf05e947d210b7c6249b6878fed95b3e83a2a63bc7f23117fc5e8f4decda78'
+  version '2.1.3888'
+  sha256 '1fb6312314c8e88f1758f3f61b753fdc162f8eb40e654b5ecf0eb531bdeaad2b'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.