### PR TITLE
Update freac from 1.1-beta1 to 1.1-beta3

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,6 +1,6 @@
 cask 'freac' do
-  version '1.1-beta1'
-  sha256 'fdf264a5e163ed5056011e06fe7610e9bffb6baf39c728ee004195cbe22d1ba2'
+  version '1.1-beta3'
+  sha256 'afd6b0d7a3a96c3c24491f95798025cdd2fe7edccb1f960c8376b10022eb5944'
 
   # github.com/enzo1982/freac was verified as official when first introduced to the cask
   url "https://github.com/enzo1982/freac/releases/download/v#{version}/freac-#{version}-macosx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.