### PR TITLE
Update ledger-live from 1.18.2 to 1.19.2

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.18.2'
-  sha256 '1abfcfa70471f17ba1ff2ae842885862308e04e7e71e6631467e2a9c7a11efb9'
+  version '1.19.2'
+  sha256 '78433006f2f59acccc97eb4ccc83adc2d737e9ccb41f69c30b05cb192ad6f99b'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.