### PR TITLE
Update tuple from 0.58.1,2020-01-03-31852687 to 0.59.0,2020-01-09-249fbd10

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.58.1,2020-01-03-31852687'
-  sha256 'fc43cec91f5f38ec00408d96d7db5371eaa585fd6b6a0a4af119a6c7871122f4'
+  version '0.59.0,2020-01-09-249fbd10'
+  sha256 '6e3862aa4a41ff4ddd944507abdc4a32a6ebc419f6daf270bddefa52ddfd1a62'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.