### PR TITLE
Update paper from 3.5 to 3.5.1

### DIFF
--- a/Casks/paper.rb
+++ b/Casks/paper.rb
@@ -1,6 +1,6 @@
 cask 'paper' do
-  version '3.5'
-  sha256 '4586ce3e5a726d61428486953dbd5800a4c26b10ada70f98f19354a15863ef95'
+  version '3.5.1'
+  sha256 'a9e6c336d1cfb8d50c2704e91a302c5b3635d6ff865a0199e49b6f6429a8f658'
 
   url "http://paperimg.meiyuan.in/pap.er_v#{version}.dmg"
   name 'Paper'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.