### PR TITLE
Update proclaim from 2.12.0.0023 to 2.12.0.0027

### DIFF
--- a/Casks/proclaim.rb
+++ b/Casks/proclaim.rb
@@ -1,6 +1,6 @@
 cask 'proclaim' do
-  version '2.12.0.0023'
-  sha256 'bc3db060c50bdd1c785ed70d4b04e35802c0b417c4365883a55777e949f17cda'
+  version '2.12.0.0027'
+  sha256 'd17cbc15512e8e9f2331cc07f0bc6caa0ed4c0e1dcc6291e815c772ce590b54c'
 
   # logoscdn.com/Proclaim was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/Proclaim/Installer/#{version}/Proclaim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.