### PR TITLE
Secure URLs

### DIFF
--- a/Casks/cocoaspell.rb
+++ b/Casks/cocoaspell.rb
@@ -2,11 +2,11 @@ cask 'cocoaspell' do
   version '2.5'
   sha256 'd8dd01e6471df86f55d5f272a33fdb421f49a2fb923a9858a8772ec4367d333c'
 
-  url "http://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg",
+  url "https://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.#{version}.dmg",
       user_agent: :fake
-  appcast 'http://people.ict.usc.edu/~leuski/cocoaspell/'
+  appcast 'https://people.ict.usc.edu/~leuski/cocoaspell/'
   name 'cocoAspell'
-  homepage 'http://people.ict.usc.edu/~leuski/cocoaspell/'
+  homepage 'https://people.ict.usc.edu/~leuski/cocoaspell/'
 
   depends_on macos: '>= :el_capitan'
 
@@ -29,6 +29,6 @@ cask 'cocoaspell' do
   caveats <<~EOS
     Non-English dictionaries must be installed separately. For more information, see
 
-      http://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php
+      https://people.ict.usc.edu/~leuski/cocoaspell/install_dict.php
   EOS
 end

--- a/Casks/dmm-player-for-chrome.rb
+++ b/Casks/dmm-player-for-chrome.rb
@@ -2,7 +2,7 @@ cask 'dmm-player-for-chrome' do
   version '1.5.0.10'
   sha256 'c9a564a31b8d29f72085c9b4eada52a03ca3fa0fd3cd50fed3a071c614ddef39'
 
-  url "http://portalapp.dmm.com/silverlightplayer/dmm/m/#{version.dots_to_underscores}/DMMPlayerForChromeInstaller_#{version.dots_to_underscores}.pkg"
+  url "https://portalapp.dmm.com/silverlightplayer/dmm/m/#{version.dots_to_underscores}/DMMPlayerForChromeInstaller_#{version.dots_to_underscores}.pkg"
   name 'DMM Player for Chrome'
   homepage 'https://www.dmm.com/digital/info_for_chrome_user_html/'
 

--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -2,7 +2,7 @@ cask 'dmm-player' do
   version '2.0.6'
   sha256 '73ae817fb519a343ba29104157d20567914705a2b8ad3349f797d39373226e35'
 
-  url "http://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
+  url "https://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name 'DMM Player'
   homepage 'https://www.dmm.com/digital/howto_dmmplayer_html/'
 

--- a/Casks/frescobaldi.rb
+++ b/Casks/frescobaldi.rb
@@ -6,7 +6,7 @@ cask 'frescobaldi' do
   url "https://github.com/frescobaldi/frescobaldi/releases/download/v#{version}/Frescobaldi-#{version}-x86_64.dmg"
   appcast 'https://github.com/frescobaldi/frescobaldi/releases.atom'
   name 'Frescobaldi'
-  homepage 'http://frescobaldi.org/'
+  homepage 'https://frescobaldi.org/'
 
   app 'Frescobaldi.app'
 

--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -6,7 +6,7 @@ cask 'gqrx' do
   url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg"
   appcast 'https://github.com/csete/gqrx/releases.atom'
   name 'Gqrx'
-  homepage 'http://gqrx.dk/'
+  homepage 'https://gqrx.dk/'
 
   app 'Gqrx.app'
   binary "#{appdir}/Gqrx.app/Contents/MacOS/airspy_info"

--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -5,7 +5,7 @@ cask 'jdownloader' do
   url 'http://installer.jdownloader.org/clean/JD2Setup.dmg',
       user_agent: :fake
   name 'JDownloader'
-  homepage 'http://jdownloader.org/'
+  homepage 'https://jdownloader.org/'
 
   preflight do
     system_command "#{staged_path}/JDownloader Installer.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/lilypond.rb
+++ b/Casks/lilypond.rb
@@ -2,10 +2,10 @@ cask 'lilypond' do
   version '2.20.0-1'
   sha256 '1680ca85ff7bdb942a39bff323956357fbb0e6ab17edf9c0e145d52b6c0dc231'
 
-  url "http://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
-  appcast 'http://lilypond.org/macos-x.html'
+  url "https://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
+  appcast 'https://lilypond.org/macos-x.html'
   name 'LilyPond'
-  homepage 'http://lilypond.org/'
+  homepage 'https://lilypond.org/'
 
   depends_on macos: '<= :mojave'
 

--- a/Casks/midikeys.rb
+++ b/Casks/midikeys.rb
@@ -6,7 +6,7 @@ cask 'midikeys' do
   url "https://github.com/flit/MidiKeys/releases/download/v#{version}/MidiKeys_#{version.major_minor}.zip"
   appcast 'https://immosw.com/versions/midikeys/appcast.xml'
   name 'MidiKeys'
-  homepage 'http://www.manyetas.com/creed/midikeys.html'
+  homepage 'https://www.manyetas.com/creed/midikeys.html'
 
   app 'MidiKeys.app'
 end

--- a/Casks/mobirise.rb
+++ b/Casks/mobirise.rb
@@ -2,7 +2,7 @@ cask 'mobirise' do
   version :latest
   sha256 :no_check
 
-  url 'http://download.mobirise.com/MobiriseSetup.dmg'
+  url 'https://download.mobirise.com/MobiriseSetup.dmg'
   name 'Mobirise'
   homepage 'https://mobirise.com/'
 

