### PR TITLE
Update deezer from 4.18.30 to 4.18.40

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.18.30'
-  sha256 'fad0c794b99b27281bc7d57dfda07e3112af22c63ff131d5ed71e8cefb760cf2'
+  version '4.18.40'
+  sha256 '1caf7017a59003857a20ea9bdfa9cc12a52948d5e693daf2166d8ec369f2e77b'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.