### PR TITLE
Update integrity from 9.5.1 to 9.5.2

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,5 +1,5 @@
 cask 'integrity' do
-  version '9.5.1'
+  version '9.5.2'
   sha256 'd89c00c8b4f8a36234d02c45ef9e29f10dead94fddd3983d5778b85af4ffd7a5'
 
   url 'https://peacockmedia.software/mac/integrity/integrity.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.