### PR TITLE
Update packetproxy from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/packetproxy.rb
+++ b/Casks/packetproxy.rb
@@ -1,6 +1,6 @@
 cask 'packetproxy' do
-  version '2.1.1'
-  sha256 'e79dd546f742618e6e93d7f4fc6a129aabdf3266db49a64cbc6bb45cc848a182'
+  version '2.1.2'
+  sha256 '3d408bf5b1cc382716c3e3222f2ce9f5f76d1473a82e91a43fc72a233bbd83bf'
 
   url "https://github.com/DeNA/PacketProxy/releases/download/#{version}/PacketProxy-#{version}-Installer-Mac-Signed.dmg"
   appcast 'https://github.com/DeNA/PacketProxy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.