### PR TITLE
Update stoplight-studio from 1.7.2 to 1.7.3

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.7.2'
-  sha256 'da1cd9d8b6e3a478d9e3f2034e6767fa2e1ac8f54d74e9951627ba09e003ac82'
+  version '1.7.3'
+  sha256 'dd8c0ee6e80f7923d757c53f54abea2181c40c773647325256ca8d46ed34c1dc'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.