### PR TITLE
Update brave-browser from 79.1.1.20,101.20 to 79.1.1.21,101.21

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '79.1.1.20,101.20'
-  sha256 '3aebec50a9e07928809c8112459cd96ba1f0536b033fb37be8e1029a441d6730'
+  version '79.1.1.21,101.21'
+  sha256 '8bef23c92132e5e0ddc665ba008632d850d449ed4c1bbdbbff5213eabe8b0b87'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/#{version.after_comma}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.