### PR TITLE
Update unity-webgl-support-for-editor from 2019.2.19f1,929ab4d01772 to 2019.3.0f6,27ab2135bccf

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.2.19f1,929ab4d01772'
-  sha256 'e66e0b6f01a50d9c41c523f17034de661b59ea0038405fdc6e048f9171c29f65'
+  version '2019.3.0f6,27ab2135bccf'
+  sha256 '548d7481d0b401179acd01f91a3f2826481c14f6f4dc9e424a4008fd66c15635'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.