### PR TITLE
Update Prince XML to latest version 13.1 (from 12.5)

### DIFF
--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -1,20 +1,20 @@
 cask 'prince' do
-  version '12.5'
-  sha256 'd7940c2f60b1e9657db1deb1144b2496cc34c728f650c36b24d6885b964e9aed'
+  version '13.1'
+  sha256 '93b50a308ed7070e49c8a0487a7e123a9a5bd239549ad64dc1143dd277231dff'
 
-  url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
+  url "https://www.princexml.com/download/prince-#{version}-macos.tar.gz"
   appcast 'https://www.princexml.com/download/'
   name 'Prince'
   homepage 'https://www.princexml.com/'
 
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/prince-#{version}-macosx/prince.wrapper.sh"
+  shimscript = "#{staged_path}/prince-#{version}-macos/prince.wrapper.sh"
   binary shimscript, target: 'prince'
 
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{staged_path}/prince-#{version}-macosx/lib/prince/bin/prince' --prefix '#{staged_path}/prince-#{version}-macosx/lib/prince' "$@"
+      exec '#{staged_path}/prince-#{version}-macos/lib/prince/bin/prince' --prefix '#{staged_path}/prince-#{version}-macos/lib/prince' "$@"
     EOS
   end
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Note that the tarball name has changed slightly since the last version (`macosx` → `macos`).
