### PR TITLE
Update renamer from 6.0.4 to 6.0.5

### DIFF
--- a/Casks/renamer.rb
+++ b/Casks/renamer.rb
@@ -1,6 +1,6 @@
 cask 'renamer' do
-  version '6.0.4'
-  sha256 'cdc57bde386870ab3ea021d9d9e76e48592baf7ba004995600e00c9c89b5c39f'
+  version '6.0.5'
+  sha256 'fbe82a98acfafa5bd2841a1ffe0c9064edc3504abe07e67363e68c20513b1609'
 
   # storage.googleapis.com/incrediblebee was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.