### PR TITLE
Update remote-desktop-manager-free from 2020.1.7.0 to 2020.1.8.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask 'remote-desktop-manager-free' do
-  version '2020.1.7.0'
-  sha256 '8e206b0379e00050d05162b33b29f74ff48f646d29eb531478a2b07cd0fb2113'
+  version '2020.1.8.0'
+  sha256 '253a4837d99be97f13974f7085c2e847a26a38e659e5facab7afb7e1096c5a5e'
 
   # devolutions.net was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.