### PR TITLE
Update lehreroffice from 2019.13.5 to 2020.1.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2019.13.5'
-  sha256 '802e071c552d8550af5167230ea432603f62797bbbb9dac04b26bbd010698184'
+  version '2020.1.0'
+  sha256 '90a8a80a7b3ec81b8a9ce4ae8a85e5642a25bed7f54d53ac4f7eee77ebd69fcf'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.