### PR TITLE
Update yourkit-java-profiler from 2019.8-b127 to 2019.8-b136

### DIFF
--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,13 +1,13 @@
 cask 'yourkit-java-profiler' do
-  version '2019.8-b136'
+  version '2019.8,b136'
   sha256 '77b76d7588677b49554c964a3faf429c0faf12bca15e56d0899b57284443dd90'
 
-  url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version}.dmg"
+  url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://www.yourkit.com/download/'
   name 'YourKit Java Profiler'
   homepage 'https://www.yourkit.com/features/'
 
   auto_updates true
 
-  app "YourKit-Java-Profiler-#{version.major_minor}.app"
+  app "YourKit-Java-Profiler-#{version.before_comma}.app"
 end

--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,6 +1,6 @@
 cask 'yourkit-java-profiler' do
-  version '2019.8-b127'
-  sha256 '1773df33d1e4ee117d6dd83b11450121bc32c865b07b02829e31738dc5e2d389'
+  version '2019.8-b136'
+  sha256 '77b76d7588677b49554c964a3faf429c0faf12bca15e56d0899b57284443dd90'
 
   url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version}.dmg"
   appcast 'https://www.yourkit.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.