### PR TITLE
Update staruml from 3.2.1 to 3.2.2

### DIFF
--- a/Casks/staruml.rb
+++ b/Casks/staruml.rb
@@ -1,6 +1,6 @@
 cask 'staruml' do
-  version '3.2.1'
-  sha256 'a39ad940c95a93c47be1f491a8072a62428574e9b0eda1d64025a9bfbff657a2'
+  version '3.2.2'
+  sha256 '03c3226c643ecc11385a5bb4e3f853921ede862433a351a665fb86416d75f53f'
 
   url "http://staruml.io/download/releases/StarUML-#{version}.dmg"
   appcast 'http://staruml.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.