### PR TITLE
Update vimediamanager from 0.7a21 to 0.7a22

### DIFF
--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -1,6 +1,6 @@
 cask 'vimediamanager' do
-  version '0.7a21'
-  sha256 '12d572fee4ceacfa24319badaa5d5910daff3579faffd5b3b890c08fa38259af'
+  version '0.7a22'
+  sha256 'dbb251822ba45a7a81847e863b092fcd06a811b184b39f17ad0754662d327b4b'
 
   url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/ViMediaManager.dmg"
   appcast 'https://github.com/vidalvanbergen/ViMediaManager/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.