### PR TITLE
Update duplicacy-web-edition from 1.1.0 to 1.2.0

### DIFF
--- a/Casks/duplicacy-web-edition.rb
+++ b/Casks/duplicacy-web-edition.rb
@@ -1,6 +1,6 @@
 cask 'duplicacy-web-edition' do
-  version '1.1.0'
-  sha256 '47297cccc35c64ec29093e1755bc93b89f4d1d940a339fc7903d0b55b67a13d1'
+  version '1.2.0'
+  sha256 '1f5da8d5e4fdf7cb5d184e697578f6fc3cc56c0d7a096ca9b3dbe332ce46dd66'
 
   # acrosync.com/duplicacy-web was verified as official when first introduced to the cask
   url "https://acrosync.com/duplicacy-web/duplicacy_web_osx_x64_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.