### PR TITLE
Update metasploit to use `latest` package as it updates nightly, but only retains the last 7 builds

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,15 +1,14 @@
 cask 'metasploit' do
-  version '5.0.66,20191223113728'
-  sha256 '7fb2595a1c0f6d2a1667490aa06764fb9a755da8481a96ea5dd46329c2c5066a'
+  version :latest
+  sha256 :no_check
 
-  url "https://osx.metasploit.com/metasploit-framework-#{version.before_comma}+#{version.after_comma}-1rapid7-1.pkg"
-  appcast 'https://osx.metasploit.com/LATEST'
+  url 'https://osx.metasploit.com/metasploitframework-latest.pkg'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
 
   depends_on formula: 'nmap'
 
-  pkg "metasploit-framework-#{version.before_comma} #{version.after_comma}-1rapid7-1.pkg"
+  pkg 'metasploitframework-latest.pkg'
   binary '/opt/metasploit-framework/bin/msfbinscan'
   binary '/opt/metasploit-framework/bin/msfconsole'
   binary '/opt/metasploit-framework/bin/msfd'


### PR DESCRIPTION
As metasploit does nightly builds and only retains the last 7 days, it makes more sense to grab the `metasploitframework-latest.pkg` which is a symlink to the most recent build.

Fixes #75142

- [x] `brew cask audit --download Casks/metasploit.rb` is error-free.
- [x] `brew cask style --fix Casks/metasploit.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Documented Exception: **There is no stable version of metasploit -- all downloads are nightly builds.**