### PR TITLE
Update mullvadvpn from 2020.1 to 2020.2

### DIFF
--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -1,6 +1,6 @@
 cask 'mullvadvpn' do
-  version '2020.1'
-  sha256 '0d1446ef79ca185017a77afa48eb2d1a30fabfbd78f758d072d37ec53aabed4b'
+  version '2020.2'
+  sha256 'ad959d3bed0674ead61d44f20f239aa5d04fbf9705ff74be6f005834268c2ad6'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.