### PR TITLE
Update superproductivity from 5.0.5 to 5.0.6

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '5.0.5'
-  sha256 'f4eb2c8658c706635dac7ed9dfb24a423eb48cc69336856c48f8e4ac87d02e55'
+  version '5.0.6'
+  sha256 '70defb38bcbe869f37524ef683e3b41b5fb2c609397ae70deb509589c5438f24'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.