### PR TITLE
Update protonmail-bridge from 1.2.5 to 1.2.6

### DIFF
--- a/Casks/protonmail-bridge.rb
+++ b/Casks/protonmail-bridge.rb
@@ -1,5 +1,5 @@
 cask 'protonmail-bridge' do
-  version '1.2.5'
+  version '1.2.6'
   sha256 '0e60e17e96b7e77fcd7ededa9abe3475f5627ab89c07c7dd05c1fe557cbad187'
 
   url 'https://protonmail.com/download/Bridge-Installer.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.