### PR TITLE
Update focuswriter from 1.7.4 to 1.7.5

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,6 +1,6 @@
 cask 'focuswriter' do
-  version '1.7.4'
-  sha256 'e2180c97f6d28d53c008ee24c22c7bf2386b6353e66d3fbc056fa384cb1e0a3c'
+  version '1.7.5'
+  sha256 '80b1892c72073a6ab225408fc0942b172a702212ab5bcd9ee87140857e389386'
 
   url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   appcast 'https://gottcode.org/focuswriter/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.