### PR TITLE
Update smartsvn from 11.0.3 to 11.0.4

### DIFF
--- a/Casks/smartsvn.rb
+++ b/Casks/smartsvn.rb
@@ -1,6 +1,6 @@
 cask 'smartsvn' do
-  version '11.0.3'
-  sha256 '5f1d4d0c84ed747d398b476aeeab90e5a188c312b77fbf548205caf7b18810a3'
+  version '11.0.4'
+  sha256 'de2f6f31b1ab7292dc7450f584445c47b6527add9773859dffa6454021ebb705'
 
   url "https://www.smartsvn.com/downloads/smartsvn/smartsvn-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.smartsvn.com/documents/smartsvn/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.