### PR TITLE
Update discord from 0.0.255 to 0.0.256

### DIFF
--- a/Casks/discord.rb
+++ b/Casks/discord.rb
@@ -1,6 +1,6 @@
 cask 'discord' do
-  version '0.0.255'
-  sha256 '9d04c35b97d40c6370318ab8301984dc982e08174b223a979007449688120fe8'
+  version '0.0.256'
+  sha256 '591058c522fea899513691a1c082212ecdaff65371f9c31b0885947488b4191a'
 
   url "https://cdn.discordapp.com/apps/osx/#{version}/Discord.dmg"
   appcast 'https://discordapp.com/api/stable/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.