### PR TITLE
Update jtool2 from latest to 2020.02.10

### DIFF
--- a/Casks/jtool2.rb
+++ b/Casks/jtool2.rb
@@ -1,7 +1,7 @@
 cask 'jtool2' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version :latest
-  sha256 :no_check
+  version '2020.02.10'
+  sha256 'a491e9a412c12d57eaa89fb8183dabc80de25224b730b55ab1c2f0072c91cf1a'
 
   url 'http://newosxbook.com/tools/jtool2.tgz'
   name 'jtool2'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.