### PR TITLE
Update android-sdk for deprecation and conflict with android-clt

### DIFF
--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -5,7 +5,7 @@ cask 'android-sdk' do
   # dl.google.com/android/repository was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
   name 'android-sdk'
-  homepage 'https://developer.android.com/index.html'
+  homepage 'https://developer.android.com/'
 
   binary "#{staged_path}/tools/android"
   binary "#{staged_path}/tools/bin/archquery"

--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -1,9 +1,9 @@
 cask 'android-sdk' do
-  version '4333796'
-  sha256 'ecb29358bc0f13d7c2fa0f9290135a5b608e38434aad9bf7067d0252c160853e'
+  version '6200805'
+  sha256 '23f0626336a98d70aff7311a73292026af31bc577c6f06b509cd4ad33752313e'
 
   # dl.google.com/android/repository was verified as official when first introduced to the cask
-  url "https://dl.google.com/android/repository/sdk-tools-darwin-#{version}.zip"
+  url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
   name 'android-sdk'
   homepage 'https://developer.android.com/index.html'
 

--- a/Casks/android-sdk.rb
+++ b/Casks/android-sdk.rb
@@ -1,11 +1,13 @@
 cask 'android-sdk' do
-  version '6200805'
-  sha256 '23f0626336a98d70aff7311a73292026af31bc577c6f06b509cd4ad33752313e'
+  version '4333796'
+  sha256 'ecb29358bc0f13d7c2fa0f9290135a5b608e38434aad9bf7067d0252c160853e'
 
   # dl.google.com/android/repository was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
   name 'android-sdk'
   homepage 'https://developer.android.com/'
+  
+  conflicts_with cask: 'android-clt'
 
   binary "#{staged_path}/tools/android"
   binary "#{staged_path}/tools/bin/archquery"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.