### PR TITLE
Update multitouch from 1.16.11 to 1.16.12

### DIFF
--- a/Casks/multitouch.rb
+++ b/Casks/multitouch.rb
@@ -1,6 +1,6 @@
 cask 'multitouch' do
-  version '1.16.11'
-  sha256 '5b644c5ac774e20d1a2fdede340e26ca0af6c7bf45377f8f447f3845edd11d74'
+  version '1.16.12'
+  sha256 '66c2fb3196d6fb8b98a0b8624f88e412db80206fe60001f6f7fc514ca0c12efa'
 
   url "https://multitouch.app/downloads/multitouch#{version}.dmg"
   appcast 'https://www.multitouch.app/downloads/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.