### PR TITLE
Update geotag from 4.7 to 4.8

### DIFF
--- a/Casks/geotag.rb
+++ b/Casks/geotag.rb
@@ -1,6 +1,6 @@
 cask 'geotag' do
-  version '4.7'
-  sha256 '60321d98a35570307a1565292d7a09ef6c5f5deda78ee7ff06d7ae21df9e73c6'
+  version '4.8'
+  sha256 '09ef5408d5a4862dceec8ee7f7e56280c5ee61845a1a74dd9e7c1b7b75781a7a'
 
   url "https://www.snafu.org/GeoTag/GeoTag-#{version}.dmg"
   appcast 'https://github.com/marchyman/GeoTag/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.