### PR TITLE
Update mu-editor from 1.0.2 to 1.0.3

### DIFF
--- a/Casks/mu-editor.rb
+++ b/Casks/mu-editor.rb
@@ -1,9 +1,9 @@
 cask 'mu-editor' do
-  version '1.0.2'
-  sha256 '70087d6f81f641829b8c457a67bc84cf4437a4fb7dec89fafdda03e26d89af88'
+  version '1.0.3'
+  sha256 'b1815923ab38d00a5ec512912e50694e29c17f087989cd21aa52c88ce10452b0'
 
   # github.com/mu-editor/mu was verified as official when first introduced to the cask
-  url "https://github.com/mu-editor/mu/releases/download/#{version}/mu-editor_#{version}_osx.dmg"
+  url "https://github.com/mu-editor/mu/releases/download/#{version}/mu-editor.dmg"
   appcast 'https://github.com/mu-editor/mu/releases.atom'
   name 'Mu'
   homepage 'https://codewith.mu/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.