### PR TITLE
Update qownnotes from 20.2.10,b5378-172543 to 20.2.11,b5381-172139

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.2.10,b5378-172543'
-  sha256 '7fe49e815ee8e0054c416c4a58964b48f3f1e1d15ea49a592ec644018bfbe52a'
+  version '20.2.11,b5381-172139'
+  sha256 '88e71ce0f23972302e2dba3d23b3c826042bb7682f735dd6a4cce612a2ae23b4'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.