### PR TITLE
Update meshlab from 2020.03 to 2020.04

### DIFF
--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -1,6 +1,6 @@
 cask 'meshlab' do
-  version '2020.03'
-  sha256 '652d187bda86c94d1a50998fe224ede213cc1b99c3a61ea540d551fffd0f46ac'
+  version '2020.04'
+  sha256 '875651a5f5614084ffee654c1b47ef1cb74d760910215946f33d13b8b9b6d503'
 
   # github.com/cnr-isti-vclab/meshlab was verified as official when first introduced to the cask
   url "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-#{version}/MeshLab#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.