### PR TITLE
Update udeler from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/udeler.rb
+++ b/Casks/udeler.rb
@@ -1,6 +1,6 @@
 cask 'udeler' do
-  version '1.8.0'
-  sha256 '2b949b86494818eb194a5e8cc97f1c7acbbdbeb87b4c5b8ff1e9e939de19e1c6'
+  version '1.8.1'
+  sha256 '54aae73a412ee07f5f60fcceab07af3080e8d0dda084bce914e5bb8148462495'
 
   url "https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v#{version}/Udeler-#{version}-mac.zip"
   appcast 'https://github.com/FaisalUmair/udemy-downloader-gui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.