### PR TITLE
Update tidepool-uploader from 2.25.0 to 2.25.1

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.25.0'
-  sha256 '4e35fb04c8200609d9a60a56e675dd9b2f5e7a1e4c615d40f12878a05e95383f'
+  version '2.25.1'
+  sha256 'ce4abb0845207a13cd26c03c13a6368242d1bddf175c98b682fa10ff4f90d590'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.