### PR TITLE
Update opencore-configurator from 1.13.3.0 to 1.14.1.1

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.13.3.0'
-  sha256 '5882c6cfdf698f72c8b96a86eb7f29eb52f289373ac87e8242f69c0a207634cf'
+  version '1.14.0.2'
+  sha256 '0bd08c8105864887995168f1da62b3ad860f6451d27b59e1fadc2a7e678aba2e'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'

--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
   version '1.14.0.2'
-  sha256 '0bd08c8105864887995168f1da62b3ad860f6451d27b59e1fadc2a7e678aba2e'
+  sha256 'fc561732a087683cc86c33c2a19d289b8f5ce9d615852ebd235fa69e69f98d20'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'

--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
   version '1.14.0.2'
-  sha256 'fc561732a087683cc86c33c2a19d289b8f5ce9d615852ebd235fa69e69f98d20'
+  sha256 'bfa7cff464a043fd431ab7a4b0017de5a2dd93ab85576ddba65ec4b63ede5e46'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'

--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.14.0.2'
-  sha256 'bfa7cff464a043fd431ab7a4b0017de5a2dd93ab85576ddba65ec4b63ede5e46'
+  version '1.14.1.1'
+  sha256 '0099915ca5733deebe53a71f5aee7e2c8c4b159098b4c5d9bcebcadb37d17c01'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'

--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
   version '1.14.1.1'
-  sha256 '0099915ca5733deebe53a71f5aee7e2c8c4b159098b4c5d9bcebcadb37d17c01'
+  sha256 'c74e2d314ec3d2824cc1166dc4811be1b5e6465276024d41d40ca13a62f00bdc'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.