### PR TITLE
Add Luna Secondary Latest

### DIFF
--- a/Casks/luna-secondary.rb
+++ b/Casks/luna-secondary.rb
@@ -1,0 +1,15 @@
+cask 'luna-secondary' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://s3.lunadisplay.com/downloads/LunaSecondary.dmg'
+  name 'Luna Secondary'
+  homepage 'https://lunadisplay.com/'
+
+  app 'Luna Secondary.app'
+
+  zap trash: [
+               '~/Library/Caches/com.astro-hq.LunaSecondaryMac',
+               '~/Library/Preferences/com.astro-hq.LunaSecondaryMac.plist',
+             ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download luna-secondary` is error-free.
- [x] `brew cask style --fix luna-secondary` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install luna-secondary` worked successfully.
- [x] `brew cask uninstall luna-secondary` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

##

Note that is this a companion—but different—app to [homebrew-cask-drivers/luna-display](https://github.com/Homebrew/homebrew-cask-drivers/blob/master/Casks/luna-display.rb). This is the client half of the pair and it does not require any additional drivers.

Related https://github.com/Homebrew/homebrew-cask/pull/56058