### PR TITLE
Update manuskript from 0.9.0 to 0.10.0

### DIFF
--- a/Casks/manuskript.rb
+++ b/Casks/manuskript.rb
@@ -1,6 +1,6 @@
 cask 'manuskript' do
-  version '0.9.0'
-  sha256 'aef7bfa96524d2905a983722bb80ad8f1e057b8cf4c3a0aac03bdd22894c7ef8'
+  version '0.10.0'
+  sha256 'f48f9c96af19b42c61a1ab6119e581e9398c33a8795ba5051cc0d44add1d2d7f'
 
   # github.com/olivierkes/manuskript was verified as official when first introduced to the cask
   url "https://github.com/olivierkes/manuskript/releases/download/#{version.major_minor_patch}/manuskript-#{version}-osx.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.