### PR TITLE
Update unity-webgl-support-for-editor from 2019.3.3f1,7ceaae5f7503 to 2019.3.4f1,4f139db2fdbd

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.3.3f1,7ceaae5f7503'
-  sha256 '4f0ff9eee9f635372d8dd598b6fb5ef9921fb739d9484cfd3d8fbaaba9d16ad4'
+  version '2019.3.4f1,4f139db2fdbd'
+  sha256 'c1640e9f55c09356981f26999fb0b74566a2cc80e2b7fe97ab0afeca8da09bd5'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.