### PR TITLE
Add Brightness Sync.app v2.0.1

### DIFF
--- a/Casks/brightness-sync.rb
+++ b/Casks/brightness-sync.rb
@@ -1,0 +1,11 @@
+cask 'brightness-sync' do
+  version '2.0.1'
+  sha256 'f522c7422bb0958a4406e9f2ec431681771dfdfe1e134f0169d630927bc62e98'
+
+  url "https://github.com/OCJvanDijk/Brightness-Sync/releases/download/v#{version}/Brightness.Sync.app.zip"
+  appcast 'https://github.com/OCJvanDijk/Brightness-Sync/releases.atom'
+  name 'Brightness Sync'
+  homepage 'https://github.com/OCJvanDijk/Brightness-Sync'
+
+  app 'Brightness Sync.app'
+end


### PR DESCRIPTION
An app to automatically synchronize the brightness of the built-in display to 1st generation LG UltraFine displays that don't support automatic brightness.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
