### PR TITLE
Update vapor from 3.1.0 to 3.2.0

### DIFF
--- a/Casks/vapor.rb
+++ b/Casks/vapor.rb
@@ -1,8 +1,8 @@
 cask 'vapor' do
-  version '3.1.0'
-  sha256 'f3bfcbc348358826704dc790ec81317f9f270b70bb6d2889eb6ece0be4c94ccb'
+  version '3.2.0'
+  sha256 '2c81e9b5f6d9744b18aadb07eb88ba1be606f0db6c062f4591fedcd6633aa072'
 
-  url "https://github.com/NCAR/VAPOR/releases/download/#{version}/Vapor-#{version}-Mac.dmg"
+  url "https://github.com/NCAR/VAPOR/releases/download/#{version}/VAPOR3-#{version}-Darwin.dmg"
   appcast 'https://github.com/NCAR/VAPOR/releases.atom'
   name 'VAPOR'
   homepage 'https://github.com/NCAR/VAPOR'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.