### PR TITLE
Update browserosaurus from 9.2.0 to 9.3.0

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '9.2.0'
-  sha256 '0ae39544e13c2d2500e7e55587a366f7e2cabd5bfc3d6b605b56d52843f72bd4'
+  version '9.3.0'
+  sha256 'fc5c79ab6d66510c47da7b85c63cbb4a548a18781dcc762ef17e602f737d2204'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.