### PR TITLE
Update qownnotes from 20.1.11,b5249-113824 to 20.1.12,b5258-175327

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.11,b5249-113824'
-  sha256 '6d032b6e5aaccb852228ca16c7de4b165385615ceb39d1a865dff704e12aa5ae'
+  version '20.1.12,b5258-175327'
+  sha256 '4cc01f017b7d7d9e276df46155c626fe6614b1e440f41646bb07b5258d58dad3'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.