### PR TITLE
Update sitebulb from 3.3 to 3.3.1

### DIFF
--- a/Casks/sitebulb.rb
+++ b/Casks/sitebulb.rb
@@ -1,6 +1,6 @@
 cask 'sitebulb' do
-  version '3.3'
-  sha256 '494f3ce9cfd56f918ca299e262d7851a784e18de6c73f1d63f4b34b71a41265b'
+  version '3.3.1'
+  sha256 '3a6510e9e919951eff36b1c0414c533ddc8f445e7167bc9220ae1efcbec30940'
 
   url "https://downloads.sitebulb.com/#{version}/macOS/Sitebulb.dmg"
   appcast 'https://sitebulb.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.