### PR TITLE
Update gnucash from 3.7,1 to 3.8b,1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,9 +1,9 @@
 cask 'gnucash' do
-  version '3.7,1'
-  sha256 'b687fb0a17b15e735a29be83354409fb8059aebf0bd97079b74eac3dfc4cbeac'
+  version '3.8b,1'
+  sha256 '4997e15b5163227890a1ad8fdd178fe646dd13af688689dbeadc787f902294f5'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
-  url "https://github.com/Gnucash/gnucash/releases/download/#{version.before_comma}/Gnucash-Intel-#{version.before_comma}-#{version.after_comma}.dmg"
+  url "https://github.com/Gnucash/gnucash/releases/download/#{version.before_comma}/Gnucash-Intel-#{version.before_comma.delete_suffix('b')}-#{version.after_comma}.dmg"
   appcast 'https://github.com/Gnucash/gnucash/releases.atom'
   name 'GnuCash'
   homepage 'https://www.gnucash.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.