### PR TITLE
Update lbry from 0.43.2 to 0.43.3

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.43.2'
-  sha256 'd0a265528c85f8b23490f343fe12e53ee87895af375c541d23d2323502228f7a'
+  version '0.43.3'
+  sha256 'cdc7dd244215d2a4d04672b8db8ded16d39593cf2caabf782c1684d893c7c1a7'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.