### PR TITLE
Update kapitainsky-rclone-browser from 1.7.0 to 1.8.0

### DIFF
--- a/Casks/kapitainsky-rclone-browser.rb
+++ b/Casks/kapitainsky-rclone-browser.rb
@@ -1,8 +1,8 @@
 cask 'kapitainsky-rclone-browser' do
-  version '1.7.0,f0dc81f'
-  sha256 'e2b94030f05b30f1075b884375c40df45afafb4bb2941367db2ed245fb88065b'
+  version '1.8.0,a0b66c6'
+  sha256 '44465643aa1a8b87ff9d68410567045674e3d979e789f8b0bd2953e1ebf7e715'
 
-  url "https://github.com/kapitainsky/RcloneBrowser/releases/download/#{version.before_comma}/rclone-browser-#{version.before_comma}-#{version.after_comma}.dmg"
+  url "https://github.com/kapitainsky/RcloneBrowser/releases/download/#{version.before_comma}/rclone-browser-#{version.before_comma}-#{version.after_comma}-macos.dmg"
   appcast 'https://github.com/kapitainsky/RcloneBrowser/releases.atom'
   name 'Rclone Browser'
   homepage 'https://github.com/kapitainsky/RcloneBrowser'


### PR DESCRIPTION
Updated with [`cask-repair`]

[`cask-repair`]: https://github.com/buo/homebrew-cask-upgrade

```
$ cask-repair --cask-version 1.8.0,a0b66c6 kapitainsky-rclone-browser --cask-url https://github.com/kapitainsky/RcloneBrowser/releases/download/1.8.0/rclone-browser-1.8.0-a0b66c6-macos.dmg
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.


refs:
- https://github.com/kapitainsky/RcloneBrowser/issues/92