### PR TITLE
Update archipelago from 3.9.0 to 3.10.0

### DIFF
--- a/Casks/archipelago.rb
+++ b/Casks/archipelago.rb
@@ -1,6 +1,6 @@
 cask 'archipelago' do
-  version '3.9.0'
-  sha256 '741d240d486cf4cc42d145b3c18e62358adc054f73a7445f4524dfc7f988a5e4'
+  version '3.10.0'
+  sha256 '81b5c48accf0e29a2612fbe0b7fc42de691cd07a77db2414f5d30d116971ab7e'
 
   url "https://github.com/npezza93/archipelago/releases/download/v#{version}/Archipelago-#{version}.dmg"
   appcast 'https://github.com/npezza93/archipelago/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.