### PR TITLE
Update shift from 4.0.10 to 4.0.11

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,6 +1,6 @@
 cask 'shift' do
-  version '4.0.10'
-  sha256 'bc6bd2eec3bf765f3566617d682622ef0e8de3499ce99220c68bfb28c5672dbd'
+  version '4.0.11'
+  sha256 'dcc445e28b9503f8ef6a364535ff04a9ac875433d62c3594bb80465d8844ab7b'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"
   appcast 'https://tryshift.com/download/?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.