### PR TITLE
Update geph from 3.5.1 to 3.5.2

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.5.1'
-  sha256 '684daa807fe0813cf9f7d85a32c6d2bb90c7b033131ff8c18311d2ea3bb8244c'
+  version '3.5.2'
+  sha256 'd3ccf59c0aae2793f73b9aefd8fe289e985a7d4e50fa034f62bee0162c21e527'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.