### PR TITLE
Update corona-tracker from 1.3.1 to 1.4

### DIFF
--- a/Casks/corona-tracker.rb
+++ b/Casks/corona-tracker.rb
@@ -1,6 +1,6 @@
 cask 'corona-tracker' do
-  version '1.3.1'
-  sha256 '94b8c54cf01a359982fa0d972d50aa57f47d0080cfd8be6b7f8ca5001bbb1238'
+  version '1.4'
+  sha256 'cd72b9d62072cc2ee5b2d0dbd8c44c9dd39ee9b2937845116cc492fc796ed821'
 
   # github.com/MhdHejazi/CoronaTracker was verified as official when first introduced to the cask
   url "https://github.com/MhdHejazi/CoronaTracker/releases/download/v#{version}/CoronaTracker-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.