### PR TITLE
Update rectangle from 0.20 to 0.21

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -1,6 +1,6 @@
 cask 'rectangle' do
-  version '0.20'
-  sha256 'dbd63a7564841aadabe340c13a3e61ed6bac10ec0933d441adec7063e7d62d54'
+  version '0.21'
+  sha256 '990956456bd161e1735cbff03faae22066f4f369e9c98d4a2ed44176ca1f99eb'
 
   # github.com/rxhanson/Rectangle/releases/download/v was verified as official when first introduced to the cask
   url "https://github.com/rxhanson/Rectangle/releases/download/v#{version}/Rectangle#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.