### PR TITLE
Update netron from 3.6.7 to 3.6.8

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.6.7'
-  sha256 '213c723e63435fd09a1638b5464f7921cc0e38f15f6a39948971bed27f7b9d4e'
+  version '3.6.8'
+  sha256 '984b23d524f2789df62f51ebf334943a5309270bdaf8e30e704a2b94ad470dc5'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.