### PR TITLE
Update hand-mirror from 1.1 to 1.1.1

### DIFF
--- a/Casks/hand-mirror.rb
+++ b/Casks/hand-mirror.rb
@@ -1,6 +1,6 @@
 cask 'hand-mirror' do
-  version '1.1'
-  sha256 'f9fcc787e09efb8b9a085331dcc6559548bcdb09e29082c0299e42d8221bf585'
+  version '1.1.1'
+  sha256 '83e9cbb5903cd37d40e648f52c0800376e73c6107403a60bf6529a675868520f'
 
   url "https://handmirror.app/Hand%20Mirror%20#{version}.dmg"
   appcast 'https://handmirror.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.