### PR TITLE
Update second-life-viewer from 6.3.6.535003 to 6.3.7.535996

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.3.6.535003'
-  sha256 '2068f3885bb60f20787dfe2f7f0d537008f980d194ef123e0ac77b7053354961'
+  version '6.3.7.535996'
+  sha256 '848e89a6c8e3edfe0d2bfb2c23ce28067601cc3b12dca69be2fb6e3aefde81bb'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.