### PR TITLE
Update prezi-next from 1.40.0 to 1.41.0

### DIFF
--- a/Casks/prezi-next.rb
+++ b/Casks/prezi-next.rb
@@ -1,6 +1,6 @@
 cask 'prezi-next' do
-  version '1.40.0'
-  sha256 '3ad61662a6db86fee8adec634f3f0884650394d5b5169327a90d0dbf31a6b4e3'
+  version '1.41.0'
+  sha256 'c40d2a41ef37290c819770f2b0a5b47764b1717bb464834b5e08258269febcbf'
 
   url "https://desktopassets.prezi.com/mac/pitch/releases/Prezi_Next_#{version}.dmg"
   appcast 'https://prezidesktop.s3.amazonaws.com/assets/mac/pitch/updates/prezi-business.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.