### PR TITLE
Update jaxx-liberty from 2.3.3 to 2.3.4

### DIFF
--- a/Casks/jaxx-liberty.rb
+++ b/Casks/jaxx-liberty.rb
@@ -1,6 +1,6 @@
 cask 'jaxx-liberty' do
-  version '2.3.3'
-  sha256 '749332186f24de5d0e93fee0575b070d789740ed2f7d24da338b0ba28ee96014'
+  version '2.3.4'
+  sha256 '4571a3a3f75b3bedd18ec3fe59d97d073b06804f9fd2d46174b6487b88f00279'
 
   url "https://download-liberty.jaxx.io/Jaxx.Liberty-#{version}.dmg"
   appcast 'https://jaxx.io/downloads.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.