### PR TITLE
Update triplecheese from 1.2.1,3898 to 1.2.1,3899

### DIFF
--- a/Casks/triplecheese.rb
+++ b/Casks/triplecheese.rb
@@ -1,13 +1,14 @@
 cask 'triplecheese' do
-  version '1.2.1,3898'
-  sha256 'd9a3e5f3e801513a74ec725bfcb722c0df3e96557a6be8813479f9ee73b59f8f'
+  version '1.2.1,3899'
+  sha256 '8a73cc611d6065ff11a43e237ff074c9b6eff591a46997362219fe6ac4bcd663'
 
   # uhedownloads-heckmannaudiogmb.netdna-ssl.com was verified as official when first introduced to the cask
-  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/TripleCheese_#{version.before_comma.dots_to_underscores}_Mac.zip"
+  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/TripleCheese_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip"
+  appcast 'https://u-he.com/products/triplecheese/releasenotes.html'
   name 'Triple Cheese'
   homepage 'https://u-he.com/products/triplecheese/'
 
-  pkg "TripleCheese#{version.after_comma}Mac/TripleCheese #{version.before_comma}.#{version.after_comma} Installer.pkg"
+  pkg "TripleCheese_#{version.after_comma}_Mac/TripleCheese #{version.before_comma} Installer.pkg"
 
   uninstall pkgutil: [
                        'com.u-he.TripleCheese.aax.pkg',

--- a/Casks/triplecheese.rb
+++ b/Casks/triplecheese.rb
@@ -16,6 +16,7 @@ cask 'triplecheese' do
                        'com.u-he.TripleCheese.data.pkg',
                        'com.u-he.TripleCheese.documentation.pkg',
                        'com.u-he.TripleCheese.presets.pkg',
+                       'com.u-he.TripleCheese.tuningFiles.pkg',
                        'com.u-he.TripleCheese.vst.pkg',
                      ]
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.