### PR TITLE
Correct vscodium version and url to 1.43.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,8 +1,8 @@
 cask 'vscodium' do
-  version '1.44.0'
-  sha256 'ddf15761cf3c9974bf6aa06837dc6fd15ff149a162e7fbf88240ee78c790cdbb'
+  version '1.43.0'
+  sha256 'c14eeaf63f1f537eb88dd03ffa61e6dd3657c83abc4c2168fa683c2cc31d6d4a'
 
-  url "https://github.com/VSCodium/vscodium/releases/download/1.43.0/VSCodium.#{version}.dmg"
+  url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-darwin-#{version}.zip"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'
   name 'VSCodium'
   homepage 'https://github.com/VSCodium/vscodium'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

#78502 breaks VSCodium **1.43.0** cask as there is no version **1.44.0** - <https://github.com/VSCodium/vscodium/releases>.

From my console:
```
> ~  brew cask upgrade vscodium
Updating Homebrew...
==> Upgrading 1 outdated package:
vscodium 1.42.1 -> 1.44.0
==> Upgrading vscodium
==> Downloading https://github.com/VSCodium/vscodium/releases/download/1.43.0/VSCodium.1.44.0.dmg

curl: (22) The requested URL returned error: 404 Not Found
==> Purging files for version 1.44.0 of Cask vscodium
Error: Download failed on Cask 'vscodium' with message: Download failed: https://github.com/VSCodium/vscodium/releases/download/1.43.0/VSCodium.1.44.0.dmg
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

Not applicable.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
