### PR TITLE
Update opencore-configurator from 1.15.0.1 to 1.16.0.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.15.0.1'
-  sha256 '48952b3558a5553ec61ae8d39c434293017213517cf77ae3b7b2dcf11124934e'
+  version '1.16.0.0'
+  sha256 'c2094360280b71ff43f891a833f2cb49ed2fee01a81bad37f7af489926c14608'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.