### PR TITLE
Update ableton-live from 10.1.6 to 10.1.7

### DIFF
--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live' do
-  version '10.1.6'
-  sha256 '26741d72756c71a7b8891fd5b97f3804699f74d000dc00157a054d80b501d847'
+  version '10.1.7'
+  sha256 '217c8e7efdafaa698dad7df58abd7dcd97b7e30d0d13e5876e9291e6ae13f523'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.