### PR TITLE
Update qownnotes from 19.12.8,b5053-154542 to 19.12.9,b5068-103555

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.8,b5053-154542'
-  sha256 '89e961a7b220476e60a5f2b4d253bd2c64a54344bd3dc58748b9b038a1715651'
+  version '19.12.9,b5068-103555'
+  sha256 'f6751da16c6a29839a4534a60957641c0c9d23b49d19dac8e16d8786a5729caf'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.