### PR TITLE
Update pagico from 9.0.3067 to 9.0.20191214

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -1,6 +1,6 @@
 cask 'pagico' do
-  version '9.0.3067'
-  sha256 '0be368af8b22bacb55c13f64705f8e37154bc2ae50c9fce2db566ec3663907a8'
+  version '9.0.20191214'
+  sha256 '7f13221ff5febbd23dbc58c826c3e341cf26798e7dd901c56e4a24c0f82f298b'
 
   url "https://www.pagico.com/downloads/Pagico_macOS_r#{version.patch}.dmg"
   appcast "https://www.pagico.com/api/pagico#{version.major}.mac.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.