### PR TITLE
Update bettertouchtool from 3.279 to 3.286

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.279'
-    sha256 'ac78990c02a3a744c6e5f3144eca74a7a4e27d728154d628d522a3c3bf6223e1'
+    version '3.286'
+    sha256 '0328899b13b45722ba30ca4b63a5201b7a52d05fd1faa111b8a5f86186608d05'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.