### PR TITLE
Update busycontacts from 1.4.5,140500 to 1.4.5,140501

### DIFF
--- a/Casks/busycontacts.rb
+++ b/Casks/busycontacts.rb
@@ -1,6 +1,6 @@
 cask 'busycontacts' do
-  version '1.4.5,140500'
-  sha256 'c22639434ef633d48c233e99f649d7d6664cedfb91d00304c103b8d3bd580778'
+  version '1.4.5,140501'
+  sha256 'd67724a0dcac6175ef0ddd7d66fd16ccc3bb85cf4e2464133a82c6208cc4ace1'
 
   url 'https://www.busymac.com/download/BusyContacts.zip'
   appcast 'https://www.busymac.com/busycontacts/news.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.