### PR TITLE
Update oracle-jdk from 13.0.2,8:d4173c853231432d94f001e99d882ca7 to 14,36:076bab302c7b4508975440c56f6cc26a

### DIFF
--- a/Casks/oracle-jdk.rb
+++ b/Casks/oracle-jdk.rb
@@ -1,6 +1,6 @@
 cask 'oracle-jdk' do
-  version '13.0.2,8:d4173c853231432d94f001e99d882ca7'
-  sha256 'dede5d020449ae004e81e39831583f5f02ca416c79fa8252f267fb4e535adc6c'
+  version '14,36:076bab302c7b4508975440c56f6cc26a'
+  sha256 '84c379bb11f67b9cf9cf41710430a7b91e9eff2dfdc7a37dae943d2a6e35ce58'
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_osx-x64_bin.dmg",
       cookies: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.