### PR TITLE
Update tv-browser from 4.2 to 4.2.1

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -1,6 +1,6 @@
 cask 'tv-browser' do
-  version '4.2'
-  sha256 '130db943301cf1548ae227c5e5f4f8cdf3f4b7591589deb267241e503c323c19'
+  version '4.2.1'
+  sha256 'bc7ce87e1d27d1d40964bdcb5b9b5779a518567d1cd36a71d62deb8da73d4f7c'
 
   # sourceforge.net/tvbrowser was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/tvbrowser/tvbrowser_#{version}_macjava.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.