### PR TITLE
Update katalon-studio from 7.2.5 to 7.2.6

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.2.5'
-  sha256 '04d36df59a2e88b96baccf98193af0327376369673704adfae7bd42880a11c47'
+  version '7.2.6'
+  sha256 '1854519c353168360aada6e7cf1f03513e8ad2e6d5f4a7876997d2ef620d6349'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.