### PR TITLE
Update melodics from 2.1.4206 to 2.1.4208

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.4206'
-  sha256 '5f978cf00fdabd9ef4dc95b189e0151d94dd972c36eca7d169bb0890a7bb0475'
+  version '2.1.4208'
+  sha256 'd28563884a51158dba465f956b894e13195f77988ad459322f745d572d7ba5f1'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.