### PR TITLE
Update haptickey from 0.4.6 to 0.5.0

### DIFF
--- a/Casks/haptickey.rb
+++ b/Casks/haptickey.rb
@@ -1,6 +1,6 @@
 cask 'haptickey' do
-  version '0.4.6'
-  sha256 '71d2905f01fe45acb74452f3a92c37bdcb2d0ca605a831fe4f0854fe3d968d04'
+  version '0.5.0'
+  sha256 'ea7ce3a3c0761a0e0cbd13f2bccdc64c3f0cff363ecf89fcacb7081f634a412f'
 
   url "https://github.com/niw/HapticKey/releases/download/#{version}/HapticKey.app.zip"
   appcast 'https://github.com/niw/HapticKey/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.