### PR TITLE
Update omegat from 4.3.1 to 4.3.2

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -1,6 +1,6 @@
 cask 'omegat' do
-  version '4.3.1'
-  sha256 '2e427d9fd8008a88877aeaa0e634f3d4ff8cbd51bb11e48314535940fc43c0a5'
+  version '4.3.2'
+  sha256 'e6fef5e4fca21ce7922b0c5fcb5a31039f87bee50b0357e12365ffb272c75210'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}/OmegaT_#{version}_Mac_Notarized.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.