### PR TITLE
Update vnote from 2.8.1 to 2.8.2

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,6 +1,6 @@
 cask 'vnote' do
-  version '2.8.1'
-  sha256 'dec52b9ff4f8352cfe9a19cd97a9684038c10f9dc5d0fe076d56449115318df4'
+  version '2.8.2'
+  sha256 '043ac56b11a04c7614e1adf43235035925e2aa3735524e884ace6bb14192b705'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.