### PR TITLE
Update roblox from 0.421.0.385673,278cee1b313a457a to 0.422.0.388145,5a33b28026914549

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.421.0.385673,278cee1b313a457a'
-  sha256 'bfcf02216011eea03de311199d118f0f4e6e398d7532b556e4870c39fe1addaf'
+  version '0.422.0.388145,5a33b28026914549'
+  sha256 'aca41c4d937e155596bf4fe3fe4cc400e96767d8be25afee0f7f09066eec58c5'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.