### PR TITLE
Update pdfelement from 7.5.5,5237 to 7.5.7,5237

### DIFF
--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,6 +1,6 @@
 cask 'pdfelement' do
-  version '7.5.5,5237'
-  sha256 'f171e3a522ed7c7d268ec90976275c26fe2c91635d1f514de1b6d2fc91425ae3'
+  version '7.5.7,5237'
+  sha256 '1fb20d36f087113c9b8e5a50c2c8b525d9aaeec58042902820125066429021e9'
 
   url "http://download.wondershare.com/cbs_down/mac-pdfelement_full#{version.after_comma}.dmg"
   appcast 'https://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.