### PR TITLE
Update wechatwebdevtools from 1.02.2003250 to 1.02.2004020

### DIFF
--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -1,6 +1,6 @@
 cask 'wechatwebdevtools' do
-  version '1.02.2003250'
-  sha256 'cdf1657fe69c3348729298afdd46e4d4da14701b43ace1e087847b13f7397dd8'
+  version '1.02.2004020'
+  sha256 '5f784d9fd9df4fcecbb476da403612e7fb2e560e848fcc02f3ee875030b466e5'
 
   url "https://dldir1.qq.com/WechatWebDev/nightly/p-ae42ee2cde4d42ee80ac60b35f183a99/wechat_devtools_#{version}.dmg"
   appcast 'https://developers.weixin.qq.com/miniprogram/dev/devtools/stable.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.