### PR TITLE
Update netspot from 2.11.972 to 2.12.997

### DIFF
--- a/Casks/netspot.rb
+++ b/Casks/netspot.rb
@@ -1,6 +1,6 @@
 cask 'netspot' do
-  version '2.11.972'
-  sha256 'c0a6b63839001720a4d77b7123f9c9df065adb53bd3c6895933770bec8efa2b2'
+  version '2.12.997'
+  sha256 '6da0fb7ee0ed8b42159a57f7c032c01ec5c027f8ce7eef20557c8f12e8f6282f'
 
   url 'https://cdn.netspotapp.com/download/NetSpot.dmg'
   appcast "https://www.netspotapp.com/updates/netspot#{version.major}-appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.