### PR TITLE
Update prudent from 79.0.3945.88,16 to 79.0.3945.88,17

### DIFF
--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -1,6 +1,6 @@
 cask 'prudent' do
-  version '79.0.3945.88,16'
-  sha256 'b7ab17d6915496ec06f264c82ea1da68990b223e795a0b0b4dc10788487af10c'
+  version '79.0.3945.88,17'
+  sha256 '62d5f78b7cbf5bc029813a3eef28f732d70d40586ff258443e7e2696fb28f78c'
 
   # github.com/PrudentMe/main was verified as official when first introduced to the cask
   url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.