### PR TITLE
Update opera from 65.0.3467.69 to 65.0.3467.72

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask 'opera' do
-  version '65.0.3467.69'
-  sha256 'ddc97946ca14f49035dff46b4e47765d698aeaffbc5ec74558917bc7fba558a0'
+  version '65.0.3467.72'
+  sha256 '73e916ae16fb99049ad45a947974e7a0fab4be467a4a375022101dcab4bb7550'
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast 'https://ftp.opera.com/pub/opera/desktop/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.