### PR TITLE
Update 4k-video-downloader from 4.11.1.3390 to 4.11.2.3400

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.11.1.3390'
-  sha256 '39f744c3de3ffcbb3a6238cd1d85ffe7f8f970eb61bed87f9d98deac5f5e9d4b'
+  version '4.11.2.3400'
+  sha256 'eaad0bbdcbbb7b0ed37e4380520ead1901e8f1c6388eca3941c92cd4df27a220'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.