### PR TITLE
Update i1profiler from 3.2.0 to 3.2.1

### DIFF
--- a/Casks/i1profiler.rb
+++ b/Casks/i1profiler.rb
@@ -1,6 +1,6 @@
 cask 'i1profiler' do
-  version '3.2.0'
-  sha256 'b30d7ebd8a251f36f2fa84589aa793974cfc2fc9eddf7644c747f61a671d8a27'
+  version '3.2.1'
+  sha256 'f78624790961c34abd5701298d3bfed1bed8743f8d410153899e7cdf39abf89d'
 
   url "https://downloads.xrite.com/downloads/software/i1Profiler/#{version}/Mac/i1Profiler.zip"
   appcast 'https://www.xrite.com/Downloads/Autoupdate/i1profiler_mac_appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.