### PR TITLE
Update qownnotes from 19.12.14,b5095-092849 to 19.12.15,b5100-080726

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.14,b5095-092849'
-  sha256 'a1e136fa62f0581725bf466784ff7ee43d0dad1ca5b55a6444a08c1a9e5fbdb6'
+  version '19.12.15,b5100-080726'
+  sha256 '7b869d3a5bed01642b6972d1c62da9ea2a9bc7a4321d17368e195f015b8cf9a4'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.