### PR TITLE
R: Fix invalid pkg URL

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -2,8 +2,8 @@ cask 'r' do
   version '3.6.3'
   sha256 '80f12a85b63b6b45640d1165d06861a84fe11efe4a564e0a755cc313d84cdfb4'
 
-  url "https://cloud.r-project.org/bin/macosx/bin/macosx/R-#{version}.pkg"
-  appcast 'https://cloud.r-project.org/bin/macosx/bin/macosx/'
+  url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
+  appcast 'https://cloud.r-project.org/bin/macosx/'
   name 'R'
   homepage 'https://www.r-project.org/'
 


### PR DESCRIPTION
The actual package is in https://cloud.r-project.org/bin/macosx/, not https://cloud.r-project.org/bin/macosx/bin/macosx (which is not a real URL).

@AlJohri This reverts your earlier commit #79318. I'm not sure if that was a temporary hiccup on cloud.r-project.org, but for me, your URL fails (https://cloud.r-project.org/bin/macosx/bin/macosx/R-3.6.3.pkg) while the one in this PR (https://cloud.r-project.org/bin/macosx/R-3.6.3.pkg) succeeds.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
