### PR TITLE
Update battlescribe from 2.03.13 to 2.03.14

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.13'
-  sha256 '7717442e007d7a13117d4b8796028a5354f9c36ec6e14df554cb5a907642363f'
+  version '2.03.14'
+  sha256 '91c4bfaf47137608bf71c14aecc2e5e5a7df61797de5d013c7fdaa5b54980650'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.