### PR TITLE
Update keybase from 5.1.1-20191211223249,15bbb94c23 to 5.2.0-20200130011203,cf82db8320

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,6 +1,6 @@
 cask 'keybase' do
-  version '5.1.1-20191211223249,15bbb94c23'
-  sha256 '4debcbdff7eee4a0106998268c28189cd1c974010f4fd42063be55bc45501ab3'
+  version '5.2.0-20200130011203,cf82db8320'
+  sha256 'b2ec06d6b733e83ab385abcfb32fe35039d4a07017a86fa9ec041e771f07fb89'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.