### PR TITLE
Update sound-control: the uninstall `launchctl` key does not accept wildcards. Fixes this cask

### DIFF
--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -12,6 +12,10 @@ cask 'sound-control' do
 
   app 'Sound Control.app'
 
-  uninstall launchctl: 'com.staticz.soundcontrol.*',
+  uninstall launchctl: [
+                         'com.staticz.soundsiphon.bridgedaemon',
+                         'com.staticz.audio.soundsiphon.playeragent',
+                         'com.static.soundsiphon.inputagent',
+                       ],
             quit:      'com.staticz.SoundControl'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.