### PR TITLE
Update eaglefiler from 1.8.10 to 1.8.11

### DIFF
--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,6 +1,6 @@
 cask 'eaglefiler' do
-  version '1.8.10'
-  sha256 '67990c22dbfca831630ecf2c227280d9ef0219cad0cc6544f6a42960664b03b6'
+  version '1.8.11'
+  sha256 'f423884234ea93ac70e32debb1c53b42bb5d55ef12f90f2df42654ba763b0c47'
 
   url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   appcast 'https://c-command.com/eaglefiler/help/version-history'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.