### PR TITLE
Update fldigi from 4.1.09,4.3.7 to 4.1.11,4.3.7

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask 'fldigi' do
-  version '4.1.09,4.3.7'
-  sha256 '99e57120d2d54de5ee3c6cd3b6b76fd9f13d5feb1e5842d50ae6e2d2392d24dc'
+  version '4.1.11,4.3.7'
+  sha256 '68ea5b357ffffbf7ea2c675312e1d51750f54ea407c4425a5390160ce941aca5'
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast 'https://sourceforge.net/projects/fldigi/rss?path=/fldigi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.