### PR TITLE
Update glip from 19.11.1 to 19.12.1

### DIFF
--- a/Casks/glip.rb
+++ b/Casks/glip.rb
@@ -1,6 +1,6 @@
 cask 'glip' do
-  version '19.11.1'
-  sha256 '77c720fd1cdb37683aa79c8a227dedc895106851d8594c817c4cf39771c77c5d'
+  version '19.12.1'
+  sha256 '5f4bde149829f61a002ae8f174199db29100064717fddad5329b6b81850733c6'
 
   # downloads.ringcentral.com/glip/rc was verified as official when first introduced to the cask
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.