### PR TITLE
Update remember-the-milk from 1.1.17 to 1.1.18

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.1.17'
-  sha256 '3d0e0b90145af9245ea185268017aaee6205225073ee5e7afe21f09849337260'
+  version '1.1.18'
+  sha256 '971d2afc5b31a4b47e9319705b5db61fcc52a934117d5318136a2cc68a1e46fa'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   appcast 'https://www.rememberthemilk.com/services/mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.