### PR TITLE
Update stoplight-studio from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.8.0'
-  sha256 'a2569489c6db40091cea81dbd13b72453d1cc5325f823385d89d65cb136b4b77'
+  version '1.8.1'
+  sha256 '1ba8638645f6fbbcec9a01783e69ee827b09a67e68a60211066b5ddb4de9a869'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.