### PR TITLE
Update eudic from 3.9.4,2019-11-27 to 3.9.5,2019-12-20

### DIFF
--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -1,6 +1,6 @@
 cask 'eudic' do
-  version '3.9.4,2019-11-27'
-  sha256 '669f646ab6fe532aaea5fa6af97e2e1ea3a0ee4acdafeff5c6809120cb565b48'
+  version '3.9.5,2019-12-20'
+  sha256 '2b52374dffa9defcd7702605dacd764db06b261e50e660e2d53266e23dca8165'
 
   # static.frdic.com was verified as official when first introduced to the cask
   url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.