### PR TITLE
Update mark-text from 0.15.1 to 0.16.1

### DIFF
--- a/Casks/mark-text.rb
+++ b/Casks/mark-text.rb
@@ -1,12 +1,12 @@
 cask 'mark-text' do
-  version '0.15.1'
-  sha256 '92a5582782c2f3de0b61ebdd265da264ffaa798521130ca43fad9d6ae0711439'
+  version '0.16.1'
+  sha256 '676fbcb7230e736f6b41b3ee21df864131565dee45b212b658990e7760218962'
 
   # github.com/marktext/marktext was verified as official when first introduced to the cask
-  url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext-#{version}.dmg"
+  url "https://github.com/marktext/marktext/releases/download/v#{version}/marktext.dmg"
   appcast 'https://github.com/marktext/marktext/releases.atom'
   name 'Mark Text'
-  homepage 'https://marktext.github.io/website/'
+  homepage 'https://marktext.app/'
 
   app 'Mark Text.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.