### PR TITLE
Update unity-lumin-support-for-editor from 2019.3.1f1,89d6087839c2 to 2019.3.2f1,c46a3a38511e

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.3.1f1,89d6087839c2'
-  sha256 'be552ff4b09b131910da817c14b5b21fd6e54998849cc0d3e605bb3abe27fb9e'
+  version '2019.3.2f1,c46a3a38511e'
+  sha256 '69ee70e39eee65f579009d751aae05a258b7f8a925d16d6b612babd2232c7015'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.