### PR TITLE
Update advancedrestclient from 15.0.2 to 15.0.3

### DIFF
--- a/Casks/advancedrestclient.rb
+++ b/Casks/advancedrestclient.rb
@@ -1,6 +1,6 @@
 cask 'advancedrestclient' do
-  version '15.0.2'
-  sha256 '23ff30cf6ed7d6002d77ce70de5a3eb619b31639aa861ea316ab53aa94f973b1'
+  version '15.0.3'
+  sha256 'ef175a1ac40d348b7c7be341d3d7963c79fdd716dca2a130d613d7ddc366b4e6'
 
   url "https://github.com/advanced-rest-client/arc-electron/releases/download/v#{version}/arc-#{version}.dmg"
   appcast 'https://github.com/advanced-rest-client/arc-electron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.