### PR TITLE
Update calibre from 4.11.1 to 4.11.2

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -4,8 +4,8 @@ cask 'calibre' do
     sha256 '68829cd902b8e0b2b7d5cf7be132df37bcc274a1e5720b4605d2dd95f3a29168'
     url "https://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"
   else
-    version '4.11.1'
-    sha256 '6293f8990eef17806c64b179223aa3370866543d43c7d3fe47336c0fbdefca09'
+    version '4.11.2'
+    sha256 '634e68c8103c5fe22167de02d4e6c725adfc52db2722668e74977139f48d85bc'
     url "https://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"
     appcast 'https://github.com/kovidgoyal/calibre/releases.atom'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.