### PR TITLE
Update zeplin from 2.8.3,832 to 3.0.0,846

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '2.8.3,832'
-  sha256 '8c9dace7ba00caa04e18cac71bc3283f4546071149730f05f2b459a342c50589'
+  version '3.0.0,846'
+  sha256 '7e773f30f556440dcdeaa18cabb74a014bd493f96cb47baf38791ce6203b7a53'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.