### PR TITLE
Update routeconverter from 2.26.69 to 2.27.88

### DIFF
--- a/Casks/routeconverter.rb
+++ b/Casks/routeconverter.rb
@@ -1,5 +1,5 @@
 cask 'routeconverter' do
-  version '2.26.69'
+  version '2.27.88'
   sha256 'ade167e527527a84e3a51df37b99622f1e3a0a4934656ee4ba088df4e780dda9'
 
   url 'https://static.routeconverter.com/download/RouteConverterMac.app.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.