### PR TITLE
Update trinity from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/trinity.rb
+++ b/Casks/trinity.rb
@@ -1,6 +1,6 @@
 cask 'trinity' do
-  version '1.2.0'
-  sha256 '0012d6e734ce1edb2211133eeb534fca9d87181b85e7e2dff26c7d2e58211521'
+  version '1.2.1'
+  sha256 '924f8a902d6724e3cc009e0bda6f836e769033362e5d4ebed39c052738edd6c1'
 
   # github.com/iotaledger/trinity-wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/trinity-wallet/releases/download/desktop-#{version}/trinity-desktop-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.