### PR TITLE
Update power-manager from 5.4.7 to 5.4.8

### DIFF
--- a/Casks/power-manager.rb
+++ b/Casks/power-manager.rb
@@ -1,6 +1,6 @@
 cask 'power-manager' do
-  version '5.4.7'
-  sha256 'c655ea9d87672a29c3e94b2596febd218106994738086011dd5aa71d7584ae50'
+  version '5.4.8'
+  sha256 '064f7172480c7b616331e7cdf374cc677be21336fd4d8c5dc7c16c5e4149fa3d'
 
   url "https://www.dssw.co.uk/powermanager/dsswpowermanager-#{version.no_dots}.dmg"
   appcast 'https://version.dssw.co.uk/powermanager/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.