### PR TITLE
Update aqua-data-studio from 20.0.0 to 20.0.4

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,6 +1,6 @@
 cask 'aqua-data-studio' do
-  version '20.0.0'
-  sha256 '0a08f44e7cf9787d7d7817ca7c98cbdb00d590c7cd85bd7af025040f64db95b8'
+  version '20.0.4'
+  sha256 '7f10cd1a68bcf2c98ccb29c6e0646f55fc332cba37f57c92e061cad1bf1bef17'
 
   url "http://downloads.aquafold.com/v#{version.major_minor}.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'https://www.aquafold.com/aquadatastudio_downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.