### PR TITLE
Update mycrypto from 1.7.4 to 1.7.5

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.7.4'
-  sha256 'd43d562412aa3d44b4688e9e2d80f231a1aa3c01026c555f7275da2de26f0935'
+  version '1.7.5'
+  sha256 '550c193f3ba0935e691244a0791e543ce7c6910e6ad792e9e21b9fceb1fe96f7'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.