### PR TITLE
Update monal from 2.4.1b5 to 2.5b1

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
-  version '2.4.1b5'
-  sha256 '1c2046be6bf8b3d21e2104192087b5ec169291e54ef5a04c680ee176a9d4e2e6'
+  version '2.5b1'
+  sha256 'd241fda6c68a07171459f83a6e21fe91174b97fcb16b2f84ba5358dea76745da'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.