### PR TITLE
Update aqua-data-studio from 20.5.0-2 to 20.5.0-3

### DIFF
--- a/Casks/aqua-data-studio.rb
+++ b/Casks/aqua-data-studio.rb
@@ -1,6 +1,6 @@
 cask 'aqua-data-studio' do
-  version '20.5.0-2'
-  sha256 '637d54ab94d0dc2f67cf3db83c9ee743b10365322b1e39f1660b0afdc6a01c71'
+  version '20.5.0-3'
+  sha256 'b0053af263a1b648764c891ce14704418ba5ec03b896d5566ccf61c5f3c04b12'
 
   url "http://downloads.aquafold.com/v#{version.major_minor}.0/osx/ads-osx-#{version}.tar.gz"
   appcast 'https://www.aquafold.com/aquadatastudio_downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.