### PR TITLE
Update aria2d from 1.3.4 to 1.3.5

### DIFF
--- a/Casks/aria2d.rb
+++ b/Casks/aria2d.rb
@@ -1,6 +1,6 @@
 cask 'aria2d' do
-  version '1.3.4'
-  sha256 '0bbfa96007fbae53d42b8a524ec21aa8cf9376d1757436aa33525ae74ddb835d'
+  version '1.3.5'
+  sha256 '9bb019fb9b19b878403767fd07423633a0daaeb1ed6ca807c64043b3b4f76ce1'
 
   # githubusercontent.com/xjbeta was verified as official when first introduced to the cask
   url "https://raw.githubusercontent.com/xjbeta/AppUpdaterAppcasts/master/Aria2D/Aria2D%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.