### PR TITLE
Use double quotes when sourcing paths with vars

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -22,11 +22,11 @@ cask 'google-cloud-sdk' do
     #{token} is installed at #{staged_path}/#{token}. Add your profile:
 
       for bash users
-        source '#{staged_path}/#{token}/path.bash.inc'
-        source '#{staged_path}/#{token}/completion.bash.inc'
+        source "#{staged_path}/#{token}/path.bash.inc"
+        source "#{staged_path}/#{token}/completion.bash.inc"
 
       for zsh users
-        source '#{staged_path}/#{token}/path.zsh.inc'
-        source '#{staged_path}/#{token}/completion.zsh.inc'
+        source "#{staged_path}/#{token}/path.zsh.inc"
+        source "#{staged_path}/#{token}/completion.zsh.inc"
   EOS
 end


### PR DESCRIPTION
Using single quotes causes the path to be interpreted literally rather then expanded into vars.

Here is what I see when using single-quotes vs double-quotes in `zsh` and `bash`:
```
# zsh
/u/local ❯❯❯ source '$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc'                                                                         
source: no such file or directory: $(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc
/u/local ❯❯❯ source "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"                                                                       

# bash
bash-5.0$ source '$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc'
bash: $(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc: No such file or directory
bash-5.0$ source "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"
bash-5.0$
```