### PR TITLE
Update understand from 5.1.1018 to 5.1.1019

### DIFF
--- a/Casks/understand.rb
+++ b/Casks/understand.rb
@@ -1,6 +1,6 @@
 cask 'understand' do
-  version '5.1.1018'
-  sha256 'c90e867a116a800eac3e04a1316cc9e9006a6bc964a87fb6750ba52b37bf96a2'
+  version '5.1.1019'
+  sha256 '403b0159a83a0c982bfe3b46eef694b6418590db7a53a4e71c50e38d14ba6553'
 
   url "http://builds.scitools.com/all_builds/b#{version.patch}/Understand/Understand-#{version}-MacOSX-x86.dmg"
   appcast 'https://scitools.com/download/all-builds/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.