### PR TITLE
Update mblock from 5.1.0 to 5.2.0

### DIFF
--- a/Casks/mblock.rb
+++ b/Casks/mblock.rb
@@ -1,6 +1,6 @@
 cask 'mblock' do
-  version '5.1.0'
-  sha256 '03de14bb9a2f2b8784b627ab1611aa04b7d8290fafa39115708891bf3c3178bf'
+  version '5.2.0'
+  sha256 '2ad10aa3223524b04cb2c5558cb6c6a7c345efdb2f2052b3795098d27ebde6e9'
 
   # dl.makeblock.com was verified as official when first introduced to the cask
   url "https://dl.makeblock.com/mblock#{version.major}/darwin/V#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.