### PR TITLE
Update rocket from 1.6.1,62 to 1.6.2,64 + update appcast

### DIFF
--- a/Casks/rocket.rb
+++ b/Casks/rocket.rb
@@ -1,6 +1,6 @@
 cask 'rocket' do
-  version '1.6.1,62'
-  sha256 '151d25f53762f955451bfb921ba67492dd1a03e44e925e95884e994ce636ebae'
+  version '1.6.2,64'
+  sha256 'bdf1bfcd8fb5cbd04896f006624ea44d464cfff252a16123f83643831cbe280e'
 
   url "https://macrelease.matthewpalmer.net/distribution/appcasts/Rocket-#{version.after_comma}.dmg"
   appcast 'https://updates.devmate.com/net.matthewpalmer.Rocket.xml'

--- a/Casks/rocket.rb
+++ b/Casks/rocket.rb
@@ -3,7 +3,7 @@ cask 'rocket' do
   sha256 'bdf1bfcd8fb5cbd04896f006624ea44d464cfff252a16123f83643831cbe280e'
 
   url "https://macrelease.matthewpalmer.net/distribution/appcasts/Rocket-#{version.after_comma}.dmg"
-  appcast 'https://updates.devmate.com/net.matthewpalmer.Rocket.xml'
+  appcast 'https://macrelease.matthewpalmer.net/distribution/appcasts/rocket.xml'
   name 'Rocket'
   homepage 'https://matthewpalmer.net/rocket/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.