### PR TITLE
Update wavebox from 10.0.82.1 to 10.0.86.1

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '10.0.82.1'
-  sha256 '8149c61fdfeb97b1cfa2e28840eac5d662b60f0aad3ce72d53ac259ff888c71f'
+  version '10.0.86.1'
+  sha256 'e1f4d9074167ab7b4957f49ba80626ff6f3e12205069ae4d94f4eedee9f74759'
 
   # download.wavebox.app was verified as official when first introduced to the cask
   url "https://download.wavebox.app/core/mac/Install%20Wavebox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.