### PR TITLE
thonny 3.2.7

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -1,14 +1,23 @@
 cask 'thonny' do
-  version '3.2.6'
-  sha256 'bf2666d4877129fc507127be162d4864eb080a005d0484ae6bf20647034b9226'
+  version '3.2.7'
+  sha256 'f70a3dc2321e2ab0abf433900a5a36c231d1cccdd1e4aba48c400926f34d3c2b'
 
   # github.com/thonny/thonny/releases/download was verified as official when first introduced to the cask
-  url "https://github.com/thonny/thonny/releases/download/v#{version}/thonny-#{version}.dmg"
+  url "https://github.com/thonny/thonny/releases/download/v#{version}/thonny-#{version}.pkg"
   appcast 'https://github.com/thonny/thonny/releases.atom'
   name 'Thonny'
   homepage 'https://thonny.org/'
 
-  app 'Thonny.app'
+  pkg "thonny-#{version}.pkg"
 
-  zap trash: '~/.thonny'
+  uninstall quit:    'Thonny',
+            pkgutil: 'org.thonny.Thonny.component',
+            delete:  '/Applications/Thonny.app'
+
+  zap trash: [
+               '~/Library/Saved Application State/org.thonny.Thonny.savedState',
+               '~/Library/Thonny',
+               '~/.thonny',
+               '~/.config/Thonny',
+             ]
 end

--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -17,7 +17,5 @@ cask 'thonny' do
   zap trash: [
                '~/Library/Saved Application State/org.thonny.Thonny.savedState',
                '~/Library/Thonny',
-               '~/.thonny',
-               '~/.config/Thonny',
              ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

- Thonny switched from .dmg to .pkg in 3.2.7
- Cleaned locations are based on
    - https://github.com/thonny/thonny/wiki/DeploymentOptions#location-of-thonnys-user-data-configuration-and-log-files
    - Activity monitor ~> open files. (`~/.thonny` is not listed but I kept it in case there is a reason to have it I'm not aware of, `~/.config/Thonny` is Linux-specific...)

Please let me know if you'd like to "zap" any of the "zapped" locations.
