### PR TITLE
Update bunch from 1.2.2,41 to 1.2.3,42

### DIFF
--- a/Casks/bunch.rb
+++ b/Casks/bunch.rb
@@ -1,6 +1,6 @@
 cask 'bunch' do
-  version '1.2.2,41'
-  sha256 '6c06d284aabde7fc35716f1e881cc377906e411e181214a8f574e95ce7aa146d'
+  version '1.2.3,42'
+  sha256 '433ae9232173a4f9e3f4b7669236790f7e6b6d3580d80f60e90907cc8bd5a6f7'
 
   url "https://cdn3.brettterpstra.com/updates/bunch/Bunch#{version.before_comma}#{version.after_comma}.dmg"
   appcast 'https://brettterpstra.com/updates/bunch/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.