### PR TITLE
Update navicat-for-mariadb from 15.0.11 to 15.0.12

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '15.0.11'
-  sha256 '066282dc92f4f6ee1ddce125f281e7aa89d3f355266003968c50dc6c8847fb3a'
+  version '15.0.12'
+  sha256 '94d4320bf67ea16eba17cba400c1280376b627a2a88f19cbf5e9914860fba79a'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.