### PR TITLE
Update retrobatch from 1.3 to 1.3.1

### DIFF
--- a/Casks/retrobatch.rb
+++ b/Casks/retrobatch.rb
@@ -1,6 +1,6 @@
 cask 'retrobatch' do
-  version '1.3'
-  sha256 '97c326a7c5051c8af59f209f1b53e28025744d1fd851ec1299b23e84c4c5e3b5'
+  version '1.3.1'
+  sha256 'f61ec9ecaa29285c828062047597f99c1228eb9725f63c3405b8d95a6b4cfbf7'
 
   url 'https://flyingmeat.com/download/Retrobatch.zip'
   appcast "https://www.flyingmeat.com/download/retrobatch#{version.major}update.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.