### PR TITLE
Update navicat-for-sql-server from 15.0.7 to 15.0.8

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.7'
-  sha256 '06b78cffefbe139a7721c0b77a70fc09efe429fa0e89223ec5164f9aae6c2fc0'
+  version '15.0.8'
+  sha256 '1db27fcfa449483fa5ecad2f2b4d1303277b44dcdfc703a4e9828d9169d024c2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.