### PR TITLE
Update typora from 0.9.9.31.3 to 0.9.9.31.4

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.31.3'
-  sha256 '52abff999be5b15439f836929a464d6ef660c6ee5c9efadf02bcd0e1d32c7367'
+  version '0.9.9.31.4'
+  sha256 '197f0f2ee85777a2cc3940c89dc77fd3116aaedbc07fa8d239fee742d2859717'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.