### PR TITLE
Update wire from 3.12.3490 to 3.15.3621

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,6 +1,6 @@
 cask 'wire' do
-  version '3.12.3490'
-  sha256 'bf94eb5fbdd9ceb3e1ac8a94234fc469f73f0d99da48dc58d881ba94f2e87077'
+  version '3.15.3621'
+  sha256 '01643a957f77ecc25eb6b5057de8e53aa59e9823462cd3ccc69bca3fd6544f8f'
 
   # github.com/wireapp/wire-desktop was verified as official when first introduced to the cask
   url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.