### PR TITLE
Update amethyst from 0.15.0 to 0.15.1

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -8,8 +8,8 @@ cask 'amethyst' do
     sha256 '9fd1ac2cfb8159b2945a4482046ee6d365353df617f4edbabc4e8cadc448c1e7'
     url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
   else
-    version '0.15.0'
-    sha256 '3a8c297f753161678a9db5d02c279e0dd266501f0887c9c9feb1b9cc4ef03ec7'
+    version '0.15.1'
+    sha256 '442480ebd9ca4b584f0d844b7858eccf9f1b1a98db4a0169420dc5ba25f35a07'
     # github.com/ianyh/Amethyst was verified as official when first introduced to the cask
     url "https://github.com/ianyh/Amethyst/releases/download/v#{version}/Amethyst.zip"
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.