### PR TITLE
Update inkdrop from 4.5.1 to 4.5.2

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,6 +1,6 @@
 cask 'inkdrop' do
-  version '4.5.1'
-  sha256 '9afd122ef75b20e97bd9e8082515c8b615ea5771029c253af1afaf221d688caf'
+  version '4.5.2'
+  sha256 'bec5d942b07cb841e848d44689f661dc9888de763320d8f483c1468775423157'
 
   # d3ip0rje8grhnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.