### PR TITLE
Update simply-fortran from 3.8.3148 to 3.8.3163

### DIFF
--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -3,7 +3,7 @@ cask 'simply-fortran' do
   sha256 '2b65975136881df56cc275fae30b810b7ca4e4c2cd11668ee41375eb52a24b69'
 
   # download.approximatrix.com/simplyfortran was verified as official when first introduced to the cask
-  url "http://download.approximatrix.com/simplyfortran/#{version.major_minor}/simplyfortran-#{version}.dmg"
+  url "https://download.approximatrix.com/simplyfortran/#{version.major_minor}/simplyfortran-#{version}.dmg"
   appcast 'https://simplyfortran.com/download/?platform=macos',
           configuration: version.major_minor
   name 'Simply Fortran'

--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -1,6 +1,6 @@
 cask 'simply-fortran' do
-  version '3.8.3148'
-  sha256 '9c8ae9916d276632365a52659346fce7b9100aff754d189de6bd4770194f86a7'
+  version '3.8.3163'
+  sha256 '2b65975136881df56cc275fae30b810b7ca4e4c2cd11668ee41375eb52a24b69'
 
   # download.approximatrix.com/simplyfortran was verified as official when first introduced to the cask
   url "http://download.approximatrix.com/simplyfortran/#{version.major_minor}/simplyfortran-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.