### PR TITLE
Update multipass from 0.9.0 to 0.10.0

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask 'multipass' do
-  version '0.9.0'
-  sha256 '930fd314e0de48cc9ef61cd822013531554ea363843f89138e5b77db305db19f'
+  version '0.10.0'
+  sha256 '1359cffaaefe44044659f0101fcf4f0f96f1d1ba30d2756c4c56cf4e6c6f3275'
 
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast 'https://github.com/CanonicalLtd/multipass/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.