### PR TITLE
Update seashore from 2.4.17 to 2.4.18

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.4.17'
-  sha256 '901aae8fa490668bd65f23ae7926a70de6c60305b8cbbf3af3f2ef96960c70ed'
+  version '2.4.18'
+  sha256 '3b5268493860857703fcd76c20e4c8102cc9df9e21b3cf1dd5e26cdc0d5ba37e'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.