### PR TITLE
Update uu-booster from 1.4.2,128 to 1.4.3,131

### DIFF
--- a/Casks/uu-booster.rb
+++ b/Casks/uu-booster.rb
@@ -1,6 +1,6 @@
 cask 'uu-booster' do
-  version '1.4.2,128'
-  sha256 'e3ce65a19101130f49275bb2bf427b9e7ee0834490816490a4f70c84ddbdc05c'
+  version '1.4.3,131'
+  sha256 '92c25ecad9d7bfb93c0ba44f4d28dc204844e2a993eff96deea755b8e8248a83'
 
   # uu.gdl.netease.com was verified as official when first introduced to the cask
   url "https://uu.gdl.netease.com/UU-macOS-#{version.before_comma}(#{version.after_comma}).dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.