### PR TITLE
Update opentoonz from 1.3.0 to 1.4.0

### DIFF
--- a/Casks/opentoonz.rb
+++ b/Casks/opentoonz.rb
@@ -1,6 +1,6 @@
 cask 'opentoonz' do
-  version '1.3.0'
-  sha256 'cb82a0ee73504ee7d324bfb844ccdcc2cd4d0dc064c4c4023d41ca2af4d5c39d'
+  version '1.4.0'
+  sha256 'dbb4d961fb7ff4cd3200faaa7de00e10f220e6ccfca430c61d409bbfc100950d'
 
   # github.com/opentoonz/opentoonz was verified as official when first introduced to the cask
   url "https://github.com/opentoonz/opentoonz/releases/download/v#{version}/OpenToonz.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.