### PR TITLE
Update ticktick from 3.3.10,125 to 3.4.00,128

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.3.10,125'
-  sha256 '2025acae60fd486335fd764b3ae32095997d91bc112562595a68cc5d381d139c'
+  version '3.4.00,128'
+  sha256 '56478d29c33e9dcd6983235ab29ad5835d57c23656ed8b022aa089aa5f87c9ee'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.