### PR TITLE
Update navicat-premium from 15.0.5 to 15.0.6

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,5 +1,5 @@
 cask 'navicat-premium' do
-  version '15.0.5'
+  version '15.0.6'
   sha256 '8461c26958c7bb7ca1f9ce4715b4f1fd852b46208b9e988a54b3559796e8362e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.