### PR TITLE
Update massreplaceit from 3.1 to 3.1.1

### DIFF
--- a/Casks/massreplaceit.rb
+++ b/Casks/massreplaceit.rb
@@ -1,6 +1,6 @@
 cask 'massreplaceit' do
-  version '3.1'
-  sha256 'e9e0c51af2f35543a979519bc2e3cf202c81518977de18e80388d9fdd1bab097'
+  version '3.1.1'
+  sha256 'e44e97787a45b0ae52346f833c0ba3bf1383b407e0fc327d536347eb3eef5509'
 
   url 'http://www.hexmonkeysoftware.com/files/MassReplaceIt.dmg'
   appcast 'http://www.hexmonkeysoftware.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.