### PR TITLE
Update bluestacks from 4.140.12.2834,7cd2a9f03632af41d802f1b6e143b9f6 to 4.140.12.2902,4804ca37dfe9b788ed01b47f9d19bdd9

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -1,6 +1,6 @@
 cask 'bluestacks' do
-  version '4.140.12.2834,7cd2a9f03632af41d802f1b6e143b9f6'
-  sha256 '6459c6fb499c7a228aaf3ea16e0ea69342374b2d5b6937834e4f99ba1c4c540f'
+  version '4.140.12.2902,4804ca37dfe9b788ed01b47f9d19bdd9'
+  sha256 '2bdac4e3a7706726c195fab3bc1fe1f5c20b46c8c2455151aec224ef6ffb3e0a'
 
   url "https://cdn3.bluestacks.com/downloads/mac/bgp64_mac/#{version.before_comma}/#{version.after_comma}/x64/BlueStacksInstaller_#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://cloud.bluestacks.com/api/getdownloadnow?platform=mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.