### PR TITLE
Update chromium from 745431 to 745782

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '745431'
-  sha256 '75383949667c16526d579e7278eee3cae614318361218aa13c24e27eb85d4414'
+  version '745782'
+  sha256 '658ecb7b8d25de006c1c2f753bd59434d38bd2d465e2f105181d9541968232a5'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.