### PR TITLE
Update blitz from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.6.0'
-  sha256 '3628baeb92ec6c524ba82896b46b145fe9501dbf63fd10948094a271cb3c5144'
+  version '1.6.1'
+  sha256 '0d4bd856a5b6e2ddc37892c6cf3305400497cb83ef16f51edd974d199fafd3b1'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.