### PR TITLE
Update rotato from 79.1581347543 to 84.1582301026

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '79.1581347543'
-  sha256 '50917acde87af872c89baf11b9e2d7788dbd3b0f6a496a530894a4895661722a'
+  version '84.1582301026'
+  sha256 'e52c58419eada696980966e2c655dae4bedeeec40c8bc091bc4f6213d085d218'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.