### PR TITLE
Update xmind-zen from 10.0.1-202001022222 to 10.0.2-202002120210

### DIFF
--- a/Casks/xmind-zen.rb
+++ b/Casks/xmind-zen.rb
@@ -1,6 +1,6 @@
 cask 'xmind-zen' do
-  version '10.0.1-202001022222'
-  sha256 'e2f5a7b7258bb319491a91c4d93d86217e5e1d313a9ff8e9f6dbc9d9ae65e260'
+  version '10.0.2-202002120210'
+  sha256 '80b3eb8b32aade6dacfa0e5ed47ec8b1b424c1811d96a75be56730346bbc166d'
 
   url "http://dl2.xmind.net/xmind-downloads/XMind-ZEN-for-macOS-#{version}.dmg"
   appcast 'https://www.xmind.net/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.