### PR TITLE
Update opera from 65.0.3467.62 to 65.0.3467.69

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '65.0.3467.62'
-  sha256 'ea5b0ee21e19f6283e5aaa6aacde475f428861d32f7dd63f02562ab96614e165'
+  version '65.0.3467.69'
+  sha256 'ddc97946ca14f49035dff46b4e47765d698aeaffbc5ec74558917bc7fba558a0'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast 'https://ftp.opera.com/pub/opera/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.