### PR TITLE
Update eclipse-platform from 4.13,201909161045 to 4.14.0,2019-12:R

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.13,201909161045'
-  sha256 '5c014eb7c200388a629b6a037ea037e933253680777214bfff630290af9d9191'
+  version '4.14.0,2019-12:R'
+  sha256 '83f0aa6fd2598ccaf3fdda8c287e599e3db5fbd665d6597ace3aef457f234f46'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.