### PR TITLE
Update qqlive from 2.13.3.50813 to 2.14.0.50900

### DIFF
--- a/Casks/qqlive.rb
+++ b/Casks/qqlive.rb
@@ -1,6 +1,6 @@
 cask 'qqlive' do
-  version '2.13.3.50813'
-  sha256 'f484a7b72ebd8a4c58db58329704e89a5e2d93397c3289b859e6aefb997358dc'
+  version '2.14.0.50900'
+  sha256 '7eee50ea2a0aecf8d942f082a77c50c12b3fc09667b92cf84fa7d165413b9af5'
 
   url "https://dldir1.qq.com/qqtv/mac/TencentVideo_V#{version}.dmg"
   appcast 'https://v.qq.com/download.html#mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.