### PR TITLE
Update tuple from 0.61.0,2020-02-06-5e1aab60 to 0.62.1,2020-02-18-52b1d4aa

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.61.0,2020-02-06-5e1aab60'
-  sha256 '1f4d8f6f1469e50e76326f91895f726dbd28784150561ab832343b187482cf9c'
+  version '0.62.1,2020-02-18-52b1d4aa'
+  sha256 'b2bcf490177b61b707e43a5c9ec3fda5274572c22081872dee196a2bf1092e50'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.