### PR TITLE
Update roboform from 8.8.2 to 8.8.1

### DIFF
--- a/Casks/roboform.rb
+++ b/Casks/roboform.rb
@@ -1,5 +1,5 @@
 cask 'roboform' do
-  version '8.8.2'
+  version '8.8.1'
   sha256 'accb52496fa599cf88fa1dd511a72905ace3ce4c87bba1cde23133a0afb837bd'
 
   url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.