### PR TITLE
Update zoc from 7.25.1 to 7.25.2

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.25.1'
-  sha256 '40f6a0695da1e5332691036624b825c7abc41529b42ca3fae8202505018799de'
+  version '7.25.2'
+  sha256 'c38c761d3602477bc663750599d47a7908e945672b81a759364434de09cee4a3'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.