### PR TITLE
Update opencore-configurator from 1.14.1.1 to 1.15.0.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.14.1.1'
-  sha256 'c74e2d314ec3d2824cc1166dc4811be1b5e6465276024d41d40ca13a62f00bdc'
+  version '1.15.0.0'
+  sha256 '48952b3558a5553ec61ae8d39c434293017213517cf77ae3b7b2dcf11124934e'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.