### PR TITLE
Update docker from 2.2.0.4,43472 to 2.2.0.5,43884

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -3,8 +3,8 @@ cask 'docker' do
     version '18.06.1-ce-mac73,26764'
     sha256 '3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5'
   else
-    version '2.2.0.4,43472'
-    sha256 'defb095871ef260ccdb77d9960ed8510bdb288124025404f6543b94ec683e160'
+    version '2.2.0.5,43884'
+    sha256 '9a80bc46b2dd73cdc4fc468144fb1c939f8de73f0a86072ec89f9a4259dcaf91'
   end
 
   url "https://download.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.