### PR TITLE
Update xca from 2.1.2 to 2.2.1

### DIFF
--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,6 +1,6 @@
 cask 'xca' do
-  version '2.1.2'
-  sha256 '1cb7d23045ef64b2c30ce927a40d4bcae20b776aa0c94e067029b3b6be63bc49'
+  version '2.2.1'
+  sha256 '329b71d8ab203317198cc502a61174db7c56f24caa8688947282bacf24cd3e9b'
 
   # github.com/chris2511/xca was verified as official when first introduced to the cask
   url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.