### PR TITLE
Update activitywatch from 0.8.4 to 0.9.0

### DIFF
--- a/Casks/activitywatch.rb
+++ b/Casks/activitywatch.rb
@@ -1,6 +1,6 @@
 cask 'activitywatch' do
-  version '0.8.4'
-  sha256 '1cb7601991f33ed2eaef2d33b91f2e54c1f0024bc57f61a4000877154516c11d'
+  version '0.9.0'
+  sha256 '4f55d3b41abfd29f91fc810e5512b538ab63f97b4807fc66bcf09ea25b7dcc24'
 
   # github.com/ActivityWatch/activitywatch was verified as official when first introduced to the cask
   url "https://github.com/ActivityWatch/activitywatch/releases/download/v#{version}/activitywatch-v#{version}-macos-x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.