### PR TITLE
Update antconc from 3.5.7 to 3.5.8

### DIFF
--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -3,7 +3,7 @@ cask 'antconc' do
   sha256 'd9870529c7e0213c6468de699fd04b2f20087005daec6948ee528fff7c817cc9'
 
   url "https://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
-  appcast 'https://www.laurenceanthony.net/software/antconc/releases/'
+  appcast 'https://www.laurenceanthony.net/software/antconc/releases/',
           configuration: version.no_dots
   name 'AntConc'
   homepage 'https://www.laurenceanthony.net/software/antconc/'

--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -4,6 +4,7 @@ cask 'antconc' do
 
   url "https://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   appcast 'https://www.laurenceanthony.net/software/antconc/releases/'
+          configuration: version.no_dots
   name 'AntConc'
   homepage 'https://www.laurenceanthony.net/software/antconc/'
 

--- a/Casks/antconc.rb
+++ b/Casks/antconc.rb
@@ -1,6 +1,6 @@
 cask 'antconc' do
-  version '3.5.7'
-  sha256 '660fb0df5376544c41bb3d7c4b4c22cd11d2d20d09e1c895cc342713089890be'
+  version '3.5.8'
+  sha256 'd9870529c7e0213c6468de699fd04b2f20087005daec6948ee528fff7c817cc9'
 
   url "https://www.laurenceanthony.net/software/antconc/releases/AntConc#{version.no_dots}/AntConc.zip"
   appcast 'https://www.laurenceanthony.net/software/antconc/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.