### PR TITLE
Update poi from 10.4.0 to 10.5.1

### DIFF
--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -1,6 +1,6 @@
 cask 'poi' do
-  version '10.4.0'
-  sha256 '88f08fa48cebae6b14893fb01f511d42ecf5df683e732b753625e2ddb3231db6'
+  version '10.5.1'
+  sha256 '5baf030cf5799ec7ea12da500d9a292bf7d7d52055250a9ffbbbe3385853f8b1'
 
   # github.com/poooi/poi was verified as official when first introduced to the cask
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.