### PR TITLE
Update simply-fortran from 3.8.3163 to 3.9.3177

### DIFF
--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -1,9 +1,9 @@
 cask 'simply-fortran' do
-  version '3.8.3163'
-  sha256 '2b65975136881df56cc275fae30b810b7ca4e4c2cd11668ee41375eb52a24b69'
+  version '3.9.3177'
+  sha256 'a065bcd451ae10556099bb1bd6847f366483448f3c2cd6521bf97c1a9418d0ed'
 
-  # download.approximatrix.com/simplyfortran was verified as official when first introduced to the cask
-  url "https://download.approximatrix.com/simplyfortran/#{version.major_minor}/simplyfortran-#{version}.dmg"
+  # simplyfortran.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
+  url "https://simplyfortran.nyc3.digitaloceanspaces.com/#{version.major_minor}/macos/simplyfortran-#{version}.dmg"
   appcast 'https://simplyfortran.com/download/?platform=macos',
           configuration: version.major_minor
   name 'Simply Fortran'

--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -2,8 +2,7 @@ cask 'simply-fortran' do
   version '3.9.3177'
   sha256 'a065bcd451ae10556099bb1bd6847f366483448f3c2cd6521bf97c1a9418d0ed'
 
-  # simplyfortran.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
-  url "https://simplyfortran.nyc3.digitaloceanspaces.com/#{version.major_minor}/macos/simplyfortran-#{version}.dmg"
+  url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}.dmg"
   appcast 'https://simplyfortran.com/download/?platform=macos',
           configuration: version.major_minor
   name 'Simply Fortran'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.