### PR TITLE
Update proclaim from 2.12.0.0016 to 2.12.0.0021

### DIFF
--- a/Casks/proclaim.rb
+++ b/Casks/proclaim.rb
@@ -1,6 +1,6 @@
 cask 'proclaim' do
-  version '2.12.0.0016'
-  sha256 'ec9a42db0bcb6002a278ff42a8f398ea7695bedb004549e2dc0f8e23aeba5763'
+  version '2.12.0.0021'
+  sha256 '2d91f4a36e2d195c68bcd27308b344553ecb9ca19e1615d64b72185025209ce5'
 
   # logoscdn.com/Proclaim was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/Proclaim/Installer/#{version}/Proclaim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.