### PR TITLE
Update monal from 2.4.1b5 to 2.5b3

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
-  version '2.4.1b5'
-  sha256 '1c2046be6bf8b3d21e2104192087b5ec169291e54ef5a04c680ee176a9d4e2e6'
+  version '2.5b3'
+  sha256 '891b9c9c46cc1069970701940a37f9769fb15943ce4ae1aaaca46fc4b35556c0'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,10 +1,10 @@
 cask 'monal' do
-  version '2.5b3'
+  version '2.5 beta 3,155'
   sha256 '891b9c9c46cc1069970701940a37f9769fb15943ce4ae1aaaca46fc4b35556c0'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',
-          configuration: version.major_minor
+          configuration: version.after_comma
   name 'Monal'
   homepage 'https://monal.im/'
 

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
   version '2.5 beta 3,155'
-  sha256 '891b9c9c46cc1069970701940a37f9769fb15943ce4ae1aaaca46fc4b35556c0'
+  sha256 'ec4e2afb9620d26bb2b597ab8f6cc6051eabd6453634c13cdaf9afecf6b70a35'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,5 +1,5 @@
 cask 'monal' do
-  version '2.5 beta 3,155'
+  version '2.5 beta 4,156'
   sha256 'ec4e2afb9620d26bb2b597ab8f6cc6051eabd6453634c13cdaf9afecf6b70a35'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.