### PR TITLE
Update chronicle from 9.1.1 to 9.5.2

### DIFF
--- a/Casks/chronicle.rb
+++ b/Casks/chronicle.rb
@@ -1,6 +1,6 @@
 cask 'chronicle' do
-  version '9.1.1'
-  sha256 '883b3ca116959481448b84f1179043edee98f662be7699a74dc83e1557f81ca9'
+  version '9.5.2'
+  sha256 '65a8b9a49467002450f8189bebcc234fc8d28d5eb67318764b19658e3e276687'
 
   url 'https://www.chronicleapp.com/static/downloads/chroniclepro.zip'
   appcast 'http://www.littlefin.com/downloads/chronicle8.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.