### PR TITLE
Update lbry from 0.43.4 to 0.44.0

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.43.4'
-  sha256 '55bccf85780ac40db7bc9a1f7f0770bc0ce94810af4d3721ea26c7c8940b1a8e'
+  version '0.44.0'
+  sha256 '362595f1addbed00c6dd9cae0ea4322de48f5d75b253b7da23c2185cf7c081ea'
 
   # github.com/lbryio/lbry-desktop was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.