### PR TITLE
Update another-redis-desktop-manager from 1.2.5 to 1.3.0

### DIFF
--- a/Casks/another-redis-desktop-manager.rb
+++ b/Casks/another-redis-desktop-manager.rb
@@ -1,8 +1,8 @@
 cask 'another-redis-desktop-manager' do
-  version '1.2.5'
-  sha256 'fe1c2c08c1c0972dee58fd4f0876b1bce80ce6ac9d56842e4c34979249f85050'
+  version '1.3.0'
+  sha256 'aff9116b25933f4d01abdee8d367073f5c7510c99b2b88034fc67a53dfc07b51'
 
-  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another.Redis.Desktop.Manager.1.2.5.dmg"
+  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another.Redis.Desktop.Manager.#{version}.dmg"
   appcast 'https://github.com/qishibo/AnotherRedisDesktopManager/releases.atom'
   name 'Another Redis Desktop Manager'
   homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.