### PR TITLE
Update dust3d from 1.0.0-beta.27 to 1.0.0-beta.28

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-beta.27'
-  sha256 'fb44d8271f911b9f8027450a936cfbe6c4f2c0b4e14a45c45f23d8bb3e91679f'
+  version '1.0.0-beta.28'
+  sha256 'ab61f3476231e8e0ab99c344fab759beba36ae2638a45850f1f67472f5af395b'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.