### PR TITLE
Update stoplight-studio from 1.6.2 to 1.7.0

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.6.2'
-  sha256 'b07010e3a42000ba4c8a6f55241a386cc94844a01c5e0db890268c9cc40ad5b2'
+  version '1.7.0'
+  sha256 'b4b035421d0808030e2e99fe6a7065f693060a5a1ca6acb26ae9c9fb3172a921'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.