### PR TITLE
Update sentinel from 0.14.4 to 0.15.1

### DIFF
--- a/Casks/sentinel.rb
+++ b/Casks/sentinel.rb
@@ -1,6 +1,6 @@
 cask 'sentinel' do
-  version '0.14.4'
-  sha256 '7beeb90c32984d6d133ffed53f1e8c391485b30df3683dfa4de4b67c40fceeba'
+  version '0.15.1'
+  sha256 '235205161ed2ab38e7795de7d709f49755faf98ec5c9d161dbd4a46477119c27'
 
   url "https://releases.hashicorp.com/sentinel/#{version}/sentinel_#{version}_darwin_amd64.zip"
   appcast 'https://docs.hashicorp.com/sentinel/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).