### PR TITLE
Update framer-x from 36826,1576240508 to 36830,1576846115

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,6 +1,6 @@
 cask 'framer-x' do
-  version '36826,1576240508'
-  sha256 '1d7cf76424dccef88cfc16a8803e70d49cf44ae9a7844e0a86fa5326f7bd9ff9'
+  version '36830,1576846115'
+  sha256 'c6282262f56672a7d42fe99b02510fddede54a25cb1095e6a36d8e6fba2fcd82'
 
   # dl.devmate.com/com.framer.x was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.