### PR TITLE
Update abscissa from 3.4.6 to 4.0.0

### DIFF
--- a/Casks/abscissa.rb
+++ b/Casks/abscissa.rb
@@ -1,6 +1,6 @@
 cask 'abscissa' do
-  version '3.4.6'
-  sha256 '319c6871e4f42eaf6b1925aff66859024241d5c11a542badeb6993d287da3da2'
+  version '4.0.0'
+  sha256 '7e4fb8b04c739342c45dacf998c2f8a020809283ce17e9da04b8bbf582349702'
 
   url "http://rbruehl.macbay.de/Abscissa/Downloads/Abscissa-#{version}.zip"
   appcast 'http://rbruehl.macbay.de/Abscissa/Downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.