### PR TITLE
Update termius from 5.6.1 to 5.6.2

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '5.6.1'
-  sha256 '4dc5c843c1e9cf2c0648ddb24750a70804489f5994caff2fecba8f3273068908'
+  version '5.6.2'
+  sha256 '4bd9319326c2e6d9d5da12f6acee9f900336933b68daeb49263522784dcacdc1'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.