### PR TITLE
Update melodics from 2.1.4141 to 2.1.4206

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.4141'
-  sha256 '8c2e57306e123dda803044f5f82c4915361a5376ca1d6228934c2e03cf77efd2'
+  version '2.1.4206'
+  sha256 '5f978cf00fdabd9ef4dc95b189e0151d94dd972c36eca7d169bb0890a7bb0475'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.