### PR TITLE
Update upwork from 5.3.3.862,0gofuuatmjqd0n86 to 5.3.3.871,51d563431f844aff

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,6 +1,6 @@
 cask 'upwork' do
-  version '5.3.3.862,0gofuuatmjqd0n86'
-  sha256 '5ab0d83880dc262061edd642393e5eea346181de34c8498a4d945416555e0b02'
+  version '5.3.3.871,51d563431f844aff'
+  sha256 '2a46292b6fb274cd8b2d1f0653a20856f4352bb3ef60b2b20669669238fda6a8'
 
   url "https://updates-desktopapp.upwork.com/binaries/v#{version.before_comma.dots_to_underscores}_#{version.after_comma}/Upwork.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://updates-desktopapp.upwork.com/binaries/versions-mac.json&splitter_1=Beta&index_1=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.