### PR TITLE
Revert "Update navicat-for-mysql from 15.0.8 to 15.0.10"

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '15.0.10'
-  sha256 '980393bfb7346a81b64cc5549fd8b1088d6d73fb25f8418003a24150bc96f72c'
+  version '15.0.8'
+  sha256 'fb27435d994cf76dbfe47f37d244f64a4b7d17bf7acc34685414b171f43d53f1'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#77440
Download still contains 15.0.8