### PR TITLE
Update quicken from 5.15.2,515.33015.100 to 5.15.3,515.33035.100

### DIFF
--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -1,6 +1,6 @@
 cask 'quicken' do
-  version '5.15.2,515.33015.100'
-  sha256 '87a02733e2fecdf5303460f9a67d33e18836a0665a8bc14e651643f6c7d2caa8'
+  version '5.15.3,515.33035.100'
+  sha256 'e68ce658659683ba34949d518b98ee929a975dc6fb3bcfec671f2503c1f8392a'
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.after_comma}/Quicken-#{version.after_comma}.zip"
   appcast 'https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.