### PR TITLE
Update termius from 5.3.2 to 5.4.1

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,5 +1,5 @@
 cask 'termius' do
-  version '5.3.2'
+  version '5.4.1'
   sha256 '3ab0116f269e25faa6eeb9e24fe61c045fd05b3d9d9b0db1fadcb69f29924c63'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.