### PR TITLE
Update yourkit-java-profiler from 2019.8,b136 to 2019.8,b137

### DIFF
--- a/Casks/yourkit-java-profiler.rb
+++ b/Casks/yourkit-java-profiler.rb
@@ -1,6 +1,6 @@
 cask 'yourkit-java-profiler' do
-  version '2019.8,b136'
-  sha256 '77b76d7588677b49554c964a3faf429c0faf12bca15e56d0899b57284443dd90'
+  version '2019.8,b137'
+  sha256 'efe7e4cefc1e6f73802e412fd6e0e13237c81f313a797d9f1b3ba22f3d210b32'
 
   url "https://www.yourkit.com/download/YourKit-JavaProfiler-#{version.before_comma}-#{version.after_comma}.dmg"
   appcast 'https://www.yourkit.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.