### PR TITLE
Update aimersoft-video-converter-ultimate from 11.5.1.8 to 11.6.2.4

### DIFF
--- a/Casks/aimersoft-video-converter-ultimate.rb
+++ b/Casks/aimersoft-video-converter-ultimate.rb
@@ -1,6 +1,6 @@
 cask 'aimersoft-video-converter-ultimate' do
-  version '11.5.1.8'
-  sha256 'ff65948c7e3b2d81099f805f0ab93df764ef201f6d5b54f2299ce2e7718c69a4'
+  version '11.6.2.4'
+  sha256 '2160c7cd83efe0eb65aaa15d10021056554076741f8e890a3e7b9f95e75cda3f'
 
   url 'http://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full747.dmg'
   name 'Aimersoft Video Converter Ultimate'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.