### PR TITLE
Update clipgrab from 3.8.9 to 3.8.10

### DIFF
--- a/Casks/clipgrab.rb
+++ b/Casks/clipgrab.rb
@@ -1,6 +1,6 @@
 cask 'clipgrab' do
-  version '3.8.9'
-  sha256 '5d92f7dea6f46a1baa231250a0cedc5ac370421da9a3a30f5c57cb41492856be'
+  version '3.8.10'
+  sha256 '2a5af505c4a061938ce8b380fcbc61abf3935265a14e6c2f191cd6c2c9c3428f'
 
   url "https://download.clipgrab.org/ClipGrab-#{version}.dmg"
   appcast 'https://clipgrab.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.