### PR TITLE
Update mellow from 0.1.15 to 0.1.16

### DIFF
--- a/Casks/mellow.rb
+++ b/Casks/mellow.rb
@@ -1,6 +1,6 @@
 cask 'mellow' do
-  version '0.1.15'
-  sha256 '309662ba2f276c209b0416be51781c6076079e03e974a5feb33c94bc9bc58c16'
+  version '0.1.16'
+  sha256 'ab5b9dcc6b92ff2893f447b88c3c0e2bb76edc71773259788f89d74c0bb4b509'
 
   url "https://github.com/mellow-io/mellow/releases/download/v#{version}/Mellow-#{version}.dmg"
   appcast 'https://github.com/mellow-io/mellow/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.