### PR TITLE
Update Nheko to Active Fork and v0.6.4

### DIFF
--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -2,6 +2,7 @@ cask 'nheko' do
   version '0.6.4'
   sha256 '1214025539bfbbcb4f0808efe1c6f49f478171d8ce9dceb786dfc200f8755546'
 
+  # github.com/Nheko-Reborn/nheko was verified as official when first introduced to the cask
   url "https://github.com/Nheko-Reborn/nheko/releases/download/v#{version}/nheko-v#{version}.dmg"
   appcast 'https://github.com/Nheko-Reborn/nheko/releases.atom'
   name 'Nheko'

--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -1,11 +1,11 @@
 cask 'nheko' do
-  version '0.6.2'
-  sha256 'b78a8322f9463a7bbb7b1c04aee2b5318c16cef9b5dafddac828e8fd59f2813e'
+  version '0.6.4'
+  sha256 '1214025539bfbbcb4f0808efe1c6f49f478171d8ce9dceb786dfc200f8755546'
 
-  url "https://github.com/mujx/nheko/releases/download/v#{version}/nheko-v#{version}.dmg"
-  appcast 'https://github.com/mujx/nheko/releases.atom'
+  url "https://github.com/Nheko-Reborn/nheko/releases/download/v#{version}/nheko-v#{version}.dmg"
+  appcast 'https://github.com/Nheko-Reborn/nheko/releases.atom'
   name 'Nheko'
-  homepage 'https://github.com/mujx/nheko'
+  homepage 'https://nheko-reborn.github.io/'
 
   app 'Nheko.app'
 end


### PR DESCRIPTION
Updated nheko cask to new fork due to original being archived.
Nheko is now maintained by Nheko-Reborn org on github.

Also updated the version from v0.6.2 to v0.6.4

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
