### PR TITLE
Update autopkgr from 1.5.1 to 1.5.2

### DIFF
--- a/Casks/autopkgr.rb
+++ b/Casks/autopkgr.rb
@@ -1,6 +1,6 @@
 cask 'autopkgr' do
-  version '1.5.1'
-  sha256 '11c3ce33822f25053731bb084b6cb0d688461306a43b3782f045bdf5745c0904'
+  version '1.5.2'
+  sha256 'db443d0e21d6379a060abb59bced973adbad497a36da1d9e1892bb26ebad0f4e'
 
   # github.com/lindegroup/autopkgr was verified as official when first introduced to the cask
   url "https://github.com/lindegroup/autopkgr/releases/download/v#{version}/AutoPkgr-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.