### PR TITLE
Update sherlock from 1.7.4 to 1.7.5

### DIFF
--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -3,7 +3,7 @@ cask 'sherlock' do
   sha256 'd73e08704081b4b87c89a84eaa9deff4b303c2746a76b1fe56000cc1c90a34da'
 
   # appcenter-filemanagement-distrib2ede6f06e.azureedge.net was verified as official when first introduced to the cask
-  url 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/4dc86610-6f44-402a-9bdd-1cee62345b9b/Sherlock%201.7.5.dmg?sv=2018-03-28&sr=c&sig=teQSveyZ6XhkRCAq6CkDxb42YQYWT72P6BtvCilRdPQ%3D&se=2020-03-25T14%3A50%3A22Z&sp=r'
+  url "https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/4dc86610-6f44-402a-9bdd-1cee62345b9b/Sherlock%20#{version}.dmg?sv=2018-03-28&sr=c&sig=teQSveyZ6XhkRCAq6CkDxb42YQYWT72P6BtvCilRdPQ%3D&se=2020-03-25T14%3A50%3A22Z&sp=r"
   appcast 'http://sparkle.sherlock.inspiredcode.io'
   name 'Sherlock'
   homepage 'https://sherlock.inspiredcode.io/'

--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -1,9 +1,9 @@
 cask 'sherlock' do
-  version '1.7.4'
-  sha256 '2eb61363bbd22ccbbf93f188a33fcc897a16311b9112b84563c7217bf6cbd958'
+  version '1.7.5'
+  sha256 'd73e08704081b4b87c89a84eaa9deff4b303c2746a76b1fe56000cc1c90a34da'
 
   # appcenter-filemanagement-distrib2ede6f06e.azureedge.net was verified as official when first introduced to the cask
-  url 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/10761dd5-e291-4944-a4f6-40411ad796c9/Sherlock_1.7.4.dmg?sv=2018-03-28&sr=c&sig=jvpVUPPMTbmSRYGgl0JNAL0mG6TLn5BmKGxTMyz8nNY%3D&se=2020-03-14T11%3A05%3A24Z&sp=r'
+  url 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/4dc86610-6f44-402a-9bdd-1cee62345b9b/Sherlock%201.7.5.dmg?sv=2018-03-28&sr=c&sig=teQSveyZ6XhkRCAq6CkDxb42YQYWT72P6BtvCilRdPQ%3D&se=2020-03-25T14%3A50%3A22Z&sp=r'
   appcast 'http://sparkle.sherlock.inspiredcode.io'
   name 'Sherlock'
   homepage 'https://sherlock.inspiredcode.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.