### PR TITLE
Update melodics from 2.1.4041 to 2.1.4119

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.4041'
-  sha256 '899eba197c368d515f2c9f4f7e03a8388a2f8d8312c7d2864711fc9332619437'
+  version '2.1.4119'
+  sha256 '65bc86df8908c4081da901e33fcb85cb2a3f918176c7e963ddc7c83ac20c7a6d'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.