### PR TITLE
Update bitwarden from 1.17.1 to 1.17.2

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,6 +1,6 @@
 cask 'bitwarden' do
-  version '1.17.1'
-  sha256 'b25bffb0c5fb48137dde3ee3f1e7351b273e8c06ce4701b1dcd5f9b471c47cc1'
+  version '1.17.2'
+  sha256 '39aba0b28aa2c0f6d1031df435875b84f96502f5866d9c6050503ca207cf01de'
 
   # github.com/bitwarden/desktop was verified as official when first introduced to the cask
   url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.