### PR TITLE
Update glyphs from 2.6.5,1292 to 2.6.5,1295

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.5,1292'
-  sha256 '6651aced7df617d9f4101bae16175408a3e5bf080e1e452045de1401f5690b80'
+  version '2.6.5,1295'
+  sha256 '2474a7da0edd69ee8f95cf52afafbd572798b3a07a57146003b0901f607b7efe'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.