### PR TITLE
Update hubstaff from 1.5.8,1992 to 1.5.9,2025

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.5.8,1992'
-  sha256 '99a65518c72c66c36983b38e7e17d0a4c920fa9914dd2ed4f0cd33d0f5a21d10'
+  version '1.5.9,2025'
+  sha256 '51da121d85af776bca859e2b27ccba4a44675b0d7bd7acbe11febebbe89c5d5d'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.