### PR TITLE
Update freedom from 2.2.6 to 2.2.7

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,6 +1,6 @@
 cask 'freedom' do
-  version '2.2.6'
-  sha256 '7354d0c70da7a3e09c29d3a7fc577d438864fe85e26c1ccb1e613f13c1b5dbe0'
+  version '2.2.7'
+  sha256 '8bc94808f9623755fe81ddf93af1f90e18f32036ddf04463f31765a07316ec71'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.