### PR TITLE
Update qownnotes from 20.1.5,b5180-171837 to 20.1.6,b5197-162638

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.5,b5180-171837'
-  sha256 '6e74aa12f2592e3c2ab679e9e0da4962a039839fa32e6fba3e64db8234160efd'
+  version '20.1.6,b5197-162638'
+  sha256 '0e97c678e125bccf001ae23c0ada681a0fcd0d44fed33e8a53155943792ec7ef'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.