### PR TITLE
Update boxcryptor from 2.32.1010 to 2.33.1015

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,6 +1,6 @@
 cask 'boxcryptor' do
-  version '2.32.1010'
-  sha256 'da6256dffe5c5015bb1986326d30c6a9231dfdb65ec89c4b7ed799dcc0950619'
+  version '2.33.1015'
+  sha256 'edcf64ba0be52662c555b18d98b57ff59ba88a2289ebf44e957721924608b8b5'
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.boxcryptor.com/l/download-macosx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.