### PR TITLE
Update ark-desktop-wallet from 2.8.1 to 2.9.0

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.8.1'
-  sha256 'fb455c3080e4894df1f0320b5559d265c2750d7c0f45c9808245d586effe7eaf'
+  version '2.9.0'
+  sha256 '8fbba3483f1a1e5a04de78d7c3ec48197d7ab05468ee45f4dca985c7fcb2fafe'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.