### PR TITLE
Update keep-it from 1.7.7 to 1.7.8

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.7.7'
-  sha256 '8f1ac9bdd7f10368709cf389176cc742156188acef5353d281d556e823af7c7d'
+  version '1.7.8'
+  sha256 'adf7e65bcd2734308e0449a86acb2be25212284aaf80fd69fdf5a82de6908288'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.