### PR TITLE
Update frhelper from 3.9.4,2019-12-09 to 3.9.4,2019-12-13

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,9 +1,9 @@
 cask 'frhelper' do
-  version '3.9.4,2019-12-13'
+  version '3.9.4,1037:2019-12-13'
   sha256 '30d03c22f3e3fd0533ef8f223f6db546f922722b4dde9eb91d53c1ce7d2f7660'
 
   # static.frdic.com was verified as official when first introduced to the cask
-  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_comma}"
+  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_colon}"
   appcast 'https://www.francochinois.com/update/frhelper_mac.xml'
   name 'Frhelper'
   name '法语助手'

--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,5 +1,5 @@
 cask 'frhelper' do
-  version '3.9.4,2019-12-09'
+  version '3.9.4,2019-12-13'
   sha256 '30d03c22f3e3fd0533ef8f223f6db546f922722b4dde9eb91d53c1ce7d2f7660'
 
   # static.frdic.com was verified as official when first introduced to the cask

--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,10 +1,11 @@
 cask 'frhelper' do
-  version '3.9.4,1037:2019-12-13'
+  version '3.9.4,2019-12-13'
   sha256 '30d03c22f3e3fd0533ef8f223f6db546f922722b4dde9eb91d53c1ce7d2f7660'
 
   # static.frdic.com was verified as official when first introduced to the cask
-  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_colon}"
-  appcast 'https://www.francochinois.com/update/frhelper_mac.xml'
+  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_comma}"
+  appcast 'https://www.eudic.net/v4/fr/app/download',
+          configuration: version.after_comma
   name 'Frhelper'
   name '法语助手'
   homepage 'https://www.eudic.net/v4/fr/app/frhelper'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.