### PR TITLE
Update parallels-client from 17.0.1-21481 to 17.1.0-21669

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -7,7 +7,7 @@ cask 'parallels-client' do
   name 'Parallels Client'
   homepage 'https://www.parallels.com/products/ras/features/rdp-client/'
 
-  pkg "RasClient-Mac-#{version}.pkg"
+  pkg "RasClient-Mac-Appstore-#{version}.pkg"
 
   uninstall pkgutil: 'com.2X.Client.Mac',
             quit:    'com.2X.Client.Mac'

--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,8 +1,8 @@
 cask 'parallels-client' do
-  version '17.0.1-21481'
-  sha256 '7d7e0503009443292b43c897e14380a1e458391b878c33c3deba4b2d1fa94c3c'
+  version '17.1.0-21669'
+  sha256 'f33ac54837c2376dd1d8c229b1368dfb17cc329cc7a0a1afea044901f0fc1eb5'
 
-  url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-#{version}.pkg"
+  url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-Appstore-#{version}.pkg"
   appcast "https://download.parallels.com/ras/v#{version.major}/RAS%20Client%20for%20Mac%20Changelog.txt"
   name 'Parallels Client'
   homepage 'https://www.parallels.com/products/ras/features/rdp-client/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.