### PR TITLE
Update picgo from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/picgo.rb
+++ b/Casks/picgo.rb
@@ -1,6 +1,6 @@
 cask 'picgo' do
-  version '2.2.1'
-  sha256 '3f526dc0ed5537f4d896a82f08053b24821a85329e2baf672fef51cd39f89ea9'
+  version '2.2.2'
+  sha256 '49eb462ed3563bff862111c3b3ec49f2c3198536b2cf69b5fc468d2cc33b8aae'
 
   url "https://github.com/Molunerfinn/PicGo/releases/download/v#{version}/PicGo-#{version}-mac.zip"
   appcast 'https://github.com/Molunerfinn/PicGo/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.