### PR TITLE
Add Camera Live.app v11

### DIFF
--- a/Casks/camera-live.rb
+++ b/Casks/camera-live.rb
@@ -1,0 +1,16 @@
+cask 'camera-live' do
+  version '11'
+  sha256 '4c7a6ecdbec677a6fbbb90af427e54b0d429278c87b49966c6448ce065c78e75'
+
+  url "https://github.com/v002/v002-Camera-Live/releases/download/#{version}/Camera.Live.zip"
+  appcast 'https://github.com/v002/v002-Camera-Live/releases.atom'
+  name 'Camera Live'
+  homepage 'https://github.com/v002/v002-Camera-Live'
+
+  app 'Camera Live.app'
+
+  zap trash: [
+               '~/Library/Preferences/info.v002.Camera-Live.plist',
+               '~/Library/Saved Application State/info.v002.Camera-Live.savedState',
+             ]
+end


### PR DESCRIPTION
> v002 Camera Live provides a Syphon server for a connected camera, allowing it to be used as a live video feed.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
