### PR TITLE
add more osx version to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: c
 os: osx
 osx_image:
   - xcode6.4   # OS X 10.10 Yosemite
+  - xcode7.3   # OS X 10.11 El Capitan
   - xcode8     # OS X 10.11 El Capitan
   - xcode9.2   # macOS 10.12 Sierra
   - xcode10.1  # macOS 10.13 High Sierra

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: c
 
 os: osx
 osx_image:
-  - xcode10.1
+  - xcode6.4   # OS X 10.10 Yosemite
+  - xcode8     # OS X 10.11 El Capitan
+  - xcode9.2   # macOS 10.12 Sierra
+  - xcode10.1  # macOS 10.13 High Sierra
+  - xcode11.3  # macOS 10.14 Mojave
   - xcode10.3
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ osx_image:
   - xcode9.2   # macOS 10.12 Sierra
   - xcode10.1  # macOS 10.13 High Sierra
   - xcode11.3  # macOS 10.14 Mojave
-  - xcode10.3
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: c
 os: osx
 osx_image:
   - xcode6.4   # OS X 10.10 Yosemite
-  - xcode7.3   # OS X 10.11 El Capitan
   - xcode8     # OS X 10.11 El Capitan
   - xcode9.2   # macOS 10.12 Sierra
   - xcode10.1  # macOS 10.13 High Sierra
@@ -39,6 +38,7 @@ install:
     export HOMEBREW_COLOR=1
     export HOMEBREW_DEVELOPER=1
     export HOMEBREW_NO_AUTO_UPDATE=1
+    brew update
     brew update-reset
     HOMEBREW_INSTALL_BUNDLER_GEMS_FIRST=1 brew config
   - |


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

improve travis test.
I add

- OS X 10.10 Yosemite
- OS X 10.11 El Capitan
- macOS 10.12 Sierra
- macOS 10.14 Mojave

to cover more environments

macOS 10.15 Catalina is not ready on travis yet https://travis-ci.community/t/macos-catalina-build-environment/5608

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
