### PR TITLE
Update openinterminal from 2.0.5 to 2.1.1

### DIFF
--- a/Casks/openinterminal.rb
+++ b/Casks/openinterminal.rb
@@ -1,6 +1,6 @@
 cask 'openinterminal' do
-  version '2.0.5'
-  sha256 'ecc02de450161c44cf9b7ce4b683b650a33879ccb72e4798d676cdf92e18df22'
+  version '2.1.1'
+  sha256 '9267950fbe169457c30575fa1e9709b20f3c0d9163601bfffd5b146d81c999b1'
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/#{version}/OpenInTerminal.app.zip"
   appcast 'https://github.com/Ji4n1ng/OpenInTerminal/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.