### PR TITLE
Update cevelop from 1.13.0-201910070714 to 1.14.1-202002280945

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -1,6 +1,6 @@
 cask 'cevelop' do
-  version '1.13.0-201910070714'
-  sha256 '00d71ac7a20a4e61598355080ec5faf4b957895eb60dbd62a4dfa59cbc061f64'
+  version '1.14.1-202002280945'
+  sha256 'f3075e6655fac42f6eca6915e348096f24d6f500969932829f52ec978f963924'
 
   url "https://www.cevelop.com/cevelop/downloads/cevelop-#{version}-macosx.cocoa.x86_64.tar.gz"
   appcast 'https://www.cevelop.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.