### PR TITLE
Uninstall witch better

### DIFF
--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -11,5 +11,11 @@ cask 'witch' do
 
   prefpane 'Witch.prefPane'
 
-  zap trash: '~/Library/Preferences/com.manytricks.Witch.plist'
+  uninstall quit:       'com.manytricks.witchdaemon',
+            login_item: 'witchdaemon'
+
+  zap trash: [
+               '~/Library/Preferences/com.manytricks.Witch.plist',
+               '~/Library/Application Support/Witch',
+             ]
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256


So this only fixes uninstallations when you select 'Install for this user only' during (manual) installation:

![image](https://user-images.githubusercontent.com/923242/76169116-34008400-616d-11ea-8d92-9d35c2aef183.png)

I've created #78337 to log future support for global prefpane removal.

Also https://manytricks.com/osticket/kb/faq.php?id=28 says that the user needs to restart System Preferences (to get rid of the pane) and this is correct. Should `brew cask uninstall` be doing this?