### PR TITLE
Update mediathekview from 13.5.0 to 13.5.1

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,6 +1,6 @@
 cask 'mediathekview' do
-  version '13.5.0'
-  sha256 'ac634ab0383270e61ed1fe91905c0f5c8dfa8a15408d1471ed1b2669974d07bd'
+  version '13.5.1'
+  sha256 '745a965c74bbd449535bdd87e8473d0c0912a0e20abe298f2f174687786f075a'
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}-mac.dmg"
   appcast 'https://mediathekview.de/changelog/index.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.