### PR TITLE
Update metabase from 0.35.0 to 0.35.1

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.35.0'
-  sha256 '8ec052262d0427310bc75a5ff457e3cfebc0099d7e59137dbef2fc6e13bf8efb'
+  version '0.35.1'
+  sha256 '967bd3806a455b56b8f22df35e77f765e5b0abb0aefd7a31572c230d669a1fe3'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.