### PR TITLE
Update iglance from 2.0.3 to 2.0.4

### DIFF
--- a/Casks/iglance.rb
+++ b/Casks/iglance.rb
@@ -1,6 +1,6 @@
 cask 'iglance' do
-  version '2.0.3'
-  sha256 '4f5c416d99c35884e28ad7b418c28b6f8c1cd75faa33895ae5f85d3ad04b0735'
+  version '2.0.4'
+  sha256 '8c0aa0c67dff70923dc1cab1e43cf8c7bdff51643ad19d1fee57bbcdb1514ad8'
 
   url "https://github.com/iglance/iglance/releases/download/v#{version}/iGlance_v#{version}.zip"
   appcast 'https://github.com/iglance/iglance/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.