### PR TITLE
Update nucleo from 2.5.5 to 2.6.0

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,6 +1,6 @@
 cask 'nucleo' do
-  version '2.5.5'
-  sha256 '2cbe0e752f87a5fef86b59a180e78ec249a710fba56eea7144f5e1dd6eab9e59'
+  version '2.6.0'
+  sha256 'faf199b5708b69564c9127e41d2b03fb06f9426e07a68d77d0dbb60a78dd5a37'
 
   # nucleo-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://nucleo-app-releases.s3.amazonaws.com/mac/Nucleo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.