### PR TITLE
Update blockstack from 0.36.3 to 0.37.0

### DIFF
--- a/Casks/blockstack.rb
+++ b/Casks/blockstack.rb
@@ -1,6 +1,6 @@
 cask 'blockstack' do
-  version '0.36.3'
-  sha256 '674d78f3f6d3cbc2578e8b5a7299393b517bda4bf349b1ab8aef378be707e41f'
+  version '0.37.0'
+  sha256 'c51a900432b7b7c2885ccd285027ff7c9656f87e934d54bb48dbfbae43ccdf32'
 
   # github.com/blockstack/blockstack-browser was verified as official when first introduced to the cask
   url "https://github.com/blockstack/blockstack-browser/releases/download/v#{version}/Blockstack-for-macOS-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.