### PR TITLE
Update cmake from 3.16.2 to 3.16.3

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.16.2'
-  sha256 'fbf7b6341b097828cf9d3a5a29e9b9279dda8688be4e2bc497ccba472f820d8b'
+  version '3.16.3'
+  sha256 '19a95a0f02ead7b6b6e81a9696405dc332f6bfa9d39fa3da7394b2db29c54c65'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   appcast 'https://cmake.org/files/LatestRelease/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.