### PR TITLE
Update fl-studio from 20.6.1.848 to 20.6.1.853

### DIFF
--- a/Casks/fl-studio.rb
+++ b/Casks/fl-studio.rb
@@ -1,6 +1,6 @@
 cask 'fl-studio' do
-  version '20.6.1.848'
-  sha256 'f8e16c6f3f0ec935d71f6d7fd2d33fe1dde52d883354f4b67aa41f018c0b134d'
+  version '20.6.1.853'
+  sha256 'a82f536002dea33dd8a84322f59b6fe041a255e065db9d29ebacc71055baea2c'
 
   url "http://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.image-line.com/redirect/flstudio20_mac_installer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.