### PR TITLE
Update lehreroffice from 2019.13.1 to 2019.13.2

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.13.1'
-  sha256 '209c0923dc33392bc01a3abbbb076a1742c9a3ae228ff255da8db66eb4d68d8e'
+  version '2019.13.2'
+  sha256 '7a715db7cf7f2da98dce3f5bc79ecfed457b652ea4aa8a0c3dfdd7e2435c39c5'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.