### PR TITLE
Update bloodhound from 3.0.1 to 3.0.2

### DIFF
--- a/Casks/bloodhound.rb
+++ b/Casks/bloodhound.rb
@@ -1,6 +1,6 @@
 cask 'bloodhound' do
-  version '3.0.1'
-  sha256 '8160fe6c7c5d98cfa69d14135b925866cf7b28689017d1883ef0b060f0777e5c'
+  version '3.0.2'
+  sha256 '046f321f30d2f6bedac62cdb099784f631bab5c68621e9e94fb81fea532da3a7'
 
   url "https://github.com/BloodHoundAD/BloodHound/releases/download/#{version}/BloodHound-darwin-x64.zip"
   appcast 'https://github.com/BloodHoundAD/BloodHound/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.