### PR TITLE
Update mucommander from 0.9.3,3 to 0.9.4

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,9 +1,9 @@
 cask 'mucommander' do
-  version '0.9.3,3'
-  sha256 '17d3fdf19b14299e8edbe3bb1b4ec5629c100d9ffc5f702e736094a1a500354b'
+  version '0.9.4'
+  sha256 '8f7aaf9734386506b0c4b10ac36c06c31b2b90d45747d250218b256aac35e352'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
-  url "https://github.com/mucommander/mucommander/releases/download/#{version.before_comma}-#{version.after_comma}/mucommander-#{version.before_comma}.dmg"
+  url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"
   appcast 'https://github.com/mucommander/mucommander/releases.atom'
   name 'muCommander'
   homepage 'https://www.mucommander.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.