### PR TITLE
Update dcp-o-matic from 2.14.26 to 2.14.30

### DIFF
--- a/Casks/dcp-o-matic.rb
+++ b/Casks/dcp-o-matic.rb
@@ -1,8 +1,8 @@
 cask 'dcp-o-matic' do
-  version '2.14.26'
-  sha256 'aaee3d2d3fc04b613190efbc0d85226e4b030efa8b47e91eb2f4b473202f032d'
+  version '2.14.30'
+  sha256 '9aad1e03a2542e8e2190218a919f624561c71dd2102b33666382078e65591e68'
 
-  url "https://dcpomatic.com/dl.php?id=osx-main&version=#{version}"
+  url "https://dcpomatic.com/dl.php?id=osx-10.9-main&version=#{version}"
   appcast 'https://dcpomatic.com/download'
   name 'DCP-o-matic'
   homepage 'https://dcpomatic.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.