### PR TITLE
Update codeexpander from 3.3.5 to 3.3.6

### DIFF
--- a/Casks/codeexpander.rb
+++ b/Casks/codeexpander.rb
@@ -1,6 +1,6 @@
 cask 'codeexpander' do
-  version '3.3.5'
-  sha256 'b72a019e8953942513d89b2586e10d4c5741980bd761b46fcb4b9cf4ddca3c26'
+  version '3.3.6'
+  sha256 '54bf88b5da08f75ec5b93677860f0a284984d83db5f92446e4937b4c56af9f07'
 
   url "https://github.com/oncework/codeexpander/releases/download/#{version.major_minor}.x/CodeExpander-#{version}.dmg"
   appcast 'https://github.com/oncework/codeexpander/releases.atom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.