### PR TITLE
Update navicat-for-sqlite from 15.0.11 to 15.0.12

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.11'
-  sha256 'e770b0956987af792e8aae0e21538772a83f772a847612b455a471948537a005'
+  version '15.0.12'
+  sha256 '9f7ce8d73f94f96ca20d9cece617e605653a4abdadbcaa0f6abb2918b4d642ae'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.