### PR TITLE
Update tuple from 0.67.0,2020-03-31-2e60e088 to 0.68.0,2020-04-01-b2694d84

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.67.0,2020-03-31-2e60e088'
-  sha256 '243c9b4a9f5d316cbcc4b4a8b685a3954c188493d012450e840decbca71a78c2'
+  version '0.68.0,2020-04-01-b2694d84'
+  sha256 'd308c94876d6f01af3cd5457599d84856cd980259feba5a86404fb11ea567bc0'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.