### PR TITLE
Update unity-webgl-support-for-editor from 2019.3.5f1,d691e07d38ef to 2019.3.6f1,5c3fb0a11183

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.3.5f1,d691e07d38ef'
-  sha256 '0c54d4aeb60b7508faf3b3430739068815b1ef9c5c9a2484acc19dfac187109d'
+  version '2019.3.6f1,5c3fb0a11183'
+  sha256 '640fa0c9efd6a24f6dd8b832fb0a9fa045e5573e1e1ac2a0f821f8d946ed40bc'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.