### PR TITLE
Update kubernetic from 2.4.3 to 2.5.0

### DIFF
--- a/Casks/kubernetic.rb
+++ b/Casks/kubernetic.rb
@@ -1,6 +1,6 @@
 cask 'kubernetic' do
-  version '2.4.3'
-  sha256 '55c5c5ca04bd970ebce7dd78058d42244d6e54d750a6ded490b6f5fac428b833'
+  version '2.5.0'
+  sha256 'f426312f7191ba86c0990a31a2d831f983777c412d5a93c92356b21fc945728b'
 
   # kubernetic.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kubernetic.s3.amazonaws.com/Kubernetic-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.