### PR TITLE
Update slite from 1.1.9 to 1.1.10

### DIFF
--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -1,6 +1,6 @@
 cask 'slite' do
-  version '1.1.9'
-  sha256 '3396ce9e2e0b20ee4e1dd4f84960ac1829ad686174fb8392a518b61d8fd29996'
+  version '1.1.10'
+  sha256 '26ec696e862c44936dbc1dd57ec9af73892a6658aeb9298634e38c2bce6ae912'
 
   # storage.googleapis.com/slite-desktop was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/slite-desktop/mac/Slite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.