### PR TITLE
Update eclipse-javascript from 4.14.0,2019-12:R to 4.15.0,2020-03:R

### DIFF
--- a/Casks/eclipse-javascript.rb
+++ b/Casks/eclipse-javascript.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-javascript' do
-  version '4.14.0,2019-12:R'
-  sha256 'e12d99702d59894efd18f7cbc9aeb955f55350d52195227a36f271975ee51ff2'
+  version '4.15.0,2020-03:R'
+  sha256 '25ce89059aa7f008ade1c308c94bb4ca8b047e581b2159b38633aa057d1b4192'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-javascript-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for JavaScript and Web Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.