### PR TITLE
Update integrity from 9.4.1 to 9.4.3

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,5 +1,5 @@
 cask 'integrity' do
-  version '9.4.1'
+  version '9.4.3'
   sha256 'dff4a23b7c414399721fd704e00544e71c5ef37b2e65617a2b52a85b4d40c428'
 
   url 'https://peacockmedia.software/mac/integrity/integrity.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.