### PR TITLE
Update kode54-cog from 0.08,9dd4f6804 to 1109,9dd4f6804

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,5 +1,5 @@
 cask 'kode54-cog' do
-  version '0.08,9dd4f6804'
+  version '1109,9dd4f6804'
   sha256 '9cc4c8553be6384fb1c6d3497e6f3f336ef5fdc9ebca42d0f878ee36f6500dd3'
 
   # losno.co/cog was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.