### PR TITLE
Add zap stanza for Flotato.app

### DIFF
--- a/Casks/flotato.rb
+++ b/Casks/flotato.rb
@@ -7,4 +7,10 @@ cask 'flotato' do
   homepage 'https://flotato.com/'
 
   app 'Flotato.app'
+
+  zap trash: [
+               '/Applications/Flotato Help.app',
+               '~/Library/Application Support/Flotato',
+               '~/Library/WebKit/com.mortenjust.flotato',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This pull request is pretty simple. It just adds a `zap` stanza for `Flotato.app` in `flotato.rb`. As far as I can tell, there are no other files related to this application besides what's included.

Flotato is an application that allows the user to create applications which function as a website. For example, someone could use it to create `GitHub.app`, and it would just be a web browser that only opens GitHub. These custom made apps are not removed by the `zap` stanza because they're functionally user files and they work independently on `Flotato.app` being installed.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
  - Version was not touched in this pull request, so it wasn't included in the commit message.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
