### PR TITLE
Update tidepool-uploader from 2.23.1 to 2.24.0

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.23.1'
-  sha256 '54b8bdb44e2debd826ba15bd81cd471ceb1ae6bc656816fc2742189bd30370c7'
+  version '2.24.0'
+  sha256 '5016b4470c09769f78469003b6a3763b03beefd233c1efc03c5fcbe2ec570ae7'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.