### PR TITLE
Update watchguard-mobile-vpn-with-ssl from 12.5.2,606431 to 12.5.3,615421

### DIFF
--- a/Casks/watchguard-mobile-vpn-with-ssl.rb
+++ b/Casks/watchguard-mobile-vpn-with-ssl.rb
@@ -1,6 +1,6 @@
 cask 'watchguard-mobile-vpn-with-ssl' do
-  version '12.5.2,606431'
-  sha256 '8f9aacfb9a167b21f004d51aa9696f1e1fb5bc7e0f262c3d3e0893d821b7152b'
+  version '12.5.3,615421'
+  sha256 'b8a4f9ce908f19df6122fdf24445fdb233d812f2f6b5f08261ca2e4cca0c3784'
 
   url "http://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.before_comma.dots_to_underscores}/WG-MVPN-SSL_#{version.before_comma.dots_to_underscores}.dmg"
   name 'WatchGuard Mobile VPN with SSL'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.