### PR TITLE
Update netron from 3.9.3 to 3.9.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.9.3'
-  sha256 'd33e790606acfa05579f390fc586acc26848096882a0e8b3ff197b294413c9ed'
+  version '3.9.4'
+  sha256 'cb8a41fab5d113bb4dc600f033ac6ec63743097c964987aefc708de1c5d69134'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.