### PR TITLE
Update flipper from 0.34.0 to 0.35.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.34.0'
-  sha256 '09c5c9558d9d01b13936b4d80c5f7d491d36ab1b47508c373423174efe1b504c'
+  version '0.35.0'
+  sha256 '0d994068aa4d5d43460cae88bb00ba9f94cfb6230955f365dcc1c83a08c225ea'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.