### PR TITLE
Update mutify from 1.1.1 to 1.1.2

### DIFF
--- a/Casks/mutify.rb
+++ b/Casks/mutify.rb
@@ -1,5 +1,5 @@
 cask 'mutify' do
-  version '1.1.1'
+  version '1.1.2'
   sha256 '761c6cba9f6db885cbc01f82ae2b539be5137adbb75384151ff6d091f3fdae8b'
 
   url 'https://storage.mutify.app/data/Mutify.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.