### PR TITLE
Update wacom-inkspace from 2.7.3 to 2.7.4

### DIFF
--- a/Casks/wacom-inkspace.rb
+++ b/Casks/wacom-inkspace.rb
@@ -1,6 +1,6 @@
 cask 'wacom-inkspace' do
-  version '2.7.3'
-  sha256 'bff10c04528e30ec9ee4d1e291cac1d4e951bafd7a5ed5320289fe582136110e'
+  version '2.7.4'
+  sha256 'f405de898bb43622b07a86c42a244cc27c462eaca0d85deae76e4271adebc4cc'
 
   url "https://cdn.wacom.com/i/m/mac/WacomInkspaceApp_#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://link.wacom.com/i/m?os=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.