### PR TITLE
Update routeconverter from 2.26.69 to 2.27.94

### DIFF
--- a/Casks/routeconverter.rb
+++ b/Casks/routeconverter.rb
@@ -3,7 +3,8 @@ cask 'routeconverter' do
   sha256 'ca6d7be4fbbefd406ef9f87b9f3713d4ab224da43acaa87d32c9ad3b45f1f9e5'
 
   url 'https://static.routeconverter.com/download/RouteConverterMac.app.zip'
-  appcast 'https://static.routeconverter.com/download/previous-releases/'
+  appcast 'https://static.routeconverter.com/download/previous-releases/',
+          configuration: version.major_minor
   name 'RouteConverter'
   homepage 'https://www.routeconverter.com/'
 

--- a/Casks/routeconverter.rb
+++ b/Casks/routeconverter.rb
@@ -1,6 +1,6 @@
 cask 'routeconverter' do
-  version '2.26.69'
-  sha256 'ade167e527527a84e3a51df37b99622f1e3a0a4934656ee4ba088df4e780dda9'
+  version '2.27.94'
+  sha256 'ca6d7be4fbbefd406ef9f87b9f3713d4ab224da43acaa87d32c9ad3b45f1f9e5'
 
   url 'https://static.routeconverter.com/download/RouteConverterMac.app.zip'
   appcast 'https://static.routeconverter.com/download/previous-releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.