### PR TITLE
Update chatty from 0.10 to 0.11

### DIFF
--- a/Casks/chatty.rb
+++ b/Casks/chatty.rb
@@ -1,6 +1,6 @@
 cask 'chatty' do
-  version '0.10'
-  sha256 '905e876269cd38b46be030d408319a0dbeb1fd71989822aed11c14d11f4e71f8'
+  version '0.11'
+  sha256 '609c742afd7a848a4d87058559f7b819eeb7d4bccadeed13c3206cb1b9cc40de'
 
   # github.com/chatty/chatty was verified as official when first introduced to the cask
   url "https://github.com/chatty/chatty/releases/download/v#{version}/Chatty_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.