### PR TITLE
Update scidvsmac from 4.20 to 4.21

### DIFF
--- a/Casks/scidvsmac.rb
+++ b/Casks/scidvsmac.rb
@@ -1,6 +1,6 @@
 cask 'scidvsmac' do
-  version '4.20'
-  sha256 'c4a17efc2a12a1745d2a34bf0f6fc4b1b46eaf98f1f98f365d2dbec583ad9ae9'
+  version '4.21'
+  sha256 '985c6bd395a93b14e697ef11ab2c36f4dd1fa374ed8799591ca8eb57c3ad0551'
 
   # downloads.sourceforge.net/scidvspc was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/scidvspc/ScidvsMac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.