### PR TITLE
Update lehreroffice from 2019.12.2 to 2019.13.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.12.2'
-  sha256 '43a6202753089676c57add31c5ba63cb84f42880d4ff40f64a45ff033fed2c20'
+  version '2019.13.0'
+  sha256 '52280b1d9a29dfc52bde6cacc85c6b297f701c3ec6a8c293c3a5c12574cc0a7d'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.