### PR TITLE
Update captin from 1.0.24,118:1585049885 to 1.1.0,119:1585846526

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -1,6 +1,6 @@
 cask 'captin' do
-  version '1.0.24,118:1585049885'
-  sha256 'cb1290938ec121849511a2a497c91963f092ee2b928195e8b882ae00ee988d1d'
+  version '1.1.0,119:1585846526'
+  sha256 '79e75a8a3b6b6d576b9f06564bca033d7f2fe6b456484d15043a08511b495491'
 
   # dl.devmate.com/com.100hps.captin was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.100hps.captin/#{version.after_comma.before_colon}/#{version.after_colon}/Captin-#{version.after_comma.before_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.