### PR TITLE
Update hstracker from 1.6.10 to 1.6.11

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.10'
-  sha256 '74e3de080e2eae68b434fabace88c4700a33d4e9ebd53ad57c80055a9c3e8b2c'
+  version '1.6.11'
+  sha256 '66db8157eee600cccc3d32097f17cf35fb509b3356fe1a3dc19c51b1ba0b2f31'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.