### PR TITLE
Update xrg from 2.7.0 to 2.8.0

### DIFF
--- a/Casks/xrg.rb
+++ b/Casks/xrg.rb
@@ -1,6 +1,6 @@
 cask 'xrg' do
-  version '2.7.0'
-  sha256 '2772d6eea11429c4bbd74e3fa1f4a5acb04d35d80afdb10634292f0f5a465ded'
+  version '2.8.0'
+  sha256 '1b90b6e4cafc7a6af8f28579b71d4b1ae083d888d6a003bce62e515f2db033fc'
 
   url "https://download.gauchosoft.com/xrg/XRG-release-#{version}.zip"
   appcast 'https://gauchosoft.com/Products/XRG/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.