### PR TITLE
Update rhinoceros from 6.23.20055.11282 to 6.24.20079.23332

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,6 +1,6 @@
 cask 'rhinoceros' do
-  version '6.23.20055.11282'
-  sha256 '31adb8a0d5f85ef122cb14c764f0fd602490e571d34b3ec1784e3655eefed54b'
+  version '6.24.20079.23332'
+  sha256 '199c6047a7a35926b3776237e3acfcb1f53ff9e6a2ada0e421e58077a782e88c'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/rhino/#{version.major}/mac/releases/rhino_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.