### PR TITLE
Update alt-tab from 3.1.3 to 3.2.0

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.1.3'
-  sha256 'a950aa39afaf6250a2b850e305bc31ebb69493a7c7c50382b88794c12f4bb14d'
+  version '3.2.0'
+  sha256 'c849693c531d808b5b9caf60f81fc6492839fee12c44ea974226eb754c7313e3'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.