### PR TITLE
Update kite from 0.20200228.0 to 0.20200304.1

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200228.0'
-  sha256 'd0b2594deb29d3853c1002378344eaaeb55f7c6315beff48c0b76533266f03df'
+  version '0.20200304.1'
+  sha256 'c4facd476bfe018227975a152a033f09ba5e5533b04ba2e6c93657370522376e'
 
   # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.