### PR TITLE
Update lark from 3.18.3 to 3.18.4

### DIFF
--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -1,6 +1,6 @@
 cask 'lark' do
-  version '3.18.3'
-  sha256 '6ca13a0041796227d4ae06a4370ea1dca268992c42187b34191ff0a54f60839d'
+  version '3.18.4'
+  sha256 '28d5d19eabc3a85702dedb157dfa03ae0649aa913091f4272278b644d5390e93'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Lark-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.