### PR TITLE
Update qgis from 3.10.1 to 3.10.2

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,6 +1,6 @@
 cask 'qgis' do
-  version '3.10.1'
-  sha256 'f5b87076959ea77b97fbb8b20759a0d3bc9ad565578a5ff5b58ddfe8ad03510a'
+  version '3.10.2'
+  sha256 '6a829ba34ef2fa6a422ddb219544a3f7f5bee3428e24e5f03e6de37ca1c910bf'
 
   url 'https://qgis.org/downloads/macos/qgis-macos-pr.dmg'
   appcast 'https://www.qgis.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.