### PR TITLE
Update praat from 6.1.09 to 6.1.10

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.1.09'
-  sha256 '5f59891eb01acc4040cc29385aaf9d3262152eaf898abd6cc585a3e796964513'
+  version '6.1.10'
+  sha256 'ae45d3edf13ab356c5243d0ed0534261568abf8ebdd6b621975c28588a5b1643'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.