### PR TITLE
Update electron-cash from 4.0.11 to 4.0.12

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.11'
-  sha256 'ab90d13ac2c8fcb7d934f6881d1de54e5d5a27918f2d2e8c9843b34128849bfc'
+  version '4.0.12'
+  sha256 'bafc139fa31a81700abc4d19c86753690cc3b297a78a51bffa34c783cab25de8'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/Electron-Cash/Electron-Cash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.