### PR TITLE
Update qownnotes from 20.3.6,b5440-181028 to 20.3.7,b5443-124854

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.3.6,b5440-181028'
-  sha256 '31af17ad8b320f510d1a9dcce818a04b1a6dfeca900f73eef90be3b9bf6afd82'
+  version '20.3.7,b5443-124854'
+  sha256 '1d4de1f0a7ba52dfff043ca88116be4fb86a5237209c6c551b1b3c60db60b30d'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.