### PR TITLE
Update smartgit from 20.1.0 to 20.1.1

### DIFF
--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,6 +1,6 @@
 cask 'smartgit' do
-  version '20.1.0'
-  sha256 '40ad821ad5d7c0f228ca67619b134f777f3788149e24c34c59468aa07d4890fc'
+  version '20.1.1'
+  sha256 'a62a4fcc053c2ab4eba2ab8d9f76b436d968ef6c4243ae2460ed9749eaf29726'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog.txt',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.