### PR TITLE
Update avocode from 4.2.1 to 4.2.2

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.2.1'
-  sha256 '016debb995684ca99f422d2d850d3788aaef829ace265f0cf1debace35c399a1'
+  version '4.2.2'
+  sha256 'db84fe578181840382d5dcbc13a7b125beca36ff782ac46e3b9ea38946797e8e'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.