### PR TITLE
Update coteditor from 3.8.10 to 3.8.11

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -6,8 +6,8 @@ cask 'coteditor' do
     version '3.2.8'
     sha256 '73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6'
   else
-    version '3.8.10'
-    sha256 'c3461ec98895f06e647ddd20baf32400a589585d08f305a448aa7bfa60515b2f'
+    version '3.8.11'
+    sha256 'b5a04b98e410f98a72153ec60284ae1bcf39a6bef1222f120fd4f613d1aef2ed'
   end
 
   # github.com/coteditor/CotEditor was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.