### PR TITLE
Update ghost-browser from 2.1.1.6 to 2.1.1.7

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.6'
-  sha256 'c9ae83ed5331d6c1624e3d198e07b0dbc610bd41f3de910abbea9d98e2b9ac7d'
+  version '2.1.1.7'
+  sha256 '01024ebb5e2636525cb1f3e3a75c305c6a3a5c9f9cc601319cc260511f7d9f23'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.