### PR TITLE
Update veracrypt from 1.24-Hotfix1 to 1.24-Update2

### DIFF
--- a/Casks/veracrypt.rb
+++ b/Casks/veracrypt.rb
@@ -1,6 +1,6 @@
 cask 'veracrypt' do
-  version '1.24-Hotfix1'
-  sha256 '5515766ebac14dcc3e397f0afd24f31f998a4a3c69571ea40b990772fede679c'
+  version '1.24-Update2'
+  sha256 'a19fb3897a74e5eac557f3e4442c6e450879b34ac3ab631976a306c4bfdc3258'
 
   # launchpad.net/veracrypt/trunk was verified as official when first introduced to the cask
   url "https://launchpad.net/veracrypt/trunk/#{version.downcase}/+download/VeraCrypt_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.