### PR TITLE
Update burn from 2.7.8 to 2.7.9

### DIFF
--- a/Casks/burn.rb
+++ b/Casks/burn.rb
@@ -1,6 +1,6 @@
 cask 'burn' do
-  version '2.7.8'
-  sha256 'b071dbed5a44cd802b262e632bf8717ba60583f9c3d31a63122614daef2a3e6c'
+  version '2.7.9'
+  sha256 '5b0c2a5a8676475b43048149d92dc3496b83ff3ec4f9a585f5112afe267f2ad7'
 
   # downloads.sourceforge.net/burn-osx was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/burn-osx/Burn/#{version}/burn-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.