### PR TITLE
Update ableton-live-suite from 10.1.5 to 10.1.6

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite' do
-  version '10.1.5'
-  sha256 'a5bdf073fd74e34307d3aa14aa2f26d49e104865547079651d94282a57a9fd30'
+  version '10.1.6'
+  sha256 '64c8f0edff44cf4b87ae9b1954031b3568977d150de6b633f11c85c609e78104'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.