### PR TITLE
Update qcad from 3.24.0 to 3.24.2

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,11 +1,11 @@
 cask 'qcad' do
-  version '3.24.0'
+  version '3.24.2'
 
   if MacOS.version <= :high_sierra
-    sha256 '785bed422b5fe01cb286ab9091b316b37bb208523ad83eba5edbf4f3135af947'
+    sha256 '4acc2104ae4876daaccc2f9e93121705d13572d49d8df9aabe6a675525129fa0'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 '6662bb59ee93396b69322f4271992a54e3cc6dc04ce76b105022e1d55885e7e8'
+    sha256 '1e2aeffa260fd1fff15c5df4e0731d2ac05a287cf7c08f1cdabdccccd79f79a9'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14-10.15.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.