### PR TITLE
Update omnipresence from 1.6,10.13 to 1.7,10.14

### DIFF
--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -10,7 +10,7 @@ cask 'omnipresence' do
     sha256 '48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b'
   else
     version '1.7,10.14'
-    sha256 '48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b'
+    sha256 '814c7178c3a674f6f65ddcf5815df1269c6519909fcac86ace2dba80b5cfc4f1'
   end
 
   url "https://downloads.omnigroup.com/software/MacOSX/#{version.after_comma}/OmniPresence-#{version.before_comma}.dmg"

--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -1,11 +1,11 @@
 cask 'omnipresence' do
-  if MacOS.version == :mavericks
+  if MacOS.version <= :mavericks
     version '1.2-r220586,10.9'
     sha256 '59a214e6393c984aead4a7242297979dc553d59af9964b5c645636e395794f0f'
-  elsif MacOS.version == :yosemite
+  elsif MacOS.version <= :yosemite
     version '1.4.1,10.10'
     sha256 '409bf272e7c4dc488f68abadb3e2ef15d4accde10f8ee9babd8b23f522bfe323'
-  elsif MacOS.version == :high_sierra
+  elsif MacOS.version <= :high_sierra
     version '1.6,10.13'
     sha256 '48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b'
   else

--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -5,8 +5,11 @@ cask 'omnipresence' do
   elsif MacOS.version == :yosemite
     version '1.4.1,10.10'
     sha256 '409bf272e7c4dc488f68abadb3e2ef15d4accde10f8ee9babd8b23f522bfe323'
-  else
+  elsif MacOS.version == :high_sierra
     version '1.6,10.13'
+    sha256 '48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b'
+  else
+    version '1.7,10.14'
     sha256 '48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.