### PR TITLE
Update vuescan from 9.7.14 to 9.7.15

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.14'
-  sha256 '6bf1224b0dcd983fbbe058206dd2886f55d1f175eb6ae26c593d3306504f834d'
+  version '9.7.15'
+  sha256 'fe6c175a31d1bb6f25db9065ae0a9697c0f860419bd2e399e778aeb3f37123d4'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.