### PR TITLE
Update gitfinder from 1.3.3 to 1.4

### DIFF
--- a/Casks/gitfinder.rb
+++ b/Casks/gitfinder.rb
@@ -1,6 +1,6 @@
 cask 'gitfinder' do
-  version '1.3.3'
-  sha256 'c94c65628faa36a9d4fa87c70a25f38035844495e967757ad5962df515106b00'
+  version '1.4'
+  sha256 '07ed6919d825283619ca24959fe620f7786f2ba5a6d32a34e9f6f9f5ad33a958'
 
   # zigz.ag/GitFinder was verified as official when first introduced to the cask
   url 'https://zigz.ag/GitFinder/updates/GitFinder.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.