### PR TITLE
Update diskcatalogmaker from 7.8.0 to 7.9.0

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '7.8.0'
-  sha256 '78c5316973c062d72b2efe1e87086b96f0893f948506271249eb2b213e106373'
+  version '7.9.0'
+  sha256 '308e171330c9a335aa0af70a25eaf9cbf5b23252ca3cd68539f97a44cfe8817f'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.