### PR TITLE
Add league displays cask

### DIFF
--- a/Casks/league-displays.rb
+++ b/Casks/league-displays.rb
@@ -2,17 +2,15 @@ cask 'league-displays' do
   version :latest
   sha256 :no_check
 
-  # riotgames.com was verified as official when first introduced to the cask
+  # screensaver.riotgames.com was verified as official when first introduced to the cask
   url 'https://screensaver.riotgames.com/v2/installer/latest/League%20Displays.dmg'
   name 'League Displays'
-  homepage 'https://na.leagueoflegends.com/en/featured/league-displays'
+  homepage 'https://leagueoflegends.com/en/featured/league-displays'
 
   app 'LeagueDisplays.app'
 
   zap trash: [
                '~/Library/Logs/LeagueDisplays-Configurator.log',
-             ],
-      rmdir: [
                '~/Library/Application Support/LolScreenSaver',
                '~/Library/Screen Savers/League.saver',
              ]

--- a/Casks/league-displays.rb
+++ b/Casks/league-displays.rb
@@ -1,0 +1,19 @@
+cask 'league-displays' do
+  version :latest
+  sha256 :no_check
+
+  # riotgames.com was verified as official when first introduced to the cask
+  url "https://screensaver.riotgames.com/v2/installer/latest/League%20Displays.dmg"
+  name 'League Displays'
+  homepage 'https://na.leagueoflegends.com/en/featured/league-displays'
+
+  app 'LeagueDisplays.app'
+
+  zap trash: [
+       '~/Library/Logs/LeagueDisplays-Configurator.log',
+      ],
+      rmdir: [
+        '~/Library/Application Support/LolScreenSaver',
+        '~/Library/Screen Savers/League.saver'
+      ]
+end

--- a/Casks/league-displays.rb
+++ b/Casks/league-displays.rb
@@ -3,17 +3,17 @@ cask 'league-displays' do
   sha256 :no_check
 
   # riotgames.com was verified as official when first introduced to the cask
-  url "https://screensaver.riotgames.com/v2/installer/latest/League%20Displays.dmg"
+  url 'https://screensaver.riotgames.com/v2/installer/latest/League%20Displays.dmg'
   name 'League Displays'
   homepage 'https://na.leagueoflegends.com/en/featured/league-displays'
 
   app 'LeagueDisplays.app'
 
   zap trash: [
-       '~/Library/Logs/LeagueDisplays-Configurator.log',
-      ],
+               '~/Library/Logs/LeagueDisplays-Configurator.log',
+             ],
       rmdir: [
-        '~/Library/Application Support/LolScreenSaver',
-        '~/Library/Screen Savers/League.saver'
-      ]
+               '~/Library/Application Support/LolScreenSaver',
+               '~/Library/Screen Savers/League.saver',
+             ]
 end


### PR DESCRIPTION
This PR adds [League Displays](https://na.leagueoflegends.com/en/featured/league-displays) cask. The download URL is from riotgames.com while the homepage is on leagueoflegends.com. Riot Games owns/created League of Legends and the app League Displays is maintained by Riot Games.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

**Help wanted**

- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
> The current `zap rmdir` does not work with my implementation because these directories are not empty. Any advice on best practices would be appreciated 🤗

