### PR TITLE
Update screens from 4.7.3,25548 to 4.7.4,25584

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,6 +1,6 @@
 cask 'screens' do
-  version '4.7.3,25548'
-  sha256 '3d1737c6f685e7ef0043abd08a1e75a8cf4940afe59b21675ec15b544588532b'
+  version '4.7.4,25584'
+  sha256 'aa8aa00fed2709ca9d041d59d3848c142e23975f1ffd6c1fd1bc2ea0550810af'
 
   url "https://updates.edovia.com/com.edovia.screens#{version.major}.mac/Screens_#{version.before_comma}b#{version.after_comma}.zip"
   appcast "https://updates.edovia.com/com.edovia.screens#{version.major}.mac/appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.