### PR TITLE
Update airdroid from 3.6.6.1 to 3.6.7.0

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask 'airdroid' do
-  version '3.6.6.1'
-  sha256 'b9092d9fba87e6c71d1ac30bf2799cd89dd99f0ec21cc8ba5fa53de767243a5e'
+  version '3.6.7.0'
+  sha256 '2c35ec891a35e1d355a4f159f1dc6d5f2f4fc2d79664ffc332fc273b10d13409'
 
   # s3.amazonaws.com/dl.airdroid.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.