### PR TITLE
Update decrediton from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,6 +1,6 @@
 cask 'decrediton' do
-  version '1.5.0'
-  sha256 '10bf6ecbba2e5c51624c1b4ef1c61dd2465c02e5241d4fc9ce810567fe97c005'
+  version '1.5.1'
+  sha256 '62c02815bb8af8f4d6638bb832d084012bf93f3375090b4fd74cf128ca75a772'
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
   appcast 'https://github.com/decred/decred-binaries/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.