### PR TITLE
Update gb-studio from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/gb-studio.rb
+++ b/Casks/gb-studio.rb
@@ -1,6 +1,6 @@
 cask 'gb-studio' do
-  version '1.2.0'
-  sha256 '0bdb91223edca531af3af09044975aa100977ce00ca2615c560f42025550a92b'
+  version '1.2.1'
+  sha256 '9d0c94179fbe56b1770cfc09b8bff392b98224a9b320235754a97a24dcbd9415'
 
   # github.com/chrismaltby/gb-studio was verified as official when first introduced to the cask
   url "https://github.com/chrismaltby/gb-studio/releases/download/v#{version}/GB-Studio-Mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.