### PR TITLE
Update cyberduck from 7.2.2.32045 to 7.2.4.32089

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,6 +1,6 @@
 cask 'cyberduck' do
-  version '7.2.2.32045'
-  sha256 '0ba1ec2f8e5a6a1f95bd397b8647db5e045c92687c9b00380f7e9654d19c3a9a'
+  version '7.2.4.32089'
+  sha256 '1ca50732d7bd4cebb6a2a05d683f77a4da7393ca23167e64066f14371ef92c18'
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast 'https://version.cyberduck.io/changelog.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.