### PR TITLE
Update jami from 20191209.1141 to 20200115.0451

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20191209.1141'
-  sha256 '1f1f34cdd69f9c59c54a559364000014695081d2ab912241da82af0df8f4f8fd'
+  version '20200115.0451'
+  sha256 '685f6fb4e91d299efb438aa60ca40a568a508d64a869a7d1c280aa5abfb2f8c0'
 
   url "https://dl.jami.net/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.jami.net/mac_osx/sparkle-ring.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.