### PR TITLE
Update tencent-lemon from 3.0.1 to 3.1.0

### DIFF
--- a/Casks/tencent-lemon.rb
+++ b/Casks/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask 'tencent-lemon' do
-  version '3.0.1'
-  sha256 '1855e5f615041a7ed5fc52e6f27a6db13103723abc67814487b30943d915f648'
+  version '3.1.0'
+  sha256 'dd445dd1d1551e53e7dd72da8578d2b07f38260239f463ad126b7cf1eb7f823f'
 
   # pm.myapp.com/invc/xfspeed/qqpcmgr was verified as official when first introduced to the cask
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/Lemon_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.