### PR TITLE
Update studio-3t from 2020.1.0 to 2020.1.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2020.1.0'
-  sha256 '9d0b3bb7d4b977a0303e01299dd18efd1a429cca9277073804de71eb6749c5d7'
+  version '2020.1.1'
+  sha256 '223bd96dbdf3e10fe8c52b2c89766e4d4bee42ce748b25c9203df167afc6c446'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.