### PR TITLE
Update dcp-o-matic-encode-server from 2.14.21 to 2.14.23

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.21'
-  sha256 '686c1ac8ff55a3527a01795b0f12010985d1abaa4a6d41e24ef1c8c1d56b3c04'
+  version '2.14.23'
+  sha256 '9e47c6a6c83d1a27d2d8ded3ff248ff9232de15358483f5eabc7811a68486069'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.