### PR TITLE
Update brave-browser from 79.1.2.43,102.43 to 80.0.3987.87,103.115

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '79.1.2.43,102.43'
-  sha256 'b5bc379c6b81cc1ce78fc27bf8b421129d7dab069759e047cf53a69f46710684'
+  version '80.0.3987.87,103.115'
+  sha256 'c79cb879119a5ad95f4f2373b100d2e0469158e0b0b696a93b6a604bd1c20462'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/#{version.after_comma}/Brave-Browser.dmg"

--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,5 +1,5 @@
 cask 'brave-browser' do
-  version '80.0.3987.87,103.115'
+  version '80.1.3.115,103.115'
   sha256 'c79cb879119a5ad95f4f2373b100d2e0469158e0b0b696a93b6a604bd1c20462'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.