### PR TITLE
Update goodsync from 10.10.25.5 to 10.10.27.7

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask 'goodsync' do
-  version '10.10.25.5'
-  sha256 '6f40befde16efc04c9c86f44fa5a0f15c34df2c680c13dbe1872e54edd6edce6'
+  version '10.10.27.7'
+  sha256 '6990a2ef67c49b097497228ca26999a8ae2b8cad6533618d711f95c83b2410ec'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast 'https://www.goodsync.com/download?os=macos',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.