### PR TITLE
Revert "Update backblaze from 7.0.0.392 to 7.0.0.402"

### DIFF
--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,6 +1,6 @@
 cask 'backblaze' do
   version '7.0.0.392'
-  sha256 'c5bb26fab34b890c643c8c6ebb23fccc1a7014530e1d6cdcc9010ab722ebe516'
+  sha256 'a0967d345e4245b13f4c1a6223e322f9f4a8f03f26dc5e2ad331a311494070ca'
 
   url 'https://secure.backblaze.com/mac/install_backblaze.dmg'
   appcast 'https://backblaze.com/blog/category/backblaze-bits/release',

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -4,7 +4,7 @@ cask 'backblaze' do
 
   url 'https://secure.backblaze.com/mac/install_backblaze.dmg'
   appcast 'https://secure.backblaze.com/api/clientversion.xml',
-          configuration: "#{version}.zip"
+          configuration: "mac_version=\"#{version}\""
   name 'Backblaze'
   homepage 'https://backblaze.com/'
 

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -3,8 +3,8 @@ cask 'backblaze' do
   sha256 'a0967d345e4245b13f4c1a6223e322f9f4a8f03f26dc5e2ad331a311494070ca'
 
   url 'https://secure.backblaze.com/mac/install_backblaze.dmg'
-  appcast 'https://backblaze.com/blog/category/backblaze-bits/release',
-          configuration: version.major_minor
+  appcast 'https://secure.backblaze.com/api/clientversion.xml',
+          configuration: "#{version}.zip"
   name 'Backblaze'
   homepage 'https://backblaze.com/'
 

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,5 +1,5 @@
 cask 'backblaze' do
-  version '7.0.0.402'
+  version '7.0.0.392'
   sha256 'c5bb26fab34b890c643c8c6ebb23fccc1a7014530e1d6cdcc9010ab722ebe516'
 
   url 'https://secure.backblaze.com/mac/install_backblaze.dmg'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#75306

version number is the app is 7.0.0.392 

homepage claims  7.0.0.392 ( https://secure.backblaze.com/update.htm )

auto-update claims 7.0.0.392 ( https://secure.backblaze.com/api/clientversion.xml )