### PR TITLE
Update fman from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/fman.rb
+++ b/Casks/fman.rb
@@ -1,6 +1,6 @@
 cask 'fman' do
-  version '1.7.1'
-  sha256 '6a49f112e37d1aa933f3bec618ecd24b3385c4e47559b483d93ff9944e7ebca7'
+  version '1.7.2'
+  sha256 'e2e4793a8192f2f58641c9b554385a9bd9b57edc090927b7d2213111aa5a2042'
 
   url "https://fman.io/updates/mac/#{version}.zip"
   appcast 'https://fman.io/updates/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.