### PR TITLE
Update kite from 0.20200115.0 to 0.20200116.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200115.0'
-  sha256 'a106c3e839767cc61990b45ed0fc5d632dc343227811cbf5640333847c03c73f'
+  version '0.20200116.0'
+  sha256 '5e3422e66c05620cfeba06591ff60076b8286851a5811d13179b9a57a21a9d72'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.