### PR TITLE
Update j from 807 to 901

### DIFF
--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -1,6 +1,6 @@
 cask 'j' do
-  version '807'
-  sha256 '3c78500eded82cd70dfff522ae61c54c0b7b8e746e43535e47f8e4c9df0987bd'
+  version '901'
+  sha256 '2d38088504f900075334c549d487769aa899e628aa7c0384092fddd2a1614678'
 
   url "https://www.jsoftware.com/download/j#{version}/install/j#{version}_mac64.zip"
   name 'J'

--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -8,34 +8,35 @@ cask 'j' do
 
   apps = ['jbrk', 'jcon', 'jhs', 'jqt']
   apps.each do |a|
-    app "j64-#{version}/#{a}.app"
+    app "j#{version}/#{a}.app"
   end
 
+  installer script: "j#{version}/macos-fix.command"
   installer script: {
-                      executable: "j64-#{version}/bin/jconsole",
-                      args:       ['-js', "exit install'qtide'"],
+                      executable: "j#{version}/bin/jconsole",
+                      args:       ['-js', "load 'pacman'", "'install' jpkg '*'", 'exit 0'],
                     }
 
   # target names according to readme.txt
   ['jcon', 'jconsole'].each do |b|
-    binary "j64-#{version}/bin/jconsole", target: b
+    binary "j#{version}/bin/jconsole", target: b
   end
   commands = ['jbrk', 'jhs', 'jqt']
   commands.each do |b|
-    binary "j64-#{version}/bin/#{b}.command", target: b
+    binary "j#{version}/bin/#{b}.command", target: b
   end
 
   postflight do
     # Use `readlink` to get full path of symlinked commands.
     commands.each do |c|
-      command = "#{staged_path}/j64-#{version}/bin/#{c}.command"
+      command = "#{staged_path}/j#{version}/bin/#{c}.command"
       IO.write command, IO.read(command).gsub('$0', '$(/usr/bin/readlink "$0" || /bin/echo "$0")')
     end
 
     # Fix relative paths inside App bundles.
     apps.each do |a|
       apprun = "#{appdir}/#{a}.app/Contents/MacOS/apprun"
-      IO.write apprun, IO.read(apprun).gsub(%r{`dirname "\$0"`.*?/bin}, "#{staged_path}/j64-#{version}/bin")
+      IO.write apprun, IO.read(apprun).gsub(%r{`dirname "\$0"`.*?/bin}, "#{staged_path}/j#{version}/bin")
     end
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.