### PR TITLE
Update gisto from 1.12.14 to 1.13.1

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.12.14'
-  sha256 'de3a4c513ad62aaa59bbe0158840ead5c6a037f23d1a72fb6800edbc618e8440'
+  version '1.13.1'
+  sha256 '4d9fedcd7c3af8c9773126cd7f2a758af6293df3644728d80b8146dc164ca9fe'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.