### PR TITLE
Update jprofiler from 11.1.1 to 11.1.2

### DIFF
--- a/Casks/jprofiler.rb
+++ b/Casks/jprofiler.rb
@@ -1,6 +1,6 @@
 cask 'jprofiler' do
-  version '11.1.1'
-  sha256 'da324d370ec6f4a98c9a1b088242e1d56cf736326fc86601406cbee497e56957'
+  version '11.1.2'
+  sha256 '6428b607ad163d9922f2c613dcecc8e48b23693eaed4db1da77ea58a15449e07'
 
   url "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://www.ej-technologies.com/feeds/jprofiler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.