### PR TITLE
Update vitalsource-bookshelf from 9.0.2.1206 to 9.1.0.1222

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,9 +1,9 @@
 cask 'vitalsource-bookshelf' do
-  version '9.0.2.1206'
-  sha256 'c3f6e6dbfc63e82078a2198633bb9072e648942c4162c49187efe1e2822395e8'
+  version '9.1.0.1222'
+  sha256 '07a180768db8e313253d3d447694569fa749340db21faea76daf3f01fe6ea7be'
 
   # downloads.vitalbook.com was verified as official when first introduced to the cask
-  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor_patch}/bookshelf/VitalSource-Bookshelf_#{version}.dmg"
+  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor}/Mac/bookshelf/VitalSource-Bookshelf_#{version}.dmg"
   appcast 'https://support.vitalsource.com/hc/en-us/articles/360014107913-Mac'
   name 'VitalSource Bookshelf'
   homepage 'https://www.vitalsource.com/bookshelf-features'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.