### PR TITLE
Update parallels-client from 17.1.0-21669 to 17.1.1-21772

### DIFF
--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -1,6 +1,6 @@
 cask 'parallels-client' do
-  version '17.1.0-21669'
-  sha256 'f33ac54837c2376dd1d8c229b1368dfb17cc329cc7a0a1afea044901f0fc1eb5'
+  version '17.1.1-21772'
+  sha256 'f027d4dbfe884188f3a695a024c2743c74b5412c8fef1dd8285bf11b96a416d8'
 
   url "https://download.parallels.com/ras/v#{version.major}/#{version.hyphens_to_dots}/RasClient-Mac-Appstore-#{version}.pkg"
   appcast "https://download.parallels.com/ras/v#{version.major}/RAS%20Client%20for%20Mac%20Changelog.txt"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.