### PR TITLE
Update local from 5.2.7 to 5.2.8

### DIFF
--- a/Casks/local.rb
+++ b/Casks/local.rb
@@ -1,6 +1,6 @@
 cask 'local' do
-  version '5.2.7'
-  sha256 'beefb262d86a456a084b5ab4b4e0afeeb36846dd3753945f801a005473860e02'
+  version '5.2.8'
+  sha256 '737ff5b5714aac196bd5764c6b8c32a893adc7b2cfe05ad8d4a03d4c0fac8d61'
 
   # local-by-flywheel-flywheel.netdna-ssl.com/releases was verified as official when first introduced to the cask
   url "https://local-by-flywheel-flywheel.netdna-ssl.com/releases/#{version.dots_to_hyphens}/local-#{version.dots_to_hyphens}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.