### PR TITLE
Update musicbrainz-picard from 2.2.3 to 2.3

### DIFF
--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -3,7 +3,7 @@ cask 'musicbrainz-picard' do
   sha256 'd8c6067caa0bf688d724bc8cccd440e7bc150373eac775ae7c4b20d430111069'
 
   # musicbrainz.osuosl.org/pub/ was verified as official when first introduced to the cask
-  url 'https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.3.dmg'
+  url 'https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}.dmg'
   appcast 'https://picard.musicbrainz.org/downloads/'
   name 'MusicBrainz Picard'
   homepage 'https://picard.musicbrainz.org/'

--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -1,9 +1,9 @@
 cask 'musicbrainz-picard' do
-  version '2.2.3'
-  sha256 'a64e6d1736da86f96022a6f4a9445496750849ee8eaa83472bd2dddc69888b86'
+  version '2.3'
+  sha256 'd8c6067caa0bf688d724bc8cccd440e7bc150373eac775ae7c4b20d430111069'
 
   # musicbrainz.osuosl.org/pub/ was verified as official when first introduced to the cask
-  url "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz.Picard.#{version}.dmg"
+  url 'https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.3.dmg'
   appcast 'https://picard.musicbrainz.org/downloads/'
   name 'MusicBrainz Picard'
   homepage 'https://picard.musicbrainz.org/'

--- a/Casks/musicbrainz-picard.rb
+++ b/Casks/musicbrainz-picard.rb
@@ -3,7 +3,7 @@ cask 'musicbrainz-picard' do
   sha256 'd8c6067caa0bf688d724bc8cccd440e7bc150373eac775ae7c4b20d430111069'
 
   # musicbrainz.osuosl.org/pub/ was verified as official when first introduced to the cask
-  url 'https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}.dmg'
+  url "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}.dmg"
   appcast 'https://picard.musicbrainz.org/downloads/'
   name 'MusicBrainz Picard'
   homepage 'https://picard.musicbrainz.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.