### PR TITLE
Update liclipse from 6.0.0,ve32xytlixmlg3x to 6.1.0,yau5fhnopa6zx04

### DIFF
--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -1,6 +1,6 @@
 cask 'liclipse' do
-  version '6.0.0,ve32xytlixmlg3x'
-  sha256 'd26d250e9edecf99108e3e37e07014f8a4347d74d9dce583c2ac1481ec3c94c3'
+  version '6.1.0,yau5fhnopa6zx04'
+  sha256 '4c653227a5fb44f570aca52e84796bab3865cac7128b5e0c7b4b943dca21a363'
 
   # mediafire.com/file was verified as official when first introduced to the cask
   url "https://www.mediafire.com/file/#{version.after_comma}/liclipse_#{version.before_comma}_macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.