### PR TITLE
Update unity-android-support-for-editor from 2019.3.1f1,89d6087839c2 to 2019.3.2f1,c46a3a38511e

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.1f1,89d6087839c2'
-  sha256 '38fe42f163eee1031194147298ca195116b918f64be702415ed7973026866be6'
+  version '2019.3.2f1,c46a3a38511e'
+  sha256 'e366914f24d4a1a6b456ac33504442e5d2d6fca4673da486dcb205065235d19d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.