### PR TITLE
Update netron from 4.0.0 to 4.0.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.0.0'
-  sha256 '5f378299337c02630c15aa1878bb9e6e59f50ab51da17d396f69ee670f4d4ea0'
+  version '4.0.1'
+  sha256 '8cb86228a4faad6bd82d19c3073396a6586503705eb091612754d12c8a893c42'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.