### PR TITLE
Update fsnotes from 4.0.22 to 4.0.23

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.0.22'
-  sha256 '9cf2e0d70a46b3d874423c48391218c4769dc578e331441640f2d0ceb18306b9'
+  version '4.0.23'
+  sha256 '7d70ca4b4d56809b8fbdcf020ae8ada54ae8a3fe72697ecce6fa213cc09befb3'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.