### PR TITLE
Update flycut from 1.9.3 to 1.9.4

### DIFF
--- a/Casks/flycut.rb
+++ b/Casks/flycut.rb
@@ -1,6 +1,6 @@
 cask 'flycut' do
-  version '1.9.3'
-  sha256 'b74e0918869d1356d0e950ea0951d0ec8fa10b44e1a6a6b953f52c071b4310e1'
+  version '1.9.4'
+  sha256 '7e9878ffefb21dc974fb39de3e2b49791fcda9149a758d2d467b5a9207ec4863'
 
   url "https://github.com/TermiT/Flycut/releases/download/#{version}/Flycut.#{version}.zip"
   appcast 'https://github.com/TermiT/Flycut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.