### PR TITLE
Update eudic from 2020-01-27,3.9.6 to 2020-02-16,3.9.7

### DIFF
--- a/Casks/eudic.rb
+++ b/Casks/eudic.rb
@@ -1,5 +1,5 @@
 cask 'eudic' do
-  version '2020-01-27,3.9.6'
+  version '2020-02-16,3.9.7'
   sha256 '5cec29af3ff50a6658c81c33466166aa0de18097ec649ec82557517cf2f73d2e'
 
   # static.frdic.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.