### PR TITLE
Delete appcast in recents.rb

### DIFF
--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -4,7 +4,6 @@ cask 'recents' do
 
   # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"
-  appcast 'https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b'
   name 'Recents'
   homepage 'https://recentsapp.com/'
 

--- a/Casks/recents.rb
+++ b/Casks/recents.rb
@@ -1,9 +1,8 @@
 cask 'recents' do
-  version '2.0.3,4867'
-  sha256 'f8c08455300ea60811ccc12aa8e70ac626ad69dfa21e673c404cbefb1bb9f068'
+  version :latest
+  sha256 :no_check
 
-  # rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/74f5ee9ebf2d4be3b92a3e8766433b8b/app_versions/#{version.after_comma}?format=zip"
+  url 'https://recentsapp.com/releases/Recents_latest.zip'
   name 'Recents'
   homepage 'https://recentsapp.com/'
 


### PR DESCRIPTION
the appcast doesn't work anymore but the download  still works - I can't find another appcast
the download from the website would be:   'https://recentsapp.com/releases/Recents_latest.zip' 
should we use this one instead and change the version staza to :latest ?