### PR TITLE
Update jami from 20191206.1121 to 20191209.1141

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20191206.1121'
-  sha256 '7103ea57730d50a82c6210f28ff8de453672d67e1d218b95de0fb99b3a6104b5'
+  version '20191209.1141'
+  sha256 '1f1f34cdd69f9c59c54a559364000014695081d2ab912241da82af0df8f4f8fd'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',

--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -2,7 +2,7 @@ cask 'jami' do
   version '20191209.1141'
   sha256 '1f1f34cdd69f9c59c54a559364000014695081d2ab912241da82af0df8f4f8fd'
 
-  url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
+  url "https://dl.jami.net/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.jami.net/mac_osx/sparkle-ring.xml',
           configuration: version.no_dots
   name 'Jami'

--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -3,11 +3,11 @@ cask 'jami' do
   sha256 '1f1f34cdd69f9c59c54a559364000014695081d2ab912241da82af0df8f4f8fd'
 
   url "https://dl.ring.cx/mac_osx/jami-#{version.no_dots}.dmg"
-  appcast 'https://dl.ring.cx/mac_osx/sparkle-ring.xml',
+  appcast 'https://dl.jami.net/mac_osx/sparkle-ring.xml',
           configuration: version.no_dots
   name 'Jami'
   name 'Savoir-faire Linux Ring'
-  homepage 'https://ring.cx/'
+  homepage 'https://jami.net/'
 
   auto_updates true
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.