### PR TITLE
Update remote-desktop-manager from 2020.1.2.0 to 2020.1.3.0

### DIFF
--- a/Casks/remote-desktop-manager.rb
+++ b/Casks/remote-desktop-manager.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager' do
-  version '2020.1.2.0'
-  sha256 '6de936194bfd2050cd988847f5c38d6da65be2391ec6609fdf240e39a562b5a8'
+  version '2020.1.3.0'
+  sha256 'c594f0606c0cc6fe4f5c7e2f17f6c7de0d5e2d36a304a8c4fba100c668e1d9a3'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.