### PR TITLE
Update youdaonote from 3.5.8 to 3.5.9

### DIFF
--- a/Casks/youdaonote.rb
+++ b/Casks/youdaonote.rb
@@ -1,6 +1,6 @@
 cask 'youdaonote' do
-  version '3.5.8'
-  sha256 '7889123a7987369849aef1bca17c25ee2a153d09ea12cf3cfa475de1ab305f6f'
+  version '3.5.9'
+  sha256 'b529384109007f86be688206d077b60e9367bfe0bdd1ecc917104da424b6d914'
 
   # download.ydstatic.com/notewebsite/downloads was verified as official when first introduced to the cask
   url 'https://download.ydstatic.com/notewebsite/downloads/YoudaoNote.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.