### PR TITLE
Update wickrme from 5.46.5 to 5.47.25

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.46.5'
-  sha256 '06eeb47c8e3a9427e7acf3e36a64e8abba98f69e0f7903998839be60e2bca20b'
+  version '5.47.25'
+  sha256 'a307f7d87a5cc8038d7e209eb2302913365d4abaccee21e7e7101a69a1440755'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.