### PR TITLE
Update photosweeper-x from 3.5.0 to 3.6.1 + update url and appcast

### DIFF
--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,8 +1,8 @@
 cask 'photosweeper-x' do
   version '3.6.1'
-  sha256 '219449a640233f67c1b111636c0a29018c5525d44929d19605b366c79e128e30'
+  sha256 '96f7fb8d6a610aa194c4639d37406ccc001e0f03a9a423b5aef18963cd38a481'
 
-  url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
+  url 'https://overmacs.com/downloads/PhotoSweeper_X.dmg'
   appcast 'https://overmacs.com/feeds/photosweeper_update.xml'
   name 'PhotoSweeper X'
   homepage 'https://overmacs.com/'

--- a/Casks/photosweeper-x.rb
+++ b/Casks/photosweeper-x.rb
@@ -1,9 +1,9 @@
 cask 'photosweeper-x' do
-  version '3.5.0'
+  version '3.6.1'
   sha256 '219449a640233f67c1b111636c0a29018c5525d44929d19605b366c79e128e30'
 
   url 'https://overmacs.com/photosweeper/downloads/PhotoSweeperTrial.dmg'
-  appcast 'https://overmacs.com/photosweeper/updates/photosweeper_update.xml'
+  appcast 'https://overmacs.com/feeds/photosweeper_update.xml'
   name 'PhotoSweeper X'
   homepage 'https://overmacs.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.