### PR TITLE
Update ark-desktop-wallet from 2.9.0 to 2.9.1

### DIFF
--- a/Casks/ark-desktop-wallet.rb
+++ b/Casks/ark-desktop-wallet.rb
@@ -1,6 +1,6 @@
 cask 'ark-desktop-wallet' do
-  version '2.9.0'
-  sha256 '8fbba3483f1a1e5a04de78d7c3ec48197d7ab05468ee45f4dca985c7fcb2fafe'
+  version '2.9.1'
+  sha256 'fe428a1d7e89fcaa870c70db9a19de93bd9def66460e03eef0f80500f7d72669'
 
   # github.com/ArkEcosystem/desktop-wallet was verified as official when first introduced to the cask
   url "https://github.com/ArkEcosystem/desktop-wallet/releases/download/#{version}/ark-desktop-wallet-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.