### PR TITLE
Update yate from 5.1.0.1 to 5.1.1

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '5.1.0.1'
-  sha256 '22fcecb4eefd22b677a5745e6a3ef56983f1819d6a1aec452333e3919cb06001'
+  version '5.1.1'
+  sha256 '4a6f928c9041d94815ff5e13e6fc69336387ac1f27b2697d2bc2f2c16d6b30c5'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.