### PR TITLE
Update sizzy from 0.11 to 0.12

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -3,7 +3,7 @@ cask 'sizzy' do
   sha256 '2bd63371a35acba0e6abd07df9a073a5a4c1e7841656fa5be0dce8ebc315a007'
 
   url 'https://sizzy.co/get-app'
-  appcast 'https://headway-widget.net/widgets/JAXRr7'
+  appcast 'hhttps://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'
   name 'Sizzy'
   homepage 'https://sizzy.co/'
 

--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -3,7 +3,7 @@ cask 'sizzy' do
   sha256 '2bd63371a35acba0e6abd07df9a073a5a4c1e7841656fa5be0dce8ebc315a007'
 
   url 'https://sizzy.co/get-app'
-  appcast 'hhttps://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'
   name 'Sizzy'
   homepage 'https://sizzy.co/'
 

--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.11'
-  sha256 '783242bf6652c7eac79da6d1fef3bbe86239819b8e0b7b74203203ae156ef0c8'
+  version '0.12'
+  sha256 '2bd63371a35acba0e6abd07df9a073a5a4c1e7841656fa5be0dce8ebc315a007'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://headway-widget.net/widgets/JAXRr7'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.