### PR TITLE
Update freeorion from 0.4.8,2018-08-23.26f16b0 to 0.4.9,2020-02-02.db53471

### DIFF
--- a/Casks/freeorion.rb
+++ b/Casks/freeorion.rb
@@ -1,6 +1,6 @@
 cask 'freeorion' do
-  version '0.4.8,2018-08-23.26f16b0'
-  sha256 '075e8e3f8b3883a6e0b986a86327d70846d69d4c09fe6ad2f50f7d2582181d59'
+  version '0.4.9,2020-02-02.db53471'
+  sha256 'b90858dd1869166836e77497237b215609577247462b0a54def1e71425f694f7'
 
   # github.com/freeorion was verified as official when first introduced to the cask
   url "https://github.com/freeorion/freeorion/releases/download/v#{version.before_comma}/FreeOrion_v#{version.before_comma}_#{version.after_comma}_MacOSX_10.9.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.