### PR TITLE
Update navicat-for-oracle from 15.0.4 to 15.0.5

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '15.0.4'
-  sha256 '93853defa51d98b659de55a0f313b8034399fd2ad81a9bafabd0704aae63c5ad'
+  version '15.0.5'
+  sha256 '090daee3d79a6e3162d475ae2b4739359a1d31c85556d7891b524fb9247296f5'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.