### PR TITLE
Update kstars from 3.3.8 to 3.3.9

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask 'kstars' do
-  version '3.3.8'
-  sha256 '141b0b695399afff0b56b9cc2dc1bdc1c03a323092267003a1205bbe2b6198d9'
+  version '3.3.9'
+  sha256 '0e615653ae081ed1829e6f5ab5ac24f5767bd2f19aae1d2605217ba7f2707ad5'
 
   # indilib.org/jdownloads/kstars was verified as official when first introduced to the cask
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.