### PR TITLE
Update connectmenow from 3.0.3 to 3.0.5

### DIFF
--- a/Casks/connectmenow.rb
+++ b/Casks/connectmenow.rb
@@ -1,6 +1,6 @@
 cask 'connectmenow' do
-  version '3.0.3'
-  sha256 'aebcb29bb939e29c492ee9b947c543843bba45c03d76bd18a3dce83e88e67924'
+  version '3.0.5'
+  sha256 'b54a1289c0d81f2d873818972f88d68e0def9b438fe7af3278c85a605b4caa82'
 
   url "https://www.tweaking4all.com/downloads/network/ConnectMeNow-v#{version}-macOS-64bit.dmg"
   appcast 'https://www.tweaking4all.com/os-tips-and-tricks/macosx-tips-and-tricks/connectmenow-v3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.