### PR TITLE
Update soulver from 3.2.2.1-80 to 3.2.3-84

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,6 +1,6 @@
 cask 'soulver' do
-  version '3.2.2.1-80'
-  sha256 '743ae8cb3b4987599f4fa9256c48c2a3baf8d0efe285e55d79efc038f60b5092'
+  version '3.2.3-84'
+  sha256 '1b0f600f6ad564c48255f59f86becdf8001092d32700b325280d7e408bbe8849'
 
   url "https://soulver.app/mac/sparkle/soulver-#{version}.zip"
   appcast 'https://soulver.app/mac/sparkle/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.