### PR TITLE
Update data-integration from 8.2.0.0-342 to 8.3.0.0-371

### DIFF
--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -1,6 +1,6 @@
 cask 'data-integration' do
-  version '8.2.0.0-342'
-  sha256 '9189d6303088c17b803dda6585c4ce9862c04494797182815c79734f3fa640ca'
+  version '8.3.0.0-371'
+  sha256 'c0dbb17248135423fe6336bc8f45b01c2cf15a9b0498fa1d27c24588b3fa2872'
 
   # sourceforge.net/pentaho was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/pentaho/pdi-ce-#{version}.zip"

--- a/Casks/data-integration.rb
+++ b/Casks/data-integration.rb
@@ -4,7 +4,7 @@ cask 'data-integration' do
 
   # sourceforge.net/pentaho was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/pentaho/pdi-ce-#{version}.zip"
-  appcast 'https://sourceforge.net/projects/pentaho/rss?path=/Data%20Integration'
+  appcast 'https://sourceforge.net/projects/pentaho/rss?path=/'
   name 'Pentaho Data Integration'
   homepage 'https://community.hitachivantara.com/community/products-and-solutions/pentaho/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.