### PR TITLE
Update frhelper from 3.9.5,2019-12-18 to 3.9.5,2019-12-19

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,5 +1,5 @@
 cask 'frhelper' do
-  version '3.9.5,2019-12-18'
+  version '3.9.5,2019-12-19'
   sha256 '4d6ae7da29343f18fea57b419c1c8a838bfa8e813af87b1eaac15acb503c9378'
 
   # static.frdic.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.