### PR TITLE
Update marginnote from 3.6.4004 to 3.6.5006

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,9 +1,9 @@
 cask 'marginnote' do
-  version '3.6.4004'
-  sha256 '39a8d11bb63dee2aacdf30199242f64a76e9888add2159a479f91321d7b8ea42'
+  version '3.6.5006'
+  sha256 '1d2875d19c9f93a56ee8bfa57f2204e2137e6f31ffdabe82f94398d2c0606e37'
 
-  # appcenter-filemanagement-distrib5ede6f06e.azureedge.net/ was verified as official when first introduced to the cask
-  url "https://appcenter-filemanagement-distrib5ede6f06e.azureedge.net/6182955f-2d2c-4394-b8db-5f3ca321be72/MarginNote#{version.major}.dmg?sv=2018-03-28&sr=c&sig=cT2ZrVN7YAv3ulvnULUGiBCk8FQxxcmuVHPL3Vh32LA%3D&se=2020-03-03T12%3A53%3A28Z&sp=r"
+  # appcenter-filemanagement-distrib3ede6f06e.azureedge.net/ was verified as official when first introduced to the cask
+  url "https://appcenter-filemanagement-distrib3ede6f06e.azureedge.net/9a587020-3de9-4f89-a1e0-7b0786d9a7ad/MarginNote%20#{version.major}.app.zip?sv=2018-03-28&sr=c&sig=UBUg7mzKRktWhwCejx81VLEEihC%2BCfbxC8Z6XfWv4aI%3D&se=2020-03-10T14%3A28%3A12Z&sp=r"
   appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/1451f4f6-9214-4d46-b91c-d5898c7e42cb'
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.