### PR TITLE
Update preform from 3.4.1,138 to 3.4.2,156

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.4.1,138'
-  sha256 '5fa98bca41894c17e375e5efd4b26c49622e808fb5dbb7ea335d815811234810'
+  version '3.4.2,156'
+  sha256 'e533bdf4f3bf4c4bc300651ec54459744aeb8a0c1815f87487690c674a5d8a8e'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.