### PR TITLE
Update macpilot from 11.0.4 to 11.0.5

### DIFF
--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -1,6 +1,6 @@
 cask 'macpilot' do
-  version '11.0.4'
-  sha256 '2db7806f18c7634d192e939b6520af09c75f9cd295bd4d03533f44bffcb9a239'
+  version '11.0.5'
+  sha256 '805d66245cce47e71a09c8eccf51b9ffa2c23b4136ebdf38477bac5c1e1e4d6c'
 
   url 'http://mirror.koingosw.com/products/macpilot/download/macpilot.dmg'
   appcast 'https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.