### PR TITLE
Update plex from 1.6.2.994-e05b79d6 to 1.6.3.1009-57cf57c8

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask 'plex' do
-  version '1.6.2.994-e05b79d6'
-  sha256 'ab3283b33756cb1d28f605628ad1c247a60c6a6cdf6e5865a7d94031deb865fd'
+  version '1.6.3.1009-57cf57c8'
+  sha256 '35b721677529cd021e99886b6f59641caaa06b2f885f1f0be7092c9c4d000a19'
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/6.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.