### PR TITLE
Update drama from 2.0.3 to 2.0.4

### DIFF
--- a/Casks/drama.rb
+++ b/Casks/drama.rb
@@ -1,6 +1,6 @@
 cask 'drama' do
-  version '2.0.3'
-  sha256 '5973062f9fbe50303aa45dbddbb333fcdd3c03c373a699f3389741fed93ae28c'
+  version '2.0.4'
+  sha256 '73d5cffdaa50f23eb12311c9b819daf9657ac59ab9ea33833e1e2421aaa5fba7'
 
   # pixelcut.com/drama was verified as official when first introduced to the cask
   url 'https://www.pixelcut.com/drama/drama.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.