### PR TITLE
ProtonMail Bridge Update to 1.2.5

### DIFF
--- a/Casks/protonmail-bridge.rb
+++ b/Casks/protonmail-bridge.rb
@@ -1,6 +1,6 @@
 cask 'protonmail-bridge' do
-  version '1.2.3'
-  sha256 '03a07e1b830c51e64897a07b437effe4266be08808a2253fda485ba9b96dbbc9'
+  version '1.2.5'
+  sha256 '15e39f27a0e205d10a3990dd93282dad36f86df234a928b5837e1e4f3e0fe67f'
 
   url 'https://protonmail.com/download/Bridge-Installer.dmg'
   appcast 'https://protonmail.com/download/current_version_darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
