### PR TITLE
Update securesafe from 2.5.0 to 2.6.0

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,6 +1,6 @@
 cask 'securesafe' do
-  version '2.5.0'
-  sha256 'c641d2934a372dd89a0103bbc993f8a18f47fbe4dd080c088cc52911cbc8ecfc'
+  version '2.6.0'
+  sha256 '3016ad51e569c9b1f06884bcb4803a1520f9435fed5c84e2626e0f40a99c33cb'
 
   url "https://www.securesafe.com/downloads/SecureSafe_#{version}.pkg"
   appcast 'https://www.securesafe.com/en/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.