### PR TITLE
Update sonic-pi from 3.1.0 to 3.2.0

### DIFF
--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -1,8 +1,8 @@
 cask 'sonic-pi' do
-  version '3.1.0'
-  sha256 'd1e232e39f875db717f4efab85362dfaac31cafb9e555b21136d7b12720c9a30'
+  version '3.2.0'
+  sha256 '7a3e8b29c30dd83cfa081cff86983f0a28269553b18636b6784a40601bb9497e'
 
-  url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-v#{version}.dmg"
+  url "https://sonic-pi.net/files/releases/v#{version}/sonic-pi-for-mac-v#{version}.zip"
   appcast 'https://github.com/samaaron/sonic-pi/releases.atom'
   name 'Sonic Pi'
   homepage 'https://sonic-pi.net/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.