### PR TITLE
Update stoplight-studio from 1.10.1 to 1.10.2

### DIFF
--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -1,6 +1,6 @@
 cask 'stoplight-studio' do
-  version '1.10.1'
-  sha256 '1a24a7b846e8a1203f468646d717d420a97757a3ae092353ce822285b09fa129'
+  version '1.10.2'
+  sha256 '8ef04ef92c26a95d23395ca3807cd1e00f2f9e10d2083be42a0ce7868aa43711'
 
   # github.com/stoplightio/studio was verified as official when first introduced to the cask
   url "https://github.com/stoplightio/studio/releases/download/v#{version}/stoplight-studio-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.