### PR TITLE
Update protonmail-bridge from 1.2.3 to 1.2.5

### DIFF
--- a/Casks/protonmail-bridge.rb
+++ b/Casks/protonmail-bridge.rb
@@ -1,5 +1,5 @@
 cask 'protonmail-bridge' do
-  version '1.2.3'
+  version '1.2.5'
   sha256 '03a07e1b830c51e64897a07b437effe4266be08808a2253fda485ba9b96dbbc9'
 
   url 'https://protonmail.com/download/Bridge-Installer.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.