### PR TITLE
Update activitywatch from 0.9.0 to 0.9.2

### DIFF
--- a/Casks/activitywatch.rb
+++ b/Casks/activitywatch.rb
@@ -1,6 +1,6 @@
 cask 'activitywatch' do
-  version '0.9.0'
-  sha256 '982bc85665e0229c4bace4c5b23d3163792b350d9344010dc672e889d412948d'
+  version '0.9.2'
+  sha256 '3eecc1f61984428d4708785e9740d350a1ee5bdb8a2b5b480344121069ac5ffa'
 
   # github.com/ActivityWatch/activitywatch was verified as official when first introduced to the cask
   url "https://github.com/ActivityWatch/activitywatch/releases/download/v#{version}/activitywatch-v#{version}-macos-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.