### PR TITLE
Update losslesscut from 3.8.0 to 3.9.1

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '3.8.0'
-  sha256 '9ddac02452c80d0e79361742ba0b082c2b600daf5490c6ded2db874f4d47f671'
+  version '3.10.0'
+  sha256 '29f536ce21db06197066d7d978d80705324924d5fc92c98af3af22e54b020372'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.