### PR TITLE
Add full name for MEGA

### DIFF
--- a/Casks/mega.rb
+++ b/Casks/mega.rb
@@ -4,6 +4,7 @@ cask 'mega' do
 
   url "https://www.megasoftware.net/releases/MEGA#{version}_mac32_setup.dmg"
   name 'MEGA'
+  name 'Molecular Evolutionary Genetics Analysis'
   homepage 'https://megasoftware.net/'
 
   app "MEGA#{version.major}.app"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Last checkpoint doesn’t apply since this isn’t a version update.

Rationale: after reading the website and name I cannot decide what it is. The full name contains critical information for users that have never heard of it before.