### PR TITLE
Update typora from 0.9.9.31.2 to 0.9.9.31.3

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.31.2'
-  sha256 '16c8890eca4a1260a536c50c9ba67a0d0d733931f0a68aa0347a096f7a481566'
+  version '0.9.9.31.3'
+  sha256 '52abff999be5b15439f836929a464d6ef660c6ee5c9efadf02bcd0e1d32c7367'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.