### PR TITLE
Update avast-secureline-vpn: remove wildcards from `launchctl:`

### DIFF
--- a/Casks/avast-secureline-vpn.rb
+++ b/Casks/avast-secureline-vpn.rb
@@ -10,8 +10,17 @@ cask 'avast-secureline-vpn' do
 
   uninstall pkgutil:   'com.avast.secureline',
             launchctl: [
-                         'com.avast.secureline*',
-                         '*.com.avast.osx.secureline.avastsecurelinehelper',
+                         'com.avast.secureline.update',
+                         'com.avast.secureline.uninstall',
+                         'com.avast.secureline.service',
+                         'com.avast.secureline.init',
+                         'com.avast.secureline.burger',
+                         'com.avast.secureline.userinit',
+                         'com.avast.secureline.update-agent',
+                         # '6H4HRTU5E3' seems like a random string, but cursory investigation shows
+                         # this launchd job has the same prefix when installed in other environments.
+                         # Also multiple results for this in Google
+                         '6H4HRTU5E3.com.avast.osx.secureline.avastsecurelinehelper',
                          'com.avast.secureline.home.userinit',
                        ],
             delete:    '/Applications/AvastSecureLine.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.