### PR TITLE
Update freeyourmusic from 5.0.6 to 5.0.9

### DIFF
--- a/Casks/freeyourmusic.rb
+++ b/Casks/freeyourmusic.rb
@@ -1,6 +1,6 @@
 cask 'freeyourmusic' do
-  version '5.0.6'
-  sha256 'c506d6d003c78f84506d122da5c84f8f9a7925f1ca19f00a004da8d307414233'
+  version '5.0.9'
+  sha256 'f59d7e876821a0bb87b1319fbab68136ac10dfa4cb71f0a5947c86cf601e2acc'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/FreeYourMusic-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.