### PR TITLE
Update electrumsv from 1.2.4 to 1.2.5

### DIFF
--- a/Casks/electrumsv.rb
+++ b/Casks/electrumsv.rb
@@ -1,6 +1,6 @@
 cask 'electrumsv' do
-  version '1.2.4'
-  sha256 '905bbc2dcf65b476452c2c5117988e3c6e5e013b1e8bebdbdc43d29f3916a6dd'
+  version '1.2.5'
+  sha256 'ebe5fd2cb2b6b9d4dfc17faf94993f629e16a3fd68b4d0fbbbeb93d4210ea4f4'
 
   # s3.us-east-2.amazonaws.com/electrumsv-downloads was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/electrumsv-downloads/releases/#{version}/ElectrumSV-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.