### PR TITLE
Update duplicati from 2.0.4.23,2019-07-14 to 2.0.5.1,2020-01-18

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -1,6 +1,6 @@
 cask 'duplicati' do
-  version '2.0.4.23,2019-07-14'
-  sha256 '160ed45028da188853e714df922a6498cebae12170a77d4c2c087e49c8d7b5de'
+  version '2.0.5.1,2020-01-18'
+  sha256 '38509531cc9a007b98527af604f9a5faeb41b9221a79c7bd36e8846a32f1fda0'
 
   # github.com/duplicati/duplicati was verified as official when first introduced to the cask
   url "https://github.com/duplicati/duplicati/releases/download/v#{version.before_comma}-#{version.before_comma}_beta_#{version.after_comma}/duplicati-#{version.before_comma}_beta_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.