### PR TITLE
Update wavebox from 10.0.54 to 10.0.69

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '10.0.54'
-  sha256 'e0f88deb704eadbb5e7c6d59b4d7d7cb407f0b72ef145e7238b030dbdb94e1da'
+  version '10.0.69'
+  sha256 '52d303b863a392961be77ec956cec782d69f87692704f8ea733a6cac2c765f2e'
 
   # download.wavebox.app was verified as official when first introduced to the cask
   url "https://download.wavebox.app/core/mac/Install%20Wavebox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.