### PR TITLE
Update wechatwork from 3.0.7.2053 to 3.0.8.2067

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.7.2053'
-  sha256 '9c15ebc28a8c8f54fb269fcf1dcf383183b3e7c3bc2b5f3acd6099cf336a8822'
+  version '3.0.8.2067'
+  sha256 '855bf829d5db34195ce4761c1eb3e5f21e7b9b2dbe4b1c312779ccc5fbb2c905'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.