### PR TITLE
Update megasync from 4.3.0.8 to 4.3.1.0

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -1,5 +1,5 @@
 cask 'megasync' do
-  version '4.3.0.8'
+  version '4.3.1.0'
   sha256 '137da3481d80c26b444a4c5c53ab6c7e9d4424e48d7c30e8fafabef11447aed8'
 
   url 'https://mega.nz/MEGAsyncSetup.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.