### PR TITLE
Revert "Revert "Update keepingyouawake from 1.5.0 to 1.5.1""

### DIFF
--- a/Casks/keepingyouawake.rb
+++ b/Casks/keepingyouawake.rb
@@ -1,6 +1,6 @@
 cask 'keepingyouawake' do
-  version '1.5.0'
-  sha256 '214e2d9a7d177abd1e3e7fddb6c02842c2ec21fc6a4da756152989b4c22c3aba'
+  version '1.5.1'
+  sha256 '9a025bb4429845a51e20bb88376f4c0e25209f7c7298f9f5f8e7306da6502021'
 
   url "https://github.com/newmarcel/KeepingYouAwake/releases/download/#{version}/KeepingYouAwake-#{version}.zip"
   appcast 'https://github.com/newmarcel/KeepingYouAwake/releases.atom'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#74858

1.5.1 is no longer a pre-release.