### PR TITLE
Update webcatalog from 20.0.6 to 20.0.7

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.0.6'
-  sha256 '037d7a2e0be97d88475cd1dc5bb873327297d04968acd3970aaa25077f299140'
+  version '20.0.7'
+  sha256 'cf8e3bf9cf59edc5c9124e4c8fe3dd5c77870dc1666d17dbb2e2952d69af8301'
 
   # github.com/quanglam2807/webcatalog was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.