### PR TITLE
Update unity-android-support-for-editor from 2019.3.5f1,d691e07d38ef to 2019.3.6f1,5c3fb0a11183

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.5f1,d691e07d38ef'
-  sha256 '11ff3513564e7382a3795b56cbc27a17c00388cca4b40cadfc6a57759209e996'
+  version '2019.3.6f1,5c3fb0a11183'
+  sha256 '4a3c6a8193af66d208ebdf763ebcc569963ac08385b754285eabefa90f2b603a'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.