### PR TITLE
Update elpass from 1.0.4,164 to 1.0.5,172

### DIFF
--- a/Casks/elpass.rb
+++ b/Casks/elpass.rb
@@ -1,6 +1,6 @@
 cask 'elpass' do
-  version '1.0.4,164'
-  sha256 'e33b2ef4a18c2e8c4a285ffaf865d64ca1c8a8f456754481423554799c21b797'
+  version '1.0.5,172'
+  sha256 '42c37a847585ba5d394edf96ba027f019e0d8477dc058985e82a358158e2fcf0'
 
   url "https://elpass.app/macos/Elpass-#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://elpass.app/macos/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.