### PR TITLE
Update qcad from 3.24.2 to 3.24.3

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,11 +1,11 @@
 cask 'qcad' do
-  version '3.24.2'
+  version '3.24.3'
 
   if MacOS.version <= :high_sierra
-    sha256 '4acc2104ae4876daaccc2f9e93121705d13572d49d8df9aabe6a675525129fa0'
+    sha256 '2313e906d1892ad7a433ff23074c9f28ab747e7731231c0c8a02ff6eab5ae44a'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 '1e2aeffa260fd1fff15c5df4e0731d2ac05a287cf7c08f1cdabdccccd79f79a9'
+    sha256 '9c03efd3d5c41952637cd6bde7b090466ef4f8d87229f509194268f3cadff4ef'
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14-10.15.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.