### PR TITLE
Update universal-media-server from 9.2.0 to 9.3.0

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,6 +1,6 @@
 cask 'universal-media-server' do
-  version '9.2.0'
-  sha256 '36d90cf4f7f440d1b9ea62dc5a326911f40b960e8d836b5b9aba9e637ce61772'
+  version '9.3.0'
+  sha256 '253415f252f979fb515dcecd3d498223d6010dc1cbf9830ea9f743f9500b80a2'
 
   # github.com/UniversalMediaServer/UniversalMediaServer was verified as official when first introduced to the cask
   url "https://github.com/UniversalMediaServer/UniversalMediaServer/releases/download/#{version}/UMS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.