### PR TITLE
Update seashore from 2.5.2 to 2.5.3

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.5.2'
-  sha256 'c8cb57bbe2a4e4a1810766287e08f0b57908d7bae20743ab17fc2b3706da9186'
+  version '2.5.3'
+  sha256 'e5ffc463c399d76e770947620747ebada3eb297a128991ebc6e68238dd2a239b'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.