### PR TITLE
Update chronicle from 9.5.2 to 9.5.3

### DIFF
--- a/Casks/chronicle.rb
+++ b/Casks/chronicle.rb
@@ -1,6 +1,6 @@
 cask 'chronicle' do
-  version '9.5.2'
-  sha256 '65a8b9a49467002450f8189bebcc234fc8d28d5eb67318764b19658e3e276687'
+  version '9.5.3'
+  sha256 '7f184305a955ad1806f313b46d380b6b41f607f63f19d92677446a48686a828b'
 
   url 'https://www.chronicleapp.com/static/downloads/chroniclepro.zip'
   appcast 'http://www.littlefin.com/downloads/chronicle8.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.