### PR TITLE
Update chrysalis from 0.7.1 to 0.7.3

### DIFF
--- a/Casks/chrysalis.rb
+++ b/Casks/chrysalis.rb
@@ -1,6 +1,6 @@
 cask 'chrysalis' do
-  version '0.7.1'
-  sha256 '1fbbaabbdd49302e23dc94022afd038bfcb1612ac85ec020eaf15941764a8bb4'
+  version '0.7.3'
+  sha256 '91e88bd06baa749b870a2b404097a86fd80f200cef7e4e5e21412ee6d24be222'
 
   url "https://github.com/keyboardio/Chrysalis/releases/download/chrysalis-#{version}/Chrysalis-#{version}.dmg"
   appcast 'https://github.com/keyboardio/Chrysalis/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.