### PR TITLE
Update capto from 1.2.16 to 1.2.17

### DIFF
--- a/Casks/capto.rb
+++ b/Casks/capto.rb
@@ -1,6 +1,6 @@
 cask 'capto' do
-  version '1.2.16'
-  sha256 '4e95462dbe07d433d55d2607cfc20ed35831bf28afd1d6a3581bbf377a551fda'
+  version '1.2.17'
+  sha256 'e2b89df15cd018957ed7de50442d8bf16a501be21c5bb3db29a29388cb362677'
 
   # d3l6g06uqih57x.cloudfront.net/Captomac was verified as official when first introduced to the cask
   url 'https://d3l6g06uqih57x.cloudfront.net/Captomac/webstore/Capto.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.