### PR TITLE
Update navicat-for-oracle from 15.0.7 to 15.0.8

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '15.0.7'
-  sha256 'c233de8b6b952667766ee26fecbdfa0f26652ddb69cbfbd6a61290f9aca02ea0'
+  version '15.0.8'
+  sha256 '7c6312f3f81dc476d9e39527e200d67c6bc28b5e444846509030faabe8762580'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.