### PR TITLE
Update atom from 1.42.0 to 1.43.0

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,6 +1,6 @@
 cask 'atom' do
-  version '1.42.0'
-  sha256 '2a306ea2e47f5bf93a82befd83b4567680c24f2edfea40faf90e64f843d6bda9'
+  version '1.43.0'
+  sha256 'c7cce11fc9f22a8fdb9a836b321dc4b3d0cdadcb139a9dc947c2473ec0f0c7b1'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.