### PR TITLE
Update axe-edit-iii from 1.05.00 to 1.05.01

### DIFF
--- a/Casks/axe-edit-iii.rb
+++ b/Casks/axe-edit-iii.rb
@@ -1,6 +1,6 @@
 cask 'axe-edit-iii' do
-  version '1.05.00'
-  sha256 '51bd1e23cfd18e05d1c65f163a9cd359b438c57a238c32a5a38e46331feb754f'
+  version '1.05.01'
+  sha256 '94aa507f25ce014f4827ec6873f7043839468cb799cf655f117832069c77b19a'
 
   url "https://www.fractalaudio.com/downloads/Axe-Edit-III/Axe-Edit-III-OSX-v#{version.tr('.', 'p')}.dmg"
   appcast 'https://www.fractalaudio.com/axe-fx-iii-edit/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.