### PR TITLE
Update qownnotes from 20.1.12,b5258-175327 to 20.1.14,b5274-162023

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.12,b5258-175327'
-  sha256 '4cc01f017b7d7d9e276df46155c626fe6614b1e440f41646bb07b5258d58dad3'
+  version '20.1.14,b5274-162023'
+  sha256 '01f131b29f7437309d864aa398f8bc31262e75d4968703f54de0e7006343b356'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.