### PR TITLE
Update conferences from 0.0.1-alpha21 to 0.0.1-alpha22

### DIFF
--- a/Casks/conferences.rb
+++ b/Casks/conferences.rb
@@ -2,7 +2,6 @@ cask 'conferences' do
   version '0.0.1-alpha22'
   sha256 '61cd7c47ecc718613c9e1ba803ae36e26c37c98bb6a46b5ced2898942c9771a5'
 
-  # github.com/zagahr/Conferences.digital was verified as official when first introduced to the cask
   url "https://github.com/zagahr/Conferences.digital/releases/download/#{version}/Conferences_v#{version}.zip"
   appcast 'https://zagahr.github.io/Conferences.digital/appcast.xml'
   name 'Conferences.digital'

--- a/Casks/conferences.rb
+++ b/Casks/conferences.rb
@@ -6,7 +6,7 @@ cask 'conferences' do
   url "https://github.com/zagahr/Conferences.digital/releases/download/#{version}/Conferences_v#{version}.zip"
   appcast 'https://zagahr.github.io/Conferences.digital/appcast.xml'
   name 'Conferences.digital'
-  homepage 'https://conferences.digital/'
+  homepage 'https://github.com/zagahr/Conferences.digital'
 
   depends_on macos: '>= :mojave'
 

--- a/Casks/conferences.rb
+++ b/Casks/conferences.rb
@@ -1,6 +1,6 @@
 cask 'conferences' do
-  version '0.0.1-alpha21'
-  sha256 '53348fd30d4c0367014d46cad1e581318ba4915259ac9845c668ebdf6184590c'
+  version '0.0.1-alpha22'
+  sha256 '61cd7c47ecc718613c9e1ba803ae36e26c37c98bb6a46b5ced2898942c9771a5'
 
   # github.com/zagahr/Conferences.digital was verified as official when first introduced to the cask
   url "https://github.com/zagahr/Conferences.digital/releases/download/#{version}/Conferences_v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.