### PR TITLE
Update tableau-public from 2019.4.2 to 2020.1.0

### DIFF
--- a/Casks/tableau-public.rb
+++ b/Casks/tableau-public.rb
@@ -1,6 +1,6 @@
 cask 'tableau-public' do
-  version '2019.4.2'
-  sha256 '33924b0651c285e5bd7e2fa9bec234405b341f9ca588f353c64eae8400822a82'
+  version '2020.1.0'
+  sha256 '2da00fbe44c7d405950a64be3f6e520656c2eeae5fd326437b354ddcfbcadc31'
 
   url "https://downloads.tableau.com/public/TableauPublic-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/public/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.