### PR TITLE
Update monal from 2.5 beta 5,159 to version :latest

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,6 +1,6 @@
 cask 'monal' do
-  version '2.5 beta 5,159'
-  sha256 'e3ffeb9dd8d86359f9eafb877a9cb46938e546c2386af35ba24ebd4fdd375f57'
+  version '4.4,570'
+  sha256 '2686301280d721a720d0f597d54b6673b4362ac73e2c13c797cecc598d159773'
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
   appcast 'https://monal.im/Monal-OSX/appcast.xml',

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,10 +1,8 @@
 cask 'monal' do
-  version '4.4,570'
-  sha256 '2686301280d721a720d0f597d54b6673b4362ac73e2c13c797cecc598d159773'
+  version :latest
+  sha256 :no_check
 
   url 'https://monal.im/Monal-OSX/Monal-OSX.zip'
-  appcast 'https://monal.im/Monal-OSX/appcast.xml',
-          configuration: version.after_comma
   name 'Monal'
   homepage 'https://monal.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.