### PR TITLE
Update beatunes from 5.2.6 to 5.2.7

### DIFF
--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -1,6 +1,6 @@
 cask 'beatunes' do
-  version '5.2.6'
-  sha256 '58a593fdb339e25a3173b8713216d0740758b161a72b1513ef80f847c9ba3b7e'
+  version '5.2.7'
+  sha256 '515585f07c91472eeb59a72064631fd9eeceeed3e19942f7c811cb9eb261eab1'
 
   url "http://coxy.beatunes.com/download/beaTunes-#{version.dots_to_hyphens}.dmg"
   appcast 'https://www.beatunes.com/en/beatunes-download.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.