### PR TITLE
Update katalon-studio from 7.2.7 to 7.2.8

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.2.7'
-  sha256 'b8be148411c118ad0d50a6d1d28fcb6fe35e881e5d17c7fe50f9d89d7aff1362'
+  version '7.2.8'
+  sha256 '2d2b933e9cd4166da63d1314a57e5f6933be5274a56a7dd95c7bb68be24f9b88'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.