### PR TITLE
Update qownnotes from 20.3.5,b5434-112733 to 20.3.6,b5440-181028

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.3.5,b5434-112733'
-  sha256 '157272669175993c66355fa56c5b76e3fcb491ab8d139e47a5d6cfd5ec3fcf6b'
+  version '20.3.6,b5440-181028'
+  sha256 '31af17ad8b320f510d1a9dcce818a04b1a6dfeca900f73eef90be3b9bf6afd82'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.