### PR TITLE
Update framer-x from 36837 to 36850,1581607967

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -1,8 +1,8 @@
 cask 'framer-x' do
-  version '36837'
-  sha256 '2a21e169b0eb30f802027d6c54a8754aee06d3295c0a11a5294917faa3731851'
+  version '36850,1581607967'
+  sha256 'cb038c9bc30b146af209bec51b1e443b937c2639da8572770e15185c275cf63c'
 
-  url "https://dl.framer.com/com.framer.x/#{version}/FramerX-#{version}.zip"
+  url "https://dl.framer.com/com.framer.x/#{version.before_comma}/#{version.after_comma}/FramerX-#{version.before_comma}.zip"
   appcast 'https://updates.framer.com/sparkle/com.framer.x'
   name 'Framer X'
   homepage 'https://framer.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.