### PR TITLE
Update itubedownloader from 6.5.15 to 6.5.16

### DIFF
--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -1,6 +1,6 @@
 cask 'itubedownloader' do
-  version '6.5.15'
-  sha256 '0131f430cd0b0e1be1c0363986ea0ab9d7413debf4c822f4c625d44b5b4b7c0d'
+  version '6.5.16'
+  sha256 '46592a86a834e71b0b23edd6e6e2520c2515c79149f6a213cdf30e8b7166a7c1'
 
   # itubedownloader.s3.us-east-2.amazonaws.com was verified as official when first introduced to the cask
   url 'https://itubedownloader.s3.us-east-2.amazonaws.com/iTubeDownloader.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.