### PR TITLE
Update tg-pro from 2.45 to 2.46

### DIFF
--- a/Casks/tg-pro.rb
+++ b/Casks/tg-pro.rb
@@ -1,6 +1,6 @@
 cask 'tg-pro' do
-  version '2.45'
-  sha256 '0d7408f07fa7f9f9d0727239aaacbf42b0928ff75c68177848c380be1fcc580c'
+  version '2.46'
+  sha256 '1f30cf5edba08cda768acff9bdd94ec249ebaaf9f3e31472e2e1d9fc36831cf4'
 
   url "https://www.tunabellysoftware.com/resources/TG%20Pro%20#{version}.dmg"
   appcast 'https://www.tunabellysoftware.com/resources/sparkle/tgpro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.