### PR TITLE
Update clockify from 2.4.4 to 2.4.5

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask 'clockify' do
-  version '2.4.4'
-  sha256 '914a219293b819b9e0aa455710030ed1c51c55d56cbedc06519aad7fd0944fb2'
+  version '2.4.5'
+  sha256 '74ee5f0d57853ed4b16e613ec4a2ada7c448500914613c0abb61b8afd7c26704'
 
   # clockify-resources.s3.eu-central-1.amazonaws.com was verified as official when first introduced to the cask
   url 'https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.