### PR TITLE
Update flash-npapi from 32.0.0.303 to 32.0.0.314

### DIFF
--- a/Casks/flash-npapi.rb
+++ b/Casks/flash-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-npapi' do
-  version '32.0.0.303'
-  sha256 '4a10e13a7e5c0a5081fcbc62e54835a20979defbd7f57ab76737a7fe81cb4960'
+  version '32.0.0.314'
+  sha256 'd441ab80cd886bb12081d4f549908b606708b2f1da692c71bbef3b8e51d7d02e'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.