### PR TITLE
Update runway from 0.10.27 to 0.10.28

### DIFF
--- a/Casks/runway.rb
+++ b/Casks/runway.rb
@@ -1,6 +1,6 @@
 cask 'runway' do
-  version '0.10.27'
-  sha256 '27a463abc167de15ece1fb9dee6a68fb3202749965cdf6b960ca630735620ef0'
+  version '0.10.28'
+  sha256 'b59c4bfa2b00e2f84a6579c486fc37fe0250189f1441f5ad60259012c91aacf5'
 
   # runway-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://runway-releases.s3.amazonaws.com/Runway-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.