### PR TITLE
Update massreplaceit from 3.0 to 3.1

### DIFF
--- a/Casks/massreplaceit.rb
+++ b/Casks/massreplaceit.rb
@@ -1,6 +1,6 @@
 cask 'massreplaceit' do
-  version '3.0'
-  sha256 'b1a5eb1e8a3196a15e10ee82185a7f15c44e27a39742b4506e274a17391a2033'
+  version '3.1'
+  sha256 'e9e0c51af2f35543a979519bc2e3cf202c81518977de18e80388d9fdd1bab097'
 
   url 'http://www.hexmonkeysoftware.com/files/MassReplaceIt.dmg'
   appcast 'http://www.hexmonkeysoftware.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.