### PR TITLE
Update qt-design-studio from 1.3.0 to 1.4.0

### DIFF
--- a/Casks/qt-design-studio.rb
+++ b/Casks/qt-design-studio.rb
@@ -1,6 +1,6 @@
 cask 'qt-design-studio' do
-  version '1.3.0'
-  sha256 '3eaa65806214f364cda3ffa103fd65bf49e3d351a4dd2a5027e7e11d58e16fae'
+  version '1.4.0'
+  sha256 '34ec6ddce1ad8b5db8ac487256d7f2abd44e94af4f401eb12f841155a19b9f86'
 
   url "https://download.qt.io/official_releases/qtdesignstudio/#{version}/qt-designstudio-mac-x86_64-#{version}-community.dmg"
   name 'Qt Design Studio'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.