### PR TITLE
Update frescobaldi from 3.1 to 3.1.1

### DIFF
--- a/Casks/frescobaldi.rb
+++ b/Casks/frescobaldi.rb
@@ -1,6 +1,6 @@
 cask 'frescobaldi' do
-  version '3.1'
-  sha256 'c4fe19067a7718ac613654f2d69ac23ec81955993e12d3e4cb3a63865799ef92'
+  version '3.1.1'
+  sha256 '06703429004db47b44b1743ef63e740b3d25048f254e6a27f4b4627bd3671bca'
 
   # github.com/frescobaldi/frescobaldi was verified as official when first introduced to the cask
   url "https://github.com/frescobaldi/frescobaldi/releases/download/v#{version}/Frescobaldi-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.