### PR TITLE
Update denemo from 2.2 to 2.3.0

### DIFF
--- a/Casks/denemo.rb
+++ b/Casks/denemo.rb
@@ -1,8 +1,9 @@
 cask 'denemo' do
-  version '2.2'
-  sha256 '6ec66279be560e6e997b1108ae9ed61e6c37c36a350fbd99cd3dded8e2cfbe5f'
+  version '2.3.0'
+  sha256 '7e2110737f216311df6e2a41e8a4060a8d9776aac2310ea94c582faa076593ae'
 
-  url "http://denemo.org/downloads/denemo-#{version}-darwin-x64.tar.bz2"
+  # ftp.gnu.org/gnu/denemo was verified as official when first introduced to the cask
+  url "https://ftp.gnu.org/gnu/denemo/denemo-#{version}.tar.gz"
   appcast 'https://ftp.gnu.org/gnu/denemo/?C=M;O=D'
   name 'Denemo'
   homepage 'http://denemo.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.