### PR TITLE
Update power-manager from 5.4.6 to 5.4.7

### DIFF
--- a/Casks/power-manager.rb
+++ b/Casks/power-manager.rb
@@ -1,6 +1,6 @@
 cask 'power-manager' do
-  version '5.4.6'
-  sha256 'c6a05a925dbb090c042f4f520d01460df18c06570e6cd06940f62f66ed07512c'
+  version '5.4.7'
+  sha256 'c655ea9d87672a29c3e94b2596febd218106994738086011dd5aa71d7584ae50'
 
   url "https://www.dssw.co.uk/powermanager/dsswpowermanager-#{version.no_dots}.dmg"
   appcast 'https://version.dssw.co.uk/powermanager/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.