### PR TITLE
Update racket from 7.5 to 7.6

### DIFF
--- a/Casks/racket.rb
+++ b/Casks/racket.rb
@@ -1,6 +1,6 @@
 cask 'racket' do
-  version '7.5'
-  sha256 '608c86bbb97b5c0f577eb50718b7304e8737dc06a702cb99fcf8565d81b289b8'
+  version '7.6'
+  sha256 '620cedb1532975955ee8d9bac758ecdcfbaf7eb5dda50611f75ec1ddd33bb44d'
 
   url "https://mirror.racket-lang.org/installers/#{version}/racket-#{version}-x86_64-macosx.dmg"
   appcast 'https://download.racket-lang.org/all-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.