### PR TITLE
Update FreeCAD sha256 version 0.18.4,16146 (unchanged)

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,6 +1,6 @@
 cask 'freecad' do
   version '0.18.4,16146'
-  sha256 'd6e00dffb7d7e7003aab408190a755615cfd8dbe3fd9b036c1106fee764d4f4c'
+  sha256 'a3e90a2b946b751082be9b0a0893466c550074cb70ec1e5e88b2d3123d7f5f16'
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor}-#{version.after_comma}-OSX-x86_64-conda-Qt5-Py3.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This checksum matches the [sha256 checksum](https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD_0.18-16146-OSX-x86_64-conda-Qt5-Py3.dmg-SHA256.txt) published on the project release page for release [0.18,16146](https://github.com/FreeCAD/FreeCAD/releases/tag/0.18.4). Looking at the history for this file it seems to be getting rebuilt pretty often in between formal releases for some reason.