### PR TITLE
Update insync from 3.0.28.40721 to 3.0.29.40725

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '3.0.28.40721'
-  sha256 '11bbdf6de20438d7935d4de987838d160d4a2f3e59c6c5f33e25a01547011373'
+  version '3.0.29.40725'
+  sha256 '0ab4e7685e115855d011c806ec6a9aa6783b5e1c40b2c41bf484f44795b9885c'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   appcast 'https://www.insynchq.com/downloads?start=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.