### PR TITLE
Update ghost-browser from 2.1.1.7 to 2.1.1.8

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.7'
-  sha256 '01024ebb5e2636525cb1f3e3a75c305c6a3a5c9f9cc601319cc260511f7d9f23'
+  version '2.1.1.8'
+  sha256 '6bf085ca84cd2542fa5078a7c2da3c4853391d56ceabd6cce80000625eaf93c2'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.