### PR TITLE
Update megasync from 4.3.1 to 4.3.2

### DIFF
--- a/Casks/megasync.rb
+++ b/Casks/megasync.rb
@@ -1,6 +1,6 @@
 cask 'megasync' do
-  version '4.3.1'
-  sha256 '187bf5c4721fa74f235aa0f9c12e8303755f840c83bbeb63ad000b33bc1ea32b'
+  version '4.3.2'
+  sha256 '896d922bb94f4e2884403a7a8d2d1979bd7c8a29ffa6056fc08d850c421340e7'
 
   url 'https://mega.nz/MEGAsyncSetup.dmg'
   appcast 'https://github.com/meganz/MEGAsync/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.