### PR TITLE
Update beatunes from 5.2.5 to 5.2.6

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,6 +1,6 @@
 cask 'beatunes' do
-  version '5.2.5'
-  sha256 '40fd463c0de5e5fd117bd997249a526bdb1417374ba2cb47fb44bee3b508e5d6'
+  version '5.2.6'
+  sha256 '58a593fdb339e25a3173b8713216d0740758b161a72b1513ef80f847c9ba3b7e'
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   appcast 'https://www.beatunes.com/en/beatunes-download.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.