### PR TITLE
Update brave-browser from 79.1.1.21,101.21 to 79.1.1.22,101.22

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '79.1.1.21,101.21'
-  sha256 '8bef23c92132e5e0ddc665ba008632d850d449ed4c1bbdbbff5213eabe8b0b87'
+  version '79.1.1.22,101.22'
+  sha256 '1689fb625ee59480587c9183bacd557ec8b783220f4ad8a2f72c226b7efe8d8c'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/#{version.after_comma}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.