### PR TITLE
Add qtmips_gui.app v0.7.3

### DIFF
--- a/Casks/qtmips_gui.rb
+++ b/Casks/qtmips_gui.rb
@@ -1,0 +1,11 @@
+cask 'qtmips_gui' do
+  version '0.7.3'
+  sha256 'da1254860245e7c4904531d4dc4d5bdb05e805975168d6a47ade8a44d6f69379'
+
+  url "https://github.com/cvut/QtMips/releases/download/v#{version}/qtmips-macos-v#{version}.zip"
+  appcast 'https://github.com/cvut/QtMips/releases.atom'
+  name 'QtMips - MIPS CPU emulator gui'
+  homepage 'https://github.com/cvut/QtMips'
+
+  app 'qtmips_gui.app'
+end


### PR DESCRIPTION
Hey. I've added qtmips_gui app, which emulates MIPS CPU architecture. It's mainly used for educational purposes at our university (Czech Technical University Prague).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x ] `brew cask audit --download {{cask_file}}` is error-free.
- [x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x ] The commit message includes the cask’s name and version.
- [x ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x ] Named the cask according to the [token reference].
- [x ] `brew cask install {{cask_file}}` worked successfully.
- [x ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x ] Checked there are no [open pull requests] for the same cask.
- [x ] Checked the cask was not [already refused].
- [x ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
