### PR TITLE
Update radarr from 0.2.0.1450 to 0.2.0.1480

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,6 +1,6 @@
 cask 'radarr' do
-  version '0.2.0.1450'
-  sha256 '6891cd4e087c2c49fdf1ddc0fcb07c6ecc2f8267b18f32e804117333248a3acc'
+  version '0.2.0.1480'
+  sha256 '8bd4770bbaa63aa0515a1b300cc2432c1e08afbb9f25a62011c63c910ec53c94'
 
   # github.com/Radarr/Radarr was verified as official when first introduced to the cask
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.develop.#{version}.osx-app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.