### PR TITLE
Update waterfox-current from 2020.02,6820.2.12 to 2020.03,6820.3.11

### DIFF
--- a/Casks/waterfox-current.rb
+++ b/Casks/waterfox-current.rb
@@ -1,6 +1,6 @@
 cask 'waterfox-current' do
-  version '2020.02,6820.2.12'
-  sha256 '2c78b718c1cbc557ec142c74f1749f2e13096c7513052c930e6f5c33be0e5b21'
+  version '2020.03,6820.3.11'
+  sha256 '72361e1f3ec8f3b403b7508cb9b392533a196e04a926bc011b2e824bd7a9c554'
 
   # storage-waterfox.netdna-ssl.com was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Current%20#{version.before_comma}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.