### PR TITLE
Update trilium-notes from 0.40.1 to 0.40.2

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.40.1'
-  sha256 '6fcb05df2310a40a41d5ac5310943817e4648468b8b4c45f9ef072acae7dc8bc'
+  version '0.40.2'
+  sha256 'cd4fbc0e08275cf91e18880c54d4293a2e75c4a18216835732cf6ba5d1706bc8'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.