### PR TITLE
Update dcp-o-matic-encode-server from 2.14.26 to 2.14.30

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,8 +1,8 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.26'
-  sha256 '4f7b590fbf6a52d525d3fd700bd6900d40f0caf23eff5881eeaa702c541455be'
+  version '2.14.30'
+  sha256 '58f28ab999db70d745fbfa69d13b180f3a03ed3ebdfc7202cb28da12101a02d2'
 
-  url "https://dcpomatic.com/dl.php?id=osx-server&version=#{version}"
+  url "https://dcpomatic.com/dl.php?id=osx-10.9-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'
   name 'DCP-o-matic Encode Server'
   homepage 'https://dcpomatic.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.