### PR TITLE
Update mgba from 0.8.0 to 0.8.1

### DIFF
--- a/Casks/mgba.rb
+++ b/Casks/mgba.rb
@@ -1,6 +1,6 @@
 cask 'mgba' do
-  version '0.8.0'
-  sha256 'c3322c3592e932b14612f7635f585fbbd72157bfa93d30717d3967f95fdc1aec'
+  version '0.8.1'
+  sha256 '867b6d588351505ffae9e90ee75373fc7044a08dbb2c40ada9b91d12e255b295'
 
   # github.com/mgba-emu/mgba was verified as official when first introduced to the cask
   url "https://github.com/mgba-emu/mgba/releases/download/#{version}/mGBA-#{version}-osx.tar.xz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.