### PR TITLE
Update seashore from 2.4.16 to 2.4.17

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.4.16'
-  sha256 'b6bbb1b71176c82fd12f69fcbdc409f4e9f521c4253ccef99279fd7482ab7820'
+  version '2.4.17'
+  sha256 '901aae8fa490668bd65f23ae7926a70de6c60305b8cbbf3af3f2ef96960c70ed'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.