### PR TITLE
Update geph from 3.5.0 to 3.5.1

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.5.0'
-  sha256 '109828be612adb059d595dfb7c5dd221fadcf86d92d4eaae1fd6bc56847247cb'
+  version '3.5.1'
+  sha256 '684daa807fe0813cf9f7d85a32c6d2bb90c7b033131ff8c18311d2ea3bb8244c'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.