### PR TITLE
Update biscuit from 1.2.0 to 1.2.1 and add `auto_update`

### DIFF
--- a/Casks/biscuit.rb
+++ b/Casks/biscuit.rb
@@ -1,12 +1,14 @@
 cask 'biscuit' do
-  version '1.2.0'
-  sha256 '93b6c59ce972d8bb2ef2b23606171470013f1d01038963a026c4034820e19927'
+  version '1.2.1'
+  sha256 '59a19b25145598021c27a5d3e5fd3b0a9cd7457a530f01d7ab8c9a19e8510cc6'
 
   # github.com/agata/dl.biscuit was verified as official when first introduced to the cask
   url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}.dmg"
   appcast 'https://github.com/agata/dl.biscuit/releases.atom'
   name 'Biscuit'
   homepage 'https://eatbiscuit.com/'
+
+  auto_updates true
 
   app 'Biscuit.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.