### PR TITLE
Update visit from 3.1.0 to 3.1.1

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -1,9 +1,18 @@
 cask 'visit' do
-  version '3.1.0'
-  sha256 '5da96f81f82d680f7c510b41f80fb5030f32436a54f59f39371eb1464c021912'
+  version '3.1.1'
 
-  # portal.nersc.gov/project/visit was verified as official when first introduced to the cask
-  url "https://portal.nersc.gov/project/visit/releases/#{version}/visit#{version}.darwin-x86_64-10_13.dmg"
+  if MacOS.version <= :high_sierra
+    sha256 '4213daed23de17ee8bcfba779a96cce3ef92d3075ae666f7aeaffa824d484924'
+
+    # github.com/visit-dav/visit was verified as official when first introduced to the cask
+    url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version}.darwin-x86_64-10.13.dmg"
+  else
+    sha256 '4bb596c4411dc5f7b19598fc1a1ccaefe227527e2623cd1c628288c12be69d99'
+
+    # github.com/visit-dav/visit was verified as official when first introduced to the cask
+    url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version}.darwin-x86_64-10_14.dmg"
+  end
+
   appcast 'https://wci.llnl.gov/simulation/computer-codes/visit/executables'
   name 'VisIt'
   homepage 'https://wci.llnl.gov/simulation/computer-codes/visit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.