### PR TITLE
Add OMX eBooks Latest

### DIFF
--- a/Casks/omx-ebooks.rb
+++ b/Casks/omx-ebooks.rb
@@ -21,7 +21,6 @@ cask 'omx-ebooks' do
                '~/Library/Preferences/org.cef.cefsimple.plist',
                '~/Library/Preferences/org.cef.cefclient.helper.plist',
                '~/Library/Logs/OMX eBooks_debug.log',
-               '~/Library/Application Support/CrashReporter/OMX eBooks Helper_565BD068-8FA5-581E-B995-A28C4228CDC4.plist',
-               '~/Library/Application Support/CrashReporter/OMX eBooks_565BD068-8FA5-581E-B995-A28C4228CDC4.plist',
+               '~/Library/Application Support/CrashReporter/OMX eBooks*',
              ]
 end

--- a/Casks/omx-ebooks.rb
+++ b/Casks/omx-ebooks.rb
@@ -1,0 +1,27 @@
+cask 'omx-ebooks' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://hello.officemax.com.au/ebooks/clkn/https/www.officemaxschools.com.au/ebooks/OMX_eBooks.pkg'
+  name 'OMX eBooks'
+  homepage 'https://hello.officemax.com.au/ebooks/'
+
+  pkg 'OMX_eBooks.pkg'
+
+  uninstall pkgutil: 'com.readcloud.OMXeBooks'
+
+  zap trash: [
+               '/Users/Shared/omxebooks',
+               '/private/var/folders/4n/y4h_w3ds6gs8h2shnrz34rw80000gn/C/org.cef.cefsimple',
+               '~/Library/Caches/org.cef.cefsimple',
+               '~/Library/Saved Application State/org.cef.cefsimple.savedState',
+               '~/Library/Caches/omxebooks',
+               '/private/var/db/receipts/com.readcloud.OMXeBooks.bom',
+               '/private/var/db/receipts/com.readcloud.OMXeBooks.plist',
+               '~/Library/Preferences/org.cef.cefsimple.plist',
+               '~/Library/Preferences/org.cef.cefclient.helper.plist',
+               '~/Library/Logs/OMX eBooks_debug.log',
+               '~/Library/Application Support/CrashReporter/OMX eBooks Helper_565BD068-8FA5-581E-B995-A28C4228CDC4.plist',
+               '~/Library/Application Support/CrashReporter/OMX eBooks_565BD068-8FA5-581E-B995-A28C4228CDC4.plist',
+             ]
+end


### PR DESCRIPTION
Adding the "Officemax eBooks powered by readcloud" application
to Cask. This application is used for school ebooks in Australia.
It is installed via "OMX_eBooks.pkg".

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
