### PR TITLE
Update kite from 0.20200107.0 to 0.20200109.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200107.0'
-  sha256 'b596a0f0cd5d15889140b6cb1d2c786bca24553855fc9d580f0788a2b68f0ad5'
+  version '0.20200109.0'
+  sha256 '8f590a05e12bacf0015a3d2b0b5d81873cbd6ba3e3c7d15d498c74b62226f866'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.