### PR TITLE
Update wavebox from 4.11.6 to 4.11.9

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.11.6'
-  sha256 'e51b0031f73b261a37c928912367c9f78fafbb185c59325811c0333fba03ff4f'
+  version '4.11.9'
+  sha256 'b3ef0f0d4112b319d9fa2497a0d6ff6cc087f9a33dcdc9afe86bc74b1ac5a2df'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.