### PR TITLE
Update bettertouchtool from 3.339-1547 to 3.340-1548

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -6,8 +6,8 @@ cask 'bettertouchtool' do
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}_final_10_9.zip"
   else
-    version '3.339-1547'
-    sha256 '77fa9e9a6288783d5d9324236283bd1a8ba3737423fab5aaa8dde7f9a38cca80'
+    version '3.340-1548'
+    sha256 '3a82b62bba77d5c56a717c26823054af6ec0a8ebf79ed8de4226aee0ecc48a3c'
 
     # bettertouchtool.net/releases was verified as official when first introduced to the cask
     url "https://bettertouchtool.net/releases/btt#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.