### PR TITLE
Update unity-download-assistant from 2019.2.19f1,929ab4d01772 to 2019.3.0f6,27ab2135bccf

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.2.19f1,929ab4d01772'
-  sha256 '0a4fa82e52e0f9e4ab365c1bc30ce8fb29abae05f9e39edff013aa6445d72115'
+  version '2019.3.0f6,27ab2135bccf'
+  sha256 '0ee26bd5261b4e3447f266190f0c564fe2584026ed69fdd8b4bc9b05146b4c6f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.