### PR TITLE
Update mongodb-compass-readonly from 1.20.4 to 1.20.5

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.20.4'
-  sha256 'a22345ffa5d3eebd9ebb73b4701fff3e40edcac3ceeeead2b2212e3c7cea642a'
+  version '1.20.5'
+  sha256 'dd5f99522b7528c535f0d03b66b64743cd135051112e9ad65ed629e096c19257'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.