### PR TITLE
Update adobe-dng-converter from 12.0 to 12.1

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -3,8 +3,8 @@ cask 'adobe-dng-converter' do
     version '9.6.1'
     sha256 '087eac5026667e4e6e3c156fd13243c9ea00f6c0238cbbb94d3099ae8772603f'
   else
-    version '12.0'
-    sha256 '567b84b46af4d4f7a323abe5ce2cdad5bd5e42ec41feb973513d89860f9d7c61'
+    version '12.1'
+    sha256 'ed087a01377559abe0f38696a8b8d884c3a5680c378c332ea3e05b32d89fd7f7'
   end
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.