### PR TITLE
Update soundsource from 4.2.2 to 4.2.3

### DIFF
--- a/Casks/soundsource.rb
+++ b/Casks/soundsource.rb
@@ -1,6 +1,6 @@
 cask 'soundsource' do
-  version '4.2.2'
-  sha256 '8706ba78c40ff892dbea0b2b4b7ae91ed010b7d7833424cfaf81cafdc145efe7'
+  version '4.2.3'
+  sha256 'b622bbcb0318a12b7b3df1db370fcdbe02a290ced589980b2560addb648bd44e'
 
   url 'https://rogueamoeba.com/soundsource/download/SoundSource.zip'
   appcast 'https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&system=10146&version=4000000'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.