### PR TITLE
Update aircall from 2.3.2 to 2.3.3

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,6 +1,6 @@
 cask 'aircall' do
-  version '2.3.2'
-  sha256 '1ef71dd64b671c1583eafee6fb7f415cc239cbd68dc8f41732c7c5b4ac9747f4'
+  version '2.3.3'
+  sha256 'e39be9465a328c3e028baddc80be1b9743265b1314dba826d3725e610e88de20'
 
   # aircall-electron-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://aircall-electron-releases.s3.amazonaws.com/production/Aircall-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.