### PR TITLE
Update blitz from 1.6.2 to 1.6.3

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.6.2'
-  sha256 '9aaa6d544125758f599196480b984c67c0437790faba5b07297122f6a90f4434'
+  version '1.6.3'
+  sha256 '096d92991bd52976c6560381ddc3b575e70940c7d6403133d1733503d72c16c9'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.