### PR TITLE
Update auryo from 2.4.0 to 2.5.1

### DIFF
--- a/Casks/auryo.rb
+++ b/Casks/auryo.rb
@@ -1,6 +1,6 @@
 cask 'auryo' do
-  version '2.4.0'
-  sha256 '7e7bd35e03662a61f63a224ecd4364b0bdaa4e4c3cc8f174b671f8627ff334fe'
+  version '2.5.1'
+  sha256 '3434bccbcba37f7990a5ab08d2bf482bdc1b56d0c4b542adc27c6289f839534b'
 
   # github.com/Superjo149/auryo was verified as official when first introduced to the cask
   url "https://github.com/Superjo149/auryo/releases/download/v#{version}/Auryo-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.