### PR TITLE
Update dendroscope from 3.6.3 to 3.7.0

### DIFF
--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -1,6 +1,6 @@
 cask 'dendroscope' do
-  version '3.6.3'
-  sha256 '2b9557232149da9d6d2fa0d07bd98b21836141e2759ca92986e5d7a3e21d0bde'
+  version '3.7.0'
+  sha256 '371df5b7413843bc5563678a22ae9b5333e9c914fd19341cdb0d30a2fb53f01a'
 
   url "https://software-ab.informatik.uni-tuebingen.de/download/dendroscope/Dendroscope_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://software-ab.informatik.uni-tuebingen.de/download/dendroscope3/welcome.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.