### PR TITLE
Update qgroundcontrol from 3.5.6 to new url

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -1,10 +1,9 @@
 cask 'qgroundcontrol' do
-  version '3.5.6'
-  sha256 'b2de1de91670889f73dbb71841d19cfa1ec376a8fadc206ae9436ef8f89d2d64'
+  version :latest
+  sha256 :no_check
 
-  # github.com/mavlink/qgroundcontrol was verified as official when first introduced to the cask
-  url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg"
-  appcast 'https://github.com/mavlink/qgroundcontrol/releases.atom'
+  # s3-us-west-2.amazonaws.com/qgroundcontrol was verified as official when first introduced to the cask
+  url 'https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.dmg'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 


### PR DESCRIPTION
The GitHub releases do not contain the dmg package any more. The manual https://docs.qgroundcontrol.com/en/getting_started/download_and_install.html#macOS points to a AWS S3 bucket.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).