### PR TITLE
Update cutter from 1.9.0 to 1.10.0

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.9.0'
-  sha256 'f5024f3eec251656ed5c5983fc04a47d0691d585818fc76abb60ae49ef9d3217'
+  version '1.10.0'
+  sha256 '3d0bd39f332e52e5a9a1bd141db0b24cd7e86eb351bd1e6099039bc577b8acb3'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.