### PR TITLE
Update monero-wallet from 0.15.0.1 to 0.15.0.2

### DIFF
--- a/Casks/monero-wallet.rb
+++ b/Casks/monero-wallet.rb
@@ -1,6 +1,6 @@
 cask 'monero-wallet' do
-  version '0.15.0.1'
-  sha256 'c8994781510e234985e24f465761355e4ae7bd58ef686bd8b0ce4401c2314d51'
+  version '0.15.0.2'
+  sha256 'a652484a2a74f0d2697a4f0c000221d2a90927b8b8d536f1429756596d048f90'
 
   url "https://downloads.getmonero.org/gui/monero-gui-mac-x64-v#{version}.tar.bz2"
   appcast 'https://github.com/monero-project/monero-gui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.