### PR TITLE
Update netron from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.6.1'
-  sha256 '43b4bac2f9fe397967e6fecaae1cc56a6f9c18a2d1d3ed563f8d4160680b152e'
+  version '3.6.2'
+  sha256 'b29282de9d1ea8dbd78bc204d1f902a0c85fb5a52bb539889add5088934400de'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.