### PR TITLE
Update Adobe Connect to 10.2 2019.9.2

### DIFF
--- a/Casks/adobe-connect.rb
+++ b/Casks/adobe-connect.rb
@@ -1,6 +1,6 @@
 cask 'adobe-connect' do
-  version '10.1,2019.1.1'
-  sha256 'eb8dab912146236d20bf904c1bcc036b95ecd76916322fe7efbefca1b13ff545'
+  version '10.2,2019.9.2'
+  sha256 'a741ddf5a863bed4a3d4730427844ec93215a472371af4fa8de9c22ac653b224'
 
   url "https://download.adobe.com/pub/connect/updaters/meeting/#{version.before_comma.dots_to_underscores}/AdobeConnect_#{version.after_comma}.dmg"
   name 'Adobe Connect'


### PR DESCRIPTION
Update Adobe Connect to Version 10.2 2019.9.2.

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

