### PR TITLE
Update eloston-chromium from 79.0.3945.88-1 to 79.0.3945.130-1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,6 +1,6 @@
 cask 'eloston-chromium' do
-  version '79.0.3945.88-1'
-  sha256 '8165213b67941f67844e56600b62667dc269d1a534a21825515ce1732258f995'
+  version '79.0.3945.130-1'
+  sha256 '2ca7ecba09007b23c42e6b3fdf51930738c024b73c3427edb6945f257c67b883'
 
   # github.com/kramred/ungoogled-chromium-binaries was verified as official when first introduced to the cask
   url "https://github.com/kramred/ungoogled-chromium-binaries/releases/download/#{version}/ungoogled-chromium_#{version}.1_macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Update eloston-chromium from 79.0.3945.88-1 to 79.0.3945.130-1