### PR TITLE
Update geogebra from 6.0.573.0 to 6.0.574.0

### DIFF
--- a/Casks/geogebra.rb
+++ b/Casks/geogebra.rb
@@ -1,6 +1,6 @@
 cask 'geogebra' do
-  version '6.0.573.0'
-  sha256 'a7fbd0f5bf5937142bfa63d144faebc532e8cf1a5835f52e23aa48b82f73706e'
+  version '6.0.574.0'
+  sha256 '0e339e6f12690b60e03ae3f705f9877416db72616c0e5db87f6776b956ba6d9e'
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-6-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   appcast "https://download.geogebra.org/installers/#{version.major_minor}/version.txt",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.