### PR TITLE
Update alt-tab from 3.1.1 to 3.1.2

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.1.1'
-  sha256 'dcaf6048a9eaa12dd5c3bb6c61f7cde891c2aa553b5fd05d94c1e0a216f2b267'
+  version '3.1.2'
+  sha256 '32c4db52cbab7eb896573fd6bef0ba7f18248e7de2982b803beb6e52f7787ecd'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.