### PR TITLE
Update nvidia-geforce-now from 2.0.16.148,845620 to 2.0.17.126,EBE832

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.16.148,845620'
-  sha256 '4b748180aea6a5034d3e38ec73c777cba59e0ffe4c14a80c23e24bc4dace29e7'
+  version '2.0.17.126,EBE832'
+  sha256 'ea515f9a4e966321571bfa0f5e4d1af4006a93cd3845bfc4ad3cff899b6a694b'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.