### PR TITLE
Update mp3gain-express from 2.3.1 to 2.3.2

### DIFF
--- a/Casks/mp3gain-express.rb
+++ b/Casks/mp3gain-express.rb
@@ -1,6 +1,6 @@
 cask 'mp3gain-express' do
-  version '2.3.1'
-  sha256 '325efe7fc36480540ce963d480ce5bc04c1c12da6efb7c47e3fb07134fb0c812'
+  version '2.3.2'
+  sha256 'ae217c3a6e6106a8bb8dab91b2526b551bd395bc677164b2461f267b36b8ba99'
 
   url "https://projects.sappharad.com/mp3gain/mp3gain_mac#{version.no_dots}.zip"
   appcast 'https://projects.sappharad.com/mp3gain/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.