### PR TITLE
Update loom from 0.30.6 to 0.30.7

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.30.6'
-  sha256 'a5d376feb49ce387d3d849590586b866a3ec156e7e849fc2ab1c457515190984'
+  version '0.30.7'
+  sha256 'fbab66965136a22569a59ff78fe1c560dffc703a8902bb6033dbddce10ddc6f8'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.