### PR TITLE
Update vox from 3396.1,1576865164 to 3398.3,1580250435

### DIFF
--- a/Casks/vox.rb
+++ b/Casks/vox.rb
@@ -1,6 +1,6 @@
 cask 'vox' do
-  version '3396.1,1576865164'
-  sha256 '6cce7ffa64fbf51a82a7fdb59131594c3d5e87932da5f3305877c767bc18b89e'
+  version '3398.3,1580250435'
+  sha256 '7b28a89217fad66944e9308e967a5e8dedb73f2536da543e6620c62575c6d730'
 
   # devmate.com/com.coppertino.Vox was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.coppertino.Vox/#{version.before_comma}/#{version.after_comma}/Vox-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.