### PR TITLE
Update elpass from 1.0.7,192 to 1.1.0,209

### DIFF
--- a/Casks/elpass.rb
+++ b/Casks/elpass.rb
@@ -1,6 +1,6 @@
 cask 'elpass' do
-  version '1.0.7,192'
-  sha256 '52b46555651c36fec740a10882f1b130ac637bb4779feb036bdd89bee362ab24'
+  version '1.1.0,209'
+  sha256 '861d755af812c527163a7a2420f34a895ca6082c031dd32dec05ad9ed5b2e908'
 
   url "https://elpass.app/macos/Elpass-#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://elpass.app/macos/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.