### PR TITLE
Revert "Add depends on catalina to macvim.rb"

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -9,7 +9,6 @@ cask 'macvim' do
 
   auto_updates true
   conflicts_with formula: 'macvim'
-  depends_on macos: '>= :catalina'
 
   app 'MacVim.app'
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#79415
sorry -  that was my mistake (the version number in the latest release is broken)
min version for this release is  still 10.9 
