### PR TITLE
Update netron from 3.6.3 to 3.6.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.6.3'
-  sha256 '2ea0261ae20137a54430bb0deae8a960d8a6e534867b356f0053af8e04fe5fbb'
+  version '3.6.4'
+  sha256 '3114206b19057433d085c2e4ecd5c3e8a28ace1893adfb03cb861cbd717181cc'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.