### PR TITLE
Update lbry from 0.38.0 to 0.38.2

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.38.0'
-  sha256 'dd2df5b31b96f4466fc2bfa8f4fad6fccae62c3cfea71e09f570c3fb764c69a3'
+  version '0.38.2'
+  sha256 '5b0b31a9842c299668c1115f7c2dd2c9f2430386a4556cb4353485c510176e5a'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.