### PR TITLE
Add `auto_updates` flag for drama 2.0.1

### DIFF
--- a/Casks/drama.rb
+++ b/Casks/drama.rb
@@ -8,6 +8,7 @@ cask 'drama' do
   name 'Drama'
   homepage 'https://www.drama.app/'
 
+  auto_updates true
   depends_on macos: '>= :high_sierra'
 
   app 'Drama.app'


### PR DESCRIPTION
Drama has it's own update mechanism via Spark.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).