### PR TITLE
Update electerm from 1.0.21 to 1.0.23

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.0.21'
-  sha256 '48645b956ff7358c9430af4198a7d310dde5eccdcbc98c35558dbb07048580a7'
+  version '1.0.23'
+  sha256 '11b856cf3d3a521a9746125352c0c520b7e5ef196faead55b4440b1ac138d00e'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.