### PR TITLE
Update katalon-studio from 7.2.2 to 7.2.3

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.2.2'
-  sha256 '796827492e575e73ff3fef94ae4f5dc9edf155265177c810786c7ff7c33356fc'
+  version '7.2.3'
+  sha256 '17a948302f6f0a3334d31f242596f8e9d4e5100f784e46270daf932518f6208f'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.