### PR TITLE
Update sidequest from 0.8.5 to 0.8.6

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,6 +1,6 @@
 cask 'sidequest' do
-  version '0.8.5'
-  sha256 '2bcddcab4e52123494f9b58811b445218a5875544cc1444b4f0eb05b8d4ad824'
+  version '0.8.6'
+  sha256 '1cff67cc4165f91e2cb86ac5bfb8b3a84785c075e00d64c9ef3d2ed61a13335d'
 
   # github.com/the-expanse/SideQuest was verified as official when first introduced to the cask
   url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.