### PR TITLE
Update corona-tracker from 1.2.1 to 1.3.1

### DIFF
--- a/Casks/corona-tracker.rb
+++ b/Casks/corona-tracker.rb
@@ -1,6 +1,6 @@
 cask 'corona-tracker' do
-  version '1.2.1'
-  sha256 '201d5b6103e6c6a7ba28779998c9e3b20077b731e36633be62e340247ada28ea'
+  version '1.3.1'
+  sha256 '94b8c54cf01a359982fa0d972d50aa57f47d0080cfd8be6b7f8ca5001bbb1238'
 
   # github.com/MhdHejazi/CoronaTracker was verified as official when first introduced to the cask
   url "https://github.com/MhdHejazi/CoronaTracker/releases/download/v#{version}/CoronaTracker-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.