### PR TITLE
Update kap from 3.1.0 to 3.2.0

### DIFF
--- a/Casks/kap.rb
+++ b/Casks/kap.rb
@@ -1,6 +1,6 @@
 cask 'kap' do
-  version '3.1.0'
-  sha256 '4276d0b6db25f7119bdd7f0dc0eecd9547cff5df964c6e46a2adde4d286bdb64'
+  version '3.2.0'
+  sha256 '3944d7a0ec9ad386e26c10f7e49827ad099e33a8afb5f82f110e48b315a7b017'
 
   # github.com/wulkano/kap was verified as official when first introduced to the cask
   url "https://github.com/wulkano/kap/releases/download/v#{version.major_minor_patch}/Kap-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.