### PR TITLE
Update fedora-media-writer from 4.1.4 to 4.1.5

### DIFF
--- a/Casks/fedora-media-writer.rb
+++ b/Casks/fedora-media-writer.rb
@@ -1,9 +1,9 @@
 cask 'fedora-media-writer' do
-  version '4.1.4'
-  sha256 '62c07e06b52a844da07cc7b19dee8a377b35f2990e58f9e872736866fe50faad'
+  version '4.1.5'
+  sha256 'c7e2284cb0a5fb5f4f54b8ed939b1549a09df3230e777ef7060b4d3b7a47e25c'
 
   # github.com/FedoraQt/MediaWriter was verified as official when first introduced to the cask
-  url "https://github.com/FedoraQt/MediaWriter/releases/download/#{version}/FedoraMediaWriter-osx-#{version}.dmg"
+  url "https://github.com/FedoraQt/MediaWriter/releases/download/#{version}/FedoraMediaWriter-osx-#{version}.unnotarized.dmg"
   appcast 'https://github.com/FedoraQt/MediaWriter/releases.atom'
   name 'Fedora Media Writer'
   homepage 'https://docs.fedoraproject.org/en-US/quick-docs/creating-and-using-a-live-installation-image/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.