### PR TITLE
Update writemapper from 2.9.1 to 2.10.0

### DIFF
--- a/Casks/writemapper.rb
+++ b/Casks/writemapper.rb
@@ -1,6 +1,6 @@
 cask 'writemapper' do
-  version '2.9.1'
-  sha256 '04e46adf4245d61361980cfa6921c505d0c80d6525f474fc10391bb0b0a9c44e'
+  version '2.10.0'
+  sha256 'faa919450d0f92d1f6a93d94f51e3ff45a1c92b70c2a408773f299d6e15624a1'
 
   url "https://writemapper.com/static/app/mac/WriteMapper-#{version}.dmg"
   appcast 'https://writemapper.com/static/app/mac/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.