### PR TITLE
Update screaming-frog-seo-spider from 12.3 to 12.4

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -1,6 +1,6 @@
 cask 'screaming-frog-seo-spider' do
-  version '12.3'
-  sha256 '446e907954a7abfaeb341b57a6aacc57f0b416fe2c4db3ee13abb1ab52a47f50'
+  version '12.4'
+  sha256 '0a00bb6fca07687a5d61d98f8cbbe394378c7cea22515d33a7aab68f3db059d2'
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   appcast 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.