### PR TITLE
Update skype from 8.56.0.103 to 8.56.0.106

### DIFF
--- a/Casks/skype.rb
+++ b/Casks/skype.rb
@@ -1,6 +1,6 @@
 cask 'skype' do
-  version '8.56.0.103'
-  sha256 '8c577d5a9923732eb647d0bf0591a0c11a612695ce1b746feec920beb8b64a3a'
+  version '8.56.0.106'
+  sha256 '9523250a5aee1b05527b0d7cf489f7875c57acd536f99a4637b7b4bb6e3476db'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.