### PR TITLE
Update camunda-modeler from 3.7.0 to 3.7.1

### DIFF
--- a/Casks/camunda-modeler.rb
+++ b/Casks/camunda-modeler.rb
@@ -1,6 +1,6 @@
 cask 'camunda-modeler' do
-  version '3.7.0'
-  sha256 '2c41d6094171165f00ee1b0f099ba011b7a27e3b5457eb61a2603e435d4dc4c9'
+  version '3.7.1'
+  sha256 '4e9fcd1db124954133271ddbe5d6e3fcfbcfdb496d781e52d9280fb9faefae75'
 
   url "https://camunda.org/release/camunda-modeler/#{version}/camunda-modeler-#{version}-mac.zip"
   appcast 'https://camunda.com/download/modeler/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.