### PR TITLE
Update metabase from 0.34.0 to 0.34.1

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.34.0'
-  sha256 'efa02c429144d1ebced614aca542c62ce1844682685c4c9b50d219e3455bb870'
+  version '0.34.1'
+  sha256 'e39294880f7584d144504ecf0633b58e748e3e4867a05b9d9343d73b940d68ec'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.