### PR TITLE
Update visual-paradigm from 16.1,20200231 to 16.1,20200301

### DIFF
--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -1,6 +1,6 @@
 cask 'visual-paradigm' do
-  version '16.1,20200231'
-  sha256 'd7b72ce3336049e27c5452f372b1072a887d2979ecf5184e87c81f00d5ef2358'
+  version '16.1,20200301'
+  sha256 '0c3233a945f62cc8a70fce8e7509e056638d0ed531f996be9bd33d53832c802e'
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.visual-paradigm.com/downloads/vp/checksum.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.