### PR TITLE
Update libreoffice from 6.3.4 to 6.4.0

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '6.3.4'
-  sha256 '0ee534a88720d1653b46ef74b0d64da881c3a323f4656a1db74fbb475a1b4587'
+  version '6.4.0'
+  sha256 '32e7af23282b6241f580d41f22114daa82a4adf96b817c87f68605743ea423cd'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.