### PR TITLE
Update navicat-for-mysql from 15.0.6 to 15.0.7

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '15.0.6'
-  sha256 '595380167711dce8c616efdc9b6b2e89b48377fa83789a0453a5ed68f0bb73c1'
+  version '15.0.7'
+  sha256 'cb84b8cea1f2c2507a33af6551cee88192a1e009c85e95931d823eacafac671a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.