### PR TITLE
Update alt-tab from 1.14.4 to 2.0.0

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '1.14.4'
-  sha256 '17be1d2b692f1d4f871ba1ed9e519fb0401bb6a845f96bbdb8ace3cba2ed5ba8'
+  version '2.0.0'
+  sha256 '83cb1b3cd83a6a00698309563c786ce754ea1b0de456edeeb773a5775a7400b6'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.