### PR TITLE
Update amazon-music from 7.9.1,20200116:01571460e4 to 7.10.0.2177,2002102177

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,11 +1,11 @@
 cask 'amazon-music' do
-  version '7.9.1,20200116:01571460e4'
-  sha256 'b5ffbbaa15a7f2e1b076f3e6732e418eb1f52ba2fed225dcf5f29aedbdb1985f'
+  version '7.10.0.2177,2002102177'
+  sha256 'ff8bb6f8175a0443d9640ed2608180271316df05369a32bb7d26ddbb78f796fd'
 
-  # ssl-images-amazon.com/images was verified as official when first introduced to the cask
-  url "https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/#{version.after_comma.before_colon}/#{version.after_colon}/AmazonMusicInstaller.dmg"
+  # morpho-releases.s3-us-west-2.amazonaws.com/mac was verified as official when first introduced to the cask
+  url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.after_comma}/AmazonMusicInstaller.dmg"
   appcast 'https://www.amazon.com/gp/dmusic/desktop/downloadPlayer',
-          configuration: "#{version.after_comma.before_colon}/#{version.after_colon}"
+          configuration: version.after_comma
   name 'Amazon Music'
   homepage 'https://www.amazon.com/musicapps'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.