### PR TITLE
Update yojimbo from 4.1.3 to 4.1.4

### DIFF
--- a/Casks/yojimbo.rb
+++ b/Casks/yojimbo.rb
@@ -1,6 +1,6 @@
 cask 'yojimbo' do
-  version '4.1.3'
-  sha256 '6bc8f4dd2095c6e9f7a6315cfa092da8e1f9b51b1ad46fda8a5c5d4ec5b1de86'
+  version '4.1.4'
+  sha256 '5662f4b131fbbbe1ff0f7b691014d19f190eb0b232930f1edea758465956c03a'
 
   # s3.amazonaws.com/BBSW-download was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/BBSW-download/Yojimbo_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.