### PR TITLE
Update unity-lumin-support-for-editor from 2019.2.18f1,bbf64de26e34 to 2019.2.19f1,929ab4d01772

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.2.18f1,bbf64de26e34'
-  sha256 '5c6c86f8bd8d16cf479ff257239310fd3870bca15f0fb19fcb48719ee11f8e88'
+  version '2019.2.19f1,929ab4d01772'
+  sha256 '1fd56f72d58594a33329aab79cbb3b3639bda4f78d0a420d04ce6acee34fb207'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.