### PR TITLE
Update capto.rb from 1.2.15,1575375754 to 1.2.16 + update appcast

### DIFF
--- a/Casks/capto.rb
+++ b/Casks/capto.rb
@@ -1,10 +1,10 @@
 cask 'capto' do
-  version '1.2.15,1575375754'
-  sha256 'af7fdda852eb242ee3358d2f06b758d1241de524887067658129be1eec735040'
+  version '1.2.16'
+  sha256 '4e95462dbe07d433d55d2607cfc20ed35831bf28afd1d6a3581bbf377a551fda'
 
-  # dl.devmate.com/com.globaldelight.Capto was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.globaldelight.Capto/#{version.before_comma}/#{version.after_comma}/Capto-#{version.before_comma}.dmg"
-  appcast 'https://updates.devmate.com/com.globaldelight.Capto.xml'
+  # d3l6g06uqih57x.cloudfront.net/Captomac was verified as official when first introduced to the cask
+  url 'https://d3l6g06uqih57x.cloudfront.net/Captomac/webstore/Capto.dmg'
+  appcast 'https://apicapto.globaldelight.net/capto-check-update.php'
   name 'Capto'
   homepage 'https://www.globaldelight.com/capto/'
 


### PR DESCRIPTION
they have changed the appcast for capto but it's still empty - the latest version is 1.2.16 - I'm not sure but I think they will use it not until the next release (?)