### PR TITLE
Update preform from 3.3.3,1762 to 3.4.0,132

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.3.3,1762'
-  sha256 '530c9159723ec4c247c406b127c8495579b2b8ddc66c7e1af45f0e315c5839e3'
+  version '3.4.0,132'
+  sha256 '73e1dd2c71f0bfc5ed041739e7a02ef1ef323bf0e0277584d9518c6fd0a68b17'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.