### PR TITLE
Update synergy from 1.10.3,b139:ca35737a to 1.11.0,b193:b2173efb

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,8 +1,8 @@
 cask 'synergy' do
-  version '1.10.3,b139:ca35737a'
-  sha256 '1417914cc2402526b51fe3045de12ce0d0861675860fb908db9bda7d94e60320'
+  version '1.11.0,b193:b2173efb'
+  sha256 '6f8de72793e69e6d55f32c2edd0e4f76031bf1f776b4c58789edd4ce94a72d8d'
 
-  url "https://binaries.symless.com/synergy/v#{version.before_comma.major}-core-standard/v#{version.before_comma}-stable-#{version.after_colon}/synergy_#{version.before_comma}-stable_#{version.after_comma.before_colon}-#{version.after_colon}_macos.dmg"
+  url "https://binaries.symless.com/synergy/v#{version.before_comma.major}-core-standard/v#{version.before_comma}-stable-#{version.after_colon}/synergy_v#{version.before_comma}-stable_#{version.after_comma.before_colon}-#{version.after_colon}_macos.dmg"
   appcast 'https://github.com/symless/synergy-core/releases.atom'
   name 'Synergy'
   homepage 'https://symless.com/synergy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.