### PR TITLE
Update zotero from 5.0.80 to 5.0.81

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.80'
-  sha256 '170f2ddaaf4dabe051b5c9c4b0cf1df8abff7a7a5cec495dff907a3e29c970ed'
+  version '5.0.81'
+  sha256 '4e967ef0e43935923eef1610eb802280aba82e1ebad5d1bb6c96e8745a5bef04'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.