### PR TITLE
Update scummvm from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/scummvm.rb
+++ b/Casks/scummvm.rb
@@ -1,6 +1,6 @@
 cask 'scummvm' do
-  version '2.1.1'
-  sha256 '2c50f2e57704fe228cb53365e73e56e37d39fed019b62c7330e6f41e1df595dd'
+  version '2.1.2'
+  sha256 'f7e63342c70157337e489d7dba6eacad61842311b6406ca56f17ff1d059443bf'
 
   url "https://scummvm.org/frs/scummvm/#{version}/scummvm-#{version}-macosx.dmg"
   appcast 'https://www.scummvm.org/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.