### PR TITLE
Update comparemerge from 2.11z,105 to 2.11z,107

### DIFF
--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -7,5 +7,5 @@ cask 'comparemerge' do
   name 'CompareMerge'
   homepage 'https://sourceforge.net/projects/comparemergenosandbox/'
 
-  app "CompareMerge#{version.before_comma}/CompareMerge#{version.before_comma}.app"
+  app "CompareMerge#{version.before_comma}#{version.after_comma}/CompareMerge#{version.before_comma}#{version.after_comma}.app"
 end

--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -1,8 +1,8 @@
 cask 'comparemerge' do
-  version '2.11z,105'
-  sha256 '5c9cfbed48fee3e913713b2b1e14c5dc2719018803f04d1f67bd3fc470b0b886'
+  version '2.11z,107'
+  sha256 'd1f669e3e7dffc3a77d193994cb4028ee5545aad20f8d36443b0f11ee8a0c74f'
 
-  url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge%20#{version.before_comma}%28#{version.major}%29.zip"
+  url "https://downloads.sourceforge.net/comparemergenosandbox/CompareMerge#{version.before_comma}#{version.after_comma}.zip"
   appcast 'https://sourceforge.net/projects/comparemergenosandbox/rss'
   name 'CompareMerge'
   homepage 'https://sourceforge.net/projects/comparemergenosandbox/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.