### PR TITLE
Update sha256 of vagrant 2.2.7

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,6 +1,6 @@
 cask 'vagrant' do
   version '2.2.7'
-  sha256 'cebe1d09123346ad9f8b5bfcd9460277e3c86b759dc860c2e7b3e4a1570c0b10'
+  sha256 '45472731bde1df0bf2e0e0cf1ee460e2851c920d8b7b8af939e41156515cf49c'
 
   # hashicorp.com/vagrant was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).