### PR TITLE
Update cisdem-document-reader from 4.5.0 to 5

### DIFF
--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -1,5 +1,5 @@
 cask 'cisdem-document-reader' do
-  version '5'
+  version '5.0.0'
   sha256 'e621f103edcd8816ca72a1b73cdebaea00e0300f9cf506bcae00178d5fb5965f'
 
   url 'https://www.cisdem.com/downloads/cisdem-documentreader-18.dmg'

--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -1,8 +1,8 @@
 cask 'cisdem-document-reader' do
-  version '4.5.0'
-  sha256 '2f58ee62e16b402adb70a02895079b98a9cc4edbcfc874155235ab21c7993915'
+  version '5'
+  sha256 'e621f103edcd8816ca72a1b73cdebaea00e0300f9cf506bcae00178d5fb5965f'
 
-  url 'http://download.cisdem.com/cisdem-documentreader.dmg'
+  url 'https://www.cisdem.com/downloads/cisdem-documentreader-18.dmg'
   appcast 'https://www.cisdem.com/document-reader-mac/release-notes.html'
   name 'Cisdem Document Reader'
   homepage 'https://www.cisdem.com/document-reader-mac.html'

--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -2,7 +2,7 @@ cask 'cisdem-document-reader' do
   version '5.0.0'
   sha256 'e621f103edcd8816ca72a1b73cdebaea00e0300f9cf506bcae00178d5fb5965f'
 
-  url 'https://www.cisdem.com/downloads/cisdem-documentreader-18.dmg'
+  url 'http://download.cisdem.com/cisdem-documentreader.dmg'
   appcast 'https://www.cisdem.com/document-reader-mac/release-notes.html'
   name 'Cisdem Document Reader'
   homepage 'https://www.cisdem.com/document-reader-mac.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.