### PR TITLE
Update hashbackup from 2447 to 2461

### DIFF
--- a/Casks/hashbackup.rb
+++ b/Casks/hashbackup.rb
@@ -1,6 +1,6 @@
 cask 'hashbackup' do
-  version '2447'
-  sha256 '54ce5fc645bdc77109332f2cd5336d96637e20610161b7e15125ccb6499f77b4'
+  version '2461'
+  sha256 '7a8a22999b22ebda97943f968ef9303555dacd2f0142a77a5d41c4ccc67988e8'
 
   url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.x86_64.bz2"
   name 'hashbackup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.