### PR TITLE
Update gpodder from 3.10.11 to 3.10.12

### DIFF
--- a/Casks/gpodder.rb
+++ b/Casks/gpodder.rb
@@ -1,6 +1,6 @@
 cask 'gpodder' do
-  version '3.10.11'
-  sha256 '061ea229663a179a3515c294a70cb4c2128d211cadee7ed3a50c47fa4fa91549'
+  version '3.10.12'
+  sha256 '02293655b99727b0c9b1f57995ba5eebc35dd1f995a02688c18c7e39cdb2ad51'
 
   # github.com/gpodder/gpodder was verified as official when first introduced to the cask
   url "https://github.com/gpodder/gpodder/releases/download/#{version}/macOS-gPodder-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.