### PR TITLE
Update psychopy from 2020.1.1 to 2020.1.2

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,6 +1,6 @@
 cask 'psychopy' do
-  version '2020.1.1'
-  sha256 'd66613d57460326f77895952452712e10d11bc66b63c5862ac55de9ff484127c'
+  version '2020.1.2'
+  sha256 'a61a2d2702a5918c8c9700a642966acbae4f28f1ee63917d2adb69af6d104ff2'
 
   url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.