### PR TITLE
Only run workflows on main repo

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   automerge:
+    if: startsWith( github.repository, 'Homebrew/' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/sync_templates_and_ci_config.yml
+++ b/.github/workflows/sync_templates_and_ci_config.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync_templates_and_ci_config:
+    if: startsWith( github.repository, 'Homebrew/' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Prevent the automerge and sync workflows from running on forks of Homebrew/homebrew-cask.