### PR TITLE
feat: 🎸 Add Fantasy Grounds Latest

### DIFF
--- a/Casks/fantasy-grounds.rb
+++ b/Casks/fantasy-grounds.rb
@@ -1,0 +1,12 @@
+cask 'fantasy-grounds' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://www.fantasygrounds.com/filelibrary/FantasyGrounds.dmg'
+  name 'Fantasy Grounds'
+  homepage 'https://www.fantasygrounds.com/home/home.php'
+
+  app 'Fantasy Grounds.app'
+
+  zap trash: '~/Library/Saved Application State/Fantasy Grounds*'
+end


### PR DESCRIPTION
Add Fantasy Grounds virtual tabletop. Previously added in #46777 but
missing.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
