### PR TITLE
Update softorino-youtube-converter from 2.1.13 to 2.1.14

### DIFF
--- a/Casks/softorino-youtube-converter.rb
+++ b/Casks/softorino-youtube-converter.rb
@@ -1,6 +1,6 @@
 cask 'softorino-youtube-converter' do
-  version '2.1.13'
-  sha256 '3886dbbc37d0c94673ab722afc57aa4c043dc191b5a72680df9f4255ce4508ab'
+  version '2.1.14'
+  sha256 '6b88e76c6b686c7a00982aaede60a171894ca726ae9020d2be4b7a6ce3ae4dff'
 
   url "https://shining.softorino.com/shine_uploads/softorinoyoutubeconverter#{version.major}mac_#{version}.dmg"
   appcast 'https://shining.softorino.com/appcast.php?abbr=syc2m'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.