### PR TITLE
Pocket Casts: Add auto_updates, zap stanza

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -7,7 +7,14 @@ cask 'pocket-casts' do
   name 'Pocket Casts'
   homepage 'https://play.pocketcasts.com/'
 
+  auto_updates true
   depends_on macos: '>= :sierra'
 
   app 'Pocket Casts.app'
+
+  zap trash: [
+               '~/Library/Application Support/au.com.shiftyjelly.PocketCasts',
+               '~/Library/Caches/au.com.shiftyjelly.PocketCasts',
+               '~/Library/Preferences/au.com.shiftyjelly.PocketCasts.plist',
+             ]
 end


### PR DESCRIPTION
I have added `auto_updates` stanza since the application is capable of self update. Also, zap stanza with known preferences and cache files.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
  - Not relevant as this doesn't change cask version
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
