### PR TITLE
Update cisco-proximity from 3.0.6 to 3.0.7

### DIFF
--- a/Casks/cisco-proximity.rb
+++ b/Casks/cisco-proximity.rb
@@ -1,6 +1,6 @@
 cask 'cisco-proximity' do
-  version '3.0.6'
-  sha256 '3dea1ffa40f31eaecb7f5ba76c8823d57ebc68f57f6fbe1e42746ff945073b31'
+  version '3.0.7'
+  sha256 '0ef97f47d97a22f66bcef53bbbab5c45cedd6d94ae121d8b33196f0a6b25908b'
 
   url 'https://proximity.cisco.com/mac/Proximity.dmg'
   appcast 'https://proximity.cisco.com/mac/version.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.