### PR TITLE
Update suitcase-fusion from 21.0.0 to 21.0.1

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,6 +1,6 @@
 cask 'suitcase-fusion' do
-  version '21.0.0'
-  sha256 '38a3c56392b88856a95a9dfd6a04f33102eed7a5ba9e675d5d054ce33acbcb5c'
+  version '21.0.1'
+  sha256 'c6592d0995876988ad82aed18e2491a6fe58d921dc68d502459fcc242d5878aa'
 
   url "https://bin.extensis.com/SuitcaseFusion-M-#{version.dots_to_hyphens}.dmg"
   appcast "https://www.extensis.com/support/suitcase-fusion-#{version.major}/release-notes/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.