### PR TITLE
transocks v2.4.2: tweak uninstall and zap stanza

### DIFF
--- a/Casks/transocks.rb
+++ b/Casks/transocks.rb
@@ -10,9 +10,7 @@ cask 'transocks' do
   pkg "Transocks_Mac_#{version}.pkg"
 
   uninstall pkgutil: 'com.穿梭Transocks',
-            trash:   [
-                       '~/.transocks_vendor',
-                     ]
+            trash:   '~/.transocks_vendor'
 
   zap trash: [
                '/Library/Logs/DiagnosticReports/穿梭Transocks*',

--- a/Casks/transocks.rb
+++ b/Casks/transocks.rb
@@ -9,16 +9,18 @@ cask 'transocks' do
 
   pkg "Transocks_Mac_#{version}.pkg"
 
-  uninstall pkgutil: 'com.穿梭Transocks'
+  uninstall pkgutil: 'com.穿梭Transocks',
+            trash:   [
+                       '~/.transocks_vendor',
+                     ]
 
   zap trash: [
                '/Library/Logs/DiagnosticReports/穿梭Transocks*',
                '~/Library/Application Support/CrashReporter/穿梭Transocks*',
-               '/Users/*/.transocks_vendor',
-               '/Users/*/.transocks_store.tmp',
-               '/Users/*/.transocks.log',
                '~/Library/Logs/穿梭Transocks',
                '~/Library/Preferences/com.github.Electron.plist',
                '~/Library/Saved Application State/com.github.Electron.savedState',
+               '~/.transocks_store.tmp',
+               '~/.transocks.log',
              ]
 end


### PR DESCRIPTION
Paths in uninstall stanza contains binaries that should be removed on uninstall.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
