### PR TITLE
Update joplin from 1.0.179 to 1.0.193

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.179'
-  sha256 'd0705af2c36c5f0fd4ef00d98da5f9bab67dd0468a36badada41b2c697c3780e'
+  version '1.0.193'
+  sha256 '59b55885064f5e271bc674df9e7d98d1e665dfda4ae7e6b201c69b2b2ac96bde'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.