### PR TITLE
Update big-mean-folder-machine from 2.40 to 2.41

### DIFF
--- a/Casks/big-mean-folder-machine.rb
+++ b/Casks/big-mean-folder-machine.rb
@@ -1,6 +1,6 @@
 cask 'big-mean-folder-machine' do
-  version '2.40'
-  sha256 '1d2e2bfa6eab3b5adb817447e3590dc2617833a7514c889185cb0bf45253048f'
+  version '2.41'
+  sha256 'd5ac6ccdc6dc01d518b69576b0d969a1d784f7170746ddccd343e8f2977204fa'
 
   url 'https://www.publicspace.net/download/BMFM.dmg'
   appcast "https://www.publicspace.net/app/bmfm#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.