### PR TITLE
Update aws-vault from 5.2.1 to 5.3.0

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,6 +1,6 @@
 cask 'aws-vault' do
-  version '5.2.1'
-  sha256 'db674affb2d48285498ab478fd4395f27ab815e85a9611db5182a60897217f83'
+  version '5.3.0'
+  sha256 '1701a93a10fb47f58852ecd5e687abaded9a01e05e6817897a77d1bb8f894980'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
   appcast 'https://github.com/99designs/aws-vault/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.