### PR TITLE
Update qownnotes from 19.12.6,b5035-165330 to 19.12.7,b5043-153743

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.6,b5035-165330'
-  sha256 '1de8b7aff771ffad0e14fb1c0a5967c2bf79672634a518b1d0c6bfef7a10199f'
+  version '19.12.7,b5043-153743'
+  sha256 'c77bb133859040f954d0eb9645c1a147b83a77dce05c6e970927962f0b213137'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.