### PR TITLE
Update kite from 0.20200109.0 to 0.20200113.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200109.0'
-  sha256 '8f590a05e12bacf0015a3d2b0b5d81873cbd6ba3e3c7d15d498c74b62226f866'
+  version '0.20200115.0'
+  sha256 'a106c3e839767cc61990b45ed0fc5d632dc343227811cbf5640333847c03c73f'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.