### PR TITLE
Update command-tab-plus from 1.109,359:1576772358 to 1.109

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,11 +1,10 @@
 cask 'command-tab-plus' do
-  version '1.109,359:1576772358'
+  version '1.109'
   sha256 '608458aa55d699f6c1d21a6bc834365d0787174b4f34b266dad8f267acfdc328'
 
-  # dl.devmate.com/com.sergey-gerasimenko.Command-Tab was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.sergey-gerasimenko.Command-Tab/#{version.after_comma.before_colon}/#{version.after_colon}/Command-Tab-#{version.after_comma.before_colon}.zip"
-  appcast 'https://updates.devmate.com/com.sergey-gerasimenko.Command-Tab.xml',
-          configuration: version.after_comma.before_colon
+  # macplus-software.com/downloads was verified as official when first introduced to the cask
+  url 'https://macplus-software.com/downloads/Command-Tab%20Plus.zip'
+  appcast 'https://macplus-software.com/downloads/Command-Tab.xml'
   name 'Command-Tab Plus'
   homepage 'http://commandtab.noteifyapp.com/'
 

--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,9 +1,8 @@
 cask 'command-tab-plus' do
   version '1.109'
-  sha256 '608458aa55d699f6c1d21a6bc834365d0787174b4f34b266dad8f267acfdc328'
+  sha256 'c133c07450b65bd8bd48b188eb99606027b3c0186aca5c4806cbb1dbeb9dfc1c'
 
-  # macplus-software.com/downloads was verified as official when first introduced to the cask
-  url 'https://macplus-software.com/downloads/Command-Tab%20Plus.zip'
+  url 'https://noteifyapp.com/download/Command-Tab%20Plus.dmg'
   appcast 'https://macplus-software.com/downloads/Command-Tab.xml'
   name 'Command-Tab Plus'
   homepage 'http://commandtab.noteifyapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.