### PR TITLE
Update obs from 24.0.5 to 24.0.6

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -1,6 +1,6 @@
 cask 'obs' do
-  version '24.0.5'
-  sha256 'bcdfe23ac20ab760456ec74c44f123cf633233cbbf07675e6a16d6a1ddcc9ce1'
+  version '24.0.6'
+  sha256 '7cb521f4eaeebf5807991d22604fd08af146728d1df7a1f4f6c38230f2f32a0d'
 
   url "https://cdn-fastly.obsproject.com/downloads/obs-mac-#{version}.dmg"
   appcast 'https://github.com/obsproject/obs-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.