### PR TITLE
Update kite from 0.20200123.0 to 0.20200128.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200123.0'
-  sha256 '13108a6bd02a9cae5d53935dbb63c2e9600fc3ef12d0ca104a41da24850397a1'
+  version '0.20200128.0'
+  sha256 '7bde284df78cef16184cee4403fb158a917285361a297c205d422716d4e92b57'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.