### PR TITLE
Update xamarin-profiler from 1.6.12-26 to 1.6.13-11

### DIFF
--- a/Casks/xamarin-profiler.rb
+++ b/Casks/xamarin-profiler.rb
@@ -1,6 +1,6 @@
 cask 'xamarin-profiler' do
-  version '1.6.12-26'
-  sha256 '8968ee2cd555efcd9058ee313683d09c731aec5bf6c0e01b65020fe4917b0c87'
+  version '1.6.13-11'
+  sha256 'd190fb22d921945a613b2b8b013cfe4cd775401e98d3350373852f3702e28ce2'
 
   url "https://dl.xamarin.com/profiler/profiler-mac-#{version}.pkg"
   appcast 'https://developer.xamarin.com/releases/profiler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.