### PR TITLE
Update eaglefiler from 1.8.11 to 1.8.12

### DIFF
--- a/Casks/eaglefiler.rb
+++ b/Casks/eaglefiler.rb
@@ -1,6 +1,6 @@
 cask 'eaglefiler' do
-  version '1.8.11'
-  sha256 'f423884234ea93ac70e32debb1c53b42bb5d55ef12f90f2df42654ba763b0c47'
+  version '1.8.12'
+  sha256 '350337cc33a77e051ad6bb803eb34ea86681b17dfb968f6a322506b72918c6db'
 
   url "https://c-command.com/downloads/EagleFiler-#{version}.dmg"
   appcast 'https://c-command.com/eaglefiler/help/version-history'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.