### PR TITLE
Update flipper from 0.30.2 to 0.31.1

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.30.2'
-  sha256 '426e0bfe65bca9f284b7543ce540ce87ce6afa67fe11c134ed5c9eacc13a13db'
+  version '0.31.1'
+  sha256 '79965edf6f02f2858ac6fbd0376c35c597092c9dd8e5757e6d1b9f68dbadd53c'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.