### PR TITLE
Update polar-bookshelf from 1.80.10 to 1.90.0

### DIFF
--- a/Casks/polar-bookshelf.rb
+++ b/Casks/polar-bookshelf.rb
@@ -1,6 +1,6 @@
 cask 'polar-bookshelf' do
-  version '1.80.10'
-  sha256 'b613e5cc583e4811431fdfe1c7248c43e0a0e6b1caca0057a6aeefbb40b48852'
+  version '1.90.0'
+  sha256 '7987c3333eb0c1b043eadfc3863c52e3a08f5ad4c749ff64142ec23df7630b52'
 
   # github.com/burtonator/polar-bookshelf was verified as official when first introduced to the cask
   url "https://github.com/burtonator/polar-bookshelf/releases/download/v#{version}/polar-bookshelf-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.