### PR TITLE
Update nozbe from 3.10.0 to 3.13.0

### DIFF
--- a/Casks/nozbe.rb
+++ b/Casks/nozbe.rb
@@ -1,6 +1,6 @@
 cask 'nozbe' do
-  version '3.10.0'
-  sha256 'e168c265171a0bb2cb5639a0c43b3954696b7cb5fa9e706720fde087be0f96d3'
+  version '3.13.0'
+  sha256 '384a15bd9b34935b7f0f152ebdd5c8653e0aed86e01c4e7844acfe34769cc4c9'
 
   url "https://files.nozbe.com/#{version.no_dots}/release/Nozbe.app.zip"
   name 'Nozbe'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.