### PR TITLE
Update geph from 3.2.5 to 3.2.6

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.2.5'
-  sha256 '2e082b40b721649fb9c52bb51e3a2f9547333cf74c0e246cb6f6f2528f3ec865'
+  version '3.2.6'
+  sha256 'f92af875500ac4efa4269d4c565ec751e0e5b494a380c98ca481e11386fdea75'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.