### PR TITLE
Update preform from 3.3.0,1705 to 3.3.1,1717

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.3.0,1705'
-  sha256 'd73392bde825111cd12694c9b8ab39140b98a5d0c957af26d3099fd6a6dec021'
+  version '3.3.1,1717'
+  sha256 'c7e9ddeb6ab15b8ee7e9c1fd9d4f3710d14783b779e186129b7e661f6e9a3d1c'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.