### PR TITLE
Update tuneinstructor from 3.7,17065 to 3.7v5,17467

### DIFF
--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,6 +1,6 @@
 cask 'tuneinstructor' do
   version '3.7v5,17467'
-  sha256 '71e03619dfe41e38a1fe34fc320a6ecb89bc68b54febd78c229c86255b0d1726'
+  sha256 'bbd0255f809da259b6c4a9d7f7fc27de2bceb5dc7caca32adc61769d9d98f9de'
 
   url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version.before_comma}.zip"
   appcast 'https://www.tune-instructor.de/de/download.html'

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,6 +1,6 @@
 cask 'tuneinstructor' do
   version '3.7v5,17467'
-  sha256 '353572f3682a04e4b1d68e29600125671de5217371b0fc73148c23f6c12ac07b'
+  sha256 'bc650838981b66f556209ae064c61edcaee020e7d5c7ef4a0299b8aadabbfb14'
 
   url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version.before_comma}.dmg"
   appcast 'https://www.tune-instructor.de/de/download.html'

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -7,7 +7,7 @@ cask 'tuneinstructor' do
   name 'Tune•Instructor'
   homepage 'https://www.tune-instructor.de/com/start.html'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :catalina'
 
   app 'Tune•Instructor.app'
 end

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,6 +1,6 @@
 cask 'tuneinstructor' do
   version '3.7v5,17467'
-  sha256 'bc650838981b66f556209ae064c61edcaee020e7d5c7ef4a0299b8aadabbfb14'
+  sha256 '71e03619dfe41e38a1fe34fc320a6ecb89bc68b54febd78c229c86255b0d1726'
 
   url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version.before_comma}.dmg"
   appcast 'https://www.tune-instructor.de/de/download.html'

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -2,7 +2,7 @@ cask 'tuneinstructor' do
   version '3.7v5,17467'
   sha256 '71e03619dfe41e38a1fe34fc320a6ecb89bc68b54febd78c229c86255b0d1726'
 
-  url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version.before_comma}.dmg"
+  url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version.before_comma}.zip"
   appcast 'https://www.tune-instructor.de/de/download.html'
   name 'Tune•Instructor'
   homepage 'https://www.tune-instructor.de/com/start.html'

--- a/Casks/tuneinstructor.rb
+++ b/Casks/tuneinstructor.rb
@@ -1,6 +1,6 @@
 cask 'tuneinstructor' do
-  version '3.7,17065'
-  sha256 '7de1475bbe5d58a0818620da02355e0cace26e79e2783a6e9081573895a2c3b1'
+  version '3.7v5,17467'
+  sha256 '353572f3682a04e4b1d68e29600125671de5217371b0fc73148c23f6c12ac07b'
 
   url "https://www.tune-instructor.de/resources/downloads/TuneInstructor#{version.before_comma}.dmg"
   appcast 'https://www.tune-instructor.de/de/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.