### PR TITLE
Update electron-fiddle from 0.13.0 to 0.13.1

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.13.0'
-  sha256 'bcb89d762d101587933ecbf6968a7fcec613a39a85eebca79239a04f45581ab8'
+  version '0.13.1'
+  sha256 'a5e81613379d900af275bd57f34b45dc860335a6a5bf5a812647c745fd70a52c'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.