### PR TITLE
Update cloudapp from 5.6.0.1883 to 5.8.1-1904

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,6 +1,6 @@
 cask 'cloudapp' do
-  version '5.6.0.1883'
-  sha256 'b93546262b4982e04715400898b2445ed828f63277f9893b4573f2f0b6993991'
+  version '5.8.1-1904'
+  sha256 '5d9e0c8c68a9a0ad79d0b18e2d54bcea035b71b6af0263513a12a758ed62a320'
 
   url "http://downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://d2plwz9jdz9z5d.cloudfront.net/mac/latest/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.