### PR TITLE
Update expandrive from 7.4.11 to 7.5.0

### DIFF
--- a/Casks/expandrive.rb
+++ b/Casks/expandrive.rb
@@ -1,6 +1,6 @@
 cask 'expandrive' do
-  version '7.4.11'
-  sha256 'f450b573cb60ef1874582680ab83fdb39e6c9f56b5e019056eed89fbe522ef8f'
+  version '7.5.0'
+  sha256 '1ca986e98480acdccd433379b349c95dd6d5b0db89fdeb8e2cdb67367699793f'
 
   url "https://updates.expandrive.com/apps/expandrive#{version.major}/v/#{version.dots_to_hyphens}/update_download"
   appcast "https://updates.expandrive.com/appcast/expandrive#{version.major}.json?version=#{version.major}.0.0"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.