### PR TITLE
Update camera-live from 11 to 13

### DIFF
--- a/Casks/camera-live.rb
+++ b/Casks/camera-live.rb
@@ -1,6 +1,6 @@
 cask 'camera-live' do
-  version '11'
-  sha256 '4c7a6ecdbec677a6fbbb90af427e54b0d429278c87b49966c6448ce065c78e75'
+  version '13'
+  sha256 'c8a4ed731c3ff5f8ea494a5117ea12956c6fcbb0dcd45d9ab50a8ab41d6efdfa'
 
   url "https://github.com/v002/v002-Camera-Live/releases/download/#{version}/Camera.Live.zip"
   appcast 'https://github.com/v002/v002-Camera-Live/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.