### PR TITLE
Update geph from 3.4.0 to 3.4.1

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.4.0'
-  sha256 'ee8187acac69f62e448fa1515269f29a52c1cc54205a4ccede3d7a409b4c4d7d'
+  version '3.4.1'
+  sha256 'fa7ecfa71bd0f1d1ee0a4a3affbe6e852b9f70b99dd224259a613d4848210f0d'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.