### PR TITLE
Update twist from 1.6.20,6872 to 1.6.21,6976

### DIFF
--- a/Casks/twist.rb
+++ b/Casks/twist.rb
@@ -1,6 +1,6 @@
 cask 'twist' do
-  version '1.6.20,6872'
-  sha256 'c1d6a1e839b3bdbf92845e5838a148f7519711d136a4bab704db72c62472b44f'
+  version '1.6.21,6976'
+  sha256 '92430f72103abd87be39c6272a4ac1f77800dc8d4c4239d02546ba61cafa7b3d'
 
   url "https://downloads.twistapp.com/mac/Twist-#{version.after_comma}.zip"
   appcast 'https://downloads.twistapp.com/mac/AppCast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.