### PR TITLE
Update rocket-chat from 2.17.8 to 2.17.9

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask 'rocket-chat' do
-  version '2.17.8'
-  sha256 'accc15e33ed175b6ae752ecb4ce86132d0eba55d0dc59a067daf2b213e9290a9'
+  version '2.17.9'
+  sha256 'd07a6dd60e90ba18ff87bfbff4de377ff2fa3a91c386cb20b269a64574a3ea73'
 
   # github.com/RocketChat/Rocket.Chat.Electron was verified as official when first introduced to the cask
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.