### PR TITLE
Update islide from 1.1.0 to 1.2.0

### DIFF
--- a/Casks/islide.rb
+++ b/Casks/islide.rb
@@ -1,6 +1,6 @@
 cask 'islide' do
-  version '1.1.0'
-  sha256 'c167cadf7bb85bb760994bc49d991b4b3a05b0c2f3cdb9648c9f61c1cc549528'
+  version '1.2.0'
+  sha256 'c91552583cb784c1a0e7d6e2db132c54e0b7065be54a93aad828470844c99e19'
 
   url "https://static.islide.cc/site/product/package/dmg/iSlide-#{version}.dmg"
   appcast 'https://static.islide.cc/site/product/package/dmg/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.