### PR TITLE
Update picgo from 2.1.2 to 2.2.0

### DIFF
--- a/Casks/picgo.rb
+++ b/Casks/picgo.rb
@@ -1,6 +1,6 @@
 cask 'picgo' do
-  version '2.1.2'
-  sha256 '518483a0bf303f09442aa749b4236af89223a47a82a8c0fcd9ff09603f2ac72f'
+  version '2.2.0'
+  sha256 '5e36ed791e4000b2b1ad832f71091c97cdce6662eb0a247403dbcaa3662eb632'
 
   url "https://github.com/Molunerfinn/PicGo/releases/download/v#{version}/PicGo-#{version}-mac.zip"
   appcast 'https://github.com/Molunerfinn/PicGo/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.