### PR TITLE
Update blackhole from 0.2.4 to 0.2.5

### DIFF
--- a/Casks/blackhole.rb
+++ b/Casks/blackhole.rb
@@ -1,6 +1,6 @@
 cask 'blackhole' do
-  version '0.2.4'
-  sha256 'b5acf234dca38b56fbfb7192218859930b984bc1f94b4ee7aea2c48c1321b19d'
+  version '0.2.5'
+  sha256 '911142980edebab6b05310c86ca4f7b4119a9dc09e1d0bdcee462ee03a82e9e8'
 
   url "https://github.com/ExistentialAudio/BlackHole/releases/download/v#{version}/BlackHole.v#{version}.pkg"
   appcast 'https://github.com/ExistentialAudio/BlackHole/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.