### PR TITLE
Update mono-mdk from 6.8.0.96 to 6.8.0.105

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk' do
-  version '6.8.0.96'
-  sha256 '7dd5454472faf9aebef9d17b2c47b12508e062e8e8428b38992cd0f58cf022af'
+  version '6.8.0.105'
+  sha256 'a585985ef908fe0ee4329255f761ff608824296219d2be44e3aca664fc988637'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://www.mono-project.com/download/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.