### PR TITLE
Update banking-4 from 7.2.8.7394 to 7.2.8.7397

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.2.8.7394'
-  sha256 'bea6e1b7253ce762db308d52c4b06862c0dee4202344668d30f115f7c3bf7c92'
+  version '7.2.8.7397'
+  sha256 '694fd6a5db026df2003f43e9bc70521c5008af086822f32bd10026d66bcc72c6'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.