### PR TITLE
Update react-studio from 1.7.6,368 to 1.7.7,369

### DIFF
--- a/Casks/react-studio.rb
+++ b/Casks/react-studio.rb
@@ -1,6 +1,6 @@
 cask 'react-studio' do
-  version '1.7.6,368'
-  sha256 '3338364a158b317e43660643cc1f7c3b03f73a3eb80cbd5ed280b94405b17cce'
+  version '1.7.7,369'
+  sha256 'b63a091ebe0e3501c72eedb48357387576789284e16b4c57f854ecd3373aefee'
 
   # s3.amazonaws.com/sc.neonto.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/sc.neonto.com/ReactStudio_v#{version.before_comma.no_dots}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.