### PR TITLE
Update mongodb-compass-community from 1.20.1 to 1.20.2

### DIFF
--- a/Casks/mongodb-compass-community.rb
+++ b/Casks/mongodb-compass-community.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-community' do
-  version '1.20.1'
-  sha256 '4cb8c005db36e916c60f8fca7a7724ad9633201d537aae0f9f86829eba5096f0'
+  version '1.20.2'
+  sha256 '7bd8210f0490256b91f1220a0981cef1cb2dc26a820f8407ea29fd73722a1154'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-community-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.