### PR TITLE
thonny: conflicts with thonny-xxl

### DIFF
--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -8,6 +8,8 @@ cask 'thonny' do
   name 'Thonny'
   homepage 'https://thonny.org/'
 
+  conflicts_with cask: 'thonny-xxl'
+
   pkg "thonny-#{version}.pkg"
 
   uninstall quit:    'Thonny',


### PR DESCRIPTION
`thonny` conflicts with `thonny-xxl`.
I had to remove this line from the previous PR (#78645) because it was causing the CI to fail.