### PR TITLE
Update favro from 1.0.36 to 1.0.39

### DIFF
--- a/Casks/favro.rb
+++ b/Casks/favro.rb
@@ -1,6 +1,6 @@
 cask 'favro' do
-  version '1.0.36'
-  sha256 'cb42e7f8bcb998d005645b22b200e38f21d9b92ca697662226f298477191eed6'
+  version '1.0.39'
+  sha256 '1761f8a2fd79eaf497eecac968d648bee0227f82067628f335a72aa9a627c4aa'
 
   url "https://download.favro.com/FavroDesktop/macOS/x64/Favro-#{version}.dmg"
   appcast 'https://download.favro.com/FavroDesktop/macOS/x64/Latest.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.