### PR TITLE
Update go64 from 1.1 to 1.1.1

### DIFF
--- a/Casks/go64.rb
+++ b/Casks/go64.rb
@@ -1,7 +1,7 @@
 cask 'go64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '1.1'
-  sha256 '54c7c7b111cabedad4d5f6ae2611b5dd81b0fda05e8819e4ae050025295729a1'
+  version '1.1.1'
+  sha256 '1eb0eb8766b531827a26743d4d0650fdba7a436707d6439bb96781bf29dbe3c5'
 
   url "https://www.stclairsoft.com/download/Go64-#{version}.zip"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?GO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.