### PR TITLE
Update loom from 0.30.4 to 0.30.5

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.30.4'
-  sha256 '90eca52662d6338905fed60c0f3a67393ac9881d549382b20b7da8002847d29d'
+  version '0.30.5'
+  sha256 '09461ee2dbe0de9240bb9ba76f1154a5b0476e88679fbac2eb03448cf822c388'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.