### PR TITLE
Update bdash from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.6.0'
-  sha256 'a5908552375a06011f0f288d78dc0af5ed1a0c94af9d21fd112e1c71c3ec79bf'
+  version '1.7.0'
+  sha256 '144e02b4f7c0ad59fc9d92ceb0bab77cd895171aa3f7e5252afc368cabf439d4'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.