### PR TITLE
Update loom from 0.31.0 to 0.31.1

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.31.0'
-  sha256 '2e751c32ac0c0d2a08399e0c24c863972d9800badd2e704d3359b073b00d33ea'
+  version '0.31.1'
+  sha256 '8cbfc08dffded007a3d5963df8dcb63f07ff367e513e4408116e29b3621258ea'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.