### PR TITLE
Update alt-tab from 2.0.2 to 2.2.0

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '2.0.2'
-  sha256 'ac03e7d64b048935bc5d36d8b31a27aa37931b0e8f62285d1cb227f642b16427'
+  version '2.2.0'
+  sha256 '593d1ebfa50b72c0c39f58355b71ee0e2611de11e0242b55539bc6c143376dfb'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.