### PR TITLE
Update losslesscut from 2.6.2 to 2.6.3

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,8 +1,8 @@
 cask 'losslesscut' do
-  version '2.6.2'
-  sha256 'd06248b1071fc5e44ac1d95beacd5a82454c1f1732f946acf097ef8155e808d9'
+  version '2.6.3'
+  sha256 'edfa24a36b4f6d639ff7717dacda8ce85ba7eae840892db80f1b525a0621c408'
 
-  url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-#{version}.dmg"
+  url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'
   name 'LosslessCut'
   homepage 'https://github.com/mifi/lossless-cut'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.