### PR TITLE
Update vscodium from 1.43.0 to 1.44.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,8 +1,8 @@
 cask 'vscodium' do
-  version '1.43.0'
-  sha256 'c14eeaf63f1f537eb88dd03ffa61e6dd3657c83abc4c2168fa683c2cc31d6d4a'
+  version '1.44.0'
+  sha256 'ddf15761cf3c9974bf6aa06837dc6fd15ff149a162e7fbf88240ee78c790cdbb'
 
-  url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
+  url "https://github.com/VSCodium/vscodium/releases/download/1.43.0/VSCodium.#{version}.dmg"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'
   name 'VSCodium'
   homepage 'https://github.com/VSCodium/vscodium'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.