### PR TITLE
secure/update URLs

### DIFF
--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -2,7 +2,6 @@ cask 'airunlock' do
   version '0.4'
   sha256 '85f4aee6bc67f6b7c0d01ab36e50a117690574c0e31b210aa3f80931269bf170'
 
-  # github.com/pinetum/AirUnlock-for-Mac was verified as official when first introduced to the cask
   url "https://github.com/pinetum/AirUnlock-for-Mac/releases/download/#{version}/AirUnlock_mac_#{version}.zip"
   appcast 'https://github.com/pinetum/AirUnlock-for-Mac/releases.atom'
   name 'AirUnlock'

--- a/Casks/airunlock.rb
+++ b/Casks/airunlock.rb
@@ -6,7 +6,7 @@ cask 'airunlock' do
   url "https://github.com/pinetum/AirUnlock-for-Mac/releases/download/#{version}/AirUnlock_mac_#{version}.zip"
   appcast 'https://github.com/pinetum/AirUnlock-for-Mac/releases.atom'
   name 'AirUnlock'
-  homepage 'http://airunlock.0068.ml/'
+  homepage 'https://github.com/pinetum/AirUnlock-for-Mac'
 
   app 'AirUnlock.app'
 end

--- a/Casks/bossa.rb
+++ b/Casks/bossa.rb
@@ -6,7 +6,7 @@ cask 'bossa' do
   url "https://github.com/shumatech/BOSSA/releases/download/#{version}/bossa-#{version}.dmg"
   appcast 'https://github.com/shumatech/BOSSA/releases.atom'
   name 'bossa'
-  homepage 'http://www.shumatech.com/web/products/bossa'
+  homepage 'https://www.shumatech.com/web/products/bossa'
 
   app 'BOSSA.app'
   binary 'bossac'

--- a/Casks/cajviewer.rb
+++ b/Casks/cajviewer.rb
@@ -5,7 +5,7 @@ cask 'cajviewer' do
   url 'http://viewer.d.cnki.net/CAJ%E4%BA%91%E9%98%85%E8%AF%BB.dmg'
   name 'CAJViewer'
   name 'CAJ云阅读'
-  homepage 'http://cajviewer.cnki.net/cajcloud/cajdownload.html'
+  homepage 'https://cajviewer.cnki.net/cajcloud/cajdownload.html'
 
   app 'CAJ云阅读.app'
 end

--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -5,7 +5,7 @@ cask 'command-tab-plus' do
   url 'https://noteifyapp.com/download/Command-Tab%20Plus.dmg'
   appcast 'https://macplus-software.com/downloads/Command-Tab.xml'
   name 'Command-Tab Plus'
-  homepage 'http://commandtab.noteifyapp.com/'
+  homepage 'https://noteifyapp.com/command-tab-plus/'
 
   app 'Command-Tab Plus.app'
 

--- a/Casks/figmadaemon.rb
+++ b/Casks/figmadaemon.rb
@@ -3,7 +3,7 @@ cask 'figmadaemon' do
   sha256 '97501a70cbba84e329e284ee223d6236d409102f58deb0282e705f2a14b171ea'
 
   url "https://font-daemon.figma.com/mac/FigmaDaemon.#{version}.zip"
-  appcast 'http://font-daemon.figma.com/mac/versions.xml'
+  appcast 'https://font-daemon.figma.com/mac/versions.xml'
   name 'Figma Font Installers'
   homepage 'https://www.figma.com/'
 

--- a/Casks/prezi-next.rb
+++ b/Casks/prezi-next.rb
@@ -3,7 +3,7 @@ cask 'prezi-next' do
   sha256 '3ad61662a6db86fee8adec634f3f0884650394d5b5169327a90d0dbf31a6b4e3'
 
   url "https://desktopassets.prezi.com/mac/pitch/releases/Prezi_Next_#{version}.dmg"
-  appcast 'https://s3.amazonaws.com/prezidesktop/assets/mac/pitch/updates/prezi-business.xml'
+  appcast 'https://prezidesktop.s3.amazonaws.com/assets/mac/pitch/updates/prezi-business.xml'
   name 'Prezi Next'
   homepage 'https://prezi.com/'
 

--- a/Casks/rescuetime.rb
+++ b/Casks/rescuetime.rb
@@ -3,7 +3,7 @@ cask 'rescuetime' do
   sha256 '68a6335156f2c17376a82c1b8204df00fa5b1ccd92d77c301bc422d41835bc5d'
 
   url 'https://www.rescuetime.com/installers/RescueTimeInstaller.pkg'
-  appcast 'http://www.rescuetime.com/installers/appcast'
+  appcast 'https://www.rescuetime.com/installers/appcast'
   name 'RescueTime'
   homepage 'https://www.rescuetime.com/'
 

--- a/Casks/sensei.rb
+++ b/Casks/sensei.rb
@@ -2,8 +2,8 @@ cask 'sensei' do
   version '1.0.2,11'
   sha256 '290a4122eef9e913fc493d968f9b0e4ec81a6fdb0abc296162ad6fe36aa70303'
 
