### PR TITLE
Update 1password-cli from 0.9.3 to 0.9.4

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask '1password-cli' do
-  version '0.9.3'
-  sha256 '95930bea6946430ecf6b3a1ac1698c8e1142e74046cac2cd1825ec74620d4b45'
+  version '0.9.4'
+  sha256 'b22238cc2c981abda2e59cb55396b34d95996c52f41f62de1c4903f77477eb3b'
 
   # cache.agilebits.com/dist/1P/op/pkg was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.