### PR TITLE
Update glyphs from 2.6.5,1289 to 2.6.5,1290

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.5,1289'
-  sha256 '53f1a056a7cbc3cf3acb12e807348716938dc3d1ee5c56bdfce826d219b18006'
+  version '2.6.5,1290'
+  sha256 'c6e489603622401234898adcd7302650da401f19a56d715c3765a151f9378b60'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.