### PR TITLE
Update jaxx-liberty from 2.3.6 to 2.3.7

### DIFF
--- a/Casks/jaxx-liberty.rb
+++ b/Casks/jaxx-liberty.rb
@@ -1,6 +1,6 @@
 cask 'jaxx-liberty' do
-  version '2.3.6'
-  sha256 '47483540de269cd2a5e20ff2cb56725f2b9eba7d7ee5653f499996d29781c2ab'
+  version '2.3.7'
+  sha256 '2611ef7485447fd53c1ad46551cc3e0ef23bcddbfaecd725a283b99bb4a91a95'
 
   url "https://download-liberty.jaxx.io/Jaxx.Liberty-#{version}.dmg"
   appcast 'https://jaxx.io/downloads.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.