### PR TITLE
Update supersync from 7.0.1 to 7.0.2

### DIFF
--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,6 +1,6 @@
 cask 'supersync' do
-  version '7.0.1'
-  sha256 '1929c697d49642125956f82c54e40ed750dbe4a007593b06f7037915919707e6'
+  version '7.0.2'
+  sha256 '7b110cee197eff492859c59c482d31181ff451739cbc3898c740b6a664c3b4c4'
 
   url "https://supersync.com/downloads/SuperSync_#{version}.dmg"
   appcast 'https://supersync.com/downloads.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.