### PR TITLE
Update tableau-prep from 2019.4.1 to 2019.4.2

### DIFF
--- a/Casks/tableau-prep.rb
+++ b/Casks/tableau-prep.rb
@@ -1,6 +1,6 @@
 cask 'tableau-prep' do
-  version '2019.4.1'
-  sha256 'c2f02bfc3f99850a10a2f3988f4a13872ba95874350740e4644b1e7c032e4779'
+  version '2019.4.2'
+  sha256 '6b3c5ace028cfea9583b7705921fcba881dc4b1a33e431bb8d772502681e837c'
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/prep/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.