### PR TITLE
Update malwarebytes from 4.0.30.3073 to 4.1.28.3352

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '4.0.30.3073'
-  sha256 'b4b3bed354204143de83af2fb44a7df1f2990e08039be8157877789cf83f0d1d'
+  version '4.1.28.3352'
+  sha256 'e4b1daf2d0fde53fc852a8155066011c0fcaaedded512704de6bb585d2a817b1'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.