### PR TITLE
Update unity-ios-support-for-editor from 2019.3.1f1,89d6087839c2 to 2019.3.2f1,c46a3a38511e

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.1f1,89d6087839c2'
-  sha256 '051098b10fa693b9a43d6994956b25909b169c7b39c0ab5cff8841d38be3fc73'
+  version '2019.3.2f1,c46a3a38511e'
+  sha256 'f57193e78b8be750d3e73e435f326735f6d47af5b1329ca1fa0a8e76d97b3625'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.