### PR TITLE
Update macsvg from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/macsvg.rb
+++ b/Casks/macsvg.rb
@@ -1,6 +1,6 @@
 cask 'macsvg' do
-  version '1.1.5'
-  sha256 'aeaf81f5f93da24038c555375e0ff0e13be10c4b2e79592ba9a489a5506d1de3'
+  version '1.1.6'
+  sha256 '879228e0afb51bd451e52801b1b434f92869f133bef9f34a42bd144c2213d5a4'
 
   # github.com/dsward2/macSVG was verified as official when first introduced to the cask
   url "https://github.com/dsward2/macSVG/releases/download/v#{version}/macSVG-v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.