### PR TITLE
Update mp3gain-express from 2.3 to 2.3.1

### DIFF
--- a/Casks/mp3gain-express.rb
+++ b/Casks/mp3gain-express.rb
@@ -1,6 +1,6 @@
 cask 'mp3gain-express' do
-  version '2.3'
-  sha256 '6694a128e418cfa59e77fb3a302349b233bf308bcc92410b14da4d9d82b0fe34'
+  version '2.3.1'
+  sha256 '325efe7fc36480540ce963d480ce5bc04c1c12da6efb7c47e3fb07134fb0c812'
 
   url "https://projects.sappharad.com/mp3gain/mp3gain_mac#{version.no_dots}.zip"
   appcast 'https://projects.sappharad.com/mp3gain/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.