### PR TITLE
Update storyboarder from 1.17.0 to 1.18.0

### DIFF
--- a/Casks/storyboarder.rb
+++ b/Casks/storyboarder.rb
@@ -1,6 +1,6 @@
 cask 'storyboarder' do
-  version '1.17.0'
-  sha256 '44e7f6626d27b542a5e7b07e8f8337d8aa12430f7b07df0df286b4d80971071c'
+  version '1.18.0'
+  sha256 '857c04ba5ed7cc06e816896cfd4f7ef6d4c463b4a481af4568bfbd7337ac9d34'
 
   # github.com/wonderunit/storyboarder was verified as official when first introduced to the cask
   url "https://github.com/wonderunit/storyboarder/releases/download/v#{version}/Storyboarder-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.