### PR TITLE
Update stremio from 4.4.77 to 4.4.106

### DIFF
--- a/Casks/stremio.rb
+++ b/Casks/stremio.rb
@@ -1,6 +1,6 @@
 cask 'stremio' do
-  version '4.4.77'
-  sha256 'b4d707e38a035aa43fc6ecc3e28c3b43f7624677c8686dc7cb12396f4c2939e0'
+  version '4.4.106'
+  sha256 '6bd8b13cd96738028eae7f3c62fedf1d9c5dfcb6f5b8ba9186c998a97e8b31a7'
 
   url "https://dl.strem.io/mac/v#{version}/Stremio+#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.strem.io/download?platform=mac%26four=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.