### PR TITLE
Update openwebstart from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/openwebstart.rb
+++ b/Casks/openwebstart.rb
@@ -1,6 +1,6 @@
 cask 'openwebstart' do
-  version '1.1.0'
-  sha256 'aaa7915e57d002d7ea8d85110f3b1debe0332c0877f2daf4d34d5f2b154093b4'
+  version '1.1.1'
+  sha256 'd79f0859a00c89954289ca4b33b28daf2b58a17d2845fc632dd7a2df4ef03fd0'
 
   # github.com/karakun/OpenWebStart was verified as official when first introduced to the cask
   url "https://github.com/karakun/OpenWebStart/releases/download/v#{version}/OpenWebStart_macos_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.