### PR TITLE
Update monero-wallet from 0.15.0.2 to 0.15.0.4

### DIFF
--- a/Casks/monero-wallet.rb
+++ b/Casks/monero-wallet.rb
@@ -1,6 +1,6 @@
 cask 'monero-wallet' do
-  version '0.15.0.2'
-  sha256 'a652484a2a74f0d2697a4f0c000221d2a90927b8b8d536f1429756596d048f90'
+  version '0.15.0.4'
+  sha256 '9b0164cd90345c5fd4014a6bc8258465c2e5aae7c527c7f64a2d795830db7ae4'
 
   url "https://downloads.getmonero.org/gui/monero-gui-mac-x64-v#{version}.tar.bz2"
   appcast 'https://github.com/monero-project/monero-gui/releases.atom'

--- a/Casks/monero-wallet.rb
+++ b/Casks/monero-wallet.rb
@@ -7,7 +7,7 @@ cask 'monero-wallet' do
   name 'Monero Wallet'
   homepage 'https://getmonero.org/'
 
-  app "monero-gui-v#{version}/monero-wallet-gui.app"
+  app 'monero-wallet-gui.app'
 
   zap trash: [
                '~/.bitmonero',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.