### PR TITLE
Update Prince to 13.4 (from 13.1)

### DIFF
--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -1,6 +1,6 @@
 cask 'prince' do
-  version '13.1'
-  sha256 '93b50a308ed7070e49c8a0487a7e123a9a5bd239549ad64dc1143dd277231dff'
+  version '13.4'
+  sha256 '42256197d9e5391336cf5b449933831aec76de7de84e7e8f8606c845b35cf115'
 
   url "https://www.princexml.com/download/prince-#{version}-macos.tar.gz"
   appcast 'https://www.princexml.com/download/'


### PR DESCRIPTION
Hope this is correct. (First commit.) I bumped the version number and sha256 with:
$ shasum --algorithm 256 prince-13.4-macos.tar.gz

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

First commit ever -- not sure how to do any of this! Cask's name and version are in subject and this is a stable version of Prince.
