### PR TITLE
Update thedesk from 20.1.0 to 20.1.1

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '20.1.0'
-  sha256 '0ee817804d29da046d2a07a7ba2de686775c579685257c6b68d9dff7a394e560'
+  version '20.1.1'
+  sha256 '0bf8c54b4fe20d8429e07bc1a2a9d8fc8c5fff38db34e505635a6cf1eb3122ca'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.