### PR TITLE
Update balsamiq-wireframes from 4.0.21 to 4.0.23

### DIFF
--- a/Casks/balsamiq-wireframes.rb
+++ b/Casks/balsamiq-wireframes.rb
@@ -1,6 +1,6 @@
 cask 'balsamiq-wireframes' do
-  version '4.0.21'
-  sha256 '996d0d31a194ab3fa398e21dcd30f444e5fe254620077af9da481e951a889f2f'
+  version '4.0.23'
+  sha256 '931db241ae178202a96f9cea501869e73bcaf5433af24a3bdc8440805b54962e'
 
   url "https://builds.balsamiq.com/bwd/Balsamiq%20Wireframes%20#{version}.dmg"
   appcast 'https://builds.balsamiq.com/bwd/mac.jsonp'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.