### PR TITLE
Update displaycal from 3.8.9.1 to 3.8.9.2

### DIFF
--- a/Casks/displaycal.rb
+++ b/Casks/displaycal.rb
@@ -1,6 +1,6 @@
 cask 'displaycal' do
-  version '3.8.9.1'
-  sha256 '8a91265d00abd0c696d243216967d99730b9fbee63e4d57325f334d66307e683'
+  version '3.8.9.2'
+  sha256 'fa6d59bdcb4b1960295eca15ee4220c3cef4da73a15616359075fae234fa25c2'
 
   # sourceforge.net/dispcalgui was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/dispcalgui/release/#{version}/DisplayCAL-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.