### PR TITLE
Update freeplane from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,6 +1,6 @@
 cask 'freeplane' do
-  version '1.8.0'
-  sha256 '639b3e0e0bc60f3b6e180a0a29f8a0fa6fc02b55332dde2c7d2647f91a618a86'
+  version '1.8.1'
+  sha256 '0f985264250e39d145f8762ab0c9d7e99908a1b1aa20eb0970d50876089df50d'
 
   # downloads.sourceforge.net/freeplane was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/Freeplane-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.