### PR TITLE
Update visual-paradigm from 16.0,20191108 to 16.1,20191206

### DIFF
--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -1,6 +1,6 @@
 cask 'visual-paradigm' do
-  version '16.0,20191108'
-  sha256 '927aff96a9f509cce080f526cff1c932bd17aaa5c8024a6ed039ee7ad131bbaf'
+  version '16.1,20191206'
+  sha256 '4508fc74e7ea289868c11ef590641cb77b4d785db7d54f09f5d6f7927b759f6c'
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   appcast "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/checksum.html",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.