### PR TITLE
Update loom from 0.27.0 to 0.27.1

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.27.0'
-  sha256 'eb7786f31ab63de95142d2a342b667d5c1b51651a4cc3cd4adb3a709968afd06'
+  version '0.27.1'
+  sha256 'ed1b1d79c7e03808874e5676b7d54b7b140117e4ceb6b870a38963b7d6c67aff'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.