### PR TITLE
Update prepros from 7.2.14 to 7.2.15

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,6 +1,6 @@
 cask 'prepros' do
-  version '7.2.14'
-  sha256 'abbb743fca038dacfbf106affd466f318cff2f9d9861741011251017816a60f4'
+  version '7.2.15'
+  sha256 'ffb21efe0f9bc2a0e6741fbdd70239201f3675245d35ff3b854a257c28f9db15'
 
   url "https://downloads.prepros.io/v#{version.major}/Prepros-#{version}.zip"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://prepros.io/downloads/stable/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.