### PR TITLE
Update tibco-jaspersoft-studio from 6.12.0 to 6.12.2

### DIFF
--- a/Casks/tibco-jaspersoft-studio.rb
+++ b/Casks/tibco-jaspersoft-studio.rb
@@ -1,6 +1,6 @@
 cask 'tibco-jaspersoft-studio' do
-  version '6.12.0'
-  sha256 '23c25c5925dbb7fcd48bbef75f61827d079c44337c7b223fd7d4562f07be83b9'
+  version '6.12.2'
+  sha256 'edba336fe4b0cbb8df930e281ac0e3d177aa13940eff6f6ab5c09e529919f629'
 
   # sourceforge.net/jasperstudio was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jasperstudio/JaspersoftStudio-#{version}/TIB_js-studiocomm_#{version}_macosx_x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.