### PR TITLE
Update flash-player-debugger from 32.0.0.330 to 32.0.0.344

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger' do
-  version '32.0.0.330'
-  sha256 '6b8a66f2aaec0286d7a25632a7456eea9ff9a536c02605260151a7658e44fba9'
+  version '32.0.0.344'
+  sha256 '46d5b3ea63f390ac4041ce1f219308496f4eb81896e81aecc30fae8ccda3e92c'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.