### PR TITLE
Update electerm from 1.0.28 to 1.0.31

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.0.28'
-  sha256 '4ab19616dc4b23376bada28f63627d13af389d96d2668d99985a9a5b83bc6bb7'
+  version '1.0.31'
+  sha256 '779df13757d5665f68f9fab78d43b2c6c33952efd948a4a54bc55447848d1402'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.