### PR TITLE
Update odrive from 6616 to 6624

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,6 +1,6 @@
 cask 'odrive' do
-  version '6616'
-  sha256 'f1e6d44de98a210ae22b9b72639bc80f6f92d6353b61e278caf23a5c53b626ca'
+  version '6624'
+  sha256 '9baf2588d72e0979939874b8235aa8fa26cfd180f32970e453e17cc17122a1e8'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.