### PR TITLE
Update wechatwork from 3.0.12.2111 to 3.0.12.2113

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.12.2111'
-  sha256 'a136ae5dd84bab04da41e4b4cd9b79ac4b6faedc0738faf51c523941e686f3c0'
+  version '3.0.12.2113'
+  sha256 '583e752fe30f1052b3f98318c0193f2cf3ebafb0b57e7ea999f4ba912a7af128'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.