### PR TITLE
Update godot-mono from 3.1.1 to 3.2

### DIFF
--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -1,6 +1,6 @@
 cask 'godot-mono' do
-  version '3.1.1'
-  sha256 '631e81b7f72284b132386e44caf7c2702a908b381cb1bcfafa412420213d2051'
+  version '3.2'
+  sha256 'cedf1ee73d53ba130b2983e3081c759f61714f3508cb1a44dbe02f9715d291b2'
 
   # downloads.tuxfamily.org/godotengine was verified as official when first introduced to the cask
   url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_osx.64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.