### PR TITLE
Update ocenaudio from 3.7.10 to 3.7.11

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,12 +1,12 @@
 cask 'ocenaudio' do
-  version '3.7.10'
+  version '3.7.11'
 
   if MacOS.version <= :high_sierra
-    sha256 '50fe4b9c5cfaf332138fe4907ee94d10c3c31d62a638f074a43b5f39e6e1f575'
+    sha256 '64ce9f59d2dadd750bf07e769a78523ea5a99c5c351ee3e057d70f7873132c5e'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 'b7d31c70ffec5ac6c9bc8efc71c535220e105411e5529b1babb7ea3f46404e48'
+    sha256 '51fd7b858ac204ddd23946b7ac1fe755d032b85c5711b29bd99703f7dc178fc6'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.