### PR TITLE
Update taskpaper from 3.8.8 to 3.8.10

### DIFF
--- a/Casks/taskpaper.rb
+++ b/Casks/taskpaper.rb
@@ -1,6 +1,6 @@
 cask 'taskpaper' do
-  version '3.8.8'
-  sha256 'bd5e4d3caa5b8e8132ba8caacae2d2aaa2c9e766166f4a270a7ed41e926f59a2'
+  version '3.8.10'
+  sha256 '18b6d7e248ed88ff1d1a3db06de7110284967f277ad2732be90cc500c7a11663'
 
   url "https://www.taskpaper.com/assets/app/TaskPaper-#{version}.dmg"
   appcast 'https://www.taskpaper.com/assets/app/TaskPaper.rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.