### PR TITLE
Update wpsoffice from 1.9.1,2994 to 1.9.2,3124

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,9 +1,9 @@
 cask 'wpsoffice' do
-  version '1.9.1,2994'
-  sha256 '0e24e91fba32b03e17c520b1037ca9c1df84042c9b6dc54812fb9da7496156b6'
+  version '1.9.2,3124'
+  sha256 'bc717e99c790483580583e32f8305e00743b3cceb1aac39a4b8a86e2c33a565a'
 
   # package.mac.wpscdn.cn was verified as official when first introduced to the cask
-  url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}(#{version.after_comma}).dmg"
+  url "http://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}_#{version.after_comma}.dmg"
   appcast 'https://www.wps.cn/product/wpsmac/'
   name 'WPS Office'
   homepage 'https://www.wps.cn/product/wpsmac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.