### PR TITLE
Update loom from 0.28.0 to 0.29.2

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.28.0'
-  sha256 '71d5f9dbdb97b830cca9e65518cc22de2c77b4152b7b4e93cfd316689afd7337'
+  version '0.29.2'
+  sha256 '0bd40209159ff43c1b7e43643d3d92c66d10135decd909a44edf038aaaa17a82'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.