### PR TITLE
Update imgotv from 6.2.1 to 6.2.2,2

### DIFF
--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -1,9 +1,9 @@
 cask 'imgotv' do
-  version '6.2.1'
-  sha256 '836845a9a3aa566d327ee94d648ae995ea76e3559240f216c2e8c43f64bba816'
+  version '6.2.2,2'
+  sha256 'a79c48c642060ec35b721c57f29d3b6ec6ebe701f23b66e811619c0d88b71223'
 
   # download.imgo.tv was verified as official when first introduced to the cask
-  url "https://download.imgo.tv/app/pc/newmac/mgtv-mango2-#{version}.dmg"
+  url "https://download.imgo.tv/app/pc/newmac/#{version.before_comma}-#{version.after_comma}/mgtv-mango2-#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?user_agent=Mac%20OS%20X&url=http://pcconf.api.mgtv.com/getPcDownloadUrl?source=mango2'
   name 'hunantv'
   name '芒果视频'

--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -5,14 +5,13 @@ cask 'imgotv' do
   # download.imgo.tv was verified as official when first introduced to the cask
   url "https://download.imgo.tv/app/pc/newmac/#{version.before_comma}-#{version.after_comma}/mgtv-mango2-#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?user_agent=Mac%20OS%20X&url=http://pcconf.api.mgtv.com/getPcDownloadUrl?source=mango2'
-  name 'hunantv'
-  name '芒果视频'
+  name '芒果TV'
   homepage 'https://www.mgtv.com/app/'
 
   auto_updates true
   depends_on macos: '>= :yosemite'
 
-  app '芒果TV极速版.app'
+  app '芒果TV.app'
 
   zap trash: [
                '~/Library/Preferences/com.hunantv.osx.imgotv.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.