### PR TITLE
Update geogebra from 6.0.564.0 to 6.0.573.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.564.0'
-  sha256 '39674a6eed15d6f11262ca6280aae6363fe3c4d2eaca6135b01b8a3ca959b11c'
+  version '6.0.573.0'
+  sha256 'a7fbd0f5bf5937142bfa63d144faebc532e8cf1a5835f52e23aa48b82f73706e'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.