### PR TITLE
Update evernote from 7.13_458080 to 7.14_458244

### DIFF
--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -9,8 +9,8 @@ cask 'evernote' do
     version '7.2.3_456885'
     sha256 'eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97'
   else
-    version '7.13_458080'
-    sha256 'f24a1ca5c75fc31d81df04ea1c32504a318811177d07533604c9ad710f9dadf0'
+    version '7.14_458244'
+    sha256 '1049a40b8497c0e37d7fed8828552dba89fa52c826134e05b0d56e431e5033ad'
   end
 
   url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.