### PR TITLE
Update alt-tab from 3.0.0 to 3.0.1

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.0.0'
-  sha256 'e1741ad75124f44d3deaebcdabcce0c967d0afd307e68cd53c40a21292a57512'
+  version '3.0.1'
+  sha256 'daf094b96bf0f616f9abaf22df67ffbbecd47a12f6a44fcc5e75cf91cb218fc6'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.