### PR TITLE
Update navicat-for-postgresql from 15.0.6 to 15.0.7

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.6'
-  sha256 'f868ada5edb0242dbc8eafbc62b25a27d692c673ff762f2966cb23f8a9313cc1'
+  version '15.0.7'
+  sha256 '2d46c2e8b01530497981e512c76ca2ce6ac3f110e9d219fea4feedb6495c6b15'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.