### PR TITLE
Update and rename prosys-opc-ua-client from 3.2.0-328 to 4.0.2-231

### DIFF
--- a/Casks/prosys-opc-ua-browser.rb
+++ b/Casks/prosys-opc-ua-browser.rb
@@ -1,11 +1,11 @@
-cask 'prosys-opc-ua-client' do
+cask 'prosys-opc-ua-browser' do
   version '4.0.2-231'
   sha256 '5886f887a282f2bd45066f8c6a85a9431457e26281e598bc35f1f44b9e58056a'
 
   url "https://www.prosysopc.com/opcua/apps/UaBrowser/dist/#{version}/prosys-opc-ua-browser-macos-#{version}.dmg"
-  appcast 'https://downloads.prosysopc.com/opc-ua-client-downloads.php'
-  name 'Prosys OPC UA Client'
+  appcast 'https://downloads.prosysopc.com/opc-ua-browser-downloads.php'
+  name 'Prosys OPC UA Browser'
   homepage 'https://www.prosysopc.com/products/opc-ua-client/'
 
-  app 'prosys-opc-ua-client.app'
+  installer manual: 'Prosys OPC UA Browser Installer.app'
 end

--- a/Casks/prosys-opc-ua-browser.rb
+++ b/Casks/prosys-opc-ua-browser.rb
@@ -11,4 +11,6 @@ cask 'prosys-opc-ua-browser' do
                       executable: 'Prosys OPC UA Browser Installer.app/Contents/MacOS/JavaApplicationStub',
                       args:       ['-q'],
                     }
+
+  uninstall delete: '/Applications/Prosys OPC UA Browser.app'
 end

--- a/Casks/prosys-opc-ua-browser.rb
+++ b/Casks/prosys-opc-ua-browser.rb
@@ -7,5 +7,8 @@ cask 'prosys-opc-ua-browser' do
   name 'Prosys OPC UA Browser'
   homepage 'https://www.prosysopc.com/products/opc-ua-client/'
 
-  installer manual: 'Prosys OPC UA Browser Installer.app'
+  installer script: {
+                      executable: 'Prosys OPC UA Browser Installer.app/Contents/MacOS/JavaApplicationStub',
+                      args:       ['-q'],
+                    }
 end

--- a/Casks/prosys-opc-ua-client.rb
+++ b/Casks/prosys-opc-ua-client.rb
@@ -1,8 +1,8 @@
 cask 'prosys-opc-ua-client' do
-  version '3.2.0-328'
-  sha256 '3d00b53949c790d212f71fa17bc463e61bd0f1d6293758a47ae87ae86cf2ec40'
+  version '4.0.2-231'
+  sha256 '5886f887a282f2bd45066f8c6a85a9431457e26281e598bc35f1f44b9e58056a'
 
-  url "https://www.prosysopc.com/opcua/apps/JavaClient/dist/#{version}/prosys-opc-ua-client-#{version}.dmg"
+  url "https://www.prosysopc.com/opcua/apps/UaBrowser/dist/#{version}/prosys-opc-ua-browser-macos-#{version}.dmg"
   appcast 'https://downloads.prosysopc.com/opc-ua-client-downloads.php'
   name 'Prosys OPC UA Client'
   homepage 'https://www.prosysopc.com/products/opc-ua-client/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.