### PR TITLE
Update gzdoom from 4.3.1 to 4.3.2

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '4.3.1'
-  sha256 '50ea5171ec52bfc43971c772d34a892003294803453701b553fa9f769522c1ca'
+  version '4.3.2'
+  sha256 'f655714de0827fa3d0f4b21cbfcd2174e196c2471b614198806bcb2fa580d7cc'
 
   # github.com/coelckers/gzdoom was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.