### PR TITLE
Update lifesize from 10.3.7-235 to 2.210.2578

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,16 +1,11 @@
 cask 'lifesize' do
-  version '10.3.7-235'
-  sha256 '7924c29dd00057f3417fb000b700d333a6cf36869ef2637b76e077ebfc813f7d'
+  version '2.210.2578'
+  sha256 'b2843d5b2773dfacdd00d9cb3b27ebca4c563d5c64aae12af6e93ce07b93c09f'
 
-  # cdn.lifesizecloud.com was verified as official when first introduced to the cask
-  url "https://cdn.lifesizecloud.com/LifesizeCloud-#{version}-signed.pkg"
-  appcast 'https://cdn.lifesizecloud.com/OSX_Clients/Sparkle_Upgrades/LifesizeAppcast.xml'
+  # download.lifesizecloud.com/Lifesize- was verified as official when first introduced to the cask
+  url "https://download.lifesizecloud.com/Lifesize-#{version}.dmg"
   name 'lifesize'
   homepage 'https://www.lifesize.com/'
 
-  auto_updates true
-
-  pkg "LifesizeCloud-#{version}-signed.pkg"
-
-  uninstall pkgutil: 'com.lifesize.Lifesize-Cloud'
+  app 'Lifesize.app'
 end


### PR DESCRIPTION
At some point Lifesize created a brand new app with a different version history and I was surprised to get an old app when I tried installing the cask today. This changes over to the new app, hence the lower version number.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


