### PR TITLE
Update lastpass from 4.38.0 to 4.39.0

### DIFF
--- a/Casks/lastpass.rb
+++ b/Casks/lastpass.rb
@@ -1,6 +1,6 @@
 cask 'lastpass' do
-  version '4.38.0'
-  sha256 'cc42b5d5e04c58c8f554bf5b694a4457e787d2c4db1a586d7a76345b620e760c'
+  version '4.39.0'
+  sha256 '82b1ff3d316fc71f10c225a6006bdc704d10bdb9db952aee6e8e9c919f3ec684'
 
   url 'https://download.cloud.lastpass.com/mac/LastPass.dmg'
   appcast 'https://download.cloud.lastpass.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.