### PR TITLE
Update understand from 5.1.1010 to 5.1.1011

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1010'
-  sha256 '23514129ee1d6547c233f0ca5457883a67354a24cc55182353dab4429dc330f3'
+  version '5.1.1011'
+  sha256 'c9fdd3716a6010589a007dfa65849e8fa8bebf88d8669f91037564392d00607f'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.