### PR TITLE
Update dcommander from latest to 3700

### DIFF
--- a/Casks/dcommander.rb
+++ b/Casks/dcommander.rb
@@ -1,8 +1,9 @@
 cask 'dcommander' do
-  version :latest
-  sha256 :no_check
+  version '3700'
+  sha256 '41c497e7d80b6667c4303a5e3e55ce3fb15c26d15817abaacbf867930e7ee178'
 
   url 'https://devstorm-apps.com/dc/download.php'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://devstorm-apps.com/dc/download.php'
   name 'DCommander'
   homepage 'https://devstorm-apps.com/dc/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.