### PR TITLE
Update netron from 3.7.1 to 3.7.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.7.1'
-  sha256 'b3aba676f4ce2d8e06785d9599a88c3e42be6c41237a0c8add32284562404575'
+  version '3.7.2'
+  sha256 'eeb208fdebdcc182a51f4937ceb2f7f379c39b1ab0430cb0daf19a0397e2f1e8'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.