### PR TITLE
Update filebot from 4.8.5 to 4.9.0

### DIFF
--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -1,6 +1,6 @@
 cask 'filebot' do
-  version '4.8.5'
-  sha256 '8e9c409ce8d9bc8b87702249897c81a32b7485a78bb15b073477413d34f94f82'
+  version '4.9.0'
+  sha256 'd8bc65a9eb2a1cdc97fd6125f3eadb978f2e178c2b0c65b354b20880af6d49a1'
 
   url "https://get.filebot.net/filebot/FileBot_#{version}/FileBot_#{version}.app.tar.xz"
   appcast 'https://app.filebot.net/update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.