### PR TITLE
Update unity from 2019.2.19f1,929ab4d01772 to 2019.3.0f6,27ab2135bccf

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.2.19f1,929ab4d01772'
-  sha256 '837e9404ab6b1505b13cee396e0dbf0b9a981018dcf213e4481b6cb293ee98ef'
+  version '2019.3.0f6,27ab2135bccf'
+  sha256 '9dbb83686d715f72560c7cb73d446c61f3b3c061688ca79a5c90849dfb6e9ed4'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.