### PR TITLE
Fix ghidra binary path for ghidra-9.1_PUBLIC_20191023

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,14 +1,14 @@
 cask 'ghidra' do
-  version '9.1_PUBLIC_20191023'
+  version '9.1_PUBLIC,20191023'
   sha256 '29d130dfe85da6ec45dfbf68a344506a8fdcc7cfe7f64a3e7ffb210052d1875e'
 
-  url "https://www.ghidra-sre.org/ghidra_#{version}.zip"
+  url "https://www.ghidra-sre.org/ghidra_#{version.before_comma}_#{version.after_comma}.zip"
   name 'Ghidra'
   homepage 'https://www.ghidra-sre.org/'
 
   conflicts_with cask: 'ghidra-beta'
 
-  binary "ghidra_#{version.major_minor_patch}_PUBLIC/ghidraRun"
+  binary "ghidra_#{version.before_comma}/ghidraRun"
 
   zap trash: '~/.ghidra'
 


### PR DESCRIPTION
The assumed path was based on the version, not taking into account
the difference between download URL and actual path included in the
release package.

The beta package does it right, backport that change to the stable
ghidra package.

An example error report can be seen at
https://discourse.brew.sh/t/brew-cask-install-ghidra-fails/6444


- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).