### PR TITLE
Update kext-updater from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,6 +1,6 @@
 cask 'kext-updater' do
-  version '3.3.1'
-  sha256 'e115ff0e8ce4a34cbb56fedaf2ffe32d724973f3d8ed8a05e9f02b07520922f5'
+  version '3.3.2'
+  sha256 '4dd08280e20b6155aea9d8929d19283cca13033df0195400707395e166ab2f0a'
 
   url 'https://update.kextupdater.de/kextupdater/kextupdaterng.zip'
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.