### PR TITLE
Update sidequest from 0.8.7 to 0.10.1

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,6 +1,6 @@
 cask 'sidequest' do
-  version '0.8.7'
-  sha256 '3248d8ca1ad80f3f310df723fe97bdd052b708616c66ccee347da4a98200d646'
+  version '0.10.1'
+  sha256 'dcdbfea5c41aca12218c53bf1c0b1f8c50d0d45966d7feeb29cbe2f2a0557397'
 
   # github.com/the-expanse/SideQuest was verified as official when first introduced to the cask
   url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.