### PR TITLE
Update metabase from 0.33.7.1 to 0.34.0

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.33.7.1'
-  sha256 '67744feb82639db10c6fe0686f710f5bc0df3e953bda09630baaaea264e106db'
+  version '0.34.0'
+  sha256 'efa02c429144d1ebced614aca542c62ce1844682685c4c9b50d219e3455bb870'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.