### PR TITLE
Update losslesscut from 3.4.0 to 3.7.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '3.4.0'
-  sha256 'd7fbac704ff73e16c8f18bd75af3958a5e7c09c3b3352dcb4c21b528abed54d7'
+  version '3.7.0'
+  sha256 'b5327c1fc9c3e089a124f8d3588ec1e367348e1fc15256dcaf33c454e19881fd'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.