### PR TITLE
Update multimc from 0.6.8 to 0.6.10

### DIFF
--- a/Casks/multimc.rb
+++ b/Casks/multimc.rb
@@ -1,6 +1,6 @@
 cask 'multimc' do
-  version '0.6.8'
-  sha256 'a015d9c9b93d15fa1ff9c9363a64bcbd3681e7bcce4de04d813baf2c484bfb7c'
+  version '0.6.10'
+  sha256 'b04f2ca50103d3c67391d04bc3b72eef2cb6485321afaf396aba2ab2411f2197'
 
   url 'https://files.multimc.org/downloads/mmc-stable-osx64.tar.gz'
   appcast 'https://github.com/MultiMC/MultiMC5/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.