### PR TITLE
Update meteorologist from 3.3.0 to 3.3.2

### DIFF
--- a/Casks/meteorologist.rb
+++ b/Casks/meteorologist.rb
@@ -1,6 +1,6 @@
 cask 'meteorologist' do
-  version '3.3.0'
-  sha256 'c13b3e5bf6525cf63d9476a71e0e6ad6403c3611a86dbd84042e7d57fa668bc6'
+  version '3.3.2'
+  sha256 '398a769772328eb66cc545724b8fa496e37969a34acb2ac510298740eed36e41'
 
   # downloads.sourceforge.net/heat-meteo was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/heat-meteo/Meteorologist-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.