### PR TITLE
Update mediaelch from 2.6.2 to 2.6.4

### DIFF
--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,6 +1,6 @@
 cask 'mediaelch' do
-  version '2.6.2'
-  sha256 '772c4ea524b5f147f061e3c7dc789e3949628ebd0f349580b2dce738873dac15'
+  version '2.6.4'
+  sha256 '99deb5d0bc8b0d84b98b7cf0dc256b2e860d7675c4c297c1c569b944a9c83935'
 
   # github.com/Komet/MediaElch was verified as official when first introduced to the cask
   url "https://github.com/Komet/MediaElch/releases/download/v#{version}/MediaElch_#{version}_macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.