### PR TITLE
Update processing from 3.5.3 to 3.5.4

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -2,7 +2,7 @@ cask 'processing' do
   version '3.5.4'
   sha256 '4d64fe42a6c5c0863cc82e93a036e73731999ee9448be45bc322f91b0010bb6b'
 
-  url "http://download.processing.org/processing-#{version}-macosx.zip"
+  url "https://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom'
   name 'Processing'
   homepage 'https://processing.org/'

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,6 +1,6 @@
 cask 'processing' do
-  version '3.5.3'
-  sha256 'c3156d91e341e1982daf5b95fa9872fbf9b40c50237f270ef714162f88c168b5'
+  version '3.5.4'
+  sha256 '4d64fe42a6c5c0863cc82e93a036e73731999ee9448be45bc322f91b0010bb6b'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.