### PR TITLE
Updated checksum for cask sunvox version 1.9.5d

### DIFF
--- a/Casks/sunvox.rb
+++ b/Casks/sunvox.rb
@@ -1,6 +1,6 @@
 cask 'sunvox' do
   version '1.9.5d'
-  sha256 '90c539f4b1ab0165c24363a4dd8b5d6b3c7efbd91ac5f9df8e143732db60fe96'
+  sha256 'c2e4bfdd4a6b807afc4559f9c8a5e948dcdb28528b86364cb3c3363f207431fb'
 
   url "https://www.warmplace.ru/soft/sunvox/sunvox-#{version}.zip"
   appcast 'https://www.warmplace.ru/soft/sunvox/changelog.txt'


### PR DESCRIPTION
Strangely I got a different checksum from the one in this cask.  The file downloaded through `brew cask` matches the one downloaded on the website, which contains a working version of SunVox 1.9.5d, so I simply replaced the checksum with the one `brew cask` reported.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
