### PR TITLE
Update pref-setter

### DIFF
--- a/Casks/pref-setter.rb
+++ b/Casks/pref-setter.rb
@@ -7,5 +7,7 @@ cask 'pref-setter' do
   name 'Pref Setter'
   homepage 'http://www.nightproductions.net/prefsetter.html'
 
+  depends_on macos: '<= :mojave'
+
   app 'Pref Setter/Pref Setter.app'
 end


### PR DESCRIPTION
Add macOS version constraint due to Pref Setter being 32bit app.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.