### PR TITLE
Update swish from 1.3 to 1.4

### DIFF
--- a/Casks/swish.rb
+++ b/Casks/swish.rb
@@ -1,8 +1,9 @@
 cask 'swish' do
-  version '1.3'
-  sha256 '8e7a39a421c69b355fb6d3f2b31135a82901648547ee159232e6783b5cde6f83'
+  version '1.4'
+  sha256 '619bf894d805916dfd749c268b14d82a7bb39dd8b5cff9b6bc291e6a234e4591'
 
-  url "https://highlyopinionated.co/swish/Swish-#{version}.zip"
+  # github.com/chrenn/swish-dl was verified as official when first introduced to the cask
+  url "https://github.com/chrenn/swish-dl/releases/download/#{version}/Swish.zip"
   appcast 'https://highlyopinionated.co/swish/appcast.xml'
   name 'Swish'
   homepage 'https://highlyopinionated.co/swish/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.