### PR TITLE
Update weka from 3.8.3 to 3.8.4

### DIFF
--- a/Casks/eclipse-javascript.rb
+++ b/Casks/eclipse-javascript.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-javascript' do
-  version '4.13.0,2019-09:R'
-  sha256 '35d650642a557b740624409e7952ff9a7d39c85a401669dc1119d3b797cdec67'
+  version '4.14.0,2019-12:R'
+  sha256 'e12d99702d59894efd18f7cbc9aeb955f55350d52195227a36f271975ee51ff2'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-javascript-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for JavaScript and Web Developers'

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -1,9 +1,9 @@
 cask 'weka' do
-  version '3.8.3'
-  sha256 '3ff3f75619f0e175ab4605ef7289e55d53d005bf84fd8385722256bd60e257ab'
+  version '3.8.4'
+  sha256 '312347853807fad45dff5afd2bc293a4c5face03e4bf16a5f0ae9b10b53aaf2a'
 
   # sourceforge.net/weka was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-corretto-jvm.dmg"
+  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-azul-zulu-osx.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://waikato.github.io/weka-wiki/downloading_weka/&splitter_1=trunk&index_1=0',
           configuration: version.dots_to_hyphens
   name 'Weka'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.