### PR TITLE
Update combine-pdfs from 5.4 to 5.5.2

### DIFF
--- a/Casks/combine-pdfs.rb
+++ b/Casks/combine-pdfs.rb
@@ -1,6 +1,6 @@
 cask 'combine-pdfs' do
-  version '5.4'
-  sha256 '28e7a4852d33add5c84dd1d63d32a8e854245cb65c4b578cecc2164988538bfe'
+  version '5.5.2'
+  sha256 '2fee2e174fd02525dc599e52d13d14f6c8b5f0a56c76e04c5821ad33d3801651'
 
   url "https://www.monkeybreadsoftware.de/Software/CombinePDFs/CombinePDFs#{version.no_dots}.zip"
   appcast 'https://www.monkeybreadsoftware.de/Software/CombinePDFs/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.