### PR TITLE
Update goldencheetah from 3.4,3957:551 to 3.5

### DIFF
--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -1,9 +1,9 @@
 cask 'goldencheetah' do
-  version '3.4,3957:551'
-  sha256 'd618a3a1a8c941774830057ed131c2bba3dae3879150580a161c378a1e3fdc09'
+  version '3.5'
+  sha256 '6f685f623e7896615ecad0df688920597ccce49a76956cc1e05e2b17857d89f9'
 
   # github.com/GoldenCheetah/GoldenCheetah was verified as official when first introduced to the cask
-  url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V3.4/GoldenCheetah_V#{version.major_minor}_build_#{version.after_comma.before_colon}_Qt#{version.after_colon}_64bit.dmg"
+  url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V#{version}/GoldenCheetah_v#{version}_64bit_MacOS.dmg"
   appcast 'https://github.com/GoldenCheetah/GoldenCheetah/releases.atom'
   name 'GoldenCheetah'
   homepage 'https://www.goldencheetah.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.