### PR TITLE
Update fantasy-map-generator from 1.1 to 1.2

### DIFF
--- a/Casks/fantasy-map-generator.rb
+++ b/Casks/fantasy-map-generator.rb
@@ -1,6 +1,6 @@
 cask 'fantasy-map-generator' do
-  version '1.1'
-  sha256 '5332121f1e7ea47d72ca4f452401f5218708cb8d022f4c4613abbad573260815'
+  version '1.2'
+  sha256 'c8c64c031afe5423c83f8ad38e39da7b41a551ca248705b5b23c7718967b07da'
 
   # github.com/Azgaar/Fantasy-Map-Generator was verified as official when first introduced to the cask
   url "https://github.com/Azgaar/Fantasy-Map-Generator/releases/download/v#{version}/FMG-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.