### PR TITLE
Update lunar from 3.1.3 to 3.1.4

### DIFF
--- a/Casks/lunar.rb
+++ b/Casks/lunar.rb
@@ -1,10 +1,9 @@
 cask 'lunar' do
-  version '3.1.3'
-  sha256 '3d92d6f47370a97c6878a84d62cfed6fd25def5419f8d81b988527e245eaa3d0'
+  version '3.1.4'
+  sha256 'f698589e23fdfb95c818b5369cb436b07e24aa6ab42969d6773b858dcac4fc77'
 
-  # github.com/alin23/Lunar was verified as official when first introduced to the cask
-  url "https://github.com/alin23/Lunar/releases/download/v#{version}/Lunar-#{version}.dmg"
-  appcast 'https://github.com/alin23/Lunar/releases.atom'
+  url "https://lunar.fyi/download/#{version}"
+  appcast 'https://lunar.fyi/appcast.xml'
   name 'Lunar'
   homepage 'https://lunar.fyi/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The download and appcast URLs have been changed to use the official app website which has a much faster mirror than the Github releases one.