### PR TITLE
Update caprine from 2.41.1 to 2.42.0

### DIFF
--- a/Casks/caprine.rb
+++ b/Casks/caprine.rb
@@ -1,6 +1,6 @@
 cask 'caprine' do
-  version '2.41.1'
-  sha256 '9cea7e038d730d047d5621cda40723e9d446695ca4314664ca50bd6227d0b405'
+  version '2.42.0'
+  sha256 'fc26024f043328bc45fb5fa2f8f60fdb555ab2495ec9ac92c99de468bed0754c'
 
   url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/Caprine-#{version}.dmg"
   appcast 'https://github.com/sindresorhus/caprine/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.