### PR TITLE
Update lifesize from 2.210.2578 to 2.210.2637

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,6 +1,6 @@
 cask 'lifesize' do
-  version '2.210.2578'
-  sha256 'b2843d5b2773dfacdd00d9cb3b27ebca4c563d5c64aae12af6e93ce07b93c09f'
+  version '2.210.2637'
+  sha256 '28acaaad991223a48cc80ec3804dc63a0ee5bfdc5557e2877b5bfcd3a77e9c0a'
 
   # download.lifesizecloud.com/Lifesize- was verified as official when first introduced to the cask
   url "https://download.lifesizecloud.com/Lifesize-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.