### PR TITLE
Update ogdesign-eagle from 1.10,4 to 1.11,3

### DIFF
--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -1,6 +1,6 @@
 cask 'ogdesign-eagle' do
-  version '1.10,4'
-  sha256 '8d9eb7c63b533acbeb8d4a0a84d6026bfc0d1d005ed583b0e8f291d5bf9d8bdd'
+  version '1.11,3'
+  sha256 'c504887564465c996e2a1ed5dfa5220dcae70bc601aa2c1606c8306cfa7751aa'
 
   # eagleapp.s3-accelerate.amazonaws.com was verified as official when first introduced to the cask
   url "https://eagleapp.s3-accelerate.amazonaws.com/releases/Eagle-#{version.before_comma}-build#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.