### PR TITLE
Update typeface from 2.6.4 to 2.6.4,2006

### DIFF
--- a/Casks/typeface.rb
+++ b/Casks/typeface.rb
@@ -1,5 +1,5 @@
 cask 'typeface' do
-  version '2.6.4'
+  version '2.6.4,2006'
   sha256 'f7a8ce7a496f33a04b12f23a937c988fd166511208726d7de4218f6fe0041128'
 
   url 'https://dcdn.typefaceapp.com/latest'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.