### PR TITLE
Update rocks-n-diamonds from 4.1.3.0 to 4.1.4.0

### DIFF
--- a/Casks/rocks-n-diamonds.rb
+++ b/Casks/rocks-n-diamonds.rb
@@ -1,6 +1,6 @@
 cask 'rocks-n-diamonds' do
-  version '4.1.3.0'
-  sha256 '4492c98a14b7b4f6c80d08f66d16d92f912059b0205b20ca5d1193b2c9b59987'
+  version '4.1.4.0'
+  sha256 'b1b609dc428d239b79eb805d4cfd0be6746e2d195dea8d1a9f798330f1da3e8f'
 
   url "https://www.artsoft.org/RELEASES/macosx/rocksndiamonds/rocksndiamonds-#{version}.dmg"
   appcast 'https://www.artsoft.org/RELEASES/macosx/rocksndiamonds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.