-  # s3.amazonaws.com/cindori was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/cindori/Sensei.dmg'
+  # cindori.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://cindori.s3.amazonaws.com/Sensei.dmg'
   appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/51fc066a-f4b4-49ec-b966-b2f476d2eede'
   name 'Sensei'
   homepage 'https://sensei.app/'

--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -3,7 +3,7 @@ cask 'thunder' do
   sha256 '197e6c77b36ca7647fd07eabc45acdf6d9a9161149ccde65a97d83e622902e0d'
 
   # down.sandai.net was verified as official when first introduced to the cask
-  url "http://down.sandai.net/mac/thunder_#{version}.dmg"
+  url "https://down.sandai.net/mac/thunder_#{version}.dmg"
   appcast 'https://static-xl9-ssl.xunlei.com/json/mac_download_url.json'
   name 'Thunder'
   name '迅雷'

--- a/Casks/unity-web-player.rb
+++ b/Casks/unity-web-player.rb
@@ -2,7 +2,7 @@ cask 'unity-web-player' do
   version :latest
   sha256 :no_check
 
-  url 'http://webplayer.unity3d.com/download_webplayer-3.x/webplayer-mini.dmg'
+  url 'https://webplayer.unity3d.com/download_webplayer-3.x/webplayer-mini.dmg'
   name 'Unity Web Player'
   homepage 'https://unity3d.com/webplayer'
 

--- a/Casks/warsow.rb
+++ b/Casks/warsow.rb
@@ -2,7 +2,7 @@ cask 'warsow' do
   version '2.1.2'
   sha256 '176b037186e4d8a1c0fc740fe8660cd960339fc4eeca5e5eaaec4028b9bd6aba'
 
-  url "http://warsow.net/warsow-#{version}.dmg"
+  url "https://warsow.net/warsow-#{version}.dmg"
   appcast 'https://www.warsow.net/bundles/client.bundle.js'
   name 'Warsow'
   homepage 'https://www.warsow.net/'

--- a/Casks/xlplayer.rb
+++ b/Casks/xlplayer.rb
@@ -3,7 +3,7 @@ cask 'xlplayer' do
   sha256 'ddfe34ea188b1ac0e77fed209659031d7e8a30015f779a6a2c7c3997525bac36'
 
   # down.sandai.net was verified as official when first introduced to the cask
-  url "http://down.sandai.net/mac/xlplayer_#{version}.dmg"
+  url "https://down.sandai.net/mac/xlplayer_#{version}.dmg"
   appcast 'https://static-xl.a.88cdn.com/json/xunlei_video_version_mac.json'
   name 'XLPlayer for Mac'
   name '迅雷影音 for Mac'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
----------
```
1 file inspected, no offenses detected
==> Downloading https://github.com/pinetum/AirUnlock-for-Mac/releases/download/0
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'airunlock'.
audit for airunlock: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/shumatech/BOSSA/releases/download/1.9.1/bossa
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'bossa'.
audit for bossa: passed

1 file inspected, no offenses detected
==> Downloading http://viewer.d.cnki.net/CAJ%E4%BA%91%E9%98%85%E8%AF%BB.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cajviewer'.
audit for cajviewer: passed

1 file inspected, no offenses detected
==> Downloading https://noteifyapp.com/download/Command-Tab%20Plus.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'command-tab-plus'.
audit for command-tab-plus: passed

1 file inspected, no offenses detected
==> Downloading https://font-daemon.figma.com/mac/FigmaDaemon.17.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'figmadaemon'.
audit for figmadaemon: passed

1 file inspected, no offenses detected
==> Downloading https://desktopassets.prezi.com/mac/pitch/releases/Prezi_Next_1.
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'prezi-next'.
audit for prezi-next: passed

1 file inspected, no offenses detected
==> Downloading https://www.rescuetime.com/installers/RescueTimeInstaller.pkg
         -=O=#   #     #     #                                                
==> Verifying SHA-256 checksum for Cask 'rescuetime'.
audit for rescuetime: passed

1 file inspected, no offenses detected
==> Downloading https://cindori.s3.amazonaws.com/Sensei.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'sensei'.
audit for sensei: passed

1 file inspected, no offenses detected
==> Downloading https://down.sandai.net/mac/thunder_3.3.9.4280.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'thunder'.
audit for thunder: passed

1 file inspected, no offenses detected
==> Downloading https://webplayer.unity3d.com/download_webplayer-3.x/webplayer-m
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'unity-web-player', skipping verificati
audit for unity-web-player: passed

1 file inspected, no offenses detected
==> Downloading https://warsow.net/warsow-2.1.2.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'warsow'.
audit for warsow: passed

1 file inspected, no offenses detected
==> Downloading https://down.sandai.net/mac/xlplayer_2.0.6.1288.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'xlplayer'.
audit for xlplayer: passed
```
