### PR TITLE
Update metasploit from 5.0.68,20200106113759 to 5.0.71,20200118113410

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,6 +1,6 @@
 cask 'metasploit' do
-  version '5.0.68,20200106113759'
-  sha256 '2da55044d4f1fdea21649e62eadefc1ec12c552fbc0b7d742c7a4d2f078f9ce2'
+  version '5.0.71,20200118113410'
+  sha256 'bb5615a0690bcc61b1cbc737e632627c6764cddb98b95ce8f6950e5257945b47'
 
   url "https://osx.metasploit.com/metasploit-framework-#{version.before_comma}+#{version.after_comma}-1rapid7-1.pkg"
   appcast 'https://osx.metasploit.com/LATEST'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.