### PR TITLE
Update logos from 8.10.0.0034 to 8.11.0.0017

### DIFF
--- a/Casks/logos.rb
+++ b/Casks/logos.rb
@@ -1,6 +1,6 @@
 cask 'logos' do
-  version '8.10.0.0034'
-  sha256 '5bce1ae412beac26d082204c7c0ba1dcb84fced6852802315e96c97003396cde'
+  version '8.11.0.0017'
+  sha256 '524b371e3aa18ebc4fe8c982727926431bf4ee5bf653f2cfff04b750cf979cce'
 
   # downloads.logoscdn.com was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/LBS8/Installer/#{version}/LogosMac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.