### PR TITLE
Update plex-media-server from 1.18.7.2457-77cb9455c to 1.18.8.2527-740d4c206

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.18.7.2457-77cb9455c'
-  sha256 'be6e4b5a2da5d8f5965846a4a50515068569d17ac2c19cd154d28cdf428ac5a5'
+  version '1.18.8.2527-740d4c206'
+  sha256 '3d9f0809f1d9fb9ddd4ee0829ccefabcd9946b6ee01bb45b10eb3c1cd51fe63e'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.