### PR TITLE
Add SHA256 sum to keyboard-cleaner 1.2 cask

### DIFF
--- a/Casks/keyboard-cleaner.rb
+++ b/Casks/keyboard-cleaner.rb
@@ -1,10 +1,10 @@
 cask 'keyboard-cleaner' do
-  version :latest
-  sha256 :no_check
+  version '1.2'
+  sha256 '75af7b4126b75e727045f4d9533b8d52a0ce4f5dc1610280f5bfc6b09814fa48'
 
-  url 'http://jan.prima.de/u/Keyboard-Cleaner-64bit.zip'
+  url 'https://jan.prima.de/u/Keyboard-Cleaner-64bit.zip'
   name 'Keyboard Cleaner'
-  homepage 'http://jan.prima.de/~jan/plok/archives/48-Keyboard-Cleaner.html'
+  homepage 'https://jan.prima.de/~jan/plok/archives/48-Keyboard-Cleaner.html'
 
   app 'Keyboard Cleaner.app'
 end


### PR DESCRIPTION
also use https for download

methodology:
```
$ wget http://jan.prima.de/u/Keyboard-Cleaner-64bit.zip
...
$ sha256sum Keyboard-Cleaner-64bit.zip
75af7b4126b75e727045f4d9533b8d52a0ce4f5dc1610280f5bfc6b09814fa48  Keyboard-Cleaner-64bit.zip
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
