### PR TITLE
Update smooze from 1.9.0 to 1.9.1

### DIFF
--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -1,6 +1,6 @@
 cask 'smooze' do
-  version '1.9.0'
-  sha256 '17e77e3f995ac5bdb6bb0f2aaaa27ec986ec908e54898c89c43ae1b04afd956a'
+  version '1.9.1'
+  sha256 'a969c55e8177764f1f4e612ce74ad235ae1b2eb6952d58e159cb560438261fa9'
 
   url 'https://smooze.co/updates/Smooze.dmg'
   appcast 'https://smooze.co/updates/update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.