### PR TITLE
Revive citrix-workspace

### DIFF
--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,0 +1,42 @@
+cask 'citrix-workspace' do
+  version :latest
+  sha256 :no_check
+
+  url do
+    require 'open-uri'
+    # No known stable URL; fetching disposable URL from landing site.
+    # The URL is stored in a rel attribute (not href):
+    # <a rel="//downloads.citrix.com/16912/CitrixWorkspaceApp.dmg?__gda__=1579015867_9f0bd2bd997f925d35c593f5415d1d99">
+    html_url = 'https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
+    url = URI.open(html_url).read.scan(%r{rel="([^"]+CitrixWorkspaceApp.dmg?[^"]+)"}).flatten.first
+    url.gsub(%r{^//}, 'https://')
+  end
+  name 'Citrix Workspace'
+  homepage 'https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
+
+  pkg 'Install Citrix Workspace.pkg'
+
+  uninstall launchctl: [
+                         'com.citrix.AuthManager_Mac',
+                         'com.citrix.ReceiverHelper',
+                         'com.citrix.ServiceRecords',
+                         'com.citrix.ctxusbd',
+                       ],
+            quit:      [
+                         'Citrix.ServiceRecords',
+                         'com.citrix.ReceiverHelper',
+                         'com.citrix.receiver.nomas',
+                       ],
+            pkgutil:   'com.citrix.ICAClient'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.citrix.receiver.nomas.sfl*',
+               '~/Library/Application Support/com.citrix.receiver.nomas',
+               '~/Library/Caches/com.citrix.receiver.nomas',
+               '~/Library/Logs/Citrix Workspace',
+               '~/Library/Preferences/com.citrix.receiver.nomas.plist',
+               '~/Library/Preferences/com.citrix.receiver.nomas.plist.lockfile',
+               '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist',
+               '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist.lockfile',
+             ]
+end


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


Citrix Workspace was previously removed in #56881, because it has no stable download URL. However, the download URL can easily be scraped from the HTML page.

This PR is based on the previous version of the cask. I have not given `uninstall` and `zap` much though, though it seems they are still working.

It seems only the latest version is available for download. This is currently version 19.12.0.23 (1912), released December 10, 2019.
