### PR TITLE
Update seashore from 2.5.5 to 2.5.6

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.5.5'
-  sha256 '0bf82e3a43b394896802ae8a4519ac017b3d8c8fbc6d37c4accfb4894d03fd31'
+  version '2.5.6'
+  sha256 'e5bbcf319b95cb39e5510e00625aeda71411d2d2c7cd3765c03be4884932a800'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.