### PR TITLE
Update logos from 8.11.0.0017 to 8.12.0.0017

### DIFF
--- a/Casks/logos.rb
+++ b/Casks/logos.rb
@@ -1,6 +1,6 @@
 cask 'logos' do
-  version '8.11.0.0017'
-  sha256 '524b371e3aa18ebc4fe8c982727926431bf4ee5bf653f2cfff04b750cf979cce'
+  version '8.12.0.0017'
+  sha256 '3900d550dc7dab9232d8f51f15b4de838b3fb4039da23eb7a84ec58f1f7696db'
 
   # downloads.logoscdn.com was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/LBS8/Installer/#{version}/LogosMac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.