### PR TITLE
Update journey from 2.14.0 to 2.14.3

### DIFF
--- a/Casks/journey.rb
+++ b/Casks/journey.rb
@@ -1,9 +1,9 @@
 cask 'journey' do
-  version '2.14.0'
-  sha256 '1e90ee31f7f8e0cba2693def2448f4dd4838cd8dfc1063d672f242c699387d34'
+  version '2.14.3'
+  sha256 'aa3de8061bb169765c44fd256b0885c807ccebb771ba045b59eaf04815231583'
 
   # github.com/2-App-Studio/journey-releases was verified as official when first introduced to the cask
-  url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-#{version}.dmg"
+  url "https://github.com/2-App-Studio/journey-releases/releases/download/v#{version}/Journey-darwin-#{version}.zip"
   appcast 'https://github.com/2-App-Studio/journey-releases/releases.atom'
   name 'Journey'
   homepage 'https://2appstudio.com/journey/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.