### PR TITLE
Update lark from 3.19.3 to 3.19.4

### DIFF
--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -1,6 +1,6 @@
 cask 'lark' do
-  version '3.19.3'
-  sha256 'e102c50fba52373536df63827f1463e466f1808e8c762706961c7d82bf6ca4e5'
+  version '3.19.4'
+  sha256 '1b2f24a993a2f19bde081faad2df6c1c5455eb130fa8bbb9734a21983987a2cb'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Lark-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.