### PR TITLE
Update anydo from 4.2.61 to 4.2.62

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.61'
-  sha256 '5211f2c93347cb43c664bb239b3093bd2fa4e6bb2361cd789337a957127de54e'
+  version '4.2.62'
+  sha256 'a9f16a58030530c6219fcd9ec74682f1f4f2c36fcf567bbedc35aab318461eec'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.