### PR TITLE
Update vscodium from 1.40.2 to 1.41.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.40.2'
-  sha256 '77f5f90e61b997e71987b60a34888b084eff11969d9334252496220e0058b6cb'
+  version '1.41.0'
+  sha256 '04338c74bd1fe15abed863467fcb4c8a0be2573a7a104da838210e0cf041ed32'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.