### PR TITLE
Update lbry from 0.42.0 to 0.43.2

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.42.0'
-  sha256 '4b5346d476257a086001fea86d81939124e21be2733786eaca8ba47cbff42dc1'
+  version '0.43.2'
+  sha256 'd0a265528c85f8b23490f343fe12e53ee87895af375c541d23d2323502228f7a'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.