### PR TITLE
Update freeze from 3.12 to 3.12.1

### DIFF
--- a/Casks/freeze.rb
+++ b/Casks/freeze.rb
@@ -1,6 +1,6 @@
 cask 'freeze' do
-  version '3.12'
-  sha256 '59bff1a92d65e2b34852c4660611b85a97f10772bc31ac753342fa80c0b9ded6'
+  version '3.12.1'
+  sha256 '815d667f6dcc5b0fabc657a40afe2fe194ce8411a8f5ca22c68b5547afff4998'
 
   url 'https://www.freezeapp.net/download/Freeze.zip'
   appcast 'https://www.freezeapp.net/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.