### PR TITLE
Update google-chat from 19.9.101 to 20.1.71

### DIFF
--- a/Casks/google-chat.rb
+++ b/Casks/google-chat.rb
@@ -1,6 +1,6 @@
 cask 'google-chat' do
-  version '19.9.101'
-  sha256 'a02ab1c58b8af0b2bd3e0cbb6b16a14979befd4be32458823ea188f3565bea32'
+  version '20.1.71'
+  sha256 '2c74b990d4db034aa856b66d2cb055aa2b92f30ea4105380e192fab8b90f1762'
 
   url "https://dl.google.com/chat/#{version}/InstallHangoutsChat.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://dl.google.com/chat/latest/InstallHangoutsChat.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.