### PR TITLE
Corrected Freecad SHA256

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
   version '0.18.4,16146'
-  sha256 '94797147c2e3b9b3aa2970ddd63647bb9517f2b4f9c48b5912258b84ab750039'
+  sha256 '6de32db5acd921d9e118ebc7a0481046b8e7bd76ec55296df72f2f5512bc8a37'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Somehow the last change to this cask introduced a shasum which isn't identical to the originally posted shasum at https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD_0.18-16146-OSX-x86_64-conda-Qt5-Py3.dmg-SHA256.txt . Homebrew errors as stated in my comment in the old Pull request https://github.com/Homebrew/homebrew-cask/pull/75345#issuecomment-573429719