### PR TITLE
Update ableton-live-lite from 10.1.6 to 10.1.7

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '10.1.6'
-  sha256 '52424d9b9143bc7053f98a3b047d705b324786761a7476cca1d5c405bec94622'
+  version '10.1.7'
+  sha256 '24e0976c9efc10067f72bfd3514417d1b1a71a4e9ab999ddcb0b71606e0406c8'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.