### PR TITLE
Update lingon-x from 7.5.1 to 7.5.2

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.5'
     sha256 'b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8'
   else
-    version '7.5.1'
-    sha256 '1ded4cf1ab7aa2005606c6c08b425188e777ba92fd0bacdd833052182b99b62f'
+    version '7.5.2'
+    sha256 'b8c9ad6714bb7dc4ff4ee3696bab640e506bcafbe5969b7507487b277426d047'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.