### PR TITLE
Update nteract from 0.15.0 to 0.21.0

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask 'nteract' do
-  version '0.15.0'
-  sha256 '1356996bce666439052cec6322105f80c9da592866384c711040c5a285f1988e'
+  version '0.21.0'
+  sha256 'b5a97dabcea03c228ff74f76af4e9fb0c78b2e2a88283e0d5b7653b50fe76c76'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.