### PR TITLE
Update losslesscut from 2.6.3 to 2.7.1

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '2.6.3'
-  sha256 'edfa24a36b4f6d639ff7717dacda8ce85ba7eae840892db80f1b525a0621c408'
+  version '2.7.1'
+  sha256 '87c049823b72b806c86bc0b4b631374c9ce1cc9e6ee08228e0676567d139f474'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.