### PR TITLE
Update roblox from 0.420.0.383960,9fb42da157684099 to 0.421.0.385673,278cee1b313a457a

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.420.0.383960,9fb42da157684099'
-  sha256 'bc066efdac8300cdb2c66d2351b238ed0f0de15f4c6d559f08808db0b5718005'
+  version '0.421.0.385673,278cee1b313a457a'
+  sha256 'bfcf02216011eea03de311199d118f0f4e6e398d7532b556e4870c39fe1addaf'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.