### PR TITLE
Update trilium-notes from 0.40.4 to 0.40.5

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.40.4'
-  sha256 '42289fbae769a6a6a09242de9e2bf36fdfac2495f285c75b2d508d91ccddb99b'
+  version '0.40.5'
+  sha256 'a77d911f10652fc7de1840da6f6f2f272c1fda143be38b35129c8ad69f3b7fce'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.