### PR TITLE
Update teamspeak-client from 3.5.0 to 3.5.1

### DIFF
--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -1,6 +1,6 @@
 cask 'teamspeak-client' do
-  version '3.5.0'
-  sha256 'e6faf6c8d6c455df0a63ab317f769024aa5af12a74b7888fe1c40ca907f3305f'
+  version '3.5.1'
+  sha256 'a36601e047a56ffa2d6e96736888c950e1b7af7fb62c867fcb48dc2abb062e61'
 
   # files.teamspeak-services.com/releases/client was verified as official when first introduced to the cask
   url "https://files.teamspeak-services.com/releases/client/#{version}/TeamSpeak#{version.major}-Client-macosx-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.