### PR TITLE
Update decrediton from 1.4.0 to 1.5.0

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,6 +1,6 @@
 cask 'decrediton' do
-  version '1.4.0'
-  sha256 '990cb6b61999be5d1100581cc84bb95f4e9e5be8a5330c5e6c8940c34fe78b19'
+  version '1.5.0'
+  sha256 '10bf6ecbba2e5c51624c1b4ef1c61dd2465c02e5241d4fc9ce810567fe97c005'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.