### PR TITLE
Update zesarux from 8.0 to 8.1

### DIFF
--- a/Casks/zesarux.rb
+++ b/Casks/zesarux.rb
@@ -1,6 +1,6 @@
 cask 'zesarux' do
-  version '8.0'
-  sha256 '8b52f1c990d9abe3c702d2771d6ff761c9295687019b78d567b0f5b793a6650b'
+  version '8.1'
+  sha256 '169e140cefce17d3d62bb1983e801f07e18d8ddae771680eb275399c6b66ce67'
 
   url "https://github.com/chernandezba/zesarux/releases/download/#{version}/ZEsarUX_macos-#{version}.dmg.gz"
   appcast 'https://github.com/chernandezba/zesarux/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.