### PR TITLE
Update cityofzion-neon from 2.3.0 to 2.4.0

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,8 +1,8 @@
 cask 'cityofzion-neon' do
-  version '2.3.0'
-  sha256 'a6e9eb6365f05b4952918cf1734fd62e172d622c2c68f728811d7624c3c1a9f1'
+  version '2.4.0'
+  sha256 'cf469cb239902fcf07c94a15ea575bca48279fbd46084730b64c98384f43caac'
 
-  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
+  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.