### PR TITLE
Update vivaldi from 2.10.1745.26 to 2.10.1745.27

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.10.1745.26'
-  sha256 'bf3451323d3c3db42a2a957ed118596f18b7f99538af0268bd81589f82941b1c'
+  version '2.10.1745.27'
+  sha256 'd2794ce2d5037936c5b5e56a2efa3eafb130493ce7a8fce67f61e8f63bdfaf6f'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).