### PR TITLE
Update rapidweaver from 8.5,20821 to 8.5.1,20823

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,6 +1,6 @@
 cask 'rapidweaver' do
-  version '8.5,20821'
-  sha256 'f8d6f6973a5ec070f7bbe12d15ecc2ba8df4979c5f7390babb9be12861420a47'
+  version '8.5.1,20823'
+  sha256 '0682646a5ca558bb2abd41be5c8104a1c7f98e77226c77c69797b5bbc4412cd8'
 
   # github.com/realmacsoftware was verified as official when first introduced to the cask
   url "https://github.com/realmacsoftware/RapidWeaver#{version.major}-releases/releases/download/#{version.before_comma}-%28#{version.after_comma}%29/RapidWeaver#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.