### PR TITLE
Update menutube from 1.4.0 to 1.5.0

### DIFF
--- a/Casks/menutube.rb
+++ b/Casks/menutube.rb
@@ -1,9 +1,9 @@
 cask 'menutube' do
-  version '1.4.0'
-  sha256 '6c8bfdaf72edd7b62c28ee931a5a67b06e5021702e1d1a9021b7ac22b19c4f51'
+  version '1.5.0'
+  sha256 '1661d6b690a619eda8e394b9328ca5db8eea980fab5cb2c5c68b220d16798935'
 
   # github.com/edanchenkov/MenuTube was verified as official when first introduced to the cask
-  url "https://github.com/edanchenkov/MenuTube/releases/download/#{version}/MenuTube.#{version}.zip"
+  url "https://github.com/edanchenkov/MenuTube/releases/download/#{version}/MenuTube.zip"
   appcast 'https://github.com/edanchenkov/MenuTube/releases.atom'
   name 'MenuTube'
   homepage 'https://edanchenkov.github.io/MenuTube/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.