### PR TITLE
Update aerial from 1.7.0 to 1.7.1

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.7.0'
-  sha256 '474e20ac7f2572d3b5d6866c9ebd83f1d38774af30570e28b5c698d670cefa0e'
+  version '1.7.1'
+  sha256 '1d829c8dc19d630fad7f50794bdd09d6d9d508ebd23ad16f3821852cf1fd5f98'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.