### PR TITLE
Update zulip from 4.0.3 to 5.0.0

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,6 +1,6 @@
 cask 'zulip' do
-  version '4.0.3'
-  sha256 '7656fdf33a29b302f10d0294ecc544309bd861dd163b96e27e43fe6d9e17531e'
+  version '5.0.0'
+  sha256 'a8189b22e9ba51db256e427e968ddd5324f6b02fa62bf7201957154733c6acb7'
 
   # github.com/zulip/zulip-desktop was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-desktop/releases/download/v#{version}/Zulip-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.