### PR TITLE
Update pocket-casts from 1.3 to 1.3.1

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,6 +1,6 @@
 cask 'pocket-casts' do
-  version '1.3'
-  sha256 'fef5f2054d025ada804eca9bb3af0447c3f90787c1ddd6d80fd9f83f72b1bcf5'
+  version '1.3.1'
+  sha256 '788309d86fac93b273d0309aac3ffd6c7a1f3bc3f76096fcab3df5ac232039ac'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
   appcast 'https://static2.pocketcasts.com/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.