### PR TITLE
Update bitshares from 3.1.191011 to 3.3.191120

### DIFF
--- a/Casks/bitshares.rb
+++ b/Casks/bitshares.rb
@@ -1,6 +1,6 @@
 cask 'bitshares' do
-  version '3.1.191011'
-  sha256 '34394912ad29512220480a3c3a1eff2c309beb9e1b9bac1050ece40987ce8b2f'
+  version '3.3.191120'
+  sha256 '27553d1038f6c301b7bcdc4f8a644e871722024d24585c6b847c868962a967aa'
 
   # github.com/bitshares/bitshares-ui was verified as official when first introduced to the cask
   url "https://github.com/bitshares/bitshares-ui/releases/download/#{version}/BitShares-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.