### PR TITLE
Update propresenter from 7.0.3,117441283 to 7.0.4,117441539

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,6 +1,6 @@
 cask 'propresenter' do
-  version '7.0.3,117441283'
-  sha256 '0fba6c670b8ec4c4e38fc27f97cdfc87806a6264e3af83af3dcaa7a011389916'
+  version '7.0.4,117441539'
+  sha256 'b634a52caa1380ea2b31f304d2376a3eaf87b02d3316ecf8c018b566064fb141'
 
   url "https://renewedvision.com/downloads/propresenter/mac/ProPresenter_#{version.before_comma}_#{version.after_comma}.zip"
   appcast 'https://api.renewedvision.com/v1/pro/upgrade?platform=macos&osVersion=0&appVersion=0&buildNumber=0&includeNotes=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.