### PR TITLE
Update boxer

### DIFF
--- a/Casks/boxer.rb
+++ b/Casks/boxer.rb
@@ -9,6 +9,7 @@ cask 'boxer' do
   homepage 'http://boxerapp.com/'
 
   auto_updates true
+  depends_on macos: '<= :mojave'
 
   app 'Boxer.app'
 end


### PR DESCRIPTION
Add version constraint `<= :mojave` due to Boxer being 32bit app.
This closes #79297


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.