### PR TITLE
Update geph from 3.4.6 to 3.5.0

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.4.6'
-  sha256 '2626e8640c9b69a178f5561f2fcefe29029a8421127349b96b8bf31a6f644d02'
+  version '3.5.0'
+  sha256 '109828be612adb059d595dfb7c5dd221fadcf86d92d4eaae1fd6bc56847247cb'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.