### PR TITLE
Revert "Update folx from 5.15.13938 to 5.16.13940"

### DIFF
--- a/Casks/folx.rb
+++ b/Casks/folx.rb
@@ -1,6 +1,6 @@
 cask 'folx' do
-  version '5.16.13940'
-  sha256 '746235de6bf236448fd59a26b0195a40efb5ad7933826d2c611c79eb30c89d6d'
+  version '5.15.13938'
+  sha256 'ceb0d3784e57f82ebf4110f2021be1fb9feec45555350cf622f2c27f3cce6650'
 
   url 'https://cdn.eltima.com/download/downloader_mac.dmg'
   appcast 'https://cdn.eltima.com/download/folx-updater/folx.xml',


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#79155
there was downgrade - the download contains svs: 5.15 bv: 13938
the appcast was reverted too
