### PR TITLE
Update balsamiq-wireframes from 4.0.19 to 4.0.20

### DIFF
--- a/Casks/balsamiq-wireframes.rb
+++ b/Casks/balsamiq-wireframes.rb
@@ -1,6 +1,6 @@
 cask 'balsamiq-wireframes' do
-  version '4.0.19'
-  sha256 '04f850df8dad70927589dadc56385c07a4aa49b4fca7f5ed8c6bfc210bde4899'
+  version '4.0.20'
+  sha256 'c364584ae8cbbcf84df39129c4f2fabdd9c060658ba794e8901677b7e4bfe51b'
 
   url "https://builds.balsamiq.com/bwd/Balsamiq%20Wireframes%20#{version}.dmg"
   appcast 'https://builds.balsamiq.com/bwd/mac.jsonp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.