### PR TITLE
Update encryptme from 4.1.1.1 to 4.2.0

### DIFF
--- a/Casks/encryptme.rb
+++ b/Casks/encryptme.rb
@@ -1,6 +1,6 @@
 cask 'encryptme' do
-  version '4.1.1.1'
-  sha256 'e71529d161824166f06f794e7d01dac2283125c4b0994352a8f6ff0ab4247baf'
+  version '4.2.0'
+  sha256 '23b9e7f15eeacc7e24f4301585e391371b95fa643150b1b84edaac0ee64adcd9'
 
   url "https://static.encrypt.me/downloads/osx/updates/Release/EncryptMe-#{version}.dmg"
   appcast 'https://www.getcloak.com/updates/osx/public/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.