### PR TITLE
Update thunderbird from 68.3.0 to 68.3.1

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,83 +1,83 @@
 cask 'thunderbird' do
-  version '68.3.0'
+  version '68.3.1'
 
   language 'cs' do
-    sha256 '325ccac98745303803ccac862b9dd7b0828e18ab32072d3dd3a87b9d6dccd66c'
+    sha256 '8496d7df00ea211a9aef368dff48f85ca13419c869b9d6f55b91ce19d2edf66c'
     'cs'
   end
 
   language 'de' do
-    sha256 '568a44005a09011d50b779eb223bc1de189c5e354f6eabcaa05d220ff6702dfe'
+    sha256 '7947da3966a3af6100d75c36b22dd21ecc004afdab8ec4de078e291ad96af32d'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '4168dacf3962c8cdda3283731d7e6eea747cfe6f4cc368f33b3f53923c7337a0'
+    sha256 'f8cec7853b6e741c81383f431025bfa13f48f1bd29ae688a682926f66bb78fd6'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'abbd224676bbfc3b66ba19097879c6a06c8f6e7bcd0f9e6974eb7541f7650ef0'
+    sha256 '6c352d7d12cb9a32d11332a4fba3b95d4ffbcda4e883459007341cb364694139'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '83ad465e9540130f5741b5ae5c90ad5680d2767f4fb460f8b6721fce289f3d48'
+    sha256 'd7ae81288d75523af70ab83a75e1edbcd409c0190162c3a72a547ea123ca161f'
     'fr'
   end
 
   language 'gl' do
-    sha256 '73bb3bab5cfe7bc6d3156f1129a4e7c5be9ba878d7fb7cada3aad3bb0449f9f1'
+    sha256 '2fe7cc94a363bb561d3b79324ee4087f42037498623124b836ccfed4b0c9b464'
     'gl'
   end
 
   language 'it' do
-    sha256 '71698227c9f7d2c85a546434e809fd71b7a5bf1b7c12950d59f086c5a7c0e125'
+    sha256 'c219a4876bfe544e7564de4ff389e1ad549a5e3fac22b4d57ee12bed80a01c53'
     'it'
   end
 
   language 'ja' do
-    sha256 'afe9da9ede996009d8f08bb0168f94a719fc28d1e1a0e5d766b3e7ca1e02a42b'
+    sha256 '12959ee779f9168dad50a5073d4b7601c225802d0159653d14aaeb7b1045b469'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '785e868279e6527d8729a55453cb8ab57f6ee68431a91fbe8928506a65691837'
+    sha256 '9d6d1250d302a506f2d7f807d3e296b076f0a29f331e47833a54951f8b569145'
     'nl'
   end
 
   language 'pl' do
-    sha256 'bba8a9e84328a62f55b2493fef29917398473e03f78edae443f3121bb1b634b2'
+    sha256 'b14cb1584e7f750a336cbe9831878afa6b13d7e9155c535919b922ec3155cb65'
     'pl'
   end
 
   language 'pt' do
-    sha256 '307b914f27aaa141869d4f766ec641d6e6f94f115670011a57ed8cb1a152bcde'
+    sha256 'd616b3a92e647b43d9294b2b8d22c22290db3ed6b0b4f4de8697b6f9699a9ffa'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '39d22d24551da3ca82a5b7c77fcce3bc2155293932b72771f5ebcdda3d42f332'
+    sha256 '66c65c6d36c16544d214bbb7b1685d5d42e9936f72467bd88b0e24c6c677ccf2'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '397e5935c58b3aa81e135f3360e0e0acd138303f1214fbb393e71bf75920db70'
+    sha256 '5ab55fd027c297b5ee4706bb24065fb267667579282ebd22c53c54d30a462f31'
     'ru'
   end
 
   language 'uk' do
-    sha256 '9ee7bd55796bf66a1d8ba572bfc4a22b3b594c6f340c75e5a45f435f47e2358a'
+    sha256 'b3659e7514fdb0b293a2a06b1e3bf93c2813e0c41d9b62a131a475681d9549f8'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '61ac63c703156d76dcba3a63270e95f98ae68b10c7f0210b35c61adddde47b82'
+    sha256 '08d0d0da51bf21b4f3f9fd0d6728f700409f1c47bc0c047dc87abb98991cbeec'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'f22c0218f2477fb3228885903071fc656a537436545416021478735f23a198a7'
+    sha256 '5546c4abdfc806f93a96ebe3aaca85795af4b6371980428a246db464b34516eb'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
