### PR TITLE
Update balenaetcher from 1.5.76 to 1.5.77

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.76'
-  sha256 '71f7fc8b59041ae5a963ebac279c001002642c4b0c296f21b64669fe274b6320'
+  version '1.5.77'
+  sha256 '137be42728d6a9bb5558be9aa2ecbfc37528c5b6c9099c53724cc07dc93a75b2'
 
   # github.com/balena-io/etcher was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.