### PR TITLE
Update deezer from 4.18.10 to 4.18.11

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.18.10'
-  sha256 '92c0443958c548e325e6ab546d64b19e4282c962d1da53f55c86c0a879d77a15'
+  version '4.18.11'
+  sha256 'e265d83772dd29056846b3a7a2fd13cb944194e4aaac529cad65b3446db708f0'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.