### PR TITLE
Update hands-off from 4.4.0 to 4.4.1

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '4.4.0'
-  sha256 'a4aa07a33ca903723ecda64c6b28d7dcdee183a94a03fb2f86c38a53b94f40e2'
+  version '4.4.1'
+  sha256 '76f796f04ad39b6c70e7f8306ef917fc88d0a663c2a6d6b8e3f51376c0a066bc'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.