### PR TITLE
Update superproductivity from 3.1.3 to 3.1.4

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '3.1.3'
-  sha256 '841721d3639e30d1f057e68a97fd9740e2a4c7c8ae81aedffc5d89c72d17de24'
+  version '3.1.4'
+  sha256 '251929cac0bb49a0dbcb5e53d20c610025a9572119606d1ac68443f6e37df983'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.