### PR TITLE
Update timing from 2020.1 to 2020.2

### DIFF
--- a/Casks/timing.rb
+++ b/Casks/timing.rb
@@ -1,8 +1,8 @@
 cask 'timing' do
-  version '2020.1'
-  sha256 '7dd2b63ba2b1a7c1a53d3556e6f35763b368dc9f83fba2f0cbc0f2bc5ce5f434'
+  version '2020.2'
+  sha256 '3d1c41fd026327afe3cec412827a789ca00c16ba43af765c31e9991a1d8aa023'
 
-  url 'https://timingapp.com/download/Timing.dmg'
+  url "https://updates.timingapp.com/download/Timing-#{version}.dmg"
   appcast 'https://timingapp.com/updates/timing2.xml'
   name 'Timing'
   homepage 'https://timingapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.