### PR TITLE
Update qcad from 3.23.0 to 3.24.0

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,12 +1,12 @@
 cask 'qcad' do
-  version '3.23.0'
+  version '3.24.0'
 
   if MacOS.version <= :high_sierra
-    sha256 '8668cf4407331bac9cdfeed2a735eb34a9bf8b29d9982c693416d0c36ab412c7'
+    sha256 '785bed422b5fe01cb286ab9091b316b37bb208523ad83eba5edbf4f3135af947'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 '50e721239e6384f836e360c527b0d2b855bbe19da00512620f5ed059274f1daa'
-    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14.dmg"
+    sha256 '6662bb59ee93396b69322f4271992a54e3cc6dc04ce76b105022e1d55885e7e8'
+    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14-10.15.dmg"
   end
 
   appcast 'https://www.qcad.org/en/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.