### PR TITLE
New cask: Loom 0.26.0

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -3,6 +3,7 @@ cask 'loom' do
   sha256 '2a595c78130498f088e1f5aa70350c238126470681a5ead4afad0c321b0d0a3a'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
+  appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'
   name 'Loom'
   homepage 'https://www.loom.com/'
 

--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,0 +1,10 @@
+cask 'loom' do
+  version '0.26.0'
+  sha256 '2a595c78130498f088e1f5aa70350c238126470681a5ead4afad0c321b0d0a3a'
+
+  url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
+  name 'Loom'
+  homepage 'https://www.loom.com/'
+
+  app 'Loom.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

Several years ago, there used to be a startup called Loom which did photo management and sharing. Loom [used to be in Homebrew Cask](https://github.com/Homebrew/homebrew-cask/pull/2825), but [it was removed in 2015](https://github.com/Homebrew/homebrew-cask/pull/10711) because [the company was acquired by Dropbox](https://techcrunch.com/2014/04/17/dropbox-acquires-cloud-photos-startup-loom-service-to-be-shut-down-as-users-transferred-to-carousel/) and shut down.

Now, there is a _different_ startup also called [Loom](https://www.loom.com/), which does video management and sharing. Despite the identical name and similar value proposition, this is a _different company_. This pull request adds the client application for the new Loom to Homebrew Cask.