### PR TITLE
Update flash-player from 32.0.0.330 to 32.0.0.344

### DIFF
--- a/Casks/flash-player.rb
+++ b/Casks/flash-player.rb
@@ -1,6 +1,6 @@
 cask 'flash-player' do
-  version '32.0.0.330'
-  sha256 '4a0c7bbcf5840d5ad96c54a812dfae352ad8f84773a4ea2da2c36fd20efb9cfa'
+  version '32.0.0.344'
+  sha256 'd7cc4d73a08a6ae1884378351312103d6f96357f8da3d46751f2efc721f2d216'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pl.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.