### PR TITLE
Update blitz from 1.6.5 to 1.6.6

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.6.5'
-  sha256 '660ac66e58d57acc7da64ba43b50f4ab22deb82875c046c3254c4362332bb4af'
+  version '1.6.6'
+  sha256 'a86ea43801d3f45fae568fe67ceccc40e261a746a687e51cb30f206573964059'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.