### PR TITLE
Update ithoughtsx from 5.18 to 5.19

### DIFF
--- a/Casks/ithoughtsx.rb
+++ b/Casks/ithoughtsx.rb
@@ -1,6 +1,6 @@
 cask 'ithoughtsx' do
-  version '5.18'
-  sha256 '523414e6478925c67a21b4451a8ad1658b7e26c07f5ed804061b1ca98618cf94'
+  version '5.19'
+  sha256 'f0c9660c8f622e77afe529b92151449e2ec14d5cd9b26488f4de7a906c56274c'
 
   # ithoughtsx.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ithoughtsx.s3.amazonaws.com/iThoughtsX_#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.