### PR TITLE
Add depends_on java6 to shinhan-ezplus

### DIFF
--- a/Casks/shinhan-ezplus.rb
+++ b/Casks/shinhan-ezplus.rb
@@ -6,7 +6,12 @@ cask 'shinhan-ezplus' do
   name 'Shinhan ezPlus'
   homepage 'https://main.shinhan.com/hpe/index.jsp#040201040200'
 
+
   pkg 'SHBEzPlusMac.pkg'
 
   uninstall pkgutil: 'com.mygreatcompany.pkg.SHBEzPlusMac'
+
+  caveats do
+    depends_on_java '6'
+  end
 end

--- a/Casks/shinhan-ezplus.rb
+++ b/Casks/shinhan-ezplus.rb
@@ -6,7 +6,6 @@ cask 'shinhan-ezplus' do
   name 'Shinhan ezPlus'
   homepage 'https://main.shinhan.com/hpe/index.jsp#040201040200'
 
-
   pkg 'SHBEzPlusMac.pkg'
 
   uninstall pkgutil: 'com.mygreatcompany.pkg.SHBEzPlusMac'


### PR DESCRIPTION
As the shinhan-ezplus depends on the legacy Java support, I added `depends_on cask: 'java6'` to the caskfile.