### PR TITLE
Update reunion from 12.0.0.191105 to 12.0.0.200127

### DIFF
--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -1,6 +1,6 @@
 cask 'reunion' do
-  version '12.0.0.191105'
-  sha256 '54c6dca89e32cf80c3751cb2d516a6ed5ed3cdc249c2c0cbec8b7e041797e918'
+  version '12.0.0.200127'
+  sha256 '9655c949b744ba3e1571b3de55d9a3c35a7391bd3d4a4591098a2e9812b3dd83'
 
   url "https://store.leisterpro.com/updates/reunion#{version.major}/Reunion-#{version.dots_to_hyphens}.zip"
   appcast "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.