### PR TITLE
Update biscuit from 1.2.5 to 1.2.6

### DIFF
--- a/Casks/biscuit.rb
+++ b/Casks/biscuit.rb
@@ -1,6 +1,6 @@
 cask 'biscuit' do
-  version '1.2.5'
-  sha256 'd1d2fa6263086958b58e8fab89c1b8ea64cbc69ce915216e5fccb8bd161a5835'
+  version '1.2.6'
+  sha256 '108f559f0e644eb6af7ce1b188fb45dd8feb9c7c67ea59e7860c738b8a6589ee'
 
   # github.com/agata/dl.biscuit was verified as official when first introduced to the cask
   url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.