### PR TITLE
Update tuple from 0.62.1,2020-02-18-52b1d4aa to 0.63.0,2020-03-10-1bff8082

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.62.1,2020-02-18-52b1d4aa'
-  sha256 'b2bcf490177b61b707e43a5c9ec3fda5274572c22081872dee196a2bf1092e50'
+  version '0.63.0,2020-03-10-1bff8082'
+  sha256 'e1f0aaa84f7b26fb5478365ff47fd342ece367b67128b8ef588b31d4f5958acc'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.