### PR TITLE
Update firefox from 71.0 to 72.0

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '71.0'
+  version '72.0'
 
   language 'cs' do
-    sha256 '8acacdec18ae8a6f9c6fee4bee0cc3b5d2ed64a5f7281e84d5d3216ffb2cb482'
+    sha256 '6f40d52d2780207787983ed8e1cc7bffab76321bd998d7d74878b0bdbb13bf43'
     'cs'
   end
 
   language 'de' do
-    sha256 '4ac2b3ea9889c3e49e3abdc899d0578ea2db1b0b77b4ff3490e450bd20cf4f4c'
+    sha256 '2c590a56dc46c17f9805cfc67fc6788ef8f4138496838bb184f66143a76c505d'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'a87a37ced6efa475d3ddad3375e789f2abf5e43ae46db8d4f632c1eaf5c576ce'
+    sha256 '400421556506e956cd37a473fed823db6c6450428dc28dba71ddea20e091b23d'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '4becd26dcbc3876935bab344788a4d1473a187f8bfb856c67844284000dc4788'
+    sha256 '1ee98cd9364a279dbafe9073f3d2d8b181ac8c66999d00d390988ac3c25d3be8'
     'en-US'
   end
 
   language 'eo' do
-    sha256 'b7bdb9d330a553c8efc4a36a3adf013ceaf3ce0b9956e9a45148cdf972bd56d6'
+    sha256 '1019bfb3712db1261843d349e92f75cf78fe65d34c0330896981cf9632c22943'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '82b2703ccd6119324e67eaabcd62f07725dd1a8701485e392ef69d55545c65ba'
+    sha256 'f856ba13ed296a9780528e886190a618727564a60a7f09d583d01049a11a3a90'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '4c4134b9fd2044c6b28e2dd8e6637db00fcad0c2d3ebdc81d724bbcf3e2e5e79'
+    sha256 '6aeeebea3fbef648771ba071ffc204571d523692faaf1fab06dcab5cf93079dd'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '582a134eadc6cb02e87b37c13e39d0714e033448cc6a4d7a65e727ec5918261e'
+    sha256 '1ff9a7947bcad86ef89195b90f807c4cfda0b1775f9be467c3d222e20a1f9038'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 'a559efa6326405fb1cb05629f3aff9442c68e43f70c64241adda4d14c99b7150'
+    sha256 '01f02773d067f5fa18acba00dc4a0f07258b33b738bfd20b25410935a2db0cf0'
     'fi'
   end
 
   language 'fr' do
-    sha256 'e52911a52c6de2dfd2ff4c4a5bb906d361a8a8f29471d03af32c07a3183a32fb'
+    sha256 'e5cbe4a87749eea9f755c4645db483ee9146800c80bc76f93a349bbd7e3d9961'
     'fr'
   end
 
   language 'gl' do
-    sha256 '527ff98ebde60bc6b6422066fb976439766c86074bfe1de1e80809558b38b9d7'
+    sha256 '562da612a7a83875e779cf9e8c0536766003f2618bd181e94aab034d3d0629a1'
     'gl'
   end
 
   language 'in' do
-    sha256 '820210ad0db5935ede8b5ae08675df6a167b057c513a3f1c3a3f96d22aba84b7'
+    sha256 '4e9c8bf43beef9f97543ebc37e5399d16d4a9d406c40d66b4bcba594a5d43b9b'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '02f566f89e91a1def80a7a42dc820ac937b5c76e68675f900c7ad519cd22bc5e'
+    sha256 'd3c1acde17761025e069be892f752f798552762d950c21d81a266c4331912dcf'
     'it'
   end
 
   language 'ja' do
-    sha256 '9a25b8933ba0ac5daa5e94456ff218e55825fd86ba433e863cdc6789fc91faf3'
+    sha256 'c9cfcf6a67661adfa7fbab4736af15952b626b07faed003e05ead5c5a36df248'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '022234cff0c78f382375c93649edcaade3fd02c3e3c09ef832715930ddabaedc'
+    sha256 'eb8d4c2596cd1f6011863e7967ccf3d4f16e89aeb18bc801744ff840ec4a3633'
     'ko'
   end
 
   language 'nl' do
-    sha256 'd3f9a6199bf12d006587f0a3d92bd2d969ff70c66681a3fae786423f1c745b4b'
+    sha256 '6c11d1da8d09eb61ea1035cf19058c15fef9969260b15a447f2146ca558e0973'
     'nl'
   end
 
   language 'pl' do
-    sha256 'c64d01ec37cc641c40fb096a96425c83aa5c3ae12656b9dbaddf5b7adbfda5d8'
+    sha256 '8205e278f66226abd4e23618c480769f10439c074d5f1b5023b8bd90ba60ebd6'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '2ff46811bfd86f72299f6298ff0696a67047eb83f43287911f3accf177ade5c3'
+    sha256 '6c6e2334dc64be998c4bd3cb5e9f69df0e712ed04d2db1e613cb79b0f8d0e4a6'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '62f7ae98f803da831982ab1df881045bc31272456a82562d6330cb070ae00c1d'
+    sha256 'f7d244fb3b90b84f0ca7281c6eae916f172a9446975b605ec5e20e64a60848c4'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'e101c023f8f29fe9f8dc1802b7d1f72625200a7675d77652dc3696ca23bc3204'
+    sha256 '7e2c71483328d43379d68ac6f61c6c53f2650933c723ac3a4599bd00b9d99a40'
     'ru'
   end
 
   language 'tr' do
-    sha256 'caf9a6b5e13966c719f7e78cd68e875b6ea03d8fdbe8c92e49bf1d1a74efff89'
+    sha256 'f7c93b028869207cd81177c76aeb41027bea641caf4cc3fa01f7b8e6fce1c6c5'
     'tr'
   end
 
   language 'uk' do
-    sha256 '2d5963f7f5c8d255e6ce46171aa4768da3cbd90702a0cae18a77ab2f0b676e76'
+    sha256 '18489eae932076e6b607b52e01a1a4722585572e0b6f86753caa7a880c3725b5'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '33b6de17924f47ae311fb81141fe053211cd4b5531f792021d00d6d1e982801f'
+    sha256 '626f4c102fb117489bc6417c4652259aea417173cf94ef484bbd6acc603038bb'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'f57957597ca9391750c106a8bf01cbd8583d013e9d76f28dc683999c210c7f81'
+    sha256 '348cb1948c9512c4b4e464a3a73083a2f5b020473e7c7a47a0e611c7a96e6e88'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).