### PR TITLE
Update ledger-live from 1.20.0 to 2.0.0

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '1.20.0'
-  sha256 '5964b2c5d40f656b03e09c79a80546bf8a22b98559a2fd8e1485059e62f8a6fb'
+  version '2.0.0'
+  sha256 '36da02e11dab1ff080094575ab81ae8109bb2763ad84165a2ad98352b77cf3a6'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.