### PR TITLE
Update quodlibet from 4.2.1 to 4.3.0

### DIFF
--- a/Casks/quodlibet.rb
+++ b/Casks/quodlibet.rb
@@ -1,6 +1,6 @@
 cask 'quodlibet' do
-  version '4.2.1'
-  sha256 '83df46eae3b7dd9d2b2e4c3ce659f4d3dff2f2a9a38dd3e6bf18b7fed1edbea3'
+  version '4.3.0'
+  sha256 '858afc8630d0df974466c7d4123ca7c46d0fa81c24ef3c25a5dc780f3334ef08'
 
   # github.com/quodlibet/quodlibet was verified as official when first introduced to the cask
   url "https://github.com/quodlibet/quodlibet/releases/download/release-#{version}/QuodLibet-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.