### PR TITLE
Update omnigraffle from 7.14 to 7.14.1

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -8,8 +8,8 @@ cask 'omnigraffle' do
     sha256 '83ef24af2dbd7977b9922e992f17f23e102562f0589d28bc37d5579b4a4d4938'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
   else
-    version '7.14'
-    sha256 '11eaedde5945aa797a10a3b9f46a01db29d6af9b87e5a1f4bd71392e1c6ebe05'
+    version '7.14.1'
+    sha256 '0c8aa7f5a7b977461c134cc41c8f4afaf724ab5891e5a48b69912c7a7d1b84d8'
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.