### PR TITLE
Update openemu from 2.2 to 2.2.1

### DIFF
--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -6,8 +6,8 @@ cask 'openemu' do
     version '2.0.9.1'
     sha256 'c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790'
   else
-    version '2.2'
-    sha256 'cd3763782e0f52ebafce5672562e1893a22ca0b63325bcd072fb31b3296d2689'
+    version '2.2.1'
+    sha256 '6ca94d3d6264464b5088aaabb551dfe5415cb217fa1e6b257ac9b93772c39de6'
   end
 
   # github.com/OpenEmu/OpenEmu was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.