### PR TITLE
Update alt-tab from 2.0.0 to 2.0.2

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '2.0.0'
-  sha256 '83cb1b3cd83a6a00698309563c786ce754ea1b0de456edeeb773a5775a7400b6'
+  version '2.0.2'
+  sha256 'ac03e7d64b048935bc5d36d8b31a27aa37931b0e8f62285d1cb227f642b16427'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.