### PR TITLE
Update QGIS 3.10.2 to 3.12.0

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,6 +1,6 @@
 cask 'qgis' do
-  version '3.10.2'
-  sha256 '6a829ba34ef2fa6a422ddb219544a3f7f5bee3428e24e5f03e6de37ca1c910bf'
+  version '3.12.0'
+  sha256 '9eba4fbf92aa7bd5fa9364a1eaf8325ab1db6ec0834acabe9539e830c41167ff'
 
   url 'https://qgis.org/downloads/macos/qgis-macos-pr.dmg'
   appcast 'https://www.qgis.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
$ brew cask install https://raw.githubusercontent.com/oncletom/homebrew-cask/patch-1/Casks/qgis.rb
==> Downloading https://raw.githubusercontent.com/oncletom/homebrew-cask/patch-1/Casks/qgis.rb.
==> Downloading https://qgis.org/downloads/macos/qgis-macos-pr.dmg
Already downloaded: /Users/oncletom/Library/Caches/Homebrew/downloads/a9de47f4624a53398d6c0ded729a773f451a29fee727f16920078d37ad5b2336--qgis-macos-pr.dmg
==> Verifying SHA-256 checksum for Cask 'qgis'.
==> Installing Cask qgis
hdiutil: attach: WARNING: ignoring IDME options (obsolete)
==> Moving App 'QGIS3.12.app' to '/Applications/QGIS3.12.app'.
🍺  qgis was successfully installed
```

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
