### PR TITLE
Update electron from 7.1.7 to 7.1.8

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '7.1.7'
-  sha256 '4f64b610112c936b7455f4a5588ba1e87bff8634f726736c1cbf11b08c1a9302'
+  version '7.1.8'
+  sha256 'c8f4e560f989b9fe327e66550ce8be855212a0aa55f8b3232668c5cf74ed90b6'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.