### PR TITLE
Update red

### DIFF
--- a/Casks/red.rb
+++ b/Casks/red.rb
@@ -6,7 +6,6 @@ cask 'red' do
   name 'Red Programming Language'
   homepage 'https://www.red-lang.org/'
 
-  # red doesn't work on Catalina, see https://github.com/red/red/issues/4359#issuecomment-602205340
   depends_on macos: '<= :mojave'
   container type: :naked
 

--- a/Casks/red.rb
+++ b/Casks/red.rb
@@ -6,6 +6,8 @@ cask 'red' do
   name 'Red Programming Language'
   homepage 'https://www.red-lang.org/'
 
+  # red doesn't work on Catalina, see https://github.com/red/red/issues/4359#issuecomment-602205340
+  depends_on macos: '<= :mojave'
   container type: :naked
 
   binary "red-#{version.no_dots}", target: 'red'


### PR DESCRIPTION
Adding macOS version constraint due to red being 32bit app. 
see: https://github.com/red/red/issues/4359#issuecomment-602205340

---
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.