### PR TITLE
Update electronmail from 4.3.0 to 4.4.0

### DIFF
--- a/Casks/electronmail.rb
+++ b/Casks/electronmail.rb
@@ -1,6 +1,6 @@
 cask 'electronmail' do
-  version '4.3.0'
-  sha256 '93ae03db3a4bee735e9247e1dbe77cbc197e0e51d26c6f66a92507ad33b77f0d'
+  version '4.4.0'
+  sha256 'b700078c86f8d57cdd15d09edf5dd1ac55e7eeea7ff43d45d990dfdb903da04d'
 
   url "https://github.com/vladimiry/ElectronMail/releases/download/v#{version}/electron-mail-#{version}-mac-mojave.dmg"
   appcast 'https://github.com/vladimiry/ElectronMail/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.