### PR TITLE
Update vivaldi from 2.11.1811.44 to 2.11.1811.47

### DIFF
--- a/Casks/vivaldi.rb
+++ b/Casks/vivaldi.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi' do
-  version '2.11.1811.44'
-  sha256 '55f719121e93a4d388cf1b5360c577558839fb77688514151807cacf90d4121c'
+  version '2.11.1811.47'
+  sha256 'fde35914e3eda41047c937d159646b9edfb723aa0fc67c6db0253f7c2caf8a07'
 
   url "https://downloads.vivaldi.com/stable/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/public/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.