### PR TITLE
powershell 7.0.0 change macos version from sierra to high_sierra

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -7,7 +7,7 @@ cask 'powershell' do
   name 'PowerShell'
   homepage 'https://github.com/PowerShell/PowerShell'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   pkg "powershell-#{version}-osx-x64.pkg"
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->
With PowerShell 7 GA it only supports macos 10.13+
https://github.com/powershell/powershell#get-powershell

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).