### PR TITLE
Update epic from 79.0.3945.130 to 79.0.3946.130

### DIFF
--- a/Casks/epic.rb
+++ b/Casks/epic.rb
@@ -1,9 +1,9 @@
 cask 'epic' do
-  version '79.0.3945.130'
-  sha256 '793ee7f965879a5747f6696d98f03bc12b419b032dad1077a28a4d55e570c0ee'
+  version '79.0.3946.130'
+  sha256 '70c99216e73fc0e3bc1051cf45b3d3b40b47a86f4da3a1b33c9a5622edfcbae5'
 
   # macepic-cbe.kxcdn.com was verified as official when first introduced to the cask
-  url "https://cdn.epicbrowser.com/epic_#{version}.dmg"
+  url "https://cdn.epicbrowser.com/mac/epic_#{version}.dmg"
   appcast 'https://epicbrowser.com/thank_you.php'
   name 'Epic Privacy Browser'
   homepage 'https://www.epicbrowser.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.