### PR TITLE
Update noteplan from 1.6.30,54 to 2.4.1,528

### DIFF
--- a/Casks/noteplan.rb
+++ b/Casks/noteplan.rb
@@ -1,5 +1,5 @@
 cask 'noteplan' do
-  version '1.6.30,54'
+  version '2.4.1,528'
   sha256 '51388ea6e157c1540907dd5efa7b2b8e752ef65d223baff34b60daab9da096a1'
 
   # rink.hockeyapp.net/api/2/apps/304b4477155e428780c345bcab69b380 was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.