### PR TITLE
Update checksum for andriod-platform-tools 29.0.6

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,6 +1,6 @@
 cask 'android-platform-tools' do
   version '29.0.6'
-  sha256 '7555e8e24958cae4cfd197135950359b9fe8373d4862a03677f089d215119a3a'
+  sha256 '17cb7642a5b34beda7fc0ef8eeb7dd8664f980c14736fd129c7b2dc0f2407c98'
 
   # google.com/android/repository/platform-tools was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip"


### PR DESCRIPTION

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
