### PR TITLE
Update vivaldi from 2.10.1745.23 to 2.10.1745.26

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.10.1745.23'
-  sha256 '81c97fc56cd5d957d33833ef013ee18b6c4ac68121480b4b1bc9e7228f537705'
+  version '2.10.1745.26'
+  sha256 'bf3451323d3c3db42a2a957ed118596f18b7f99538af0268bd81589f82941b1c'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.