### PR TITLE
Update xaos from 3.6 to 4.0

### DIFF
--- a/Casks/xaos.rb
+++ b/Casks/xaos.rb
@@ -1,9 +1,9 @@
 cask 'xaos' do
-  version '3.6'
-  sha256 '1a3864f354759c03c13150ef541b48d06cf74351360a85a8b46e73a45edc7054'
+  version '4.0'
+  sha256 '228b03d656f82483c3a9cbcae4a66601341be446807bb4fdf425544fbd8fa76a'
 
   # github.com/xaos-project/XaoS was verified as official when first introduced to the cask
-  url "https://github.com/xaos-project/XaoS/releases/download/release-#{version}/xaos-#{version}-macosx.dmg"
+  url "https://github.com/xaos-project/XaoS/releases/download/release-#{version}/XaoS-#{version}.dmg"
   appcast 'https://github.com/xaos-project/XaoS/releases.atom'
   name 'GNU XaoS'
   homepage 'https://xaos-project.github.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.