### PR TITLE
Update sqlpro-for-postgres from 2020.10 to 2020.14

### DIFF
--- a/Casks/sqlpro-for-postgres.rb
+++ b/Casks/sqlpro-for-postgres.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-postgres' do
-  version '2020.10'
-  sha256 '93c23dd63ddc007071b2ab2463f5a1f02ff6e0801af5bdb766432699c093e6cc'
+  version '2020.14'
+  sha256 '6f10aebbef223021e59d2feb65b60000e644d8c9838948855fa4791649799ad8'
 
   # d3fwkemdw8spx3.cloudfront.net/postgres was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/postgres/SQLProPostgres.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.