### PR TITLE
Update react-studio from 1.7.8,370 to 1.7.9,372

### DIFF
--- a/Casks/react-studio.rb
+++ b/Casks/react-studio.rb
@@ -1,6 +1,6 @@
 cask 'react-studio' do
-  version '1.7.8,370'
-  sha256 '4ed31a23ac7554a2f6be5cf4c914b7c54ef85b7ceb08cc368c5757e29a47c265'
+  version '1.7.9,372'
+  sha256 'fdbda36703ea770a24a0ecfa9b799ca41cf6ebb5efde23221a78faecab6740fb'
 
   # s3.amazonaws.com/sc.neonto.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/sc.neonto.com/ReactStudio_v#{version.before_comma.no_dots}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.