### PR TITLE
Fix Webcamoid zap and uninstall

### DIFF
--- a/Casks/webcamoid.rb
+++ b/Casks/webcamoid.rb
@@ -10,8 +10,11 @@ cask 'webcamoid' do
 
   app 'webcamoid.app'
 
+  uninstall quit:      'com.webcamoidprj.webcamoid',
+            launchctl: 'org.webcamoid.cmio.AkVCam.Assistant',
+            delete:    '/Library/CoreMediaIO/Plug-Ins/DAL/AkVirtualCamera.plugin'
+
   zap trash: [
-               '/Library/CoreMediaIO/Plug-Ins/DAL/AkVirtualCamera.plugin',
                '~/Library/Application Support/CrashReporter/webcamoid_*.plist',
                '~/Library/Logs/DiagnosticReports/webcamoid_*.crash',
                '~/Library/Saved Application State/com.webcamoidprj.webcamoid.savedState',


### PR DESCRIPTION
Move where we deal with the plugin from zap to uninstall. I'd expect any
system components of the application to be removed on uninstall. Using
trash always failed for removing the plugin directory, so this switches
it to delete.

So, on uninstall, we'll:

 * Quit the app
 * Remove the AkVCam plugin assistant launch agent
 * Delete the AkVCam plugin completely

And zap will just remove user files.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).