### PR TITLE
Update jamf-migrator from 4.1.3 to 5.0.0

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '4.1.3'
-  sha256 'd1a081ecf3d9a4153763e74fc346fb9a8f301a4d262df073f208171c219205ff'
+  version '5.0.0'
+  sha256 '637265a6b22195c4b70f9720459e9fb92aceef83960486be830a1be19aa9a3ec'
 
   url 'https://github.com/jamf/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamf/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.