### PR TITLE
Update local from 5.2.3 to 5.2.4

### DIFF
--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -1,6 +1,6 @@
 cask 'local' do
-  version '5.2.3'
-  sha256 '0b7af0b61bb3e7c44142d01a2c059394d27ddebc9b116363803bd9856dd6a52b'
+  version '5.2.4'
+  sha256 'befa440218086eaa206c4633b31392d96217ecc05bb8b89b3706dd4be1c7c761'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-#{version.dots_to_hyphens}-mac.dmg"

--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -7,7 +7,7 @@ cask 'local' do
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://local-by-flywheel-flywheel.netdna-ssl.com/latest/mac',
           configuration: version.dots_to_hyphens
   name 'Local by Flywheel'
-  homepage 'https://localbyflywheel.com/'
+  homepage 'https://localwp.com'
 
   app 'Local.app'
 

--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -7,7 +7,7 @@ cask 'local' do
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://local-by-flywheel-flywheel.netdna-ssl.com/latest/mac',
           configuration: version.dots_to_hyphens
   name 'Local by Flywheel'
-  homepage 'https://localwp.com'
+  homepage 'https://localwp.com/'
 
   app 'Local.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.