### PR TITLE
Update notion from 2.0.5 to 2.0.7

### DIFF
--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -1,6 +1,6 @@
 cask 'notion' do
-  version '2.0.5'
-  sha256 '71ba30264bf3e7238b65d0a8e630d5fc20b79b79584a7201e6eacc6b16d27311'
+  version '2.0.7'
+  sha256 '48915df088d544c7dc41767c14d9c165a5b867668270cd985875354af8b65166'
 
   # desktop-release.notion-static.com was verified as official when first introduced to the cask
   url "https://desktop-release.notion-static.com/Notion-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.