### PR TITLE
Update vuescan from 9.7.17 to 9.7.18

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.17'
-  sha256 '1cb9736b65c41ddd11c59a5347a137ae790020cb7dd8141a41cc412cfba8322f'
+  version '9.7.18'
+  sha256 'a107d03c2f9df03e2589ec8e1fa7404ecb14710d12a906effe1148ee7aa4c689'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.