### PR TITLE
Update dcp-o-matic-encode-server from 2.14.30 to 2.14.31

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.30'
-  sha256 '58f28ab999db70d745fbfa69d13b180f3a03ed3ebdfc7202cb28da12101a02d2'
+  version '2.14.31'
+  sha256 'eb87ddd56db2e91f02d18ab21dbeb4ef4723f546c6bc8e03a3e6ecdb5647ab6b'
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.