### PR TITLE
Update goldencheetah v3.5 sha256 checksum

### DIFF
--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -1,6 +1,6 @@
 cask 'goldencheetah' do
   version '3.5'
-  sha256 '6f685f623e7896615ecad0df688920597ccce49a76956cc1e05e2b17857d89f9'
+  sha256 'b9a4e4575783c0f043260c12ddb5d02272bc566dbb2a31109b4d5166f7025fcd'
 
   # github.com/GoldenCheetah/GoldenCheetah was verified as official when first introduced to the cask
   url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V#{version}/GoldenCheetah_v#{version}_64bit_MacOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.