### PR TITLE
Update timely from 1.0.9 to 1.0.10

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,6 +1,6 @@
 cask 'timely' do
-  version '1.0.9'
-  sha256 '3aa1746e0931e139a52b0d2c792c759fb57742a320ecab0074a1cdbb030209f7'
+  version '1.0.10'
+  sha256 '121e5b3075c9de953c2fa0b585ec45824a8dc08668992c444143ca6af5d73152'
 
   # github.com/Timely was verified as official when first introduced to the cask
   url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.