### PR TITLE
Update monal from 2.5 beta 4,156 to 2.5 beta 5,159

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
-  version '2.5 beta 4,156'
-  sha256 'ec4e2afb9620d26bb2b597ab8f6cc6051eabd6453634c13cdaf9afecf6b70a35'
+  version '2.5 beta 5,159'
+  sha256 'e3ffeb9dd8d86359f9eafb877a9cb46938e546c2386af35ba24ebd4fdd375f57'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',

--- a/Casks/tencent-lemon.rb
+++ b/Casks/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask 'tencent-lemon' do
-  version '3.1.0'
-  sha256 'dd445dd1d1551e53e7dd72da8578d2b07f38260239f463ad126b7cf1eb7f823f'
+  version '3.2.0'
+  sha256 'c144ad19bae6360db380a120c519d9324c51edb7e56c220da4ab55ac0823b2e6'
 
   # pm.myapp.com/invc/xfspeed/qqpcmgr was verified as official when first introduced to the cask
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/Lemon_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.