### PR TITLE
Update wpsoffice from 1.8.1,2821 to 1.8.2,2861

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
-  version '1.8.1,2821'
-  sha256 'fb69d6798354138073134f0ba345ad19ea69f25731bcbe60f0c1c5536c718399'
+  version '1.8.2,2861'
+  sha256 '9b2543cb8b611b864ee5826e1ecec9add3c8d5baf249c9f4fb3475bf763fae9d'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
   url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}(#{version.after_comma}).dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.