### PR TITLE
Update navicat-for-sqlite from 15.0.4 to 15.0.5

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.4'
-  sha256 'ce148a3b182b413dc79d05f8bce6066ef62fae797d22979eea777f786ecd73fd'
+  version '15.0.5'
+  sha256 '9dfb154306e20dff4111be45de2cfa36dd5fa7187a8b6531dfb32845a6582497'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.