### PR TITLE
Update cmake from 3.16.3 to 3.16.4

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.16.3'
-  sha256 '19a95a0f02ead7b6b6e81a9696405dc332f6bfa9d39fa3da7394b2db29c54c65'
+  version '3.16.4'
+  sha256 '8414278d1213998223932cd621c4fa22f93abee51964c7e3d75df2ba3ea58864'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   appcast 'https://cmake.org/files/LatestRelease/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.