### PR TITLE
Update manuscripts from 1.3.0,209 to 1.3.3,209

### DIFF
--- a/Casks/manuscripts.rb
+++ b/Casks/manuscripts.rb
@@ -1,6 +1,6 @@
 cask 'manuscripts' do
-  version '1.3.0,209'
-  sha256 'e946171a414e9dcc06a20bba743e5a3d73f4547c1ead27bed838363b06935b09'
+  version '1.3.3,209'
+  sha256 'b528a1f4c0be56925a479207c2fa840d524a759e2d02a607fe2d11f53e01c25a'
 
   # hockeyapp.net/api/2/apps/280aaebd99e1f12edc41b48d909db0c4 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/280aaebd99e1f12edc41b48d909db0c4/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.