### PR TITLE
Update melodics from 2.1.3888 to 2.1.3936

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.3888'
-  sha256 '1fb6312314c8e88f1758f3f61b753fdc162f8eb40e654b5ecf0eb531bdeaad2b'
+  version '2.1.3936'
+  sha256 'f8c6b3fcceb46a666eaf61ced6c3972cd3249aff4949724a5d2566e660c421d4'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.