### PR TITLE
Update amazon-chime from 4.27.7094 to 4.28.7232

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -1,8 +1,8 @@
 cask 'amazon-chime' do
-  version '4.27.7094'
-  sha256 '2194aeb4fd0ae3a92cbff8c60122378689a54d235545f9782ffd7970ee8f9dbc'
+  version '4.28.7232'
+  sha256 'bd744377acba987b33af4bbd864377fac701db2f55c61c87e59cddcab4232836'
 
-  url "https://clients.chime.aws/mac/releases/AmazonChime-OSX-#{version}.dmg"
+  url "https://clients.chime.aws/mac/releases/AmazonChime-OSX.release-#{version}.dmg"
   appcast 'https://clients.chime.aws/mac/appcast'
   name 'Amazon Chime'
   homepage 'https://chime.aws/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.