### PR TITLE
Update patchwork from 3.17.2 to 3.17.3

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.17.2'
-  sha256 '53d08948316fb31dfe23a72cec40747267b4561b0de6f3f241ed8710b160a1b2'
+  version '3.17.3'
+  sha256 '69cbe8e2b09fbbde8918d94974222da869058ab799a41e0082af17466b16011b'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.