### PR TITLE
Update qtum-qt from 0.18.2 to 0.18.3

### DIFF
--- a/Casks/qtum-qt.rb
+++ b/Casks/qtum-qt.rb
@@ -1,6 +1,6 @@
 cask 'qtum-qt' do
-  version '0.18.2'
-  sha256 'de21ee839e2ea67ab85e684358deaaecfd6f3c990a9c2f3bfdcbdf92ceb478f7'
+  version '0.18.3'
+  sha256 '80639e7cb0f38a6c2cea72361720629bad3fc99475075ae3771ef6c857637c7e'
 
   # github.com/qtumproject/qtum was verified as official when first introduced to the cask
   url "https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v#{version}/qtum-#{version}-osx-unsigned.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.