### PR TITLE
Update feishu from 3.12.3 to 3.12.5

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,6 +1,6 @@
 cask 'feishu' do
-  version '3.12.3'
-  sha256 '90e36be48d5386cf24b0411c51bd8ef4d4953b4b55bd586662fc164bc76ab6b1'
+  version '3.12.5'
+  sha256 '1099d6f46cb6d7aafa0c13ffdfa944233af8fdc87ca6bcc0ee22322f44e424d6'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.