### PR TITLE
Update altserver from latest to 1.1.2

### DIFF
--- a/Casks/altserver.rb
+++ b/Casks/altserver.rb
@@ -1,9 +1,10 @@
 cask 'altserver' do
-  version :latest
-  sha256 :no_check
+  version '1.1.2'
+  sha256 '782add0c2b65e71e1c3dc6ff84d5e260cc7c79ada1c60f9f0d178f60c91f2593'
 
   # f000.backblazeb2.com/file was verified as official when first introduced to the cask
-  url 'https://f000.backblazeb2.com/file/altstore/altserver.dmg'
+  url "https://f000.backblazeb2.com/file/altstore/altserver-#{version.dots_to_underscores}.dmg"
+  appcast 'https://altstore.io/altserver/sparkle-macos.xml'
   name 'AltServer'
   homepage 'https://altstore.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.