### PR TITLE
Update fontlab from 7.1.1.7382 to 7.1.1.7383

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,6 +1,6 @@
 cask 'fontlab' do
-  version '7.1.1.7382'
-  sha256 '9b9fc338d047539e64b1042062d739875d7e49afc556fc0f8a50f25caa8a44f8'
+  version '7.1.1.7383'
+  sha256 '4c22cafad1e9d3575d0eb354aa615c24053617fcac3b14cbda535c3b15664776'
 
   # fontlab.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fontlab.s3.amazonaws.com/fontlab-#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.