### PR TITLE
Update psychopy from 2020.1.2 to 2020.1.3

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -1,8 +1,8 @@
 cask 'psychopy' do
-  version '2020.1.2'
-  sha256 'a61a2d2702a5918c8c9700a642966acbae4f28f1ee63917d2adb69af6d104ff2'
+  version '2020.1.3'
+  sha256 'bccf335b807d8934dfb55f7d6e654e9cd371e01d54268031be8717216221c348'
 
-  url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy3-#{version}-MacOS.dmg"
+  url "https://github.com/psychopy/psychopy/releases/download/2020.2.3/StandalonePsychoPy3-#{version}-MacOS.dmg"
   appcast 'https://github.com/psychopy/psychopy/releases.atom'
   name 'PsychoPy'
   homepage 'https://github.com/psychopy/psychopy'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.