### PR TITLE
Update unity-lumin-support-for-editor from 2019.3.0f6,27ab2135bccf to 2019.3.1f1,89d6087839c2

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.3.0f6,27ab2135bccf'
-  sha256 '70cf981fa3780e07d62f4d8f2618c94d0b99211d74eb0c26f1903fa12ea86743'
+  version '2019.3.1f1,89d6087839c2'
+  sha256 'be552ff4b09b131910da817c14b5b21fd6e54998849cc0d3e605bb3abe27fb9e'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.