### PR TITLE
Update cabal from 4.1.0 to 4.1.1

### DIFF
--- a/Casks/cabal.rb
+++ b/Casks/cabal.rb
@@ -1,6 +1,6 @@
 cask 'cabal' do
-  version '4.1.0'
-  sha256 '189a8e1569fcdbca626e941acd3f0b03548f3586e3bff66d538ff769b6930849'
+  version '4.1.1'
+  sha256 '9b0c959135674663839cc0b80533a7a94603dda8977f817fa954e4d1ca5e40d3'
 
   # github.com/cabal-club/cabal-desktop was verified as official when first introduced to the cask
   url "https://github.com/cabal-club/cabal-desktop/releases/download/v#{version}/cabal-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.