### PR TITLE
Update dictionaries from 1.3.3,305:1559998396 to 1.4,322:1576167636

### DIFF
--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -1,6 +1,6 @@
 cask 'dictionaries' do
-  version '1.3.3,305:1559998396'
-  sha256 '730a524969d58c18434e797d15042f9e56d1ea365ebba85a7c3f7d5be3a9e409'
+  version '1.4,322:1576167636'
+  sha256 'fefdddd3165a0cd53f201058b28ba365ced4f7be54bfcb7e6f0b41aa48e10143'
 
   # dl.devmate.com/io.dictionaries.Dictionaries was verified as official when first introduced to the cask
   url "https://dl.devmate.com/io.dictionaries.Dictionaries/#{version.after_comma.before_colon}/#{version.after_colon}/Dictionaries-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.