### PR TITLE
Update sigil from 0.9.18 to 1.0.0

### DIFF
--- a/Casks/sigil.rb
+++ b/Casks/sigil.rb
@@ -1,6 +1,6 @@
 cask 'sigil' do
-  version '0.9.18'
-  sha256 'ecda56b7c6b4daac89c1c2eb38ac69cba7e5edbcd9a65d27be9e40d8e16100f9'
+  version '1.0.0'
+  sha256 '1db9f16460b4d2ff6a83556c58d380ba7bd2a1b741ff0c0c2c7fca3ed6b60321'
 
   # github.com/Sigil-Ebook/Sigil was verified as official when first introduced to the cask
   url "https://github.com/Sigil-Ebook/Sigil/releases/download/#{version}/Sigil.app-#{version}-Mac.txz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.