### PR TITLE
Update tinderbox from 8.5.1 to 8.6.0

### DIFF
--- a/Casks/tinderbox.rb
+++ b/Casks/tinderbox.rb
@@ -4,8 +4,8 @@ cask 'tinderbox' do
     sha256 '765a6245d25f9c2185802f36caa1f620f276637b884260fffa74bf639670e211'
     app 'TinderboxSix.app'
   else
-    version '8.5.1'
-    sha256 'c0b796268f9a60ad3b467a8e98a1afa6f34e5517ce8c50e4304b018ecc3f2246'
+    version '8.6.0'
+    sha256 'de4c585fd92dba0320a6ef42faf10cf32eee25e02ac3e682f60fce8b8588d8b8'
     app "Tinderbox #{version.major}.app"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.