### PR TITLE
Update anka-flow from 2.1.2.112 to 2.2.0.113

### DIFF
--- a/Casks/anka-flow.rb
+++ b/Casks/anka-flow.rb
@@ -1,6 +1,6 @@
 cask 'anka-flow' do
-  version '2.1.2.112'
-  sha256 '3f6b5654dc625ca700dab3cb7b79cb755353fa56b4cc254c1cb44dab52c92849'
+  version '2.2.0.113'
+  sha256 '1e72468679b6226bb39bf8298dd4c4ebd973a2a7cc74c72d69a2170f4c90c85b'
 
   # d1efqjhnhbvc57.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1efqjhnhbvc57.cloudfront.net/Anka-#{version}.pkg",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.