### PR TITLE
Update dosbox-x from 0.82.25,20191231233544 to 0.82.26,20200131111201

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.82.25,20191231233544'
-  sha256 'bdf150db560161ec7e42fe9aabc2275a298dff01d1dbb224e2fe2fafbdd86dca'
+  version '0.82.26,20200131111201'
+  sha256 'a4d7f9dce5d7c3d8ce2631d41a1e99c734f2b7bb0fa4cf296cc8e1c2667e63db'
 
   # github.com/joncampbell123/dosbox-x was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.