### PR TITLE
Update wechatwork from 3.0.0.2009 to 3.0.1.2005

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.0.2009'
-  sha256 '37764d9bc4564a8c5995342817c8442e311d17ca47238f57cb3ec8bc3d06b4d4'
+  version '3.0.1.2005'
+  sha256 '36771bc94ac8bcda08cb39e88a6b0fb41ba2087d49084de50a82dec4cdb53865'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.