### PR TITLE
Replace AltDeploy homepage with the official one

### DIFF
--- a/Casks/altdeploy.rb
+++ b/Casks/altdeploy.rb
@@ -2,11 +2,10 @@ cask 'altdeploy' do
   version '1.1'
   sha256 'c9f1c27e3c83022fe0fae7abe3ea825792bc799390d3fb5492f8cfb97a9d7f56'
 
-  # github.com/pixelomer/AltDeploy was verified as official when first introduced to the cask
   url "https://github.com/pixelomer/AltDeploy/releases/download/v#{version}/AltDeploy.zip"
   appcast 'https://github.com/pixelomer/AltDeploy/releases.atom'
   name 'AltDeploy'
-  homepage 'https://cydia-app.com/altdeploy/'
+  homepage 'https://github.com/pixelomer/AltDeploy'
 
   app 'AltDeploy.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The commit message does not include the Cask version because I wasn't aware that it was necessary. Only the homepage is changed though, so I don't think the version is necessary.

The person who added this cask specified an unofficial as the homepage. As the developer of this utility (AltDeploy), I want to replace it with the official one.