### PR TITLE
Update splashtop-business from 3.3.4.0 to 3.3.6.0

### DIFF
--- a/Casks/splashtop-business.rb
+++ b/Casks/splashtop-business.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-business' do
-  version '3.3.4.0'
-  sha256 '9b3b885cce45584a8c7ae5137c4c597f442ad521d397637872f69a2941d12fff'
+  version '3.3.6.0'
+  sha256 '8a8cd410288be799d5c23ad4a4f0c46549be45f269bceeb93a5a6d8bf9450fd5'
 
   # d17kmd0va0f0mp.cloudfront.net/macclient/STB was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STB/Splashtop_Business_Mac_INSTALLER_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.