### PR TITLE
Update frhelper from 3.9.6,2020-02-09 to 3.9.6,2020-02-11

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,5 +1,5 @@
 cask 'frhelper' do
-  version '3.9.6,2020-02-09'
+  version '3.9.6,2020-02-11'
   sha256 'ec638576b929dfd9c2637b5dd152c59fc05812bdfa670c2419d056e329c6e44b'
 
   # static.frdic.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.