### PR TITLE
Update ring from 2.4.2 to 2.5.0

### DIFF
--- a/Casks/ring.rb
+++ b/Casks/ring.rb
@@ -1,6 +1,6 @@
 cask 'ring' do
-  version '2.4.2'
-  sha256 '1b1314aa5bb9b1b8b16bb3760a707405589c234eb9e92ea45bbfaf8bd4afb8dc'
+  version '2.5.0'
+  sha256 'eab1d877c8812017e416683c2ceea4e5b8a200e662ea84c5109817d8799c5c47'
 
   # ring-mac-app-assets.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ring-mac-app-assets.s3.amazonaws.com/production/Ring_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.