### PR TITLE
Revert "Update navicat-for-oracle from 15.0.8 to 15.0.10"

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '15.0.10'
-  sha256 '25215fe54888370a17f1217bf658992ac017e29119e69d917dd2377c775f1f24'
+  version '15.0.8'
+  sha256 '7c6312f3f81dc476d9e39527e200d67c6bc28b5e444846509030faabe8762580'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#77444
The download still contains v 15.0.8