### PR TITLE
Update vellum from 2.6.4 to 2.6.5

### DIFF
--- a/Casks/vellum.rb
+++ b/Casks/vellum.rb
@@ -1,6 +1,6 @@
 cask 'vellum' do
-  version '2.6.4'
-  sha256 '0172ce57e122d7159f83aa2e0491fbf626a91bb05d28e797a17760b22e1a4476'
+  version '2.6.5'
+  sha256 'ff5f5ccdeae7ac5cc966d04abf6c29a7e5f0481ea5cbf6980fe6a3f59aad14fc'
 
   # 180g.s3.amazonaws.com/downloads was verified as official when first introduced to the cask
   url "https://180g.s3.amazonaws.com/downloads/Vellum-#{version.no_dots}00.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.