### PR TITLE
Update stellarium from 0.19.2 to 0.19.3

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,6 +1,6 @@
 cask 'stellarium' do
-  version '0.19.2'
-  sha256 'e64f8c73aa9db7734db1b419cc002ccbfa6650e4af6f6a1625fd2874ece474cb'
+  version '0.19.3'
+  sha256 '58e649ddbefdf13cbb56af6a195a29620e15d2be3e1dc9431da541123b51c853'
 
   # github.com/Stellarium/stellarium was verified as official when first introduced to the cask
   url "https://github.com/Stellarium/stellarium/releases/download/v#{version}/Stellarium-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.