### PR TITLE
Update disk-inventory-x from 1.2 to 1.3

### DIFF
--- a/Casks/disk-inventory-x.rb
+++ b/Casks/disk-inventory-x.rb
@@ -1,6 +1,6 @@
 cask 'disk-inventory-x' do
-  version '1.2'
-  sha256 '05ce4ffcb012545601fd87fef5aa1719f47f2fffbbd3ee7d314ec0bf4a0bdda5'
+  version '1.3'
+  sha256 '78af3506435adaa53d8cc2ce601cac2e13b56e708358eb3bde2c3aa322bad8e5'
 
   url "http://www.derlien.com/diskinventoryx/downloads/Disk%20Inventory%20X%20#{version}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.