### PR TITLE
Fix onedrive 19.192.0926.0012 dependency conflict check

### DIFF
--- a/Casks/onedrive.rb
+++ b/Casks/onedrive.rb
@@ -9,7 +9,7 @@ cask 'onedrive' do
   homepage 'https://onedrive.live.com/'
 
   auto_updates true
-  conflicts_with cask: 'microsot-office'
+  conflicts_with cask: 'microsoft-office'
   depends_on macos: '>= :sierra'
 
   pkg 'OneDrive.pkg'


### PR DESCRIPTION
- Typo in `microsoft-office` was preventing a proper dependency conflict check.
- It should reference this cask instead: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/microsoft-office.rb

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] The commit message includes the cask’s name and version.
