### PR TITLE
Update wasabi-wallet from 1.1.10.3 to 1.1.10.2

### DIFF
--- a/Casks/wasabi-wallet.rb
+++ b/Casks/wasabi-wallet.rb
@@ -1,6 +1,6 @@
 cask 'wasabi-wallet' do
-  version '1.1.10.3'
-  sha256 '8a8502c3d6be9f9686e4344cfed6bb1c1fd92a3837b74dbe883696c56e0c4f19'
+  version '1.1.10.2'
+  sha256 'ce5f2dc33745b50ccd516b56618fa615b7ecae7d70b3877b43ecb2f67ae73065'
 
   # github.com/zkSNACKs/WalletWasabi was verified as official when first introduced to the cask
   url "https://github.com/zkSNACKs/WalletWasabi/releases/download/v#{version}/Wasabi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.