### PR TITLE
Update qlab from 4.6.1 to 4.6.2

### DIFF
--- a/Casks/qlab.rb
+++ b/Casks/qlab.rb
@@ -1,6 +1,6 @@
 cask 'qlab' do
-  version '4.6.1'
-  sha256 'a66a7f3c7142dbd35047ffb73e685f748d965349ef4f42c6fce85c71ef7b2c94'
+  version '4.6.2'
+  sha256 '21feecc79f6f19d3c8ecc8f700d89f8c6b260848c1daa8219eba58fbcec34c62'
 
   url "https://figure53.com/qlab/downloads/QLab-#{version}.zip"
   appcast "https://figure53.com/qlab/downloads/appcast-v#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.