### PR TITLE
Update orange from 3.23.1 to 3.24.0

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,6 +1,6 @@
 cask 'orange' do
-  version '3.23.1'
-  sha256 '03220412b455df991a101a353b373a50663e2061be916daf88eb6bb4073439a1'
+  version '3.24.0'
+  sha256 'ee584da07231faddc447386a494ef70dafe3482042b071d6f8fa1fd7782b18d7'
 
   url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://service.biolab.si/download/orange?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.