### PR TITLE
Add mojave case to touch-bar-simulator + update to 4.1.0

### DIFF
--- a/Casks/touch-bar-simulator.rb
+++ b/Casks/touch-bar-simulator.rb
@@ -2,13 +2,15 @@ cask 'touch-bar-simulator' do
   if MacOS.version <= :high_sierra
     version '1.2.0'
     sha256 '4abe55de716ae56a41031cdb1d3b27bf6b1efae18b33b80bb0419669a9a76aa1'
-    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch-Bar-Simulator-#{version}.dmg"
-  else
+  elsif MacOS.version <= :mojave
     version '3.2.0'
     sha256 'bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6'
-    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
+  else
+    version '4.1.0'
+    sha256 'bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6'
   end
 
+  url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
   appcast 'https://github.com/sindresorhus/touch-bar-simulator/releases.atom'
   name 'Touch Bar Simulator'
   homepage 'https://github.com/sindresorhus/touch-bar-simulator'

--- a/Casks/touch-bar-simulator.rb
+++ b/Casks/touch-bar-simulator.rb
@@ -2,6 +2,8 @@ cask 'touch-bar-simulator' do
   if MacOS.version <= :high_sierra
     version '1.2.0'
     sha256 '4abe55de716ae56a41031cdb1d3b27bf6b1efae18b33b80bb0419669a9a76aa1'
+ 
+    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch-Bar-Simulator-#{version}.dmg"
   elsif MacOS.version <= :mojave
     version '3.2.0'
     sha256 'bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6'

--- a/Casks/touch-bar-simulator.rb
+++ b/Casks/touch-bar-simulator.rb
@@ -2,7 +2,7 @@ cask 'touch-bar-simulator' do
   if MacOS.version <= :high_sierra
     version '1.2.0'
     sha256 '4abe55de716ae56a41031cdb1d3b27bf6b1efae18b33b80bb0419669a9a76aa1'
- 
+
     url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch-Bar-Simulator-#{version}.dmg"
   elsif MacOS.version <= :mojave
     version '3.2.0'

--- a/Casks/touch-bar-simulator.rb
+++ b/Casks/touch-bar-simulator.rb
@@ -7,7 +7,7 @@ cask 'touch-bar-simulator' do
     sha256 'bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6'
   else
     version '4.1.0'
-    sha256 'bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6'
+    sha256 '95e098b5b78f5f3c2ab0e49d4c0341f9f71fdf87d2924c8c2af0e18073f311dd'
   end
 
   url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"

--- a/Casks/touch-bar-simulator.rb
+++ b/Casks/touch-bar-simulator.rb
@@ -7,12 +7,15 @@ cask 'touch-bar-simulator' do
   elsif MacOS.version <= :mojave
     version '3.2.0'
     sha256 'bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6'
+
+    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
   else
     version '4.1.0'
     sha256 '95e098b5b78f5f3c2ab0e49d4c0341f9f71fdf87d2924c8c2af0e18073f311dd'
+
+    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
   end
 
-  url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
   appcast 'https://github.com/sindresorhus/touch-bar-simulator/releases.atom'
   name 'Touch Bar Simulator'
   homepage 'https://github.com/sindresorhus/touch-bar-simulator'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.