### PR TITLE
Update metabase from 0.34.1 to 0.34.2

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.34.1'
-  sha256 'e39294880f7584d144504ecf0633b58e748e3e4867a05b9d9343d73b940d68ec'
+  version '0.34.2'
+  sha256 '387b7258741b2360fe69559b2d758fb7a2e429afd95b37876b3d5ec32406ea09'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.