### PR TITLE
Update keymanager from 3.9.28 to 3.9.37

### DIFF
--- a/Casks/keymanager.rb
+++ b/Casks/keymanager.rb
@@ -1,6 +1,6 @@
 cask 'keymanager' do
-  version '3.9.28'
-  sha256 'a70f4187f79608de70f40d733a70b942ce15a17c49d653e4270b576cca240c3f'
+  version '3.9.37'
+  sha256 '6950bca6c6a25c52ca6306c279c7b412eb6ec74a79183d13b53248acd8b24fb4'
 
   # keymanager.trustasia.com was verified as official when first introduced to the cask
   url "https://keymanager.trustasia.com/release/KeyManager-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.