### PR TITLE
Add ghdl v0.37

### DIFF
--- a/Casks/ghdl.rb
+++ b/Casks/ghdl.rb
@@ -1,0 +1,11 @@
+cask 'ghdl' do
+  version '0.37'
+  sha256 'cb870085dd55167eda162b2d8b0020b30574b47fa8f8dfc7a1fd6aa3eb32ee91'
+
+  url "https://github.com/ghdl/ghdl/releases/download/v#{version}/ghdl-#{version}-macosx-mcode.tgz"
+  appcast 'https://github.com/ghdl/ghdl/releases.atom'
+  name 'ghdl'
+  homepage 'https://github.com/ghdl/ghdl/'
+
+  binary 'bin/ghdl'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

This PR re-adds `ghdl` to Homebrew Cask.

Even though this is an open-source CLI tool, I am submitting it as a cask instead of a "normal" Homebrew formula because building `ghdl` from source requires an Ada compiler, which is not currently supported by Homebrew and would be likely not be worth the trouble to add (see [this comment](https://github.com/Homebrew/homebrew-cask/pull/46031#issuecomment-388602940)). However, `ghdl` does supply pre-compiled binaries for macOS, so it is easy to simply provide a Cask formula to install binaries directly.

This new formula also addresses the issues raised [here](https://github.com/Homebrew/homebrew-cask/pull/46031#issuecomment-388602940) about installing `lib` and `include` files in a Cask formula. This formula does not install these files: if users need to link against `ghdl` in their own applications, they can add `/usr/local/Caskroom/ghdl/vX.Y/{include,lib}` to their include/library search paths.