### PR TITLE
keepassxc 2.5.3: emergency fix for macOS 10.15.4

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,9 +1,9 @@
 cask 'keepassxc' do
   version '2.5.3'
-  sha256 'fb9af9c2eab788e710f93165f063ed26281140266181d3904b4a6b2d62c5c9d8'
+  sha256 'e278f02466e3fb294c5c676d7b0ba3c60302d0b08273b8088ff39ca2e97e79af'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-2.dmg"
   appcast 'https://github.com/keepassxreboot/keepassxc/releases.atom'
   name 'KeePassXC'
   homepage 'https://keepassxc.org/'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Open PR with incorrect URL: #79267

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
