### PR TITLE
Update dosbox-x from 0.82.24,20191130163446 to 0.82.25,20191231233544

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.24,20191130163446'
-  sha256 '60fadf3cca2164a2cb432c3a778ed38f4bd74d8ebbfbf13d36f6ef6c241776b5'
+  version '0.82.25,20191231233544'
+  sha256 'bdf150db560161ec7e42fe9aabc2275a298dff01d1dbb224e2fe2fafbdd86dca'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.