### PR TITLE
Update superproductivity from 4.1.1 to 5.0.5

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '4.1.1'
-  sha256 '762b59b1a2fbc58590a129f6a13db30603642b044301ea95fc912c4c63c8e068'
+  version '5.0.5'
+  sha256 'f4eb2c8658c706635dac7ed9dfb24a423eb48cc69336856c48f8e4ac87d02e55'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.