### PR TITLE
Update aria2d from 1.3.3 to 1.3.4

### DIFF
--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,6 +1,6 @@
 cask 'aria2d' do
-  version '1.3.3'
-  sha256 '14e649369bac231edb8b4374c0de142297027a5de0e04c80f4dbfcaf634af216'
+  version '1.3.4'
+  sha256 '0bbfa96007fbae53d42b8a524ec21aa8cf9376d1757436aa33525ae74ddb835d'
 
   # githubusercontent.com/xjbeta was verified as official when first introduced to the cask
   url "https://raw.githubusercontent.com/xjbeta/AppUpdaterAppcasts/master/Aria2D/Aria2D%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.