### PR TITLE
Update fontforge from 2019.08.01.ac635b8 to 2020.03.14.67687b0

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,6 +1,6 @@
 cask 'fontforge' do
-  version '2019.08.01.ac635b8'
-  sha256 'c5c117b083d8fa73c2ffa19e000d698a3e3cb323b47002c54c1b9047633a227e'
+  version '2020.03.14.67687b0'
+  sha256 '394e4b1d216abd3d716dba94d9b6c7eacfdd9b3fa0c48d29fcaa1e27695593ce'
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
   url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.