### PR TITLE
Update springtoolsuite from 4.4.2.RELEASE,4.13.0 to 4.5.0.RELEASE,4.13.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask 'springtoolsuite' do
-  version '4.4.2.RELEASE,4.13.0'
-  sha256 'dd5b9e60c2db62ebb8e13321649bd5555e1e7d1c6bc9a321ade0cb6fec79f305'
+  version '4.5.0.RELEASE,4.13.0'
+  sha256 '399ffb99367d4ed761a81907342afc8c0bc7dfafcc7b41da5a86fc1ba2d497da'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.