### PR TITLE
Update wavebox from 4.11.9 to 4.11.11

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.11.9'
-  sha256 'b3ef0f0d4112b319d9fa2497a0d6ff6cc087f9a33dcdc9afe86bc74b1ac5a2df'
+  version '4.11.11'
+  sha256 '2405c51c27c85c8e1f8e4556d7911ceaeb778d776c808bd78c58c40b9bd66c4b'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.