### PR TITLE
Update segger-embedded-studio-for-arm from 4.42 to 4.42a

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.42'
-  sha256 '471378e6d8b5db8fbbb7d27088df73d8fe6606df42594bc857a25058cde0593c'
+  version '4.42a'
+  sha256 '43bd4345de952a957b87e1b6cedc58b019ffd74fa00d599388229f5e02cb5395'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   appcast 'https://studio.segger.com/arm_segger_studio_release_notes.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.