### PR TITLE
Update maintenance from 2.6.3 to 2.6.4

### DIFF
--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -18,8 +18,8 @@ cask 'maintenance' do
     version '2.5.6'
     sha256 'd3b0152ce543b84ed597daba3360f74c3f20b4fb2b41d71005f3a7b311d4d681'
   else
-    version '2.6.3'
-    sha256 '6a358be5c5b1faf949c5b5e040dc1826ad63fe2298cbfa4af55138ec89191fac'
+    version '2.6.4'
+    sha256 'd3b0152ce543b84ed597daba3360f74c3f20b4fb2b41d71005f3a7b311d4d681'
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/Maintenance.dmg"

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -19,7 +19,7 @@ cask 'maintenance' do
     sha256 'd3b0152ce543b84ed597daba3360f74c3f20b4fb2b41d71005f3a7b311d4d681'
   else
     version '2.6.4'
-    sha256 'd3b0152ce543b84ed597daba3360f74c3f20b4fb2b41d71005f3a7b311d4d681'
+    sha256 'be94c093f030240da2a63207a8c8d2a16e64a7aac1c04e225ac6ffb3d3f0844e'
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete('.')}/Maintenance.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.