### PR TITLE
Update downie from 3.9.4,3015 to 3.9.5,3020

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.9.4,3015'
-  sha256 '35b2b7e6b4ff6d1faed90c0201105a676b58a35708a0d5cef61f5ddafc3d79a3'
+  version '3.9.5,3020'
+  sha256 'd2a67677d159b65f7773277f1d0cd5c8ba9c408208c5d406ccf366322a2c9a2b'
 
   # charliemonroesoftware.com was verified as official when first introduced to the cask
   url "https://charliemonroesoftware.com/trial/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.