### PR TITLE
Revert "Update navicat-for-postgresql from 15.0.8 to 15.0.10"

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.10'
-  sha256 '1d859a1d7a0dfcd0f801aad04ff0cb5a0363beb9c120f8c7b6f7864c4d6d727a'
+  version '15.0.8'
+  sha256 '37c77372829f0766c16a4ca30faf3cf4e78f366a541c00d313bdab26692b1cf8'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#77435
download still contains 15.0.8