### PR TITLE
Update unity from 2019.2.16f1,b9898e2d04a4 to 2019.2.17f1,8e603399ca02

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.16f1,b9898e2d04a4'
-  sha256 '6b3bc284c759c17483fa09bd3c8f58fa1f66812421ce0d13b0f92b4462d0eebf'
+  version '2019.2.17f1,8e603399ca02'
+  sha256 'd1f011ef8310a68fd407bf66986362aa40ff4bf464bc1313849d1eb8418571e9'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.