### PR TITLE
Update station from 1.63.1 to 1.63.2

### DIFF
--- a/Casks/station.rb
+++ b/Casks/station.rb
@@ -1,6 +1,6 @@
 cask 'station' do
-  version '1.63.1'
-  sha256 'e1ff74cca99cf39a24fcdd01b9343a8e47686b3da87809f25b4546ea9923a454'
+  version '1.63.2'
+  sha256 '3ee0210920aa838b073c2f669a0666f3e143b5b5c605487dbe9e450a2958482e'
 
   # github.com/getstation/desktop-app-releases was verified as official when first introduced to the cask
   url "https://github.com/getstation/desktop-app-releases/releases/download/#{version}/Station-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.