### PR TITLE
Update m3unify from 2.0.1 to 2.1.0

### DIFF
--- a/Casks/m3unify.rb
+++ b/Casks/m3unify.rb
@@ -1,6 +1,6 @@
 cask 'm3unify' do
-  version '2.0.1'
-  sha256 'b272b6e2ec97fb1e8885d57892da9e3bfb2b7f162bf85b104b0d3fa80b69ca55'
+  version '2.1.0'
+  sha256 'eefb09a4586b296868ecf6e5e57bb57330993a88c4341d3bb455d406b73912c6'
 
   url "https://dougscripts.com/itunes/scrx/m3unifyv#{version.no_dots}.zip"
   appcast 'https://dougscripts.com/itunes/itinfo/m3unify_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.