### PR TITLE
Update protonvpn from 1.5.7 to 1.5.8

### DIFF
--- a/Casks/protonvpn.rb
+++ b/Casks/protonvpn.rb
@@ -1,6 +1,6 @@
 cask 'protonvpn' do
-  version '1.5.7'
-  sha256 'bc6fe9aa67cf394129bb933410ae57d025729f2341ce8e3ffee75e3c4affd2d7'
+  version '1.5.8'
+  sha256 'ab58cb0018a1e877a624efdb1962ea4e8b555719edd77dd775de640960f78eee'
 
   url "https://protonvpn.com/download/ProtonVPN_mac_v#{version}.dmg"
   appcast 'https://protonvpn.com/download/macos-update2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.