### PR TITLE
Update stack from 2.4.1.70454 to 2.6.2.20200306

### DIFF
--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -1,6 +1,6 @@
 cask 'stack' do
-  version '2.4.1.70454'
-  sha256 '41daf141ffe51fe2c6357e6fe9a289303323c4b5421da89673878e0bfe475bed'
+  version '2.6.2.20200306'
+  sha256 'f3b03c6a3a6f4bdafdceb2a7c626ed473cdb127e8254a517c4c998d5c286eabd'
 
   # transip.net/stack was verified as official when first introduced to the cask
   url "https://mirror.transip.net/stack/software/osx/stack-#{version}.pkg"

--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -4,7 +4,7 @@ cask 'stack' do
 
   # transip.net/stack was verified as official when first introduced to the cask
   url "https://mirror.transip.net/stack/software/osx/stack-#{version}.pkg"
-  appcast 'https://mirror.transip.net/stack/update/?version=2.4.0.1&platform=macos&oem=stack&versionsuffix=&sparkle=true'
+  appcast 'https://mirror.transip.net/stack/update/?version=0.0.0&platform=macos&oem=stack&versionsuffix=&sparkle=true'
   name 'STACK'
   homepage 'https://www.transip.nl/stack'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.