### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.17f1,8e603399ca02 to 2019.2.18f1,bbf64de26e34

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.17f1,8e603399ca02'
-  sha256 '86ade63cf3acd7355762af8d319d3a395f12ba0e7754ef90d8b2ad7fa54e7169'
+  version '2019.2.18f1,bbf64de26e34'
+  sha256 'c7ba0f501b92b6dddfe61b4e8c479ba2f3650bd81e0fd74abcaa347206253ff7'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.