### PR TITLE
Update setapp from 2.3.4,1573055108 to 2.5.1,1579269411

### DIFF
--- a/Casks/setapp.rb
+++ b/Casks/setapp.rb
@@ -1,6 +1,6 @@
 cask 'setapp' do
-  version '2.3.4,1573055108'
-  sha256 '1ebb3fd27672a6b5d6dc1cbdc27f13e91d598f63698a8641b6dee5fc96690b04'
+  version '2.5.1,1579269411'
+  sha256 '9852a47b798f7c46ca8c2610f6035f60d99cd6ba23bb74a2e2586e0039854e97'
 
   # devmate.com/com.setapp.InstallSetapp was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.setapp.InstallSetapp/#{version.before_comma}/#{version.after_comma}/InstallSetapp-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.