### PR TITLE
Update crystalmaker from 10.4.7 to 10.5.0

### DIFF
--- a/Casks/crystalmaker.rb
+++ b/Casks/crystalmaker.rb
@@ -1,6 +1,6 @@
 cask 'crystalmaker' do
-  version '10.4.7'
-  sha256 '0ab005b3117ce4a2da305b8e136def8aaed934b2c5c09c32291c70f208cf26e1'
+  version '10.5.0'
+  sha256 '7bc6cd2498989ef7886cd17d7af24d30229b78998aefabf8e026301d42caf05e'
 
   url 'http://crystalmaker.com/downloads/crystalmaker_mac.zip'
   appcast "http://crystalmaker.com/crystalmaker/release-notes/mac/#{version.major}/index.html"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.