### PR TITLE
Update nucleo from 2.6.0 to 2.6.1

### DIFF
--- a/Casks/nucleo.rb
+++ b/Casks/nucleo.rb
@@ -1,6 +1,6 @@
 cask 'nucleo' do
-  version '2.6.0'
-  sha256 'faf199b5708b69564c9127e41d2b03fb06f9426e07a68d77d0dbb60a78dd5a37'
+  version '2.6.1'
+  sha256 '15488d5c51dd7ea3af414f68d6e5e855d880e0ef71a48ea08f00ab56e0f9a736'
 
   # nucleo-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://nucleo-app-releases.s3.amazonaws.com/mac/Nucleo_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.