### PR TITLE
Update dcp-o-matic-batch-converter from 2.14.23 to 2.14.25

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.14.23'
-  sha256 '9db6b3e20abd89ac28d6df060b0988b11f875dbfcdad37f4cd29934da9f877e2'
+  version '2.14.25'
+  sha256 'f654d0169a667dae82df507a420a80a900915acec98b0bef30b3627ace85455f'
 
   url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.