### PR TITLE
Update timeular from 3.0.0 to 3.0.1

### DIFF
--- a/Casks/timeular.rb
+++ b/Casks/timeular.rb
@@ -1,6 +1,6 @@
 cask 'timeular' do
-  version '3.0.0'
-  sha256 '9ff06a9d0b52b718659105788536cc9965b19b5bb140a631f2fba5d05deec3af'
+  version '3.0.1'
+  sha256 '8383e90a507c0ffc6d740ea82972ecdc35bdda7b51fb8f16daad84e8a2c6046d'
 
   # timeular-desktop-packages.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://timeular-desktop-packages.s3.amazonaws.com/mac/production/Timeular-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.