### PR TITLE
Update iringg from 1.0.43,1576268168 to 1.0.44

### DIFF
--- a/Casks/iringg.rb
+++ b/Casks/iringg.rb
@@ -1,10 +1,9 @@
 cask 'iringg' do
-  version '1.0.43,1576268168'
-  sha256 'de278f40b045fa76a31c4c1f48b0ce3cae3793f0da65f748a06e189879eb5918'
+  version '1.0.44'
+  sha256 'aae95d6a86d4f4bbe10f67cee0f9f6f1567c4b936197b6d6451fef006d29e1b2'
 
-  # dl.devmate.com/com.softorino.iringg was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.softorino.iringg/#{version.before_comma}/#{version.after_comma}/iRinggforMac-#{version.before_comma}.zip"
-  appcast 'https://updates.devmate.com/com.softorino.iringg.xml'
+  url "https://shining.softorino.com/shine_uploads/iringgmac_#{version}.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://shining.softorino.com/download.php?abbr=irgm'
   name 'iRingg'
   homepage 'https://softorino.com/iringg/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.