### PR TITLE
Update navicat-for-sqlite from 15.0.5 to 15.0.6

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,5 +1,5 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.5'
+  version '15.0.6'
   sha256 '9dfb154306e20dff4111be45de2cfa36dd5fa7187a8b6531dfb32845a6582497'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.