### PR TITLE
Update rocket-chat from 2.17.3 to 2.17.5

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask 'rocket-chat' do
-  version '2.17.3'
-  sha256 '268e3fdbd717540ef39102df295f9275408e3e91103a6a848df400fd1445d24c'
+  version '2.17.5'
+  sha256 'd0ee96988cf30283d1a7f47b7181b31d3376189b5f60872c2a5dbc60a41be00a'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.