### PR TITLE
Update kugoumusic from 2.9.6 to 2.9.8

### DIFF
--- a/Casks/kugoumusic.rb
+++ b/Casks/kugoumusic.rb
@@ -1,6 +1,6 @@
 cask 'kugoumusic' do
-  version '2.9.6'
-  sha256 'ba52014dd47bc79dae6534f94b4fdff8587df9a95faff877fb33361adc2193d8'
+  version '2.9.8'
+  sha256 'b7cc6628b5546c76b1e13be504283787f225168a7939661512496bb90a031b52'
 
   url "http://downmini.kugou.com/mac/Kugou_V#{version}.dmg"
   appcast 'http://download.kugou.com/mac.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.