### PR TITLE
Update liteide from 36.2 to 36.3

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,6 +1,6 @@
 cask 'liteide' do
-  version '36.2'
-  sha256 '2457801b281062140273c681fd0ee1623a97cba47aa96cb519a0a1fddc793590'
+  version '36.3'
+  sha256 '61b028c893dcbabf2412d9c76d264208e1a29636b25dafeacb34f9fc73109b55'
 
   # github.com/visualfc/liteide was verified as official when first introduced to the cask
   url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.12.5.zip"

--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -2,11 +2,10 @@ cask 'liteide' do
   version '36.3'
   sha256 '61b028c893dcbabf2412d9c76d264208e1a29636b25dafeacb34f9fc73109b55'
 
-  # github.com/visualfc/liteide was verified as official when first introduced to the cask
   url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.12.5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom'
   name 'LiteIDE'
-  homepage 'http://liteide.org/'
+  homepage 'https://github.com/visualfc/liteide'
 
   depends_on macos: '>= :sierra'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.