### PR TITLE
Update kodelife from 0.8.8.110 to 0.8.10.122

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,6 +1,6 @@
 cask 'kodelife' do
-  version '0.8.8.110'
-  sha256 'd3f26d60923f824f0bf29d53038f503847affe9dd0cc0041888ef30936fc15a4'
+  version '0.8.10.122'
+  sha256 '3bacdb848a1d1eca4b299123d125feb76dc710d1108e1f61bef9fbcc991cdcaa'
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-macos.zip"
   appcast 'https://hexler.net/pub/kodelife/appcast.hex'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.