### PR TITLE
Update captin from 1.0.21,111:1577032431 to 1.0.22,116:1581835006

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.21,111:1577032431'
-  sha256 'be20bf61be05b00fef65a9fe28032cd142fad90611c34b239c7f3204c6ece847'
+  version '1.0.22,116:1581835006'
+  sha256 '683f1050a96f1ccaef954ed8c29fe6e7b75bd45baeb930c63a3e3c972efe5836'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.