### PR TITLE
Update milanote from 1.6.3 to 1.6.4

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '1.6.3'
-  sha256 'f75652e8501933201e9425e1a7b0c6137928edfa422c4bf2ed6f2550d68517b2'
+  version '1.6.4'
+  sha256 '46979d3cc4c77e5679d11ed40ccd32cf193d0100e3ff2beba0e7a1ca6378d30f'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.