### PR TITLE
Update bilimini from 1.4.1 to 1.4.2

### DIFF
--- a/Casks/bilimini.rb
+++ b/Casks/bilimini.rb
@@ -1,6 +1,6 @@
 cask 'bilimini' do
-  version '1.4.1'
-  sha256 '9ef45dfffaeefd271e2aa75cc1e7b8fac1fe912631ba012fe54cb2dcd886b74e'
+  version '1.4.2'
+  sha256 '43cdb421868ad1a6f7c0ec555e914dd531267c6ffaa8853bdd022b66ac2400b7'
 
   url "https://github.com/chitosai/bilimini/releases/download/v#{version}/bilimini-#{version}-mac.zip"
   appcast 'https://github.com/chitosai/bilimini/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.