### PR TITLE
Update sunvox from 1.9.5 to 1.9.5d

### DIFF
--- a/Casks/sunvox.rb
+++ b/Casks/sunvox.rb
@@ -1,6 +1,6 @@
 cask 'sunvox' do
-  version '1.9.5'
-  sha256 'b11104a4e3925944bb005a29eda49e6f58cfb6fe2605dc7bb67b62bc9ef22c04'
+  version '1.9.5d'
+  sha256 '90c539f4b1ab0165c24363a4dd8b5d6b3c7efbd91ac5f9df8e143732db60fe96'
 
   url "https://www.warmplace.ru/soft/sunvox/sunvox-#{version}.zip"
   appcast 'https://www.warmplace.ru/soft/sunvox/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.