### PR TITLE
Update postico from 1.5.10 to 1.5.12

### DIFF
--- a/Casks/postico.rb
+++ b/Casks/postico.rb
@@ -1,6 +1,6 @@
 cask 'postico' do
-  version '1.5.10'
-  sha256 'f0318ddfafa1d52438cc38e160507e8140f595576f829cd4c0b7ff1c4d1f6e1d'
+  version '1.5.12'
+  sha256 'df3ba8a0c6ade249969a63af433067fa00263a00695a864d607565277a1db47a'
 
   # eggerapps-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://eggerapps-downloads.s3.amazonaws.com/postico-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.