### PR TITLE
Update pdfpenpro from 1120.2,1572922655 to 1121.1,1578972536

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1120.2,1572922655'
-  sha256 '73a7a1fb33678d1266e5426ddd1bf715a51491aa3e948054f5add03e4d49b078'
+  version '1121.1,1578972536'
+  sha256 '61053548cf98f4dc4fd45c0ec925347053fb60272b54fa5986d3dfd40f5998bd'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.