### PR TITLE
Update understand from 5.1.1014 to 5.1.1015

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1014'
-  sha256 '1270371637aa3fdbec69482c382cee5435378eacf904e682fb0a56c4b89a9abe'
+  version '5.1.1015'
+  sha256 '640c111bd4d6a70a70ce7343360babd81221c2736e55f22d7e9e06119dd836c2'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.