### PR TITLE
Update thedesk from 20.0.6 to 20.1.0

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '20.0.6'
-  sha256 'd1b08da0c7c811fd31ae7f989944776a6f7bf36cb06f26101d780f665ae7bbdc'
+  version '20.1.0'
+  sha256 '0ee817804d29da046d2a07a7ba2de686775c579685257c6b68d9dff7a394e560'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.