### PR TITLE
Update camunda-modeler from 3.6.0 to 3.7.0

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '3.6.0'
-  sha256 '88bd1397b5d56de015cb4253991e0dd05a7d630331be92ba5043aef1e3330a10'
+  version '3.7.0'
+  sha256 '2c41d6094171165f00ee1b0f099ba011b7a27e3b5457eb61a2603e435d4dc4c9'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-mac.zip"
   appcast 'https://camunda.com/download/modeler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.