### PR TITLE
Update bisq from 1.2.4 to 1.2.5

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '1.2.4'
-  sha256 '87bc589892a04157a39620632d87c1b29d5109582018db04ee0849ab944c8b48'
+  version '1.2.5'
+  sha256 'de0d7fd5471b30e6f2428776bac5874e560507a10cf93369199bd0c232d7e8ce'
 
   # github.com/bisq-network/bisq was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.