### PR TITLE
Update gitify from 3.0.0 to 3.0.1

### DIFF
--- a/Casks/gitify.rb
+++ b/Casks/gitify.rb
@@ -1,8 +1,8 @@
 cask 'gitify' do
-  version 'v3.0.0'
-  sha256 '119525631abd5468f8b0494d6bba0288b7d543af1f0f042a9eabf001ef8736f0'
+  version '3.0.1'
+  sha256 '7c4aec3e4812692922c05a3b2aa5a98eff4d25f4953b7a5f7813fceca81af597'
 
-  url "https://github.com/manosim/gitify/releases/download/#{version}/gitify-osx.zip"
+  url "https://github.com/manosim/gitify/releases/download/v#{version}/Gitify-#{version}-mac.zip"
   appcast 'https://github.com/manosim/gitify/releases.atom'
   name 'Gitify'
   homepage 'https://github.com/manosim/gitify'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

The URL for the binary changed, so `cask-repair` failed and I had to do this manually. In version 2.0.2 and earlier, there was only `gitify-osx.zip`. For version 3.0.0 there were `Gitify-3.0.0-mac.zip`, `Gitify-3.0.0.dmg` and `gitify-osx.zip`. In this version there are only `Gitify-3.0.1-mac.zip` and `Gitify-3.0.1.dmg`. I chose to use `Gitify-3.0.1-mac.zip`.
I removed the `v` in front of the version number because I needed the version without the `v` in the URL. Does this cause any problems?