### PR TITLE
Update unity-android-support-for-editor from 2019.3.6f1,5c3fb0a11183 to 2019.3.7f1,6437fd74d35d

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.6f1,5c3fb0a11183'
-  sha256 '4a3c6a8193af66d208ebdf763ebcc569963ac08385b754285eabefa90f2b603a'
+  version '2019.3.7f1,6437fd74d35d'
+  sha256 'f0bfd98820233ccce1d091f80077e1a91444de58274a28ddab3f77b4ef5b153f'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.