### PR TITLE
Update unity-download-assistant from 2019.2.15f1,dcb72c2e9334 to 2019.2.16f1,b9898e2d04a4

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.2.15f1,dcb72c2e9334'
-  sha256 '6f2749b88188f34c60f4fe82058c2b316d6da11bd29c055a10186d8dd2602bc9'
+  version '2019.2.16f1,b9898e2d04a4'
+  sha256 'cdeda117ecd496e2ed65b0963c62a865f9f1a32f67011a995debab9579cb9d10'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.