### PR TITLE
Update retro-virtual-machine from 1.1.8 to 2.0.beta-1.r7,6783

### DIFF
--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -1,11 +1,12 @@
 cask 'retro-virtual-machine' do
-  version '1.1.8'
-  sha256 '49ea57688d0afbe63cc886606067f400c0e827e60db9c781e2f8c93cc993d139'
+  version '2.0.beta-1.r7,6783'
+  sha256 '75e94f2df589ead3fb1eab529713312a17dc16e6b2ba547594cd9d5975def566'
 
-  url "http://static1.retrovirtualmachine.org/release/Retro%20Virtual%20Machine%20v#{version}.dmg"
+  # retrovirtualmachine.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
+  url "https://retrovirtualmachine.ams3.digitaloceanspaces.com/release/beta1/macos/RetroVirtualMachine.#{version.before_comma}.macos.dmg"
   appcast 'https://www.retrovirtualmachine.org/en/downloads'
   name 'Retro Virtual Machine'
   homepage 'https://www.retrovirtualmachine.org/en/'
 
-  app 'Retro Virtual Machine.app'
+  app 'Retro Virtual Machine 2.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.