### PR TITLE
Update psychopy from 2020.1.0 to 2020.1.1

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '2020.1.0'
-  sha256 '2fb811b2b2394bf5a8620189630f9568f6fb839bd82d07b9215cd7b611070832'
+  version '2020.1.1'
+  sha256 'd66613d57460326f77895952452712e10d11bc66b63c5862ac55de9ff484127c'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.