### PR TITLE
Update deepl from 1.5.1 to 1.6.0

### DIFF
--- a/Casks/deepl.rb
+++ b/Casks/deepl.rb
@@ -1,6 +1,6 @@
 cask 'deepl' do
-  version '1.5.1'
-  sha256 '8385faf802b88158b25a4e6f65473a4a0cee7e64ffda870a18cfdad7341bc30c'
+  version '1.6.0'
+  sha256 '2982015c3bde03e909a79b14fdd910e0b4281f626bd851e1ab6182e7a9e90e13'
 
   url "https://www.deepl.com/macos/download/LpsA0EG5frbfX8p5/DeepL#{version}.zip"
   name 'DeepL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.