### PR TITLE
Update chromium from 739767 to 740278

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '739767'
-  sha256 '51d537fdd5b3e37588f108c9abd9c18128010298049a30dc84eabadb5ee6b2d8'
+  version '740278'
+  sha256 '419e56a5adef4e0f157210927c034d025cf46757ecfd4243733d3a4a3801494d'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.