### PR TITLE
Update appcast in orange.rb

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -3,7 +3,7 @@ cask 'orange' do
   sha256 '4f31193260c4f2d9f0a495d664e8fbc7438aebfadc7e83f1d950c1c672873887'
 
   url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://service.biolab.si/download/orange?platform=mac'
+  appcast 'https://github.com/biolab/orange3/releases.atom'
   name 'Orange'
   homepage 'https://orange.biolab.si/'
 


### PR DESCRIPTION
redirect wasn't working anymore - I took the github atom feed - seems reliable
here are some other sources:
https://orange.biolab.si/download/
https://download.biolab.si/download/files/
https://download.biolab.si/download/files/versions.json
 