### PR TITLE
Update timeular from 3.0.1 to 3.1.0

### DIFF
--- a/Casks/timeular.rb
+++ b/Casks/timeular.rb
@@ -1,6 +1,6 @@
 cask 'timeular' do
-  version '3.0.1'
-  sha256 '8383e90a507c0ffc6d740ea82972ecdc35bdda7b51fb8f16daad84e8a2c6046d'
+  version '3.1.0'
+  sha256 '8e9214c1d26ee1d68f46a46eb00698b01d2677affd0beef0258a5a7f1f6f39e8'
 
   # timeular-desktop-packages.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://timeular-desktop-packages.s3.amazonaws.com/mac/production/Timeular-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.