### PR TITLE
Update vox from 3395.1,1575047276 to 3396.1,1576865164

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,6 +1,6 @@
 cask 'vox' do
-  version '3395.1,1575047276'
-  sha256 '7b5287251365dea2535ee60813561106036a4475c24f350aaa6c1063ba55c5e8'
+  version '3396.1,1576865164'
+  sha256 '6cce7ffa64fbf51a82a7fdb59131594c3d5e87932da5f3305877c767bc18b89e'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.coppertino.Vox/#{version.before_comma}/#{version.after_comma}/Vox-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.