### PR TITLE
Update c0re100-qbittorrent from 4.1.9.4 to 4.2.1.10

### DIFF
--- a/Casks/c0re100-qbittorrent.rb
+++ b/Casks/c0re100-qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'c0re100-qbittorrent' do
-  version '4.1.9.4'
-  sha256 '3241423c099379bcc66ffb77451ec09c08917661b852b9f152d8ca3cb5eac90f'
+  version '4.2.1.10'
+  sha256 'fa16cad5c7edd623a940aa2d2dcb1a333b6e3f79e0b5e1ed33cc8f748969aa2c'
 
   url "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-#{version}/qBittorrent-#{version}.dmg"
   appcast 'https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.