### PR TITLE
Update zoho-mail from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.1.0'
-  sha256 '17ae1d39d526abdec84decbca3ac24d9a46e9d3394600c3575cb45e7336cb24f'
+  version '1.1.1'
+  sha256 'b29f3dfd6b8f0427319dca68ef9c9033e9b8a817fc9cd7da04ba5c024e7745aa'
 
   # downloads.zohocdn.com/zmail-desktop/mac was verified as official when first introduced to the cask
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.