### PR TITLE
Update sizzy from 0.18.1 to 0.18.2

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.18.1'
-  sha256 '1b3780ed5ed15fd14cbf867139e4cb00ae282ec099a33fb9cc33ecd09711a75a'
+  version '0.18.2'
+  sha256 '4cc34e2efb70dd002b6761d7de6f86d43172182f0763abc1e077228bb276ecc7'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.