### PR TITLE
Update powerphotos from 1.7.7 to 1.7.9

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -16,8 +16,8 @@ cask 'powerphotos' do
     sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.7.7'
-    sha256 '0167d99b9e2da825104f9f38051ad46e4849536d81af56b2ccd8612ba12f9e34'
+    version '1.7.9'
+    sha256 '173b825fdbdca15ba816856679357ec4e6954433d37d3bfee07446ced0644e11'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.