### PR TITLE
Update podolski from 1.2.1,3898 to 1.2.2,9724

### DIFF
--- a/Casks/podolski.rb
+++ b/Casks/podolski.rb
@@ -1,21 +1,25 @@
 cask 'podolski' do
-  version '1.2.1,3898'
-  sha256 '2fb8736267a01aca6e65cdc855d8159a21ab25dcc2f81290a5e2f413b5062fe8'
+  version '1.2.2,9724'
+  sha256 '36c3e778a3aaa82dcdb18459b9e01ba490884b52cc200941c299362024523994'
 
   # uhedownloads-heckmannaudiogmb.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/Podolski_#{version.before_comma.dots_to_underscores}_Mac.zip"
+  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/Podolski_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip"
+  appcast 'https://u-he.com/products/podolski/releasenotes.html'
   name 'Podolski'
   homepage 'https://u-he.com/products/podolski/'
 
-  pkg "Podolski#{version.after_comma}Mac/Podolski #{version.before_comma}.#{version.after_comma} Installer.pkg"
+  pkg "Podolski_#{version.after_comma}_Mac/Podolski #{version.before_comma} Installer.pkg"
 
   uninstall pkgutil: [
                        'com.u-he.Podolski.aax.pkg',
                        'com.u-he.Podolski.au.pkg',
                        'com.u-he.Podolski.data.pkg',
                        'com.u-he.Podolski.documentation.pkg',
+                       'com.u-he.Podolski.nks.pkg',
                        'com.u-he.Podolski.presets.pkg',
+                       'com.u-he.Podolski.tuningFiles.pkg',
                        'com.u-he.Podolski.vst.pkg',
+                       'com.u-he.Podolski.vst3.pkg',
                      ]
 
   caveats do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.