### PR TITLE
Update navicat-for-mariadb from 15.0.6 to 15.0.7

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '15.0.6'
-  sha256 '79fa0d9a67ad131e8d257a5bc9b3aea010b48b4a2b5eafab06bc8f4ff238b8c9'
+  version '15.0.7'
+  sha256 '13e7a2266f49b9dc966caf4fc20ac11932c91c36f9832cb719a12ea3e883a9e2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.