### PR TITLE
Update chiaki from 1.1.2 to 1.1.3

### DIFF
--- a/Casks/chiaki.rb
+++ b/Casks/chiaki.rb
@@ -1,6 +1,6 @@
 cask 'chiaki' do
-  version '1.1.2'
-  sha256 '9c02049614a0902c022609fdfe6234f76ee1e2bc2166506e34c15790bd84b326'
+  version '1.1.3'
+  sha256 '40e6d2deb0ff42a041e969e3712927e9ffbda1ea13b89d91f5f1207d589776c4'
 
   url "https://github.com/thestr4ng3r/chiaki/releases/download/v#{version}/Chiaki-v#{version}-macOS-x86_64.dmg"
   appcast 'https://github.com/thestr4ng3r/chiaki/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.