### PR TITLE
Update dash to 5.1.2

### DIFF
--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -3,8 +3,8 @@ cask 'dash' do
     version '4.6.7'
     sha256 'e2b5eb996645b25f12ccae15e24b1b0d8007bc5fed925e14ce7be45a2b693fb6'
   else
-    version '5.1.1'
-    sha256 '7759d18edf700a171d809024a36a28c291c30829acd97952b7f42b846d19043c'
+    version '5.1.2'
+    sha256 '53622aa3b8064ef33ea923dace55e407566f770612c0de0d8431e1c7ce7f2c83'
   end
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.