### PR TITLE
Update dmm-player from 2.0.6 to 2.0.8

### DIFF
--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -1,6 +1,6 @@
 cask 'dmm-player' do
-  version '2.0.6'
-  sha256 '73ae817fb519a343ba29104157d20567914705a2b8ad3349f797d39373226e35'
+  version '2.0.8'
+  sha256 '4309deb1c2ca0a4e9ade8147b229056b6719cc79b9746cbd01dfefd7f7f66e83'
 
   url "https://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name 'DMM Player'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.