### PR TITLE
Update jami from 20200331.1220 to 20200402.0924

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20200331.1220'
-  sha256 '63c6db42349647645e5ebf54b32528429f5fc7f6c4785b37a7d1e3cbb6d27d25'
+  version '20200402.0924'
+  sha256 '1fcdf401541e7afe056f64d23d947be14a1479e4eb721fe03971051e1a0096c3'
 
   url "https://dl.jami.net/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.jami.net/mac_osx/sparkle-ring.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.