### PR TITLE
Update staruml from 3.2.0 to 3.2.1

### DIFF
--- a/Casks/staruml.rb
+++ b/Casks/staruml.rb
@@ -1,6 +1,6 @@
 cask 'staruml' do
-  version '3.2.0'
-  sha256 '1b84fc011eeeb6ad71d4442c8232557c4cb68d9ebcd771b710a0fac3053b4307'
+  version '3.2.1'
+  sha256 'a39ad940c95a93c47be1f491a8072a62428574e9b0eda1d64025a9bfbff657a2'
 
   url "http://staruml.io/download/releases/StarUML-#{version}.dmg"
   appcast 'http://staruml.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.