### PR TITLE
Update tinderbox from 8.2.3 to 8.5.0

### DIFF
--- a/Casks/tinderbox.rb
+++ b/Casks/tinderbox.rb
@@ -4,8 +4,8 @@ cask 'tinderbox' do
     sha256 '765a6245d25f9c2185802f36caa1f620f276637b884260fffa74bf639670e211'
     app 'TinderboxSix.app'
   else
-    version '8.2.3'
-    sha256 '5e415ec482106b9ae185aea19aa125dd0b714034ca70d372b8af59b8167e0244'
+    version '8.5.0'
+    sha256 '14628024ea508f27787d7ef0b81239cdadbc9351c596544767ba7f6e3ad5b198'
     app "Tinderbox #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.