### PR TITLE
Update sizzy from 0.13.1 to 0.14.0

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.13.1'
-  sha256 'f3a8f0226d22c596cf42e5b312d732744f09936c668af2c8fd1a85bbff50ad4f'
+  version '0.14.0'
+  sha256 '9933ac96e687ba0e4f61970de44777d45ee4a09cf4eebcb69d3919289d6395f4'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.