### PR TITLE
Update avocode from 4.2.2 to 4.3.0

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.2.2'
-  sha256 'db84fe578181840382d5dcbc13a7b125beca36ff782ac46e3b9ea38946797e8e'
+  version '4.3.0'
+  sha256 '0a229874dd28c88dfd5e00ebec0e68b224ed7b9e2b95b10991b8967cb473461d'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.