### PR TITLE
Update netron from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.6.0'
-  sha256 'b912906c91d817b89344a8bd7a039ed8c34177999b255686aceb200015acb5cb'
+  version '3.6.1'
+  sha256 '43b4bac2f9fe397967e6fecaae1cc56a6f9c18a2d1d3ed563f8d4160680b152e'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.