### PR TITLE
Add OpenAudible.app v1.6.5

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,0 +1,16 @@
+cask 'openaudible' do
+  version '1.6.5'
+  sha256 'ef56040ad7f050097c936944f116c5d3f1a21f24a18030d53befcdd8342056ae'
+
+  # github.com/openaudible was verified as official when first introduced to the cask
+  url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"
+  appcast 'https://github.com/openaudible/openaudible/releases.atom'
+  name 'Open Audible'
+  homepage 'https://openaudible.org/'
+
+  app 'OpenAudible.app'
+
+  zap trash: [
+               '/Library/OpenAudible',
+             ]
+end

--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -5,7 +5,7 @@ cask 'openaudible' do
   # github.com/openaudible was verified as official when first introduced to the cask
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"
   appcast 'https://github.com/openaudible/openaudible/releases.atom'
-  name 'Open Audible'
+  name 'OpenAudible'
   homepage 'https://openaudible.org/'
 
   app 'OpenAudible.app'

--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -10,7 +10,5 @@ cask 'openaudible' do
 
   app 'OpenAudible.app'
 
-  zap trash: [
-               '/Library/OpenAudible',
-             ]
+  zap trash: '/Library/OpenAudible'
 end


### PR DESCRIPTION
Added the latest release of the app OpenAudible for using Audible books on Mac.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
