### PR TITLE
Update workflowy from 1.3.5-5631 to 1.3.5-5665

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.5-5631'
-  sha256 '6a70b1ecefdf91ebeeecbfc56cf4b4ed4710f3b9f3d603489d8317cab9fbecf9'
+  version '1.3.5-5665'
+  sha256 'cb7e225817dfa66d4f6dfef80489f85b95a47455a6632a82a713b09ec8f05bd0'
 
   # github.com/workflowy/desktop was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.