### PR TITLE
Update typeface from 2.6.3 to 2.6.4

### DIFF
--- a/Casks/typeface.rb
+++ b/Casks/typeface.rb
@@ -1,6 +1,6 @@
 cask 'typeface' do
-  version '2.6.3'
-  sha256 'f96ddda8876f0b0f25d8f9d448cd0057806b94ee55d08c81e215d7031a88c544'
+  version '2.6.4'
+  sha256 '3969f91d5255b8d1acdbcbf9a8887572ba640035a71a989a525289c99486944c'
 
   url 'https://dcdn.typefaceapp.com/latest'
   appcast 'https://dcdn.typefaceapp.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.