### PR TITLE
Update fliqlo from 1.8 to 1.8.1

### DIFF
--- a/Casks/fliqlo.rb
+++ b/Casks/fliqlo.rb
@@ -1,6 +1,6 @@
 cask 'fliqlo' do
-  version '1.8'
-  sha256 'f5ef7c842a5e45229737cfd38712225b4edc5b5c15879254d00932cf2dde5710'
+  version '1.8.1'
+  sha256 '7d77145bc140290fb6f779d2d5d95b88f85efcd498e19f8cb4de68f09a904c21'
 
   url "https://fliqlo.com/download/Fliqlo%20#{version}.dmg",
       referer: 'https://fliqlo.com/#about'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.