### PR TITLE
Update multimc from 0.6.7 to 0.6.8

### DIFF
--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -1,11 +1,11 @@
 cask 'multimc' do
-  version '0.6.7'
-  sha256 '56b912bcbac9c91dc9651963b8575837718a2b4f239897b399ff6afdb552b301'
+  version '0.6.8'
+  sha256 'a015d9c9b93d15fa1ff9c9363a64bcbd3681e7bcce4de04d813baf2c484bfb7c'
 
   url 'https://files.multimc.org/downloads/mmc-stable-osx64.tar.gz'
   appcast 'https://github.com/MultiMC/MultiMC5/releases.atom'
   name 'Multi MC'
   homepage 'https://multimc.org/'
 
-  app 'MultiMC/MultiMC.app'
+  app 'MultiMC.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.