### PR TITLE
Update corretto from 11.0.6.10.1 to 11.0.6.10.1-1

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,8 +1,8 @@
 cask 'corretto' do
-  version '11.0.6.10.1'
-  sha256 '03d832483d32de96125a56d40a1b8320f91deb0c0a422552c520cb10b9f779c5'
+  version '11.0.6.10.1-1'
+  sha256 '4c685635b690cf905e5c2e533503c96ddbc6fdc205a1867a7e8a0bea9fea77ea'
 
-  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
+  url "https://corretto.aws/downloads/resources/#{version.sub(%r{-\d+}, '')}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://docs.aws.amazon.com/en_us/corretto/latest/corretto-#{version.major}-ug/corretto-#{version.major}-ug.rss"
   name 'Amazon Corretto'
   homepage 'https://corretto.aws/'


### PR DESCRIPTION
Update Corretto to 11.0.6.10.1-1 corretto/corretto-11#73

Is it ok to use the regular expression `#{version.sub(%r{-\d+}, '')}` to determine the download URL? I haven't found any other way to deal with the 5-part version scheme in the version [documentation](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/version.md)


After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
