### PR TITLE
Update unity-download-assistant from 2019.3.6f1,5c3fb0a11183 to 2019.3.7f1,6437fd74d35d

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.6f1,5c3fb0a11183'
-  sha256 '00665192e5aaa490496b588011f1634dab6e3712533f1af19dcaf078f5b60010'
+  version '2019.3.7f1,6437fd74d35d'
+  sha256 'fa6b2cfde4d2eaf6b3234b92ccc8045af717b722b5e731c5ef03f5ebac30986e'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.