### PR TITLE
Update sizzy from 0.12 to 0.13.1

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.12'
-  sha256 '2bd63371a35acba0e6abd07df9a073a5a4c1e7841656fa5be0dce8ebc315a007'
+  version '0.13.1'
+  sha256 'f3a8f0226d22c596cf42e5b312d732744f09936c668af2c8fd1a85bbff50ad4f'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.