### PR TITLE
Update unity-ios-support-for-editor from 2019.3.3f1,7ceaae5f7503 to 2019.3.4f1,4f139db2fdbd

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.3f1,7ceaae5f7503'
-  sha256 'be4188108ae0eeb9bfa2166e9e1e2bc6babaf8495faa61c7f7d64fffcdcc322c'
+  version '2019.3.4f1,4f139db2fdbd'
+  sha256 '64dbe59cc75fc4fbf3826226bc367f3c8190e4126aa1935c9170baeb19552360'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.