### PR TITLE
Update supersync from 7.0.8 to 7.0.9

### DIFF
--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -1,6 +1,6 @@
 cask 'supersync' do
-  version '7.0.8'
-  sha256 'dab4f7c66186313b7903cbd0c06df0815c34de57a6e350e5b04d4fd1dddecd94'
+  version '7.0.9'
+  sha256 'e4948c43dc9f6eebadea0cd1864d8b0f8bb63a5930c0d22b57de1cd7bd4a04b5'
 
   url "https://supersync.com/downloads/SuperSync_#{version}.dmg"
   appcast 'https://supersync.com/downloads.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.