### PR TITLE
Update grafx from 2.6.2492,41 to 2.7

### DIFF
--- a/Casks/grafx.rb
+++ b/Casks/grafx.rb
@@ -1,6 +1,6 @@
 cask 'grafx' do
-  version '2.6.2492,41'
-  sha256 '31658ed8983ac3ed7778e2fd0b6dfc5e1abc4c1302c5bc77a4dc584cd7c7efb5'
+  version '2.7'
+  sha256 '4b340f5dbe3d0b9223bfd5d13125cef2177fec039ea439d936f2105e08823600'
 
   url "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{version.after_comma}"
   appcast 'https://gitlab.com/GrafX2/grafX2/-/tags?format=atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.