### PR TITLE
Update geotag-photos-pro from 1.5.5 to 1.5.6

### DIFF
--- a/Casks/geotag-photos-pro.rb
+++ b/Casks/geotag-photos-pro.rb
@@ -1,6 +1,6 @@
 cask 'geotag-photos-pro' do
-  version '1.5.5'
-  sha256 '80779b8316547f00a812d410edede1782bd8a23b18d64ad6eaa87c28e73fab71'
+  version '1.5.6'
+  sha256 'e82d2a3c2c3656625e4863bcda36c3df223a6f4e038a8313754d0615a8ce8c24'
 
   # github.com/tappytaps/geotag-desktop-app was verified as official when first introduced to the cask
   url "https://github.com/tappytaps/geotag-desktop-app/releases/download/v#{version}/Geotag-Photos-Pro-2-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.