### PR TITLE
Update quicken from 5.14.0,514.31804.100 to 5.14.1,514.31834.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.14.0,514.31804.100'
-  sha256 '55a912d69af906e9ca79e1bf3a081e963a3d8ef8d377768a37ea21237d7891f0'
+  version '5.14.1,514.31834.100'
+  sha256 '28dcf8c41eca19c6db05e1ecc947c0fda3635f6f1b3911903faf38da2cbb45e6'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.