### PR TITLE
Update rectangle from 0.15 to 0.19

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -1,6 +1,6 @@
 cask 'rectangle' do
-  version '0.15'
-  sha256 '6cfb7d95c37a3b43c1d348bd95ef4a77a9892df7d0b3161690ccbc894479af45'
+  version '0.19'
+  sha256 'a00d8cc85a0b86218be65a790d97f7f1aa55b56d18fc050c1aac5e9f9382c5fc'
 
   # github.com/rxhanson/Rectangle/releases/download/v was verified as official when first introduced to the cask
   url "https://github.com/rxhanson/Rectangle/releases/download/v#{version}/Rectangle#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.