### PR TITLE
Update cmake from 3.16.5 to 3.17.0

### DIFF
--- a/Casks/cmake.rb
+++ b/Casks/cmake.rb
@@ -1,6 +1,6 @@
 cask 'cmake' do
-  version '3.16.5'
-  sha256 'c6f9d22e435414a7b453cd7f517f1c16c9a505ea64a36695ce498c8679b59332'
+  version '3.17.0'
+  sha256 '3bed01c6535a75725d523785419122f2080f7ce943d2c180f5f3ade644504a44'
 
   url "https://www.cmake.org/files/v#{version.major_minor}/cmake-#{version}-Darwin-x86_64.dmg"
   appcast 'https://cmake.org/files/LatestRelease/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.