### PR TITLE
Update airtame from 3.6.1 to 4.0.0

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '3.6.1'
-  sha256 '1ed7013a174da6964bdc180f4a851c330701f7a93ecc1bfb7e4ec7d00d70be3f'
+  version '4.0.0'
+  sha256 '90d315fbacca451e88171bce3156ac6859b2078bcb7846e6af1b0c91c994be0e'
 
   url "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.