### PR TITLE
Update qlab from 4.6 to 4.6.1

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,6 +1,6 @@
 cask 'qlab' do
-  version '4.6'
-  sha256 'f289aa5114eacbb5e8b30ef60d1b5ce87d9e831efa4b7155e16c8336719e8cee'
+  version '4.6.1'
+  sha256 'a66a7f3c7142dbd35047ffb73e685f748d965349ef4f42c6fce85c71ef7b2c94'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.