### PR TITLE
Update tuple from 0.60.0,2020-01-15-db62d289 to 0.61.0,2020-02-06-5e1aab60

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.60.0,2020-01-15-db62d289'
-  sha256 'a0505458e6d3c1681ea2b808c56e483bd72ed186c788f6f243e77a4cc4f140ca'
+  version '0.61.0,2020-02-06-5e1aab60'
+  sha256 '1f4d8f6f1469e50e76326f91895f726dbd28784150561ab832343b187482cf9c'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.