### PR TITLE
Update netxms-console from 3.1.300 to 3.1.343

### DIFF
--- a/Casks/netxms-console.rb
+++ b/Casks/netxms-console.rb
@@ -1,6 +1,6 @@
 cask 'netxms-console' do
-  version '3.1.300'
-  sha256 'fba16e71742d0b0e2dcf3ac98fce5c07e46638ab40156ddfdb408998a68ef51a'
+  version '3.1.343'
+  sha256 '69f520fd221ab51c23a6df5c1ecbe26a3008a47c6e92c73e8b7fe0cc5046f106'
 
   url "https://netxms.org/download/releases/#{version.major_minor}/nxmc-#{version}.dmg"
   appcast "https://netxms.org/download/releases/#{version.major_minor}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.