### PR TITLE
Update komodo-ide from 11.1.1,91089 to 12.0.0,91824

### DIFF
--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -1,6 +1,6 @@
 cask 'komodo-ide' do
-  version '11.1.1,91089'
-  sha256 'a522a104da9023311955cfe4ebf3c4e50f7f709e58432a47ea0c4a829d7b2335'
+  version '12.0.0,91824'
+  sha256 '361abef403feaf8f00f504ea8fdbd1d587c1ce720d640493d233868fb58aeb61'
 
   url "https://downloads.activestate.com/Komodo/releases/#{version.before_comma}/Komodo-IDE-#{version.before_comma}-#{version.after_comma}-macosx-x86_64.dmg"
   appcast 'https://www.activestate.com/komodo-ide/downloads/ide'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.