### PR TITLE
Update zeplin from 2.8,786 to 2.8.1,797

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.8,786'
-  sha256 'f101e3f5834fb6c3320afb48a542a12c3f854e5536754cbba84f3ef27fd59f71'
+  version '2.8.1,797'
+  sha256 '6018f4851fc7c45dacea765c7bfc173c82ecacf31d69cca3564e8358c0166720'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.