### PR TITLE
Update ckan from 1.26.10 to 1.27.0

### DIFF
--- a/Casks/ckan.rb
+++ b/Casks/ckan.rb
@@ -1,6 +1,6 @@
 cask 'ckan' do
-  version '1.26.10'
-  sha256 '08149d57c60d9d054db95d8d6ecf5c90c152f41c24c3e5f36600d32b504a12a9'
+  version '1.27.0'
+  sha256 '34b131cec535445ef9759ef669fe3250ec65f4ba0047cf0bba9e2f8410c5052c'
 
   url "https://github.com/KSP-CKAN/CKAN/releases/download/v#{version}/CKAN.dmg"
   appcast 'https://github.com/KSP-CKAN/CKAN/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.