### PR TITLE
Update aimersoft-video-converter-ultimate from 11.6.2.4 to 11.6.5.2

### DIFF
--- a/Casks/aimersoft-video-converter-ultimate.rb
+++ b/Casks/aimersoft-video-converter-ultimate.rb
@@ -1,6 +1,6 @@
 cask 'aimersoft-video-converter-ultimate' do
-  version '11.6.2.4'
-  sha256 '2160c7cd83efe0eb65aaa15d10021056554076741f8e890a3e7b9f95e75cda3f'
+  version '11.6.5.2'
+  sha256 'eebe898d4a1b9fe7fcab56ec978b383a4f3d2f2079e29cbc8396552279ff18b7'
 
   url 'http://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full747.dmg'
   name 'Aimersoft Video Converter Ultimate'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.