### PR TITLE
Update inkdrop from 4.5.0 to 4.5.1

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,6 +1,6 @@
 cask 'inkdrop' do
-  version '4.5.0'
-  sha256 '144d50d10d176a89d6cf8cee4d5b8782b6f19d79331ef9212c4056d776acc489'
+  version '4.5.1'
+  sha256 '9afd122ef75b20e97bd9e8082515c8b615ea5771029c253af1afaf221d688caf'
 
   # d3ip0rje8grhnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.