### PR TITLE
Update unite from 3.0 to 3.0.1

### DIFF
--- a/Casks/unite.rb
+++ b/Casks/unite.rb
@@ -1,9 +1,9 @@
 cask 'unite' do
-  version '3.0.1'
+  version '3.0.1,DlLu0Oy7SNODqh2FocjT'
   sha256 'a6f524772789f919d8e0a9374bd06697407f06e9c1abb3c350985747a42968a4'
 
   # paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531 was verified as official when first introduced to the cask
-  url 'https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/DlLu0Oy7SNODqh2FocjT_Unite.zip'
+  url "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/#{version.after_comma}_Unite.zip"
   appcast 'https://drive.google.com/uc?export=download&id=1pPlm8G1yluV7ipcRh-2pmXP-nATWsjTK'
   name 'Unite'
   homepage 'https://bzgapps.com/unite'

--- a/Casks/unite.rb
+++ b/Casks/unite.rb
@@ -1,9 +1,9 @@
 cask 'unite' do
-  version '3.0'
-  sha256 'baccda6edae65a8322ef31d9e40c5806a87a6fc6d462e6d2158c24e8c99a83b3'
+  version '3.0.1'
+  sha256 'a6f524772789f919d8e0a9374bd06697407f06e9c1abb3c350985747a42968a4'
 
   # paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531 was verified as official when first introduced to the cask
-  url 'https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/i0KpuCjrQtuPoyGcIcZO_Unite.zip'
+  url 'https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/DlLu0Oy7SNODqh2FocjT_Unite.zip'
   appcast 'https://drive.google.com/uc?export=download&id=1pPlm8G1yluV7ipcRh-2pmXP-nATWsjTK'
   name 'Unite'
   homepage 'https://bzgapps.com/unite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.