### PR TITLE
Update openra from 20191117 to 20200202

### DIFF
--- a/Casks/openra.rb
+++ b/Casks/openra.rb
@@ -1,6 +1,6 @@
 cask 'openra' do
-  version '20191117'
-  sha256 'ff5fafd5a3233c562d6a7515b15938d461815d36373bc1e23d46642d465ab1b6'
+  version '20200202'
+  sha256 '4fe30d596133b96b1b66f1edcc6925ebcb3170e6cff076c7c1c74005460db8f5'
 
   # github.com/OpenRA/OpenRA was verified as official when first introduced to the cask
   url "https://github.com/OpenRA/OpenRA/releases/download/release-#{version}/OpenRA-release-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.