### PR TITLE
Update sensei from 1.1.7,23 to 1.1.8,24

### DIFF
--- a/Casks/sensei.rb
+++ b/Casks/sensei.rb
@@ -1,6 +1,6 @@
 cask 'sensei' do
-  version '1.1.7,23'
-  sha256 'a82cee406d07624e64c6f03cad3f8418d02a23e48636b2b2927b475f16128278'
+  version '1.1.8,24'
+  sha256 'b669e3c9393a5c764a7ebdebfd1c95644895522eb62082d70a4fdafc2117da84'
 
   # cindori.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://cindori.s3.amazonaws.com/Sensei.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.