### PR TITLE
Update milanote from 2.0.3 to 2.0.4

### DIFF
--- a/Casks/milanote.rb
+++ b/Casks/milanote.rb
@@ -1,6 +1,6 @@
 cask 'milanote' do
-  version '2.0.3'
-  sha256 '6540ef1331a3770f231f16b31637b3f73f7accc46955d54722cf817d321834e6'
+  version '2.0.4'
+  sha256 '8baf63ec3e125263af919abdfc3310e770bc144058c702cec0b0bc6fb982a0b4'
 
   # milanote-app-releases.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://milanote-app-releases.s3.amazonaws.com/Milanote-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.