### PR TITLE
Update retroarch from 1.8.2 to 1.8.4

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask 'retroarch' do
-  version '1.8.2'
-  sha256 'b05b509c72a9d1102692e3d4b5cd7e0fec735c6df70f80ed076fe0d98b6792d8'
+  version '1.8.4'
+  sha256 'e7b78358b07ec92cc6b437fe039b08c1b116e8e9efa8e40dfd1dd30cdc6cfa5c'
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   appcast 'https://buildbot.libretro.com/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.