### PR TITLE
Update waterfox from 2020.01 to 2020.01.1

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,6 +1,6 @@
 cask 'waterfox' do
-  version '2020.01'
-  sha256 '26388f57b84150fe883cf541fcfcdb186415cfecb2e159a1568bb1d1f66a86db'
+  version '2020.01.1'
+  sha256 'efb8402184d10f90824a4e6d2e7b213581be13415d17bb49f1df2f6bb816e3b7'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Classic%20#{version}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.