### PR TITLE
Update 4k-youtube-to-mp3 from 3.10.0.3243 to 3.10.1.3255

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.10.0.3243'
-  sha256 '326947dd57e7336ded79f1a8822fe86bda8ab22cd616dafca07fbc695ad4eb4c'
+  version '3.10.1.3255'
+  sha256 '1a60cbf6f0bb901a492891d120ee39efc0ecf57c2ace82b4f85f6786019614d0'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.