### PR TITLE
Update hbuilderx from 2.6.1.20200226 to 2.6.5.20200314

### DIFF
--- a/Casks/hbuilderx.rb
+++ b/Casks/hbuilderx.rb
@@ -1,6 +1,6 @@
 cask 'hbuilderx' do
-  version '2.6.1.20200226'
-  sha256 'a228ad446f14b0b3c7cf6124973e1da2f1c9e453ba2ab1a30ea99196102b0742'
+  version '2.6.5.20200314'
+  sha256 'd364ed39856c5306fd36cad6f15874f65498dc2cd52e0b9a8ef9b3e37886e9a0'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "https://download.dcloud.net.cn/HBuilderX.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.