### PR TITLE
Update editaro from 1.5.1 to 1.6.1

### DIFF
--- a/Casks/editaro.rb
+++ b/Casks/editaro.rb
@@ -1,6 +1,6 @@
 cask 'editaro' do
-  version '1.5.1'
-  sha256 '2b7708d762147b8213a5e191fd86a97071c2e82671668e57c79e74f4eb643d9c'
+  version '1.6.1'
+  sha256 'a1fe9a2c3279a7632e0fb6e0e9239f08594fe5d6e6a2dbaa37e164516783e97e'
 
   # github.com/kkosuge/editaro was verified as official when first introduced to the cask
   url "https://github.com/kkosuge/editaro/releases/download/#{version}/Editaro-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.