### PR TITLE
Update trilium-notes from 0.38.2 to 0.38.3

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.38.2'
-  sha256 'c9c5981e60131ab4a309046765cd137c55ca5cc7d48db257b55670a44607c343'
+  version '0.38.3'
+  sha256 'b771ea76546ca956eebc38703bf5ac6f009919fb4cf569f463eacff44a632638'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.