### PR TITLE
Update texturepacker from 5.2.0 to 5.3.0

### DIFF
--- a/Casks/texturepacker.rb
+++ b/Casks/texturepacker.rb
@@ -1,6 +1,6 @@
 cask 'texturepacker' do
-  version '5.2.0'
-  sha256 'bf90c2db57b206d16ed590daa56641df8033bef4e97f111f62a70fd518d82fc1'
+  version '5.3.0'
+  sha256 '6fb9508719138c8bfd6469bc7a13c4a7f157f30f9608a1a3f4d7c3583c67a0c1'
 
   url "https://www.codeandweb.com/download/texturepacker/#{version}/TexturePacker-#{version}-uni.dmg"
   appcast 'https://www.codeandweb.com/releases/TexturePacker/appcast-mac-release.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.