### PR TITLE
Update 1password from 7.4.1 to 7.4.2

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -1,6 +1,6 @@
 cask '1password' do
-  version '7.4.1'
-  sha256 'ba2044c3a57c5f94066b6427ab922764166996a2fddcaf8654164e2d0a27ee6c'
+  version '7.4.2'
+  sha256 '4f16c0efdab3bf81bd194940078cdb1cd136505839f3901dc6b3a3c844289f7f'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.