### PR TITLE
Update megahertz-knotes from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/megahertz-knotes.rb
+++ b/Casks/megahertz-knotes.rb
@@ -1,6 +1,6 @@
 cask 'megahertz-knotes' do
-  version '2.2.1'
-  sha256 'c32719d5128800f71cb685c7f846d227f3e01e3a61a9db1f12236ff25b310b35'
+  version '2.2.2'
+  sha256 'febed9f148142e814a2014ed9a2fbb112efdbc88837b84c2d1030b26b277d3aa'
 
   url "http://cdn.knotesapp.cn/download/%e7%b3%af%e8%af%8d%e7%ac%94%e8%ae%b0-#{version}.dmg"
   appcast "https://knotes#{version.major}-release-cn.s3.amazonaws.com/mac/latest-mac.yml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.