### PR TITLE
Update freac from 1.1-alpha-20190423a to 1.1-beta1

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,9 +1,9 @@
 cask 'freac' do
-  version '1.1-alpha-20190423a'
-  sha256 'f6cbe820d0c8c114064b1282ea45e256a95df0c4433483043477cfe77c3627f5'
+  version '1.1-beta1'
+  sha256 'fdf264a5e163ed5056011e06fe7610e9bffb6baf39c728ee004195cbe22d1ba2'
 
   # github.com/enzo1982/freac was verified as official when first introduced to the cask
-  url "https://github.com/enzo1982/freac/releases/download/v#{version.chomp('a')}/freac-#{version}-macosx.dmg"
+  url "https://github.com/enzo1982/freac/releases/download/v#{version}/freac-#{version}-macosx.dmg"
   appcast 'https://github.com/enzo1982/freac/releases.atom'
   name 'fre:ac'
   homepage 'https://www.freac.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.