### PR TITLE
Update microsoft-edge from 80.0.361.66 to 80.0.361.69

### DIFF
--- a/Casks/microsoft-edge.rb
+++ b/Casks/microsoft-edge.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge' do
-  version '80.0.361.66'
-  sha256 '11b14ed28608d1d02046f0cdea161ccb020bcb16213859329be66ef6e6753a19'
+  version '80.0.361.69'
+  sha256 'a9d909f52f48a9f8b1cdfde3824f3dda4c824757abd1c3f57c07873d580a1ffb'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdge-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.