### PR TITLE
Update qownnotes from 20.2.1,b5313-171245 to 20.2.2,b5316-163252

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.2.1,b5313-171245'
-  sha256 '4afe3db7ae36f23d43318d12c7df12700548226b093fd1360f200bf40b2b6dbe'
+  version '20.2.2,b5316-163252'
+  sha256 '8199fec8911935d743395c0a704cbf12a01fda45eaae08feb0e8f14aadec1976'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.