### PR TITLE
Update middleclick from 2.4.8 to 2.4.8.1

### DIFF
--- a/Casks/middleclick.rb
+++ b/Casks/middleclick.rb
@@ -1,6 +1,6 @@
 cask 'middleclick' do
-  version '2.4.8'
-  sha256 '764b74654129267b40fb7ff1c733b6acf3b61613b90bbf4bb63e0cfef60e0700'
+  version '2.4.8.1'
+  sha256 'c17d944d9305d6da6c949ab1d5032326668d0e9dbd38ef3061955af4484d3f62'
 
   url "https://github.com/DaFuqtor/MiddleClick/releases/download/#{version}/MiddleClick.zip"
   appcast 'https://github.com/DaFuqtor/MiddleClick/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).