### PR TITLE
Update unity-download-assistant from 2019.3.4f1,4f139db2fdbd to 2019.3.5f1,d691e07d38ef

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.4f1,4f139db2fdbd'
-  sha256 '5149aecdcf500193d61d6a7a339fb5674aff5c9b326c75a717f2fc7eaab2becd'
+  version '2019.3.5f1,d691e07d38ef'
+  sha256 'f6784145abf05ad68f8f07de748f36c4a5dcd71acc0d2a734054bc8eeab6f2e7'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.