### PR TITLE
Update receipts from 1.9.6-289 to 1.9.6-291

### DIFF
--- a/Casks/receipts.rb
+++ b/Casks/receipts.rb
@@ -1,6 +1,6 @@
 cask 'receipts' do
-  version '1.9.6-289'
-  sha256 'e7d715a3e21900f090016d86b29390a9ac6ed90483dbd2d9a0e2b8317a6d90c1'
+  version '1.9.6-291'
+  sha256 '5829716ef4fd811d9508de07684b134c06d78e2c4d9b87fbae9cccf8493dde46'
 
   url "https://www.receipts-app.com/update/download/Receipts-#{version}.zip"
   appcast 'https://www.receipts-app.com/updater.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.