### PR TITLE
Update loom from 0.33.2 to 0.33.4

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.33.2'
-  sha256 'cfeac08ea5468a9d392e852c8b664dd2a54db8841c9a0f45d943357a82a23ea1'
+  version '0.33.4'
+  sha256 '6d4dea090ff2fc910a3e48d44763b36c21562514932a8f2cf47bd7a80902eb49'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.