### PR TITLE
Update daisydisk from 4.8.2 to 4.9

### DIFF
--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -4,8 +4,8 @@ cask 'daisydisk' do
     sha256 'fe2aa86f2ea8a1f0c4791857a5b7991ecad295b5b969849bb7b15a890ab54b86'
     url "https://www.daisydiskapp.com/downloads/DaisyDisk_#{version.dots_to_underscores}.zip"
   else
-    version '4.8.2'
-    sha256 '2949d6d3cb4e653e8650c8b1dc825e4fa39c8a8ae8c906a3392aff360c5d6c1a'
+    version '4.9'
+    sha256 '9dcea775eef52cfea8a4123c152b1ae1e6231d2178e636540655a5d2d35c5a97'
     url 'https://www.daisydiskapp.com/downloads/DaisyDisk.zip'
     appcast 'https://daisydiskapp.com/downloads/appcastReleaseNotes.php?appEdition=Standard&osVersion=10.15'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.