### PR TITLE
Update owasp-zap from 2.8.0 to 2.9.0

### DIFF
--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -7,7 +7,7 @@ cask 'owasp-zap' do
   appcast 'https://github.com/zaproxy/zaproxy/releases.atom'
   name 'OWASP Zed Attack Proxy'
   name 'ZAP'
-  homepage 'https://www.zaproxy.org'
+  homepage 'https://www.zaproxy.org/'
 
   app 'OWASP ZAP.app'
 

--- a/Casks/owasp-zap.rb
+++ b/Casks/owasp-zap.rb
@@ -1,13 +1,13 @@
 cask 'owasp-zap' do
-  version '2.8.0'
-  sha256 '8fe3c30411524a05d662c2a2d1e2762a43291db7c39b23963b7de0f259ab122c'
+  version '2.9.0'
+  sha256 'b00949bf632b16c29085ebb3eb7b0962afe9ded166f6bade8a8ce8d3dbf1b9bd'
 
   # github.com/zaproxy/zaproxy was verified as official when first introduced to the cask
   url "https://github.com/zaproxy/zaproxy/releases/download/v#{version}/ZAP_#{version}.dmg"
   appcast 'https://github.com/zaproxy/zaproxy/releases.atom'
   name 'OWASP Zed Attack Proxy'
   name 'ZAP'
-  homepage 'https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project'
+  homepage 'https://www.zaproxy.org'
 
   app 'OWASP ZAP.app'
 


### PR DESCRIPTION
A new version of ZAP was released yesterday.
Details: https://www.zaproxy.org/download/

I'm submitting this PR through the Github web interface (edit mode), unfortunately I don't have a Mac upon which to do the tasks per the [template of the previous update](https://github.com/Homebrew/homebrew-cask/pull/64582):

- [x] `brew cask audit --download {{cask_file}}` is error-free. (Edit: I've checked this off since `CI / ci` reports `audit for owasp-zap: passed`
- [x] `brew cask style --fix {{cask_file}}` left no offenses. (Edit: I've checked this off since `CI / style` completed successfully)
- [x] The commit message includes the cask’s name and version.
