### PR TITLE
Update springtoolsuite from 4.5.1.RELEASE,4.14.0 to 4.6.0.RELEASE,4.15.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,12 +1,12 @@
 cask 'springtoolsuite' do
-  version '4.5.1.RELEASE,4.14.0'
-  sha256 '5854e62adccee10c7e3222cf72514c3848816ff0ef8d2fc5d777bf8dd49a180d'
+  version '4.6.0.RELEASE,4.15.0'
+  sha256 '55b7e316e4c1932a5791302dadd91019e4dffc61f77ed8fc1d02d4d6eb9b80e3'
 
   # download.springsource.com/release/STS was verified as official when first introduced to the cask
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}-e#{version.after_comma}-macosx.cocoa.x86_64.dmg"
   appcast 'https://github.com/spring-projects/sts4/releases.atom'
   name 'Spring Tool Suite'
-  homepage 'https://spring.io/tools/sts'
+  homepage 'https://spring.io/tools'
 
   auto_updates true
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.