### PR TITLE
Update nextcloud from 2.6.2.20191224 to 2.6.3.20200217

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -1,10 +1,10 @@
 cask 'nextcloud' do
   if MacOS.version <= :el_capitan
-    version '2.6.2.20191224-legacy'
-    sha256 '65a507096658b9128c122f117f6326fc96bb0397cfc9940daf4eb2d4b8b5997c'
+    version '2.6.3.20200217-legacy'
+    sha256 '9e3f5c509cd7889b78bb0375e01f0e46b457a98845f0a222d71235cd65413dec'
   else
-    version '2.6.2.20191224'
-    sha256 'dc92a94370963d8ee74693a02b761fac8dd040e4c35c308c3df63eedcaf7ca1b'
+    version '2.6.3.20200217'
+    sha256 'baee483ef22ad6aec13aeea19d550f3a89f008dda48749f7feaf621b1a3d457f'
   end
 
   url "https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.