### PR TITLE
Update electron from 7.1.4 to 7.1.6

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '7.1.4'
-  sha256 'fd37d03c28436d0d5a87c8c9218716b3815c86803880a108113792b921ec979d'
+  version '7.1.6'
+  sha256 '78c5d4001ff6f54cd96c114ffbd7f970fedfc56e9a425315717dba3b7291387f'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.