### PR TITLE
Update aws-vault from 5.2.0 to 5.2.1

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,6 +1,6 @@
 cask 'aws-vault' do
-  version '5.2.0'
-  sha256 'd7583ef9e2e875046628a38b9947068d0d41643ee1e0ad1c0e9c1c5066542c80'
+  version '5.2.1'
+  sha256 'db674affb2d48285498ab478fd4395f27ab815e85a9611db5182a60897217f83'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
   appcast 'https://github.com/99designs/aws-vault/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.