### PR TITLE
Update vuescan from 9.7.16 to 9.7.17

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.16'
-  sha256 '0e51ecff42a24a2e34ee174cef8609dd65e988b1dadf27276f1c829a8dc91c5c'
+  version '9.7.17'
+  sha256 '1cb9736b65c41ddd11c59a5347a137ae790020cb7dd8141a41cc412cfba8322f'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.