### PR TITLE
Update elpass from 1.1.1,215 to 1.1.2,224

### DIFF
--- a/Casks/elpass.rb
+++ b/Casks/elpass.rb
@@ -1,6 +1,6 @@
 cask 'elpass' do
-  version '1.1.1,215'
-  sha256 '838a7a5a5e4757a63f2fc863632fe87556eb00dfc2f8977f8165b91968141483'
+  version '1.1.2,224'
+  sha256 'ae5232cc13549e3f7f914bfd927cf1678c35031d0811e197302c665f22635562'
 
   url "https://elpass.app/macos/Elpass-#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://elpass.app/macos/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.