### PR TITLE
Update avocode from 4.4.0 to 4.4.1

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.4.0'
-  sha256 'c2c6784a8cc030c30807ac5510846e47d8202f7342fd0570ba2d665a42560983'
+  version '4.4.1'
+  sha256 '6ef3982cfd48531a036410992bab4fa7ef228a07276cd5fd5c28b2a0dfbe192f'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.