### PR TITLE
Update sidequest from 0.8.1 to 0.8.2

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,6 +1,6 @@
 cask 'sidequest' do
-  version '0.8.1'
-  sha256 '019d1525ca4a3da1f4261bda88950d58aabbabf72502e2fdb9ff02b856f1c2bc'
+  version '0.8.2'
+  sha256 '847866b4431ad0fab7b6aa27a85479b6567c3bcf6f3a9ef4c38c6145c8c09c79'
 
   # github.com/the-expanse/SideQuest was verified as official when first introduced to the cask
   url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.