### PR TITLE
Update website-watchman from 2.5.5 to 2.5.6

### DIFF
--- a/Casks/website-watchman.rb
+++ b/Casks/website-watchman.rb
@@ -1,6 +1,6 @@
 cask 'website-watchman' do
-  version '2.5.5'
-  sha256 '39252e6808266ab7b3c7ec5bb0a85191471dedaf7f5412ffe10f21498198191e'
+  version '2.5.6'
+  sha256 '886d0db02f9233544e5cf2fe92625bb606742f36076f47efb0677e12b4ee0b00'
 
   url 'https://peacockmedia.software/mac/watchman/watchman.dmg'
   appcast 'https://peacockmedia.software/mac/watchman/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.