### PR TITLE
Update navicat-for-postgresql from 15.0.8 to 15.0.11

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.8'
-  sha256 '37c77372829f0766c16a4ca30faf3cf4e78f366a541c00d313bdab26692b1cf8'
+  version '15.0.11'
+  sha256 'bcc79532d3644515e541af643bf14a6c8f224a00461523f308cd55857dc9260e'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.