### PR TITLE
Update retro-virtual-machine from 1.1.8 to 2.0,1:7

### DIFF
--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -1,11 +1,12 @@
 cask 'retro-virtual-machine' do
-  version '1.1.8'
-  sha256 '49ea57688d0afbe63cc886606067f400c0e827e60db9c781e2f8c93cc993d139'
+  version '2.0,1:7'
+  sha256 '75e94f2df589ead3fb1eab529713312a17dc16e6b2ba547594cd9d5975def566'
 
-  url "http://static1.retrovirtualmachine.org/release/Retro%20Virtual%20Machine%20v#{version}.dmg"
+  # retrovirtualmachine.ams3.digitaloceanspaces.com/release was verified as official when first introduced to the cask
+  url "https://retrovirtualmachine.ams3.digitaloceanspaces.com/release/beta#{version.before_colon.after_comma}/macos/RetroVirtualMachine.#{version.before_comma}.beta-#{version.before_colon.after_comma}.r#{version.after_colon}.macos.dmg"
   appcast 'https://www.retrovirtualmachine.org/en/downloads'
   name 'Retro Virtual Machine'
   homepage 'https://www.retrovirtualmachine.org/en/'
 
-  app 'Retro Virtual Machine.app'
+  app "Retro Virtual Machine #{version.major}.app"
 end

--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -2,7 +2,7 @@ cask 'retro-virtual-machine' do
   version '2.0,1:7'
   sha256 '75e94f2df589ead3fb1eab529713312a17dc16e6b2ba547594cd9d5975def566'
 
-  # retrovirtualmachine.ams3.digitaloceanspaces.com/release was verified as official when first introduced to the cask
+  # retrovirtualmachine.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://retrovirtualmachine.ams3.digitaloceanspaces.com/release/beta#{version.before_colon.after_comma}/macos/RetroVirtualMachine.#{version.before_comma}.beta-#{version.before_colon.after_comma}.r#{version.after_colon}.macos.dmg"
   appcast 'https://www.retrovirtualmachine.org/en/downloads'
   name 'Retro Virtual Machine'

--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -1,9 +1,9 @@
 cask 'retro-virtual-machine' do
-  version '2.0,1:7'
+  version '2.0,1.r7'
   sha256 '75e94f2df589ead3fb1eab529713312a17dc16e6b2ba547594cd9d5975def566'
 
   # retrovirtualmachine.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
-  url "https://retrovirtualmachine.ams3.digitaloceanspaces.com/release/beta#{version.before_colon.after_comma}/macos/RetroVirtualMachine.#{version.before_comma}.beta-#{version.before_colon.after_comma}.r#{version.after_colon}.macos.dmg"
+  url "https://retrovirtualmachine.ams3.digitaloceanspaces.com/release/beta#{version.after_comma.major}/macos/RetroVirtualMachine.#{version.before_comma}.beta-#{version.after_comma}.macos.dmg"
   appcast 'https://www.retrovirtualmachine.org/en/downloads'
   name 'Retro Virtual Machine'
   homepage 'https://www.retrovirtualmachine.org/en/'


### PR DESCRIPTION
The most recent working link is for the beta release `2.0-beta1-r7`.

The latest non-beta release is `1.1.8`, for which the download link no longer works.