### PR TITLE
Update aqua-data-studio from 20.5.0 to 20.5.0-2

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,6 +1,6 @@
 cask 'aqua-data-studio' do
-  version '20.5.0'
-  sha256 '48f3b3c15746fd6f1fbe6b151ddbefa64d1c10d6ac6cff802581a42c07648081'
+  version '20.5.0-2'
+  sha256 '637d54ab94d0dc2f67cf3db83c9ee743b10365322b1e39f1660b0afdc6a01c71'
 
   url "http://downloads.aquafold.com/v#{version.major_minor}.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'https://www.aquafold.com/aquadatastudio_downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.