### PR TITLE
Update app-tamer from 2.4.9 to 2.5

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,6 +1,6 @@
 cask 'app-tamer' do
-  version '2.4.9'
-  sha256 '2a1fdf0108567606b5e59df1f93e640a6d02d17082df7c1772b7c54b7a83757a'
+  version '2.5'
+  sha256 '9b65803e106af3a2cb0f0e05dd1c95a4cf45d904fa5a44c57d142b6eeb31812d'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.