### PR TITLE
Update mendeley-reference-manager from 2.16.0 to 2.17.0

### DIFF
--- a/Casks/mendeley-reference-manager.rb
+++ b/Casks/mendeley-reference-manager.rb
@@ -1,6 +1,6 @@
 cask 'mendeley-reference-manager' do
-  version '2.16.0'
-  sha256 '53612db726c41690e3d0c935149a735e8895aec9fa6341ac9bcc622fccebf96f'
+  version '2.17.0'
+  sha256 '1b8b7b3bb4f552e52d8916008f7b561cc34de81bea93f0f38157ffa0809b0f3b'
 
   url "https://static.mendeley.com/bin/desktop/mendeley-reference-manager-#{version}.dmg"
   appcast 'https://static.mendeley.com/bin/desktop/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.