### PR TITLE
Update navicat-for-oracle from 15.0.8 to 15.0.11

### DIFF
--- a/Casks/navicat-for-oracle.rb
+++ b/Casks/navicat-for-oracle.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-oracle' do
-  version '15.0.8'
-  sha256 '7c6312f3f81dc476d9e39527e200d67c6bc28b5e444846509030faabe8762580'
+  version '15.0.11'
+  sha256 '72d886e5c9c3f6b5edbfec9d4dfaf11cec27d68127eb46714261b9b5e1370be5'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_ora_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20Oracle&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.