### PR TITLE
Update augur from 1.16.6 to 1.16.7

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.16.6'
-  sha256 '298c0612a9ffb6baf94ec4aa35965e80bb68c77d8f0aaed458713fec3550ea74'
+  version '1.16.7'
+  sha256 '2d0c732664b0da0f15e907661516efc5314de1cb8fefd53b315c6535d288f901'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.