### PR TITLE
Update eclipse-platform from 4.13,201909161045 to 4.14,201912100610

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.13,201909161045'
-  sha256 '5c014eb7c200388a629b6a037ea037e933253680777214bfff630290af9d9191'
+  version '4.14,201912100610'
+  sha256 '94bb5066a346de86f6ded0e762f7518ed82950b0dcb31a34493a1e7c58f749ef'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.