### PR TITLE
Update eclipse-java from 4.13.0,2019-09:R to 4.14.0,2019-12:R

### DIFF
--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-java' do
-  version '4.13.0,2019-09:R'
-  sha256 '6e1a79f6d4199eca12693313c1f4a213e36c310781c2acb038e0cf15939965c8'
+  version '4.14.0,2019-12:R'
+  sha256 'c6eecdebfea42fc3801c842d107be28cf45ce894c9aa618bcdb60e08093c911b'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.