### PR TITLE
Update qsync-client from 3.3.4.0916 to 3.3.5.1209

### DIFF
--- a/Casks/qsync-client.rb
+++ b/Casks/qsync-client.rb
@@ -1,6 +1,6 @@
 cask 'qsync-client' do
-  version '3.3.4.0916'
-  sha256 'f000324f5ff0f8c5f46d58133aa124701cc2e4399cec69e29a9066a397e08985'
+  version '3.3.5.1209'
+  sha256 'dc4794193a1f6bc37abdda0618d2f140a93f1adb0704c2ea7266a2e198e518eb'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQsyncClientMac-#{version}.dmg"
   appcast 'https://update.qnap.com/SoftwareRelease.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.