### PR TITLE
Update musictube from 1.11 to 1.11.1

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,6 +1,6 @@
 cask 'musictube' do
-  version '1.11'
-  sha256 'ff4a2db171b480f3feec212c5aef5eef831af62ae182bf091f465378a685872a'
+  version '1.11.1'
+  sha256 'b2a7501cb07ef2d78a83dd5e1b8bbd8194e8db464b35a9b1a77b2aed5eb08948'
 
   url 'https://flavio.tordini.org/files/musictube/musictube.dmg'
   appcast 'https://flavio.tordini.org/musictube-ws/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.