### PR TITLE
Update mate-translate from 6.1.1,1570627713 to 6.1.4

### DIFF
--- a/Casks/mate-translate.rb
+++ b/Casks/mate-translate.rb
@@ -1,10 +1,10 @@
 cask 'mate-translate' do
-  version '6.1.1,1570627713'
-  sha256 '05c2446f4bdd2d9363a4846ac019168dfa7ce476ca93edd08fc54a7d44d5d203'
+  version '6.1.4'
+  sha256 'b2fe0ae8353b496b43dda07c21f89a7c9604d72d922213894e31efb5904a2365'
 
-  # dl.devmate.com/com.twopeoplesoftware.InstantTranslate-nomas was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.twopeoplesoftware.InstantTranslate-nomas/#{version.before_comma}/#{version.after_comma}/InstantTranslate-#{version.before_comma}.zip"
-  appcast 'https://updates.devmate.com/com.twopeoplesoftware.InstantTranslate-nomas.xml'
+  # gikken.co/mate was verified as official when first introduced to the cask
+  url 'https://gikken.co/mate/MateTranslate.zip'
+  appcast 'https://gikken.co/mate/appcast.xml'
   name 'Mate Translate'
   homepage 'https://twopeoplesoftware.com/mate'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.