### PR TITLE
Update loom from 0.30.8 to 0.30.9

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.30.8'
-  sha256 '6a57c66402243117ee297809697421fc3df67df5e75795c5a9368faa4b6b5e54'
+  version '0.30.9'
+  sha256 'd9f4c48cfc70f718d8ccb1f0b7a473dd30b5d45c550bf471568d3452fa8f7acb'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.