### PR TITLE
Update wechatwork to 3.0.10.2094

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.8.2080'
-  sha256 '2fac3e3b6b6fb7b1a933dd69e8df62cc213fac555d03298bfec4a515f137f035'
+  version '3.0.10.2094'
+  sha256 '119021f1f3ead74aa40d1fcb1e83053abad74a984cef9440c6dfb68add72e1c5'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.