### PR TITLE
Update pluralsight from 1.11.260 to 1.12.261

### DIFF
--- a/Casks/pluralsight.rb
+++ b/Casks/pluralsight.rb
@@ -1,6 +1,6 @@
 cask 'pluralsight' do
-  version '1.11.260'
-  sha256 'b8cffa4a530db18891b844ccff20b5a72305bba7d5a519358409be09ff1acf26'
+  version '1.12.261'
+  sha256 '1eb9d66b43d987575c0b8ce8b8b5505c19553d4ade46b89a88e06cbffc4db53f'
 
   url "https://macapp.pluralsight.com/installpluralsight#{version}.dmg"
   appcast 'https://macapp.pluralsight.com/appcast'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.