### PR TITLE
Update ticktick from 3.4.52,134 to 3.5.00,136

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.4.52,134'
-  sha256 'e1937f7c66037c5f06debf66595435f11e394e4d99aee4cbf9c6c0ea5d7e908a'
+  version '3.5.00,136'
+  sha256 'd6ec2b5cd153900d77dee9245e3e30787584fb3bfd3df85c844dd514155f07ff'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.