### PR TITLE
Update magiccap from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/magiccap.rb
+++ b/Casks/magiccap.rb
@@ -1,6 +1,6 @@
 cask 'magiccap' do
-  version '2.1.1'
-  sha256 'f5a1e6ae19fb676556e0ce9994ce4a6e41627f6c7c248b8f298144bf08c0a4dd'
+  version '2.1.2'
+  sha256 '98bfe7b74f112d8887cc64befe494a92909eac26e20103923caf01a71a364944'
 
   # github.com/magiccap/MagicCap was verified as official when first introduced to the cask
   url "https://github.com/magiccap/MagicCap/releases/download/v#{version}/magiccap-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.