### PR TITLE
Update fontlab from 7.1.0.7363 to 7.1.1.7380

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,6 +1,6 @@
 cask 'fontlab' do
-  version '7.1.0.7363'
-  sha256 '4f04709328045673e5be4db31f547e91a2af8af3ce9aa90818bf8d227c4c2c35'
+  version '7.1.1.7380'
+  sha256 'f31f1a3c0b13d0b13617649606e7ff95bc7b0a20b2852a2262fbc54042b8b502'
 
   # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fontlab.s3.amazonaws.com/fontlab-#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.