### PR TITLE
Update bettertouchtool from 3.270 to 3.279

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.270'
-    sha256 'ffcb62290a37c70c7abc7ce713fcd7d026a22981e17b0222c9d7c40907a0ed8c'
+    version '3.279'
+    sha256 'ac78990c02a3a744c6e5f3144eca74a7a4e27d728154d628d522a3c3bf6223e1'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.