### PR TITLE
Update kid3 from 3.8.1 to 3.8.2

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,7 +1,7 @@
 cask 'kid3' do
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  version '3.8.1'
-  sha256 '1a47c1ae065ee73f6d3e53b6e58dadf88e4a2d3bc9257cbad9c4a5b7d731074b'
+  version '3.8.2'
+  sha256 '0265456af936c96f36c3fb29d60077d5123d670a6bb2cb26e40251daf7e8964d'
 
   # downloads.sourceforge.net/kid3 was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.