### PR TITLE
Update meshlab from 2016.12 to 2020.02

### DIFF
--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -1,9 +1,9 @@
 cask 'meshlab' do
-  version '2016.12'
-  sha256 '1a9d81f7bb7fb3da223e83768d13601b4728abde9276a415049bbb33b74baecf'
+  version '2020.02'
+  sha256 'f18de648c1d73d264ba6e4d68418fc7c33897643a16d8fdf62a68c583bdbc1f2'
 
   # github.com/cnr-isti-vclab/meshlab was verified as official when first introduced to the cask
-  url "https://github.com/cnr-isti-vclab/meshlab/releases/download/v#{version}/MeshLab#{version}.dmg"
+  url "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-#{version}/MeshLab#{version}-macos.dmg"
   appcast 'https://github.com/cnr-isti-vclab/meshlab/releases.atom'
   name 'MeshLab'
   homepage 'http://www.meshlab.net/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.