### PR TITLE
Update banking-4 from 7.2.5.7324 to 7.2.5.7327

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.2.5.7324'
-  sha256 'fa928ee0bd93003610698ec4a67fb02dce29d7f3cb4a6525f50f05ca052fec6a'
+  version '7.2.5.7327'
+  sha256 '2b3c8de6fe2d74ea39ea562287c9f370af4f98c6b3dea0b8ada565fef6bfbcfa'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.