### PR TITLE
Update vuescan from 9.7.18 to 9.7.19

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.18'
-  sha256 '22010d1fec4eee4fa5b5987f58253a69a98545598eb5e210c9e1071404d9fad0'
+  version '9.7.19'
+  sha256 '549dcd2c3562f3628fae2eb4b339aec15f11a778bd3cfb59a9b00018af3ecfa1'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.