### PR TITLE
Update sketchup-pro.rb to 20.0.362- no more language stanza?

### DIFF
--- a/Casks/sketchup-pro.rb
+++ b/Casks/sketchup-pro.rb
@@ -1,5 +1,5 @@
 cask 'sketchup-pro' do
-  version '19.3.252,2019'
+  version '20.0.362,2020'
 
   language 'de' do
     sha256 '534e5fa125a8652a7abcbb9ee2bbc8162bf66de9dbe8cfe33ac7f354dc7a9b71'


### PR DESCRIPTION
hey @vitorgalvao @reitermarkus - sketchup-pro had an upgrade to v 20.0.362,2020 but I there seems to be no more language stanza download - I just found an installer download here: https://sketchup.com/download/all - I'm not sure - shall we change it?  