### PR TITLE
Update mullvadvpn from 2020.2 to 2020.3

### DIFF
--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -1,6 +1,6 @@
 cask 'mullvadvpn' do
-  version '2020.2'
-  sha256 'ad959d3bed0674ead61d44f20f239aa5d04fbf9705ff74be6f005834268c2ad6'
+  version '2020.3'
+  sha256 '9be5918608c89a4d49a55996f7897796c06ce6e6092588ed9ded809dd0526d5a'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.