### PR TITLE
Update seadrive from 1.0.10 to 1.0.11

### DIFF
--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -1,6 +1,6 @@
 cask 'seadrive' do
-  version '1.0.10'
-  sha256 '8ff20f7f7d79e7afe9ff2ec2dcd413e0a47958f1022387bd2731e8c5903b04a8'
+  version '1.0.11'
+  sha256 '7b38a0b4870e2ac8221dc737c0b16fa2ab9d41604a20be017069dd71fe60900a'
 
   # download.seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seadrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.