### PR TITLE
Update augur from 1.16.9 to 1.16.10

### DIFF
--- a/Casks/augur.rb
+++ b/Casks/augur.rb
@@ -1,6 +1,6 @@
 cask 'augur' do
-  version '1.16.9'
-  sha256 '4f8bb5c5bdfd659ef3b3a3259cd13295234d2cebc39ce563965904174e2abfb0'
+  version '1.16.10'
+  sha256 '141aeeff2fc5bfa22c12d64c63f157af89b2c55bcde1cefed41e69232fa78082'
 
   url "https://github.com/AugurProject/augur-app/releases/download/v#{version}/mac-Augur-#{version}.dmg"
   appcast 'https://github.com/AugurProject/augur-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.