### PR TITLE
Update weka from 3.8.3 to 3.8.4

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,13 +1,13 @@
 cask 'weka' do
-  version '3.8.3'
-  sha256 '3ff3f75619f0e175ab4605ef7289e55d53d005bf84fd8385722256bd60e257ab'
+  version '3.8.4'
+  sha256 '312347853807fad45dff5afd2bc293a4c5face03e4bf16a5f0ae9b10b53aaf2a'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
+  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-azul-zulu-osx.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://waikato.github.io/weka-wiki/downloading_weka/&splitter_1=trunk&index_1=0',
           configuration: version.dots_to_hyphens
   name 'Weka'
   homepage 'https://www.cs.waikato.ac.nz/ml/weka/'
 
-  app "weka-#{version.dots_to_hyphens}-corretto-jvm.app"
+  app "weka-#{version.dots_to_hyphens}-azul-zulu.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.