### PR TITLE
Update quaternion from 0.0.9.4c to 0.0.9.4e

### DIFF
--- a/Casks/quaternion.rb
+++ b/Casks/quaternion.rb
@@ -1,6 +1,6 @@
 cask 'quaternion' do
-  version '0.0.9.4c'
-  sha256 'e37ea8c82108346df903df3a7390d327c665ad10b6fb1eaaba418358fb2c09f9'
+  version '0.0.9.4e'
+  sha256 '9df5cec6517c390edce156033101460b0e256ec9aefcf6d8ac8ae91ef1191f1a'
 
   url "https://github.com/quotient-im/Quaternion/releases/download/#{version}/quaternion-#{version}.dmg"
   appcast 'https://github.com/quotient-im/Quaternion/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.