### PR TITLE
Update power-manager from 5.4.5 to 5.4.6

### DIFF
--- a/Casks/power-manager.rb
+++ b/Casks/power-manager.rb
@@ -1,6 +1,6 @@
 cask 'power-manager' do
-  version '5.4.5'
-  sha256 '20bc03f8e4775c2cfcc32b8d31fd7eac7738ed2af7fc326e25d064dcd0adb36d'
+  version '5.4.6'
+  sha256 'c6a05a925dbb090c042f4f520d01460df18c06570e6cd06940f62f66ed07512c'
 
   url "https://www.dssw.co.uk/powermanager/dsswpowermanager-#{version.no_dots}.dmg"
   appcast 'https://version.dssw.co.uk/powermanager/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.