### PR TITLE
Update signal from 1.29.4 to 1.29.5

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.29.4'
-  sha256 '2e7c6ccda1d569dfbb8daa266c351f384610cf5cb6bc1f4d5f40a5bb5565bf23'
+  version '1.29.5'
+  sha256 'a9144443c7a70658b8caaee6c3cd9d149209884f650b8bb8a6902526f87c0d83'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.