### PR TITLE
Update scidavis from 1.25.1 to 1.26

### DIFF
--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -1,6 +1,6 @@
 cask 'scidavis' do
-  version '1.25.1'
-  sha256 '5bce640bf16b6df9a0733684db5366c9982aa39a79bb6dc9f6a3e289653b79ff'
+  version '1.26'
+  sha256 'bc49df3fc712cdcfee7804bf5e6b6e3d378e4178e07e6f664e05795b93829a1b'
 
   # downloads.sourceforge.net/scidavis was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scidavis/scidavis-#{version}-mac-dist.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.