### PR TITLE
Update mongodb-compass-isolated-edition from 1.20.1 to 1.20.2

### DIFF
--- a/Casks/mongodb-compass-isolated-edition.rb
+++ b/Casks/mongodb-compass-isolated-edition.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-isolated-edition' do
-  version '1.20.1'
-  sha256 'b62a08100af8a2c9ea861a9dea093b886940db1afd63e9d0d5b0fbc0b30a43fd'
+  version '1.20.2'
+  sha256 '76f262a368f5eb4878f18add2f1c684437c2c3a247556832b29f808c2c965479'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-isolated-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.