### PR TITLE
Update yandex-disk from 3.1.11,30 to 3.1.12,30

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,6 +1,6 @@
 cask 'yandex-disk' do
-  version '3.1.11,30'
-  sha256 'c63d03284d3d7d3039b98a6447defcf0ad5b6e1062250e76e93b80a7368d4fb1'
+  version '3.1.12,30'
+  sha256 'cb18ea6012fe23049bd49ef83f4a946151c1fdc4a7576c2532e959542806ff94'
 
   url "https://disk.yandex.ru/download/YandexDisk#{version.after_comma}.dmg/?instant=1"
   name 'Yandex.Disk'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.