### PR TITLE
Update lingon-x from 7.4.6 to 7.5

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.5'
     sha256 'b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8'
   else
-    version '7.4.6'
-    sha256 'cb3a2ef3f1c485f546c73e1c876438911735a4418fc3c2fc63264e54d5e63514'
+    version '7.5'
+    sha256 'ec27a4e5525c9e5aa8309a59216d35cebc23d24a14802780aee45a00b55d3aff'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.