### PR TITLE
Update textual from 7.1.1,ab24aeff0 to 7.1.2,6c6753847

### DIFF
--- a/Casks/textual.rb
+++ b/Casks/textual.rb
@@ -1,8 +1,8 @@
 cask 'textual' do
-  version '7.1.1,ab24aeff0'
-  sha256 '4e25b168c10798085a9876a59d3cd21ebdddcdb1c2c9dea881ba7d9c07169e07'
+  version '7.1.2,6c6753847'
+  sha256 '50257306c91de79030aa5dc5f09a1963d8d75c21cd9b3e76a6aabef14b48ac94'
 
-  url "https://cached.codeux.com/textual/downloads/resources/builds/standard-release/Textual-#{version.after_comma}.dmg"
+  url "https://cached.codeux.com/textual/downloads/resources/builds/standard-release/Textual-#{version.after_comma}.zip"
   appcast 'https://textual-updates-backend.codeux.com/sparkle/feeds/v7/feed-one.xml'
   name 'Textual'
   homepage 'https://www.codeux.com/textual/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.