### PR TITLE
Update macx-dvd-ripper-pro from 6.5.0,20191023 to 6.5.1,20191223

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.5.0,20191023'
-  sha256 '77b68a26e2a8ff6eb9c1792f12c4748a294bbec36a5d6721089358ced39f82f7'
+  version '6.5.1,20191223'
+  sha256 '291758ace70b0a11c3bef51f442d8ee93ce1a2f8b5fed9ead186b093803e6f4c'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
   appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.