### PR TITLE
Update wechatwork from 3.0.12.2113 to 3.0.14.2115

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.12.2113'
-  sha256 '583e752fe30f1052b3f98318c0193f2cf3ebafb0b57e7ea999f4ba912a7af128'
+  version '3.0.14.2115'
+  sha256 'ea484a6659ef6010fabb617902627a5b862c67d5be30fae5107214316f4f4cd1'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.