### PR TITLE
Update blue-jeans from 2.19.0.311 to 2.19.1.15

### DIFF
--- a/Casks/blue-jeans.rb
+++ b/Casks/blue-jeans.rb
@@ -1,6 +1,6 @@
 cask 'blue-jeans' do
-  version '2.19.0.311'
-  sha256 '2f786a3b0a7ca730387a645d2499b086e64a99329b076a04b175269988872ea7'
+  version '2.19.1.15'
+  sha256 '001b22c3d742f9775fdac0d1dac053dcf57c874452a51b443050e58ffbccfb8a'
 
   url "https://swdl.bluejeans.com/desktop-app/mac/#{version.major_minor_patch}/#{version}/BlueJeansInstaller.dmg"
   appcast 'https://www.bluejeans.com/downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.