### PR TITLE
Update segger-embedded-studio-for-arm from 4.50 to 4.52

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.50'
-  sha256 '93435340cf7038a103f88d1c4a17492aa86af228018de9e621ed37a334a7b9e4'
+  version '4.52'
+  sha256 '6fe1344a72c64c136e8825705b5e8f6bfc4e2e21c8264e7f14bce0448bffa478'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   appcast 'https://studio.segger.com/arm_segger_studio_release_notes.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.