### PR TITLE
Update sourcetrail from 2019.4.61 to 2019.4.102

### DIFF
--- a/Casks/sourcetrail.rb
+++ b/Casks/sourcetrail.rb
@@ -1,6 +1,6 @@
 cask 'sourcetrail' do
-  version '2019.4.61'
-  sha256 '03ffaa3152121d2131229b5df5599967c5c1b30fbe489b08dafeba07806fe1ac'
+  version '2019.4.102'
+  sha256 '4d98f578b8452ddf39f37eb7ca588802ba65c27aff5f4fd06709403c7f845766'
 
   url "https://www.sourcetrail.com/downloads/#{version}/osx/64bit"
   appcast 'https://github.com/CoatiSoftware/Sourcetrail/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.