### PR TITLE
Update activedock from 460,1574458848 to 502,1576140160

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '460,1574458848'
-  sha256 '1d6f03f60705579740f99e28b9296f9bc2a17422e7aeeccf1ac05ec13b5f765f'
+  version '502,1576140160'
+  sha256 '64f75d442b9119f7470dfbb0ce38790bee07df8cf280ae8d6f2f2692810dfcbf'
 
   # dl.devmate.com/com.sergey-gerasimenko.ActiveDock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.ActiveDock/#{version.before_comma}/#{version.after_comma}/ActiveDock-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.