### PR TITLE
Update backblaze from 7.0.0.392 to 7.0.0.402

### DIFF
--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,5 +1,5 @@
 cask 'backblaze' do
-  version '7.0.0.392'
+  version '7.0.0.402'
   sha256 'c5bb26fab34b890c643c8c6ebb23fccc1a7014530e1d6cdcc9010ab722ebe516'
 
   url 'https://secure.backblaze.com/mac/install_backblaze.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.