### PR TITLE
Update brave-browser from 79.1.2.42,102.42 to 79.1.2.43,102.43

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '79.1.2.42,102.42'
-  sha256 'b23a3871b5fb74222a308158295bfe94a928c52ca785a0e727e4fc3bf76e5914'
+  version '79.1.2.43,102.43'
+  sha256 'b5bc379c6b81cc1ce78fc27bf8b421129d7dab069759e047cf53a69f46710684'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/#{version.after_comma}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.