### PR TITLE
Update iringg from 1.0.42,1568243164 to 1.0.43,1576268168

### DIFF
--- a/Casks/iringg.rb
+++ b/Casks/iringg.rb
@@ -1,6 +1,6 @@
 cask 'iringg' do
-  version '1.0.42,1568243164'
-  sha256 '8d826d665b36285adfeec5877f6c0d8bf54fcbb847df62f0b4039ba834a49b43'
+  version '1.0.43,1576268168'
+  sha256 'de278f40b045fa76a31c4c1f48b0ce3cae3793f0da65f748a06e189879eb5918'
 
   # dl.devmate.com/com.softorino.iringg was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.softorino.iringg/#{version.before_comma}/#{version.after_comma}/iRinggforMac-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.