### PR TITLE
Update clover-configurator from 5.9.2.0 to 5.9.2.1

### DIFF
--- a/Casks/clover-configurator.rb
+++ b/Casks/clover-configurator.rb
@@ -1,6 +1,6 @@
 cask 'clover-configurator' do
-  version '5.9.2.0'
-  sha256 '5ce3fbba0e283e8fa5911426bcfb5a0a09ffe1eaf2ef1ba9e74febf5ad3a0070'
+  version '5.9.2.1'
+  sha256 '02a66bcbaf3c7beaef68adf0cb33465118a077a8a95c563612dea97d2b88650f'
 
   url 'https://mackie100projects.altervista.org/apps/cloverconf/download-new-build.php?version=global'
   appcast 'https://mackie100projects.altervista.org/apps/cloverconf/CCG/update-data-builds.xml'


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/76103

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.