### PR TITLE
Update mudlet from 4.4.0 to 4.5.0

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '4.4.0'
-  sha256 '89cfcc8ea605fbd6c0220c514cb5a1dad04ac2052a070bc0f7b39fb17023aceb'
+  version '4.5.0'
+  sha256 '8ef1291449137748ff7c02ab34995dc8d6e4135676bceb8a009cf54bd4aa41d0'
 
   url "https://www.mudlet.org/wp-content/files/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.