### PR TITLE
Update qownnotes from 20.1.8,b5213-161739 to 20.1.10,b5245-171113

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.8,b5213-161739'
-  sha256 'a326fa476184d51803b894da609e079dc042297f847405c63f774174f1595651'
+  version '20.1.10,b5245-171113'
+  sha256 '733b4b4e76f0172c4c6ff952949903c839ea5bf2b0a3ddec08094d43c8a71b09'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.