### PR TITLE
Update prusaslicer from 2.1.1,201912101508 to 2.2.0,202003211132

### DIFF
--- a/Casks/prusaslicer.rb
+++ b/Casks/prusaslicer.rb
@@ -1,6 +1,6 @@
 cask 'prusaslicer' do
-  version '2.1.1,201912101508'
-  sha256 '0a27929b446349056633ae1b07114bb0641aeb53d4c61f146e4cf3c2ac922734'
+  version '2.2.0,202003211132'
+  sha256 '4634361151e0ceb0b75cff6edafa523e3cc92d7979789c32ca50861eb0c3c7c6'
 
   # github.com/prusa3d/PrusaSlicer was verified as official when first introduced to the cask.
   url "https://github.com/prusa3d/PrusaSlicer/releases/download/version_#{version.before_comma}/PrusaSlicer-#{version.before_comma}+-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.