### PR TITLE
Update chronosync from 4.9.8 to 4.9.9

### DIFF
--- a/Casks/chronosync.rb
+++ b/Casks/chronosync.rb
@@ -1,6 +1,6 @@
 cask 'chronosync' do
-  version '4.9.8'
-  sha256 'af52fbc8e762317ed3b38ef7a02d73bb20aacafc05867c587184ba629d295182'
+  version '4.9.9'
+  sha256 '39133ad9ba812efe2a2d0740ca2f85b0d79c07251805363a5bc3b790affc2b6e'
 
   url 'https://downloads.econtechnologies.com/CS4_Download.dmg'
   appcast "https://www.econtechnologies.com/UC/updatecheck.php?prod=ChronoSync&vers=#{version.major_minor}.0&lang=en&plat=mac&os=10.14.1&hw=i64&req=1"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.