### PR TITLE
Change version from 4.6 to 4.6.18 progressive-downloader.rb

### DIFF
--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -4,7 +4,7 @@ cask 'progressive-downloader' do
 
   url "https://www.macpsd.net/update/#{version.major_minor}/PSD.dmg"
   appcast 'https://www.macpsd.net/',
-          configuration: 'version.major_minor'
+          configuration: version.major_minor
   name 'Progressive Downloader'
   homepage 'https://www.macpsd.net/'
 

--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -3,7 +3,8 @@ cask 'progressive-downloader' do
   sha256 '12ba2053bc41e4d1c7e453c23f19743a3e2b42de0acf6f9f60637581274ff4f5'
 
   url "https://www.macpsd.net/update/#{version.major_minor}/PSD.dmg"
-  appcast 'https://www.macpsd.net/'
+  appcast 'https://www.macpsd.net/',
+          configuration: 'version.major_minor'
   name 'Progressive Downloader'
   homepage 'https://www.macpsd.net/'
 

--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -1,8 +1,8 @@
 cask 'progressive-downloader' do
-  version '4.6'
+  version '4.6.18'
   sha256 '12ba2053bc41e4d1c7e453c23f19743a3e2b42de0acf6f9f60637581274ff4f5'
 
-  url "https://www.macpsd.net/update/#{version}/PSD.dmg"
+  url "https://www.macpsd.net/update/#{version.major_minor}/PSD.dmg"
   appcast 'https://www.macpsd.net/'
   name 'Progressive Downloader'
   homepage 'https://www.macpsd.net/'


### PR DESCRIPTION
would it be possible to use the whole version number here? There are already 5 different versions of 4.6.x 