### PR TITLE
Update get-iplayer-automator from 1.17,b20191130002 to 1.18.1,b20200217002

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,6 +1,6 @@
 cask 'get-iplayer-automator' do
-  version '1.17,b20191130002'
-  sha256 '44128ad80e31ed21c0cd1580041f4dec51ecc7b72e7383a9e0ce8f6bbde20be5'
+  version '1.18.1,b20200217002'
+  sha256 '3e00ab3db0c2dd822640f6077acec48a1b596e7412c9e799036a1675b5dc04cd'
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.before_comma}/Get.iPlayer.Automator.v#{version.before_comma}.#{version.after_comma}.zip"
   appcast 'https://github.com/Ascoware/get-iplayer-automator/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.