### PR TITLE
Update proclaim from 2.12.0.0027 to 2.12.0.0029

### DIFF
--- a/Casks/proclaim.rb
+++ b/Casks/proclaim.rb
@@ -1,6 +1,6 @@
 cask 'proclaim' do
-  version '2.12.0.0027'
-  sha256 'd17cbc15512e8e9f2331cc07f0bc6caa0ed4c0e1dcc6291e815c772ce590b54c'
+  version '2.12.0.0029'
+  sha256 'ebc25386eb03244b6d7d4c6b3616883969d6f784911de5b796957f5cdfca9a53'
 
   # logoscdn.com/Proclaim was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/Proclaim/Installer/#{version}/Proclaim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.