### PR TITLE
Update audirvana from 3.5.29 to 3.5.30

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.29'
-  sha256 'af8d55460063ece6820a612ee3fd023af847a5d1b5309eed78e5db21486ed79e'
+  version '3.5.30'
+  sha256 '63352952140be4d50f46a852aa416761f433fc537e21b2f82fd256142e523fb5'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.