### PR TITLE
Update supersync from 7.0.5 to 7.0.6

### DIFF
--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,6 +1,6 @@
 cask 'supersync' do
-  version '7.0.5'
-  sha256 '188a60ae85f0dc2d8df633dfb95241a65f163dd3b370c883f7f3366ad748d4f7'
+  version '7.0.6'
+  sha256 '95a9ad2d2e9571c28cec289162ef8ffb2d81c82c8107be9b7895e117ee9f1767'
 
   url "https://supersync.com/downloads/SuperSync_#{version}.dmg"
   appcast 'https://supersync.com/downloads.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.