### PR TITLE
Update ableton-live-lite from 10.1.7 to 10.1.9

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite' do
-  version '10.1.7'
-  sha256 '24e0976c9efc10067f72bfd3514417d1b1a71a4e9ab999ddcb0b71606e0406c8'
+  version '10.1.9'
+  sha256 '0aec3cdf6e351adcff4a49daba22bbfb32b0b5e3dbc3b42dba54c7b84bc971b3'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.