### PR TITLE
Update devdocs from 0.6.9 to 0.7.1

### DIFF
--- a/Casks/devdocs.rb
+++ b/Casks/devdocs.rb
@@ -1,6 +1,6 @@
 cask 'devdocs' do
-  version '0.6.9'
-  sha256 'fb983d3f17fd987afbe624e4949c79dd8f19b11072430da4e81e02ad4bb761f1'
+  version '0.7.1'
+  sha256 'cec5ab99d9d3cff879fedf5379904d0993b09a43cf3fb5838e02450e3798753a'
 
   url "https://github.com/egoist/devdocs-desktop/releases/download/v#{version}/DevDocs-#{version}.dmg"
   appcast 'https://github.com/egoist/devdocs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.