### PR TITLE
Update glyphs from 2.6.5,1300 to 2.6.5,1303

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.5,1300'
-  sha256 '6c81791878ed1a880fe0b415f1360428cef7b5ec98378e5cee6a77f2d3c7f555'
+  version '2.6.5,1303'
+  sha256 'c3560627a4f38cea808c2f71433321cd07a659a479adbf8198c269d5cea714be'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.