### PR TITLE
Update subler from 1.6.4 to 1.6.5

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask 'subler' do
-  version '1.6.4'
-  sha256 '9103f430da2b5e7afde211c825f1112ed57dda6b665989e71daf53c85a1db7d8'
+  version '1.6.5'
+  sha256 '7f57f7433dedf273b6e14d2d9d38518609027369f95a56e6f8284433b7a88b13'
 
   # bitbucket.org/galad87/subler was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.