### PR TITLE
Update qt-creator from 4.11.0 to 4.11.1

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.11.0'
-  sha256 '5d92ecb1c54a6d5bf08aa8155fea53e5cf2fd89b624299e25e7f4bd0adddf18e'
+  version '4.11.1'
+  sha256 'b2f57ba6a1df8a30d0d75beb37bbbb6598dd733082e4ccf6ddf33203b32ba74c'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qtcreator/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.