### PR TITLE
fontforge 2017.07.31, 2015.04.31

### DIFF
--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,5 +1,4 @@
 cask 'fontforge' do
-
   # https://github.com/fontforge/fontforge/releases/download/20200314/FontForge-2020-03-14-67687b0.app.dmg
   if MacOS.version >= :sierra
     depends_on macos: '>= :sierra'
@@ -27,9 +26,10 @@ cask 'fontforge' do
           configuration: version.major_minor_patch.dots_to_hyphens
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'
+
   app 'FontForge.app'
 
   zap trash: [
-               '~/.cache/fontforge'
+               '~/.cache/fontforge',
              ]
 end

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -1,15 +1,35 @@
 cask 'fontforge' do
-  version '2020.03.14.67687b0'
-  sha256 '394e4b1d216abd3d716dba94d9b6c7eacfdd9b3fa0c48d29fcaa1e27695593ce'
+
+  # https://github.com/fontforge/fontforge/releases/download/20200314/FontForge-2020-03-14-67687b0.app.dmg
+  if MacOS.version >= :sierra
+    depends_on macos: '>= :sierra'
+    version '2020.03.14.67687b0'
+    sha256 '394e4b1d216abd3d716dba94d9b6c7eacfdd9b3fa0c48d29fcaa1e27695593ce'
+    url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"
+
+  # https://github.com/fontforge/fontforge/releases/download/20170731/FontForge-20170730-Mac.dmg
+  elsif MacOS.version >= :yosemite
+    depends_on macos: '>= :yosemite'
+    version '2017.07.31'
+    sha256 '980c66e00f0f5c7a722eadd8b78a0ef2b20a7ccd952149cbfdfeaae9e66e4d4e'
+    url "https://github.com/fontforge/fontforge/releases/download/#{version.no_dots}/FontForge-#{version.no_dots.to_i - 1}-Mac.dmg"
+
+  # https://github.com/fontforge/fontforge/releases/download/20150430/FontForge-2015-04-30-Mac.app.dmg
+  else
+    depends_on macos: '>= :mavericks'
+    version '2015.04.31'
+    sha256 '69f01a6d15fc0e93c259828ec29e8e6243ba5a35017bee17d101ee54c2c2ab86'
+    url "https://github.com/fontforge/fontforge/releases/download/#{version.no_dots}/FontForge-#{version.dots_to_hyphens}-Mac.dmg"
+  end
 
   # github.com/fontforge/fontforge was verified as official when first introduced to the cask
-  url "https://github.com/fontforge/fontforge/releases/download/#{version.major_minor_patch.no_dots}/FontForge-#{version.dots_to_hyphens}.app.dmg"
   appcast 'https://github.com/fontforge/fontforge/releases.atom',
           configuration: version.major_minor_patch.dots_to_hyphens
   name 'FontForge'
   homepage 'https://fontforge.github.io/en-US/'
-
-  depends_on macos: '>= :yosemite'
-
   app 'FontForge.app'
+
+  zap trash: [
+               '~/.cache/fontforge'
+             ]
 end


### PR DESCRIPTION
Add older versions of FontForge and zap preferences.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
