### PR TITLE
Update chromium from 727851 to 727928

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '727851'
-  sha256 'a500c2c1ac396803cb4851c1d605e6a87131d6350a3628dd0a68bfed85909fa4'
+  version '727928'
+  sha256 '05a3381f330bbfe24e3a6f88c2049e0a859d319d09a691fb40699bcbf55f4cff'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.