### PR TITLE
Update electron from 8.0.1 to 8.0.2

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '8.0.1'
-  sha256 'c7becd20aa2efea2f25fd8e546cc154e0b128b6474d05dc6e489b785874982ca'
+  version '8.0.2'
+  sha256 'a0ba4ecb236dcc411152b406d6e81d1f209cb34c93e4037a3ee1fd08b713a4df'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.