### PR TITLE
Update electerm from 1.0.24 to 1.0.26

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.0.24'
-  sha256 '95270f3dd048816ac13ec0f13fc7b2250bbf4f6e263c042b4dc3aeaeed42725d'
+  version '1.0.26'
+  sha256 '7cac0f2db9123d55928b28c908b2ca45cf4600d0f14772759920ce3f0900819c'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.