### PR TITLE
Update ledger-live from 2.0.0 to 2.0.1

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '2.0.0'
-  sha256 '36da02e11dab1ff080094575ab81ae8109bb2763ad84165a2ad98352b77cf3a6'
+  version '2.0.1'
+  sha256 '3f1cc1912d6168ab7f9524d1f334120737d2f30d7f4e844263f62c7935e7cc5e'
 
   # github.com/LedgerHQ/ledger-live-desktop was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.