### PR TITLE
Update navicat-for-sqlite from 15.0.6 to 15.0.7

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.6'
-  sha256 'bb39e5e1a34b958fb5134a34d30e9e10cfdd54bed4e4f906fed6c9e62e21983e'
+  version '15.0.7'
+  sha256 '3c1162fe9e2b4cf3f36b08629218d8f78165d5887dcf3a687d511bebd3dcde96'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.