### PR TITLE
Update roblox from 0.425.0.394331,d0bce11daa3740b1 to 0.426.0.397338,d18bc94b3a0943fc

### DIFF
--- a/Casks/roblox.rb
+++ b/Casks/roblox.rb
@@ -1,6 +1,6 @@
 cask 'roblox' do
-  version '0.425.0.394331,d0bce11daa3740b1'
-  sha256 'bc5c5e63c635f14e21649981e9a8e9490a4fd5523d7ac3ea0215ab3cbbedfc83'
+  version '0.426.0.397338,d18bc94b3a0943fc'
+  sha256 '237c7b99cdda407dedc88fd3320c27d048428b13e731559af5067f6b29763c3c'
 
   # setup.rbxcdn.com was verified as official when first introduced to the cask
   url "https://setup.rbxcdn.com/mac/version-#{version.after_comma}-Roblox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.