### PR TITLE
Update trilium-notes from 0.40.2 to 0.40.3

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.40.2'
-  sha256 'cd4fbc0e08275cf91e18880c54d4293a2e75c4a18216835732cf6ba5d1706bc8'
+  version '0.40.3'
+  sha256 '316ccd5eeb1d4806909f988c79f4678d6ff07312a67c1ee709cf0352b3e2a46c'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.