### PR TITLE
Update kactus from 0.3.25 to 0.3.26

### DIFF
--- a/Casks/kactus.rb
+++ b/Casks/kactus.rb
@@ -1,6 +1,6 @@
 cask 'kactus' do
-  version '0.3.25'
-  sha256 'f2e9fbf3f3b59e21832f2eeba35c379b173b1ae33cec84d6e02c7653ad2e356b'
+  version '0.3.26'
+  sha256 'c1df3a992629d7766d9d9cf906a4d351a08ff4f49b7a6929c331bc4f07bd9bdd'
 
   # github.com/kactus-io/kactus was verified as official when first introduced to the cask
   url "https://github.com/kactus-io/kactus/releases/download/v#{version}/Kactus-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.