### PR TITLE
Update scaleft from 1.41.0 to 1.44.2

### DIFF
--- a/Casks/scaleft.rb
+++ b/Casks/scaleft.rb
@@ -1,6 +1,6 @@
 cask 'scaleft' do
-  version '1.41.0'
-  sha256 'a390a8aee88513712e279ff6a5306ec9244a3df9568917b8d4d99b0c5c638099'
+  version '1.44.2'
+  sha256 '5352f3bec33d9457bbfc16d8375e3934c8307f7db32748926dfff7d04702cf05'
 
   url "https://dist.scaleft.com/client-tools/mac/v#{version}/ScaleFT-#{version}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.