### PR TITLE
Update Wireshark 3.2.0 to use wireshark.org's appcast URL.

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -3,10 +3,11 @@ cask 'wireshark' do
   sha256 'a1f5b86d3ae8a2be38db218d07ad1d123315433292adae71a9756bbc881438ee'
 
   url "https://1.na.dl.wireshark.org/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.wireshark.org/download.html&splitter_1=stable&index_1=1&splitter_2=development&index_2=0'
+  appcast "https://www.wireshark.org/update/0/Wireshark/#{version}/macOS/x86-64/en-US/stable.xml"
   name 'Wireshark'
   homepage 'https://www.wireshark.org/'
 
+  auto_updates true
   conflicts_with cask: 'wireshark-chmodbpf'
   depends_on macos: '>= :sierra'
 

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -3,7 +3,7 @@ cask 'wireshark' do
   sha256 'a1f5b86d3ae8a2be38db218d07ad1d123315433292adae71a9756bbc881438ee'
 
   url "https://1.na.dl.wireshark.org/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
-  appcast "https://www.wireshark.org/update/0/Wireshark/0.0.0/macOS/x86-64/en-US/stable.xml"
+  appcast 'https://www.wireshark.org/update/0/Wireshark/0.0.0/macOS/x86-64/en-US/stable.xml'
   name 'Wireshark'
   homepage 'https://www.wireshark.org/'
 

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -3,7 +3,7 @@ cask 'wireshark' do
   sha256 'a1f5b86d3ae8a2be38db218d07ad1d123315433292adae71a9756bbc881438ee'
 
   url "https://1.na.dl.wireshark.org/osx/all-versions/Wireshark%20#{version}%20Intel%2064.dmg"
-  appcast "https://www.wireshark.org/update/0/Wireshark/#{version}/macOS/x86-64/en-US/stable.xml"
+  appcast "https://www.wireshark.org/update/0/Wireshark/0.0.0/macOS/x86-64/en-US/stable.xml"
   name 'Wireshark'
   homepage 'https://www.wireshark.org/'
 


### PR DESCRIPTION
Wireshark 3.2.0 adds automatic updates using Sparkle. Switch to the
macOS appcast URL on www.wireshark.org and set auto_updates to true.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).