### PR TITLE
Update anki from 2.1.21 to 2.1.23

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -1,6 +1,6 @@
 cask 'anki' do
-  version '2.1.21'
-  sha256 '1fe04dd0e7f34611a20b2602a63407f64131348950b95e43bbe07302c25aa932'
+  version '2.1.23'
+  sha256 '7dbe282f81ef20645479b750c0f2cde4c8f81d7752ca89262c10710533978389'
 
   # github.com/ankitects/anki was verified as official when first introduced to the cask
   url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.