### PR TITLE
Update mountain-duck from 3.3.4.15443 to 3.3.5.15470

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,6 +1,6 @@
 cask 'mountain-duck' do
-  version '3.3.4.15443'
-  sha256 '6bfc4235ae7a1e7c8c7901eb0499d78dce0df07cacbd5b952743c9016b6e2703'
+  version '3.3.5.15470'
+  sha256 '10c4450d360e99a164342d426289dd2f9554c19684fc10f150e6e4f719c52f3e'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast "https://version.mountainduck.io/#{version.major}/macos/changelog.rss"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.