### PR TITLE
Update unity-download-assistant from 2019.3.0f6,27ab2135bccf to 2019.3.1f1,89d6087839c2

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.0f6,27ab2135bccf'
-  sha256 '0ee26bd5261b4e3447f266190f0c564fe2584026ed69fdd8b4bc9b05146b4c6f'
+  version '2019.3.1f1,89d6087839c2'
+  sha256 '6b8343bed77f8070246abf6015853a08588b3f2a5bf90f5bd045ddda859fe3af'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.