### PR TITLE
Update signal from 1.30.0 to 1.30.1

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.30.0'
-  sha256 '76de771145d571cc75acc9f935f197993218d12b9457bbd3706a8420535c08aa'
+  version '1.30.1'
+  sha256 '726b98a947262d73a5450623d27ed65edc8f10c80a3f234b66e69187e854f450'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.