### PR TITLE
Update dcp-o-matic-encode-server from 2.14.25 to 2.14.26

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.25'
-  sha256 '477518def6f4a767a8e3ed68eba5ceee96aed573039e65bcd3dd34e7fa9188be'
+  version '2.14.26'
+  sha256 '4f7b590fbf6a52d525d3fd700bd6900d40f0caf23eff5881eeaa702c541455be'
 
   url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.