### PR TITLE
Update hubstaff from 1.5.7,1893 to 1.5.8,1992

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.5.7,1893'
-  sha256 'ba062167e9657c0046f5265ffc52a32e998c425534b6b38aa062b0f070b9ba3d'
+  version '1.5.8,1992'
+  sha256 '99a65518c72c66c36983b38e7e17d0a4c920fa9914dd2ed4f0cd33d0f5a21d10'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.