### PR TITLE
Update stoplight-studio from 1.8.2 to 1.9.0

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.8.2'
-  sha256 'ded7c821ab4185e6a09e86fe547e407065ee689e5f372a93344dca28a6f5dd99'
+  version '1.9.0'
+  sha256 '79885346191807704edd66eaaa6ff3d486f179e19a4abfdc47f277037893c997'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.