### PR TITLE
Update nimble-commander from 1.2.6,3051 to 1.2.7,3120

### DIFF
--- a/Casks/nimble-commander.rb
+++ b/Casks/nimble-commander.rb
@@ -1,6 +1,6 @@
 cask 'nimble-commander' do
-  version '1.2.6,3051'
-  sha256 '7f04a2a5b51f6d4faf7a5eaf4c05a414744cc46b0be0e6fdeb8692cd9c6a4e5c'
+  version '1.2.7,3120'
+  sha256 'f4975decc6251a5310d05b9e906a9bbcde9828f44b75b1f9666d9afd5d4c95bd'
 
   url "https://magnumbytes.com/downloads/releases/nimble-commander-#{version.before_comma}(#{version.after_comma}).dmg"
   appcast 'https://magnumbytes.com/downloads/releases/sparkle-nimble-commander.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.