### PR TITLE
Update marginnote from 3.5.9003,1576017290 to 3.5.9007,1576409180

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,6 +1,6 @@
 cask 'marginnote' do
-  version '3.5.9003,1576017290'
-  sha256 '4a53a85612feea0da868ddb356a9214af48bb2ea239da3856cbc64803b054163'
+  version '3.5.9007,1576409180'
+  sha256 '4132d81bd9b88ea1cbf05385e64431210ea03c8bba152a1a799651264eae4245'
 
   # dl.devmate.com/QReader.MarginStudyMac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/QReader.MarginStudyMac/#{version.before_comma}/#{version.after_comma}/MarginNote#{version.major}-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.