### PR TITLE
Update qtspim from 9.1.20 to 9.1.21

### DIFF
--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -1,9 +1,9 @@
 cask 'qtspim' do
-  version '9.1.20'
-  sha256 '69ea4d4e8e7cf4788aaf3cd366a3876fb500bcfa3fe979c0a52de76a4d46a284'
+  version '9.1.21'
+  sha256 '14fea7dd17e01c01820c9a52dfe577f764765ca7c4e9f7e99881e8badbe04595'
 
   # downloads.sourceforge.net/spimsimulator was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.mpkg.zip"
+  url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.pkg"
   appcast 'https://sourceforge.net/projects/spimsimulator/rss'
   name 'QtSpim'
   homepage 'https://spimsimulator.sourceforge.io/'

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -6,9 +6,9 @@ cask 'qtspim' do
   url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.pkg"
   appcast 'https://sourceforge.net/projects/spimsimulator/rss'
   name 'QtSpim'
-  homepage 'https://spimsimulator.sourceforge.io/'
+  homepage 'http://spimsimulator.sourceforge.net/'
 
-  pkg 'QtSpim.mpkg'
+  pkg "QtSpim_#{version}_mac.pkg"
 
   uninstall pkgutil: 'org.larusstone.pkg.QtSpim'
 end

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -6,7 +6,7 @@ cask 'qtspim' do
   url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.pkg"
   appcast 'https://sourceforge.net/projects/spimsimulator/rss'
   name 'QtSpim'
-  homepage 'http://spimsimulator.sourceforge.net/'
+  homepage 'https://spimsimulator.sourceforge.io/'
 
   pkg "QtSpim_#{version}_mac.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.