### PR TITLE
Update pyfa from 2.16.1 to 2.16.2

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.16.1'
-  sha256 '49857dc81f2b33516d88218b7231d967aa9da500059b1cf56f1165ffce985526'
+  version '2.16.2'
+  sha256 '8c9bc379db1c3833acd1183cbfd1c380bcc9035682febc757dac55ff59b3d4c5'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.