### PR TITLE
Update netron from 3.8.8 to 3.8.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.8.8'
-  sha256 'c1a20ddaf04d720a65721e9b61e01c81b7a17efc905738438b854fe86c318029'
+  version '3.8.9'
+  sha256 'cc8a1d5e7a1990589abab3a8e6d2a29aa620a9db3a9cad7c269c9026c7956775'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.