### PR TITLE
Update publish-or-perish from 7.19.2716 to 7.19.2726

### DIFF
--- a/Casks/publish-or-perish.rb
+++ b/Casks/publish-or-perish.rb
@@ -1,6 +1,6 @@
 cask 'publish-or-perish' do
-  version '7.19.2716'
-  sha256 '5b3cd54ac45b717ca5eb02d0aac6142ae68eea940b94db001b4de7c821842e89'
+  version '7.19.2726'
+  sha256 'f2080f018d4c0d89829398d61c1d9926a76d6f70e40e0a10c9feca89367169de'
 
   url 'https://harzing.com/download/PoP7Mac.pkg'
   appcast 'https://harzing.com/resources/publish-or-perish/os-x'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.