### PR TITLE
Update shift from 4.0.21 to 4.0.22

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,5 +1,5 @@
 cask 'shift' do
-  version '4.0.21'
+  version '4.0.22'
   sha256 'aa92f2ed2a3eff3e6a356493c70754e7dfcaa3010318e5f004712a7d1374a6ff'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.