### PR TITLE
Update murus from 2.0 to 2.0.1

### DIFF
--- a/Casks/murus.rb
+++ b/Casks/murus.rb
@@ -1,6 +1,6 @@
 cask 'murus' do
-  version '2.0'
-  sha256 'ca8d475f28b3cb4c1a2e5e1e65fb74be2e6575b8f9ab8541b9d1a9c1b6aac16c'
+  version '2.0.1'
+  sha256 'f9f8174fc928009f0990e38ce650e95582004f729b5c018c098382cde92b3408'
 
   # github.com/TheMurusTeam/Murus was verified as official when first introduced to the cask
   url "https://github.com/TheMurusTeam/Murus/releases/download/v#{version}/murus-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.