### PR TITLE
Update qownnotes from 20.4.0,b5463-165249 to 20.4.1,b5466-160246

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.4.0,b5463-165249'
-  sha256 '56fbad138984b8fab5d93b2c58d32a87f5a206e9cd51cdea42cfc088a889acc1'
+  version '20.4.1,b5466-160246'
+  sha256 'dddae6f8390c19b5bc3c250705c5f1011608b87d3e80bcbf5d771873b79b848f'
 
   # github.com/pbek/QOwnNotes was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.