### PR TITLE
Update powder-player from 1.20 to 1.50

### DIFF
--- a/Casks/powder-player.rb
+++ b/Casks/powder-player.rb
@@ -1,6 +1,6 @@
 cask 'powder-player' do
-  version '1.20'
-  sha256 'd5df37eca8446b2b832ca5c7d5d480df589b4ff05df4a0e0f5a6d58f3585c105'
+  version '1.50'
+  sha256 'c178993f8f4e210a1f2f7f945981376a27f2b32b62582ce51df450d6af860d39'
 
   # github.com/jaruba/PowderPlayer was verified as official when first introduced to the cask
   url "https://github.com/jaruba/PowderPlayer/releases/download/v#{version}/PowderPlayer_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.