### PR TITLE
Revert "Update alacritty from 0.4.0 to 0.4.1 (#75324)"

### DIFF
--- a/Casks/alacritty.rb
+++ b/Casks/alacritty.rb
@@ -1,6 +1,6 @@
 cask 'alacritty' do
-  version '0.4.1'
-  sha256 '9718c3b0b5cd430cac162a15f5b7a1e84adb7eba3974c6a391bce96e9d2d2e38'
+  version '0.4.0'
+  sha256 'db9f75dc3221709c86362e6de0e3671d328a8bd8eb306122b901ca11e142757c'
 
   url "https://github.com/jwilm/alacritty/releases/download/v#{version}/Alacritty-v#{version}.dmg"
   appcast 'https://github.com/jwilm/alacritty/releases.atom'


### PR DESCRIPTION
This reverts commit 3e733d8663a6e165d1e648bc166def9328fe2fd8.

alacritty/alacritty#3188 is a fairly significant bug.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).