### PR TITLE
Update ableton-live-standard from 10.1.5 to 10.1.6

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard' do
-  version '10.1.5'
-  sha256 '66b33914d617864a104f86381007070637cbd6ac2af74ec7b65c2478b8213745'
+  version '10.1.6'
+  sha256 '5433febb9ab9edb35d635f7cc34f1d93b400ea7b7cea1b1169aa6ce3626e1926'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.