### PR TITLE
Update freeze from 3.11.1 to 3.12

### DIFF
--- a/Casks/freeze.rb
+++ b/Casks/freeze.rb
@@ -1,6 +1,6 @@
 cask 'freeze' do
-  version '3.11.1'
-  sha256 '0fd43f3742451b3b1e537a8498be8203b1c3baf1b5ea439ba3e0105e3b370a5e'
+  version '3.12'
+  sha256 '59bff1a92d65e2b34852c4660611b85a97f10772bc31ac753342fa80c0b9ded6'
 
   url 'https://www.freezeapp.net/download/Freeze.zip'
   appcast 'https://www.freezeapp.net/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.