### PR TITLE
Update shotcut from 19.12.16 to 19.12.31

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '19.12.16'
-  sha256 '50bcebcc5259c10a71210a353a35f3797e8a444cc7c94fa335556eae215c2e7c'
+  version '19.12.31'
+  sha256 '7184cc16aa9a681f95f410188ba52f26699b6ad10ad4d4727249b961c0d8e155'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.