### PR TITLE
Update juicebar from 1.0.55 to 1.0.57

### DIFF
--- a/Casks/juicebar.rb
+++ b/Casks/juicebar.rb
@@ -1,6 +1,6 @@
 cask 'juicebar' do
-  version '1.0.55'
-  sha256 'c790ceb57eb007647278701bb7dfc1ad90e312c0ebc833089b0139da21ce7129'
+  version '1.0.57'
+  sha256 'acbaa1eb19e1658de4d0024b355eb47d889eab87fcd8a28ea727578a94e71568'
 
   url "https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.