### PR TITLE
Update ledger-live from 1.19.2 to 1.20.0

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.19.2'
-  sha256 '78433006f2f59acccc97eb4ccc83adc2d737e9ccb41f69c30b05cb192ad6f99b'
+  version '1.20.0'
+  sha256 '5964b2c5d40f656b03e09c79a80546bf8a22b98559a2fd8e1485059e62f8a6fb'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.