### PR TITLE
Update nextcloud from 2.6.3.20200217 to 2.6.4.20200303

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -1,10 +1,10 @@
 cask 'nextcloud' do
   if MacOS.version <= :el_capitan
-    version '2.6.3.20200217-legacy'
-    sha256 '9e3f5c509cd7889b78bb0375e01f0e46b457a98845f0a222d71235cd65413dec'
+    version '2.6.4.20200303-legacy'
+    sha256 '63118b878e36e9213297015798a3822d92fe36010690a0951ed1b2f255259368'
   else
-    version '2.6.3.20200217'
-    sha256 'baee483ef22ad6aec13aeea19d550f3a89f008dda48749f7feaf621b1a3d457f'
+    version '2.6.4.20200303'
+    sha256 '989be2911e096b1f20132c0649f8a4a42f2c9d6111c6d46dfec7278f783721b6'
   end
 
   url "https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.