### PR TITLE
Update plex from 1.4.1.940-574c2fa7 to 1.5.0.951-eb39ca04

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask 'plex' do
-  version '1.4.1.940-574c2fa7'
-  sha256 '80380d4cb710c3234d7dadfc2bbfe58046ca02518a2b4df8d773a70da609a490'
+  version '1.5.0.951-eb39ca04'
+  sha256 '06df15f4a33953c2b0a59596b19e76e51348eaa413cd50e737f898704c6a6eb4'
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/6.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.