### PR TITLE
Update rekordbox from 5.8.1 to 5.8.2

### DIFF
--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -1,6 +1,6 @@
 cask 'rekordbox' do
-  version '5.8.1'
-  sha256 '79cd29aded110bda14154efa6794f4dd44bac7c771c12311d140940f12f6b05c'
+  version '5.8.2'
+  sha256 '197ad1a5cc243155a9af1771c4dcd389e97fd3d42ff579e689eaaa42b84f531b'
 
   url "https://rekordbox.com/_app/files/Install_rekordbox_#{version.dots_to_underscores}.pkg.zip"
   appcast 'https://rekordbox.com/en/support/releasenote.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.