### PR TITLE
Update gisto from 1.13.1 to 1.13.2

### DIFF
--- a/Casks/gisto.rb
+++ b/Casks/gisto.rb
@@ -1,6 +1,6 @@
 cask 'gisto' do
-  version '1.13.1'
-  sha256 '4d9fedcd7c3af8c9773126cd7f2a758af6293df3644728d80b8146dc164ca9fe'
+  version '1.13.2'
+  sha256 '1d314ba1f87202d29b25b2d11a2f832baaf8f0b378e24d6d09de8ef89aeaa308'
 
   # github.com/Gisto/Gisto was verified as official when first introduced to the cask
   url "https://github.com/Gisto/Gisto/releases/download/v#{version}/Gisto-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.