### PR TITLE
Update doomsday-engine from 2.1.1 to 2.2.2

### DIFF
--- a/Casks/doomsday-engine.rb
+++ b/Casks/doomsday-engine.rb
@@ -1,6 +1,6 @@
 cask 'doomsday-engine' do
-  version '2.1.1'
-  sha256 '144a98dc5ff99f84b92556295f750e5b9d3fbcdcc235082dec9da7fcff1bcb58'
+  version '2.2.2'
+  sha256 'da2d59a5f548bfa686a55e418c1b342997aded307e3f60bfcc20ca39344b529a'
 
   url "https://files.dengine.net/archive/doomsday_#{version}_x86_64.dmg"
   appcast 'http://api.dengine.net/1/builds/feed'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.