### PR TITLE
Update moodo from 1.4.1 to 1.4.2

### DIFF
--- a/Casks/moodo.rb
+++ b/Casks/moodo.rb
@@ -1,6 +1,6 @@
 cask 'moodo' do
-  version '1.4.1'
-  sha256 'b9974d621f17a972bf06cae3ae666997b0377ea13b8e7f348cc6c64347fcff7d'
+  version '1.4.2'
+  sha256 'b23c3db327030b43742f9329be68a4a8f64d917c3389a167a1e6d4fba34bcdc0'
 
   # github.com/MooDoApp/MooDoApp.github.io was verified as official when first introduced to the cask
   url "https://github.com/MooDoApp/MooDoApp.github.io/releases/download/v#{version}/Moo.do-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.