### PR TITLE
Update debookee from 7.3.2 to 7.4.1

### DIFF
--- a/Casks/debookee.rb
+++ b/Casks/debookee.rb
@@ -1,6 +1,6 @@
 cask 'debookee' do
-  version '7.3.2'
-  sha256 '75d4da3098f8ff5ce008bfcf397deb60f39f310f032e6d1e9c590b644efa3554'
+  version '7.4.1'
+  sha256 '68984eb09333a545dbb634e3a323295ca0042c215df22a442fe56e138fe70d9a'
 
   # iwaxx.com/debookee was verified as official when first introduced to the cask
   url 'https://www.iwaxx.com/debookee/debookee.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.