### PR TITLE
Update zoc from 7.25.3 to 7.25.4

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.25.3'
-  sha256 'b4704781b94c99e27aa8343369d711a0e82bbb904431b9da55f7233def300bef'
+  version '7.25.4'
+  sha256 'bf29697e5b882076e791a683f24ae0fef00adffea96478acbe08f2cc5c1ca8f6'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.