### PR TITLE
Update java from 13.0.2,8:d4173c853231432d94f001e99d882ca7 to 14,36:076bab302c7b4508975440c56f6cc26a

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,6 +1,6 @@
 cask 'java' do
-  version '13.0.2,8:d4173c853231432d94f001e99d882ca7'
-  sha256 '08fd2db3a3ab6fb82bb9091a035f9ffe8ae56c31725f4e17d573e48c39ca10dd'
+  version '14,36:076bab302c7b4508975440c56f6cc26a'
+  sha256 'f3e7439e19ea22f71a96b5563e0e0967e7df1563f2f9d7922209793498ca4698'
 
   url "https://download.java.net/java/GA/jdk#{version.before_comma}/#{version.after_colon}/#{version.after_comma.before_colon}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Java Development Kit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.