### PR TITLE
Update prezi-next from 1.41.0 to 1.41.1

### DIFF
--- a/Casks/prezi-next.rb
+++ b/Casks/prezi-next.rb
@@ -1,6 +1,6 @@
 cask 'prezi-next' do
-  version '1.41.0'
-  sha256 'c40d2a41ef37290c819770f2b0a5b47764b1717bb464834b5e08258269febcbf'
+  version '1.41.1'
+  sha256 '297c37566a259f39ed9a2347892e36fa5252fbd248d3b9fb94f536711868a6bf'
 
   url "https://desktopassets.prezi.com/mac/pitch/releases/Prezi_Next_#{version}.dmg"
   appcast 'https://prezidesktop.s3.amazonaws.com/assets/mac/pitch/updates/prezi-business.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.