### PR TITLE
Update unity-windows-support-for-editor from 2019.3.3f1,7ceaae5f7503 to 2019.3.4f1,4f139db2fdbd

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.3.3f1,7ceaae5f7503'
-  sha256 'f0dfa3452a16a7ffb4b765f7969771018ec0a48895467ed6f2d71244658cf9cf'
+  version '2019.3.4f1,4f139db2fdbd'
+  sha256 '9e22fd731cc302f4e79436dd75410ee262929a84e9fe7e868169949049291538'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.