### PR TITLE
Update kite from 0.20200310.0 to 0.20200324.3

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200320.0'
-  sha256 '4211dca35c9b2cd995e333fa14a957a8d621fbd4318041cc232878fee3b0bc23'
+  version '0.20200324.3'
+  sha256 '192decefc7a762c449e292c7da4229b45f9c8bd3c2ddd34c8d7e6db7b1eb9f42'
 
   # draqv87tt43s0.cloudfront.net was verified as official when first introduced to the cask
   url "https://draqv87tt43s0.cloudfront.net/mac/#{version}/Kite.dmg"

--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,9 +1,9 @@
 cask 'kite' do
-  version '0.20200310.0'
-  sha256 'b7ad7b2c1456475bd09a84e68c24b8b3f242031b6abf898f0d0013cf2653d7a3'
+  version '0.20200320.0'
+  sha256 '4211dca35c9b2cd995e333fa14a957a8d621fbd4318041cc232878fee3b0bc23'
 
-  # kite-downloads.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://kite-downloads.s3.amazonaws.com/Kite-#{version}.dmg"
+  # azure-cdn-kite-downloads.azureedge.net was verified as official when first introduced to the cask
+  url "https://azure-cdn-kite-downloads.azureedge.net/mac/#{version}/Kite.dmg"
   appcast 'https://release.kite.com/appcast.xml'
   name 'Kite'
   homepage 'https://kite.com/'

--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -2,8 +2,8 @@ cask 'kite' do
   version '0.20200320.0'
   sha256 '4211dca35c9b2cd995e333fa14a957a8d621fbd4318041cc232878fee3b0bc23'
 
-  # azure-cdn-kite-downloads.azureedge.net was verified as official when first introduced to the cask
-  url "https://azure-cdn-kite-downloads.azureedge.net/mac/#{version}/Kite.dmg"
+  # draqv87tt43s0.cloudfront.net was verified as official when first introduced to the cask
+  url "https://draqv87tt43s0.cloudfront.net/mac/#{version}/Kite.dmg"
   appcast 'https://release.kite.com/appcast.xml'
   name 'Kite'
   homepage 'https://kite.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.