### PR TITLE
Update lightproxy from 1.1.10 to 1.1.11

### DIFF
--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -1,6 +1,6 @@
 cask 'lightproxy' do
-  version '1.1.10'
-  sha256 'da31062bc4112332bb745c6199fb681a5eb533c0475fe6b44a46f56c558a2b41'
+  version '1.1.11'
+  sha256 '6c8be69236e3b9f4ba64370666fd30287e84cd7e67911908580aa13af2c0e8e3'
 
   # gw.alipayobjects.com/os/LightProxy was verified as official when first introduced to the cask
   url 'https://gw.alipayobjects.com/os/LightProxy/LightProxy.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.