--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -3,7 +3,7 @@ cask 'orange' do
   sha256 '4f31193260c4f2d9f0a495d664e8fbc7438aebfadc7e83f1d950c1c672873887'
 
   url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://service.biolab.si/download/orange?platform=mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://service.biolab.si/download/orange?platform=mac'
   name 'Orange'
   homepage 'https://orange.biolab.si/'
 

--- a/Casks/pdfsam-basic.rb
+++ b/Casks/pdfsam-basic.rb
@@ -6,7 +6,7 @@ cask 'pdfsam-basic' do
   url "https://github.com/torakiki/pdfsam/releases/download/v#{version}/PDFsam-#{version}.dmg"
   appcast 'https://github.com/torakiki/pdfsam/releases.atom'
   name 'PDFsam Basic'
-  homepage 'https://www.pdfsam.org/'
+  homepage 'https://pdfsam.org/'
 
   pkg "PDFsam Basic-#{version}.pkg"
 

--- a/Casks/questrade-iq-edge.rb
+++ b/Casks/questrade-iq-edge.rb
@@ -2,7 +2,7 @@ cask 'questrade-iq-edge' do
   version :latest
   sha256 :no_check
 
-  url 'http://media.questrade.com/iq_downloads/QuestradeIQEdge.dmg'
+  url 'https://media.questrade.com/iq_downloads/QuestradeIQEdge.dmg'
   name 'Questrade IQ Edge'
   homepage 'https://www.questrade.com/'
 

--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -2,7 +2,7 @@ cask 'serviio' do
   version '2.0'
   sha256 '69ca6080fc92d147ee9c6d2bc7d71d9548e5770762e0e73066d4ac82557fbc6e'
 
-  url "http://download.serviio.org/releases/serviio-#{version}-osx.tar.gz"
+  url "https://download.serviio.org/releases/serviio-#{version}-osx.tar.gz"
   appcast 'https://www.serviio.org/download'
   name 'Serviio'
   homepage 'https://serviio.org/'

--- a/Casks/vrep.rb
+++ b/Casks/vrep.rb
@@ -2,10 +2,10 @@ cask 'vrep' do
   version '3.6.0'
   sha256 '6d028ec84112fc85518c6a5298d70c651eadc9267d300f10502ea593817f8f78'
 
-  url "http://coppeliarobotics.com/files/V-REP_PRO_EDU_V#{version.dots_to_underscores}_Mac.zip"
-  appcast 'http://www.coppeliarobotics.com/helpFiles/en/versionInfo.htm'
+  url "https://coppeliarobotics.com/files/V-REP_PRO_EDU_V#{version.dots_to_underscores}_Mac.zip"
+  appcast 'https://www.coppeliarobotics.com/helpFiles/en/versionInfo.htm'
   name 'V-REP'
-  homepage 'http://www.coppeliarobotics.com/index.html'
+  homepage 'https://www.coppeliarobotics.com/index.html'
 
   suite "V-REP_PRO_EDU_V#{version.dots_to_underscores}_Mac"
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses. [*]
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[*] `cocoaspell` has an issue, which was pre-existing, couldn't figure how to fix it. Maybe it also needs a fake user-agent.
```
1 file inspected, no offenses detected
==> Downloading https://people.ict.usc.edu/~leuski/cocoaspell/cocoAspell.2.5.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cocoaspell'.
audit for cocoaspell: failed
 - The URL https://people.ict.usc.edu/~leuski/cocoaspell/ is not reachable (HTTP status code 403)
Error: audit failed for casks: cocoaspell

1 file inspected, no offenses detected
==> Downloading https://portalapp.dmm.com/silverlightplayer/dmm/m/1_5_0_10/DMMPl
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'dmm-player-for-chrome'.
audit for dmm-player-for-chrome: passed

1 file inspected, no offenses detected
==> Downloading https://portalapp.dmm.com/dmmplayerv2/dmm/2_0_6/DMMPlayerV2Insta
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'dmm-player'.
audit for dmm-player: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/frescobaldi/frescobaldi/releases/download/v3.
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'frescobaldi'.
audit for frescobaldi: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/csete/gqrx/releases/download/v2.11.5/Gqrx-2.1
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'gqrx'.
audit for gqrx: passed

1 file inspected, no offenses detected
==> Downloading http://installer.jdownloader.org/clean/JD2Setup.dmg
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'jdownloader', skipping verification.
audit for jdownloader: passed

1 file inspected, no offenses detected
==> Downloading https://lilypond.org/downloads/binaries/darwin-x86/lilypond-2.20
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'lilypond'.
audit for lilypond: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/flit/MidiKeys/releases/download/v1.9.0/MidiKe
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'midikeys'.
audit for midikeys: passed

1 file inspected, no offenses detected
==> Downloading https://download.mobirise.com/MobiriseSetup.dmg
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'mobirise', skipping verification.
audit for mobirise: passed

1 file inspected, no offenses detected
==> Downloading https://download.biolab.si/download/files/Orange3-3.24.1.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'orange'.
audit for orange: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/torakiki/pdfsam/releases/download/v4.1.1/PDFs
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'pdfsam-basic'.
audit for pdfsam-basic: passed

1 file inspected, no offenses detected
==> Downloading https://media.questrade.com/iq_downloads/QuestradeIQEdge.dmg
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'questrade-iq-edge', skipping verificat
audit for questrade-iq-edge: passed

1 file inspected, no offenses detected
==> Downloading https://download.serviio.org/releases/serviio-2.0-osx.tar.gz
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'serviio'.
audit for serviio: passed

1 file inspected, no offenses detected
==> Downloading https://coppeliarobotics.com/files/V-REP_PRO_EDU_V3_6_0_Mac.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'vrep'.
audit for vrep: passed
```