### PR TITLE
Update navicat-for-sql-server from 15.0.4 to 15.0.5

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.4'
-  sha256 'ed462c247e0ef150335cce624956082a37067744e582960fcf07b5d6073758bc'
+  version '15.0.5'
+  sha256 '9cc75eb4e5f3cf6fc4c155deabb6e8f448fe38f162f91a4004e578955b229eb9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.