### PR TITLE
Update qownnotes from 19.12.13,b5087-173206 to 19.12.14,b5095-092849

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.13,b5087-173206'
-  sha256 '5100555f5c79c71c5d0963dc185d7220a4b52f63c143a367e75e2eb7a3359107'
+  version '19.12.14,b5095-092849'
+  sha256 'a1e136fa62f0581725bf466784ff7ee43d0dad1ca5b55a6444a08c1a9e5fbdb6'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.