### PR TITLE
Update deepl from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/deepl.rb
+++ b/Casks/deepl.rb
@@ -1,8 +1,8 @@
 cask 'deepl' do
-  version '1.5.0'
-  sha256 '2a7a7d7bd9a7938d024bac765110f87996c06676161e85e499a6e260882e998d'
+  version '1.5.1'
+  sha256 '8385faf802b88158b25a4e6f65473a4a0cee7e64ffda870a18cfdad7341bc30c'
 
-  url "https://www.deepl.com/macos/download/LpsA0EG5frbfX8p5/DeepL#{version.no_dots}.zip"
+  url "https://www.deepl.com/macos/download/LpsA0EG5frbfX8p5/DeepL#{version}.zip"
   name 'DeepL'
   homepage 'https://www.deepl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.