### PR TITLE
Re-add Synfig Studio v1.2.2 (stable)

### DIFF
--- a/Casks/synfigstudio.rb
+++ b/Casks/synfigstudio.rb
@@ -4,7 +4,7 @@ cask 'synfigstudio' do
 
   # github.com/synfig/synfig was verified as official when first introduced to the cask
   url "https://github.com/synfig/synfig/releases/download/v#{version.major_minor_patch}/SynfigStudio-#{version}.dmg"
-  appcast 'https://github.com/synfig/synfig/releases.atom'
+  appcast 'https://github.com/synfig/synfig/releases.atom',
           configuration: version.major_minor_patch
   name 'Synfig Studio'
   homepage 'https://synfig.org/'

--- a/Casks/synfigstudio.rb
+++ b/Casks/synfigstudio.rb
@@ -4,6 +4,8 @@ cask 'synfigstudio' do
 
   # github.com/synfig/synfig was verified as official when first introduced to the cask
   url "https://github.com/synfig/synfig/releases/download/v#{version.major_minor_patch}/SynfigStudio-#{version}.dmg"
+  appcast 'https://github.com/synfig/synfig/releases.atom'
+          configuration: version.major_minor_patch
   name 'Synfig Studio'
   homepage 'https://synfig.org/'
 

--- a/Casks/synfigstudio.rb
+++ b/Casks/synfigstudio.rb
@@ -1,0 +1,13 @@
+cask 'synfigstudio' do
+  version '1.2.2-20180914'
+  sha256 '4b914173208950caddfeea16fc02ac7497f5f19a9af1ad5b291172acc8b61aac'
+
+  # github.com/synfig/synfig was verified as official when first introduced to the cask
+  url "https://github.com/synfig/synfig/releases/download/v#{version.major_minor_patch}/SynfigStudio-#{version}.dmg"
+  name 'Synfig Studio'
+  homepage 'https://synfig.org/'
+
+  app 'SynfigStudio.app'
+
+  zap trash: '~/Library/Synfig'
+end

--- a/Casks/synfigstudio.rb
+++ b/Casks/synfigstudio.rb
@@ -1,11 +1,10 @@
 cask 'synfigstudio' do
-  version '1.2.2-20180914'
+  version '1.2.2,20180914'
   sha256 '4b914173208950caddfeea16fc02ac7497f5f19a9af1ad5b291172acc8b61aac'
 
   # github.com/synfig/synfig was verified as official when first introduced to the cask
-  url "https://github.com/synfig/synfig/releases/download/v#{version.major_minor_patch}/SynfigStudio-#{version}.dmg"
-  appcast 'https://github.com/synfig/synfig/releases.atom',
-          configuration: version.major_minor_patch
+  url "https://github.com/synfig/synfig/releases/download/v#{version.before_comma}/SynfigStudio-#{version.before_comma}-#{version.after_comma}.dmg"
+  appcast 'https://github.com/synfig/synfig/releases.atom'
   name 'Synfig Studio'
   homepage 'https://synfig.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

I don’t understand why the audit is failing - it looks like `version.major_minor_patch` isn’t working [as documented](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/version.md#version-methods):

```
➜ brew cask audit --download https://raw.githubusercontent.com/MTCoster/homebrew-cask/patch-2/Casks/synfigstudio.rb
==> Downloading https://github.com/synfig/synfig/releases/download/v1.2.2-20180914/SynfigStudio-1.2.2-20180914.dmg
######################################################################## 100.0%
curl: (22) The requested URL returned error: 404 Not Found
audit for synfigstudio: failed
 - download not possible: Download failed on Cask 'synfigstudio' with message: Download failed: https://github.com/synfig/synfig/releases/download/v1.2.2-20180914/SynfigStudio-1.2.2-20180914.dmg
 - The URL https://github.com/synfig/synfig/releases/download/v1.2.2-20180914/SynfigStudio-1.2.2-20180914.dmg is not reachable (HTTP status code 404)
```

Additionally, I’m not sure if the `appcast` stanza should be included since not every release on GitHub is considered stable.

*This PR follows my comment on #79704.*