### PR TITLE
Update publish-or-perish from 7.17.2685 to 7.18.2702

### DIFF
--- a/Casks/publish-or-perish.rb
+++ b/Casks/publish-or-perish.rb
@@ -1,6 +1,6 @@
 cask 'publish-or-perish' do
-  version '7.17.2685'
-  sha256 'a2828912c358ef9dcfa033fc2ad973782c849a583cdca4521695b47ce47b9160'
+  version '7.18.2702'
+  sha256 'c546fcb3a6c5cf0934bbf63fe37ce4ef39daea6b641d4d5675d2be37de1120dc'
 
   url 'https://harzing.com/download/PoP7Mac.pkg'
   appcast 'https://harzing.com/resources/publish-or-perish/os-x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.