### PR TITLE
Update navicat-for-sqlite from 15.0.8 to 15.0.11

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.8'
-  sha256 'eac8ea5042746c8fad1cc3fa9fcec011f6c2968c9115b1f8dcb7a2fa437506cd'
+  version '15.0.11'
+  sha256 'e770b0956987af792e8aae0e21538772a83f772a847612b455a471948537a005'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.