### PR TITLE
Update alephone from 20150620 to 20190331

### DIFF
--- a/Casks/alephone.rb
+++ b/Casks/alephone.rb
@@ -1,6 +1,6 @@
 cask 'alephone' do
-  version '20150620'
-  sha256 'b278d702f3d21d85af040fe94d57f6fc7106a2d9752e00d2dae3ee9342657f6b'
+  version '20190331'
+  sha256 '4aaa16cd93aeee6e22fee5808a2e1a96bcb395945fd45a337c62832aee3303cc'
 
   # github.com/Aleph-One-Marathon/alephone was verified as official when first introduced to the cask
   url "https://github.com/Aleph-One-Marathon/alephone/releases/download/release-#{version}/AlephOne-#{version}-Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.