### PR TITLE
Update sizzy from 0.14.0 to 0.15.1

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.14.0'
-  sha256 '9933ac96e687ba0e4f61970de44777d45ee4a09cf4eebcb69d3919289d6395f4'
+  version '0.15.1'
+  sha256 '0ef6cfcdbe9d4c16d0286794cdec3f80c089905c0d0a320d038f2d566041d890'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.