### PR TITLE
Update metashape from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/metashape.rb
+++ b/Casks/metashape.rb
@@ -1,6 +1,6 @@
 cask 'metashape' do
-  version '1.6.1'
-  sha256 '9c442e8afbc298510de1927a31179fb0fb3e98140f6847f9319c6df66d94c3fd'
+  version '1.6.2'
+  sha256 '702692280a24618ef7b3fc9175c592c65d47b2ae876cb0bc1e84d4e8ed77f6c7'
 
   url "http://download.agisoft.com/metashape_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.agisoft.com/downloads/installer/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.