### PR TITLE
Update dcp-o-matic-encode-server from 2.14.18 to 2.14.19

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.18'
-  sha256 'e30bedea174696a1273f20e871e3400a0d1209f122fc7fbefd497b6134720ae6'
+  version '2.14.19'
+  sha256 '357dfd704ae231563b523096115a31921334d1aa27260b05cee380c8d8be98ed'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.