### PR TITLE
Update kitematic from 0.17.9 to 0.17.10

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -1,6 +1,6 @@
 cask 'kitematic' do
-  version '0.17.9'
-  sha256 '1c22a87b82c57f8c5d7b264c7ebb79bb243a9f34668b936c5237cbe4c0247e40'
+  version '0.17.10'
+  sha256 '4c4e232586c896b588856fab9e8bba7df6a0d329f86f030efa3530f76e5a0d92'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.