### PR TITLE
Update macspice from 3.1.21 to 3.1.22

### DIFF
--- a/Casks/macspice.rb
+++ b/Casks/macspice.rb
@@ -1,6 +1,6 @@
 cask 'macspice' do
-  version '3.1.21'
-  sha256 'cee7530d0f442d9c9d27063efd1c9c009edef82c9a5c4c39df9cf364b285d129'
+  version '3.1.22'
+  sha256 '66ef2ec06ddd723b25837aa1b14b53bc9d542bc68677a203c2416c8a45f05b4f'
 
   url "https://www.macspice.com/mirror/binaries/v#{version}/MacSpice3f5.dmg"
   appcast 'https://www.macspice.com/AppCast-v2.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.