### PR TITLE
Update notable from 1.8.3 to 1.8.4

### DIFF
--- a/Casks/notable.rb
+++ b/Casks/notable.rb
@@ -1,6 +1,6 @@
 cask 'notable' do
-  version '1.8.3'
-  sha256 'f5190e20628526bae567642b8bb664f2a65ed7ca61dca432306389f92e7025bc'
+  version '1.8.4'
+  sha256 '5ca00f5135e769165c683dc0174ea95bd9052ca751a0704b1a1a20dd297b4e3d'
 
   url "https://github.com/notable/notable/releases/download/v#{version}/Notable-#{version}.dmg"
   appcast 'https://github.com/notable/notable/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.