### PR TITLE
Update sonic-pi from 3.2.0 to 3.2.1

### DIFF
--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -1,6 +1,6 @@
 cask 'sonic-pi' do
-  version '3.2.0'
-  sha256 '7a3e8b29c30dd83cfa081cff86983f0a28269553b18636b6784a40601bb9497e'
+  version '3.2.1'
+  sha256 '17e32ea392b3f324022bbdab8ecdb7d7f159b06e922ca65cf26ed41090c349cd'
 
   url "https://sonic-pi.net/files/releases/v#{version}/sonic-pi-for-mac-v#{version}.zip"
   appcast 'https://github.com/samaaron/sonic-pi/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.