### PR TITLE
Update tinymediamanager from 3.1.3 to 3.1.4

### DIFF
--- a/Casks/tinymediamanager.rb
+++ b/Casks/tinymediamanager.rb
@@ -1,6 +1,6 @@
 cask 'tinymediamanager' do
-  version '3.1.3'
-  sha256 'c146c5a2ab7877abf19996b59a788a0546a901dfcb4789368356903c99e8df4a'
+  version '3.1.4'
+  sha256 '9386928df1021f51856457de0ed4b4edeca934c731a6b4dd2cfe4b1fa677c527'
 
   url "https://release.tinymediamanager.org/v#{version.major}/dist/tmm_#{version}_mac.zip"
   appcast 'https://release.tinymediamanager.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.