### PR TITLE
Update minizincide from 2.3.2 to 2.4.0

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask 'minizincide' do
-  version '2.3.2'
-  sha256 '219e934876423217f51d461d605e78e87f74ab1d02d9f2968d0911fbb62f7924'
+  version '2.4.0'
+  sha256 '254fc85193d1d6006483911d76e1e45fc83b57b70dba3bd7bb136dd8cf2d1a8c'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.