### PR TITLE
Update cycling74-max from 8.1.2_200128 to 8.1.3_200310

### DIFF
--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask 'cycling74-max' do
-  version '8.1.2_200128'
-  sha256 '6675c92041444dcba5c36eec52e4aa235f956425d6d5796d847ed17de1edddb7'
+  version '8.1.3_200310'
+  sha256 'e452b62f2932582001a2f3b49d731a02177857d4d775b4f55fc6313a03bb575d'
 
   # akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://akiaj5esl75o5wbdcv2a-maxmspjitter.s3.amazonaws.com/Max#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.