### PR TITLE
Update lark from 3.20.5 to 3.20.6

### DIFF
--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -1,6 +1,6 @@
 cask 'lark' do
-  version '3.20.5'
-  sha256 'f308204d59d154520760e239b0418407ab359fe6454648b80a368bad8f7d0971'
+  version '3.20.6'
+  sha256 '232d1d19b1687cedf47f19b297494a47c43c347fb0229e65d69a9f5a45542221'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Lark-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.