### PR TITLE
Update tencent-lemon from 3.2.0 to 3.3.0

### DIFF
--- a/Casks/tencent-lemon.rb
+++ b/Casks/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask 'tencent-lemon' do
-  version '3.2.0'
-  sha256 'c144ad19bae6360db380a120c519d9324c51edb7e56c220da4ab55ac0823b2e6'
+  version '3.3.0'
+  sha256 '2b3df990d53816be624b4608e21f6f9119ae0d877c6c8fc8fd92bfd58aa176e9'
 
   # pm.myapp.com/invc/xfspeed/qqpcmgr was verified as official when first introduced to the cask
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/Lemon_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.