### PR TITLE
Update securityspy from 5.2.1 to 5.2.2

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -1,6 +1,6 @@
 cask 'securityspy' do
-  version '5.2.1'
-  sha256 'aad491e6fc3d8ab65e8574762529be1788df16ae02e5ed0f5612cea0194a091e'
+  version '5.2.2'
+  sha256 '16939f668a9249fc932b86ae6ec922407e8ad31fb21b67d3b97e42f1e11585e4'
 
   url 'https://www.bensoftware.com/securityspy/SecuritySpy.dmg'
   appcast 'https://www.bensoftware.com/securityspy/versionhistory.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.