### PR TITLE
Update zeplin from 3.0,846 to 3.1,862

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '3.0,846'
-  sha256 '7e773f30f556440dcdeaa18cabb74a014bd493f96cb47baf38791ce6203b7a53'
+  version '3.1,862'
+  sha256 'bb2858dde9f8324d717a3f501e0057dfefcc3e58855ff9314f628b9b91f18665'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

EDIT: Oops, I just noticed there's `cask-repair` script and I didn't have to do this manually 😅 

I'm new to this repo and Homebrew/Mac in general. I tried to install Zeplin today and received error, so I decided to help a community a bit. Took this PR as a reference: #77706

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
