### PR TITLE
Update freedom from 2.2.4 to 2.2.5

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,6 +1,6 @@
 cask 'freedom' do
-  version '2.2.4'
-  sha256 '9f32c73526f49ed75de49d7884de473d148eddc5718db37bf2a1a415b354a7fb'
+  version '2.2.5'
+  sha256 'c10d7a8a95387237a30eeba889f9ee0570efc75da783dd117704c9f1e635929e'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.