### PR TITLE
Update sizzy from 0.16.0 to 0.17.2

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.16.0'
-  sha256 '8b95363a78be59ef8dcad8ad4921e51519b27bf99cfd81f5c9815a4cd5909c87'
+  version '0.17.2'
+  sha256 'd4deb78e85195014b10e0161b661197671dbafe46f6ac81781eb0235c481ea04'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.