### PR TITLE
Update brook from 20200102 to 20200201

### DIFF
--- a/Casks/brook.rb
+++ b/Casks/brook.rb
@@ -1,6 +1,6 @@
 cask 'brook' do
-  version '20200102'
-  sha256 'ee4fbeba88fa57bb0702612ba32e8e5d04036eaad3740f58c38788406b692a47'
+  version '20200201'
+  sha256 '4b964bad957e69d94bf7ef2ec6616d7329f9e5b1a3967296c1fa7968cb99b0c6'
 
   url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.pkg"
   appcast 'https://github.com/txthinking/brook/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.