### PR TITLE
Update couchbase-server-enterprise from 6.0.2 to 6.5.0

### DIFF
--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -2,14 +2,19 @@ cask 'couchbase-server-enterprise' do
   if MacOS.version <= :el_capitan
     version '4.5.1'
     sha256 'de014c7c134eb97ff00be6b2e6f5d0da84295ce05bbb7bb3a4d3c747a365cd22'
+
+    url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"
+
+    app "couchbase-server-enterprise_#{version}/Couchbase Server.app"
   else
-    version '6.0.2'
-    sha256 'e1d9e39a36aa7f0fb5743b24f7e67e45211a2d739108024f6442029f9a2632de'
+    version '6.5.0'
+    sha256 'd6eec86d867dd0ffc39bd9e4ac8832fa607076bc9446105a063d1a7e2ca7c0ee'
+
+    url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.dmg"
+
+    app 'Couchbase Server.app'
   end
 
-  url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.zip"
   name 'Couchbase Server'
   homepage 'https://www.couchbase.com/'
-
-  app "couchbase-server-enterprise_#{version}/Couchbase Server.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.