### PR TITLE
Update navicat-data-modeler-essentials from 3.0.5 to 3.0.6

### DIFF
--- a/Casks/navicat-data-modeler-essentials.rb
+++ b/Casks/navicat-data-modeler-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-data-modeler-essentials' do
-  version '3.0.5'
-  sha256 '735b770eefa0f2c880b983bfdd2d000244c5ffdf5e0a8b4ebf92ae66664d4547'
+  version '3.0.6'
+  sha256 'ff30dafd25c21633b04611e859d84be873845150aa22f669ef92021f964aac59'
 
   url "http://download3.navicat.com/updater/modeler0#{version.major_minor.no_dots}_ess_mac_en.zip"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Data%20Modeler%20Essentials'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.