### PR TITLE
Update ticktick from 3.5.00,136 to 3.5.10,138

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.5.00,136'
-  sha256 'd6ec2b5cd153900d77dee9245e3e30787584fb3bfd3df85c844dd514155f07ff'
+  version '3.5.10,138'
+  sha256 'a9f846e872c474d05e822e31de6383acb2dc6c4984041c8514ad4610c13e01b3'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.