### PR TITLE
Update metaz from 1.0.beta-94 to 1.0.beta-113

### DIFF
--- a/Casks/metaz.rb
+++ b/Casks/metaz.rb
@@ -1,6 +1,6 @@
 cask 'metaz' do
-  version '1.0.beta-94'
-  sha256 '738506d0cdba73650563bb1d9078e4d60ccffab926f05b58504d0715fc50ebb7'
+  version '1.0.beta-113'
+  sha256 '5f0d43794ac76c025ad1c0f6419dfea58c8c696d7e2782060d2aa12554316588'
 
   # github.com/griff/metaz was verified as official when first introduced to the cask
   url "https://github.com/griff/metaz/releases/download/v#{version}/MetaZ-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.