### PR TITLE
Update alt-tab from 2.3.3 to 2.3.4

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '2.3.3'
-  sha256 '821feaefda367fc341b8c3684fc6e99f580b646040c395e54859f4f7efd8bb1c'
+  version '2.3.4'
+  sha256 'ad0dc9dfdb9cc6d719249575382455e4873e95aa5e08aae20bc0ae1eb36aee2b'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.