### PR TITLE
Update ridibooks from 2.7.5 to 0.7.2

### DIFF
--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -1,8 +1,9 @@
 cask 'ridibooks' do
-  version '2.7.5'
-  sha256 '1aec169de07735513fa37c2329e660db0a9a47f53c40e25d9a8c145d255f5da4'
+  version '0.7.2'
+  sha256 '1092abf977976a664ce32fd432e54ed8da1d72f0a6b5843df372a8ec27774395'
 
-  url "https://viewer-ota.ridibooks.com/mac/ridibooks-#{version}.dmg"
+  # ridicdn.net/pc_electron was verified as official when first introduced to the cask
+  url "https://viewer-ota.ridicdn.net/pc_electron/Ridibooks-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://getapp.ridibooks.com/mac'
   name 'Ridibooks'
   homepage 'https://ridibooks.com/support/app/download'

--- a/Casks/ridibooks.rb
+++ b/Casks/ridibooks.rb
@@ -2,9 +2,9 @@ cask 'ridibooks' do
   version '0.7.2'
   sha256 '1092abf977976a664ce32fd432e54ed8da1d72f0a6b5843df372a8ec27774395'
 
-  # ridicdn.net/pc_electron was verified as official when first introduced to the cask
+  # viewer-ota.ridicdn.net/pc_electron was verified as official when first introduced to the cask
   url "https://viewer-ota.ridicdn.net/pc_electron/Ridibooks-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://getapp.ridibooks.com/mac'
+  appcast 'https://s3-ap-northeast-2.amazonaws.com/viewer-ota.ridicdn.net/pc_electron/latest-mac.yml'
   name 'Ridibooks'
   homepage 'https://ridibooks.com/support/app/download'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.