### PR TITLE
Update plex-media-server from 1.18.7.2438-f342a5a43 to 1.18.7.2457-77cb9455c

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.18.7.2438-f342a5a43'
-  sha256 '2e77433b5e5634d6f6ad4f856bc4b20dd2e96c87664839169f2cb2270d443563'
+  version '1.18.7.2457-77cb9455c'
+  sha256 'be6e4b5a2da5d8f5965846a4a50515068569d17ac2c19cd154d28cdf428ac5a5'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.