### PR TITLE
Update eudic from 3.9.5,2019-12-20 to 3.9.6,2020-01-25

### DIFF
--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -1,10 +1,10 @@
 cask 'eudic' do
-  version '3.9.5,2019-12-20'
-  sha256 '2b52374dffa9defcd7702605dacd764db06b261e50e660e2d53266e23dca8165'
+  version '3.9.6,2020-01-25'
+  sha256 '5cec29af3ff50a6658c81c33466166aa0de18097ec649ec82557517cf2f73d2e'
 
   # static.frdic.com was verified as official when first introduced to the cask
   url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.after_comma}"
-  appcast 'https://www.eudic.net/update/eudic_mac.xml'
+  appcast 'https://www.eudic.net/v4/en/app/download'
   name 'Eudic'
   name '欧路词典'
   homepage 'https://www.eudic.net/v4/en/app/eudic'

--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -1,5 +1,5 @@
 cask 'eudic' do
-  version '3.9.6,2020-01-25'
+  version '3.9.6,2020-01-27'
   sha256 '5cec29af3ff50a6658c81c33466166aa0de18097ec649ec82557517cf2f73d2e'
 
   # static.frdic.com was verified as official when first introduced to the cask

--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -1,9 +1,9 @@
 cask 'eudic' do
-  version '3.9.6,2020-01-27'
+  version '2020-01-27,3.9.6'
   sha256 '5cec29af3ff50a6658c81c33466166aa0de18097ec649ec82557517cf2f73d2e'
 
   # static.frdic.com was verified as official when first introduced to the cask
-  url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.after_comma}"
+  url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.before_comma}"
   appcast 'https://www.eudic.net/v4/en/app/download'
   name 'Eudic'
   name '欧路词典'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.