### PR TITLE
Update kiwi-for-g-suite from 2.0.32v to 2.0.34v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask 'kiwi-for-g-suite' do
-  version '2.0.32v'
-  sha256 '75ee2543056b9f611861a7ff10b42b663311f15acf7676da8e59d7c34fcae104'
+  version '2.0.34v'
+  sha256 '782037a9536a2bdee4f2937ef1b0543c2e530e7ca4d8d306e3058a38a9f92fe5'
 
   # kiwiforgsuite.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.