### PR TITLE
Update glyphs from 2.6.5,1295 to 2.6.5,1296

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.5,1295'
-  sha256 '2474a7da0edd69ee8f95cf52afafbd572798b3a07a57146003b0901f607b7efe'
+  version '2.6.5,1296'
+  sha256 '44c16bac5a20c3387673adf3ab7734e252abe4f1fffd460b16e87a74518fef3f'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.