### PR TITLE
Update supersync from 7.0.7 to 7.0.8

### DIFF
--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,6 +1,6 @@
 cask 'supersync' do
-  version '7.0.7'
-  sha256 'a93270c12a641a4e2badd150b84a8218f68d95f7026781254647b134e1cd79c9'
+  version '7.0.8'
+  sha256 'dab4f7c66186313b7903cbd0c06df0815c34de57a6e350e5b04d4fd1dddecd94'
 
   url "https://supersync.com/downloads/SuperSync_#{version}.dmg"
   appcast 'https://supersync.com/downloads.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.