### PR TITLE
Update qownnotes from 19.12.16,b5106-161921 to 19.12.17,b5118-164943

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '19.12.16,b5106-161921'
-  sha256 '1d3772f6b562ce7c268ae86c2cdf3642100bca7038fff8278ca69e7364d24ca2'
+  version '19.12.17,b5118-164943'
+  sha256 'a3ea967577016a2593836eafc91221c62cb38cb4fabb884cb3ad18fe4f02157f'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.