### PR TITLE
Update netron from 3.8.5 to 3.8.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.8.5'
-  sha256 'c0758763cbe6fe193a1d43d04257e3e31c3a4f0ad93e391500bb3f6542d2cc55'
+  version '3.8.6'
+  sha256 '864cef7e398c6b46c3b5a5aaba35cd9d0b6d509803b0822b36250eadd06c683a'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.