### PR TITLE
Update brave-browser from 80.1.3.115,103.115 to 80.1.3.118,103.118

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '80.1.3.115,103.115'
-  sha256 'c79cb879119a5ad95f4f2373b100d2e0469158e0b0b696a93b6a604bd1c20462'
+  version '80.1.3.118,103.118'
+  sha256 '82d65d37b64a092373379684c0f2b6d2174fa9a20a6006ef4de4e98cbbf4b0d4'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/#{version.after_comma}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.