### PR TITLE
Update tuple from 0.64.2,2020-03-18-14ba6ac8 to 0.65.0,2020-03-19-c0e09737

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.64.2,2020-03-18-14ba6ac8'
-  sha256 '95f791d2236ab6e7d962b6d2ad021dae88ad59050c82f167202e1aaae23a5e79'
+  version '0.65.0,2020-03-19-c0e09737'
+  sha256 'def43bda6501295e70e41ce3d41234d7b14ef47207d64000cb1923480845840c'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.