### PR TITLE
Update loom from 0.26.0 to 0.26.1

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.26.0'
-  sha256 '2a595c78130498f088e1f5aa70350c238126470681a5ead4afad0c321b0d0a3a'
+  version '0.26.1'
+  sha256 'e99ea7ba08da91be713073d1d67da6ddc97d65d69e2be8abaf3b57ac18cfddfb'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.