### PR TITLE
Update qownnotes from 20.1.18,b5297-181335 to 20.1.19,b5304-171959

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.18,b5297-181335'
-  sha256 '1a8c6d459eeb74f60a7a0d3c24269d96a6b2f124f0fe2af48bc39c3c41863d08'
+  version '20.1.19,b5304-171959'
+  sha256 '22d420841aab62379a3b0cf7acff00038566586e5cfe78434f6ace8f018985b7'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.