### PR TITLE
Update 4k-video-downloader from 4.10.1.3240 to 4.11.1.3390

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.10.1.3240'
-  sha256 '61e6e7f6626474aeb08aea244f61e792fc1b4fbbc9e440ef89908f51299f10c9'
+  version '4.11.1.3390'
+  sha256 '39f744c3de3ffcbb3a6238cd1d85ffe7f8f970eb61bed87f9d98deac5f5e9d4b'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.