### PR TITLE
Update fontlab from 7.0.1.7276 to 7.1.0.7355

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,6 +1,6 @@
 cask 'fontlab' do
-  version '7.0.1.7276'
-  sha256 '0ce2655f7238c5b7a29308a124ba2e1790fafd4103a7545d779672f5354ca4f6'
+  version '7.1.0.7355'
+  sha256 'bde40abbbfc5048b58ec41d9f797ae65ac405b384df03358fe40101a938c7805'
 
   # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fontlab.s3.amazonaws.com/fontlab-#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.