### PR TITLE
Update itubedownloader from 6.5.10 to 6.5.11

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,5 +1,5 @@
 cask 'itubedownloader' do
-  version '6.5.10'
+  version '6.5.11'
   sha256 'ccb01f26a10f5446011f22dc7d679bc85acf40be6b561ce8a2f9bd874505480b'
 
   # dl.devmate.com/com.AlphaSoft.iTubeDownloader was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.