### PR TITLE
Update unity-lumin-support-for-editor from 2019.2.16f1,b9898e2d04a4 to 2019.2.17f1,8e603399ca02

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.2.16f1,b9898e2d04a4'
-  sha256 '3a2e97facce1709e8883bb75406c421f8d015b476fc93d7c1a797e44b0e9f372'
+  version '2019.2.17f1,8e603399ca02'
+  sha256 'b2fda57ea153005cd38348391e48f08d24ce377252964f205f8682a0d91f4096'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.