### PR TITLE
Update rotato from 95.1585224957 to 96.1585398399

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '95.1585224957'
-  sha256 'b2a6298ac5013cc0f190f0aa6b37d5857d269e0be6e3020a22405a19bda1b759'
+  version '96.1585398399'
+  sha256 'e62560e6a9a43f795489287e0cf0ebe1f3d3e4a55e45a2f037ee542c27c2cda4'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.