### PR TITLE
Update elpass from 1.0.5,172 to 1.0.5,173

### DIFF
--- a/Casks/elpass.rb
+++ b/Casks/elpass.rb
@@ -1,6 +1,6 @@
 cask 'elpass' do
-  version '1.0.5,172'
-  sha256 '42c37a847585ba5d394edf96ba027f019e0d8477dc058985e82a358158e2fcf0'
+  version '1.0.5,173'
+  sha256 '250a1aed16cf07de1394bf51d1cb2ec4c6bd0366106180f467095dc2d98d063d'
 
   url "https://elpass.app/macos/Elpass-#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://elpass.app/macos/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.