### PR TITLE
Update outline-manager from 1.3.1 to 1.4.0

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.3.1'
-  sha256 '68be00fe803fcfe54da10239a0b79a521ae40b4297c3040abf80bc3cbad34c20'
+  version '1.4.0'
+  sha256 'ad775993051c8f1476dab8282fc4aabb8e730481cb0cf280c72be22f269c931b'
 
   # github.com/Jigsaw-Code/outline-server was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.