### PR TITLE
Revert "Update clashx from 1.17.1 to 1.17.2"

### DIFF
--- a/Casks/clashx.rb
+++ b/Casks/clashx.rb
@@ -1,6 +1,6 @@
 cask 'clashx' do
-  version '1.17.2'
-  sha256 '816f796977457b86b7a9d49865a02bd9f6f542b0f4a8fa3315f3db499b0bb8c1'
+  version '1.17.1'
+  sha256 'b18a5b73b3955ef04aa9cb6650d4adca4ba15c25d9a031db1ed686a4b91c620c'
 
   url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   appcast 'https://github.com/yichengchen/clashX/releases.atom'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#76814
It's now marked as pre release and the appcast doesn't contain the version number anymore 