### PR TITLE
Update debookee from 7.3.1 to 7.3.2

### DIFF
--- a/Casks/debookee.rb
+++ b/Casks/debookee.rb
@@ -1,6 +1,6 @@
 cask 'debookee' do
-  version '7.3.1'
-  sha256 'e4aecb9e4e8ac8cd295b0b1a29351f5577fd2e3b18f901f10ed5f62876afc676'
+  version '7.3.2'
+  sha256 '75d4da3098f8ff5ce008bfcf397deb60f39f310f032e6d1e9c590b644efa3554'
 
   # iwaxx.com/debookee was verified as official when first introduced to the cask
   url 'https://www.iwaxx.com/debookee/debookee.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.