### PR TITLE
Update ark-desktop-wallet from 2.6.2 to 2.7.0

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.6.2'
-  sha256 'e1cc0f3bfa09105b484299794c9e3f1e8bc4bf256f9331234fe26f40ea7dc36e'
+  version '2.7.0'
+  sha256 'c7496e1586c0958b80da73ea3f96cda8a86d50bd9b26cb1157b6c5d6b6b5837b'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.