### PR TITLE
Corrected sha256 sum for Shotcut version 20.02.17

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
   version '20.02.17'
-  sha256 'ac47f945e0e1ec6fe6b8a9f06e0a1e642e08d7405da50a0a889599bd8b8a9392'
+  sha256 'b427c2e3a3273b649a9beb79d3c2914b6c09f5cea3b70948848f5f3d459aa9d5'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg"


### PR DESCRIPTION
Brew formular for Shotcut version 20.02.17 contained the wrong sha256 sum.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).