### PR TITLE
Update jd-gui from 1.6.5 to 1.6.6

### DIFF
--- a/Casks/jd-gui.rb
+++ b/Casks/jd-gui.rb
@@ -1,6 +1,6 @@
 cask 'jd-gui' do
-  version '1.6.5'
-  sha256 'dc0feaf057c63705fe7a8cd44501f0fb5136320cca363fd73f0e8baeb15f665f'
+  version '1.6.6'
+  sha256 'b16ce61bbcfd2f006046b66c8896c512a36c6b553afdca75896d7c5e27c7477d'
 
   # github.com/java-decompiler/jd-gui was verified as official when first introduced to the cask
   url "https://github.com/java-decompiler/jd-gui/releases/download/v#{version}/jd-gui-osx-#{version}.tar"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.