### PR TITLE
Update obs from 24.0.2 to 24.0.5

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -7,19 +7,5 @@ cask 'obs' do
   name 'OBS'
   homepage 'https://obsproject.com/'
 
-  pkg "obs-mac-#{version}-installer.pkg"
-
-  uninstall pkgutil: [
-                       'org.obsproject.pkg.obs-studio',
-                       'zakk.lol.SyphonInject',
-                     ]
-
-  zap trash: [
-               '/Library/Application Support/obs-studio',
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.obsproject.obs-studio.sfl*',
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/zakk.lol.syphoninject.sfl*',
-               '~/Library/Application Support/obs-studio',
-               '/private/var/db/receipts/zakk.lol.SyphonInject.bom',
-               '/private/var/db/receipts/zakk.lol.SyphonInject.plist',
-             ]
+  app "OBS.app"
 end

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -1,8 +1,8 @@
 cask 'obs' do
-  version '24.0.2'
-  sha256 'b4126102224369c9aa36a4de21ad316db43ce771d6d8b92b21571395192eea4d'
+  version '24.0.5'
+  sha256 'bcdfe23ac20ab760456ec74c44f123cf633233cbbf07675e6a16d6a1ddcc9ce1'
 
-  url "https://cdn-fastly.obsproject.com/downloads/obs-mac-#{version}-installer.pkg"
+  url "https://cdn-fastly.obsproject.com/downloads/obs-mac-#{version}.dmg"
   appcast 'https://github.com/obsproject/obs-studio/releases.atom'
   name 'OBS'
   homepage 'https://obsproject.com/'

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -7,5 +7,5 @@ cask 'obs' do
   name 'OBS'
   homepage 'https://obsproject.com/'
 
-  app "OBS.app"
+  app 'OBS.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.