### PR TITLE
Update timemator from 2.0.1 to 2.0.2

### DIFF
--- a/Casks/timemator.rb
+++ b/Casks/timemator.rb
@@ -1,6 +1,6 @@
 cask 'timemator' do
-  version '2.0.1'
-  sha256 '1225a71adb70004f14edb9c10d8e218a3ca38b7c85fbcea3535217b255d2cf0c'
+  version '2.0.2'
+  sha256 'd31979481b5661963b3eae8d61c83e20ebaee30b2b1f9b635e56ad025e248e10'
 
   # catforce-timemator.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://catforce-timemator.s3.amazonaws.com/releases/Timemator.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.