### PR TITLE
Update swiftformat-for-xcode from 0.44.0 to 0.44.1

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask 'swiftformat-for-xcode' do
-  version '0.44.0'
-  sha256 '3d99613225d7d32ba0f32866d22e59548e34adedffb45dea923224d5597bb41b'
+  version '0.44.1'
+  sha256 'dd4f2e16dca47a07b7d2611f20ca9dc4c59c4a5435e9379d8156dc56cdd4c720'
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   appcast 'https://github.com/nicklockwood/SwiftFormat/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.