### PR TITLE
Update sqlpro-for-mssql from 2019.54 to 2019.70

### DIFF
--- a/Casks/sqlpro-for-mssql.rb
+++ b/Casks/sqlpro-for-mssql.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-mssql' do
-  version '2019.54'
-  sha256 'f90a53a666b1521c6cbe5672906a9b578bf054808cb584b9b30cba842a7d7918'
+  version '2019.70'
+  sha256 '8366de954fec7506e1fb59233b96d08df0c718ff15caa87466600751d1a13cb0'
 
   # d3fwkemdw8spx3.cloudfront.net/mssql was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mssql/SQLProMSSQL.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.