### PR TITLE
Update bluestacks from 4.140.13.2803,7b51e6488db874e4f7fb6a253786c8f1 to 4.160.10.2058,1758593b86f4809a6c06f6b402b1c121

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -1,6 +1,6 @@
 cask 'bluestacks' do
-  version '4.140.13.2803,7b51e6488db874e4f7fb6a253786c8f1'
-  sha256 'af415dc8f1a5e901583aae8e01192281b1e6a62f4dbe7edde647f777574064fc'
+  version '4.160.10.2058,1758593b86f4809a6c06f6b402b1c121'
+  sha256 'b4aaa17c759297184a7bbfd46bd4289ee9590954ffdebd6b626e11e3be0dafb1'
 
   url "https://cdn3.bluestacks.com/downloads/mac/bgp64_mac/#{version.before_comma}/#{version.after_comma}/x64/BlueStacksInstaller_#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://cloud.bluestacks.com/api/getdownloadnow?platform=mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.