### PR TITLE
Update airtool from 1.8 to 1.9

### DIFF
--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -3,7 +3,7 @@ cask 'airtool' do
   sha256 '605cf374a8c12ea2f976e78e33289095232a80a6ece1e748103c6f109b234d50'
 
   url "https://www.adriangranados.com/downloads/Airtool_#{version}.pkg"
-  appcast 'https://updates.devmate.com/com.adriangranados.Airtool.xml'
+  appcast 'https://www.adriangranados.com/apps/airtool'
   name 'Airtool'
   homepage 'https://www.adriangranados.com/apps/airtool'
 

--- a/Casks/airtool.rb
+++ b/Casks/airtool.rb
@@ -1,6 +1,6 @@
 cask 'airtool' do
-  version '1.8'
-  sha256 '00a0c5b378ada363c3ecb69b4d5078edc84755c1fc446d61bb562c99a5ccb123'
+  version '1.9'
+  sha256 '605cf374a8c12ea2f976e78e33289095232a80a6ece1e748103c6f109b234d50'
 
   url "https://www.adriangranados.com/downloads/Airtool_#{version}.pkg"
   appcast 'https://updates.devmate.com/com.adriangranados.Airtool.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.