### PR TITLE
Update tidepool-uploader from 2.25.1 to 2.26.0

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.25.1'
-  sha256 'ce4abb0845207a13cd26c03c13a6368242d1bddf175c98b682fa10ff4f90d590'
+  version '2.26.0'
+  sha256 '7e0d82deb0ae5cdbd65cdc5f83c00c95c4ae6121aaaca3d5f5b84af93b42c719'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.