### PR TITLE
Update splitshow from 0.9.10-alpha to 0.9.12-alpha

### DIFF
--- a/Casks/splitshow.rb
+++ b/Casks/splitshow.rb
@@ -1,8 +1,8 @@
 cask 'splitshow' do
-  version '0.9.10-alpha'
-  sha256 '2bd1a68dda450e1052a54499731f710d119728f85f34187436cdffb5707dccd4'
+  version '0.9.12-alpha'
+  sha256 '742b5ddc5d171c4bcc8281f4469df8ca62a59c71a7b318ff29ad9a664b80f2b8'
 
-  url "https://github.com/mpflanzer/splitshow/releases/download/v.#{version}/SplitShow.app.zip"
+  url "https://github.com/mpflanzer/splitshow/releases/download/v#{version}/SplitShow.app.zip"
   appcast 'https://github.com/mpflanzer/splitshow/releases.atom'
   name 'SplitShow'
   homepage 'https://github.com/mpflanzer/splitshow'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.