### PR TITLE
Update monal from 2.5 beta 5,159 to 2.5 beta 5,160

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,5 +1,5 @@
 cask 'monal' do
-  version '2.5 beta 5,159'
+  version '2.5 beta 5,160'
   sha256 'e3ffeb9dd8d86359f9eafb877a9cb46938e546c2386af35ba24ebd4fdd375f57'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.