### PR TITLE
Update fontgoggles from 1.1.7 to 1.1.8

### DIFF
--- a/Casks/fontgoggles.rb
+++ b/Casks/fontgoggles.rb
@@ -1,6 +1,6 @@
 cask 'fontgoggles' do
-  version '1.1.7'
-  sha256 '36546080ca22fdaf81aa9238962dcd9101cfff1e794ac13369946eb2a9f77a46'
+  version '1.1.8'
+  sha256 '043e5f44c823cf3025c8f6c21ef56cfaa2a81db0639a6423cf33f334a2b0d832'
 
   # github.com/justvanrossum/fontgoggles was verified as official when first introduced to the cask
   url "https://github.com/justvanrossum/fontgoggles/releases/download/v#{version}/FontGoggles.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.