### PR TITLE
Update lando from 3.0.0-rrc.2 to 3.0.0-rrc.3

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.0-rrc.2'
-  sha256 'ec3ce543fb51c1e2b3bce264b2ccd07c649368d2b23159d78d1e6260794707ef'
+  version '3.0.0-rrc.3'
+  sha256 '01f93f409725fa892ddc9aca7bee95603ec92f3b35adfe7efd4a7f553fb094a3'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.