### PR TITLE
Update geph from 3.5.3 to 3.5.4

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.5.3'
-  sha256 'cabe3521694223152000116e4d9d4b580b7165e5501ce7a3e936ebdd82faac11'
+  version '3.5.4'
+  sha256 'f4ef8fe1bc5e194ad34ecd917f7e6f4a7229d89fd181342561135d55fd71e145'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.