### PR TITLE
Update beatunes from 5.2.2 to 5.2.3

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,6 +1,6 @@
 cask 'beatunes' do
-  version '5.2.2'
-  sha256 'd3e2e102898c651722e6c11c66b7da3d4e63af0942638ef2475904aef52c2f57'
+  version '5.2.3'
+  sha256 '8f9aa40dbfd6d41d930beef2b8b3025a48d93301f01fdfaa766de1a64ffab3d3'
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   appcast 'https://www.beatunes.com/en/beatunes-download.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.