### PR TITLE
Update hook from 2947,1575524372 to 1.3.3,10

### DIFF
--- a/Casks/hook.rb
+++ b/Casks/hook.rb
@@ -1,10 +1,10 @@
 cask 'hook' do
-  version '2947,1575524372'
-  sha256 '19e5279af842c15029898b0f0d66dfbc6e6c8a872bc174cee3be12fe783b5ece'
+  version '1.3.3,10'
+  sha256 '725241d6bb79ef0f2588b9bb9bf4e929e449cb0e346d60597727b08854a3b338'
 
-  # dl.devmate.com/com.cogsciapps.hook was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.cogsciapps.hook/#{version.before_comma}/#{version.after_comma}/Hook-#{version.before_comma}.dmg"
-  appcast 'https://updates.devmate.com/com.cogsciapps.hook.xml'
+  # rink.hockeyapp.net/api/2/apps/a77a1a877d69435d90ea7365b2f7bddb was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/a77a1a877d69435d90ea7365b2f7bddb/app_versions/#{version.after_comma}?format=zip"
+  appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/a77a1a87-7d69-435d-90ea-7365b2f7bddb'
   name 'Hook'
   homepage 'https://hookproductivity.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.