### PR TITLE
Update studio-3t from 2020.1.2 to 2020.2.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2020.1.2'
-  sha256 '605b93d72f591bab4424cae319ff23c1d0fc86d024fc6ed25e7742b5c1ad388e'
+  version '2020.2.0'
+  sha256 'c31a520ce40441a4122ecf56d9344744a5f7579bf9c76514faa9111ec60df2b1'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.