### PR TITLE
Update wickrme from 5.49.6 to 5.50.6

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.49.6'
-  sha256 '9dc2028b2412e1e1f23987e4656e43737723ebae34c48cd47a2082ff0799e3b2'
+  version '5.50.6'
+  sha256 'b5bd437cddda03f72f66dbae6a07555056b10586c0c256ba162d53cd8cd1f45f'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.