### PR TITLE
Update toggl from 7.4.1092 to 7.5.3

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.4.1092'
-  sha256 '0a6bb7925513e64e3d9cdce0ef2beb692051d628907ca21be39696796be57cda'
+  version '7.5.3'
+  sha256 '24cffd27ba014088de2e1910dc3c43e871956d67a5a6da62043a97c1f3b9a365'
 
   # github.com/toggl-open-source/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.