### PR TITLE
Update gramps from 5.1.1,1 to 5.1.2,1

### DIFF
--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -1,6 +1,6 @@
 cask 'gramps' do
-  version '5.1.1,1'
-  sha256 '66398f859ef6e4be9fbe7c9970d69f778ba021f0a93ebbd483e26cdd1cb54418'
+  version '5.1.2,1'
+  sha256 'a67c3f4e389dc0128697905ed4be20dfc6ad7790874f020e8bd471ff4f0e17eb'
 
   # github.com/gramps-project/gramps was verified as official when first introduced to the cask
   url "https://github.com/gramps-project/gramps/releases/download/v#{version.before_comma}/Gramps-Intel-#{version.before_comma}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.