### PR TITLE
Update xmind from 3.7.8.201807240049,8-update8 to 3.7.9.201912052356,8-update9

### DIFF
--- a/Casks/xmind.rb
+++ b/Casks/xmind.rb
@@ -1,8 +1,8 @@
 cask 'xmind' do
-  version '3.7.8.201807240049,8-update8'
-  sha256 '95cc8d8950e8b10fa60a831cc5b3e33da17932336320f0f803cfae94cc1f814e'
+  version '3.7.9.201912052356,8-update9'
+  sha256 '120745d98a6122af56f944f666c59a6c3e06099be3838c365e6554e82db19211'
 
-  url "https://www.xmind.net/xmind/downloads/xmind-#{version.after_comma}-macosx.dmg"
+  url "https://dl3.xmind.net/xmind-#{version.after_comma}-macosx.dmg"
   appcast 'https://www.xmind.net/download/xmind8/'
   name 'XMind'
   homepage 'https://www.xmind.net/'

--- a/Casks/xmind.rb
+++ b/Casks/xmind.rb
@@ -3,7 +3,8 @@ cask 'xmind' do
   sha256 '120745d98a6122af56f944f666c59a6c3e06099be3838c365e6554e82db19211'
 
   url "https://dl3.xmind.net/xmind-#{version.after_comma}-macosx.dmg"
-  appcast 'https://www.xmind.net/download/xmind8/'
+  appcast 'https://www.xmind.net/download/xmind8/',
+          configuration: version.after_comma
   name 'XMind'
   homepage 'https://www.xmind.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.