### PR TITLE
Fix Parsec.app installation on case-sensitive fs

### DIFF
--- a/Casks/parsec.rb
+++ b/Casks/parsec.rb
@@ -11,6 +11,8 @@ cask 'parsec' do
 
   postflight do
     set_ownership '~/.parsec'
+    system 'diskutil info / | grep -i \'case\\-sensitive\' &> /dev/null && ' \
+           'sudo ln -s /Applications/Parsec.app/Contents/Macos /Applications/Parsec.app/Contents/MacOS'
   end
 
   uninstall pkgutil: 'tv.parsec.www'


### PR DESCRIPTION
The Parsec.app bundle contains a 'Macos' directory holding its binary.
This prevents it from opening on case-sensitive filesystems which expect
the binary in a 'MacOS' directory. Now after the package installation a
check for case-sensitivity will be performed and if it succeeds a
symbolic link 'MacOS' directory will be created in the installed bundle
pointing to the 'Macos' directory.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
