### PR TITLE
Update dcp-o-matic from 2.14.18 to 2.14.19

### DIFF
--- a/Casks/dcp-o-matic.rb
+++ b/Casks/dcp-o-matic.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic' do
-  version '2.14.18'
-  sha256 'e0ec579844f74d0d66f6a02b5bd9dbf7d7788663a460ae4fb777ccdd1ebfc888'
+  version '2.14.19'
+  sha256 'c27bed5ded06c4ea6031f361d167a9073923e68815d4c45bb0671f870f524e1d'
 
   url "https://dcpomatic.com/dl.php?id=osx-main&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.