### PR TITLE
Update drawbot from 3.123 to 3.124

### DIFF
--- a/Casks/drawbot.rb
+++ b/Casks/drawbot.rb
@@ -1,6 +1,6 @@
 cask 'drawbot' do
-  version '3.123'
-  sha256 'ad395d11706ac4a621fb2f1e88131ad0e0d9bb8595f19d65253b2175fdd43707'
+  version '3.124'
+  sha256 '53650c98b0636b716c9ada9660658025425ac76f5975a9fbbff081d137b88557'
 
   # github.com/typemytype/drawbot was verified as official when first introduced to the cask
   url "https://github.com/typemytype/drawbot/releases/download/#{version}/DrawBot.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.