### PR TITLE
Update flame from 0.2.2 to 2.6.0

### DIFF
--- a/Casks/flame.rb
+++ b/Casks/flame.rb
@@ -1,9 +1,9 @@
 cask 'flame' do
-  version '0.2.2'
-  sha256 '72e7b5959ab608dbf38bbb33fac086c33544f97702ec16fdf1194f4a9bdf843c'
+  version '2.6.0'
+  sha256 'fc86b75a0f2be52be3ec6ce2e260fa816fffe8e0d14caf87c3e8050ed0ec0b1a'
 
-  # tominsam-web.s3.amazonaws.com/uploads was verified as official when first introduced to the cask
-  url "https://tominsam-web.s3.amazonaws.com/uploads/2012/Flame-#{version}.zip"
+  # github.com/tominsam/flametouch was verified as official when first introduced to the cask
+  url "https://github.com/tominsam/flametouch/releases/download/#{version}/Flame_#{version}.zip"
   appcast 'https://movieos.org/code/flame/'
   name 'Flame'
   homepage 'https://movieos.org/code/flame/'

--- a/Casks/flame.rb
+++ b/Casks/flame.rb
@@ -4,7 +4,7 @@ cask 'flame' do
 
   # github.com/tominsam/flametouch was verified as official when first introduced to the cask
   url "https://github.com/tominsam/flametouch/releases/download/#{version}/Flame_#{version}.zip"
-  appcast 'https://movieos.org/code/flame/'
+  appcast 'https://github.com/tominsam/flametouch/releases.atom'
   name 'Flame'
   homepage 'https://movieos.org/code/flame/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.