### PR TITLE
Fix download URL for sqlitestudio 3.2.1

### DIFF
--- a/Casks/sqlitestudio.rb
+++ b/Casks/sqlitestudio.rb
@@ -4,7 +4,7 @@ cask 'sqlitestudio' do
 
   # github.com/pawelsalawa/sqlitestudio/releases/download/ was verified as official when first introduced to the cask
   url "https://github.com/pawelsalawa/sqlitestudio/releases/download/#{version}/SQLiteStudio-#{version}.dmg"
-  appcast 'https://sqlitestudio.pl/rss.rvt'
+  appcast 'https://github.com/pawelsalawa/sqlitestudio/releases.atom'
   name 'SQLiteStudio'
   homepage 'https://sqlitestudio.pl/'
 

--- a/Casks/sqlitestudio.rb
+++ b/Casks/sqlitestudio.rb
@@ -2,7 +2,8 @@ cask 'sqlitestudio' do
   version '3.2.1'
   sha256 'b66ce10747ca734c7f0dacf19fc773936756db1ab5441ec29b9b5ba23308844c'
 
-  url "https://sqlitestudio.pl/files/sqlitestudio#{version.major}/complete/macosx/SQLiteStudio-#{version}.dmg"
+  # github.com/pawelsalawa/sqlitestudio/releases/download/ was verified as official when first introduced to the cask
+  url "https://github.com/pawelsalawa/sqlitestudio/releases/download/#{version}/SQLiteStudio-#{version}.dmg"
   appcast 'https://sqlitestudio.pl/rss.rvt'
   name 'SQLiteStudio'
   homepage 'https://sqlitestudio.pl/'


### PR DESCRIPTION
As announced on https://sqlitestudio.pl

> **Files moved to GitHub
2019-12-30**
Today all binary & source code packages were moved to [GitHub Releases page](https://github.com/pawelsalawa/sqlitestudio/releases), where there will no longer be any slowness of file hosting. It also makes process of releasing files much easier.

---

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).