### PR TITLE
Update historyhound from 2.0.3 to 2.1

### DIFF
--- a/Casks/historyhound.rb
+++ b/Casks/historyhound.rb
@@ -1,6 +1,6 @@
 cask 'historyhound' do
-  version '2.0.3'
-  sha256 'd4725cb315c2d6ea6bfda98b7369f1c159aa7384e51c4d21f41ffcf3ae80c105'
+  version '2.1'
+  sha256 '2c5f75af5efe9d2c43bfc066952be071c18251d3b443adb8cad49074c43f80d4'
 
   url "https://www.stclairsoft.com/download/HistoryHound-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?HH'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.