### PR TITLE
Update mjml from 3.0.1 to 3.0.2

### DIFF
--- a/Casks/mjml.rb
+++ b/Casks/mjml.rb
@@ -1,6 +1,6 @@
 cask 'mjml' do
-  version '3.0.1'
-  sha256 '5bafe9f12e3f6fd9c74fa5b73cb2ccb78063cdb07e005d4a8ad73037c8ad7727'
+  version '3.0.2'
+  sha256 'ab7118386b9a39d34ebf9e4101dac640a7b59bc3eee499500fa51cd7531dc307'
 
   # github.com/mjmlio/mjml-app was verified as official when first introduced to the cask
   url "https://github.com/mjmlio/mjml-app/releases/download/v#{version}/mjml-app-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.