### PR TITLE
Update android-studio from 3.6.1.0,192.6241897 to 3.6.2.0,192.6308749

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -1,6 +1,6 @@
 cask 'android-studio' do
-  version '3.6.1.0,192.6241897'
-  sha256 '0e99a8f855636b1be1072089c78c064ff80209115f81ec0312cc2ddaa2f34578'
+  version '3.6.2.0,192.6308749'
+  sha256 '94d337b4bb743a9676dae78d60c61bcb52bfdea771edcb4be07c6016da29942f'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.