### PR TITLE
Update electron from 8.1.0 to 8.1.1

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '8.1.0'
-  sha256 'ed6a5e95aea04f7c892d26fc575d96b451abb852bbd2bb2019cdaebc7f2ff661'
+  version '8.1.1'
+  sha256 '70bea27834f78a159d878c7db6e56ec429da207d0ab7b7be66666bbe5572289f'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.