### PR TITLE
Update datovka from 4.14.1 to 4.15.0

### DIFF
--- a/Casks/datovka.rb
+++ b/Casks/datovka.rb
@@ -1,6 +1,6 @@
 cask 'datovka' do
-  version '4.14.1'
-  sha256 'c09e40ec3a10b26c3913eba33f0b9a5bd42b7341937308124fe40c105a10cc56'
+  version '4.15.0'
+  sha256 'b7b76c092252a45f66b11b43a049ce062ff58b2a9d0d5b027081ac6e3f5131e8'
 
   # secure.nic.cz/files/datove_schranky was verified as official when first introduced to the cask
   url "https://secure.nic.cz/files/datove_schranky/#{version}/datovka-#{version}-64bit-osx10.7.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.