### PR TITLE
Update unity-android-support-for-editor from 2019.2.18f1,bbf64de26e34 to 2019.3.0f6,27ab2135bccf

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.2.18f1,bbf64de26e34'
-  sha256 '2095160b73d50b172cf8623df9c03c3b6997cb48031f0c215152e9bf806c5729'
+  version '2019.3.0f6,27ab2135bccf'
+  sha256 'b68b9765236740be461ac12884698edda8a7abf839a01bb2a90ad0f7ca106a3a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.