### PR TITLE
Update rrcc from 0.8.7 to 0.8.8

### DIFF
--- a/Casks/rrcc.rb
+++ b/Casks/rrcc.rb
@@ -1,6 +1,6 @@
 cask 'rrcc' do
-  version '0.8.7'
-  sha256 '66b181d17acb4477a148d8759d517da078ff9cead3f6a5ff3e0feed439a2dcec'
+  version '0.8.8'
+  sha256 '7c1a657544eb026aeef679d796d2032fb5cd83eadc26f8bf784c59702bcb434e'
 
   url "https://github.com/LazyT/rrcc/releases/download/#{version}/rrcc-#{version.no_dots}.dmg"
   appcast 'https://github.com/LazyT/rrcc/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.