### PR TITLE
Update lingo from 10.0 to 10.1

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,5 +1,5 @@
 cask 'lingo' do
-  version '10.0'
+  version '10.1'
   sha256 'bc16c02a73b23ac3c9889d1dd524eb125b0826b621ff6298fcf3023d94e1f903'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.