### PR TITLE
Update fetch from 5.7.7 to 5.8

### DIFF
--- a/Casks/fetch.rb
+++ b/Casks/fetch.rb
@@ -1,8 +1,8 @@
 cask 'fetch' do
-  version '5.7.7'
-  sha256 '8b543edd7b31cb519fa8d898c6b5b6095cd3b725a477ce32238e08002ac77681'
+  version '5.8'
+  sha256 '88b102ff11c8dd0f932cbc8b1586be3c32a8f171030b6329ebdf7538c3ccf49e'
 
-  url "https://fetchsoftworks.com/fetch/download/Fetch_#{version}.dmg?direct=1"
+  url "https://fetchsoftworks.com/fetch/download/Fetch_#{version}.zip"
   appcast 'https://fetchsoftworks.com/fetch/download/'
   name 'Fetch'
   homepage 'https://fetchsoftworks.com/fetch/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.