### PR TITLE
Update cura-lulzbot from 3.6.20 to 3.6.20,73b212e94766420d7130e8a298c39ce9

### DIFF
--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -1,10 +1,10 @@
 cask 'cura-lulzbot' do
-  version '3.6.20,73b212e94766420d7130e8a298c39ce9'
+  version '3.6.21,ce3e47a08065c6687f0a226a4f1b2dc3'
   sha256 '454dd66f219b7a85e4fb4802ba5e23584eb95518e016668837fd5f77e3a20651'
 
   # gitlab.com/lulzbot3d/cura-le/cura-lulzbot was verified as official when first introduced to the cask
   url "https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot/uploads/#{version.after_comma}/cura-lulzbot_#{version.before_comma}.dmg"
-  appcast 'https://download.lulzbot.com/Software/cura-lulzbot/mac/'
+  appcast 'https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot/-/tags?format=atom'
   name 'Cura LulzBot Edition'
   homepage 'https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-osx'
 

--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -1,8 +1,9 @@
 cask 'cura-lulzbot' do
-  version '3.6.20'
+  version '3.6.20,73b212e94766420d7130e8a298c39ce9'
   sha256 '454dd66f219b7a85e4fb4802ba5e23584eb95518e016668837fd5f77e3a20651'
 
-  url "https://download.lulzbot.com/Software/cura-lulzbot/mac/cura-lulzbot_#{version}.dmg"
+  # gitlab.com/lulzbot3d/cura-le/cura-lulzbot was verified as official when first introduced to the cask
+  url "https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot/uploads/#{version.after_comma}/cura-lulzbot_#{version.before_comma}.dmg"
   appcast 'https://download.lulzbot.com/Software/cura-lulzbot/mac/'
   name 'Cura LulzBot Edition'
   homepage 'https://www.lulzbot.com/learn/tutorials/cura-lulzbot-edition-installation-osx'

--- a/Casks/cura-lulzbot.rb
+++ b/Casks/cura-lulzbot.rb
@@ -1,6 +1,6 @@
 cask 'cura-lulzbot' do
   version '3.6.21,ce3e47a08065c6687f0a226a4f1b2dc3'
-  sha256 '454dd66f219b7a85e4fb4802ba5e23584eb95518e016668837fd5f77e3a20651'
+  sha256 '1548b15734ab2299f2fb8106e1b6f3242e5efe66286306f64b7675a0f354ff2c'
 
   # gitlab.com/lulzbot3d/cura-le/cura-lulzbot was verified as official when first introduced to the cask
   url "https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot/uploads/#{version.after_comma}/cura-lulzbot_#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.