### PR TITLE
Update eclipse-dsl from 4.13.0,2019-09:R to 4.15.0,2020-03:R

### DIFF
--- a/Casks/eclipse-dsl.rb
+++ b/Casks/eclipse-dsl.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-dsl' do
-  version '4.13.0,2019-09:R'
-  sha256 'ec5737cb756d70b1f622c0aa4855d62bdfed25fba7257d271b10a755fe82c0ad'
+  version '4.15.0,2020-03:R'
+  sha256 '94d5c1212d36e2ed5f6e5eeecc757307507b36c37223405a26d90ad62ecb0824'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-dsl-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java and DSL Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.