### PR TITLE
Update hstracker from 1.6.13 to 1.6.14

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.13'
-  sha256 '6cd28c26402ee0e7984460db182d13cda95aa79878300c607d1693b2e4607ffe'
+  version '1.6.14'
+  sha256 '5c3b339622c8299e55145d94b90f4f3eb72d1716a7b0b68ecabc8f51793d472b'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.