### PR TITLE
Update wechat from 2.3.29.17 to 2.3.29 (12948)

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,5 +1,5 @@
 cask 'wechat' do
-  version '2.3.29.17'
+  version '2.3.29 (12948)'
   sha256 '4da19cac0076fda35dc3ae97526adac49367be08c3fbc04b4886cffcd64f0815'
 
   url 'https://dldir1.qq.com/weixin/mac/WeChatMac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.