### PR TITLE
Update netxms-console from 3.1.242 to 3.1.300

### DIFF
--- a/Casks/netxms-console.rb
+++ b/Casks/netxms-console.rb
@@ -1,6 +1,6 @@
 cask 'netxms-console' do
-  version '3.1.242'
-  sha256 '57968fe224f0883af0a649f379e55456477a26a7816cdb8a8bafe1276d12bf36'
+  version '3.1.300'
+  sha256 'fba16e71742d0b0e2dcf3ac98fce5c07e46638ab40156ddfdb408998a68ef51a'
 
   url "https://netxms.org/download/releases/#{version.major_minor}/nxmc-#{version}.dmg"
   appcast "https://netxms.org/download/releases/#{version.major_minor}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.