### PR TITLE
Update navicat-premium-essentials from 15.0.11 to 15.0.12

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '15.0.11'
-  sha256 'f0f0e3afb96a14a1ae078a8a6f5706240c29b38bc9d72bf9bfd1a9f6f24a74a1'
+  version '15.0.12'
+  sha256 'feab820b0c8eaef02cc9f6f3321650eeae41cc3f052eb061d9c80cbea2f42fc9'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Premium%20Essentials&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.