### PR TITLE
Update tower from 3.6.0 to 4.0

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,10 +1,10 @@
 cask 'tower' do
-  version '3.6.0,205:1262a183'
-  sha256 '704998cdd473860d2e90eaaa774c4c9011a54712f844b8d658670e8cd12dd8cd'
+  version '4.0,218:df8aba72'
+  sha256 'b8a50fb1af2a56843297e3dd4b90d74246430d9f50b473ec612a6c2cfb54a38d'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.after_comma.before_colon}-#{version.after_colon}/Tower-#{version.before_comma}-#{version.after_comma.before_colon}.zip"
-  appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable"
+  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma.before_colon}-#{version.after_colon}/Tower-#{version.before_comma}-#{version.after_comma.before_colon}.zip"
+  appcast 'https://updates.fournova.com/updates/tower3-mac/stable'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
Tower 4 is *not* a paid upgrade from version 3, it still uses the same appcast as version 3.

<hr>

After making all changes to the cask:

- [x] `brew cask audit --download tower` is error-free.
- [x] `brew cask style --fix tower` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
