### PR TITLE
Update qownnotes from 20.3.1,b5392-164222 to 20.3.2,b5396-081740

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.3.1,b5392-164222'
-  sha256 '744affc39d7055914bb785156629136208a901f26d0037a654f3e13f4e8cd85f'
+  version '20.3.2,b5396-081740'
+  sha256 '9305be3cb72344f260c8b25733b4a7431f2d22af6550b73a754a9c8db7ee483e'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.