### PR TITLE
Update freeplane from 1.7.11 to 1.7.12

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,6 +1,6 @@
 cask 'freeplane' do
-  version '1.7.11'
-  sha256 'eaae4622cb27d7c26e0facd10c87eb9f26e0e5b8082e0642154d049eaaadc1d1'
+  version '1.7.12'
+  sha256 '6633d8bde1b612efb47bb4ada7dc454fe25acbeb30d26428728bae0226ac8068'
 
   # downloads.sourceforge.net/freeplane was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/freeplane_app_jre-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.