### PR TITLE
Family Tree Builder 8.2.0.8516 Does not work on Catalina (32-bit)

### DIFF
--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -8,5 +8,7 @@ cask 'family-tree-builder' do
   name 'Family Tree Builder'
   homepage 'https://www.myheritage.com/'
 
+  depends_on macos: '<= :catalina'
+
   app 'Family Tree Builder.app'
 end

--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -8,7 +8,7 @@ cask 'family-tree-builder' do
   name 'Family Tree Builder'
   homepage 'https://www.myheritage.com/'
 
-  depends_on macos: '<= :catalina'
+  depends_on macos: '< :catalina'
 
   app 'Family Tree Builder.app'
 end

--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -8,7 +8,7 @@ cask 'family-tree-builder' do
   name 'Family Tree Builder'
   homepage 'https://www.myheritage.com/'
 
-  depends_on macos: '< :catalina'
+  depends_on macos: '<= :mojave'
 
   app 'Family Tree Builder.app'
 end


### PR DESCRIPTION
See https://faq.myheritage.com/en/article/is-family-tree-builder-compatible-with-the-new-macos-catalina for:

> MyHeritage's Family Tree Builder is currently incompatible with macOS Catalina. We're working hard to make the necessary changes to Family Tree Builder to ensure its compatibility with macOS Catalina.
>
> We expect this work to be completed soon in 2020.

Please note - I'm not sure what `depends_on` is supposed to do for a MacOS requirement - but it still installs this cask on my system even after the patch. However, I see other Casks with the same `depends on catalina` requirement also continue to install (bonjour-browser), so I'm not quite sure what adding this dependency is supposed to do?

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

