### PR TITLE
Update eclipse-platform from 4.14,201912100610 to 4.15.0,2020-03:R

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.14,201912100610'
-  sha256 '94bb5066a346de86f6ded0e762f7518ed82950b0dcb31a34493a1e7c58f749ef'
+  version '4.15.0,2020-03:R'
+  sha256 '313b9921190d1b184bfa7432900ca2c42da9a3149e024da1a1731c6abbda1e8c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.