### PR TITLE
Update wechatwork from 3.0.2.2008 to 3.0.2.2011

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.2.2008'
-  sha256 'fe4282ba92ec9a4b80989ec2bc3d70c6a965ab26e83401b7d082243249e6674f'
+  version '3.0.2.2011'
+  sha256 '418ba8cec1c6adee76b342229bc460a43b5433c67cdacbf1f7c587df3832586e'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.