### PR TITLE
Update qgis from 3.10 to 3.10.1

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,5 +1,5 @@
 cask 'qgis' do
-  version '3.10'
+  version '3.10.1'
   sha256 'f5b87076959ea77b97fbb8b20759a0d3bc9ad565578a5ff5b58ddfe8ad03510a'
 
   url 'https://qgis.org/downloads/macos/qgis-macos-pr.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.