### PR TITLE
Update dcp-o-matic-player from 2.14.26 to 2.14.30

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,8 +1,8 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.26'
-  sha256 '2d3da7a740198957ec1152c79609709b3fb6f30a92f596007c62478ea0f7b9e8'
+  version '2.14.30'
+  sha256 '044c25f72ed1035bfd84f84fd3f0e2588ef44c92600086db11bf3cc0fea8a762'
 
-  url "https://dcpomatic.com/dl.php?id=osx-player&version=#{version}"
+  url "https://dcpomatic.com/dl.php?id=osx-10.9-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'
   name 'DCP-o-matic Player'
   homepage 'https://dcpomatic.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.