### PR TITLE
Update shotcut from 19.10.20 to 19.12.16

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '19.10.20'
-  sha256 '7601bc7405767e03a5c61a2c630e2c0465e982e80ea8e22c5326197f3b845cdf'
+  version '19.12.16'
+  sha256 '50bcebcc5259c10a71210a353a35f3797e8a444cc7c94fa335556eae215c2e7c'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.