### PR TITLE
Update activedock from 1.53 to 1.54

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
   version '1.54'
-  sha256 'd37db887147f9027278ee030406d5a00e72f5cb3acae390ee51f4d695911e265'
+  sha256 '95206e53fa4d62d8ad0b9eb3cd42c1ac7a552bc0e2a2e49d345c631ea19a1890'
 
   url 'https://noteifyapp.com/download/ActiveDock.dmg'
   appcast 'https://macplus-software.com/downloads/ActiveDock.xml'

--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -2,8 +2,7 @@ cask 'activedock' do
   version '1.54'
   sha256 'd37db887147f9027278ee030406d5a00e72f5cb3acae390ee51f4d695911e265'
 
-  # s3.amazonaws.com/downloads.macplussoftware was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/downloads.macplussoftware/ActiveDock.zip'
+  url 'https://noteifyapp.com/download/ActiveDock.dmg'
   appcast 'https://macplus-software.com/downloads/ActiveDock.xml'
   name 'ActiveDock'
   homepage 'https://www.noteifyapp.com/activedock/'

--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,10 +1,10 @@
 cask 'activedock' do
-  version '1.53'
+  version '1.54'
   sha256 'd37db887147f9027278ee030406d5a00e72f5cb3acae390ee51f4d695911e265'
 
   # s3.amazonaws.com/downloads.macplussoftware was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/downloads.macplussoftware/ActiveDock.zip'
-  appcast 'https://s3.amazonaws.com/downloads.macplussoftware/ActiveDock.xml'
+  appcast 'https://macplus-software.com/downloads/ActiveDock.xml'
   name 'ActiveDock'
   homepage 'https://www.noteifyapp.com/activedock/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.