### PR TITLE
Update vuescan from 9.7.19 to 9.7.20

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,6 +1,6 @@
 cask 'vuescan' do
-  version '9.7.19'
-  sha256 'bdbb3b3560b10dc22ad79b89c3e58e258f0ae2850d986e88366c55abe7181f23'
+  version '9.7.20'
+  sha256 '7edee0af776000dbd1c99c93e53403d591d30dc4c4104e093d2736b217e4d4e1'
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"
   appcast 'https://www.hamrick.com/alternate-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.