### PR TITLE
Update manico from 2.6.3,380 to 2.7.1,385

### DIFF
--- a/Casks/manico.rb
+++ b/Casks/manico.rb
@@ -1,9 +1,9 @@
 cask 'manico' do
-  version '2.6.3,380'
-  sha256 '81447e84d9cbffdc26d9919e14051d98768e5f550d22470b78832737c1d1550e'
+  version '2.7.1,385'
+  sha256 'ac5d3601dfd9d8c8845b7d58bdba9673549e8c37a7582079e9d537adc51c3f24'
 
-  url "https://manico.im/static/Manico-#{version.after_comma}.zip"
-  appcast 'https://manico.im/static/manico-official-appcast.xml'
+  url "https://manico.im/api/release_manager/downloads/im.manico.Manico/#{version.after_comma}.zip"
+  appcast 'https://manico.im/api/release_manager/im.manico.Manico.xml'
   name 'Manico'
   homepage 'https://manico.im/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.