### PR TITLE
Update electronmail from 4.4.1 to 4.4.2

### DIFF
--- a/Casks/electronmail.rb
+++ b/Casks/electronmail.rb
@@ -1,6 +1,6 @@
 cask 'electronmail' do
-  version '4.4.1'
-  sha256 '902ac93ea0f61b3c6a83dd86982855207a69350f4897f0ee55296abd1e579cc6'
+  version '4.4.2'
+  sha256 '0e88951a333c6979497a89d0831e7efd0f5c2ebf87c5dc276cf27ac47fe337a7'
 
   url "https://github.com/vladimiry/ElectronMail/releases/download/v#{version}/electron-mail-#{version}-mac-mojave.dmg"
   appcast 'https://github.com/vladimiry/ElectronMail/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.