### PR TITLE
Update elpass from 1.1.3,237 to 1.1.4,248

### DIFF
--- a/Casks/elpass.rb
+++ b/Casks/elpass.rb
@@ -1,6 +1,6 @@
 cask 'elpass' do
-  version '1.1.3,237'
-  sha256 'c74dc8c1a928b20484662f0e44d4c87c5a1af997c35113b2e350420a902f8513'
+  version '1.1.4,248'
+  sha256 '25615ab9be324c40e0ae260e30691d4f95550ed2f72442eba712cf6d68a1c9f8'
 
   url "https://elpass.app/macos/Elpass-#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://elpass.app/macos/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.