### PR TITLE
Update xamarin-mac from 6.14.1.30 to 6.10.0.21

### DIFF
--- a/Casks/xamarin-mac.rb
+++ b/Casks/xamarin-mac.rb
@@ -1,6 +1,6 @@
 cask 'xamarin-mac' do
-  version '6.14.1.30'
-  sha256 'a3bb2e2f6890ad641e8e26705e4b12316ce24ab4830282b96ac629822f1ecce1'
+  version '6.10.0.21'
+  sha256 '77c48943618528a41891305bca2b873cb9f9e1205ae300d4d6c616b11b1e2f9c'
 
   url "https://dl.xamarin.com/XamarinforMac/Mac/xamarin.mac-#{version}.pkg"
   appcast 'https://docs.microsoft.com/en-us/xamarin/mac/release-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.