### PR TITLE
Update jbrowse from 1.16.6 to 1.16.7

### DIFF
--- a/Casks/jbrowse.rb
+++ b/Casks/jbrowse.rb
@@ -1,6 +1,6 @@
 cask 'jbrowse' do
-  version '1.16.6'
-  sha256 '5e12f08574cdc596abf54e784598075e1ea990c8164871b9b742355907f083c5'
+  version '1.16.7'
+  sha256 '13d4e096a4153e735df0296142d970b78156e2cb7d86a3867bdd7e858ac25227'
 
   # github.com/GMOD/jbrowse was verified as official when first introduced to the cask
   url "https://github.com/GMOD/jbrowse/releases/download/#{version}-release/JBrowse-#{version}-desktop-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.