### PR TITLE
Update cctalk from 7.6.4.2 to 7.6.4.18

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask 'cctalk' do
-  version '7.6.4.2'
-  sha256 'd8434aa6570bb7b08fa3f14ab7b9cd37c33d842719deda6c4f58d670915976f6'
+  version '7.6.4.18'
+  sha256 '2f5c2e7329838f20f8423c40a59bb50eec68657cda8362859f6fc1e2d204b116'
 
   # cc.hjfile.cn was verified as official when first introduced to the cask
-  url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
+  url "https://cc.hjfile.cn/cc/CCtalk.#{version}/8/1/103/CCtalk.#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.