### PR TITLE
Update wechatwork from 3.0.8.2074 to 3.0.8.2080

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.8.2074'
-  sha256 '06bf5d6d7f939d8bfa863ba033ac243d4e2ea6a172cc8a7b55c525264cb6efe0'
+  version '3.0.8.2080'
+  sha256 '2fac3e3b6b6fb7b1a933dd69e8df62cc213fac555d03298bfec4a515f137f035'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.