### PR TITLE
Update comparemerge from 2.11(2)y,104 to 2.11z,105

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,6 +1,6 @@
 cask 'comparemerge' do
-  version '2.11(2)y,104'
-  sha256 '4f386114f41a4faf2056db5744489aa011b65bc55949194891b2ee7690e7e098'
+  version '2.11z,105'
+  sha256 '1354834bc0bf02e947289097bd5fe07e8f7f62548890568454500cb6c72bb478'
 
   url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version.before_comma}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss'

--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -7,5 +7,5 @@ cask 'comparemerge' do
   name 'CompareMerge'
   homepage 'https://sourceforge.net/projects/comparemergenosandbox/'
 
-  app "CompareMerge #{version.before_comma}.app"
+  app "CompareMerge #{version.before_comma}/CompareMerge #{version.before_comma}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.