### PR TITLE
Update visicut from 1.9-16-gb498e3a1 to 1.9-24-gea6d76ce

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask 'visicut' do
-  version '1.9-16-gb498e3a1'
-  sha256 '05a85c47ab8e0d9ce119732737bb7fd41b237f540550a34d22d0ee95c28b9d52'
+  version '1.9-24-gea6d76ce'
+  sha256 '6d62fdc0c06ba146d735f6190ebb591d86e694ba52446ca75f86de6c41a264c8'
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast 'https://download.visicut.org'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.