### PR TITLE
Update fitbit-os-simulator from 0.8.1 to 0.8.2

### DIFF
--- a/Casks/fitbit-os-simulator.rb
+++ b/Casks/fitbit-os-simulator.rb
@@ -1,6 +1,6 @@
 cask 'fitbit-os-simulator' do
-  version '0.8.1'
-  sha256 'ed0dc28be133db1984446df686dc78903c77ec058563b4b2e9b8609af1818f1a'
+  version '0.8.2'
+  sha256 '435b085f6489691140621bec49d81cc72ea0879a0b4d49d0788bd45ca5bbf43b'
 
   url "https://simulator-updates.fitbit.com/Fitbit%20OS%20Simulator-latest-#{version}.dmg"
   appcast 'https://simulator-updates.fitbit.com/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.