### PR TITLE
Update tibco-jaspersoft-studio from 6.10.0 to 6.11.0

### DIFF
--- a/Casks/tibco-jaspersoft-studio.rb
+++ b/Casks/tibco-jaspersoft-studio.rb
@@ -1,6 +1,6 @@
 cask 'tibco-jaspersoft-studio' do
-  version '6.10.0'
-  sha256 'f01fdf496d96ba3b8ef2b0690cff7d5c6dd2178686f109a06846ab05e143420e'
+  version '6.11.0'
+  sha256 '45f415a11fe29c5746f05cdb814617cd42d4c009f268ca19f6fea4a93a0d55e8'
 
   # sourceforge.net/jasperstudio was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jasperstudio/JaspersoftStudio-#{version}/TIB_js-studiocomm_#{version}_macosx_x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.