### PR TITLE
Update bria from 6.0.1_102001 to 6.0.3_102645

### DIFF
--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -4,7 +4,7 @@ cask 'bria' do
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://counterpath.s3.amazonaws.com/downloads/Bria_#{version}.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://solo.softphone.com/downloads/bria-for-mac'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.counterpath.com/Bria6forMac'
   name 'Bria'
   homepage 'https://www.counterpath.com/bria-solo/'
 

--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -2,7 +2,7 @@ cask 'bria' do
   version '6.0.3_102645'
   sha256 'e1acfe6f624f276f318aa77504b3b11192b2c31acf89ed0b16c55618a1710c50'
 
-  # s3.amazonaws.com was verified as official when first introduced to the cask
+  # counterpath.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://counterpath.s3.amazonaws.com/downloads/Bria_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.counterpath.com/Bria6forMac'
   name 'Bria'

--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -1,6 +1,6 @@
 cask 'bria' do
-  version '6.0.3_102645'
-  sha256 'e1acfe6f624f276f318aa77504b3b11192b2c31acf89ed0b16c55618a1710c50'
+  version '6.1.0_103103'
+  sha256 'e9ed4d75d022eda758ca963c4155e80e7d0d6fa5140871baef77289ea7ee7500'
 
   # counterpath.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://counterpath.s3.amazonaws.com/downloads/Bria_#{version}.dmg"

--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -1,6 +1,6 @@
 cask 'bria' do
   version '6.0.3_102645'
-  sha256 '9730d408fabecc1cfb6e525d64973ea1cb6b7819e7f7f22863740557a50663a6'
+  sha256 'e1acfe6f624f276f318aa77504b3b11192b2c31acf89ed0b16c55618a1710c50'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://counterpath.s3.amazonaws.com/downloads/Bria_#{version}.dmg"

--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -1,8 +1,9 @@
 cask 'bria' do
-  version '6.0.1_102001'
-  sha256 'd327f8518f8c4aa16e67f3c557fe4985c158d448f889f87f0bf1858a6ae95ea0'
+  version '6.0.3_102645'
+  sha256 '9730d408fabecc1cfb6e525d64973ea1cb6b7819e7f7f22863740557a50663a6'
 
-  url "https://secure.counterpath.com/Downloads/Bria_#{version}.dmg"
+  # s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://counterpath.s3.amazonaws.com/downloads/Bria_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://solo.softphone.com/downloads/bria-for-mac'
   name 'Bria'
   homepage 'https://www.counterpath.com/bria-solo/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.