### PR TITLE
Update ghost-browser from 2.1.1.9 to 2.1.1.10

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.9'
-  sha256 'c5288a4fb4dbb570ddd5e8ecef52b56d647e2e82566ca839b6a166ce1a6d711f'
+  version '2.1.1.10'
+  sha256 'a664883c68f881bf2d3c85278543f355ab263fc2fac68dc829354d675ce1c095'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.