### PR TITLE
Update pixelstick from 2.16.0 to 2.16.2

### DIFF
--- a/Casks/pixelstick.rb
+++ b/Casks/pixelstick.rb
@@ -1,6 +1,6 @@
 cask 'pixelstick' do
-  version '2.16.0'
-  sha256 '979182e735012cfbf4ab58f81778447da08a779187a8f8be65c13db831a332e6'
+  version '2.16.2'
+  sha256 'b1b19315cdd3632d503789df6da1842f5ce3fbf7b0da9e2da63503af27f8934c'
 
   url 'https://plumamazing.com/bin/pixelstick/pixelstick.zip'
   appcast 'https://plumamazing.com/product/pixelstick/changelog/appcast/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.