### PR TITLE
Update and rename balsamiq-mockups.rb to balsamiq-wireframes.rb from 3.5.17 to 4.0.19

### DIFF
--- a/Casks/balsamiq-wireframes.rb
+++ b/Casks/balsamiq-wireframes.rb
@@ -4,7 +4,7 @@ cask 'balsamiq-wireframes' do
 
   # build_archives.s3.amazonaws.com/wireframes-desktop was verified as official when first introduced to the cask
   url "https://build_archives.s3.amazonaws.com/wireframes-desktop/mac/Balsamiq%20Wireframes%20#{version}.dmg"
-  appcast 'https://balsamiq.com/wireframes/desktop/'
+  appcast 'https://builds.balsamiq.com/bwd/mac.jsonp'
   name 'Balsamiq Wireframes'
   homepage 'https://balsamiq.com/'
 

--- a/Casks/balsamiq-wireframes.rb
+++ b/Casks/balsamiq-wireframes.rb
@@ -2,8 +2,7 @@ cask 'balsamiq-wireframes' do
   version '4.0.19'
   sha256 '04f850df8dad70927589dadc56385c07a4aa49b4fca7f5ed8c6bfc210bde4899'
 
-  # build_archives.s3.amazonaws.com/wireframes-desktop was verified as official when first introduced to the cask
-  url "https://build_archives.s3.amazonaws.com/wireframes-desktop/mac/Balsamiq%20Wireframes%20#{version}.dmg"
+  url "https://builds.balsamiq.com/bwd/Balsamiq%20Wireframes%20#{version}.dmg"
   appcast 'https://builds.balsamiq.com/bwd/mac.jsonp'
   name 'Balsamiq Wireframes'
   homepage 'https://balsamiq.com/'

--- a/Casks/balsamiq-wireframes.rb
+++ b/Casks/balsamiq-wireframes.rb
@@ -2,12 +2,13 @@ cask 'balsamiq-wireframes' do
   version '4.0.19'
   sha256 '04f850df8dad70927589dadc56385c07a4aa49b4fca7f5ed8c6bfc210bde4899'
 
+  # build_archives.s3.amazonaws.com/wireframes-desktop was verified as official when first introduced to the cask
   url "https://build_archives.s3.amazonaws.com/wireframes-desktop/mac/Balsamiq%20Wireframes%20#{version}.dmg"
   appcast 'https://balsamiq.com/wireframes/desktop/'
   name 'Balsamiq Wireframes'
   homepage 'https://balsamiq.com/'
 
-  app "Balsamiq Wireframes.app"
+  app 'Balsamiq Wireframes.app'
 
   zap trash: [
                "~/Library/Caches/BalsamiqMockups#{version.major}.*",

--- a/Casks/balsamiq-wireframes.rb
+++ b/Casks/balsamiq-wireframes.rb
@@ -1,13 +1,13 @@
-cask 'balsamiq-mockups' do
-  version '3.5.17'
-  sha256 'a89f2a7959bc7f987710b7f3d6ae665e5765180dd02763d1b5f953415c130df2'
+cask 'balsamiq-wireframes' do
+  version '4.0.19'
+  sha256 '04f850df8dad70927589dadc56385c07a4aa49b4fca7f5ed8c6bfc210bde4899'
 
-  url "https://builds.balsamiq.com/mockups-desktop/Balsamiq_Mockups_#{version}.dmg"
-  appcast 'https://builds.balsamiq.com/mockups-desktop/version.jsonp'
-  name 'Balsamiq Mockups'
+  url "https://build_archives.s3.amazonaws.com/wireframes-desktop/mac/Balsamiq%20Wireframes%20#{version}.dmg"
+  appcast 'https://balsamiq.com/wireframes/desktop/'
+  name 'Balsamiq Wireframes'
   homepage 'https://balsamiq.com/'
 
-  app "Balsamiq Mockups #{version.major}.app"
+  app "Balsamiq Wireframes.app"
 
   zap trash: [
                "~/Library/Caches/BalsamiqMockups#{version.major}.*",


### PR DESCRIPTION
thanks for the info @whalesingswee  
The app was renamed but I haven't found a proper appcast until now 