### PR TITLE
Update rambox from 0.7.2 to 0.7.3

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,6 +1,6 @@
 cask 'rambox' do
-  version '0.7.2'
-  sha256 '4b3855962515b5c0abbafdcd076ada4584f257d9dfb35d6bd9912bb094205867'
+  version '0.7.3'
+  sha256 'ddaff19e5a2fdd8cd29083a0d84a6d639db7fc690ff5af90363dc93c7b88e461'
 
   # github.com/ramboxapp/community-edition was verified as official when first introduced to the cask
   url "https://github.com/ramboxapp/community-edition/releases/download/#{version}/Rambox-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.