### PR TITLE
Update opencore-configurator from 1.13.2.0 to 1.13.3.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.13.2.0'
-  sha256 '83dd59725091db57c4f265d59cc1098223247d196882393e7250332eaa9a42ec'
+  version '1.13.3.0'
+  sha256 '5882c6cfdf698f72c8b96a86eb7f29eb52f289373ac87e8242f69c0a207634cf'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.