### PR TITLE
Update qownnotes from 20.2.11,b5381-172139 to 20.3.0,b5386-105159

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.2.11,b5381-172139'
-  sha256 '88e71ce0f23972302e2dba3d23b3c826042bb7682f735dd6a4cce612a2ae23b4'
+  version '20.3.0,b5386-105159'
+  sha256 'd4e6e3b46cf32bbf04f051f0b4d436a3fd457d65b4256044a11c0e84b6136c8e'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.