### PR TITLE
Update multipass from 0.10.0 to 1.0.0

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask 'multipass' do
-  version '0.10.0'
-  sha256 '1359cffaaefe44044659f0101fcf4f0f96f1d1ba30d2756c4c56cf4e6c6f3275'
+  version '1.0.0'
+  sha256 'd52e2e5cc139499d134a970a2f3ab319c88eaca80c2d0e0e2662eb2c3d97c723'
 
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast 'https://github.com/CanonicalLtd/multipass/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.