### PR TITLE
Update visual-paradigm from 16.1,20200101 to 16.1,20200108

### DIFF
--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -1,6 +1,6 @@
 cask 'visual-paradigm' do
-  version '16.1,20200101'
-  sha256 '2664559d8e5d2ed94e2b7b691a0fddd15f0cc4df0b3a5213472ca4ec1faf145e'
+  version '16.1,20200108'
+  sha256 '297a31f3debff6e01c81499077caf533f110b5ebc844c309685c849e6d020c21'
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.visual-paradigm.com/downloads/vp/checksum.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.