### PR TITLE
Update navicat-for-postgresql from 15.0.5 to 15.0.6

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,5 +1,5 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.5'
+  version '15.0.6'
   sha256 'cf7f620f19ea603fc74913a6b28176221df30d534818c8ec4e10f00ec5db9feb'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.