### PR TITLE
Update powder-player from 1.50 to 1.55

### DIFF
--- a/Casks/powder-player.rb
+++ b/Casks/powder-player.rb
@@ -1,6 +1,6 @@
 cask 'powder-player' do
-  version '1.50'
-  sha256 'c178993f8f4e210a1f2f7f945981376a27f2b32b62582ce51df450d6af860d39'
+  version '1.55'
+  sha256 '8b52dc9772d255c753693c95ff4ca381dc4da8a897f7d3b51ff51728bf01c002'
 
   # github.com/jaruba/PowderPlayer was verified as official when first introduced to the cask
   url "https://github.com/jaruba/PowderPlayer/releases/download/v#{version}/PowderPlayer_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.