### PR TITLE
Update lacona from 1.1.4 to 1.1.8

### DIFF
--- a/Casks/lacona.rb
+++ b/Casks/lacona.rb
@@ -1,6 +1,6 @@
 cask 'lacona' do
-  version '1.1.4'
-  sha256 '5a84412185c8cc8de6f627eb4400b81b314742a56e779db1cb65ba3e2b504230'
+  version '1.1.8'
+  sha256 'df2886d3553ef8cf9936af3d944963c8e61c83479bcb0e7617a7a367816e9399'
 
   url "https://download.lacona.io/packages/#{version}/Lacona.zip"
   appcast 'https://download.lacona.io/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.