### PR TITLE
Update anydo from 4.2.57 to 4.2.58

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.57'
-  sha256 'bb6215b93bd6baa6a570a97486f9023f513f854f503b09c8c01550c7e34cc8ba'
+  version '00000004.2.58'
+  sha256 'cb7c75deb0fb3bd422059596ad3f52293636e82f26a173c55d5c5692e56ab058'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'

--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,5 +1,5 @@
 cask 'anydo' do
-  version '00000004.2.58'
+  version '4.2.58'
   sha256 'cb7c75deb0fb3bd422059596ad3f52293636e82f26a173c55d5c5692e56ab058'
 
   url 'https://electron-app.any.do/Any.do.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.