### PR TITLE
Update get-backup-pro from 3.5 to 3.5.1

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,6 +1,6 @@
 cask 'get-backup-pro' do
-  version '3.5'
-  sha256 '73899755cca8db66bcdaa59b0dabaf4cf9c0d5bdf8a04c81c770c8c03365241d'
+  version '3.5.1'
+  sha256 'b9dce46ade0250931117d03268ec32a58a94e5944297c52ecbd0072e13a2d539'
 
   # belightsoft.s3.amazonaws.com/updates was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.