### PR TITLE
Update alt-tab from 3.0.1 to 3.0.4

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.0.1'
-  sha256 'daf094b96bf0f616f9abaf22df67ffbbecd47a12f6a44fcc5e75cf91cb218fc6'
+  version '3.0.4'
+  sha256 '659aef96d83f5820c253b170e4dc5e16c7145b5641ddc1cb19ca5d95ccbbbc61'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.