### PR TITLE
Update shift from 4.0.20 to 4.0.21

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,5 +1,5 @@
 cask 'shift' do
-  version '4.0.20'
+  version '4.0.21'
   sha256 'f4c0f56acd9c0a9e1d07bf3ef7817424e67b889e3f15d9019b4c5b58e7b2fbb7'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.