### PR TITLE
Update icq from 3.0.25681 to 3.0.25725

### DIFF
--- a/Casks/icq.rb
+++ b/Casks/icq.rb
@@ -1,6 +1,6 @@
 cask 'icq' do
-  version '3.0.25681'
-  sha256 '9200a3db1f5b1e0ecdc6bd07f692dcba3608668d0b716c4c628c33812fbfd8ef'
+  version '3.0.25725'
+  sha256 'cfadd63d25b3171c40832a4fca3639bb3dbff560426735c500767e89da1d182b'
 
   # hb.bizmrg.com/icq-www was verified as official when first introduced to the cask
   url 'https://hb.bizmrg.com/icq-www/mac/x64/icq.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.