### PR TITLE
Update seashore from 2.5.3 to 2.5.4

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.5.3'
-  sha256 '35b70ee317b40ad5b66774b25e0880e76d87d5b695467bfcbe51cbea440d0a4c'
+  version '2.5.4'
+  sha256 'e1a903a57b6a1ce298c5594d91a7de4f6945c5dd8e36d666763da23d147ad05d'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.