### PR TITLE
Update plex-media-player from 2.53.0.1063-4c40422c to 2.54.0.1067-1a7bc4f6

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-player' do
-  version '2.53.0.1063-4c40422c'
-  sha256 '7ba1aa849d6ea74330c87345d8bdca8ffa2dffe857b53b2b0f524ebdf1fd9091'
+  version '2.54.0.1067-1a7bc4f6'
+  sha256 'd81b0ecb2b7e85401f953fda9f39c2df88f2063cf7baa1f1796bc645d55739b5'
 
   url "https://downloads.plex.tv/plexmediaplayer/#{version}/PlexMediaPlayer-#{version}-macosx-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/3.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.