### PR TITLE
Update gopass-ui from 0.4.0 to 0.6.0

### DIFF
--- a/Casks/gopass-ui.rb
+++ b/Casks/gopass-ui.rb
@@ -1,6 +1,6 @@
 cask 'gopass-ui' do
-  version '0.4.0'
-  sha256 '41453158709801fa2993168a5997556acacaa328eeab1ccd34cd0979cb6b6aeb'
+  version '0.6.0'
+  sha256 '8fd4845d3ae4e4f0caa92f2f8140e09d9538736a5f61f402959f6909b7b1c4b6'
 
   url "https://github.com/codecentric/gopass-ui/releases/download/v#{version}/Gopass.UI-#{version}.dmg"
   appcast 'https://github.com/codecentric/gopass-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.