### PR TITLE
Update ableton-live-suite from 10.1.7 to 10.1.9

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite' do
-  version '10.1.7'
-  sha256 '82c8c145bfb644978c4ad7c363e9e4ac892f0d2f8fad261bc33799bd6f9dcc0d'
+  version '10.1.9'
+  sha256 '8aa5b1e0ed0fc904ddd32083a074665cf4e275618f75c4834685b114ab1e181b'
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.