### PR TITLE
Update visual-paradigm from 16.1,20191231 to 16.1,20191237

### DIFF
--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -1,6 +1,6 @@
 cask 'visual-paradigm' do
-  version '16.1,20191231'
-  sha256 '6b1a7a050d69217f6c41ef203542d84cbb4402efcda53d96047d3db9b0b58972'
+  version '16.1,20191237'
+  sha256 'cbac2019f205eef9d5b181973d53b2e0649ab6cb71d183668e3cc6fe3b4ef442'
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.visual-paradigm.com/downloads/vp/checksum.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.