### PR TITLE
Update chemdoodle from 10.2.0 to 10.3.0

### DIFF
--- a/Casks/chemdoodle.rb
+++ b/Casks/chemdoodle.rb
@@ -1,6 +1,6 @@
 cask 'chemdoodle' do
-  version '10.2.0'
-  sha256 'b188eede7ce3e98c4c1e49aa9a72bd008c62e298ac00f91220b6d9821758df79'
+  version '10.3.0'
+  sha256 '897755ac77be93a799b0df6e1c2e315846ae915be4e00126484f9702b272eceb'
 
   url "https://www.ichemlabs.com/downloads/ChemDoodle-osx-#{version}.dmg"
   appcast 'https://www.ichemlabs.com/download#chemdoodle/osx-installation-instructions/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.