### PR TITLE
Update glyphs from 2.6.4,1277 to 2.6.4,1278

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.4,1277'
-  sha256 '34ceceffd7a64e54718f6ee36ea3d8eed6977791dc5b3e9d42d28eb01392c926'
+  version '2.6.4,1278'
+  sha256 '1ebe152a362f952802c1e8453c7f0b564eafb4ad737bb2474a61a17dd34753a0'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.