### PR TITLE
Update battlescribe from 2.03.10 to 2.03.11

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.10'
-  sha256 'efaa96644192767b440298906f6e08933a58902a78ddde247037557ff7b1a65d'
+  version '2.03.11'
+  sha256 '4418ec733cce89dd5151c9fabb487a9ab5963aea00893134cfcf1294d349a15a'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
   appcast 'https://battlescribe.net/?tab=downloads'

--- a/Casks/eclipse-javascript.rb
+++ b/Casks/eclipse-javascript.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-javascript' do
-  version '4.13.0,2019-09:R'
-  sha256 '35d650642a557b740624409e7952ff9a7d39c85a401669dc1119d3b797cdec67'
+  version '4.14.0,2019-12:R'
+  sha256 'e12d99702d59894efd18f7cbc9aeb955f55350d52195227a36f271975ee51ff2'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-javascript-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for JavaScript and Web Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.