### PR TITLE
Update sizzy from 0.18.0 to 0.18.1

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.18.0'
-  sha256 '8365377523c236be8a9cb3cb24b689a6af5d275c906db7a31419b717692cf409'
+  version '0.18.1'
+  sha256 '1b3780ed5ed15fd14cbf867139e4cb00ae282ec099a33fb9cc33ecd09711a75a'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.