### PR TITLE
Update jprofiler from 11.1 to 11.1.1

### DIFF
--- a/Casks/jprofiler.rb
+++ b/Casks/jprofiler.rb
@@ -1,6 +1,6 @@
 cask 'jprofiler' do
-  version '11.1'
-  sha256 '55e8d301a8566e60b11fef4ecf74babb31ae18c70093a1a77dd485ca008f664a'
+  version '11.1.1'
+  sha256 'da324d370ec6f4a98c9a1b088242e1d56cf736326fc86601406cbee497e56957'
 
   url "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.ej-technologies.com/feeds/jprofiler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.