### PR TITLE
Update qfinder-pro from 7.1.3.1112 to 7.2.0.0131

### DIFF
--- a/Casks/qfinder-pro.rb
+++ b/Casks/qfinder-pro.rb
@@ -1,6 +1,6 @@
 cask 'qfinder-pro' do
-  version '7.1.3.1112'
-  sha256 '343c204673083bbfb42e09949e96f429bd1b82aab8f4afe7afc51496b38e37b2'
+  version '7.2.0.0131'
+  sha256 '60a6eb27c6d9c2e9888eb0729be07ada9ab133aa517a44b3843abafb86447936'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://update.qnap.com/SoftwareRelease.xml&splitter_1=Mac_for_QT&index_1=1&splitter_2=downloadURL&index_2=1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.