### PR TITLE
jtool2: changed version to :latest, hash to :no_check

### DIFF
--- a/Casks/jtool2.rb
+++ b/Casks/jtool2.rb
@@ -1,7 +1,5 @@
 cask 'jtool2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  # Author builds nightly without updating the filename, so there's no way to
-  # track a hash
   version :latest
   sha256 :no_check
 

--- a/Casks/jtool2.rb
+++ b/Casks/jtool2.rb
@@ -1,8 +1,9 @@
 cask 'jtool2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  # "version" is based on the release date as noted in WhatsNew.txt
-  version '2020.01.01'
-  sha256 '88ab8587a8528238b3c27605d9581fc97b43850c9aa62ad83c63b1674ce7e52b'
+  # Author builds nightly without updating the filename, so there's no way to
+  # track a hash
+  version :latest
+  sha256 :no_check
 
   url 'http://newosxbook.com/tools/jtool2.tgz'
   name 'jtool2'


### PR DESCRIPTION
Can we remove hash checking for now until nightly builds stop?
I'll ask the author if he's willing to cut a "jtool2_1.0.tgz" release and do a
separate "-nightly" release.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
