### PR TITLE
Update mongodb-compass-readonly from 1.20.3 to 1.20.4

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.20.3'
-  sha256 '48be259119252462b181686712481cddb93fcdbfa3c5396c35ade10de6d1d1ef'
+  version '1.20.4'
+  sha256 'a22345ffa5d3eebd9ebb73b4701fff3e40edcac3ceeeead2b2212e3c7cea642a'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.