### PR TITLE
Update termius from 5.0.6 to 5.1.1

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -4,7 +4,7 @@ cask 'termius' do
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'
-  appcast 'https://www.termius.com/mac-os'
+  appcast 'https://docs.termius.com/changelog/desktop'
   name 'Termius'
   homepage 'https://www.termius.com/'
 

--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '5.0.6'
-  sha256 '07721b007c136ccc0b64d861e6a4464d2ed4b6ffa3c933415c4850fd7feb19f4'
+  version '5.1.1'
+  sha256 '44bcda41ef58318ff58850ef240fdfbcb0327a786220dde1b8c02a1bbb646a26'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.