### PR TITLE
Update lingo from 10.0 to 10.3

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -2,7 +2,7 @@ cask 'lingo' do
   version '10.3,111'
   sha256 '14841d33d6c753b47a0420d6433dfac8bcc764a3fc30b5ac9c5a1a718f87145e'
 
-  # https://rink.hockeyapp.net/api/2/apps was verified as official when first introduced to the cask
+  # rink.hockeyapp.net/api/2/apps was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/7d71478daf6447bda4094e216e97b0cf/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://www.lingoapp.com/mac/appcast'
   name 'Lingo'

--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,9 +1,9 @@
 cask 'lingo' do
-  version '10.3'
-  sha256 'bc16c02a73b23ac3c9889d1dd524eb125b0826b621ff6298fcf3023d94e1f903'
+  version '10.3,111'
+  sha256 '14841d33d6c753b47a0420d6433dfac8bcc764a3fc30b5ac9c5a1a718f87145e'
 
-  # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask
-  url 'https://nounproject.s3.amazonaws.com/lingo/Lingo.dmg'
+  # https://rink.hockeyapp.net/api/2/apps was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/7d71478daf6447bda4094e216e97b0cf/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://www.lingoapp.com/mac/appcast'
   name 'Lingo'
   homepage 'https://www.lingoapp.com/'

--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,5 +1,5 @@
 cask 'lingo' do
-  version '10.0'
+  version '10.3'
   sha256 'bc16c02a73b23ac3c9889d1dd524eb125b0826b621ff6298fcf3023d94e1f903'
 
   # nounproject.s3.amazonaws.com/lingo was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.