### PR TITLE
Update minizincide from 2.4.2 to 2.4.3

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask 'minizincide' do
-  version '2.4.2'
-  sha256 '0775ddd221fc8ed5e0b9a1393fb86dd6dc95eab23f3d55b3b071476ee00b275b'
+  version '2.4.3'
+  sha256 'ac62403d386fd3b2471f347ce7d78fb2a5eb80fd08964c46881fc91a2603524e'
 
   # github.com/MiniZinc/MiniZincIDE was verified as official when first introduced to the cask
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.