### PR TITLE
Update duefocus from 2.2.0 to 2.3.0

### DIFF
--- a/Casks/duefocus.rb
+++ b/Casks/duefocus.rb
@@ -1,6 +1,6 @@
 cask 'duefocus' do
-  version '2.2.0'
-  sha256 'f5ddeaa4c8afd0c4cc75c4f51ea778a6ba629a92cdcb99c864e898e8575d503b'
+  version '2.3.0'
+  sha256 'a30330d89cace86f228c18c04b7087c655a7e99ddde0ee78a19390af8ff54090'
 
   url "https://web.duefocus.com/distribution/darwin/v3/DueFocus-#{version}-mac.zip"
   appcast 'https://web.duefocus.com/distribution/darwin/v3/appcast.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.