### PR TITLE
Update file-juicer from 4.83 to 4.84

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,5 +1,5 @@
 cask 'file-juicer' do
-  version '4.83'
+  version '4.84'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.