### PR TITLE
Update lingon-x from 7.5.3 to 7.5.4

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -3,8 +3,8 @@ cask 'lingon-x' do
     version '6.6.5'
     sha256 'b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8'
   else
-    version '7.5.3'
-    sha256 'f3b074c1cbe104d893bdf0a7197abfefae98ea9cfed56baaaf38183ee6b25686'
+    version '7.5.4'
+    sha256 '3528a6743e73549ca372e5d52e66d1785f64f58c6261352b14da79d8795a8dbd'
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.