### PR TITLE
Update cutter from 1.10.1 to 1.10.2

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.10.1'
-  sha256 '00605f55cd4d797b618ca5c6ba24c7162ae8115a635a3ff773eaa36b3e6f0e62'
+  version '1.10.2'
+  sha256 'c999722f7ba4442c3cd9aa619baec2389459526a243c0af48697e18de5893eba'
 
   # github.com/radareorg/cutter was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.