### PR TITLE
Update metasploit to 5.0.68+20200106113759

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,14 +1,15 @@
 cask 'metasploit' do
-  version :latest
-  sha256 :no_check
+  version '5.0.68,20200106113759'
+  sha256 '2da55044d4f1fdea21649e62eadefc1ec12c552fbc0b7d742c7a4d2f078f9ce2'
 
-  url 'https://osx.metasploit.com/metasploitframework-latest.pkg'
+  url "https://osx.metasploit.com/metasploit-framework-#{version.before_comma}+#{version.after_comma}-1rapid7-1.pkg"
+  appcast 'https://osx.metasploit.com/LATEST'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
 
   depends_on formula: 'nmap'
 
-  pkg 'metasploitframework-latest.pkg'
+  pkg "metasploit-framework-#{version.before_comma} #{version.after_comma}-1rapid7-1.pkg"
   binary '/opt/metasploit-framework/bin/msfbinscan'
   binary '/opt/metasploit-framework/bin/msfconsole'
   binary '/opt/metasploit-framework/bin/msfd'

--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,15 +1,14 @@
 cask 'metasploit' do
-  version '5.0.66,20191223113728'
-  sha256 '7fb2595a1c0f6d2a1667490aa06764fb9a755da8481a96ea5dd46329c2c5066a'
+  version :latest
+  sha256 :no_check
 
-  url "https://osx.metasploit.com/metasploit-framework-#{version.before_comma}+#{version.after_comma}-1rapid7-1.pkg"
-  appcast 'https://osx.metasploit.com/LATEST'
+  url 'https://osx.metasploit.com/metasploitframework-latest.pkg'
   name 'Metasploit Framework'
   homepage 'https://www.metasploit.com/'
 
   depends_on formula: 'nmap'
 
-  pkg "metasploit-framework-#{version.before_comma} #{version.after_comma}-1rapid7-1.pkg"
+  pkg 'metasploitframework-latest.pkg'
   binary '/opt/metasploit-framework/bin/msfbinscan'
   binary '/opt/metasploit-framework/bin/msfconsole'
   binary '/opt/metasploit-framework/bin/msfd'


### PR DESCRIPTION
- [x] `brew cask audit --download Casks/metasploit.rb` is error-free.
- [x] `brew cask style --fix Casks/metasploit.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Documented Exception: `metasploit` has no stable release

@vitorgalvao Can you take a look? Feel free to do a `merge --squash` if it suits you.