### PR TITLE
Update krita from 4.2.8 to 4.2.9

### DIFF
--- a/Casks/krita.rb
+++ b/Casks/krita.rb
@@ -1,9 +1,9 @@
 cask 'krita' do
-  version '4.2.8'
-  sha256 '55c62ecaf319689921c58d563f5ef6016b872fe9d606672a1819da4ee994f382'
+  version '4.2.9'
+  sha256 '1947aadbca6a6bfd7089f05076a72894623fb003eabc7653066e95382025671e'
 
   # kde.org/stable/krita was verified as official when first introduced to the cask
-  url "https://download.kde.org/stable/krita/#{version}/krita-#{version}.dmg"
+  url "https://download.kde.org/stable/krita/#{version}/krita-x64-#{version}.zip"
   appcast 'https://download.kde.org/stable/krita/',
           configuration: version.major_minor_patch
   name 'Krita'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.