### PR TITLE
Update chromium from 729167 to 730459

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '729167'
-  sha256 'fd99474b934c845f1177d3a5b3611e5f44941093ef03cf78f431505a0652356e'
+  version '730459'
+  sha256 'd2f19f80ce549100f1ebab785be5a5e0a48579777082b63112f32370c8b77e7b'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.