### PR TITLE
Update aircall from 2.2.2 to 2.3.0

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,6 +1,6 @@
 cask 'aircall' do
-  version '2.2.2'
-  sha256 '807641269359fb12225d8d198a8dc8fd04fa8f507f5101779c6bc814405133eb'
+  version '2.3.0'
+  sha256 'f85433a83c0aa28da5f1bd281f44367aa0dbc088d2bd2d4b633bd4f20a70fdc5'
 
   # aircall-electron-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://aircall-electron-releases.s3.amazonaws.com/production/Aircall-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.