### PR TITLE
Update gnucash from 3.8b,3 to 3.9,1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask 'gnucash' do
-  version '3.8b,3'
-  sha256 '05744be1fc8c60609e9315c2bdaf5f7c7ad51c513bea8408df7546f7d1ed30e7'
+  version '3.9,1'
+  sha256 '121ccd52e49e27fd998ae8d2a34d65b3afd0ea184a5d752143008406a5e99053'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.before_comma}/Gnucash-Intel-#{version.before_comma.chomp('b')}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.