### PR TITLE
Update neo4j from 1.2.4 to 1.2.5

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,9 +1,9 @@
 cask 'neo4j' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '1.2.4'
-  sha256 '3cd53b075027dac97745678bb73e76e9919def26a40b1c632b3314944283465c'
+  version '1.2.5'
+  sha256 '5f52b93aa87e74a377efaaa2160a7c1a9431e23044a76ea5b5cee5fcc6fb5c7b'
 
-  url "https://neo4j.com/artifact.php?name=neo4j-desktop-offline-#{version}.dmg"
+  url "https://neo4j.com/artifact.php?name=neo4j-desktop-#{version}.dmg"
   appcast 'https://neo4j.com/download/'
   name 'Neo4j Desktop'
   homepage 'https://neo4j.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.