### PR TITLE
Update electerm from 1.0.19 to 1.0.21

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.0.19'
-  sha256 '10f815767ce6f38aa9604169936638186b292052d2a651f5506858df0abac679'
+  version '1.0.21'
+  sha256 '48645b956ff7358c9430af4198a7d310dde5eccdcbc98c35558dbb07048580a7'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.