### PR TITLE
Update metabase from 0.33.6.0 to 0.33.7.1

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,9 +1,9 @@
 cask 'metabase' do
-  version '0.33.6.0'
-  sha256 'cbb66145f7b6d8705983601a519346525305a99275dcc2ea6399bd362752a5e7'
+  version '0.33.7.1'
+  sha256 '67744feb82639db10c6fe0686f710f5bc0df3e953bda09630baaaea264e106db'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/downloads.metabase.com/v#{version.major_minor_patch}/Metabase.zip"
+  url "https://s3.amazonaws.com/downloads.metabase.com/v#{version}/Metabase.zip"
   appcast 'https://s3.amazonaws.com/downloads.metabase.com/appcast.xml'
   name 'Metabase'
   homepage 'https://www.metabase.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.