### PR TITLE
Update lightproxy from 1.1.7 to 1.1.8

### DIFF
--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -1,6 +1,6 @@
 cask 'lightproxy' do
-  version '1.1.7'
-  sha256 'dad8d44ee3b092f046a767676d0131df8d70ab930b5620237dbbe8c7ff102d8f'
+  version '1.1.8'
+  sha256 '287cfc258692bf89acb450111b0c7f1ac63ccc66f82f9b13982cf6a1d29cd27c'
 
   # gw.alipayobjects.com/os/LightProxy was verified as official when first introduced to the cask
   url 'https://gw.alipayobjects.com/os/LightProxy/LightProxy.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.