### PR TITLE
Update understand from 5.1.1012 to 5.1.1013

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1012'
-  sha256 'c7c3c94b32c2b70694fdd5378734fcf262e034260c0258ad85da41ffc9032232'
+  version '5.1.1013'
+  sha256 'fcf1d6e2887f18ec6e517ade37cc873ed40b2798b618e1f6073e8f87c8d9cd2a'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.