### PR TITLE
Adds jdk mission control 7.0

### DIFF
--- a/Casks/jdk-mission-control.rb
+++ b/Casks/jdk-mission-control.rb
@@ -1,8 +1,10 @@
 cask 'jdk-mission-control' do
-  version '7.0,14' # JMC 7 build 14
+  version '7.0.0,14'
   sha256 '81a7754c75be718cee852f988cc64d5cb1f2aa90a3a4bbe0f8fdc70d9c719ab3'
 
   url "https://download.java.net/java/GA/jmc#{version.major}/#{version.after_comma}/jmc-#{version.major}_osx-x64_bin.tar.gz"
+  appcast 'https://jdk.java.net/jmc/',
+          configuration: version.after_comma
   name 'JDK Mission Control'
   homepage 'https://jdk.java.net/jmc/'
 

--- a/Casks/jdk-mission-control.rb
+++ b/Casks/jdk-mission-control.rb
@@ -1,0 +1,14 @@
+cask 'jdk-mission-control' do
+  version '7.0,14' # JMC 7 build 14
+  sha256 '81a7754c75be718cee852f988cc64d5cb1f2aa90a3a4bbe0f8fdc70d9c719ab3'
+
+  url "https://download.java.net/java/GA/jmc#{version.major}/#{version.after_comma}/jmc-#{version.major}_osx-x64_bin.tar.gz"
+  name 'JDK Mission Control'
+  homepage 'https://jdk.java.net/jmc/'
+
+  app "jmc-#{version.major}+#{version.after_comma}_osx-x64_bin/JDK Mission Control.app"
+
+  caveats do
+    depends_on_java '11'
+  end
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.

```
==> Downloading https://download.java.net/java/GA/jmc7/14/jmc-7_osx-x64_bin.tar.gz
Already downloaded: /Users/bric3/Library/Caches/Homebrew/downloads/ac896fdc1c8d7088e3fcb6a84a82b58e0ce29d56aa8eb824cd35236629c54612--jmc-7_osx-x64_bin.tar.gz
==> Verifying SHA-256 checksum for Cask 'jdk-mission-control'.
audit for jdk-mission-control: passed
```

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
```

- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

I noticed this ticket #57387 and it affected the zulu mission control cask, I believe this open ticket should not block these casks because these are separate apps that merely need a java runtime to be started, they are part of the java/jdk distribution _matrix_.
