### PR TITLE
Update anydo from 4.2.64 to 4.2.65

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.64'
-  sha256 '850f1377fbcd2e2c70f08b4c1374de05f23460685313bca775b119bbe3b348d9'
+  version '4.2.65'
+  sha256 'd60596088e0bce51e15affa9ee52ddcc0ebc09f2081c515e4aad71b754a58376'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.