### PR TITLE
Update zotero from 5.0.82 to 5.0.83

### DIFF
--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -1,6 +1,6 @@
 cask 'zotero' do
-  version '5.0.82'
-  sha256 '85de73413509767ef94b2cc16e4af26ac7dcb3168073e7b77942785bd82f513e'
+  version '5.0.83'
+  sha256 'adf3e55dbb3a33c8702e0bcee9202f0527f622e749da648e41ba6fc02217a04f'
 
   url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}.dmg"
   appcast 'https://github.com/zotero/zotero/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.