### PR TITLE
Update icons8 from 5.6.9 to 5.7.2

### DIFF
--- a/Casks/icons8.rb
+++ b/Casks/icons8.rb
@@ -1,7 +1,7 @@
 cask 'icons8' do
   # note: "8" is not a version number, but an intrinsic part of the product name
-  version '5.6.9'
-  sha256 '1561520f684a1c22de2fcc780b8c72b69444e3f2689801aa3ed4c3b2b34b008d'
+  version '5.7.2'
+  sha256 '03fa42e93265346cbb33f02c83fe162f1bbd4eaa4f7aa37f743f805c3e204cb4'
 
   url 'https://desktop.icons8.com/updates/mac/Icons8App_for_Mac_OS.dmg'
   appcast 'https://desktop.icons8.com/updates/mac/icons8_cast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.