### PR TITLE
Update downie from 3.9.7,3027 to 3.9.8,3031

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '3.9.7,3027'
-  sha256 '23966765b30f4502473435171b3e78f0db7cee3ecbcd4d86c64a92a64c5d6fa2'
+  version '3.9.8,3031'
+  sha256 '894d903616d485c18c04f661fcc9a46feceb3f0a6bc3ac3f9285c1ea825ef8f1'
 
   # charliemonroesoftware.com was verified as official when first introduced to the cask
   url "https://charliemonroesoftware.com/trial/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.