### PR TITLE
Update unity-lumin-support-for-editor from 2019.3.5f1,d691e07d38ef to 2019.3.6f1,5c3fb0a11183

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.3.5f1,d691e07d38ef'
-  sha256 '65b7f1f15c1a3b4d27c34a71eab07e502d4c65ec55c2f7012bb34f6e9f483ba0'
+  version '2019.3.6f1,5c3fb0a11183'
+  sha256 '2858b9aca9d651e1760d31c286e5263af8d24cf65116c8ff510c82e81620931b'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.