### PR TITLE
Update mailbutler from 2,2525-13060 to 2,2610-13094

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2,2525-13060'
-  sha256 '96ba38b143e23ade1bf8b494cfa9f17365f85f65e496df96b0d75219a95c59f2'
+  version '2,2610-13094'
+  sha256 '074885810f78f2ae650da13411da662f9ccb812aabbd178ac1c2e192f676a925'
 
   url "https://downloads.mailbutler.io/sparkle/public/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.