### PR TITLE
Update showyedge from 3.7.0 to 3.8.0

### DIFF
--- a/Casks/showyedge.rb
+++ b/Casks/showyedge.rb
@@ -1,6 +1,6 @@
 cask 'showyedge' do
-  version '3.7.0'
-  sha256 'f94c5eb699f03daa44db74829ab76935971b031c52bb116fcc8e2c44c2dc3cf3'
+  version '3.8.0'
+  sha256 '19c19e8755bca3ef532ba8893d7f12f604b7b90fe93f0ad3b84134acf3290a33'
 
   # github.com/pqrs-org/ShowyEdge was verified as official when first introduced to the cask
   url "https://github.com/pqrs-org/ShowyEdge/releases/download/v#{version}/ShowyEdge-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.