### PR TITLE
Update appium from 1.16.0 to 1.15.1

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -1,6 +1,6 @@
 cask 'appium' do
-  version '1.16.0'
-  sha256 '579fe46ec6ed9df077a393edb4d264ff09ed2c742e61b48df88f2a08bf02ce88'
+  version '1.15.1'
+  sha256 'f32cd3aea642df1df818fa09c11c434270d81b3e389b635024a676c6a5d36449'
 
   # github.com/appium/appium-desktop was verified as official when first introduced to the cask.
   url "https://github.com/appium/appium-desktop/releases/download/v#{version}/Appium-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.