### PR TITLE
Update ghost-browser from 2.1.1.8 to 2.1.1.9

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.8'
-  sha256 '6bf085ca84cd2542fa5078a7c2da3c4853391d56ceabd6cce80000625eaf93c2'
+  version '2.1.1.9'
+  sha256 'c5288a4fb4dbb570ddd5e8ecef52b56d647e2e82566ca839b6a166ce1a6d711f'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.