### PR TITLE
Update powerphotos from 1.7.11 to 1.7.12

### DIFF
--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -16,8 +16,8 @@ cask 'powerphotos' do
     sha256 'e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a'
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
   else
-    version '1.7.11'
-    sha256 '258d005ffc7cb8bcd82ebe6ce017325042ccb06fefa5699e7aca873cf4efc023'
+    version '1.7.12'
+    sha256 'f09540c507b36eb7d959c724e6f7d9313bcc8f7fbb8a197c2d6b286cfb01a695'
     url 'https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.