### PR TITLE
Update netron from 3.6.9 to 3.7.0

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.6.9'
-  sha256 'c6d8b5d16334b0c913459f0fac1b236b97ac1d3145963f64c6aa76eb68b6a834'
+  version '3.7.0'
+  sha256 'f72e4f25416a63e031976dfde9fb57e0eaa18e87e4dbe6058539a5e54676d04b'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.