### PR TITLE
Update soundsource from 4.1.4 to 4.2.0

### DIFF
--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -1,6 +1,6 @@
 cask 'soundsource' do
-  version '4.1.4'
-  sha256 '98b7777c6a24f465cde3e844183364293538e9beae0cb0b53287dbe31518d776'
+  version '4.2.0'
+  sha256 'bdf1882d6642659cdb57885a9bd78499d3a7b26cd6e7e911557d8b06ff292768'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&system=10146&version=4000000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.