### PR TITLE
Update metaz from 1.0.beta-91 to 1.0.beta-94

### DIFF
--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -1,6 +1,6 @@
 cask 'metaz' do
-  version '1.0.beta-91'
-  sha256 'ace9e527bff419f9fed4df95996ff245db7446e585593d308544420540bfc53f'
+  version '1.0.beta-94'
+  sha256 '738506d0cdba73650563bb1d9078e4d60ccffab926f05b58504d0715fc50ebb7'
 
   # github.com/griff/metaz was verified as official when first introduced to the cask
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.