### PR TITLE
Update electerm from 1.3.7 to 1.3.8

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.7'
-  sha256 'd6f6e1d45d5c0665c4bb9bb536d150bc9077b1e5c73821415458076b7fdb8faf'
+  version '1.3.8'
+  sha256 'a68a25a5a8594a2a979b03d0b20b85f5529948808ce9aa54be02ba89a142c94a'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.