### PR TITLE
Update webcatalog from 19.4.3 to 19.4.4

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '19.4.3'
-  sha256 'e73566a1b68edbf969943e4b1f99889d7c44c3d71090ff75ce67508ed0c8c5b3'
+  version '19.4.4'
+  sha256 '75cd36f506027388049ceecce1389a11c9ace7c0fb3b11e46849870eeac4b849'
 
   # github.com/quanglam2807/webcatalog was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.