### PR TITLE
Update sloth from 2.8.1 to 2.9

### DIFF
--- a/Casks/sloth.rb
+++ b/Casks/sloth.rb
@@ -1,6 +1,6 @@
 cask 'sloth' do
-  version '2.8.1'
-  sha256 '3596507018a6321226863862bd4377ac388dffdf54ebce1ace50d87869114c0e'
+  version '2.9'
+  sha256 'b8fecd3ca901012b92be681d9e20eac5deea65e184b2a5313223247ffb43d6b5'
 
   url "https://sveinbjorn.org/files/software/sloth/sloth-#{version}.zip"
   appcast 'https://sveinbjorn.org/files/appcasts/SlothAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.