### PR TITLE
Update keep-it from 1.7.10 to 1.8

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.7.10'
-  sha256 'af453de9064db95aff361b42981b9860a47e38e6bfd3cba884957f8341c746e8'
+  version '1.8'
+  sha256 '6149571831246d9bc02e8b33fd408a70911e734e96c528a443f0cff7057ab772'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.