### PR TITLE
Update notebooks from 2.1 to 2.1.1

### DIFF
--- a/Casks/notebooks.rb
+++ b/Casks/notebooks.rb
@@ -1,6 +1,6 @@
 cask 'notebooks' do
-  version '2.1'
-  sha256 '3b7473e7e53a921a864dfb74ec17b9b87ab3af5261a911729d8b12340e950cfa'
+  version '2.1.1'
+  sha256 '804a4d06b15acc4579f9f6a0846971ffd851a7571b1af2b5fa5dd501e8a10d10'
 
   url "https://www.notebooksapp.com/Download/macOS/v#{version.major}/Notebooks.dmg"
   appcast "https://notebooksapp.com/Download/macOS/v#{version.major}/Notebooks#{version.major}Appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.