### PR TITLE
Update unity from 2019.3.3f1,7ceaae5f7503 to 2019.3.4f1,4f139db2fdbd

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.3.3f1,7ceaae5f7503'
-  sha256 'ea52db8091edc87fef5b9ebea9fd368ac9aef08189762adf54b6a09c06ec8ce0'
+  version '2019.3.4f1,4f139db2fdbd'
+  sha256 '6ff1c67104fcde2aa07935ea3e80d7f3c2c75d9362345cd768990c847726e2a3'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.