### PR TITLE
Update kite from 0.20200324.3 to 0.20200327.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200324.3'
-  sha256 '192decefc7a762c449e292c7da4229b45f9c8bd3c2ddd34c8d7e6db7b1eb9f42'
+  version '0.20200327.0'
+  sha256 'c60cdbdc98d739a5f9f7699f309e28e922865001d44265ee4cf2e4cbc952c632'
 
   # draqv87tt43s0.cloudfront.net was verified as official when first introduced to the cask
   url "https://draqv87tt43s0.cloudfront.net/mac/#{version}/Kite.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.