### PR TITLE
Update altair-graphql-client from 2.4.4 to 2.4.5

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.4.4'
-  sha256 '57b0e1d62e6d9d3969fba4bea31e3fb261d5da291777ffaa09ac373af6e57a50'
+  version '2.4.5'
+  sha256 'd742f7232f1f8fdd9dde903d38d37aace1158929f9dd9835839a61ef34bf14a2'
 
   # github.com/imolorhe/altair was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair_#{version}_mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.