### PR TITLE
Update mucommander from 0.9.4 to 0.9.4-2

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,6 +1,6 @@
 cask 'mucommander' do
-  version '0.9.4'
-  sha256 '8f7aaf9734386506b0c4b10ac36c06c31b2b90d45747d250218b256aac35e352'
+  version '0.9.4-2'
+  sha256 '1f0dee9c1a4713b462d5ccae5799ca3bb48178c1877715dd34213183d0fc960a'
 
   # github.com/mucommander/mucommander was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).