### PR TITLE
Update hbuilderx from 2.6.0.20200223 to 2.6.1.20200226

### DIFF
--- a/Casks/hbuilderx.rb
+++ b/Casks/hbuilderx.rb
@@ -1,6 +1,6 @@
 cask 'hbuilderx' do
-  version '2.6.0.20200223'
-  sha256 'b6da09883b339395b277dc75dc3a0f2a549ac7e2a49258ce6f85292703b7913a'
+  version '2.6.1.20200226'
+  sha256 'a228ad446f14b0b3c7cf6124973e1da2f1c9e453ba2ab1a30ea99196102b0742'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "https://download.dcloud.net.cn/HBuilderX.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.