### PR TITLE
Update mudlet from 4.6.0 to 4.6.1

### DIFF
--- a/Casks/mudlet.rb
+++ b/Casks/mudlet.rb
@@ -1,6 +1,6 @@
 cask 'mudlet' do
-  version '4.6.0'
-  sha256 'c9ec4c4b27b3f138970119d152763445b0c18c0542b3278629467cbbd7b47549'
+  version '4.6.1'
+  sha256 '0b3fec5bfa3784754dd46773083c9d51fc64d4cc6d3fbdcfa5e0f48dbe7befd0'
 
   url "https://www.mudlet.org/wp-content/files/Mudlet-#{version}.dmg"
   appcast 'https://github.com/Mudlet/Mudlet/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.