### PR TITLE
Update bot-framework-emulator from 4.6.0 to 4.7.0

### DIFF
--- a/Casks/bot-framework-emulator.rb
+++ b/Casks/bot-framework-emulator.rb
@@ -1,6 +1,6 @@
 cask 'bot-framework-emulator' do
-  version '4.6.0'
-  sha256 'a3044a4b1d3cade3a59cd1c87d406c4d135e1ebd1f9a683c5afa2012bdb9ed1a'
+  version '4.7.0'
+  sha256 '1e7b0444538e81bb1b1a1ce6254e0474afcce21105d1da9766db6a517b78b54a'
 
   url "https://github.com/Microsoft/BotFramework-Emulator/releases/download/v#{version}/botframework-emulator-#{version}-mac.zip"
   appcast 'https://github.com/Microsoft/BotFramework-Emulator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.