### PR TITLE
Update netron from 3.9.6 to 3.9.7

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '3.9.6'
-  sha256 '6339fe3c2d48e1b2ee0d54f02522c00e5725ee8fee6fd7840657fd7a131afcbf'
+  version '3.9.7'
+  sha256 'db8e096228d07c0aef18eb2c37aac73483ddf6219115fe18991996a44a4c974d'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.