### PR TITLE
Update superproductivity from 3.0.3 to 3.0.4

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '3.0.3'
-  sha256 '467eaebc147e34743296f6315291d41bff6cc5e9ac9a501247795cd9c0e29c0d'
+  version '3.0.4'
+  sha256 '5cd3a39c3be9e9196dbb82ec72bc404df6c94d0bc756847704ab50a69e5619a1'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.