### PR TITLE
Update studio-3t from 2020.2.0 to 2020.2.1

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2020.2.0'
-  sha256 'c31a520ce40441a4122ecf56d9344744a5f7579bf9c76514faa9111ec60df2b1'
+  version '2020.2.1'
+  sha256 '5f136b4860b6413ecd70f5d04e937d12054a44726e53700e62a23b1b1473d62e'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.