### PR TITLE
Update opencore-configurator from 1.18.1.0 to 1.19.0.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.18.1.0'
-  sha256 '917868cbfd5af0f74e4a19555af1afb8d7499501478fba2b9a4baea0b347c08e'
+  version '1.19.0.0'
+  sha256 'c4586922a6306837e0b12a07d5e66f35e94aac0f034f80a30d96020b58c3d79d'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.