### PR TITLE
Update wavebox from 4.11.11 to 4.11.12

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '4.11.11'
-  sha256 '2405c51c27c85c8e1f8e4556d7911ceaeb778d776c808bd78c58c40b9bd66c4b'
+  version '4.11.12'
+  sha256 'cd114d80445587420895963471422c393f4507363b38cff6f7a2ce380407650f'
 
   # github.com/wavebox/waveboxapp was verified as official when first introduced to the cask
   url "https://github.com/wavebox/waveboxapp/releases/download/v#{version}/Wavebox_#{version.dots_to_underscores}_osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.