### PR TITLE
Update rescuetime from latest to 2.14.5.1

### DIFF
--- a/Casks/rescuetime.rb
+++ b/Casks/rescuetime.rb
@@ -1,8 +1,9 @@
 cask 'rescuetime' do
-  version :latest
-  sha256 :no_check
+  version '2.14.5.1'
+  sha256 '68a6335156f2c17376a82c1b8204df00fa5b1ccd92d77c301bc422d41835bc5d'
 
   url 'https://www.rescuetime.com/installers/RescueTimeInstaller.pkg'
+  appcast 'http://www.rescuetime.com/installers/appcast'
   name 'RescueTime'
   homepage 'https://www.rescuetime.com/'
 

--- a/Casks/tencent-lemon.rb
+++ b/Casks/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask 'tencent-lemon' do
-  version '3.1.0'
-  sha256 'dd445dd1d1551e53e7dd72da8578d2b07f38260239f463ad126b7cf1eb7f823f'
+  version '3.2.0'
+  sha256 'c144ad19bae6360db380a120c519d9324c51edb7e56c220da4ab55ac0823b2e6'
 
   # pm.myapp.com/invc/xfspeed/qqpcmgr was verified as official when first introduced to the cask
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/Lemon_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.