### PR TITLE
update gnucash.rb cask from 3.8-2 to 3.8-3

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask 'gnucash' do
-  version '3.8b,2'
-  sha256 '4a32ba1b770d1c3f72549235c9333d96472f549435fe9d11c2a6b85b325b1a7a'
+  version '3.8b,3'
+  sha256 '05744be1fc8c60609e9315c2bdaf5f7c7ad51c513bea8408df7546f7d1ed30e7'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.before_comma}/Gnucash-Intel-#{version.before_comma.chomp('b')}-#{version.after_comma}.dmg"


### PR DESCRIPTION
3.8-2 does not exist at https://github.com/Gnucash/gnucash/releases/ as of this writing.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
could not build / install nokogiri; error "mkmf.rb can't find header files for ruby at /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/include/ruby.h"
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
It appears that the cask is a beta version (not sure about this; based on the "b" in the version name), but it is replacing a beta version that does not exist.

