### PR TITLE
Update gns3 from 2.2.5 to 2.2.6

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.2.5'
-  sha256 '68c421fa1568a518234084d9982f1d8f12fe228d6fdc5f204906d3b30ebe4071'
+  version '2.2.6'
+  sha256 '7d5ab5c18aa148163fd3fca2d6b334a272251cde0704c07ee328e7c47488dd34'
 
   # github.com/GNS3/gns3-gui was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.