### PR TITLE
Update tuple from 0.64.1,2020-03-17-4c460060 to 0.64.2,2020-03-18-14ba6ac8

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.64.1,2020-03-17-4c460060'
-  sha256 '3551d8546cbbd0f6e8e15dadd9ceb0b42ddd7147f7b9799c982bc00c51f8be90'
+  version '0.64.2,2020-03-18-14ba6ac8'
+  sha256 '95f791d2236ab6e7d962b6d2ad021dae88ad59050c82f167202e1aaae23a5e79'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.