### PR TITLE
Update cabal from 4.0.0 to 4.1.0

### DIFF
--- a/Casks/cabal.rb
+++ b/Casks/cabal.rb
@@ -1,6 +1,6 @@
 cask 'cabal' do
-  version '4.0.0'
-  sha256 '019f4c89a372dd5f7e3b5c6e8ccedda8e8ae6fa4b7ffa566f527c70f8d30bf60'
+  version '4.1.0'
+  sha256 '189a8e1569fcdbca626e941acd3f0b03548f3586e3bff66d538ff769b6930849'
 
   # github.com/cabal-club/cabal-desktop was verified as official when first introduced to the cask
   url "https://github.com/cabal-club/cabal-desktop/releases/download/v#{version}/cabal-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.