### PR TITLE
Update emclient from 7.2.37929 to 7.2.37934

### DIFF
--- a/Casks/emclient.rb
+++ b/Casks/emclient.rb
@@ -1,6 +1,6 @@
 cask 'emclient' do
-  version '7.2.37929'
-  sha256 '623421dcde73b9d1849dbfd23615ea0976e99d7b1c7be2f4f6b9281120e3a282'
+  version '7.2.37934'
+  sha256 '1213f49663cf6a2bab74d09ed677748cd12958da337085993f1d76f151a7d71f'
 
   url "https://cdn-dist.emclient.com/dist/v#{version}_Mac/setup.pkg"
   appcast 'https://www.emclient.com/release-history?os=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.