### PR TITLE
Update yinxiangbiji from 9.2.6_459459 to 9.3.0_459506

### DIFF
--- a/Casks/yinxiangbiji.rb
+++ b/Casks/yinxiangbiji.rb
@@ -1,6 +1,6 @@
 cask 'yinxiangbiji' do
-  version '9.2.6_459459'
-  sha256 '8d8c9777a3a7214aaa646c97d092c53f61495eadce4d97b43aaa664beb6486b9'
+  version '9.3.0_459506'
+  sha256 'bbdebc54153b8183b23f0cd9187048e66c3ebc30509aa02423f10ee9afdf5469'
 
   url "https://cdn.yinxiang.com/mac-smd/public/YinxiangBiji_RELEASE_#{version}.dmg"
   appcast 'https://update.yinxiang.com/public/ENMacSMD/EvernoteMacUpdate.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.