### PR TITLE
Update navicat-for-mariadb from 15.0.5 to 15.0.6

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,5 +1,5 @@
 cask 'navicat-for-mariadb' do
-  version '15.0.5'
+  version '15.0.6'
   sha256 '99c780b70f088b97e8d9c3f6e3a7fa0519461ba53a73a4237988f3ac20298825'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.