### PR TITLE
Update augur from 1.16.5 to 1.16.6

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.16.5'
-  sha256 '0860f41a6c8e558f86fa5430eb0c0a03e09053ce5ebefd5025d30d8e7ea16f40'
+  version '1.16.6'
+  sha256 '298c0612a9ffb6baf94ec4aa35965e80bb68c77d8f0aaed458713fec3550ea74'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.