### PR TITLE
Update hbuilderx from 2.6.8.20200330 to 2.6.9.20200403

### DIFF
--- a/Casks/hbuilderx.rb
+++ b/Casks/hbuilderx.rb
@@ -1,6 +1,6 @@
 cask 'hbuilderx' do
-  version '2.6.8.20200330'
-  sha256 '28f076c679bfba441d83ef38558bed545e661055b92d2d164f414f62369bd3a6'
+  version '2.6.9.20200403'
+  sha256 '38e85e181806f54198da56cd70c2fa877b5df176a1277e74e89326c2267f01ef'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "https://download.dcloud.net.cn/HBuilderX.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.