### PR TITLE
Update eclipse-java from 4.14.0,2019-12:R to 4.15.0,2020-03:R

### DIFF
--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-java' do
-  version '4.14.0,2019-12:R'
-  sha256 'c6eecdebfea42fc3801c842d107be28cf45ce894c9aa618bcdb60e08093c911b'
+  version '4.15.0,2020-03:R'
+  sha256 '262c29ea38134360089232d8276fb479e3a9f70a5b1a6ffdf6463bc2aeac00f3'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-java-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.