### PR TITLE
Update reaper from 6.01 to 6.20.0,602

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -2,7 +2,7 @@ cask 'reaper' do
   version '6.20.0,6.02'
 
   if MacOS.version <= :mojave
-    sha256 '05f5eedf73ece7f928c32aa7bdc0bfd799503f3f9fba5a2ed990b6ee4237e91e'
+    sha256 '7880daac2682e56531f435639f69cddea0a05117ef105faad01afe04ae245869'
 
     url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"
   else

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,14 +1,14 @@
 cask 'reaper' do
-  version '6.01'
+  version '6.20.0,602'
 
   if MacOS.version <= :mojave
     sha256 '05f5eedf73ece7f928c32aa7bdc0bfd799503f3f9fba5a2ed990b6ee4237e91e'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma}_x86_64.dmg"
   else
-    sha256 'f53b892b0337f147206a2842aafe3c9cd3d1217cf1bc439cb513aec7198119fa'
+    sha256 'b85b2ccd3f95faf5b91fb2fc572114d25ce246a12ef4775dba25090c308ecb2d'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64_catalina.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma}_x86_64_catalina.dmg"
   end
 
   appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,17 +1,18 @@
 cask 'reaper' do
-  version '6.20.0,602'
+  version '6.20.0,6.02'
 
   if MacOS.version <= :mojave
     sha256 '05f5eedf73ece7f928c32aa7bdc0bfd799503f3f9fba5a2ed990b6ee4237e91e'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma}_x86_64.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"
   else
     sha256 'b85b2ccd3f95faf5b91fb2fc572114d25ce246a12ef4775dba25090c308ecb2d'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma}_x86_64_catalina.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64_catalina.dmg"
   end
 
-  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'
+  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',
+          configuration: version.after_comma
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.