### PR TITLE
Update netron from 3.9.5 to 3.9.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.9.5'
-  sha256 'bb490e3ab1a75f63055c11907be3ae75382f22632a8678d7ee23a5ccc127534f'
+  version '3.9.6'
+  sha256 '6339fe3c2d48e1b2ee0d54f02522c00e5725ee8fee6fd7840657fd7a131afcbf'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.