### PR TITLE
Update lehreroffice from 2019.13.2 to 2019.13.3

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.13.2'
-  sha256 '7a715db7cf7f2da98dce3f5bc79ecfed457b652ea4aa8a0c3dfdd7e2435c39c5'
+  version '2019.13.3'
+  sha256 'ca3cf5f66864611de37d83a99d847c5e468e7471fea9f966e65fca84847cd806'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.