### PR TITLE
Revert "Update navicat-premium-essentials from 15.0.8 to 15.0.10"

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '15.0.10'
-  sha256 'd4066d145c9b5934f7010e2776059d564d92c4d6453faf1dbe6c38bb0149c1c5'
+  version '15.0.8'
+  sha256 '99717f96d5b33bf234888f1f58fb7ac3a26c0cc4b545b1bf9a31a9d83c848f3e'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Premium%20Essentials&appLang=en'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#77439
the website download still contains 15.0.8