### PR TITLE
Update whatsapp from 0.4.1302 to 0.4.1307

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'whatsapp' do
-  version '0.4.1302'
-  sha256 '0c51043aa497a2b04972b0eb88d74c9ccc74839379372d3941a65d2b7cd8319a'
+  version '0.4.1307'
+  sha256 'b1a1859720cd97ed38f91bdcab60f503987031612b502afb2162ee9b2d5e6bc8'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.