### PR TITLE
Update gitup from 1.1.1 to 1.1.2

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,6 +1,6 @@
 cask 'gitup' do
-  version '1.1.1'
-  sha256 '3a4cee7ede28188a014d4fb9704c6a37255152002e96aa2f0ab41542d6753c98'
+  version '1.1.2'
+  sha256 '78b10d8e489d7ff0ddd5f7c3bbbdcbecf4c9896619eaf6a3a268e9debef28203'
 
   # gitup-builds.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://gitup-builds.s3.amazonaws.com/stable/GitUp.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.