### PR TITLE
Update datweatherdoe from 1.2.5 to 1.11

### DIFF
--- a/Casks/datweatherdoe.rb
+++ b/Casks/datweatherdoe.rb
@@ -1,6 +1,6 @@
 cask 'datweatherdoe' do
-  version '1.2.5'
-  sha256 'cc3bd6aea7dda073b399fd32e4d0e77d7b453b3ef3fc39bac6cba491af9327d4'
+  version '1.11'
+  sha256 '6b1eac172c178045328f1dd200cf1ecd346dcf7180525b8a91bcacb24b621b87'
 
   url "https://github.com/inderdhir/DatWeatherDoe/releases/download/#{version}/DatWeatherDoe-#{version}.dmg"
   appcast 'https://github.com/inderdhir/DatWeatherDoe/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.