### PR TITLE
Update unity-ios-support-for-editor from 2019.2.19f1,929ab4d01772 to 2019.3.0f6,27ab2135bccf

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.2.19f1,929ab4d01772'
-  sha256 'aeee89b0462f40e86e15fd391dac746f77e78559734a824e412c8d9f97b0d643'
+  version '2019.3.0f6,27ab2135bccf'
+  sha256 '8e3ee6c2b14b6b5ef8ecf159888eb30e42c0ed11cf91cc6927122a01a6adefa8'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.