### PR TITLE
Update nteract from 0.22.0 to 0.22.4

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask 'nteract' do
-  version '0.22.0'
-  sha256 '0c84c73d6cca925ccfb4f98f6362af9bbe8ed80b10ee680e2b1ca0f9d47b64c1'
+  version '0.22.4'
+  sha256 '0f08015dd130433f63db2d8aeb4119bc2403033fed9716a80b4fcbb6dcbfef29'
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast 'https://github.com/nteract/nteract/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.