### PR TITLE
Update datadog-agent from 7.16.0-1 to 7.16.1-1

### DIFF
--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -1,6 +1,6 @@
 cask 'datadog-agent' do
-  version '7.16.0-1'
-  sha256 '906e38de5c82f337bf62cfa35970a2f925efd07d8da0c1f04a6eb9b6cb5482ba'
+  version '7.16.1-1'
+  sha256 '784309d42e9d5b5c53d1b65c8cfb13e4bef85bf8c544b759f6f43cf6149d32b0'
 
   # dd-agent.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://dd-agent.s3.amazonaws.com/datadog-agent-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.