### PR TITLE
Update mockplus from 3.6.0.4 to 3.6.1.2

### DIFF
--- a/Casks/mockplus.rb
+++ b/Casks/mockplus.rb
@@ -1,9 +1,9 @@
 cask 'mockplus' do
-  version '3.6.0.4'
-  sha256 'e7b4cb2dca00d4b5574948d76d7114d6504b1f7dbde4e07f79bd23797161db74'
+  version '3.6.1.2'
+  sha256 'e01e6904c9e23a21cdddbaa8ccc5b38943897ec4beef08093046ad9e9342cac8'
 
   # mockplus-static.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://mockplus-static.s3.amazonaws.com/software/macos/Mockplus_v#{version}.dmg"
+  url "https://mockplus-static.s3.amazonaws.com/software/macos/Mockplus_v#{version}_auto.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.mockplus.com/download/mockplus-rp&encoding=utf8&user_agent=Macintosh'
   name 'Mockplus'
   name '摩客'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.