### PR TITLE
Update touchdesigner from 2020.20020 to 2020.20620

### DIFF
--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -1,6 +1,6 @@
 cask 'touchdesigner' do
-  version '2020.20020'
-  sha256 '5fa5d8dfbfd8592c6819bcc61bd01c372c8694eb309cc1208c854bc3903b97c5'
+  version '2020.20620'
+  sha256 '7b7d154950cf3e9cd58b762ba4def696a85e57078913fb2691b4575852ce2226'
 
   url "https://download.derivative.ca/TouchDesigner.#{version}.dmg"
   appcast 'https://www.derivative.ca/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.