### PR TITLE
Fix perforce shasum for new 19.2 release updated in place

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask 'perforce' do
   version '19.2'
-  sha256 :no_check # required as upstream package is updated in-place'
+  sha256 '6a67de554be77ba7d12c0ca807181bbeae6ea954d65c44c1bebc728170fe0ddc'
 
   url "https://cdist2.perforce.com/perforce/r#{version}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'

--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -2,7 +2,7 @@ cask 'perforce' do
   version '19.2'
   sha256 :no_check # required as upstream package is updated in-place'
 
-  url "https://cdist2.perforce.com/perforce/r#{version.major_minor}/bin.macosx1010x86_64/helix-core-server.tgz"
+  url "https://cdist2.perforce.com/perforce/r#{version}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'
   homepage 'https://www.perforce.com/'
 

--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask 'perforce' do
   version '19.2'
-  sha256 'b39f2c2c16ba268d4a9e5a2b6be4a063d7cc4da573cdc4accf9bdf803ca45d95'
+  sha256 :no_check # required as upstream package is updated in-place'
 
   url "https://cdist2.perforce.com/perforce/r#{version.major_minor}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Archive was changed in-place so the sha256 check doesn't work anymore:
```
$ brew cask install perforce
==> Caveats
Instructions on using the Helix Versioning Engine are available in

  /usr/local/Caskroom/perforce/19.2

==> Downloading https://cdist2.perforce.com/perforce/r19.2/bin.macosx1010x86_64/helix-core-server.tgz
Already downloaded: /Users/salvadorj/Library/Caches/Homebrew/downloads/4cb11ae50817efc20a22f83bf15c33e1c79837011d47f80243e49775e9d81563--helix-core-server.tgz
==> Verifying SHA-256 checksum for Cask 'perforce'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
Error: Checksum for Cask 'perforce' does not match.
Expected: b39f2c2c16ba268d4a9e5a2b6be4a063d7cc4da573cdc4accf9bdf803ca45d95
  Actual: 6a67de554be77ba7d12c0ca807181bbeae6ea954d65c44c1bebc728170fe0ddc
    File: /Users/salvadorj/Library/Caches/Homebrew/downloads/4cb11ae50817efc20a22f83bf15c33e1c79837011d47f80243e49775e9d81563--helix-core-server.tgz
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/master/doc/reporting_bugs/checksum_does_not_match_error.md
```