### PR TITLE
Update glyphfinder from 1.0.0 to 1.1.1

### DIFF
--- a/Casks/glyphfinder.rb
+++ b/Casks/glyphfinder.rb
@@ -1,6 +1,6 @@
 cask 'glyphfinder' do
-  version '1.0.0'
-  sha256 'acd3bf6465629fe742af651e05ef79fc28720b4d6851ca66a52e5c3cb6a2e6db'
+  version '1.1.1'
+  sha256 'c0344f61eca8d371817379a48e66ce7926c6c9c418716e3c311197ed846303b1'
 
   # ueber.fra1.cdn.digitaloceanspaces.com/glyphfinder was verified as official when first introduced to the cask
   url "https://ueber.fra1.cdn.digitaloceanspaces.com/glyphfinder/mac/Glyphfinder-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.