### PR TITLE
Update microsoft-edge from 80.0.361.50 to 80.0.361.54

### DIFF
--- a/Casks/microsoft-edge.rb
+++ b/Casks/microsoft-edge.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge' do
-  version '80.0.361.50'
-  sha256 '86713909bab904b5ab8cb1d28adc9d96940d7d6022716765130ceb4d2388542d'
+  version '80.0.361.54'
+  sha256 'c45b97fa4f470cb91b927835b69b0af7655dfc9f13bd8bd498648ea003cad797'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdge-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.