### PR TITLE
Update proxyman from 1.20.0 to 1.21.0

### DIFF
--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -1,6 +1,6 @@
 cask 'proxyman' do
-  version '1.20.0'
-  sha256 'd50cf91c1d0bba1f3ae8039cb189dd4572a880579c15df3f15c935890f92342a'
+  version '1.21.0'
+  sha256 '3ea55bb49b017f622ade32a8f252d3af9dba93e0d8ca5589c63a9f85039984b2'
 
   # github.com/ProxymanApp/Proxyman was verified as official when first introduced to the cask
   url "https://github.com/ProxymanApp/Proxyman/releases/download/#{version}/Proxyman_#{version}.dmg"

--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -13,7 +13,14 @@ cask 'proxyman' do
   app 'Proxyman.app'
 
   uninstall delete:    '/Library/PrivilegedHelperTools/com.proxyman.NSProxy.HelperTool',
-            launchctl: 'com.proxyman.NSProxy.HelperTool'
+            launchctl: 'com.proxyman.NSProxy.HelperTool',
+            script:    {
+                         executable:   '/usr/bin/security',
+                         args:         ['delete-certificate', '-c', 'Proxyman CA'],
+                         must_succeed: false,
+                         print_stderr: false,
+                         sudo:         true,
+                       }
 
   zap trash: [
                '~/Library/Application Support/com.proxyman',

--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -24,8 +24,9 @@ cask 'proxyman' do
     end
   end
 
-  uninstall delete:    '/Library/PrivilegedHelperTools/com.proxyman.NSProxy.HelperTool',
-            launchctl: 'com.proxyman.NSProxy.HelperTool'
+  uninstall quit:      'com.proxyman.NSProxy',
+            launchctl: 'com.proxyman.NSProxy.HelperTool',
+            delete:    '/Library/PrivilegedHelperTools/com.proxyman.NSProxy.HelperTool'
 
   zap trash: [
                '~/Library/Application Support/com.proxyman',

--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -12,15 +12,20 @@ cask 'proxyman' do
 
   app 'Proxyman.app'
 
+  uninstall_postflight do
+    stdout, * = system_command '/usr/bin/security',
+                               args: ['find-certificate', '-a', '-c', 'Proxyman', '-Z'],
+                               sudo: true
+    hashes = stdout.lines.grep(%r{^SHA-256 hash:}) { |l| l.split(':').second.strip }
+    hashes.each do |h|
+      system_command '/usr/bin/security',
+                     args: ['delete-certificate', '-Z', h],
+                     sudo: true
+    end
+  end
+
   uninstall delete:    '/Library/PrivilegedHelperTools/com.proxyman.NSProxy.HelperTool',
-            launchctl: 'com.proxyman.NSProxy.HelperTool',
-            script:    {
-                         executable:   '/usr/bin/security',
-                         args:         ['delete-certificate', '-c', 'Proxyman CA'],
-                         must_succeed: false,
-                         print_stderr: false,
-                         sudo:         true,
-                       }
+            launchctl: 'com.proxyman.NSProxy.HelperTool'
 
   zap trash: [
                '~/Library/Application Support/com.proxyman',


### PR DESCRIPTION
Update `zap` stanza & uninstall privileged helper tool.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.