### PR TITLE
Update mongodb-compass-isolated-edition from 1.20.3 to 1.20.4

### DIFF
--- a/Casks/mongodb-compass-isolated-edition.rb
+++ b/Casks/mongodb-compass-isolated-edition.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-isolated-edition' do
-  version '1.20.3'
-  sha256 '92563533005ad801ec76b29f514917f19a73f89934134c9ff30e2aec39ad0432'
+  version '1.20.4'
+  sha256 'cdb6949223d2f9c58467b077d12fbf44add036809c853c681af59eb8086985df'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-isolated-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.