### PR TITLE
Update losslesscut from 3.12.0 to 3.13.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '3.12.0'
-  sha256 '95851aea6c37a0f9d6534883966221415bcf9fddd077d2e6de62ce8d9e418c34'
+  version '3.13.0'
+  sha256 'c81a304433df92b1f1a7bc753bca7b98fac9e8091f7af505011bb2cf54301b45'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.