### PR TITLE
Update maciasl from 1.4 to 1.5.7

### DIFF
--- a/Casks/maciasl.rb
+++ b/Casks/maciasl.rb
@@ -1,11 +1,11 @@
 cask 'maciasl' do
-  version '1.4'
-  sha256 '24c0dbaa9a13231b8c8e364ef0e6d60656718320ce69d8bb23aa5bc27e82e87d'
+  version '1.5.7'
+  sha256 'ee99590b7e8821fe61f13245d404f98cf36cfedd52e09f293d67b1f76cac03ca'
 
-  url "https://downloads.sourceforge.net/maciasl/#{version}/MaciASL.zip"
-  appcast 'https://sourceforge.net/projects/maciasl/rss'
+  url "https://github.com/acidanthera/MaciASL/releases/download/#{version}/MaciASL-#{version}-RELEASE.zip"
+  appcast 'https://github.com/acidanthera/MaciASL/releases.atom'
   name 'MaciASL'
-  homepage 'https://sourceforge.net/projects/maciasl/'
+  homepage 'https://github.com/acidanthera/MaciASL'
 
   app 'MaciASL.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.