### PR TITLE
Update reaper from 6.50.0,6.05 to 6.06

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,17 +1,18 @@
 cask 'reaper' do
-  version '6.06'
+  version '6.60.0,6.06'
 
   if MacOS.version <= :mojave
     sha256 '4629c12f15d98aed55d4a2261a3cb0d58427395b26e700e57fbd6799c946e139'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"
   else
     sha256 '699783865b478f697f337611549213f2679fd34377b546d0dc225f263660ae06'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64_catalina.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64_catalina.dmg"
   end
 
-  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'
+  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',
+          configuration: version.after_comma
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,18 +1,17 @@
 cask 'reaper' do
-  version '6.50.0,6.05'
+  version '6.06'
 
   if MacOS.version <= :mojave
-    sha256 '3cacd09a8af998df06047308a50677014c82599791facebdffb373bdc4fde21a'
+    sha256 '4629c12f15d98aed55d4a2261a3cb0d58427395b26e700e57fbd6799c946e139'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64.dmg"
   else
-    sha256 'a1ee59d1e91806eb17ebeb7d354a84a8a85f27c093b46bc4b66ea8a41137854a'
+    sha256 '699783865b478f697f337611549213f2679fd34377b546d0dc225f263660ae06'
 
-    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.after_comma.no_dots}_x86_64_catalina.dmg"
+    url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.no_dots}_x86_64_catalina.dmg"
   end
 
-  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64',
-          configuration: version.after_comma
+  appcast 'https://www.cockos.com/reaper/latestversion/?p=osx_64'
   name 'REAPER'
   homepage 'https://www.reaper.fm/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I removed the 6.60.0 part of the version because it only appears as the version of the app bundle itself. Everywhere else (e.g. in the about dialog or on the website), the version number 6.06 is used. I personally think this makes sense, but I can also revert that change if it is undesired.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
