### PR TITLE
Update electrocrud from 2.6.0 to 2.6.1

### DIFF
--- a/Casks/electrocrud.rb
+++ b/Casks/electrocrud.rb
@@ -1,6 +1,6 @@
 cask 'electrocrud' do
-  version '2.6.0'
-  sha256 '8915ff804c9d9f392d3d0ca0201246a7b3a9a53a5eefbab3602572074dcee12a'
+  version '2.6.1'
+  sha256 '445373333da3810a10a8bfceafcb7a4033e00fadfd203de7df11a31b88f5f404'
 
   url "https://github.com/garrylachman/ElectroCRUD/releases/download/#{version}/ElectroCRUD-#{version}.dmg"
   appcast 'https://github.com/garrylachman/ElectroCRUD/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.