### PR TITLE
Allow to download spatial in China from the chinese domain

### DIFF
--- a/Casks/spatial.rb
+++ b/Casks/spatial.rb
@@ -2,7 +2,14 @@ cask 'spatial' do
   version :latest
   sha256 :no_check
 
-  url 'https://console.improbable.io/toolbelt/download/latest/mac'
+  language 'en', default: true do
+    url 'https://console.improbable.io/toolbelt/download/latest/mac'
+  end
+
+  language 'zh', 'CN' do
+    url 'https://console.spatialoschina.com/toolbelt/download/latest/mac'
+  end
+
   name 'Spatial'
   homepage 'https://spatialos.improbable.io/docs'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free. **The CI check is failing to download from the Chinese domain likely due to restrictions on bandwidth/reachability when going from the West to a China domain. I have tested this locally successfully, and this would not present any issues when downloaded in China.**
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
