### PR TITLE
Update loginputmac from 2.2.9 to 2.3.0

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '2.2.9'
-  sha256 'd45198b2820be76a0e2d172ecbe860f46c64f0700982501d6875984dfea93138'
+  version '2.3.0'
+  sha256 '5be3517b20280da8027663a01440575787eae6efb9afdc926d5dfa25878c8367'
 
   # loginput-mac2.content-delivery.top was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.