### PR TITLE
Update ghidra from 9.1 to 9.1.1

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,6 +1,6 @@
 cask 'ghidra' do
-  version '9.1_PUBLIC,20191023'
-  sha256 '29d130dfe85da6ec45dfbf68a344506a8fdcc7cfe7f64a3e7ffb210052d1875e'
+  version '9.1.1_PUBLIC,20191218'
+  sha256 'b0d40a4497c66011084e4a639d61ac76da4b4c5cabd62ab63adadb7293b0e506'
 
   url "https://www.ghidra-sre.org/ghidra_#{version.before_comma}_#{version.after_comma}.zip"
   name 'Ghidra'


### PR DESCRIPTION
Changes the version number as well as hash to the new release

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
