### PR TITLE
Adding the AWS CLI v2.

### DIFF
--- a/Casks/awscli.rb
+++ b/Casks/awscli.rb
@@ -1,0 +1,21 @@
+cask 'awscli' do
+  version '2.0.0'
+  sha256 'a99c26cd2b5655970db91259a247f585aea32cfb7347e1a28a25b6f6484b16dc'
+
+  # awscli.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://awscli.amazonaws.com/AWSCLIV2.pkg'
+  name 'AWS Command Line Interface'
+  homepage 'https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html'
+
+  auto_updates false
+  conflicts_with formula: 'awscli'
+  depends_on macos: '>= :high_sierra'
+
+  pkg "AWSCLIV#{version.major}.pkg"
+
+  uninstall pkgutil: 'com.amazon.aws.cli.*'
+
+  caveats do
+    files_in_usr_local
+  end
+end

--- a/Casks/awscli.rb
+++ b/Casks/awscli.rb
@@ -3,12 +3,10 @@ cask 'awscli' do
   sha256 'a99c26cd2b5655970db91259a247f585aea32cfb7347e1a28a25b6f6484b16dc'
 
   # awscli.amazonaws.com was verified as official when first introduced to the cask
-  url 'https://awscli.amazonaws.com/AWSCLIV2.pkg'
+  url "https://awscli.amazonaws.com/AWSCLIV#{version.major}.pkg"
   name 'AWS Command Line Interface'
   homepage 'https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html'
 
-  auto_updates false
-  conflicts_with formula: 'awscli'
   depends_on macos: '>= :high_sierra'
 
   pkg "AWSCLIV#{version.major}.pkg"


### PR DESCRIPTION
This is a cask for the AWS CLI v2 as this is now packaged as a pkg
rather than a python module to be installed with pip.

Tested in a tap and appears to work as it should.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
