### PR TITLE
Update gpxsee from 7.23 to 7.24

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.23'
-  sha256 '6cc12d2e8af264746b84c0e722a734bfed36c387d599b4729d3c3b148cde14a7'
+  version '7.24'
+  sha256 '120e45ef1aad7d6e475ace0c0fc8b8be73bdeeb51ce67824475214b6b65eda24'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.