### PR TITLE
Update brook from 20190601 to 20200101

### DIFF
--- a/Casks/brook.rb
+++ b/Casks/brook.rb
@@ -1,11 +1,13 @@
 cask 'brook' do
-  version '20190601'
-  sha256 '221c3e4fc2a0505fc76638b76d94fe2535b8f3d84b7640dc4fafad56523156f4'
+  version '20200101'
+  sha256 'ee4fbeba88fa57bb0702612ba32e8e5d04036eaad3740f58c38788406b692a47'
 
-  url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.dmg"
+  url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.pkg"
   appcast 'https://github.com/txthinking/brook/releases.atom'
   name 'Brook'
   homepage 'https://github.com/txthinking/brook'
 
-  app 'Brook.app'
+  pkg 'Brook.pkg'
+
+  uninstall pkgutil: 'com.txthinking.base.pkg'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.