### PR TITLE
Update unity-linux-support-for-editor from 2019.2.17f1,8e603399ca02 to 2019.2.18f1,bbf64de26e34

### DIFF
--- a/Casks/unity-linux-support-for-editor.rb
+++ b/Casks/unity-linux-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-linux-support-for-editor' do
-  version '2019.2.17f1,8e603399ca02'
-  sha256 '595c9d40f1752fe762be48e044a1cd9014058186b42cee9ec1367b88339586d1'
+  version '2019.2.18f1,bbf64de26e34'
+  sha256 '4be9d325fedbd18b1914f8e357a5f2798d79522b12491e45422d7674201794d7'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.