### PR TITLE
Update dcp-o-matic from 2.14.25 to 2.14.26

### DIFF
--- a/Casks/dcp-o-matic.rb
+++ b/Casks/dcp-o-matic.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic' do
-  version '2.14.25'
-  sha256 'c533629833953eb9ef925ae162ef5b85025f9c054ced738637271968f0d8c6cd'
+  version '2.14.26'
+  sha256 'aaee3d2d3fc04b613190efbc0d85226e4b030efa8b47e91eb2f4b473202f032d'
 
   url "https://dcpomatic.com/dl.php?id=osx-main&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.