### PR TITLE
Update anydo from 4.2.70 to 4.2.71

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.70'
-  sha256 '8d120bd50563c814e8dc4c76b4bd3f68f9f844e0b067a8b260538798da353a72'
+  version '4.2.71'
+  sha256 '26cee0d0293045c380165079fba318f7e219670f2fe5ab782a65aa6c1858f734'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.