### PR TITLE
Update qtum-qt from 0.18.3 to 0.19.0.1

### DIFF
--- a/Casks/qtum-qt.rb
+++ b/Casks/qtum-qt.rb
@@ -1,9 +1,9 @@
 cask 'qtum-qt' do
-  version '0.18.3'
-  sha256 '80639e7cb0f38a6c2cea72361720629bad3fc99475075ae3771ef6c857637c7e'
+  version '0.19.0.1'
+  sha256 'bb957b66f55173f342dd78d089e2d60c6271fda8653579d7bea6143d09869204'
 
   # github.com/qtumproject/qtum was verified as official when first introduced to the cask
-  url "https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v#{version}/qtum-#{version}-osx-unsigned.dmg"
+  url "https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v#{version.major_minor_patch}/qtum-#{version}-osx-unsigned.dmg"
   appcast 'https://github.com/qtumproject/qtum/releases.atom'
   name 'Qtum'
   homepage 'https://qtum.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.