### PR TITLE
Update lbry from 0.38.2 to 0.39.0

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.38.2'
-  sha256 '5b0b31a9842c299668c1115f7c2dd2c9f2430386a4556cb4353485c510176e5a'
+  version '0.39.0'
+  sha256 'c89591f216ac3d284c5003e08b8aab560b7213ebd2c43737d0f41fd146825f6c'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.