### PR TITLE
Update pixelsnap from 2.2.3 to 2.3

### DIFF
--- a/Casks/pixelsnap.rb
+++ b/Casks/pixelsnap.rb
@@ -1,6 +1,6 @@
 cask 'pixelsnap' do
-  version '2.2.3'
-  sha256 '128964352c230184701ffe8b2ca9ab0d6f1ac9c3a40e178ab04cad7d47da777e'
+  version '2.3'
+  sha256 '2fe48972f155ccf5943de4eee9de61f3a95f17913ab1bbaced09a120b711b40a'
 
   url "https://updates.getpixelsnap.com/v#{version.major}/PixelSnap-#{version.major}-#{version}.dmg"
   appcast "https://updates.getpixelsnap.com/v#{version.major}/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.