### PR TITLE
Update emclient from 7.2.37943 to 7.2.37961

### DIFF
--- a/Casks/emclient.rb
+++ b/Casks/emclient.rb
@@ -1,6 +1,6 @@
 cask 'emclient' do
-  version '7.2.37943'
-  sha256 '3d19538e92a62931582d9cd5c9bca554fa08258ab91134bde1122e46903ea098'
+  version '7.2.37961'
+  sha256 '4b38b07cb6b172e92aeb9b91482b560bda1cb8dbaf728440201ce6e584fcea81'
 
   url "https://cdn-dist.emclient.com/dist/v#{version}_Mac/setup.pkg"
   appcast 'https://www.emclient.com/release-history?os=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.