### PR TITLE
Update cozy-drive from 3.18.0 to 3.19.0

### DIFF
--- a/Casks/cozy-drive.rb
+++ b/Casks/cozy-drive.rb
@@ -1,6 +1,6 @@
 cask 'cozy-drive' do
-  version '3.18.0'
-  sha256 '2100dade150cf9b5c8f195162c43a1b8b22d553a3059bd3b53d73ed087c81dc6'
+  version '3.19.0'
+  sha256 '40852a2b3138419079d808cb7d7e2bb9c29a6b852b25da52b12ce26ba09127f8'
 
   # nuts.cozycloud.cc was verified as official when first introduced to the cask
   url "https://nuts.cozycloud.cc/download/channel/stable/CozyDrive-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.