### PR TITLE
Update moonlight from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/moonlight.rb
+++ b/Casks/moonlight.rb
@@ -1,6 +1,6 @@
 cask 'moonlight' do
-  version '1.2.0'
-  sha256 'd27c185f031986050a13b0d2983c87c1b6dc8af0b3f50570788c0423a1fe1204'
+  version '1.2.1'
+  sha256 'e93ebbd3954763653262ac6dc955c340a8ae1d8273fda49cc9f6f48c4c9e6956'
 
   # github.com/moonlight-stream/moonlight-qt was verified as official when first introduced to the cask
   url "https://github.com/moonlight-stream/moonlight-qt/releases/download/v#{version}/Moonlight-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.