### PR TITLE
Update scapple from 1.3.3 to 1.3.4

### DIFF
--- a/Casks/scapple.rb
+++ b/Casks/scapple.rb
@@ -1,6 +1,6 @@
 cask 'scapple' do
-  version '1.3.3'
-  sha256 '2693a64a4eed698fa64d2d772a6224a1b2a4c3c88c06af0fa7c5584d53fab8c7'
+  version '1.3.4'
+  sha256 '0f81d00286f0c49fafc03966bfb2c4dd9fc036495d69def64988d489223e7892'
 
   # scrivener.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://scrivener.s3.amazonaws.com/Scapple.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.