### PR TITLE
Update unity-webgl-support-for-editor from 2019.3.1f1,89d6087839c2 to 2019.3.2f1,c46a3a38511e

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.3.1f1,89d6087839c2'
-  sha256 '7b75e5509d70139be6dd4d4c7fc03fe3fd21d7c2e29d49a15ba72663e34025d0'
+  version '2019.3.2f1,c46a3a38511e'
+  sha256 'b5a4b1f01d1033dbeee0c5e610794f30234c349aae9dda7fe92184bf35151b48'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.