### PR TITLE
Update keymanager from 3.7.10 to 3.9.28

### DIFF
--- a/Casks/keymanager.rb
+++ b/Casks/keymanager.rb
@@ -1,6 +1,6 @@
 cask 'keymanager' do
-  version '3.7.10'
-  sha256 '74820161ce1828a669f7ad56f3787ce51fed5167d8c8a3d746e9d518bb7a1838'
+  version '3.9.28'
+  sha256 'a70f4187f79608de70f40d733a70b942ce15a17c49d653e4270b576cca240c3f'
 
   # keymanager.trustasia.com was verified as official when first introduced to the cask
   url "https://keymanager.trustasia.com/release/KeyManager-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.