### PR TITLE
Update sitebulb from 3.3.1 to 3.4

### DIFF
--- a/Casks/sitebulb.rb
+++ b/Casks/sitebulb.rb
@@ -1,6 +1,6 @@
 cask 'sitebulb' do
-  version '3.3.1'
-  sha256 '3a6510e9e919951eff36b1c0414c533ddc8f445e7167bc9220ae1efcbec30940'
+  version '3.4'
+  sha256 'c3d2bfcaac54eb6bfba856a20ba857bfc3174b801f5f70b0283f442ef4dab156'
 
   url "https://downloads.sitebulb.com/#{version}/macOS/Sitebulb.dmg"
   appcast 'https://sitebulb.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.