### PR TITLE
Update mycrypto from 1.7.5 to 1.7.7

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.7.5'
-  sha256 '550c193f3ba0935e691244a0791e543ce7c6910e6ad792e9e21b9fceb1fe96f7'
+  version '1.7.7'
+  sha256 'c7bbcee32f7ac9831ca4db1f091ad154181ed2e5ada3e1f9895e674b218e2df4'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.