### PR TITLE
Update amazon-music from 7.8.7,20191125:084217a638 to 7.9.0,20191210:0817399808

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask 'amazon-music' do
-  version '7.8.7,20191125:084217a638'
-  sha256 '4e6401f63d34639ceda8038e55b4a42a9e265721acf170995b958e12ceef83f7'
+  version '7.9.0,20191210:0817399808'
+  sha256 'bbb89096aac3245ef08c59ef277611f137da4a5137f33cb528d9e56058deebd8'
 
   # ssl-images-amazon.com/images was verified as official when first introduced to the cask
   url "https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/#{version.after_comma.before_colon}/#{version.after_colon}/AmazonMusicInstaller.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.