### PR TITLE
Update boostnote from 0.15.1 to 0.15.2

### DIFF
--- a/Casks/boostnote.rb
+++ b/Casks/boostnote.rb
@@ -1,6 +1,6 @@
 cask 'boostnote' do
-  version '0.15.1'
-  sha256 '63310ae49a470870f577e135d1fd84503d607a5d55bb0b396b3df0708e0cda84'
+  version '0.15.2'
+  sha256 'd32aae20f26667c2cac2fa2e31aa0d31092f410a8681fcea7cc0d0147b4b0c1d'
 
   # github.com/BoostIO/boost-releases was verified as official when first introduced to the cask
   url "https://github.com/BoostIO/boost-releases/releases/download/v#{version}/Boostnote-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.