### PR TITLE
Update netron from 4.0.1 to 4.0.2

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.0.1'
-  sha256 '8cb86228a4faad6bd82d19c3073396a6586503705eb091612754d12c8a893c42'
+  version '4.0.2'
+  sha256 'c67d74b4c9aa3f97fcae0beac73fef05de14a3c4c3b2eb74153cf4adfd39d2dc'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.