### PR TITLE
Mark macintosh-explorer as discontinued

### DIFF
--- a/Casks/macintosh-explorer.rb
+++ b/Casks/macintosh-explorer.rb
@@ -6,5 +6,11 @@ cask 'macintosh-explorer' do
   name 'Macintosh Explorer'
   homepage 'https://www.ragesw.com/products/explorer.html'
 
+  depends_on macos: '<= :mojave'
+
   app 'Macintosh Explorer.app'
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Add macOS version constraint due to Macintosh Explorer being
32bit app.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.