### PR TITLE
Update command-tab-plus from 1.105,357:1576760900 to 359,359:1576772358

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask 'command-tab-plus' do
-  version '1.105,357:1576760900'
-  sha256 '2bb441b6c8cd65f34dfe4072e97178808a6bdd8fb6eceec2b1de5fd90454a244'
+  version '359,359:1576772358'
+  sha256 '608458aa55d699f6c1d21a6bc834365d0787174b4f34b266dad8f267acfdc328'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.