### PR TITLE
Update ibm-cloud-cli from 0.18.1 to 0.21.0

### DIFF
--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -1,6 +1,6 @@
 cask 'ibm-cloud-cli' do
-  version '0.18.1'
-  sha256 'd727b6da308812e3e1736e5e5b25bca333db90ce011f064465530526a282f214'
+  version '0.21.0'
+  sha256 '2ff070a944fd9516a72bf7659513f8351acd09eb5d434601e754b33b2e411faa'
 
   # public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli was verified as official when first introduced to the cask
   url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/IBM_Cloud_CLI_#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.