### PR TITLE
Update electronmail from 4.2.2 to 4.3.0

### DIFF
--- a/Casks/electronmail.rb
+++ b/Casks/electronmail.rb
@@ -1,6 +1,6 @@
 cask 'electronmail' do
-  version '4.2.2'
-  sha256 '5f3d9d3deb327c8812e0283ba5489e24b1e4ce9c6a1c10a94aee111c0c5cfe04'
+  version '4.3.0'
+  sha256 '93ae03db3a4bee735e9247e1dbe77cbc197e0e51d26c6f66a92507ad33b77f0d'
 
   url "https://github.com/vladimiry/ElectronMail/releases/download/v#{version}/electron-mail-#{version}-mac-mojave.dmg"
   appcast 'https://github.com/vladimiry/ElectronMail/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.