### PR TITLE
copyq: fix shimscript for case-sensitive filesystems

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -16,7 +16,7 @@ cask 'copyq' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/bash
-      exec '#{appdir}/CopyQ.app/Contents/MacOS/copyq' "$@"
+      exec '#{appdir}/CopyQ.app/Contents/MacOS/CopyQ' "$@"
     EOS
   end
 end


### PR DESCRIPTION
Otherwise it fails for me with:

```console
$ copyq --version
/usr/local/bin/copyq: line 2: /Applications/CopyQ.app/Contents/MacOS/copyq: No such file or directory
/usr/local/bin/copyq: line 2: exec: /Applications/CopyQ.app/Contents/MacOS/copyq: cannot execute: No such file or directory

$ ls /Applications/CopyQ.app/Contents/MacOS/
/Applications/CopyQ.app/Contents/MacOS/CopyQ

$ brew cask reinstall Casks/copyq.rb
...

$ copyq --version
CopyQ Clipboard Manager v3.10.0
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256