### PR TITLE
Update aws-vault from 5.1.1 to 5.1.2

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,6 +1,6 @@
 cask 'aws-vault' do
-  version '5.1.1'
-  sha256 '257d3d9e886344583930ed662b8ffe8e6d57d41fd92fe24318d493c01b56740a'
+  version '5.1.2'
+  sha256 '7c121b2cf94a4cd9b73425b213feb4ff7e3b2512463f55bc401fd1795cca653b'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
   appcast 'https://github.com/99designs/aws-vault/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.