### PR TITLE
Update electron from 7.1.6 to 7.1.7

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '7.1.6'
-  sha256 '78c5d4001ff6f54cd96c114ffbd7f970fedfc56e9a425315717dba3b7291387f'
+  version '7.1.7'
+  sha256 '4f64b610112c936b7455f4a5588ba1e87bff8634f726736c1cbf11b08c1a9302'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.