### PR TITLE
Update fork from 1.0.88 to 1.0.89

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,6 +1,6 @@
 cask 'fork' do
-  version '1.0.88'
-  sha256 '3ca47cb7fc2cc01b5a57cb22b78c73d173861d47f1c7878db7439b8332618f37'
+  version '1.0.89'
+  sha256 'a9477b4e45e2417489cc7e817a8b086aa02ef022495f55f1f8845adcbab6183a'
 
   # forkapp.ams3.cdn.digitaloceanspaces.com/mac was verified as official when first introduced to the cask
   url "https://forkapp.ams3.cdn.digitaloceanspaces.com/mac/Fork-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.