### PR TITLE
Update sococo from 6.5.0-20770 to 6.5.8,12-09-2019

### DIFF
--- a/Casks/sococo.rb
+++ b/Casks/sococo.rb
@@ -4,7 +4,7 @@ cask 'sococo' do
 
   url "https://s.sococo.com/rs/client/mac/#{version.after_comma}-SococoProd.dmg"
   appcast 'https://app.sococo.com/a/download',
-          configuraton: version.after_comma
+          configuration: version.after_comma
   name 'Sococo'
   homepage 'https://www.sococo.com/'
 

--- a/Casks/sococo.rb
+++ b/Casks/sococo.rb
@@ -1,9 +1,10 @@
 cask 'sococo' do
-  version '6.5.0-20770'
-  sha256 'f1e128fecd89b84f751234bea3f5c5b52e94eb0e333a9fda149efc397c1e39b8'
+  version '6.5.8,12-09-2019'
+  sha256 'e235a6a98c8a83eaa3e379c01eee51370f643846f6a8a594ad91f7a182c7eeec'
 
-  url "https://s.sococo.com/rs/client/mac/Sococo-#{version}.dmg"
-  appcast 'https://s.sococo.com/rs/client/latest.json'
+  url "https://s.sococo.com/rs/client/mac/#{version.after_comma}-SococoProd.dmg"
+  appcast 'https://app.sococo.com/a/download',
+          configuraton: version.after_comma
   name 'Sococo'
   homepage 'https://www.sococo.com/'
 

--- a/Casks/sococo.rb
+++ b/Casks/sococo.rb
@@ -3,7 +3,7 @@ cask 'sococo' do
   sha256 'e235a6a98c8a83eaa3e379c01eee51370f643846f6a8a594ad91f7a182c7eeec'
 
   url "https://s.sococo.com/rs/client/mac/#{version.after_comma}-SococoProd.dmg"
-  appcast 'https://app.sococo.com/a/download',
+  appcast 'https://app.sococo.com/app/app.min.js',
           configuration: version.after_comma
   name 'Sococo'
   homepage 'https://www.sococo.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.