### PR TITLE
Update goodsync from 10.10.20.7 to 10.10.21.1

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask 'goodsync' do
-  version '10.10.20.7'
-  sha256 '85459f65c0cd98b65bf6bd25d970d5056d8e849572181566d9681a1154c523bb'
+  version '10.10.21.1'
+  sha256 '651cfd0bde0a55a9d3466efb4155368402a613faee09397e578193480b5701d8'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast 'https://www.goodsync.com/download?os=macos',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.