### PR TITLE
Update kite from 0.20200221.0 to 0.20200228.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200221.0'
-  sha256 '9b441a84805fe50a918864811a1ed27ab8a8f59002bf43b7f1d5536651925b68'
+  version '0.20200228.0'
+  sha256 'd0b2594deb29d3853c1002378344eaaeb55f7c6315beff48c0b76533266f03df'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.