### PR TITLE
Update inkdrop from 4.6.0 to 4.6.1

### DIFF
--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -1,6 +1,6 @@
 cask 'inkdrop' do
-  version '4.6.0'
-  sha256 'abf73c9b3218f936b452104b2384c2c6ce2d922a827be6ae77e7030bdc4f5d5a'
+  version '4.6.1'
+  sha256 '2219bdf2140f67fb3e0c93820c697d9624915273331598ea651621bc86ada6a1'
 
   # d3ip0rje8grhnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-Mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.