### PR TITLE
Update iconjar from 2.2.0,38416 to 2.3.0,38894

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,6 +1,6 @@
 cask 'iconjar' do
-  version '2.2.0,38416'
-  sha256 '16a5888f385ff7cc913ef6d061d4b6487dde8667991d26f70baaa68a7c597fa1'
+  version '2.3.0,38894'
+  sha256 'fec801ec023b211a5685075bcf8e6209190aee6dd5e8f35e62db16a604f8d815'
 
   url "https://geticonjar.com/releases/IconJar.app.#{version.after_comma}.zip"
   appcast 'https://geticonjar.com/releases/stable.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.