### PR TITLE
Update marginnote from 3.6.2004 to 3.6.3002

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -2,7 +2,7 @@ cask 'marginnote' do
   version '3.6.3002'
   sha256 'c800fb301172d050b92810500757444b6712cc6968ce86a733554938e335ef82'
 
-  # appcenter-filemanagement-distrib4ede6f06e.azureedge.net/e817e853-6a6f-413c-b5cf-001dcc236caa was verified as official when first introduced to the cask
+  # appcenter-filemanagement-distrib4ede6f06e.azureedge.net/ was verified as official when first introduced to the cask
   url "https://appcenter-filemanagement-distrib4ede6f06e.azureedge.net/e817e853-6a6f-413c-b5cf-001dcc236caa/MarginNote#{version.major}.dmg?sv=2018-03-28&sr=c&sig=Cjah0NylL6vVfJBoJZkkLBy82DO78kwjh%2FclWqRDBEI%3D&se=2020-02-08T15%3A05%3A13Z&sp=r"
   appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/1451f4f6-9214-4d46-b91c-d5898c7e42cb'
   name 'MarginNote'

--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,9 +1,9 @@
 cask 'marginnote' do
-  version '3.6.2004'
-  sha256 'ca5a2060f10e742ba7005b23833e7dc594498b837355c1fa2de72be8178adc3b'
+  version '3.6.3002'
+  sha256 'c800fb301172d050b92810500757444b6712cc6968ce86a733554938e335ef82'
 
-  # appcenter-filemanagement-distrib4ede6f06e.azureedge.net/895929dc-b9be-4b30-8ccd-15383dd786bd was verified as official when first introduced to the cask
-  url "https://appcenter-filemanagement-distrib4ede6f06e.azureedge.net/895929dc-b9be-4b30-8ccd-15383dd786bd/MarginNote%20#{version.major}.app.zip?sv=2018-03-28&sr=c&sig=OjCIng7U4P7qM906WE9Ny4xxXdY%2FLbiDNBEDEJ3q4g4%3D&se=2020-01-30T17%3A52%3A08Z&sp=r"
+  # appcenter-filemanagement-distrib4ede6f06e.azureedge.net/e817e853-6a6f-413c-b5cf-001dcc236caa was verified as official when first introduced to the cask
+  url "https://appcenter-filemanagement-distrib4ede6f06e.azureedge.net/e817e853-6a6f-413c-b5cf-001dcc236caa/MarginNote#{version.major}.dmg?sv=2018-03-28&sr=c&sig=Cjah0NylL6vVfJBoJZkkLBy82DO78kwjh%2FclWqRDBEI%3D&se=2020-02-08T15%3A05%3A13Z&sp=r"
   appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/1451f4f6-9214-4d46-b91c-d5898c7e42cb'
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.