### PR TITLE
Update adobe-digital-editions from 4.5.10 to 4.5.11

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,6 +1,6 @@
 cask 'adobe-digital-editions' do
-  version '4.5.10'
-  sha256 '33f784ab50188cc9e5a6c575a739af726cb1deda5970b075851e03b0e9b26d62'
+  version '4.5.11'
+  sha256 '4bfdb9fdefb7a65bc5227518531ffba2cd2d547a1293265709a526a153800e7e'
 
   url "https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_#{version.major_minor}_Installer.dmg"
   appcast 'https://www.adobe.com/solutions/ebook/digital-editions/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.