### PR TITLE
Update jbrowse from 1.16.7 to 1.16.8

### DIFF
--- a/Casks/jbrowse.rb
+++ b/Casks/jbrowse.rb
@@ -1,6 +1,6 @@
 cask 'jbrowse' do
-  version '1.16.7'
-  sha256 '13d4e096a4153e735df0296142d970b78156e2cb7d86a3867bdd7e858ac25227'
+  version '1.16.8'
+  sha256 '73b7c99b8afd6d28713397937b09e64b4451461f0ae91b4b6d6981fa00fb3341'
 
   # github.com/GMOD/jbrowse was verified as official when first introduced to the cask
   url "https://github.com/GMOD/jbrowse/releases/download/#{version}-release/JBrowse-#{version}-desktop-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.