### PR TITLE
Update seashore from 2.5.4 to 2.5.5

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.5.4'
-  sha256 'e1a903a57b6a1ce298c5594d91a7de4f6945c5dd8e36d666763da23d147ad05d'
+  version '2.5.5'
+  sha256 '0bf82e3a43b394896802ae8a4519ac017b3d8c8fbc6d37c4accfb4894d03fd31'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.