### PR TITLE
Update patchwork from 3.17.4 to 3.17.5

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.17.4'
-  sha256 '8ef7ae979763bb5b357e8db30b01b90d21405e847959e5680c150d82a1f80e9e'
+  version '3.17.5'
+  sha256 '3ba1a780a0a218ed91d12dc7a0d5a26d452037b31180498b3d5302cf777da149'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.