### PR TITLE
Update marshallofsound-google-play-music-player from 4.6.1 to 4.7.1

### DIFF
--- a/Casks/marshallofsound-google-play-music-player.rb
+++ b/Casks/marshallofsound-google-play-music-player.rb
@@ -1,6 +1,6 @@
 cask 'marshallofsound-google-play-music-player' do
-  version '4.6.1'
-  sha256 '14bbaf4f81c302b787b36c1d0fdc44a990dcb73dd987e8b5fd0f259283a1fa2e'
+  version '4.7.1'
+  sha256 'de6409bca32072d231ff636b68589329731923239ebf1c36e6f557fa26ebddf6'
 
   # github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL- was verified as official when first introduced to the cask
   url "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v#{version}/Google.Play.Music.Desktop.Player.OSX.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.