### PR TITLE
Update ticktick from 3.3.10,123 to 3.3.10,125

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.3.10,123'
-  sha256 '095f145a7dd95ff798e3a48fc59a296325da7f6ad3beea7225e98eb2b71e0c3a'
+  version '3.3.10,125'
+  sha256 '2025acae60fd486335fd764b3ae32095997d91bc112562595a68cc5d381d139c'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.