### PR TITLE
Update losslesscut from 2.7.1 to 2.8.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '2.7.1'
-  sha256 '87c049823b72b806c86bc0b4b631374c9ce1cc9e6ee08228e0676567d139f474'
+  version '2.8.0'
+  sha256 'c7ca099cbc24f3df2d41e7eb36577fab7d32a254476fa9ecf799e4d719ff361c'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.