### PR TITLE
Update r from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,6 +1,6 @@
 cask 'r' do
-  version '3.6.1'
-  sha256 'd86ab88eb33ddecf1c9432e08d177b40d0e1b07bb31e07d33c18d70e13b5051b'
+  version '3.6.2'
+  sha256 '96bdb2a2017bd34f5ead2f7a7b537073e76a212ffdf1df25dddbe93d03bba843'
 
   url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   appcast 'https://cloud.r-project.org/bin/macosx/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.