### PR TITLE
Update qownnotes from 19.12.11,b5080-152431 to 19.12.13,b5087-173206

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.11,b5080-152431'
-  sha256 '5bb7ee6a7e8322e91f48ec66ac99d7532e31680b721ecdd56c4e5337703cb299'
+  version '19.12.13,b5087-173206'
+  sha256 '5100555f5c79c71c5d0963dc185d7220a4b52f63c143a367e75e2eb7a3359107'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.