### PR TITLE
Update espresso from 5.3 to 5.3.2

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,6 +1,6 @@
 cask 'espresso' do
-  version '5.3'
-  sha256 '608520ea3aa87aea287f2b3c25f792704f2663ded5474ac7e4a168a26ed168b0'
+  version '5.3.2'
+  sha256 'ce23df1e9c4874805f91c838d0f8d0d368c6acbc09e3b20af0f3f8d62c4a4083'
 
   # downloads.kangacode.com was verified as official when first introduced to the cask
   url "https://downloads.kangacode.com/Espresso/Espresso_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.