### PR TITLE
Update rocket-chat from 2.17.1 to 2.17.2

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask 'rocket-chat' do
-  version '2.17.1'
-  sha256 '22d346893272dd415f9b9e51068b43a6e4e4e83f8c5d8847a31f9ed0f3c466d4'
+  version '2.17.2'
+  sha256 'a67b4b0a873382828065dab79718535993cb3b24aed3361853f2b5835e041689'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.