### PR TITLE
Update lrtimelapse from 5.3.3 to 5.4.0

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,5 +1,5 @@
 cask 'lrtimelapse' do
-  version '5.3.3'
+  version '5.4.0'
   sha256 '9c0550a1ad18a884ace37844509777a0178da7d3911c5cfe989f8c7d29868709'
 
   url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.