### PR TITLE
Update unity-webgl-support-for-editor from 2019.3.6f1,5c3fb0a11183 to 2019.3.7f1,6437fd74d35d

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.3.6f1,5c3fb0a11183'
-  sha256 '640fa0c9efd6a24f6dd8b832fb0a9fa045e5573e1e1ac2a0f821f8d946ed40bc'
+  version '2019.3.7f1,6437fd74d35d'
+  sha256 '7570e62a95fb10b58adc347362075c5046f16563b7960dbd03b77247d06b5d74'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.