### PR TITLE
Update stamp from 4.15.4 to 4.15.5

### DIFF
--- a/Casks/stamp.rb
+++ b/Casks/stamp.rb
@@ -1,6 +1,6 @@
 cask 'stamp' do
-  version '4.15.4'
-  sha256 'f4a3d411781d54282b3a2cbd8e72ef02b4ba40c5e0b236d4b169fb4abc5d231a'
+  version '4.15.5'
+  sha256 '7712a1485ed09486c3fba921b032869439baa6d6d23fafb07516ff77c94bc87b'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/STAMP#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.