### PR TITLE
Update standard-notes from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,6 +1,6 @@
 cask 'standard-notes' do
-  version '3.3.1'
-  sha256 '1c323b2608e7be1541e615414ab0187fc6d45377ea66fcab099ad7cf338ba32b'
+  version '3.3.2'
+  sha256 '27f0538bb824f100a2c2c89f7e458be08c3763ecd9d4c8b61ac2a548a99b0866'
 
   # github.com/standardnotes/desktop was verified as official when first introduced to the cask
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.