### PR TITLE
Update navicat-for-sql-server from 15.0.5 to 15.0.6

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,5 +1,5 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.5'
+  version '15.0.6'
   sha256 '9cc75eb4e5f3cf6fc4c155deabb6e8f448fe38f162f91a4004e578955b229eb9'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.