### PR TITLE
Update kitty from 0.17.0 to 0.17.1

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -1,6 +1,6 @@
 cask 'kitty' do
-  version '0.17.0'
-  sha256 'ce5b4c5e35006ba9f31b35cb6f8464069c7f9e051a1cb54f6bc16ab37a8c2634'
+  version '0.17.1'
+  sha256 '29bd5dc6c253e908c7b06f67225b5eed5bf6ce79134916aec3fbb32a0d900778'
 
   url "https://github.com/kovidgoyal/kitty/releases/download/v#{version}/kitty-#{version}.dmg"
   appcast 'https://github.com/kovidgoyal/kitty/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.