### PR TITLE
Update lightproxy from 1.1.7 to 1.1.8

### DIFF
--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -1,12 +1,11 @@
 cask 'lightproxy' do
-  version '1.1.7'
-  sha256 'dad8d44ee3b092f046a767676d0131df8d70ab930b5620237dbbe8c7ff102d8f'
+  version '1.1.8'
+  sha256 '287cfc258692bf89acb450111b0c7f1ac63ccc66f82f9b13982cf6a1d29cd27c'
 
   # gw.alipayobjects.com/os/LightProxy was verified as official when first introduced to the cask
-  url 'https://gw.alipayobjects.com/os/LightProxy/LightProxy.dmg'
-  appcast 'https://github.com/alibaba/lightproxy/tree/develop/CHANGELOG'
+  url "https://gw.alipayobjects.com/os/LightProxy/7372dabd-cb4e-43e5-98a2-e7f22785dc76/LightProxy.dmg"
   name 'LightProxy'
-  homepage 'https://alibaba.github.io/lightproxy/'
+  homepage 'https://github.com/alibaba/lightproxy'
 
   app 'LightProxy.app'
 end

--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -4,6 +4,7 @@ cask 'lightproxy' do
 
   # gw.alipayobjects.com/os/LightProxy was verified as official when first introduced to the cask
   url 'https://gw.alipayobjects.com/os/LightProxy/7372dabd-cb4e-43e5-98a2-e7f22785dc76/LightProxy.dmg'
+  appcast 'https://github.com/alibaba/lightproxy/tree/develop/CHANGELOG'
   name 'LightProxy'
   homepage 'https://github.com/alibaba/lightproxy/'
 

--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -3,9 +3,9 @@ cask 'lightproxy' do
   sha256 '287cfc258692bf89acb450111b0c7f1ac63ccc66f82f9b13982cf6a1d29cd27c'
 
   # gw.alipayobjects.com/os/LightProxy was verified as official when first introduced to the cask
-  url "https://gw.alipayobjects.com/os/LightProxy/7372dabd-cb4e-43e5-98a2-e7f22785dc76/LightProxy.dmg"
+  url 'https://gw.alipayobjects.com/os/LightProxy/7372dabd-cb4e-43e5-98a2-e7f22785dc76/LightProxy.dmg'
   name 'LightProxy'
-  homepage 'https://github.com/alibaba/lightproxy'
+  homepage 'https://github.com/alibaba/lightproxy/'
 
   app 'LightProxy.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
