### PR TITLE
Update scap-workbench from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/scap-workbench.rb
+++ b/Casks/scap-workbench.rb
@@ -1,6 +1,6 @@
 cask 'scap-workbench' do
-  version '1.2.0'
-  sha256 '5acd7e167c8c5f874dc7b0980f9d36b4ea5832307c50b7ea0fd7cfc662dc7f55'
+  version '1.2.1'
+  sha256 'e5a250a8baa6107ba719fec0d6236ece5658e1adb3a5b8dd207c00b51a311628'
 
   # github.com/OpenSCAP/scap-workbench was verified as official when first introduced to the cask
   url "https://github.com/OpenSCAP/scap-workbench/releases/download/#{version.sub(%r{-.+}, '')}/scap-workbench-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.