### PR TITLE
Update dbeaver-enterprise from 6.2.0 to 6.3.0

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -1,6 +1,6 @@
 cask 'dbeaver-enterprise' do
-  version '6.2.0'
-  sha256 'f723a7d26ee82cbebbdf3bd7fe809f9d1c9f67f71b8266d4ea5712d802856ca8'
+  version '6.3.0'
+  sha256 'b4a4ad2c157fa70af8f2c00e05076d1d6dcdfa2fb49d4d07a944c786264b95fa'
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos.dmg"
   appcast 'https://dbeaver.com/product/version.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.