### PR TITLE
Update tagspaces from 3.3.2 to 3.4.0

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask 'tagspaces' do
-  version '3.3.2'
-  sha256 '68ddb090cbe9ab8ff38c05d6de5611fc190f17b9ba1925a85fe789fc3ff61428'
+  version '3.4.0'
+  sha256 '4157cf316c4b57badd65ba4bf1845b553d726ebea57bf292f1f85cdf88f2cea9'
 
   # github.com/tagspaces/tagspaces was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.