### PR TITLE
Update imazing from 2.11.2.13553 to 2.11.4.13602

### DIFF
--- a/Casks/imazing.rb
+++ b/Casks/imazing.rb
@@ -1,6 +1,6 @@
 cask 'imazing' do
-  version '2.11.2.13553'
-  sha256 '3b8775b9ed98dd59457372f8b936b9c98a0fcf72d6466ba56fb387221bedfa77'
+  version '2.11.4.13602'
+  sha256 '4eeaa96cd939c27a3bf37e84e2b28177dc363eee5e5cee63ebdfd800b99ed96e'
 
   url "https://downloads.imazing.com/mac/iMazing/#{version}/iMazing_#{version}.dmg"
   appcast "https://downloads.imazing.com/com.DigiDNA.iMazing#{version.major}Mac.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.