### PR TITLE
Update publish-or-perish from 7.15.2643 to 7.17.2677

### DIFF
--- a/Casks/publish-or-perish.rb
+++ b/Casks/publish-or-perish.rb
@@ -1,6 +1,6 @@
 cask 'publish-or-perish' do
-  version '7.15.2643'
-  sha256 '22ead7a451e20b25fb1340ec8a553dd309a57e6d83d44a11c19913a2f7753319'
+  version '7.17.2677'
+  sha256 'aec6387b10e8fbd7f85af4b377441a1472b04ac71d1e4f46d872409026d1d321'
 
   url 'https://harzing.com/download/PoP7Mac.pkg'
   appcast 'https://harzing.com/resources/publish-or-perish/os-x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.