### PR TITLE
Switches activitywatch v0.9.0 from binary to app

### DIFF
--- a/Casks/activitywatch.rb
+++ b/Casks/activitywatch.rb
@@ -1,14 +1,14 @@
 cask 'activitywatch' do
   version '0.9.0'
-  sha256 '4f55d3b41abfd29f91fc810e5512b538ab63f97b4807fc66bcf09ea25b7dcc24'
+  sha256 '982bc85665e0229c4bace4c5b23d3163792b350d9344010dc672e889d412948d'
 
   # github.com/ActivityWatch/activitywatch was verified as official when first introduced to the cask
-  url "https://github.com/ActivityWatch/activitywatch/releases/download/v#{version}/activitywatch-v#{version}-macos-x86_64.zip"
+  url "https://github.com/ActivityWatch/activitywatch/releases/download/v#{version}/activitywatch-v#{version}-macos-x86_64.dmg"
   appcast 'https://github.com/ActivityWatch/activitywatch/releases.atom'
   name 'ActivityWatch'
   homepage 'https://activitywatch.net/'
 
-  binary 'activitywatch/aw-qt'
+  app 'ActivityWatch.app'
 
   zap trash: '~/Library/Application Support/activitywatch'
 end


### PR DESCRIPTION
Self signed macOS packaged app is released starting from v0.9.0

see ActivityWatch/activitywatch#334

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
