### PR TITLE
Correct freecad 0.18.4 build 16146 SHA256... again

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
   version '0.18.4,16146'
-  sha256 'cd2c88f5ad3281c27fe3fdd41ddfee2891dc81dd63563b0e48a26f85a2755eae'
+  sha256 '8f9a13d3c9a3728cd8d4065995ddf002e010cbce157e506520506bc8773a2fb7'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
More than a dozen new bundles since the version or its build number was last bumped. Not sure what's happening upstream. SHA matches that downloadable from their [release page](https://github.com/FreeCAD/FreeCAD/releases/tag/0.18.4).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
