### PR TITLE
Update trilium-notes from 0.39.5 to 0.40.1

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.39.5'
-  sha256 '02ad1f7211cc322957151016a2fc4886b37c1e600eae0be944cd288de958bc83'
+  version '0.40.1'
+  sha256 '6fcb05df2310a40a41d5ac5310943817e4648468b8b4c45f9ef072acae7dc8bc'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.