### PR TITLE
Update todometer from 1.0.4 to 2.0.0

### DIFF
--- a/Casks/todometer.rb
+++ b/Casks/todometer.rb
@@ -1,9 +1,9 @@
 cask 'todometer' do
-  version '1.0.4'
-  sha256 '49a744d996cfa925b50064f1853f8bf1372a3073f449a482f7896ccc5ca15d48'
+  version '2.0.0'
+  sha256 'e10a9c481ca31235bda964dd25907a389a1085439e3a05ee3c43490874d9cf37'
 
   # github.com/cassidoo/todometer was verified as official when first introduced to the cask
-  url "https://github.com/cassidoo/todometer/releases/download/v#{version}/install-todometer.dmg"
+  url "https://github.com/cassidoo/todometer/releases/download/v#{version}/todometer.for.Mac.zip"
   appcast 'https://github.com/cassidoo/todometer/releases.atom'
   name 'todometer'
   homepage 'https://cassidoo.github.io/todometer/'

--- a/Casks/todometer.rb
+++ b/Casks/todometer.rb
@@ -8,5 +8,5 @@ cask 'todometer' do
   name 'todometer'
   homepage 'https://cassidoo.github.io/todometer/'
 
-  app 'todometer.app'
+  app 'mac/todometer.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.