### PR TITLE
Fix termius checksum

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
   version '5.6.1'
-  sha256 '4dc5c843c1e9cf2c0648ddb24750a70804489f5994caff2fecba8f3273068908'
+  sha256 '4bd9319326c2e6d9d5da12f6acee9f900336933b68daeb49263522784dcacdc1'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
Fix termius checksum

```text
==> Upgrading termius
==> Downloading https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg
Already downloaded: /Users/djerfy/Library/Caches/Homebrew/downloads/3394ebaa7ddcec7e4a2e988162d1abcbf08b11a7c13f6f0790b705dbaecb2c87--Termius.dmg
==> Verifying SHA-256 checksum for Cask 'termius'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
==> Purging files for version 5.6.1 of Cask termius
Error: Checksum for Cask 'termius' does not match.
Expected: 4dc5c843c1e9cf2c0648ddb24750a70804489f5994caff2fecba8f3273068908
  Actual: 4bd9319326c2e6d9d5da12f6acee9f900336933b68daeb49263522784dcacdc1
    File: /Users/djerfy/Library/Caches/Homebrew/downloads/3394ebaa7ddcec7e4a2e988162d1abcbf08b11a7c13f6f0790b705dbaecb2c87--Termius.dmg
To retry an incomplete download, remove the file above.
```