### PR TITLE
Update texstudio from 2.12.20 to 2.12.22

### DIFF
--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -1,6 +1,6 @@
 cask 'texstudio' do
-  version '2.12.20'
-  sha256 '6b99c5a875c2c82c3347103916051bf676336006d89d320084370d431847d70e'
+  version '2.12.22'
+  sha256 '1a509b7b58f5bf4d7a88cb0e36fb712bc52f7ca0c682346f37507002d5373220'
 
   # github.com/texstudio-org/texstudio was verified as official when first introduced to the cask
   url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.