### PR TITLE
Update ivpn from 2.10.9 to 2.11.0

### DIFF
--- a/Casks/ivpn.rb
+++ b/Casks/ivpn.rb
@@ -1,9 +1,9 @@
 cask 'ivpn' do
-  version '2.10.9'
-  sha256 '5a9e2e13fcb703fae321325dcbff56f98023e0ded220f8ec9db8152529912c0e'
+  version '2.11.0'
+  sha256 '843bb033829f93da6d579fee1cfe03810fce95c4c6d782bf17a2aea35a470682'
 
   url "https://cdn.ivpn.net/releases/osx/IVPN-#{version}.dmg"
-  appcast 'https://www.ivpn.net/updates/mac/sparkle/ivpn_mac_appcast.xml'
+  appcast 'https://www.ivpn.net/setup/mac-changelog.html'
   name 'IVPN'
   homepage 'https://www.ivpn.net/apps-macos'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.