### PR TITLE
Update remote-desktop-manager-free from 2020.1.0.0 to 2020.1.1.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '2020.1.0.0'
-  sha256 'cf9258b1f737537aa12731069ab09af3c20f28dd481176db7fe13f23c74b8843'
+  version '2020.1.1.0'
+  sha256 '31ebb217c40f55ec8a920520cc37b5206d03c882fa6a23c1b95ee79f4cb69237'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.