### PR TITLE
Update idagio from 0.0.112 to 0.0.113

### DIFF
--- a/Casks/idagio.rb
+++ b/Casks/idagio.rb
@@ -1,6 +1,6 @@
 cask 'idagio' do
-  version '0.0.112'
-  sha256 'e2910f45195d546883e1e74737042f6413193cdcdee953c1530930b96b4b3765'
+  version '0.0.113'
+  sha256 '13cbd0600a59561d1c6a41a18c41e7e38392382a1d443ee5a5751a77c776909b'
 
   url "https://dl.idagio.com/IDAGIO-#{version}.dmg"
   name 'IDAGIO'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.