### PR TITLE
Update marginnote from 3.6.3002 to 3.6.4004

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,9 +1,9 @@
 cask 'marginnote' do
-  version '3.6.3002'
-  sha256 'c800fb301172d050b92810500757444b6712cc6968ce86a733554938e335ef82'
+  version '3.6.4004'
+  sha256 '39a8d11bb63dee2aacdf30199242f64a76e9888add2159a479f91321d7b8ea42'
 
-  # appcenter-filemanagement-distrib4ede6f06e.azureedge.net/ was verified as official when first introduced to the cask
-  url "https://appcenter-filemanagement-distrib4ede6f06e.azureedge.net/e817e853-6a6f-413c-b5cf-001dcc236caa/MarginNote#{version.major}.dmg?sv=2018-03-28&sr=c&sig=Cjah0NylL6vVfJBoJZkkLBy82DO78kwjh%2FclWqRDBEI%3D&se=2020-02-08T15%3A05%3A13Z&sp=r"
+  # appcenter-filemanagement-distrib5ede6f06e.azureedge.net/ was verified as official when first introduced to the cask
+  url "https://appcenter-filemanagement-distrib5ede6f06e.azureedge.net/6182955f-2d2c-4394-b8db-5f3ca321be72/MarginNote#{version.major}.dmg?sv=2018-03-28&sr=c&sig=cT2ZrVN7YAv3ulvnULUGiBCk8FQxxcmuVHPL3Vh32LA%3D&se=2020-03-03T12%3A53%3A28Z&sp=r"
   appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/1451f4f6-9214-4d46-b91c-d5898c7e42cb'
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.