### PR TITLE
Update hbuilderx from 2.5.1.20200103 to 2.6.0.20200223

### DIFF
--- a/Casks/hbuilderx.rb
+++ b/Casks/hbuilderx.rb
@@ -1,6 +1,6 @@
 cask 'hbuilderx' do
-  version '2.5.1.20200103'
-  sha256 'c903859c373d6c430d280b646d072e4328eb4a70c753834e3f9ccde2c8078bc0'
+  version '2.6.0.20200223'
+  sha256 'b6da09883b339395b277dc75dc3a0f2a549ac7e2a49258ce6f85292703b7913a'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "https://download.dcloud.net.cn/HBuilderX.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.