### PR TITLE
Update tuxguitar from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/tuxguitar.rb
+++ b/Casks/tuxguitar.rb
@@ -1,6 +1,6 @@
 cask 'tuxguitar' do
-  version '1.5.2'
-  sha256 '0a08bacd93a1d3d685d79e7af490c63db0b95bb508e84deaca24f64853996e7c'
+  version '1.5.3'
+  sha256 '3a25eb11df03904ae5c3bcb21e458c90ec4964cb46f0b1556457ec08800ea1d6'
 
   url "https://downloads.sourceforge.net/tuxguitar/tuxguitar-#{version}-macosx-cocoa-64.app.tar.gz"
   appcast 'https://sourceforge.net/projects/tuxguitar/rss?path=/TuxGuitar'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.