### PR TITLE
Update buttercup from 1.18.1 to 1.18.2

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.18.1'
-  sha256 'c8ffeee81b44c4734d94799a28bf7912037fe5ca04a0a487a1c05badfdca719a'
+  version '1.18.2'
+  sha256 '6128a5e68e1911e6a0ed760ba3ce88d929373e537900247082837d2149c3fb9a'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.