### PR TITLE
Update anka-flow from 2.2.1.114 to 2.2.2.116

### DIFF
--- a/Casks/anka-flow.rb
+++ b/Casks/anka-flow.rb
@@ -1,6 +1,6 @@
 cask 'anka-flow' do
-  version '2.2.1.114'
-  sha256 '5a9cbee1a0c8a93e41905b5b5263c023bf3bcea79b0905144403852d0085ed5f'
+  version '2.2.2.116'
+  sha256 '72b01734ef1e53f93f809eee31257c418424ee8afa1616e99063c8fbceeed5cf'
 
   # d1efqjhnhbvc57.cloudfront.net was verified as official when first introduced to the cask
   url "https://d1efqjhnhbvc57.cloudfront.net/Anka-#{version}.pkg",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.