### PR TITLE
Update dust3d from 1.0.0-beta.29 to 1.0.0-rc.1

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-beta.29'
-  sha256 '14c12c0f2cb5e85781b689a971497d4c352cce45383fdb283acfa4492a3cce56'
+  version '1.0.0-rc.1'
+  sha256 'bb3e5d10288e3a9419051f761c3c0b4776550cbd3e3d354f0aad38abc88e5e38'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.