### PR TITLE
Update ipsecuritas from 4.9.1 to 4.9.5

### DIFF
--- a/Casks/ipsecuritas.rb
+++ b/Casks/ipsecuritas.rb
@@ -3,8 +3,8 @@ cask 'ipsecuritas' do
     version '4.7'
     sha256 '42e85f68aa6a321fdaea7a352f5d85d7a987bb7e2a8067360d23633a9df3baba'
   else
-    version '4.9.1'
-    sha256 '4e23830ab3a8b15f25bfe602c6f1b29c9766ae680afcaf0831047216b05836df'
+    version '4.9.5'
+    sha256 'f27bd4afd505d2df213d5da3df339a3f9a7ee882d2db0d5ae74b7ebfe85308a3'
   end
 
   url "https://www.lobotomo.com/products/downloads/IPSecuritas%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.