### PR TITLE
Update zoho-mail from 1.1.1 to 1.1.2

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.1.1'
-  sha256 'b29f3dfd6b8f0427319dca68ef9c9033e9b8a817fc9cd7da04ba5c024e7745aa'
+  version '1.1.2'
+  sha256 '57194c54ce3450238fd4dbce4d629452968fc6ef239c8fa720f9553751626b13'
 
   # downloads.zohocdn.com/zmail-desktop/mac was verified as official when first introduced to the cask
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.