### PR TITLE
Update script-debugger from 7.0.10-7A99 to 7.0.11-7A110

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,6 +1,6 @@
 cask 'script-debugger' do
-  version '7.0.10-7A99'
-  sha256 '1f2e2ff31750e912e1559928cbd31e7f3f512ff28dfc5618b87fe7dac98785a7'
+  version '7.0.11-7A110'
+  sha256 'eaf7852be5b0595128f484ae9d97b81079feb62349ab7a8fed28cfa09b65ec38'
 
   # s3.amazonaws.com/latenightsw.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.