### PR TITLE
Update wasabi-wallet from 1.1.10 to 1.1.10.1

### DIFF
--- a/Casks/wasabi-wallet.rb
+++ b/Casks/wasabi-wallet.rb
@@ -1,6 +1,6 @@
 cask 'wasabi-wallet' do
-  version '1.1.10'
-  sha256 'd26d830cbfbfc77d3690e95ce0efc88ef32710c508b3fb33e6edfbb9ee7b0ba5'
+  version '1.1.10.1'
+  sha256 '4c7898daa7ffec5f79e0860fd7339778243abe689113d31defa623ac9fbb3e2d'
 
   # github.com/zkSNACKs/WalletWasabi was verified as official when first introduced to the cask
   url "https://github.com/zkSNACKs/WalletWasabi/releases/download/v#{version}/Wasabi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.