### PR TITLE
Update mountain-duck from 3.3.5.15470 to 3.3.6.15539

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -1,6 +1,6 @@
 cask 'mountain-duck' do
-  version '3.3.5.15470'
-  sha256 '10c4450d360e99a164342d426289dd2f9554c19684fc10f150e6e4f719c52f3e'
+  version '3.3.6.15539'
+  sha256 '56744543ef30538faeebda84120940ad43575e670b4953f470cf23ff875ff039'
 
   url "https://dist.mountainduck.io/Mountain%20Duck-#{version}.zip"
   appcast "https://version.mountainduck.io/#{version.major}/macos/changelog.rss"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.