### PR TITLE
Update google-chrome from 78.0.3904.108 to 79.0.3945.79

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,6 +1,6 @@
 cask 'google-chrome' do
-  version '78.0.3904.108'
-  sha256 '9f221a1342c566dca747db38635391f0483c558b855e2d801b439a232afb3c50'
+  version '79.0.3945.79'
+  sha256 '9abc6ab31aedf6e05836ff1855a7b94e2571ecf9074ac970b0920ee83559156a'
 
   url 'https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg'
   appcast 'https://omahaproxy.appspot.com/history?os=mac;channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.