### PR TITLE
Add Collabshot.app v1.2.3.985

### DIFF
--- a/Casks/collabshot.rb
+++ b/Casks/collabshot.rb
@@ -1,6 +1,6 @@
 cask 'collabshot' do
   version '1.2.3.985'
-  sha256 '30bffefc6baf6c34966d746bef57929027863451'
+  sha256 'a2d298dc2e6cf813c90c5dc64d9eaedf5ff4ef2e0ad45001d35ecefc511390c3'
 
   url "https://collabshot.s3.amazonaws.com/desktop/builds/mac/Collabshot_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.collabshot.com/desktop/latest/mac'

--- a/Casks/collabshot.rb
+++ b/Casks/collabshot.rb
@@ -2,7 +2,7 @@ cask 'collabshot' do
   version '1.2.3.985'
   sha256 '30bffefc6baf6c34966d746bef57929027863451'
 
-  url 'https://collabshot.s3.amazonaws.com/desktop/builds/mac/Collabshot_#{version}.dmg'
+  url "https://collabshot.s3.amazonaws.com/desktop/builds/mac/Collabshot_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.collabshot.com/desktop/latest/mac'
   name 'Collabshot'
   homepage 'https://www.collabshot.com/'

--- a/Casks/collabshot.rb
+++ b/Casks/collabshot.rb
@@ -1,8 +1,8 @@
 cask 'collabshot' do
-  version :latest
-  sha256 :no_check
+  version '1.2.3.985'
+  sha256 '30bffefc6baf6c34966d746bef57929027863451'
 
-  url 'https://api.collabshot.com/desktop/latest/mac'
+  url 'https://collabshot.s3.amazonaws.com/desktop/builds/mac/Collabshot_#{version}.dmg'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.collabshot.com/desktop/latest/mac'
   name 'Collabshot'
   homepage 'https://www.collabshot.com/'

--- a/Casks/collabshot.rb
+++ b/Casks/collabshot.rb
@@ -2,6 +2,7 @@ cask 'collabshot' do
   version '1.2.3.985'
   sha256 'a2d298dc2e6cf813c90c5dc64d9eaedf5ff4ef2e0ad45001d35ecefc511390c3'
 
+  # collabshot.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://collabshot.s3.amazonaws.com/desktop/builds/mac/Collabshot_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.collabshot.com/desktop/latest/mac'
   name 'Collabshot'

--- a/Casks/collabshot.rb
+++ b/Casks/collabshot.rb
@@ -3,6 +3,7 @@ cask 'collabshot' do
   sha256 :no_check
 
   url 'https://api.collabshot.com/desktop/latest/mac'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.collabshot.com/desktop/latest/mac'
   name 'Collabshot'
   homepage 'https://www.collabshot.com/'
 

--- a/Casks/collabshot.rb
+++ b/Casks/collabshot.rb
@@ -1,0 +1,10 @@
+cask 'collabshot' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://api.collabshot.com/desktop/latest/mac'
+  name 'Collabshot'
+  homepage 'https://www.collabshot.com/'
+
+  app 'Collabshot.app'
+end


### PR DESCRIPTION
Collabshot is a collaborative screenshot app, developed by Toptal.
The download link is unversioned and will always provide the latest version,
so there is no check for the sha256.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256