### PR TITLE
Update tiger-trade from 5.3.0,20191218:B9DE81 to 5.3.1,20191224:BACCCE

### DIFF
--- a/Casks/tiger-trade.rb
+++ b/Casks/tiger-trade.rb
@@ -1,6 +1,6 @@
 cask 'tiger-trade' do
-  version '5.3.0,20191218:B9DE81'
-  sha256 '1d990eb94ddddbf696cb3933f11ec7386646b3f327d4173216275078a71c2d85'
+  version '5.3.1,20191224:BACCCE'
+  sha256 '34153f46fc100964934cdadc0a4ea751315d270da0834e4b8324f07d730b0797'
 
   # s.tigerfintech.com was verified as official when first introduced to the cask
   url "https://s.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version.before_comma}_#{version.after_comma.before_colon}_#{version.after_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.