### PR TITLE
Update mjml from 2.12.0 to 3.0.0

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,6 +1,6 @@
 cask 'mjml' do
-  version '2.12.0'
-  sha256 'a64ceba133100982260eff2ec091239951e2c943df622108ce8e47c6fac15f25'
+  version '3.0.0'
+  sha256 '8f91a614c1aeca4105b929ec82b8b1a117281cc62f4cdd23766fd06258dbb6ff'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/v#{version}/mjml-app-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.