### PR TITLE
Update torguard from 3.98.0 to 3.98.2

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,6 +1,6 @@
 cask 'torguard' do
-  version '3.98.0'
-  sha256 '78d9df847e73a148f21365ca2d1acde3b032cc0a084b06c49e96ec5f113c4661'
+  version '3.98.2'
+  sha256 '86a718f93539410cad509aaf6e3cb8efc88c8ca3d3da2d879aeca396eb7b0553'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.