### PR TITLE
Update bettertouchtool from 3.332-1517 to 3.332-1524

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.332-1517'
-    sha256 'a84a5b3f8cfa1d535a691262f1fa6358a53bfcbccff648654111cf635b9b1c91'
+    version '3.332-1524'
+    sha256 '34ee7cfeebab45b7e487a2e5815cc58b76977b924296f19dcc44bccea5436695'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.