### PR TITLE
Update jsui from 0.0.24 to 0.0.25

### DIFF
--- a/Casks/jsui.rb
+++ b/Casks/jsui.rb
@@ -1,6 +1,6 @@
 cask 'jsui' do
-  version '0.0.24'
-  sha256 '28972f9f941360b23a29a5646233c75eb564c831600b3182ea1e6e9f54d8932c'
+  version '0.0.25'
+  sha256 'c262c5875ff90521a7785b17de011acb3dce54e67e124c64ec005b87ef897736'
 
   url "https://github.com/kitze/JSUI/releases/download/v#{version}/JSUI-#{version}-mac.zip"
   appcast 'https://github.com/kitze/JSUI/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.