### PR TITLE
Update wechatwork from 2.8.19.2015 to 3.0.0.2009

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '2.8.19.2015'
-  sha256 'da0257acc7e7e5225dfab64c799742ef03e48a2d070d799b979294af37fc03a7'
+  version '3.0.0.2009'
+  sha256 '37764d9bc4564a8c5995342817c8442e311d17ca47238f57cb3ec8bc3d06b4d4'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.