### PR TITLE
Update altserver from 1.2 to 1.2.1

### DIFF
--- a/Casks/altserver.rb
+++ b/Casks/altserver.rb
@@ -1,9 +1,9 @@
 cask 'altserver' do
-  version '1.2'
-  sha256 '247efe3dee1e2bd27bf409b421cff7b569a891bf9bcb388ab1f4b6046e92386e'
+  version '1.2.1'
+  sha256 '6dcbcd514d6d9bd0c0332a2d6e392680e292dd3d2b494d68bcb2ad25ccbc6420'
 
   # f000.backblazeb2.com/file was verified as official when first introduced to the cask
-  url "https://f000.backblazeb2.com/file/altstore/altserver/altserver-#{version.dots_to_underscores}.zip"
+  url "https://f000.backblazeb2.com/file/altstore/altserver/#{version.dots_to_underscores}.zip"
   appcast 'https://altstore.io/altserver/sparkle-macos.xml'
   name 'AltServer'
   homepage 'https://altstore.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.