### PR TITLE
Update izip from 3.6 to 3.7

### DIFF
--- a/Casks/izip.rb
+++ b/Casks/izip.rb
@@ -1,6 +1,6 @@
 cask 'izip' do
-  version '3.6'
-  sha256 '951b631107a532077c99f1bbd1579f6435d3c5715f657068950388af351bd164'
+  version '3.7'
+  sha256 '7be4dbc10384072058e56164b3a58a5164127e556e4a343a3acc14fd6f8104ba'
 
   url 'https://www.izip.com/izip.dmg'
   appcast 'https://www.izip.com/updates'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.