### PR TITLE
Update ringcentral from 19.4.0 to 20.1.0

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '19.4.0'
-  sha256 'f04cc4e35718aa1fe4fed4b9c0bb55d8984327e3aa30ef8bd99ac714c0ec102b'
+  version '20.1.0'
+  sha256 '2a16143b8b167783c19bd47e79fa7fd94d6d942efdc6a41e19b2cb0c4fbcd816'
 
   url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads.ringcentral.com/sp/RingCentralForMac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.