### PR TITLE
Update refined-github-safari from 2.0.27 to 2.0.28

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask 'refined-github-safari' do
-  version '2.0.27'
-  sha256 '08e63c7ae360b93e54a44e9309a37e2729d04f20cb3fc28ed01980ed56820135'
+  version '2.0.28'
+  sha256 'e01c30935b789a5fa3c61579bfe50e67d8c654cce6cc48e01dff5a0f64c77c36'
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast 'https://github.com/lautis/refined-github-safari/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.