### PR TITLE
Update spectx from 1.4.51 to 1.4.52

### DIFF
--- a/Casks/spectx.rb
+++ b/Casks/spectx.rb
@@ -1,6 +1,6 @@
 cask 'spectx' do
-  version '1.4.51'
-  sha256 '0872cd241f209b80e93166ac0f547ce5df73fb233e35a7430ab4f8a990b0033d'
+  version '1.4.52'
+  sha256 '91958889c5eeb0699789d81a698427a84b313f529aa7112f8c806321e7b5684f'
 
   url "https://get.spectx.com/03f21b939e022/SpectXDesktop-v#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://go.spectx.com/get/?desktop-osx64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.