### PR TITLE
multipass: require Sierra or later

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -7,6 +7,8 @@ cask 'multipass' do
   name 'Multipass'
   homepage 'https://github.com/CanonicalLtd/multipass/'
 
+  depends_on macos: '>= :sierra'
+
   pkg "multipass-#{version} mac-Darwin.pkg"
 
   uninstall launchctl: 'com.canonical.multipassd',


### PR DESCRIPTION
Multipass requires "Sierra 10.12.0 or later, 2010 or newer Mac".
See https://multipass.run/

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).