### PR TITLE
Update zulip from 4.0.0 to 4.0.3

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,6 +1,6 @@
 cask 'zulip' do
-  version '4.0.0'
-  sha256 '3028a7d4820fa42b94eb43717715e2d8c677dac1111bf604bd868bf062081117'
+  version '4.0.3'
+  sha256 '7656fdf33a29b302f10d0294ecc544309bd861dd163b96e27e43fe6d9e17531e'
 
   # github.com/zulip/zulip-desktop was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-desktop/releases/download/v#{version}/Zulip-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.