### PR TITLE
Update idisplay

### DIFF
--- a/Casks/idisplay.rb
+++ b/Casks/idisplay.rb
@@ -2,7 +2,7 @@ cask 'idisplay' do
   version :latest
   sha256 :no_check
 
-  url 'https://getidisplay.com/downloads/iDisplayMac.dmg'
+  url 'http://getidisplay.com/downloads/iDisplayMac.dmg'
   name 'iDisplay'
   homepage 'https://getidisplay.com/'
 

--- a/Casks/idisplay.rb
+++ b/Casks/idisplay.rb
@@ -4,7 +4,7 @@ cask 'idisplay' do
 
   url 'http://getidisplay.com/downloads/iDisplayMac.dmg'
   name 'iDisplay'
-  homepage 'https://getidisplay.com/'
+  homepage 'http://getidisplay.com/'
 
   pkg 'iDisplay.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The https version of the site no longer works.