### PR TITLE
Update xrg from 2.8.0 to 2.8.1

### DIFF
--- a/Casks/xrg.rb
+++ b/Casks/xrg.rb
@@ -1,6 +1,6 @@
 cask 'xrg' do
-  version '2.8.0'
-  sha256 '1b90b6e4cafc7a6af8f28579b71d4b1ae083d888d6a003bce62e515f2db033fc'
+  version '2.8.1'
+  sha256 '8eceb847d241d5bc2955298df6832047dd2ef954a45d497525cded947629f0ad'
 
   url "https://download.gauchosoft.com/xrg/XRG-release-#{version}.zip"
   appcast 'https://gauchosoft.com/Products/XRG/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.