### PR TITLE
Update Sabaki from 0.43.3 to 0.50.0

### DIFF
--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,6 +1,6 @@
 cask 'sabaki' do
-  version '0.43.3'
-  sha256 '8d3a9eec8b6330ebf9d321dc6ddfe26e56e046bbe7ec581a998403ba508c9284'
+  version '0.50.0'
+  sha256 '567a3c93720915508766fd03f939487765d8a5da941dabf41bb9abdcc0f861f1'
 
   # github.com/SabakiHQ/Sabaki was verified as official when first introduced to the cask
   url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-x64.7z"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Removed checkboxes below, because **not a new cask**.