### PR TITLE
Correction of the version notation in command-tab-plus.rb from 359,359… to 1.109,359…

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -4,7 +4,8 @@ cask 'command-tab-plus' do
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"
-  appcast 'https://updates.devmate.com/com.sergey-gerasimenko.Command-Tab.xml'
+  appcast 'https://updates.devmate.com/com.sergey-gerasimenko.Command-Tab.xml',
+          configuration: version.after_comma.before_colon
   name 'Command-Tab Plus'
   homepage 'http://commandtab.noteifyapp.com/'
 

--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,5 +1,5 @@
 cask 'command-tab-plus' do
-  version '359,359:1576772358'
+  version '1.109,359:1576772358'
   sha256 '608458aa55d699f6c1d21a6bc834365d0787174b4f34b266dad8f267acfdc328'
 
   # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask


### PR DESCRIPTION
there was a mistake in the notation of the version number - should be: short version string,bundle version:downloadtoken