### PR TITLE
Update bitwig-studio from 3.1 to 3.1.1

### DIFF
--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -1,6 +1,6 @@
 cask 'bitwig-studio' do
-  version '3.1'
-  sha256 'a7a0e00249f2618196bee7c835f817fde68e012d1e6c9d703a705db59fcc94cf'
+  version '3.1.1'
+  sha256 'e6d0703f96b9dafdae8c05cdc2453080821d92a0732795eddcd46fba9beeb776'
 
   url "https://downloads.bitwig.com/stable/#{version}/Bitwig%20Studio%20#{version}.dmg"
   appcast 'https://www.bitwig.com/en/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.