### PR TITLE
Update polar-bookshelf from 1.60.11 to 1.70.4

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.60.11'
-  sha256 '27f2315f75ec7b65f6914292cf876fbfc30f9f11a8701b8b508e74b0775f58e0'
+  version '1.70.4'
+  sha256 '842a89b138e4889d20f39203325c837da1580ca231f6c58904c33f75b4ea98b7'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.