### PR TITLE
Update yandex-disk from 3.1.10,30 to 3.1.11,30

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
-  version '3.1.10,30'
-  sha256 'e1eef43b41f1fc59cf4e1816cd37d7f769d79979020d8a885fe8644a1d17f874'
+  version '3.1.11,30'
+  sha256 'c63d03284d3d7d3039b98a6447defcf0ad5b6e1062250e76e93b80a7368d4fb1'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.after_comma}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.