### PR TITLE
Update runway from 0.10.18 to 0.10.19

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.10.18'
-  sha256 'd86d9b5c6eb77ead6dc49de75332d85624ca8b190786eb6368d7cc9d7dab142e'
+  version '0.10.19'
+  sha256 '049e2239e78c7e37df4432148d1ecb2e2a450677db4c1be8fb300efdaa37561e'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.