### PR TITLE
Update snagit from 2020.1.1 to 2020.1.2

### DIFF
--- a/Casks/snagit.rb
+++ b/Casks/snagit.rb
@@ -1,5 +1,5 @@
 cask 'snagit' do
-  version '2020.1.1'
+  version '2020.1.2'
   sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://download.techsmith.com/snagitmac/releases/Snagit.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.