### PR TITLE
Update eve-launcher from 1669171 to 1672302

### DIFF
--- a/Casks/eve-launcher.rb
+++ b/Casks/eve-launcher.rb
@@ -1,6 +1,6 @@
 cask 'eve-launcher' do
-  version '1669171'
-  sha256 'ac1d87d73d53c18d81bcde4bef903da7b05795560ae4a8ef83f22fab3bb562d2'
+  version '1672302'
+  sha256 '2cab814d846b67573b9592f4c9601c38125dbfb061d4e4fb87dedfbb8899c3dd'
 
   url "https://binaries.eveonline.com/EveLauncher-#{version}.dmg"
   appcast 'https://launcher.eveonline.com/launcherVersions.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.