### PR TITLE
Update unity-download-assistant from 2019.3.1f1,89d6087839c2 to 2019.3.2f1,c46a3a38511e

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.1f1,89d6087839c2'
-  sha256 '6b8343bed77f8070246abf6015853a08588b3f2a5bf90f5bd045ddda859fe3af'
+  version '2019.3.2f1,c46a3a38511e'
+  sha256 'd87bb07acba10b03fdb8d56a1c8de6cc2d2a7efb82025ee88f97e4c1215c77a6'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.