### PR TITLE
Update nomachine from 6.8.2_1 to 6.9.2_1

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -1,6 +1,6 @@
 cask 'nomachine' do
-  version '6.8.2_1'
-  sha256 '72326d10545f372d99d7ebed7b97e3154abd46d41a4a0bfb2131273389d591f0'
+  version '6.9.2_1'
+  sha256 '253bea1c7658a4301d536280b3bdd93533cb90ee85c56a2b6a1f662b3a1d7090'
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   appcast 'https://www.nomachine.com/download/download&id=7'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.