### PR TITLE
Update colorsnapper from 1.6.0 to 1.6.2

### DIFF
--- a/Casks/colorsnapper.rb
+++ b/Casks/colorsnapper.rb
@@ -1,6 +1,6 @@
 cask 'colorsnapper' do
-  version '1.6.0'
-  sha256 '3a1c3c98201554a67e141cade48cd6508c2ffb0af2c6c441fa53e1d3761871b4'
+  version '1.6.2'
+  sha256 '687cfc23035804db63bca7fff606ab512c1297d057e0da6d7424f1e29ec427de'
 
   # cs2-binaries.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://cs2-binaries.s3.amazonaws.com/ColorSnapper2-#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.