### PR TITLE
Update megahertz-knotes from 2.1.0 to 2.2.0

### DIFF
--- a/Casks/megahertz-knotes.rb
+++ b/Casks/megahertz-knotes.rb
@@ -1,6 +1,6 @@
 cask 'megahertz-knotes' do
-  version '2.1.0'
-  sha256 'd2070cfc96cf168db45e3390866950d1eabb5fdf719bfc85ca558cd68dc151fb'
+  version '2.2.0'
+  sha256 '24cf81de4d27bc7001b06cf86b3933bd25d3a29cab675d907d5bef3ccabca900'
 
   url "http://cdn.knotesapp.cn/download/%e7%b3%af%e8%af%8d%e7%ac%94%e8%ae%b0-#{version}.dmg"
   appcast "https://knotes#{version.major}-release-cn.s3.amazonaws.com/mac/latest-mac.yml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.