### PR TITLE
Update flipper from 0.35.0 to 0.36.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.35.0'
-  sha256 '0d994068aa4d5d43460cae88bb00ba9f94cfb6230955f365dcc1c83a08c225ea'
+  version '0.36.0'
+  sha256 '662163a522db077de0b710480ef8aefd68b386cd91d35282f0dffe978f05396f'
 
   # github.com/facebook/flipper was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.