### PR TITLE
Update futuniuniu from 9.10.564_201910142014 to 9.12.584_201912041835

### DIFF
--- a/Casks/futuniuniu.rb
+++ b/Casks/futuniuniu.rb
@@ -1,6 +1,6 @@
 cask 'futuniuniu' do
-  version '9.10.564_201910142014'
-  sha256 'f08e87d9a0efcafb7a4569cee387ee6323be0d03edc2cbe62750e2446856a063'
+  version '9.12.584_201912041835'
+  sha256 '406dfc1af6c54063ad80c220f1842c2aa9e640340b22113854b31a0af589c6d6'
 
   # software-file-1251001049.file.myqcloud.com was verified as official when first introduced to the cask
   url "https://software-file-1251001049.file.myqcloud.com/FTNNForMac_#{version}_website.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.