### PR TITLE
Add xamarin-workbooks 1.5.0

### DIFF
--- a/Casks/xamarin-workbooks.rb
+++ b/Casks/xamarin-workbooks.rb
@@ -5,7 +5,7 @@ cask 'xamarin-workbooks' do
   # github.com/Microsoft/workbooks was verified as official when first introduced to the cask
   url "https://github.com/Microsoft/workbooks/releases/download/v#{version}/XamarinInteractive-#{version}.pkg"
   appcast 'https://docs.microsoft.com/en-us/xamarin/tools/inspector/release-notes/',
-          configuration: version.major_minor
+          configuration: version.chomp('.0')
   name 'Xamarin Workbooks'
   homepage 'https://docs.microsoft.com/en-us/xamarin/tools/workbooks/'
 

--- a/Casks/xamarin-workbooks.rb
+++ b/Casks/xamarin-workbooks.rb
@@ -1,0 +1,16 @@
+cask 'xamarin-workbooks' do
+  version '1.5.0'
+  sha256 '1fb3cebb67d0fc68f56a38485ea7ea015f7b294893455c458dc39a2b63d1d6dd'
+
+  # github.com/Microsoft/workbooks was verified as official when first introduced to the cask
+  url "https://github.com/Microsoft/workbooks/releases/download/v#{version}/XamarinInteractive-#{version}.pkg"
+  appcast 'https://docs.microsoft.com/en-us/xamarin/tools/inspector/release-notes/', configuration: version.chomp('.0')
+  name 'Xamarin Workbooks'
+  homepage 'https://docs.microsoft.com/en-us/xamarin/tools/workbooks/'
+
+  depends_on macos: '>= :el_capitan'
+
+  pkg "XamarinInteractive-#{version}.pkg"
+
+  uninstall pkgutil: 'com.xamarin.Inspector'
+end

--- a/Casks/xamarin-workbooks.rb
+++ b/Casks/xamarin-workbooks.rb
@@ -5,7 +5,7 @@ cask 'xamarin-workbooks' do
   # github.com/Microsoft/workbooks was verified as official when first introduced to the cask
   url "https://github.com/Microsoft/workbooks/releases/download/v#{version}/XamarinInteractive-#{version}.pkg"
   appcast 'https://docs.microsoft.com/en-us/xamarin/tools/inspector/release-notes/',
-          configuration: version.chomp('.0')
+          configuration: version.major_minor
   name 'Xamarin Workbooks'
   homepage 'https://docs.microsoft.com/en-us/xamarin/tools/workbooks/'
 

--- a/Casks/xamarin-workbooks.rb
+++ b/Casks/xamarin-workbooks.rb
@@ -4,7 +4,8 @@ cask 'xamarin-workbooks' do
 
   # github.com/Microsoft/workbooks was verified as official when first introduced to the cask
   url "https://github.com/Microsoft/workbooks/releases/download/v#{version}/XamarinInteractive-#{version}.pkg"
-  appcast 'https://docs.microsoft.com/en-us/xamarin/tools/inspector/release-notes/', configuration: version.chomp('.0')
+  appcast 'https://docs.microsoft.com/en-us/xamarin/tools/inspector/release-notes/',
+          configuration: version.chomp('.0')
   name 'Xamarin Workbooks'
   homepage 'https://docs.microsoft.com/en-us/xamarin/tools/workbooks/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download xamarin-workbooks` is error-free.
- [x] `brew cask style --fix xamarin-workbooks` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install xamarin-workbooks` worked successfully.
- [x] `brew cask uninstall xamarin-workbooks` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
