### PR TITLE
Update blocs from 3.4.4 to 3.4.5

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,6 +1,6 @@
 cask 'blocs' do
-  version '3.4.4'
-  sha256 'dcaaabddc84521c7d4215a10cdd6fe95f5f153e99e060ab52a404f47e75194d2'
+  version '3.4.5'
+  sha256 'cec6f9b0f1933db92ef884ff878a7a8955dcd658b706fd1ffb04fbd2e0005309'
 
   url "https://blocsapp.com/download/Blocs#{version.major}.zip"
   appcast 'https://blocsapp.com/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.