### PR TITLE
Update runjs from 1.7.0 to 1.8.0

### DIFF
--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -1,6 +1,6 @@
 cask 'runjs' do
-  version '1.7.0'
-  sha256 '601a1f3b7d8572022127f9a5b5b7323efa4b4f88a91085857ebe68b91295d68e'
+  version '1.8.0'
+  sha256 '754590fa7e40b46722ecb654a113e2789a51501601712977d8a4002ae9d48da5'
 
   # github.com/lukehaas/runjs was verified as official when first introduced to the cask
   url "https://github.com/lukehaas/runjs/releases/download/v#{version}/RunJS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.