### PR TITLE
Update latexit from 2.14.0 to 2.14.1

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,6 +1,6 @@
 cask 'latexit' do
-  version '2.14.0'
-  sha256 '2017e607f343ee25a04d0e13d35bc9a17ce549e01cb8609c659ddbe32e49b426'
+  version '2.14.1'
+  sha256 '39c366360321890de09b342a950a59d3e8cdf8db19703e8dac95b6a3479834a6'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.