### PR TITLE
Update opencore-configurator from 1.16.0.0 to 1.17.0.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
   version '1.17.0.0'
-  sha256 'e1d71a3e3e7d696b7e70e5873aef079db475b01a639e797cb250ce7c0aefc3ae'
+  sha256 '225fef71ffa1338b95f5c08d75fe2dd8a0cc83682431bca0d0c635e4f0826463'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'

--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
   version '1.17.0.0'
-  sha256 '225fef71ffa1338b95f5c08d75fe2dd8a0cc83682431bca0d0c635e4f0826463'
+  sha256 'f2aec36c46623baabce9c46df8812290bdc29687987f871c53091fc6ba1fa987'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'

--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.16.0.0'
-  sha256 'c2094360280b71ff43f891a833f2cb49ed2fee01a81bad37f7af489926c14608'
+  version '1.17.0.0'
+  sha256 'e1d71a3e3e7d696b7e70e5873aef079db475b01a639e797cb250ce7c0aefc3ae'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.