### PR TITLE
Update fsnotes from 4.0.14 to 4.0.15

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.0.14'
-  sha256 '922fd7c3d8a3c439cbe5174e31dbc9d5d9bf58f9ef3c4a728799244bda6f3504'
+  version '4.0.15'
+  sha256 'aa9159c353cbb3f5200fa734830dd7fbd5090348bd3602a10956ab5030a79f78'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.