### PR TITLE
Update unity-windows-support-for-editor from 2019.2.16f1,b9898e2d04a4 to 2019.2.17f1,8e603399ca02

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.2.16f1,b9898e2d04a4'
-  sha256 '93ecbc3229645b7040d1713f4de6be5fcc641e910a0087f15100ed65f58d946a'
+  version '2019.2.17f1,8e603399ca02'
+  sha256 '5b893035969e5f44046f678ec24343bb0711b01008ba39686bc91f89566cc2b4'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.