### PR TITLE
Update insync from 3.0.29.40727 to 3.0.30.40732

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '3.0.29.40727'
-  sha256 '82c87ed074b31772ca49b5c2841913c81f47f6e5283c9e79f7c8de0b485cc842'
+  version '3.0.30.40732'
+  sha256 '467cb819175dba033aab4dc87a5f82fe1f492b0bf8e1923ab8e96e15c4dfd0c9'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   appcast 'https://www.insynchq.com/downloads?start=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.