### PR TITLE
Update geneious-prime from 2020.0.4 to 2020.0.5

### DIFF
--- a/Casks/geneious-prime.rb
+++ b/Casks/geneious-prime.rb
@@ -1,6 +1,6 @@
 cask 'geneious-prime' do
-  version '2020.0.4'
-  sha256 '34146eb8f9de56c4aceebdc50291254fcf309fd35a2980780dcc9a29ac0c2449'
+  version '2020.0.5'
+  sha256 '5ef6ac1ed4b1cf15f3021c30f590296c65a8458b744047689a66cf905a0dd8fb'
 
   url "https://assets.geneious.com/installers/geneious/release/Geneious_Prime_mac64_#{version.dots_to_underscores}_with_jre.dmg"
   appcast 'https://www.geneious.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.