### PR TITLE
Update banking-4 from 7.2.6.7339 to 7.2.7.7373

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.2.6.7339'
-  sha256 'b5c968fbcaf69940b48bba6e78b6d19f51508c5afa667df2577f54aeb82297b8'
+  version '7.2.7.7373'
+  sha256 '3a460d0bed803120610e4d6bc2fb31ebe0b3e8757b110562e4b7cff77afe59a4'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.