### PR TITLE
Update trinity from 1.4.1 to 1.4.2

### DIFF
--- a/Casks/trinity.rb
+++ b/Casks/trinity.rb
@@ -1,6 +1,6 @@
 cask 'trinity' do
-  version '1.4.1'
-  sha256 'cf6993e146415e2128c625b9c6f45f69fe2f23dc9306d364798717873f79d882'
+  version '1.4.2'
+  sha256 '5c626e7324ef123bd570799b76457e8417dacd1420b7e5ac31e16304947a3307'
 
   # github.com/iotaledger/trinity-wallet was verified as official when first introduced to the cask
   url "https://github.com/iotaledger/trinity-wallet/releases/download/desktop-#{version}/trinity-desktop-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.