### PR TITLE
Update livechat from 9.0.7 to 9.0.8

### DIFF
--- a/Casks/livechat.rb
+++ b/Casks/livechat.rb
@@ -1,6 +1,6 @@
 cask 'livechat' do
-  version '9.0.7'
-  sha256 '34a4941b7429e094770d55dd864de0a4d795c8e875aa36344921e89d36d94d06'
+  version '9.0.8'
+  sha256 'ad9f350f4313bc2054a1bbc3bf2fe2f18f73c7d4c0e6e74c5c168a620548c75a'
 
   url 'https://www.livechatinc.com/download/Mac/LiveChat.dmg'
   appcast 'https://dal-livechat-main-web.s3.amazonaws.com/download/Mac/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.