### PR TITLE
Update alt-tab 2.3.2 with correct macOS minimum version

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -7,7 +7,7 @@ cask 'alt-tab' do
   name 'alt-tab'
   homepage 'https://github.com/lwouis/alt-tab-macos'
 
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :sierra'
 
   app 'AltTab.app'
 end


### PR DESCRIPTION
This PR corrects the minimum macOS version that `alt-tab` supports, from the incorrect `10.14` to the correct `10.12`.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
