### PR TITLE
Update softmaker-freeoffice from 2018,974 to 2018,976

### DIFF
--- a/Casks/softmaker-freeoffice.rb
+++ b/Casks/softmaker-freeoffice.rb
@@ -1,6 +1,6 @@
 cask 'softmaker-freeoffice' do
-  version '2018,974'
-  sha256 'd4f5228086d7ac81cb775adfa7d45fc90ef70a65f62fc9cc9c09694d7f991f57'
+  version '2018,976'
+  sha256 'a93564f66b1c5748dea3cd3672226dedb3d6c1f9126c3c73eaa843c222336b56'
 
   # softmaker.net was verified as official when first introduced to the cask
   url "https://www.softmaker.net/down/softmaker-freeoffice-#{version.before_comma}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.