### PR TITLE
Update openaudible from 1.6.5 to 1.6.6

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,6 +1,6 @@
 cask 'openaudible' do
-  version '1.6.5'
-  sha256 'ef56040ad7f050097c936944f116c5d3f1a21f24a18030d53befcdd8342056ae'
+  version '1.6.6'
+  sha256 'bc020967f2ee24070db8ccbff4e0807fd1568f0af2f30d360d54d600ab61d5be'
 
   # github.com/openaudible was verified as official when first introduced to the cask
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.