### PR TITLE
Update cracked from 0.2.12 to 0.2.13

### DIFF
--- a/Casks/cracked.rb
+++ b/Casks/cracked.rb
@@ -1,6 +1,6 @@
 cask 'cracked' do
-  version '0.2.12'
-  sha256 '7c57781085c901df9e67368a72c8fe93883fe4657ed92b8ef22d7338df981dae'
+  version '0.2.13'
+  sha256 'e564ea4701f791b2176b45c933714b3c78915dce14b83df419b5216dfaf1ab9b'
 
   url "https://github.com/billorcutt/Cracked/releases/download/#{version}/Cracked.dmg"
   appcast 'https://github.com/billorcutt/Cracked/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.