### PR TITLE
Update publish-or-perish from 7.18.2702 to 7.19.2716

### DIFF
--- a/Casks/publish-or-perish.rb
+++ b/Casks/publish-or-perish.rb
@@ -1,6 +1,6 @@
 cask 'publish-or-perish' do
-  version '7.18.2702'
-  sha256 'c546fcb3a6c5cf0934bbf63fe37ce4ef39daea6b641d4d5675d2be37de1120dc'
+  version '7.19.2716'
+  sha256 '5b3cd54ac45b717ca5eb02d0aac6142ae68eea940b94db001b4de7c821842e89'
 
   url 'https://harzing.com/download/PoP7Mac.pkg'
   appcast 'https://harzing.com/resources/publish-or-perish/os-x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.