### PR TITLE
Update raw-photo-processor from 1896Beta to 1904Beta

### DIFF
--- a/Casks/raw-photo-processor.rb
+++ b/Casks/raw-photo-processor.rb
@@ -1,7 +1,7 @@
 cask 'raw-photo-processor' do
   # Betas of this software are release quality: https://groups.google.com/d/msg/raw-photo-processor/PJyyP2JwIwI/dn3CFknuCwAJ
-  version '1896Beta'
-  sha256 '94158a5b31bd22b98e7130ebe98704e39dabee61862db04ac1fc6cfb2785f4f1'
+  version '1904Beta'
+  sha256 '9e18765aad727aede5563a7c81cb5c4630e41a058799566f16424e481b897465'
 
   url "https://www.raw-photo-processor.com/RPP/RPP64_#{version}.zip"
   appcast 'https://groups.google.com/forum/feed/raw-photo-processor/msgs/rss.xml?num=50'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.