### PR TITLE
Update qgis from 3.12.0 to 3.12.1

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -3,7 +3,8 @@ cask 'qgis' do
   sha256 '69cc98ac7017f62aa16b14c6e8b5743f5abc7d073643a428e45363300d15c110'
 
   url 'https://qgis.org/downloads/macos/qgis-macos-pr.dmg'
-  appcast 'https://www.qgis.org/'
+  appcast 'https://qgis.org/downloads/macos/qgis-macos-pr.sha256sum',
+          configuration: version.dots_to_underscores
   name 'QGIS'
   homepage 'https://www.qgis.org/'
 

--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -1,6 +1,6 @@
 cask 'qgis' do
-  version '3.12.0'
-  sha256 '9eba4fbf92aa7bd5fa9364a1eaf8325ab1db6ec0834acabe9539e830c41167ff'
+  version '3.12.1'
+  sha256 '69cc98ac7017f62aa16b14c6e8b5743f5abc7d073643a428e45363300d15c110'
 
   url 'https://qgis.org/downloads/macos/qgis-macos-pr.dmg'
   appcast 'https://www.qgis.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.