### PR TITLE
Update vuescan from 9.7.11 to 9.7.12

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.11'
-  sha256 '65e053227f7accca3fc39914dde96c79e352771fc15775a6d66b3c2d29e22f7a'
+  version '9.7.12'
+  sha256 'ac2ac7afd81776b81417d8457bc5f0d9fd52974fc060cff6fb84ab63eb9ac812'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.