### PR TITLE
Update mat from 1.9.2.20200115 to 1.10.0.20200225

### DIFF
--- a/Casks/mat.rb
+++ b/Casks/mat.rb
@@ -1,6 +1,6 @@
 cask 'mat' do
-  version '1.9.2.20200115'
-  sha256 'ab379da580e07659e713996ed0169375246c88b36245a35c9f375a63c3114655'
+  version '1.10.0.20200225'
+  sha256 'dc711052e9ede8b6e9af0443035cee590bb5d2609705440f32d0ef0d6f66cbf3'
 
   url "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/#{version.major_minor_patch}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.x86_64.zip"
   appcast 'https://www.eclipse.org/mat/downloads.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.