### PR TITLE
Update bettertouchtool from 3.209 to 3.213

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.209'
-    sha256 '9b7421383f72e9fab644d2e20c0331dfed0e35d85b9a44d81c4595cccf3bec1e'
+    version '3.213'
+    sha256 '9fdd9b568ea21f6d750c79e25868a27a144f6bd833924a004a47ddd6f2f2fed9'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.