### PR TITLE
Update diskcatalogmaker from 7.5.9 to 7.6

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.5.9'
-  sha256 '9fc1f46e47e37cffbe3ec292a8db90c353cf8e4a6592c978caa21acd1decdfd5'
+  version '7.6'
+  sha256 'd541d979231226edafd1089ceec2dd52373b5043caa5d5f6a44bc2107f2f3960'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.