### PR TITLE
Update tandem from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/tandem.rb
+++ b/Casks/tandem.rb
@@ -1,6 +1,6 @@
 cask 'tandem' do
-  version '1.5.0'
-  sha256 '02917cbdf5dec79c9bfb84696e606dc2b64667971ce5ff9758a4361fb1eb6055'
+  version '1.5.1'
+  sha256 'c1ca526b4efb9c412b40cf2054e6102f3bb57d9aab9c48e8f25143d5bde00ff2'
 
   # tandem-app.sfo2.cdn.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://tandem-app.sfo2.cdn.digitaloceanspaces.com/Tandem-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.