### PR TITLE
Update lando from 3.0.0-aft.1 to 3.0.0-aft.2

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.0-aft.1'
-  sha256 'e6e9016855680990f3ad21a8a774a44bb0ce08866dc634eb15930f36ab956a77'
+  version '3.0.0-aft.2'
+  sha256 'a7f742f084da0d8a726f448b758b18e38c6c79ca24de379451c4f892d97d56ca'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.