### PR TITLE
Update supercollider from 3.10.3 to 3.10.4

### DIFF
--- a/Casks/supercollider.rb
+++ b/Casks/supercollider.rb
@@ -1,6 +1,6 @@
 cask 'supercollider' do
-  version '3.10.3'
-  sha256 '7adaff8916f9db6f9ee839cb0520e84c29a18244a62e97ef172759cf6cfa7311'
+  version '3.10.4'
+  sha256 'ad4558c8515b4e5fca442d9a889e212060209b8435e61906d0d840d00eef750f'
 
   # github.com/supercollider/supercollider was verified as official when first introduced to the cask
   url "https://github.com/supercollider/supercollider/releases/download/Version-#{version}/SuperCollider-#{version}-macOS-signed.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.