### PR TITLE
Update clickup from 2.0.4 to 2.0.5

### DIFF
--- a/Casks/clickup.rb
+++ b/Casks/clickup.rb
@@ -1,6 +1,6 @@
 cask 'clickup' do
-  version '2.0.4'
-  sha256 'c9b3a4773c07a38ab9e4bd87e3355dbb01a2be01df1cdf417caaaa1650a38ff7'
+  version '2.0.5'
+  sha256 '2486ad9094da1ecc7ebe8884990fccb232cba280b7aac263331ac351219e8aff'
 
   url "https://attachments.clickup.com/desktop/clickup-desktop-#{version}-mac.dmg"
   name 'ClickUp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.