### PR TITLE
Update macupdater from 1.5.3 to 1.5.4

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,6 +1,6 @@
 cask 'macupdater' do
-  version '1.5.3'
-  sha256 '26f25428cf772363e78390210bd73d6fc10577a23a1877187f56c2f934895b71'
+  version '1.5.4'
+  sha256 '173056d0a21a27eb9c308afa9de1862f22d3acd2f117f9d193ff249650f77f3d'
 
   url "https://www.corecode.io/downloads/macupdater_#{version}.dmg"
   appcast 'https://www.corecode.io/macupdater/macupdater.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.