### PR TITLE
Update kite from 0.20200205.1 to 0.20200211.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200205.1'
-  sha256 '82f8d2516bca6100f96273059f982e5e932a93cfbb501b18cb65bd220aea703e'
+  version '0.20200211.0'
+  sha256 '42c5dee15b584f0b464cd7c89abb645fee711ab255af2db9579bd1f429231d69'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.