### PR TITLE
Update wpsoffice from 1.9.0,2959 to 1.9.1,2994

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
-  version '1.9.0,2959'
-  sha256 '1e68efdd5d3cdcb63dc18f9f7028a4172b8de6c5049f3636ad5a0e1351a9d142'
+  version '1.9.1,2994'
+  sha256 '0e24e91fba32b03e17c520b1037ca9c1df84042c9b6dc54812fb9da7496156b6'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
   url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}(#{version.after_comma}).dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.