### PR TITLE
Update kode54-cog from 1125,b7596caa4 to 1127,5fbf722f2

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '1125,b7596caa4'
-  sha256 '3880fbfd68a7e95ad3566971b79a8a6b0dee76bb30a203904624100e8ec77f92'
+  version '1127,5fbf722f2'
+  sha256 'ad19b4283aaacd15a5e5135ceecc9eb2de17012d1849de55d406cf000d952d2c'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.