### PR TITLE
Update wickrme from 5.50.6 to 5.51.2

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.50.6'
-  sha256 'b5bd437cddda03f72f66dbae6a07555056b10586c0c256ba162d53cd8cd1f45f'
+  version '5.51.2'
+  sha256 '42fa023fead5b3cd0f4a183c595b85d771d8d8f274f0d65178692322d457bd77'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.