### PR TITLE
Update electorrent from 2.6.1 to 2.7.0

### DIFF
--- a/Casks/electorrent.rb
+++ b/Casks/electorrent.rb
@@ -1,6 +1,6 @@
 cask 'electorrent' do
-  version '2.6.1'
-  sha256 '097b7d7b851719f696ff0f1698151883fb5338b7204625fbc0889f4b9c696e80'
+  version '2.7.0'
+  sha256 '2498ec8f0679ff6827988037616c5c21a7f5876bf2c12d2ca991e36d464c9d2e'
 
   url "https://github.com/Tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
   appcast 'https://github.com/Tympanix/Electorrent/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.