### PR TITLE
Update audirvana from 3.5.31 to 3.5.32

### DIFF
--- a/Casks/audirvana.rb
+++ b/Casks/audirvana.rb
@@ -1,6 +1,6 @@
 cask 'audirvana' do
-  version '3.5.31'
-  sha256 '0675a031aeb2f22834e3b720c009c04378aa36558a013219d03b294ea6b596ef'
+  version '3.5.32'
+  sha256 '43b581c0e75407b5fb41319fc74080af4c7bb6b2e29a24a7f501e714c9846e59'
 
   url "https://audirvana.com/delivery/Audirvana_#{version}.dmg"
   appcast "https://audirvana.com/delivery/audirvana#{version.major}_#{version.minor}_appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
