### PR TITLE
Update ableton-live from 10.1.5 to 10.1.6

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live' do
-  version '10.1.5'
-  sha256 '7a501294ce131cbb1558b1e3aa3343e3590072d9794bf1dc88966b21fc51e824'
+  version '10.1.6'
+  sha256 '26741d72756c71a7b8891fd5b97f3804699f74d000dc00157a054d80b501d847'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.