### PR TITLE
Update obyte from 3.0.2 to 3.0.3

### DIFF
--- a/Casks/obyte.rb
+++ b/Casks/obyte.rb
@@ -1,6 +1,6 @@
 cask 'obyte' do
-  version '3.0.2'
-  sha256 'f48899aed7ab46c9f84e8003f3b5cbc623756fadc1177b469fb8e195d0095195'
+  version '3.0.3'
+  sha256 'c5dd6ce93defc9a6f3b0a4fa33f6410cdd86c561a5c3b02033bbd95a13502ebd'
 
   # github.com/byteball/obyte-gui-wallet was verified as official when first introduced to the cask
   url "https://github.com/byteball/obyte-gui-wallet/releases/download/v#{version}/Obyte-osx64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.