### PR TITLE
Update gog-galaxy from 1.2.64.2 to 2.0.12.48

### DIFF
--- a/Casks/gog-galaxy.rb
+++ b/Casks/gog-galaxy.rb
@@ -1,6 +1,6 @@
 cask 'gog-galaxy' do
-  version '1.2.64.2'
-  sha256 '974eed5c031eb0980fd50b631858e57e39d5faad4dd25a2bdeedd445d2dde415'
+  version '2.0.12.48'
+  sha256 '00e3ee9a8a6e95123fcc951df528fd86761fbad545314ff5cc6b32f254ac3421'
 
   url "https://cdn.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
   appcast 'https://www.gog.com/galaxy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.