### PR TITLE
Update dcp-o-matic-batch-converter from 2.14.26 to 2.14.30

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,8 +1,8 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.14.26'
-  sha256 'e7b68d9121875461f93c4aa7763bf107160f658abe0794bf32fbfe9c672195db'
+  version '2.14.30'
+  sha256 'dd1f85d88aaf10290ad360282920c7394fbd1e5e0ad50999529d7a807a5f4e21'
 
-  url "https://dcpomatic.com/dl.php?id=osx-batch&version=#{version}"
+  url "https://dcpomatic.com/dl.php?id=osx-10.9-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'
   name 'DCP-o-matic Batch converter'
   homepage 'https://dcpomatic.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.