### PR TITLE
Update wechatwork from 3.0.10.2096 to 3.0.11.2101

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.10.2096'
-  sha256 '8c0e87c9fb9000de0885030a60921341c5cdbdbf64f4529489026088a6fae828'
+  version '3.0.11.2101'
+  sha256 '02bbf0cbbb6b99f38c5024e619bec2c0dc8201111d7e0f87dadccfd4113d9840'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.