### PR TITLE
Update tuple from 0.63.2,2020-03-12-f143ee17 to 0.64.1,2020-03-17-4c460060

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.63.2,2020-03-12-f143ee17'
-  sha256 'ab2df19e131f74e5fe0f9e18f3a543f4a578cccbfd6f3f31bf438d123ebca6d4'
+  version '0.64.1,2020-03-17-4c460060'
+  sha256 '3551d8546cbbd0f6e8e15dadd9ceb0b42ddd7147f7b9799c982bc00c51f8be90'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.