### PR TITLE
Update geph from 3.4.2 to 3.4.3

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.4.2'
-  sha256 '0a74f8bda87a84fcec1e92b3463db92173223ae22447f442c9a07cfd4d921ac3'
+  version '3.4.3'
+  sha256 '4ea38e14c7df360c3879a4f15b31a3666eaaeeecf1f4f2750d67413dfafbfb4b'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.