### PR TITLE
Update macpilot from 11.0.9 to 11.1

### DIFF
--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -1,6 +1,6 @@
 cask 'macpilot' do
-  version '11.0.9'
-  sha256 '448ba08b0a06debd1e252c6ce3434b224379e5dd1ebd6d9c18bd68818a3bf259'
+  version '11.1'
+  sha256 'b56201f9e726218ca1cc5e793b9069c047f644efb24581d0bc3cdd38f86729ac'
 
   url 'http://mirror.koingosw.com/products/macpilot/download/macpilot.dmg'
   appcast 'https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.