### PR TITLE
Update hazel from 4.4.2 to 4.4.4

### DIFF
--- a/Casks/hazel.rb
+++ b/Casks/hazel.rb
@@ -1,6 +1,6 @@
 cask 'hazel' do
-  version '4.4.2'
-  sha256 'e8c1bae5fcfc1adc48904b09035f95a648a6daee0b0f2d76612b3a4453391b91'
+  version '4.4.4'
+  sha256 '4419e2a2930d3650778bffa53ef006985cd9de266dfd0b9ac3c686407fdafe01'
 
   # s3.amazonaws.com/Noodlesoft was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/Noodlesoft/Hazel-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.