### PR TITLE
Update vuescan from 9.7.13 to 9.7.14

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.13'
-  sha256 '77e024e4b5737744b627d3b34f53d619112d493ddf419e9752fcb0c6db51f701'
+  version '9.7.14'
+  sha256 '1a2013fe9d4af8784e7f200c783f85d0b699e8fe0fd74e02025529e94ac1d2e8'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.