### PR TITLE
Update seafile-client from 7.0.6 to 7.0.7

### DIFF
--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -1,6 +1,6 @@
 cask 'seafile-client' do
-  version '7.0.6'
-  sha256 'f7b891dc5c858d6f4a8ccf43fcd54e403f37fbd950ee507eae9fc78f0ec75e83'
+  version '7.0.7'
+  sha256 'f1b8db34cad0bf5a86fbe55974e2c3506455dbd937d37ab732fc7f9053ed09f0'
 
   # seadrive.org was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seafile-client-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.