### PR TITLE
Update copyclip from 2.9.92 to 2.9.95

### DIFF
--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -1,6 +1,6 @@
 cask 'copyclip' do
-  version '2.9.92'
-  sha256 '9806fa5d22e79ecbcd6cb1d217b0b8b6ad723b0fd19619229ec3deaa9b6a67e0'
+  version '2.9.95'
+  sha256 'e0ff793fa16b3e436e219eb6edb76149d463a5161babb6fd675c433cc094b6f7'
 
   # rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379?format=zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.