### PR TITLE
Update iridium from 2019.04.73.0,2019.04-0 to 2019.11.79.0,2019.11-0

### DIFF
--- a/Casks/iridium.rb
+++ b/Casks/iridium.rb
@@ -1,8 +1,8 @@
 cask 'iridium' do
-  version '2019.04.73.0,2019.04-0'
-  sha256 '3d402a406e7ff8a7370d025baf37aee20ac4da06fe0b9ad30d06f3238dd10e8e'
+  version '2019.11.79.0,2019.11-0'
+  sha256 'a53342aa2cad7df3e3792a66efa82e5d9ff61210e6c1ec8e880c65f899942099'
 
-  url "https://downloads.iridiumbrowser.de/macos/#{version.after_comma}/iridium-browser_#{version.after_comma}_macos_x64.dmg"
+  url "https://downloads.iridiumbrowser.de/macos/#{version.after_comma}/iridium-browser_#{version.after_comma}_macos.dmg"
   appcast 'https://downloads.iridiumbrowser.de/macos/'
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.