### PR TITLE
Update boom-3d from 1.3.3,1571300754 to 1.3.5

### DIFF
--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -6,7 +6,7 @@ cask 'boom-3d' do
   url "https://d3jbf8nvvpx3fh.cloudfront.net/Boom3D/Update/v#{version}/Boom_3D_Update.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/send_post_request_data.cgi?url=https://apiboom3.globaldelight.net/v1/native/queryupdate/&data={%22AppIdentifier%22:%22com.globaldelight.Boom3D%22,%22ApplicationVersion%22:%221.3.3%22,%22AppVersion%22:%22101.3.3018%22,%22ApplicationId%22:%22com.globaldelight.Boom3D%22,%22RequestType%22:0,%22AppName%22:%22Boom%203D%22}'
   name 'Boom 3D'
-  homepage 'https://www.globaldelight.com/boom3d'
+  homepage 'https://www.globaldelight.com/boom/'
 
   depends_on macos: '>= :yosemite'
 

--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -1,10 +1,10 @@
 cask 'boom-3d' do
-  version '1.3.3,1571300754'
-  sha256 'd65bd4bd1c146b8c9bd061f35c4e64b8e1d29c6796f6db0bc42a8b9e2f16741a'
+  version '1.3.5'
+  sha256 '5378befcfc5d1d0e2f2b6eb7fea3f4c435cab0d70d86eb23ceb5103607fccbe5'
 
-  # devmate.com/com.globaldelight.Boom3D was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.globaldelight.Boom3D/#{version.before_comma}/#{version.after_comma}/Boom3D-#{version.before_comma}.dmg"
-  appcast 'https://updates.devmate.com/com.globaldelight.Boom3D.xml'
+  # d3jbf8nvvpx3fh.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d3jbf8nvvpx3fh.cloudfront.net/Boom3D/Update/v#{version}/Boom_3D_Update.dmg"
+  appcast 'https://www.macupdater.net/cgi-bin/extract_text/send_post_request_data.cgi?url=https://apiboom3.globaldelight.net/v1/native/queryupdate/&data={%22AppIdentifier%22:%22com.globaldelight.Boom3D%22,%22ApplicationVersion%22:%221.3.3%22,%22AppVersion%22:%22101.3.3018%22,%22ApplicationId%22:%22com.globaldelight.Boom3D%22,%22RequestType%22:0,%22AppName%22:%22Boom%203D%22}'
   name 'Boom 3D'
   homepage 'https://www.globaldelight.com/boom3d'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.