### PR TITLE
Update remotix-agent from 1.2.9 to 1.3

### DIFF
--- a/Casks/remotix-agent.rb
+++ b/Casks/remotix-agent.rb
@@ -1,8 +1,9 @@
 cask 'remotix-agent' do
-  version '1.2.9'
-  sha256 '2b76536a853462f3d60fc7e243fe2a64f904b47c2a7935d123f890a93f9cacf6'
+  version '1.3'
+  sha256 '18de94f6be4a3da33b2d6a30383b5e07de438d6b0502cbf7a161de9c4f8afeb9'
 
   url 'https://downloads.remotixcloud.com/agent-mac/RemotixAgent.pkg'
+  appcast 'https://remotixcloud.com/downloads/'
   name 'Remotix Agent'
   homepage 'https://remotixcloud.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.