### PR TITLE
Update avocode from 4.4.3 to 4.4.4

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.4.3'
-  sha256 '156e867861d245e2bb9cc676cb18217a7c63763471720f4ab2e1dfcfe74640e4'
+  version '4.4.4'
+  sha256 '8cc5e5b1a3b815678a9bad54fbe7ee6f2ca3dba133d0f3aef41004083bbda2c2'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.