### PR TITLE
Update diskcatalogmaker from 8.0.0 to 8.0.1

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '8.0.0'
-  sha256 '49bceaa453e823bb18253e384d7d68f8556786d8ffe70698bd25f3a72aa8274d'
+  version '8.0.1'
+  sha256 '6e99919f3a43b51251c899219e11e2a760ffd60c48fc72ebfdb20045154c9191'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.