### PR TITLE
Update alt-tab from 1.14.3 to 1.14.4

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.14.3'
-  sha256 '35e82eba842c806eff7e242eb763e6c22b9eca6283a57bd72e8dd2e34a8e9e49'
+  version '1.14.4'
+  sha256 '17be1d2b692f1d4f871ba1ed9e519fb0401bb6a845f96bbdb8ace3cba2ed5ba8'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.