### PR TITLE
Update typora from 0.9.9.31 to 0.9.9.31.1

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.31'
-  sha256 '3bca78020bb4a82dd29000bd40dd50e605114b9fb12309572f4487acf2291196'
+  version '0.9.9.31.1'
+  sha256 'bf3ca54f38bffefbcd668e50403902bc8ae9684cdd9619f09f3fa10ec97130c8'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.