### PR TITLE
Update opensc from 0.19.0 to 0.20.0

### DIFF
--- a/Casks/opensc.rb
+++ b/Casks/opensc.rb
@@ -1,6 +1,6 @@
 cask 'opensc' do
-  version '0.19.0'
-  sha256 'caa6151241652d5448ea3bb83958e1c823f0138841d187a347ca5cbeb2ce0e9d'
+  version '0.20.0'
+  sha256 'fd456cd3920bead10d9f1845623408eb16c6b0f934f960d52d5850f0ee205eab'
 
   url "https://github.com/OpenSC/OpenSC/releases/download/#{version}/OpenSC-#{version}.dmg"
   appcast 'https://github.com/OpenSC/OpenSC/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.