### PR TITLE
Update tropy from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -1,6 +1,6 @@
 cask 'tropy' do
-  version '1.6.0'
-  sha256 '2c061c7dc96f79d45039034f639d9143cb7903a6450faf0fe54c6696d6a0cbc9'
+  version '1.7.0'
+  sha256 '97aa6280cfd094c1d0136fcae40874e91bad33975e80df37dde9a1bd29026a37'
 
   # github.com/tropy/tropy was verified as official when first introduced to the cask
   url "https://github.com/tropy/tropy/releases/download/#{version}/tropy-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.