### PR TITLE
Update dotnet from 3.0.0,1b09851c-1c1a-4aeb-a94a-7065db8741c0:b22a0b5501191fe1a263913d8ed11b2e to 3.1.0,861a1498-68dd-4b8d-8400-4636d6375074:f7fe3a98e33d6a93f35b64d399b346f9

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,6 +1,6 @@
 cask 'dotnet' do
-  version '3.0.0,1b09851c-1c1a-4aeb-a94a-7065db8741c0:b22a0b5501191fe1a263913d8ed11b2e'
-  sha256 'ae40801509711b254ca281d23ff20fc2dcd2ac8ab474f55c936e91e43495a573'
+  version '3.1.0,861a1498-68dd-4b8d-8400-4636d6375074:f7fe3a98e33d6a93f35b64d399b346f9'
+  sha256 'f03663eae170bd6e5b5c3a3f3075c3af855514547d34473850ca145b0ec94967'
 
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.