### PR TITLE
Update freecad from 0.18.4,16146 to 0.19.pre.19566

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,5 +1,5 @@
 cask 'freecad' do
-  version '0.18.4,16146'
+  version '0.19.pre.19566'
   sha256 :no_check # required as upstream package is updated in-place
 
   # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.