### PR TITLE
Update freac from 1.1-beta3 to 1.1

### DIFF
--- a/Casks/freac.rb
+++ b/Casks/freac.rb
@@ -1,6 +1,6 @@
 cask 'freac' do
-  version '1.1-beta3'
-  sha256 'afd6b0d7a3a96c3c24491f95798025cdd2fe7edccb1f960c8376b10022eb5944'
+  version '1.1'
+  sha256 'f11c944751882ea84b9075df23a03c05c1694479307165a49c39dc474eb267cf'
 
   # github.com/enzo1982/freac was verified as official when first introduced to the cask
   url "https://github.com/enzo1982/freac/releases/download/v#{version}/freac-#{version}-macosx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.