### PR TITLE
Update understand from 5.1.1014 to 5.1.1017

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1014'
-  sha256 '1270371637aa3fdbec69482c382cee5435378eacf904e682fb0a56c4b89a9abe'
+  version '5.1.1017'
+  sha256 'c81a3a4c247281d14b5fa8a3ff92d988a4185d77c0d260ac0be33afa1057a5bd'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'

--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1017'
-  sha256 'c81a3a4c247281d14b5fa8a3ff92d988a4185d77c0d260ac0be33afa1057a5bd'
+  version '5.1.1018'
+  sha256 'c90e867a116a800eac3e04a1316cc9e9006a6bc964a87fb6750ba52b37bf96a2'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.