### PR TITLE
Update sentinel from 0.14.3 to 0.14.4

### DIFF
--- a/Casks/sentinel.rb
+++ b/Casks/sentinel.rb
@@ -1,6 +1,6 @@
 cask 'sentinel' do
-  version '0.14.3'
-  sha256 '86feb4cd422546e6d50d3eb55b01e995eff36d7451153a0d9840cb8de05ad801'
+  version '0.14.4'
+  sha256 '7beeb90c32984d6d133ffed53f1e8c391485b30df3683dfa4de4b67c40fceeba'
 
   url "https://releases.hashicorp.com/sentinel/#{version}/sentinel_#{version}_darwin_amd64.zip"
   appcast 'https://docs.hashicorp.com/sentinel/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.