### PR TITLE
Update fontgoggles from 1.1.8 to 1.1.9

### DIFF
--- a/Casks/fontgoggles.rb
+++ b/Casks/fontgoggles.rb
@@ -1,6 +1,6 @@
 cask 'fontgoggles' do
-  version '1.1.8'
-  sha256 '043e5f44c823cf3025c8f6c21ef56cfaa2a81db0639a6423cf33f334a2b0d832'
+  version '1.1.9'
+  sha256 '4f21efa1a5593cb3dea421974eb36509579f97efeacb48b376de8a552342cae4'
 
   # github.com/justvanrossum/fontgoggles was verified as official when first introduced to the cask
   url "https://github.com/justvanrossum/fontgoggles/releases/download/v#{version}/FontGoggles.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.