### PR TITLE
Update navicat-premium from 15.0.10 to 15.0.11

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '15.0.10'
-  sha256 '4c9946e10cb4163a396af38a2d6d39f23da8d2e989c23ff5cccd4897af32e9a8'
+  version '15.0.11'
+  sha256 'f94612841a8285290e14362d6805bad6f66b842ece3fb32b15cce4bcdf7416f8'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Premium&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.