### PR TITLE
Update navicat-for-oracle from 15.0.6 to 15.0.7

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '15.0.6'
-  sha256 'e0345b757bb0262360dbe0504632a6dc79da20f50d978f23735687c25dbdc3a2'
+  version '15.0.7'
+  sha256 'c233de8b6b952667766ee26fecbdfa0f26652ddb69cbfbd6a61290f9aca02ea0'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.