### PR TITLE
Update timecamp from latest to 1.4.6.2

### DIFF
--- a/Casks/timecamp.rb
+++ b/Casks/timecamp.rb
@@ -1,8 +1,9 @@
 cask 'timecamp' do
-  version :latest
-  sha256 :no_check
+  version '1.4.6.2'
+  sha256 '74dee429fabfcdd3f6a9d0d755bbe1ca056433392d73f4b64e14182fdfb70c0c'
 
-  url 'https://www.timecamp.com/downloadsoft/TimeCamp.dmg'
+  # timecamp.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://timecamp.s3.amazonaws.com/downloadsoft/#{version}/TimeCampSetup_macOS.dmg"
   name 'TimeCamp'
   homepage 'https://www.timecamp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.