### PR TITLE
Update localdev from 0.5.6 to 0.9.3

### DIFF
--- a/Casks/localdev.rb
+++ b/Casks/localdev.rb
@@ -1,6 +1,6 @@
 cask 'localdev' do
-  version '0.5.6'
-  sha256 '5981ed6eb22b920df98ac6c07cc1638d852530b16216dc5745db5ee6adbdf591'
+  version '0.9.3'
+  sha256 'a5cb4c4a47bea142d5edd8b807805bba512ab2ed3e20744c26ec52368a669b11'
 
   # pantheon-localdev.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://pantheon-localdev.s3.amazonaws.com/Localdev-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.