### PR TITLE
Update neteasemusic from 2.3.1_828,644549937.3284.2019119122743 to 2.3.2_832,680685466.242a.20191112165731

### DIFF
--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask 'neteasemusic' do
-  version '2.3.1_828,644549937.3284.2019119122743'
-  sha256 '3ee3bf4c8ace3649995435b5999f8cc3d4f8e457b108dc51dfd3d7aabefc9258'
+  version '2.3.2_832,680685466.242a.20191112165731'
+  sha256 '52977697538bd24df242e3120e4644aaeab951a07ecb081da62a07b9f6846a62'
 
   # d1.music.126.net was verified as official when first introduced to the cask
   url "https://d1.music.126.net/dmusic/obj/w5zCg8OCw6fCn2vDicOl/#{version.after_comma.major}/#{version.after_comma.minor}/#{version.after_comma.patch}/NeteaseMusic_#{version.before_comma}_web.dmg",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.