### PR TITLE
Update ark-desktop-wallet from 2.8.0 to 2.8.1

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.8.0'
-  sha256 '9edc88ae490fc40f6544be26f473d0ba0249ed6facc6575c63e657504e987e76'
+  version '2.8.1'
+  sha256 'fb455c3080e4894df1f0320b5559d265c2750d7c0f45c9808245d586effe7eaf'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.