### PR TITLE
Update endless-sky from 0.9.10 to 0.9.11

### DIFF
--- a/Casks/endless-sky.rb
+++ b/Casks/endless-sky.rb
@@ -1,6 +1,6 @@
 cask 'endless-sky' do
-  version '0.9.10'
-  sha256 'f2e7aa2bcd29c6070cac386111362bd353239cbaf6061c22dfa3b440426fd06b'
+  version '0.9.11'
+  sha256 'd7e268de713df3b6533b71ff6943827eb800c2dc457ad129e9b151c5df6f4d05'
 
   # github.com/endless-sky/endless-sky was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.