### PR TITLE
Update advancedrestclient from 14.0.4 to 15.0.0

### DIFF
--- a/Casks/advancedrestclient.rb
+++ b/Casks/advancedrestclient.rb
@@ -1,6 +1,6 @@
 cask 'advancedrestclient' do
-  version '14.0.4'
-  sha256 '9a3ab7deeabe7271698a481dd85abfae501f2c530c99191df1ce9a8313c9b81f'
+  version '15.0.0'
+  sha256 '012a6d586264e7007784bff0f2ba358c45e631207c912042c956b6bd0b486922'
 
   url "https://github.com/advanced-rest-client/arc-electron/releases/download/v#{version}/arc-#{version}.dmg"
   appcast 'https://github.com/advanced-rest-client/arc-electron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.