### PR TITLE
Update abstract from 88.0.0 to 88.1.0

### DIFF
--- a/Casks/abstract.rb
+++ b/Casks/abstract.rb
@@ -1,6 +1,6 @@
 cask 'abstract' do
-  version '88.0.0'
-  sha256 '9e4fe4731dcd6e4ca36c82232a0a40b5d7322791360d2bcfd858acb4dc393095'
+  version '88.1.0'
+  sha256 'c5c0433b668da51a9a0c034d1151fbfe406eaa10fca54acbd0459602d374e536'
 
   url "https://downloads.goabstract.com/Abstract-#{version}.dmg"
   appcast 'https://www.goabstract.com/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.