### PR TITLE
Update praat from 6.1.08 to 6.1.09

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.1.08'
-  sha256 '40ccbabc95295157a5746ebaefd699500be4434720e10d333650b18dc4eaf8b8'
+  version '6.1.09'
+  sha256 '5f59891eb01acc4040cc29385aaf9d3262152eaf898abd6cc585a3e796964513'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.