### PR TITLE
Update time-sink from 2.0.1 to 2.1.0

### DIFF
--- a/Casks/time-sink.rb
+++ b/Casks/time-sink.rb
@@ -1,6 +1,6 @@
 cask 'time-sink' do
-  version '2.0.1'
-  sha256 'd4453a1cd9c2219368b82e86dfa89bcca5a74b28a70ff1e31284c35bfb4b3b31'
+  version '2.1.0'
+  sha256 '6a2cec3828d7d3bf244825419dc82e3d5e0a6b640736c401c3b56305ddfef0ba'
 
   url "https://manytricks.com/download/_do_not_hotlink_/timesink#{version.no_dots}.dmg"
   appcast 'https://manytricks.com/timesink/appcast'

--- a/Casks/time-sink.rb
+++ b/Casks/time-sink.rb
@@ -3,7 +3,8 @@ cask 'time-sink' do
   sha256 '6a2cec3828d7d3bf244825419dc82e3d5e0a6b640736c401c3b56305ddfef0ba'
 
   url "https://manytricks.com/download/_do_not_hotlink_/timesink#{version.no_dots}.dmg"
-  appcast 'https://manytricks.com/timesink/appcast'
+  appcast 'https://manytricks.com/timesink/appcast',
+          configuration: version.chomp('.0')
   name 'Time Sink'
   homepage 'https://manytricks.com/timesink/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.