### PR TITLE
Update suitcase-fusion from 9,20.0.7 to 21.0.0

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,13 +1,13 @@
 cask 'suitcase-fusion' do
-  version '9,20.0.7'
-  sha256 '3301f192a5cc6eb4c56c8057b8b2ee2595f124a55bcb02884902249a99f43188'
+  version '21.0.0'
+  sha256 '38a3c56392b88856a95a9dfd6a04f33102eed7a5ba9e675d5d054ce33acbcb5c'
 
-  url "https://bin.extensis.com/SuitcaseFusion#{version.before_comma}-M-#{version.after_comma.dots_to_hyphens}.dmg"
-  appcast "https://sparkle.extensis.com/u/ST/EN/suitcase#{version.after_comma.major}en.xml"
+  url "https://bin.extensis.com/SuitcaseFusion-M-#{version.dots_to_hyphens}.dmg"
+  appcast "https://www.extensis.com/support/suitcase-fusion-#{version.major}/release-notes/"
   name 'Extensis Suitcase Fusion'
-  homepage 'https://www.extensis.com/'
+  homepage 'https://www.extensis.com/suitcase-fusion/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   app 'Suitcase Fusion.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.