### PR TITLE
Update netron from 3.9.0 to 3.9.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.9.0'
-  sha256 '3b09c08390942dbbf3dda654ea2ebe35ffd70b249026518584bfc5bbee85f730'
+  version '3.9.1'
+  sha256 '8c31ce2abf6e6576985529c69d74326075fc17a8b6aa9d0523fd3eb71838f715'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.