### PR TITLE
Update wordpresscom from 4.7.0 to 5.0.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '4.7.0'
-  sha256 '417449d249a7448dbbf002a13c74c5fce2894a8e995bb9b90e01a9fcd934c80e'
+  version '5.0.0'
+  sha256 '64a5313011b22d13bb825eb00cee0b3542912d7002fadd2ca1cac780b726fb58'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.