### PR TITLE
Update banking-4 from 7.2.2,7272 to 7.2.2.7289

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.2.2,7272'
-  sha256 '331ddc867919a0a6474ed9969d1e1a886e33b4601d94004337fbd4a968cf35f2'
+  version '7.2.2.7289'
+  sha256 'c234e70b1aafd4ea7a4b1daa5d191cbf91551a15b262edbb9f7388642c8f25f9'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.