### PR TITLE
Update mailmaster to 2.14.1

### DIFF
--- a/Casks/mailmaster.rb
+++ b/Casks/mailmaster.rb
@@ -1,6 +1,6 @@
 cask 'mailmaster' do
-  version :latest
-  sha256 :no_check
+  version '2.14.1'
+  sha256 '4fe9fb8956a8290eb4f6dad34ba8991a840aaf9c72724ab98c0c4d9db977b704'
 
   # client.dl.126.net/macmail/dashi was verified as official when first introduced to the cask
   url 'http://client.dl.126.net/macmail/dashi/mailmaster.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.