### PR TITLE
Update qownnotes from 20.1.19,b5304-171959 to 20.2.0,b5308-115751

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.1.19,b5304-171959'
-  sha256 '22d420841aab62379a3b0cf7acff00038566586e5cfe78434f6ace8f018985b7'
+  version '20.2.0,b5308-115751'
+  sha256 '699117c34e0e68a9845ae7ba7f52f0b0ae4a052dcfa50a5d8a8ee5291baf3da8'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.