### PR TITLE
Update gingko from 2.4.8 to 2.4.9

### DIFF
--- a/Casks/gingko.rb
+++ b/Casks/gingko.rb
@@ -1,6 +1,6 @@
 cask 'gingko' do
-  version '2.4.8'
-  sha256 'eb245787d2866fa56b91a3bac23d857cc8e55af5d0de393d1757ff8cf89e1bc2'
+  version '2.4.9'
+  sha256 'fbdd504224382f3ec615d5fe6c03d18e0e719fb27dc7771f27088dbff98a98c2'
 
   # github.com/gingko/client was verified as official when first introduced to the cask
   url "https://github.com/gingko/client/releases/download/v#{version}/Gingko-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.