### PR TITLE
Add CLI tool binary for monodraw 1.4,b103

### DIFF
--- a/Casks/monodraw.rb
+++ b/Casks/monodraw.rb
@@ -10,6 +10,7 @@ cask 'monodraw' do
   depends_on macos: '>= :mojave'
 
   app 'Monodraw.app'
+  binary "#{appdir}/Monodraw.app/Contents/Resources/monodraw"
 
   zap trash: [
                '~/Library/Application Support/com.helftone.monodraw',


### PR DESCRIPTION
Link CLI tool binary:

<img width="662" alt="Screenshot 2020-01-14 at 17 59 13" src="https://user-images.githubusercontent.com/13354491/72355005-b59cde00-36f7-11ea-8815-8ac19d5c02d4.png">

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
