### PR TITLE
Update minecraft-server from 1.15 to 1.15.1

### DIFF
--- a/Casks/minecraft-server.rb
+++ b/Casks/minecraft-server.rb
@@ -1,6 +1,6 @@
 cask 'minecraft-server' do
-  version '1.15,e9f105b3c5c7e85c7b445249a93362a22f62442d'
-  sha256 'e0fe1749263b5ec211b358b598b46e787645bffa8411414f0c812a92bdc70c84'
+  version '1.15.1,4d1826eebac84847c71a77f9349cc22afd0cf0a1'
+  sha256 'a0c062686bee5a92d60802ca74d198548481802193a70dda6d5fe7ecb7207993'
 
   # launcher.mojang.com was verified as official when first introduced to the cask
   url "https://launcher.mojang.com/v#{version.major}/objects/#{version.after_comma}/server.jar"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.