### PR TITLE
Update mate-translate from 6.1.4 to 6.2.0

### DIFF
--- a/Casks/mate-translate.rb
+++ b/Casks/mate-translate.rb
@@ -1,6 +1,6 @@
 cask 'mate-translate' do
-  version '6.1.4'
-  sha256 'b2fe0ae8353b496b43dda07c21f89a7c9604d72d922213894e31efb5904a2365'
+  version '6.2.0'
+  sha256 'af3e6543d3206e91e5ed16eac9d6cad49d02f4a1517f5eb56cbd3ab8a9992e94'
 
   # gikken.co/mate was verified as official when first introduced to the cask
   url 'https://gikken.co/mate/MateTranslate.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.