### PR TITLE
Update thedesk from 20.1.1 to 20.1.2

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '20.1.1'
-  sha256 '0bf8c54b4fe20d8429e07bc1a2a9d8fc8c5fff38db34e505635a6cf1eb3122ca'
+  version '20.1.2'
+  sha256 '377d1343c465e6398cf21a169d6716d9a37eac258ce03008677dd05a157ec6d2'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.