### PR TITLE
wireshark: check if access_bpf group exists before trying to delete

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -18,7 +18,7 @@ cask 'wireshark' do
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
 
-    if system_command 'getent', args: ['group', 'access_bpf']
+    if File.read('/etc/group').match?(/^access_bpf/)
       system_command '/usr/sbin/dseditgroup', args: ['-o', 'delete', 'access_bpf'], sudo: true
     end
   end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -18,7 +18,7 @@ cask 'wireshark' do
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
 
-    if File.read('/etc/group').match?(/^access_bpf/)
+    if File.read('/etc/group').match?(%r{^access_bpf})
       system_command '/usr/sbin/dseditgroup', args: ['-o', 'delete', 'access_bpf'], sudo: true
     end
   end

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -17,7 +17,10 @@ cask 'wireshark' do
 
   uninstall_preflight do
     set_ownership '/Library/Application Support/Wireshark'
-    system_command '/usr/sbin/dseditgroup', args: ['-o', 'delete', 'access_bpf'], sudo: true
+
+    if system_command 'getent', args: ['group', 'access_bpf']
+      system_command '/usr/sbin/dseditgroup', args: ['-o', 'delete', 'access_bpf'], sudo: true
+    end
   end
 
   uninstall pkgutil:   'org.wireshark.*',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Only try to delete the group if it exists, so it doesn’t [fail the whole uninstallation](https://github.com/Homebrew/homebrew-cask/issues/78440).