### PR TITLE
Update preform from 3.3.1,1717 to 3.3.2,1726

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,9 +1,9 @@
 cask 'preform' do
-  version '3.3.1,1717'
-  sha256 'c7e9ddeb6ab15b8ee7e9c1fd9d4f3710d14783b779e186129b7e661f6e9a3d1c'
+  version '3.3.2,1726'
+  sha256 'b201ff87cc6c9b43b654d904ddce5e80f1c22fa140c35389fee2d7131e653c2a'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"
+  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://formlabs.com/download-preform-mac/'
   name 'PreForm'
   homepage 'https://formlabs.com/tools/preform/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.