### PR TITLE
Update carbon-copy-cloner from 5.1.15.5923 to 5.1.15.5925

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.1.15.5923'
-  sha256 'bacaf9e0a4b87dbd8d4985b090ade9ebe37c3ba994f7bb13454db00b68fd149f'
+  version '5.1.15.5925'
+  sha256 '41845b3dd2307f2ab3dc00ea7bb1f40bfb120249a4ec1680df937294f269bccc'
 
   # bombich.scdn1.secure.raxcdn.com/software/files was verified as official when first introduced to the cask
   url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.