### PR TITLE
Update microsoft-edge from 80.0.361.62 to 80.0.361.66

### DIFF
--- a/Casks/microsoft-edge.rb
+++ b/Casks/microsoft-edge.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge' do
-  version '80.0.361.62'
-  sha256 '7618377f6323d99a9473f38974ec3a7f2c2488124cb014d2a824d02d3e0dd2d0'
+  version '80.0.361.66'
+  sha256 '11b14ed28608d1d02046f0cdea161ccb020bcb16213859329be66ef6e6753a19'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdge-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.