### PR TITLE
Update dingtalk from 4.7.27.6 to 4.7.28.0

### DIFF
--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,6 +1,6 @@
 cask 'dingtalk' do
-  version '4.7.27.6'
-  sha256 'e203bc4a0dfc2b5dd69c1a706a719b8c49cdf20aa9d986951956708cede9b81f'
+  version '4.7.28.0'
+  sha256 '4c101b9cd33b44b68ea57f4ecb39fceead3c1d4d3dcb6e7011261fdd32615f4f'
 
   url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version}.dmg"
   appcast 'https://im.dingtalk.com/manifest/appcast_en.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.