### PR TITLE
Update hook from 1.4,13 to 1.4,9833b7ef-39a1-42cc-ab0e-6def214e04ad:YBun9pUPin6JIlq1PEQEFNLRnpGUqmrgVVn%2BGqw9Cog%3D

### DIFF
--- a/Casks/hook.rb
+++ b/Casks/hook.rb
@@ -1,9 +1,9 @@
 cask 'hook' do
-  version '1.4,13'
+  version '1.4,9833b7ef-39a1-42cc-ab0e-6def214e04ad:YBun9pUPin6JIlq1PEQEFNLRnpGUqmrgVVn%2BGqw9Cog%3D'
   sha256 '60b25c4c5c160ce1360c55700d5aaf6357fc76a931aeae86a8e2e2c0cfdd9564'
 
-  # rink.hockeyapp.net/api/2/apps/a77a1a877d69435d90ea7365b2f7bddb was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/a77a1a877d69435d90ea7365b2f7bddb/app_versions/#{version.after_comma}?format=zip"
+  # appcenter-filemanagement-distrib5ede6f06e.azureedge.net was verified as official when first introduced to the cask
+  url "https://appcenter-filemanagement-distrib5ede6f06e.azureedge.net/#{version.after_comma.before_colon}/Hook_productivity_app_#{version.before_comma}.dmg?sv=2018-03-28&sr=c&sig=#{version.after_colon}&se=2020-03-14T11%3A34%3A35Z&sp=r"
   appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/a77a1a87-7d69-435d-90ea-7365b2f7bddb'
   name 'Hook'
   homepage 'https://hookproductivity.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.