### PR TITLE
Update rambox from 0.7.4 to 0.7.5

### DIFF
--- a/Casks/rambox.rb
+++ b/Casks/rambox.rb
@@ -1,6 +1,6 @@
 cask 'rambox' do
-  version '0.7.4'
-  sha256 'c2fc326a4eac266a2fc4f37e6cf6081572a0b84661a46914cec0d7f5aa86802b'
+  version '0.7.5'
+  sha256 '3977a7b9929969624663390296fc644a72d107852ce1b7c786e3f84f4412057a'
 
   # github.com/ramboxapp/community-edition was verified as official when first introduced to the cask
   url "https://github.com/ramboxapp/community-edition/releases/download/#{version}/Rambox-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.