### PR TITLE
Update protopie from 4.3.0 to 4.3.1

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '4.3.0'
-  sha256 'c346eab0e98ac7b0d7f1d3a5e5914beea116c9ca4d5ed7b6a4ceb7fb7f1edee1'
+  version '4.3.1'
+  sha256 '894c101b51858ef527c562c2bd666179efa09286be5c72abd8c4dad7dc641b54'
 
   url "https://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.