### PR TITLE
Update electron-fiddle from 0.11.1 to 0.12.0

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.11.1'
-  sha256 'ddcadf24a72c1e7a140e73840172630d3f6f22a04a49f8bd1f1589ff231946ed'
+  version '0.12.0'
+  sha256 '84314b7e58bdd45ca2a28bfc42ade803bf19caf0a5acdb5db248381a4839367f'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.