### PR TITLE
Update superproductivity from 4.0.3 to 4.1.1

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '4.0.3'
-  sha256 '6b381b5dad65def1cc846e80d49e3117f8378871507195b2e9b072ed46898d30'
+  version '4.1.1'
+  sha256 '762b59b1a2fbc58590a129f6a13db30603642b044301ea95fc912c4c63c8e068'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.