### PR TITLE
Update telegram-desktop from 1.9.7 to 1.9.8

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop' do
-  version '1.9.7'
-  sha256 'ebdabc3f5728c301ff785016417b74465c04fb93142a8e5731ef68689d3542e6'
+  version '1.9.8'
+  sha256 '5086a21997837f4abb1ea6de0346b9e7748dd423b6a30fe2eef4bd9593943c65'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.