### PR TITLE
Update geph from 3.2.6 to 3.2.7

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.2.6'
-  sha256 'f92af875500ac4efa4269d4c565ec751e0e5b494a380c98ca481e11386fdea75'
+  version '3.2.7'
+  sha256 '28e95553dd2d1ecf28221d3ee05e24d7afbdf25925d5346a80ac2ec079f6f205'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.