### PR TITLE
Update navicat-for-mysql from 15.0.11 to 15.0.12

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '15.0.11'
-  sha256 'b42699d2256498e08743e4502e701a90437b46053afde2cc23789bfab00573d8'
+  version '15.0.12'
+  sha256 'fba931fe5e0843cdaa4873e165797e1eb2230b6c644c8c8a3fa8300d78a5e742'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.