### PR TITLE
Update downie from 4.0.4,4076 to 4.0.5,4082

### DIFF
--- a/Casks/downie.rb
+++ b/Casks/downie.rb
@@ -1,6 +1,6 @@
 cask 'downie' do
-  version '4.0.4,4076'
-  sha256 'd9696b67df373c31e03ed0afd906ba88067c6a3e4bc28b85737d1c08c218bfe3'
+  version '4.0.5,4082'
+  sha256 'f031d344ccf0aae9d50db13b7e0f25585e0f66247ac9162ad7f17d9193d31b62'
 
   # charliemonroesoftware.com was verified as official when first introduced to the cask
   url "https://charliemonroesoftware.com/trial/downie/v#{version.major}/Downie_#{version.major}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.