### PR TITLE
Update doxygen from 1.8.16 to 1.8.17

### DIFF
--- a/Casks/doxygen.rb
+++ b/Casks/doxygen.rb
@@ -1,6 +1,6 @@
 cask 'doxygen' do
-  version '1.8.16'
-  sha256 'b95c91f85346ccd5ad1847697867acc8663e33460976319f544d824ec9d35278'
+  version '1.8.17'
+  sha256 'bf051b2c26ad5569efe9ca09396199340d03c6c96d61b730d50d5cd8f547425b'
 
   url "http://doxygen.nl/files/Doxygen-#{version}.dmg"
   appcast 'http://www.doxygen.nl/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.