### PR TITLE
Update propresenter from 7.0,117440539 to 7.0.2,117441028

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,6 +1,6 @@
 cask 'propresenter' do
-  version '7.0,117440539'
-  sha256 '047292587f7e7b558f02e8012d5e7189886e7262336ba1886fed90aa29d93236'
+  version '7.0.2,117441028'
+  sha256 '68e1d4bda33e587a04f9d4ca81f2afdae3edf4a09429c4b974b7f755b905e8c4'
 
   url "https://renewedvision.com/downloads/propresenter/mac/ProPresenter_#{version.before_comma}_#{version.after_comma}.zip"
   appcast 'https://api.renewedvision.com/v1/pro/upgrade?platform=macos&osVersion=0&appVersion=0&buildNumber=0&includeNotes=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.