### PR TITLE
Update sherlock.rb from 1.7.3 to 1.7.4 + update appcast and url 

### DIFF
--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -1,9 +1,10 @@
 cask 'sherlock' do
-  version '1.7.3'
-  sha256 '41c48300fc7989f080acab97888a4ea656ca7107410ecb24a555c9a2d57f5bf9'
+  version '1.7.4'
+  sha256 '2eb61363bbd22ccbbf93f188a33fcc897a16311b9112b84563c7217bf6cbd958'
 
-  url 'https://sherlock.inspiredcode.io/download-dmg'
-  appcast 'https://updates.devmate.com/io.inspiredcode.Sherlock.xml'
+# rink.hockeyapp.net/api was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/d2096a451f9849fd84ddb59fc0a30efe/app_versions/2?format=zip"
+  appcast 'http://sparkle.sherlock.inspiredcode.io'
   name 'Sherlock'
   homepage 'https://sherlock.inspiredcode.io/'
 

--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -2,8 +2,8 @@ cask 'sherlock' do
   version '1.7.4'
   sha256 '2eb61363bbd22ccbbf93f188a33fcc897a16311b9112b84563c7217bf6cbd958'
 
-# rink.hockeyapp.net/api was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/d2096a451f9849fd84ddb59fc0a30efe/app_versions/2?format=zip"
+  # rink.hockeyapp.net/api was verified as official when first introduced to the cask
+  url 'https://rink.hockeyapp.net/api/2/apps/d2096a451f9849fd84ddb59fc0a30efe/app_versions/2?format=zip'
   appcast 'http://sparkle.sherlock.inspiredcode.io'
   name 'Sherlock'
   homepage 'https://sherlock.inspiredcode.io/'


### PR DESCRIPTION
I'm not sure about this update because the website download still contains v 1.7.3 - but the downloaded version contains this appcast as SUFeedURL
