### PR TITLE
Update ark-desktop-wallet from 2.7.0 to 2.8.0

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.7.0'
-  sha256 'c7496e1586c0958b80da73ea3f96cda8a86d50bd9b26cb1157b6c5d6b6b5837b'
+  version '2.8.0'
+  sha256 '9edc88ae490fc40f6544be26f473d0ba0249ed6facc6575c63e657504e987e76'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.