### PR TITLE
Update macpilot from 11.1 to 11.1.3

### DIFF
--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -1,6 +1,6 @@
 cask 'macpilot' do
-  version '11.1'
-  sha256 'b56201f9e726218ca1cc5e793b9069c047f644efb24581d0bc3cdd38f86729ac'
+  version '11.1.3'
+  sha256 '1990b04414896ef24767e58cd9b56901460375ee8fb805572ca34da019bcda58'
 
   url 'http://mirror.koingosw.com/products/macpilot/download/macpilot.dmg'
   appcast 'https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.