### PR TITLE
Update double-commander from 0.9.7-9235 to 0.9.8-9296

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,9 +1,9 @@
 cask 'double-commander' do
-  version '0.9.7-9235'
-  sha256 '0fa494197b1db249efb82a5f0e5c255b6656f2c507de884b7ef27b0c305a0453'
+  version '0.9.8-9296'
+  sha256 '4f80b2eb299c54bf83ff389c60f60d4381530f8631874897ec6e294ac2b83e84'
 
   # downloads.sourceforge.net/doublecmd was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.cocoa.x86_64.zip"
+  url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg"
   appcast 'https://sourceforge.net/projects/doublecmd/rss'
   name 'Double Commander'
   homepage 'https://doublecmd.sourceforge.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.