### PR TITLE
Update firecamp from 1.0.0 to 1.0.1

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask 'firecamp' do
-  version '1.0.0'
-  sha256 'a49a87342707b745d98a58ccec2a5db18af67c3f72a537481dca878f713486b7'
+  version '1.0.1'
+  sha256 '9e55a4e6ba354babc7adf9d935136afc5ceddf46edfcb10b1c90b5ed17c7ac7c'
 
   # firecamp.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.