### PR TITLE
Update qt-creator from 4.10.2 to 4.11.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.10.2'
-  sha256 '5f650600b7c46a1357cc66959dece896c2de2ee49bfb787ae3e65d736a7dd37e'
+  version '4.11.0'
+  sha256 '5d92ecb1c54a6d5bf08aa8155fea53e5cf2fd89b624299e25e7f4bd0adddf18e'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qtcreator/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.