### PR TITLE
Concept2 utility

### DIFF
--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -1,15 +1,17 @@
 cask 'concept2-utility' do
-    if MacOS.version <= :el_capitan
-        version '7.09.02'
-        sha256 'e4ebee8cde57c7ef63c3903285c3fc0ee8f87221e7c5529b9dcf97b3f9ebb57e'
-    else
-        version '7.09.07'
-        sha256 '425e81c49d52ea1f3a84a9a1e004beaacee0b7556a03235d8be7a9869b81adcd'
-    end
+  if MacOS.version <= :el_capitan
+    version '7.09.02'
+    sha256 'e4ebee8cde57c7ef63c3903285c3fc0ee8f87221e7c5529b9dcf97b3f9ebb57e'
+  else
+    version '7.09.07'
+    sha256 '425e81c49d52ea1f3a84a9a1e004beaacee0b7556a03235d8be7a9869b81adcd'
+  end
 
-    url "http://software.concept2.com/utility/Concept2Utility#{version}.dmg"
-    name 'Concept2 Utility'
-    homepage 'http://www.concept2.com/service/software/concept2-utility'
-    depends_on macos: '>= :yosemite'
-    app 'Concept2 Utility.app'
+  url "https://software.concept2.com/utility/Concept2Utility#{version.split('.').join('')}.dmg"
+  name 'Concept2 Utility'
+  homepage 'https://www.concept2.com/service/software/concept2-utility'
+
+  depends_on macos: '>= :yosemite'
+
+  app 'Concept2 Utility.app'
 end

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -13,5 +13,9 @@ cask 'concept2-utility' do
 
   depends_on macos: '>= :yosemite'
 
-  app 'Concept2 Utility.app'
+  pkg "Concept2 Utility #{version}.pkg"
+
+  uninstall pkgutil: [
+                       'com.concept2.pkg.Concept2Utility',
+                     ]
 end

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -1,0 +1,15 @@
+cask 'concept2-utility' do
+    if MacOS.version <= :el_capitan
+        version '7.09.02'
+        sha256 'e4ebee8cde57c7ef63c3903285c3fc0ee8f87221e7c5529b9dcf97b3f9ebb57e'
+    else
+        version '7.09.07'
+        sha256 '425e81c49d52ea1f3a84a9a1e004beaacee0b7556a03235d8be7a9869b81adcd'
+    end
+
+    url "http://software.concept2.com/utility/Concept2Utility#{version}.dmg"
+    name 'Concept2 Utility'
+    homepage 'http://www.concept2.com/service/software/concept2-utility'
+    depends_on macos: '>= :yosemite'
+    app 'Concept2 Utility.app'
+end


### PR DESCRIPTION
The Concept2 Utility is free software that allows you to update the firmware on your Performance Monitor and manage the workout data on your USB flash drive or Concept2 LogCard. You can also upload your workout data to your Online Logbook at concept2.com.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x ] The commit message includes the cask’s name and version.
- [ x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ x ] Named the cask according to the [token reference].
- [ x ] `brew cask install {{cask_file}}` worked successfully.
- [ x ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ x ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ x ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

There was a refused PR https://github.com/Homebrew/homebrew-cask/pull/40120 but it was a really old one and it seems that understanding of the application was not correct so that it was wrongly proposed to be moved to [caskroom/drivers](https://github.com/caskroom/homebrew-drivers) because this is not a driver on it's own, but it can manage firmware update for the training machines, it gives some additional abilities that makes this app more then just an driver.
