### PR TITLE
Update flic from 2.0.0 to 2.0.2

### DIFF
--- a/Casks/flic.rb
+++ b/Casks/flic.rb
@@ -1,6 +1,6 @@
 cask 'flic' do
-  version '2.0.0'
-  sha256 '5b7a2cac9772723f7ddd9d8a54be21c094c35851ade650384277e6b9770043d6'
+  version '2.0.2'
+  sha256 '46fad4ca0e69128b28906e8c2e7b785e39a1dc406a775a6c48184e8bf90869b6'
 
   # misc-scl-cdn.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://misc-scl-cdn.s3.amazonaws.com/Flic.#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.