### PR TITLE
Update brook from 20200101 to 20200102

### DIFF
--- a/Casks/brook.rb
+++ b/Casks/brook.rb
@@ -1,5 +1,5 @@
 cask 'brook' do
-  version '20200101'
+  version '20200102'
   sha256 'ee4fbeba88fa57bb0702612ba32e8e5d04036eaad3740f58c38788406b692a47'
 
   url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.