### PR TITLE
Update qownnotes from 20.1.10,b5245-171113 to 20.1.11,b5249-113824

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.10,b5245-171113'
-  sha256 '733b4b4e76f0172c4c6ff952949903c839ea5bf2b0a3ddec08094d43c8a71b09'
+  version '20.1.11,b5249-113824'
+  sha256 '6d032b6e5aaccb852228ca16c7de4b165385615ceb39d1a865dff704e12aa5ae'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.