### PR TITLE
Update shift from 4.0.6 to 4.0.9

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,6 +1,6 @@
 cask 'shift' do
-  version '4.0.6'
-  sha256 '32b6a5875f784826d800b0b93dc5a3024cfa5f105085842aff02eeb8e85d2846'
+  version '4.0.9'
+  sha256 '54cd7b140bc1b3a4522c380a1f177c3c2091019f5ca90ef65be8d483561b6d07'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"
   appcast 'https://tryshift.com/download/?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.