### PR TITLE
Update kite from 0.20191212.0 to 0.20191213.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20191212.0'
-  sha256 'ef38b72047874a169b43e7c72c46db7d8617a0c69cc90c10824c461c65f709e9'
+  version '0.20191213.0'
+  sha256 '7efb0491f4a010afa9944f996546b4d336e1a3da9f54b501085a5a0b9b0a19c2'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.