### PR TITLE
Update lehreroffice from 2019.13.4 to 2019.13.5

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.13.4'
-  sha256 'b7d84e03a672f196ec72426d313df8bf9c7d868d350a0ada12e9bed7b1811ebb'
+  version '2019.13.5'
+  sha256 '802e071c552d8550af5167230ea432603f62797bbbb9dac04b26bbd010698184'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.