### PR TITLE
Update cleanmymac from 4.5.1,1575024206 to 4.5.2,1576752725

### DIFF
--- a/Casks/cleanmymac.rb
+++ b/Casks/cleanmymac.rb
@@ -1,6 +1,6 @@
 cask 'cleanmymac' do
-  version '4.5.1,1575024206'
-  sha256 '5726b24dc1cd76ff71c38dee5fd8d8fcb09b1f8ab89a4c7ca8a2548390cd9070'
+  version '4.5.2,1576752725'
+  sha256 'ae73f245f2296af57cc3b8cfeeb8f136b54105a67c990acd70ac653c03091b56'
 
   # devmate.com/com.macpaw.CleanMyMac was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.CleanMyMac#{version.major}/#{version.major_minor_patch}/#{version.after_comma}/CleanMyMacX-#{version.major_minor_patch}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.