### PR TITLE
Update electerm from 1.3.1 to 1.3.4

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.1'
-  sha256 '5acb33bbb49534de18b77277aa57a3f1bae31127bf8ebbd3aaa838abad39ced9'
+  version '1.3.4'
+  sha256 'f1c7e0ff75741f83be52a5ed7e2ade1f861190b9c875dfddca38512ca81f09e9'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.