### PR TITLE
Update buttercup from 1.18.2 to 1.19.0

### DIFF
--- a/Casks/buttercup.rb
+++ b/Casks/buttercup.rb
@@ -1,6 +1,6 @@
 cask 'buttercup' do
-  version '1.18.2'
-  sha256 '0e75d28d54edf7b9fcc0e7d8eb616156c32f074c700ef8a62f15337b05e7f971'
+  version '1.19.0'
+  sha256 'c93ee64117e2728ab21ec1e1c71ec8c477464f807a13c272923e0d66d45d3668'
 
   # github.com/buttercup/buttercup-desktop was verified as official when first introduced to the cask
   url "https://github.com/buttercup/buttercup-desktop/releases/download/v#{version}/Buttercup-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.