### PR TITLE
Update polar-bookshelf from 1.70.4 to 1.80.10

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.70.4'
-  sha256 '842a89b138e4889d20f39203325c837da1580ca231f6c58904c33f75b4ea98b7'
+  version '1.80.10'
+  sha256 'b613e5cc583e4811431fdfe1c7248c43e0a0e6b1caca0057a6aeefbb40b48852'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.