### PR TITLE
Update zoho-mail from 1.1.0 to 1.0.20

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.1.0'
-  sha256 '17ae1d39d526abdec84decbca3ac24d9a46e9d3394600c3575cb45e7336cb24f'
+  version '1.0.20'
+  sha256 '96ead615b34f574b9fa591b6abbb469dbdf89c1635bc23aa63ad245722c5b1a7'
 
   # downloads.zohocdn.com/zmail-desktop/mac was verified as official when first introduced to the cask
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.