### PR TITLE
Switch adoptopenjdk install to pkg.

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,14 +1,16 @@
 cask 'adoptopenjdk' do
   version '13.0.2,8'
-  sha256 '0ddb24efdf5aab541898d19b7667b149a1a64a8bd039b708fc58ee0284fa7e07'
+  sha256 '7b60830e61a0483ee81ed6ca6463e211a529e43b1f3815a57c2e3780ce4ba0ba'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.pkg"
   appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK Java Development Kit'
   homepage 'https://adoptopenjdk.net/'
 
-  artifact "jdk-#{version.before_comma}+#{version.after_comma}", target: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+  pkg "OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.pkg"
+
+  uninstall pkgutil: "net.adoptopenjdk.#{version.major}.jdk"
 
   caveats <<~EOS
     More versions are available in the AdoptOpenJDK tap:


### PR DESCRIPTION
This is necessary for OS X Catalina.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [+] `brew cask audit --download {{cask_file}}` is error-free.
- [+] `brew cask style --fix {{cask_file}}` reports no offenses.
- [+] The commit message includes the cask’s name and version.
- [+] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This was created to fix https://github.com/Homebrew/homebrew-cask/pull/73145, which has been stale for months now. 