### PR TITLE
Update expandrive from 7.4.5 to 7.4.6

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,6 +1,6 @@
 cask 'expandrive' do
-  version '7.4.5'
-  sha256 '7db4f446323b1a9a12d5938a108e9ad0ee3af08f58cf3f7bacf193b7d74c8394'
+  version '7.4.6'
+  sha256 'abbb69b57394035cbd62f568e658e1b8f4695956a219925d884f79e812f16272'
 
   url "https://updates.expandrive.com/apps/expandrive#{version.major}/v/#{version.dots_to_hyphens}/update_download"
   appcast "https://updates.expandrive.com/appcast/expandrive#{version.major}.json?version=#{version.major}.0.0"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.