### PR TITLE
Update miktex-console from 2.9.7250-1 to 2.9.7300-1

### DIFF
--- a/Casks/miktex-console.rb
+++ b/Casks/miktex-console.rb
@@ -1,6 +1,6 @@
 cask 'miktex-console' do
-  version '2.9.7250-1'
-  sha256 'bae786c68a2c9873392047e8330384db5ce13bc52751c7bcc152b5c2416a3ce5'
+  version '2.9.7300-1'
+  sha256 'da3b5b2ce6189ab7f66aca533c715f91ee0f2dadaede3fbb40e0a070ecf5d9d0'
 
   url "https://miktex.org/download/ctan/systems/win32/miktex/setup/darwin-x86_64/miktex-#{version}-darwin-x86_64.dmg"
   appcast 'https://miktex.org/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.