### PR TITLE
Update unity from 2019.2.18f1,bbf64de26e34 to 2019.2.19f1,929ab4d01772

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.18f1,bbf64de26e34'
-  sha256 '0b6a4a01fe3e70d9557ced8ea8d4e3b6e7e80fb48d0307bd0ff7aba98df17ada'
+  version '2019.2.19f1,929ab4d01772'
+  sha256 '837e9404ab6b1505b13cee396e0dbf0b9a981018dcf213e4481b6cb293ee98ef'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.