### PR TITLE
Update atom from 1.43.0 to 1.44.0

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -1,6 +1,6 @@
 cask 'atom' do
-  version '1.43.0'
-  sha256 'c7cce11fc9f22a8fdb9a836b321dc4b3d0cdadcb139a9dc947c2473ec0f0c7b1'
+  version '1.44.0'
+  sha256 'e679864702860ce7dbb5d944975dbf0aa9a23a11c9e9c089fb2097615bf8b626'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.