### PR TITLE
Update jamf-migrator from 5.1.0 to 5.2.0

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '5.1.0'
-  sha256 '3f602c2d74f0092d03aa514cbfb5f533b837278d8889c8f09983e4f60655cfae'
+  version '5.2.0'
+  sha256 '548bc64e1b3d04594289df6ad8db08b3d19d0a80e0ea236fbb1e213c180bb5b0'
 
   url 'https://github.com/jamf/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamf/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.