### PR TITLE
Update quicken from 5.15.0,515.32908.100 to 5.15.1,515.32947.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.15.0,515.32908.100'
-  sha256 'cf9145400b32e723dca2b5533299cec8d68cbc3d2e7fd4e3a0f315927a81dc21'
+  version '5.15.1,515.32947.100'
+  sha256 'aafbd0b09c2eaf64201ffbaea20dca0b26ac6d70b3e0473ac9c8b487cdfc0a46'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.