### PR TITLE
Update one-switch from 1.9 to 1.9.1,216

### DIFF
--- a/Casks/one-switch.rb
+++ b/Casks/one-switch.rb
@@ -1,10 +1,9 @@
 cask 'one-switch' do
-  version '1.9'
-  sha256 '1580d0e85e59af3efbbce06dbf12f908ae5eb5da5167e250511071b0d3b3c2a9'
+  version '1.9.1,216'
+  sha256 '7165f18c7e201ace33c8aa43eed7a78051c2cb050fe782da862243f96813c96c'
 
-  # dl.devmate.com/studio.fireball.OneSwitch was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/studio.fireball.OneSwitch/OneSwitch.zip'
-  appcast 'https://updates.devmate.com/studio.fireball.OneSwitch.xml'
+  url "https://fireball.studio/api/release_manager/downloads/studio.fireball.OneSwitch/#{version.after_comma}.zip"
+  appcast 'https://fireball.studio/api/release_manager/studio.fireball.OneSwitch.xml'
   name 'One Switch'
   homepage 'https://fireball.studio/oneswitch'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.