### PR TITLE
Update gpxsee from 7.25 to 7.26

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.25'
-  sha256 '3a0c5d440cc631eaf042fe91d5e560dc93e582a5f30a29665a9a81628342cf6c'
+  version '7.26'
+  sha256 '81c745dfb616e8f5535b66eb8651917949a41b47f8f99147f1279790520c0c40'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.