### PR TITLE
Update krisp from 1.8.2 to 1.9.10

### DIFF
--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -3,7 +3,7 @@ cask 'krisp' do
   sha256 'b6d07e8c2258f53d6a9b35c936dd0293eee8ecc5dad3ab902ece0ebb24c14c2f'
 
   url "https://cdn.krisp.ai/mac/release/v#{version.major}.#{version.minor}/krisp_#{version}.pkg"
-  appcast 'https://krisp.ai/'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.krisp.ai/v2/download/mac'
   name 'Krisp'
   homepage 'https://krisp.ai/'
 

--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -1,6 +1,6 @@
 cask 'krisp' do
-  version '1.8.2'
-  sha256 '78dcb867c4354792aa198db9f1cfbe88a32fb17ec33a9677b3038610f7315532'
+  version '1.9.10'
+  sha256 'b6d07e8c2258f53d6a9b35c936dd0293eee8ecc5dad3ab902ece0ebb24c14c2f'
 
   url "https://cdn.krisp.ai/mac/release/v#{version.major}.#{version.minor}/krisp_#{version}.pkg"
   appcast 'https://krisp.ai/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.