### PR TITLE
Update jalbum from 19.3 to 19.3.6

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,6 +1,6 @@
 cask 'jalbum' do
-  version '19.3'
-  sha256 '674bff94bda00a88725fb2f51f1038b07031e19af405584457b09df1892d30bd'
+  version '19.3.6'
+  sha256 '36453c2ddfc8e20b9fd0bb0d80182aa241b68d976680d00b56d6a71e45834dde'
 
   url "https://download.jalbum.net/download/#{version}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.