### PR TITLE
Update unity from 2019.2.17f1,8e603399ca02 to 2019.2.18f1,bbf64de26e34

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.17f1,8e603399ca02'
-  sha256 'd1f011ef8310a68fd407bf66986362aa40ff4bf464bc1313849d1eb8418571e9'
+  version '2019.2.18f1,bbf64de26e34'
+  sha256 '0b6a4a01fe3e70d9557ced8ea8d4e3b6e7e80fb48d0307bd0ff7aba98df17ada'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.