### PR TITLE
Update dbeaver-community from 6.3.3 to 6.3.4

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,6 +1,6 @@
 cask 'dbeaver-community' do
-  version '6.3.3'
-  sha256 '15cfb86f4a99a090e7844b2dfbb6070026866e97f5d231d3f4a26bbc395df571'
+  version '6.3.4'
+  sha256 '18d7941cde96136fc0c36aa5ad4d5412b88955a322449500ef517c565edd9454'
 
   # github.com/dbeaver/dbeaver was verified as official when first introduced to the cask
   url "https://github.com/dbeaver/dbeaver/releases/download/#{version}/dbeaver-ce-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.