### PR TITLE
Update remote-desktop-manager-free from 2020.1.4.0 to 2020.1.5.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '2020.1.4.0'
-  sha256 '470c40326173219f2faa6dbbba84608298e53710c45f57069c4ee765cae73911'
+  version '2020.1.5.0'
+  sha256 '892891f144621e1f7ebc7517c45f589efdc99914921f9f0a26aff073869715c9'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.