### PR TITLE
Update rsyncosx from 6.1.5 to 6.1.7

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,6 +1,6 @@
 cask 'rsyncosx' do
-  version '6.1.5'
-  sha256 '40c26498dd57385aee7db6e8de74f6485a6dd023f1166296a10f97bf1225ac81'
+  version '6.1.7'
+  sha256 '764cb1f5c96958a1c05e960f3f4a9169a3afc574a64cca23f95cf5daeeb56b9e'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX-#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.