### PR TITLE
Update mapillary-uploader from 1.2.1 to 1.2.3

### DIFF
--- a/Casks/mapillary-uploader.rb
+++ b/Casks/mapillary-uploader.rb
@@ -1,6 +1,6 @@
 cask 'mapillary-uploader' do
-  version '1.2.1'
-  sha256 '2ceba51833f157f11461a2b2d121a0240adbf792a5d1c0f3b87ba0bc82c4516e'
+  version '1.2.3'
+  sha256 '9509ff4bf4efbee115b477004b9755e70ebde40fa3e808c9ffa035016f275ea3'
 
   url "https://tools.mapillary.com/uploader/Mapillary%20Uploader-#{version}.dmg"
   appcast 'https://www.mapillary.com/desktop-uploader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.