### PR TITLE
Update qownnotes from 20.3.3,b5422-182156 to 20.3.4,b5431-173104

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.3.3,b5422-182156'
-  sha256 'ab7ed066655a940b7c08048775362015412b8945caa1fe8ec42a8eb1ecdbd656'
+  version '20.3.4,b5431-173104'
+  sha256 '591b6111fdb8aac676052e204945190bcc2b7dd47222dd17fafaf5474fc2de73'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.