### PR TITLE
Update trilium-notes from 0.40.3 to 0.40.4

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.40.3'
-  sha256 '316ccd5eeb1d4806909f988c79f4678d6ff07312a67c1ee709cf0352b3e2a46c'
+  version '0.40.4'
+  sha256 '42289fbae769a6a6a09242de9e2bf36fdfac2495f285c75b2d508d91ccddb99b'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.