### PR TITLE
Update deezer from 4.18.11 to 4.18.30

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.18.11'
-  sha256 'e265d83772dd29056846b3a7a2fd13cb944194e4aaac529cad65b3446db708f0'
+  version '4.18.30'
+  sha256 'fad0c794b99b27281bc7d57dfda07e3112af22c63ff131d5ed71e8cefb760cf2'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.