### PR TITLE
Update imitone from 0.10.0b to 0.10.0c

### DIFF
--- a/Casks/imitone.rb
+++ b/Casks/imitone.rb
@@ -1,6 +1,6 @@
 cask 'imitone' do
-  version '0.10.0b'
-  sha256 'bd04abd9ab61c23eb0a94d0c1da0158f265d33462b6d5b6c71cd6a3a5ec21265'
+  version '0.10.0c'
+  sha256 '18aedd3b06737cbb71e04260c5e79a0c541d6f8b2745c7679fe4777fca515cf0'
 
   url "https://imitone.com/beta/imitone-#{version}.dmg"
   appcast 'https://imitone.com/beta/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.