### PR TITLE
Update arq-cloud-backup from 1.4.3 to 1.4.4

### DIFF
--- a/Casks/arq-cloud-backup.rb
+++ b/Casks/arq-cloud-backup.rb
@@ -1,6 +1,6 @@
 cask 'arq-cloud-backup' do
-  version '1.4.3'
-  sha256 '8a44d27b00fd69ee7e1a55156e61d0a524bc60687e42de14436d764f3e1670c0'
+  version '1.4.4'
+  sha256 '4b9c95a0e859dc89c709c6cfa313fb7cef1b46c6717516b267526b52aa290ea7'
 
   url 'https://www.arqbackup.com/download/arqcloudbackup/ArqCloudBackup.dmg'
   appcast 'https://www.arqbackup.com/download/arqcloudbackup/arqcloudbackup_release_notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.