### PR TITLE
Update handbrake from 1.3.0 to 1.3.1

### DIFF
--- a/Casks/handbrake.rb
+++ b/Casks/handbrake.rb
@@ -1,6 +1,6 @@
 cask 'handbrake' do
-  version '1.3.0'
-  sha256 '6789cdd2054bccb1d623d0ff32e4246d4d4c49c21cec85a7d1ea5922b5075a55'
+  version '1.3.1'
+  sha256 'b713ebd6185a4836129fa520c94a2197325f5132d80056358b258ab5f471a26e'
 
   url "https://download.handbrake.fr/handbrake/releases/#{version}/HandBrake-#{version}.dmg"
   appcast 'https://github.com/HandBrake/HandBrake/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.