### PR TITLE
Update prudent from 79.0.3945.88,19 to 79.0.3945.88,20

### DIFF
--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -1,6 +1,6 @@
 cask 'prudent' do
-  version '79.0.3945.88,19'
-  sha256 '3ca9fd9cae0f287e171b99cd1a2c5cc03e4ffd81fedfa03a5a9cf2b8983e2cdf'
+  version '79.0.3945.88,20'
+  sha256 'e59778c5683cc2b648d962365f5879030f9a467f02b4d6d4bb6df2975d5af361'
 
   # github.com/PrudentMe/main was verified as official when first introduced to the cask
   url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.