### PR TITLE
Update unity-windows-support-for-editor from 2019.3.1f1,89d6087839c2 to 2019.3.2f1,c46a3a38511e

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.3.1f1,89d6087839c2'
-  sha256 '7e379ac48d18ec1fdc58298b7cff828dde31fe372e088db2cc25eb9e9e485fd2'
+  version '2019.3.2f1,c46a3a38511e'
+  sha256 'b0ae6a42e051806642d0cba6c74a49e10aeeae9f11123af7b62f5ebd43ac8f19'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.