### PR TITLE
Add HA-Menu.app v2.1.1

### DIFF
--- a/Casks/ha-menu.rb
+++ b/Casks/ha-menu.rb
@@ -1,0 +1,12 @@
+cask 'ha-menu' do
+  version '2.1.1'
+  sha256 'd5370514cfef3687760acfe32569fe8b02815a81a4aa722e7a3a2c0c844d5ef1'
+
+  # github.com/codechimp-org/ha-menu was verified as official when first introduced to the cask
+  url "https://github.com/codechimp-org/ha-menu/releases/download/#{version}/HA.Menu.zip"
+  appcast 'https://github.com/codechimp-org/ha-menu/releases.atom'
+  name 'HA Menu'
+  homepage 'https://hamenu.codechimp.org/'
+
+  app 'HA Menu.app'
+end


### PR DESCRIPTION
Added HA-Menu application utility for Home Assistant
Homepage is a vanity URL currently pointing to github repo.  It may become a product landing page later, hence different from repo url.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
