### PR TITLE
Update 4k-youtube-to-mp3 from 3.9.1.3240 to 3.10.0.3243

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.9.1.3240'
-  sha256 'c346b628057b97c647a680762cccfb439f2bb21d58004fed94ac3b1ac0997686'
+  version '3.10.0.3243'
+  sha256 '326947dd57e7336ded79f1a8822fe86bda8ab22cd616dafca07fbc695ad4eb4c'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.