### PR TITLE
Update aws-vault from 5.3.0 to 5.3.1

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,6 +1,6 @@
 cask 'aws-vault' do
-  version '5.3.0'
-  sha256 '1701a93a10fb47f58852ecd5e687abaded9a01e05e6817897a77d1bb8f894980'
+  version '5.3.1'
+  sha256 '4cc078787ada287acae0bfc3cd0d0288e8c62e1534e5e2a9e6cf9cab9248f22d'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
   appcast 'https://github.com/99designs/aws-vault/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.