### PR TITLE
Update aerial from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask 'aerial' do
-  version '1.8.1'
-  sha256 '3c44a2ae388aa99196a5ba7fc24c1cedd1f12f8772c537c839647962d728deee'
+  version '1.8.2'
+  sha256 '68819c2563abe1fb96218aea1fbf64e3d87116cacd19bcdd384c8708eff8817a'
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast 'https://github.com/JohnCoates/Aerial/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.