### PR TITLE
Update dcp-o-matic-kdm-creator from 2.14.25 to 2.14.26

### DIFF
--- a/Casks/dcp-o-matic-kdm-creator.rb
+++ b/Casks/dcp-o-matic-kdm-creator.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-kdm-creator' do
-  version '2.14.25'
-  sha256 '759e84468dee6c01c94d53c1ed36082d9b5ff0dd6ddfb37fa849e1623c477cc4'
+  version '2.14.26'
+  sha256 'a05ddaca96b27e6e6293243b596b3aec7649ca351c91dce971756d1e67b6453f'
 
   url "https://dcpomatic.com/dl.php?id=osx-kdm&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.