### PR TITLE
Update scope from 1.2.3 to 1.2.4

### DIFF
--- a/Casks/scope.rb
+++ b/Casks/scope.rb
@@ -1,6 +1,6 @@
 cask 'scope' do
-  version '1.2.3'
-  sha256 '45ee3569fc458841c3b44902ec8d1ea6a12d5ac2ffe34fc0835d901250ea6727'
+  version '1.2.4'
+  sha256 '7b6903513a944d250f360a2524e8228a0c7baaf9f68a443810be5c51ec4707c4'
 
   # releases.undefinedlabs.com/scope was verified as official when first introduced to the cask
   url "https://releases.undefinedlabs.com/scope/local/mac/#{version}/Scope.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.