### PR TITLE
Update fl-studio from 20.5.1.522 to 20.6.0.793

### DIFF
--- a/Casks/fl-studio.rb
+++ b/Casks/fl-studio.rb
@@ -1,6 +1,6 @@
 cask 'fl-studio' do
-  version '20.5.1.522'
-  sha256 '283beca8b276b82aa32f2c9fa731191c99192f5be74b43eee98ad28588649043'
+  version '20.6.0.793'
+  sha256 'c6756dc5a15eee40d6a490345cb4cb71ded3febeb4113a4cf64d867a277d149d'
 
   url "http://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.image-line.com/redirect/flstudio20_mac_installer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.