### PR TITLE
Update vuescan from 9.7.12 to 9.7.13

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.12'
-  sha256 '94725345a1e9d303e98f33f9dd45c7f2b8747f36a65fc08843378bd23a1153e1'
+  version '9.7.13'
+  sha256 '4943794b7e36c0a3cd735057470f3eea2baa89f2a4090f28228f442d4c3cc71a'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.