### PR TITLE
Update avast-secureline-vpn: Use official `uninstall.sh` script to uninstall

### DIFF
--- a/Casks/avast-secureline-vpn.rb
+++ b/Casks/avast-secureline-vpn.rb
@@ -8,24 +8,15 @@ cask 'avast-secureline-vpn' do
 
   pkg 'Avast SecureLine VPN.pkg'
 
-  uninstall pkgutil:   'com.avast.secureline',
-            launchctl: [
-                         'com.avast.secureline.update',
-                         'com.avast.secureline.uninstall',
-                         'com.avast.secureline.service',
-                         'com.avast.secureline.init',
-                         'com.avast.secureline.burger',
-                         'com.avast.secureline.userinit',
-                         'com.avast.secureline.update-agent',
-                         # '6H4HRTU5E3' seems like a random string, but cursory investigation shows
-                         # this launchd job has the same prefix when installed in other environments.
-                         # Also multiple results for this in Google
-                         '6H4HRTU5E3.com.avast.osx.secureline.avastsecurelinehelper',
-                         'com.avast.secureline.home.userinit',
-                       ],
-            delete:    '/Applications/AvastSecureLine.app'
+  uninstall script: {
+                      executable: '/Library/Application Support/AvastSecureLine/hub/uninstall.sh',
+                      sudo:       true,
+                    }
 
   zap trash: [
+               '/Library/Application Support/AvastHUB',
+               '/Library/Application Support/AvastSecureLine',
+               '~/Library/Application Support/AvastSecureLine',
                '~/Library/Cookies/com.avast.osx.secureline.binarycookies',
                '~/Library/Caches/com.avast.osx.secureline',
                '~/Library/Group Containers/*.com.avast.osx.secureline*',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.