### PR TITLE
Update electron-cash from 4.0.13 to 4.0.14

### DIFF
--- a/Casks/electron-cash.rb
+++ b/Casks/electron-cash.rb
@@ -1,6 +1,6 @@
 cask 'electron-cash' do
-  version '4.0.13'
-  sha256 '51774cbc85e676227ab5c6c43223f4ddf345e1ab78608a3cd5c24f1c1eb03db9'
+  version '4.0.14'
+  sha256 '167b7a84d267f6776787a6a3c40589fb3dbefc2395be98fe44513bfe627b3a58'
 
   url "https://electroncash.org/downloads/#{version}/mac/Electron-Cash-#{version}-macosx.dmg"
   appcast 'https://github.com/Electron-Cash/Electron-Cash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.