### PR TITLE
Update qownnotes from 20.3.8,b5452-082031 to 20.4.0,b5463-165249

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.3.8,b5452-082031'
-  sha256 'ba10a0f9be53b5851fcbe125fd3b74fb9b060d3d9470abc702ef4a40d67c74f8'
+  version '20.4.0,b5463-165249'
+  sha256 '56fbad138984b8fab5d93b2c58d32a87f5a206e9cd51cdea42cfc088a889acc1'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.