### PR TITLE
Update macpass from 0.7.11 to 0.7.12

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -1,6 +1,6 @@
 cask 'macpass' do
-  version '0.7.11'
-  sha256 '1ad6eda44db56efe2d83dc2eee658eead6a34cc885cd0d92c457abe1c46d9f23'
+  version '0.7.12'
+  sha256 'acde7f51fd0b6529553e1e4ad4a7cbc137096bd355987bb5f4fb869f578f33be'
 
   # github.com/MacPass/MacPass was verified as official when first introduced to the cask
   url "https://github.com/MacPass/MacPass/releases/download/#{version}/MacPass-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.