### PR TITLE
Update line-bot-designer from 1.3.2 to 1.3.3

### DIFF
--- a/Casks/line-bot-designer.rb
+++ b/Casks/line-bot-designer.rb
@@ -1,6 +1,6 @@
 cask 'line-bot-designer' do
-  version '1.3.2'
-  sha256 'd0a32f955004cfd880dbc5ba0a24f000a92f6ddc4f2c98cd2ab09202382e8634'
+  version '1.3.3'
+  sha256 '96216a3614a2c1419fa7b94043db23d55a86d128d44a1b4f2bccd5fdd03f7667'
 
   # d.line-scdn.net was verified as official when first introduced to the cask
   url "https://d.line-scdn.net/r/devcenter/bot-designer/LINE%20Bot%20Designer-#{version}.dmg"

--- a/Casks/line-bot-designer.rb
+++ b/Casks/line-bot-designer.rb
@@ -6,7 +6,7 @@ cask 'line-bot-designer' do
   url "https://d.line-scdn.net/r/devcenter/bot-designer/LINE%20Bot%20Designer-#{version}.dmg"
   appcast 'https://developers.line.biz/en/bot-designer/download/'
   name 'LINE Bot Designer'
-  homepage 'https://developers.line.me/en/bot-designer/overview/'
+  homepage 'https://developers.line.biz/en/'
 
   app 'LINE Bot Designer.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.