### PR TITLE
Update propresenter from 7.0.5,117441797 to 7.0.5,117441799

### DIFF
--- a/Casks/propresenter.rb
+++ b/Casks/propresenter.rb
@@ -1,6 +1,6 @@
 cask 'propresenter' do
-  version '7.0.5,117441797'
-  sha256 '9524e5ad7f5ce350409fbe413c9c62086afa826a524f034c23abc2a58c51d8dd'
+  version '7.0.5,117441799'
+  sha256 'fab63928030965e27d7bec61d3a191dbf6e1a0a0a6de24230fb06b9c56daee8b'
 
   url "https://renewedvision.com/downloads/propresenter/mac/ProPresenter_#{version.before_comma}_#{version.after_comma}.zip"
   appcast 'https://api.renewedvision.com/v1/pro/upgrade?platform=macos&osVersion=0&appVersion=0&buildNumber=0&includeNotes=0'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.