### PR TITLE
Update navicat-for-sql-server from 15.0.11 to 15.0.12

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.11'
-  sha256 '4117d5107ddf47ebae1814aeceb7cf323281261d310e136bae237c1ff0eeee3d'
+  version '15.0.12'
+  sha256 '953c9e149f7ad50bc614cc8964f1529f8b31276960fee2876e88fe8b637561da'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.