### PR TITLE
Update hubstaff from 1.5.4,1728 to 1.5.5,1761

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.5.4,1728'
-  sha256 '597a8fd886e1c1fbc0e4135f47e37f950daf9e804af48babd985688007ed6fd3'
+  version '1.5.5,1761'
+  sha256 '9fb6e2d9d7113320d813f3b4090c46c8707e64499fd94fd105127f72b27f1e89'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.