### PR TITLE
Update firefox.rb from 73.0 to 73.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '73.0'
+  version '73.0.1'
 
   language 'cs' do
-    sha256 'e274c5d1ad9422c9844ce00b1aebe66e64673c1f1e082eefa561c4eaa3da0bdf'
+    sha256 '9b0b754de727cb9085de2b88ede009df8ce5198524f9a5312fcd63d14f7372b1'
     'cs'
   end
 
   language 'de' do
-    sha256 '79f434867738764a1e57f68ff497dfaf65a726f6a02bd4eda4daac6b8e694958'
+    sha256 '6c043c80dcb7a3ad2dfa62421203fcfc99701df05874e70b38f0cb5cf08c5760'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '0241185c56facebc18784327adfc3e70543e6156c6448c50cf1cc5bccda95170'
+    sha256 '59125d92079da7367d397036af3e7efee363782f836946a65b2274ac9adbf8fc'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'eb0eeba647d8ba332b30d98d3ee845213a4b18db97890910a35a1f94c1b37250'
+    sha256 '4a017e616121e2563acfffe8bb1018f02490ee4506e1e56a9c3b2acdc660f5b7'
     'en-US'
   end
 
   language 'eo' do
-    sha256 'fddb5edfd9b80c23e88d5728b691a287da32977170df36460474f9a72e3bda09'
+    sha256 'e36187087cd57e2b27002d6452d01781199e4c108c12921277d13602d44bf028'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '2476f97df9dc721e724935a3b0f5c77c001e34a6122787c7fa1fe10523f6a1e5'
+    sha256 '1c6c5c983a43dba260a34423538274f7d749f6a004a37c9b863c94a4f491d547'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '995a0cc25b8887e26a974a68b070c95f1ea82d51b906109e2350f66eeab521d9'
+    sha256 '7900cb8712d709fc9057ddfef8e19b81d856f9669a78a9a3eff70c3d60d5d473'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'b471979598841cf635669014e8ff607234ccff2f3199b999fd57b57d2d4eb37b'
+    sha256 '9951b316234cc7f6c8e8db6f788ebfaec4c1921404cc3ad8b8028df1801d141f'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '8a67ca21626c082f57069a81883cf101f37a8174f240b5addd7c7ee4da90a3b8'
+    sha256 'b74f879b7d77faf0c43039ff4f2254c790ca1e694913d19526cf9dc9d9d290e1'
     'fi'
   end
 
   language 'fr' do
-    sha256 '398e21e650de2aabd18414a716979ef0807f2d111b6cf156f2583d02cfe2affb'
+    sha256 '7d867698502d679568606e47c9f28b67c96bfb8060d262c69c7bc7a110812632'
     'fr'
   end
 
   language 'gl' do
-    sha256 'e33d458b38f13fa02464a64b33ebd7b67c72e2a6aa5206671ae712169629ab33'
+    sha256 '67bf8176a9e6159df6fd14bca7942fa4687f78298705bc1c0e45fb1e1ce2feab'
     'gl'
   end
 
   language 'in' do
-    sha256 'a613010889fadce903b0503ad898a4c543af2143c0aff58e8462459a6f2c0838'
+    sha256 'd67b875cf2f9b3575d070c7ee6765f1dea4cb24ab6fd9442f8ac7c9448fe0cfb'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '010877dd869dc2f17b825f6ab8505751fe965c5bca63840ad520ffbd4b6a5461'
+    sha256 '820d3a3c1d7aca768dde2f553fb8c3128f4b01081b856cea34dc7e51319262c1'
     'it'
   end
 
   language 'ja' do
-    sha256 'e092e7a135e1d4ea9c29c27dd132971b291aa06f3c6583a358e1e3acd55a9525'
+    sha256 '5ff3ff0b65f477c48d4f4288e8fade623e76d935b92b86ca64847a50c7e71437'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 'f8dd5cfbf56d446d3bc1218cd684e07f6a595100734a2248225ca2758022cb9c'
+    sha256 'c86afa8721cd2e12f49bedbcb884f3383ceb1ee3d072fb5df137e681eb8377d9'
     'ko'
   end
 
   language 'nl' do
-    sha256 'e12faf3ae2a944dc29f685c780e46651eb2ed9731dea4693ed4cc8e535ee2e62'
+    sha256 '88a481a333539f652a1f8b1b5a9f821fdd9aa25b4662d16e251103c2fa82425a'
     'nl'
   end
 
   language 'pl' do
-    sha256 '75f08d9441e022b09499b365fa8ca06c430089dcd3216a3934ee392d709098b5'
+    sha256 '8a4115ae1931debe79793ab6e8d2edbe9a79d02ece766ffde3e972f46481be3c'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '307fd3f83451c544c0b72680bec36f2215a07c4ff8c5cc6d26d2e5f8c9cb65c4'
+    sha256 '250d4fafee9599df377a97663242af007fae78be3e193a989d797fa918c7e716'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'd005b09647a5c2a1f9862093d01b1a10495cdbc632276efc56362f87cdfd1c4b'
+    sha256 'f4767825bc327fc7ccc8589bf03d89dfb11bb024db7965ee72535857f0bf4326'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '3036a60e46190db661b7af31564a6f3e9d0d898993d1edacaba613f9dcbc9644'
+    sha256 'd2f99d0ee65b0d75d34dac082b5f76e731cffbf946ff44bfc4c6b6b3d7e02093'
     'ru'
   end
 
   language 'tr' do
-    sha256 '8a03a7367050407a053926b320751ce2562eb7332fb88226d35a9e961942df4e'
+    sha256 '1de337c19ae4840c0ca5efe52da2fa670f087c077dbd2a06bbb172294ce80acd'
     'tr'
   end
 
   language 'uk' do
-    sha256 '2c726f192e8dd2103b5e3c00b65df0dc3df5358795a43432cf12bbb91c792fb4'
+    sha256 '97eaa05c9f5d9aa58cdaff6a452ea382560fb0589f86a91f488a4e202953aaba'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'c391bf1274a1b4211a18822174351e3c620ea1889d4c5562a07f48edf63db3d5'
+    sha256 'ca0ae706bd6a2a66ee4b5c3f688155372b57d3729854db902b02f1696be35c59'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'ab9d7cd19ab38a0e40bfb9e9168309f953e0dda415890551255e66e5997d8acc'
+    sha256 '2f89a71dd1c936c4bc9f4610b611465b57ab81bd2a87ac6b6bd7b16acd8794a5'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
