### PR TITLE
Update dcp-o-matic-player from 2.14.30 to 2.14.31

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.30'
-  sha256 '044c25f72ed1035bfd84f84fd3f0e2588ef44c92600086db11bf3cc0fea8a762'
+  version '2.14.31'
+  sha256 '3756f19ccdc1454f8b46a975037c751b9615258d3eea8f72f45b5ab742fa4dc8'
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.