### PR TITLE
Update jclasslib-bytecode-viewer from 5.4 to 5.5

### DIFF
--- a/Casks/jclasslib-bytecode-viewer.rb
+++ b/Casks/jclasslib-bytecode-viewer.rb
@@ -1,6 +1,6 @@
 cask 'jclasslib-bytecode-viewer' do
-  version '5.4'
-  sha256 'abaed92ec3b3fb0150bee19deace4e070adf7a7f406c19f1bb5d20ea4039e5ea'
+  version '5.5'
+  sha256 '3c8e04e4560298fa276f7cfd1c4733d3dd049ab06c69e42e1f7b300ea76ccda4'
 
   url "https://github.com/ingokegel/jclasslib/releases/download/#{version}/jclasslib_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/ingokegel/jclasslib/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.