### PR TITLE
Update captin from 1.0.23,117:1584800886 to 1.0.24,118:1585049885

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.23,117:1584800886'
-  sha256 'a21c1746f40034a9bcc9db1cc86b81068dea1d364521d16877e659e818dd8d1e'
+  version '1.0.24,118:1585049885'
+  sha256 'cb1290938ec121849511a2a497c91963f092ee2b928195e8b882ae00ee988d1d'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.