### PR TITLE
Update gifox from 2.1.0,020100.00 to 2.1.1,020101.00

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -1,6 +1,6 @@
 cask 'gifox' do
-  version '2.1.0,020100.00'
-  sha256 '7846fb0faefa124c256b40118280f6c34e040fcdc7e87de9fab4747469e369ae'
+  version '2.1.1,020101.00'
+  sha256 '0b414ab558e4a1e1a96744f67a9722f1828234bfbb20fd5b769b5594f35311da'
 
   # d3si16icyi9iar.cloudfront.net/gifox was verified as official when first introduced to the cask
   url "https://d3si16icyi9iar.cloudfront.net/gifox/#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.