### PR TITLE
Update wechatwork from 3.0.4.2008 to 3.0.4.2023

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.4.2008'
-  sha256 '24dc1bd12bd66a294054240f005da7aef1c028ee5aeb17191cfd1f89008e35c7'
+  version '3.0.4.2023'
+  sha256 'f8eb508d119b8f6bf03399722cf0885df2257ff75c9509da7b6abf16d26cb739'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.