### PR TITLE
Update fsnotes from 4.0.17 to 4.0.18

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.0.17'
-  sha256 'adfb8d4ca374065a9fda62aee660fc4c64a7a9ee44a3f79c699a94e10a61be0c'
+  version '4.0.18'
+  sha256 'd709e3810dead14c25d9582287d715abfacab72413fbf5b0e68fd32deb6fc132'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.