### PR TITLE
Update alt-tab from 3.0.4 to 3.0.5

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.0.4'
-  sha256 '659aef96d83f5820c253b170e4dc5e16c7145b5641ddc1cb19ca5d95ccbbbc61'
+  version '3.0.5'
+  sha256 '2a1bb453d9dcd5d51bec1f15b0890bad2c051393e719fbb7004b9d0b7ffeec79'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.