### PR TITLE
Update moneywiz from 3.7.4 to 3.7.5

### DIFF
--- a/Casks/moneywiz.rb
+++ b/Casks/moneywiz.rb
@@ -1,6 +1,6 @@
 cask 'moneywiz' do
-  version '3.7.4'
-  sha256 '9b8d6d064528e59045d3c5b0d740fc3a4e4628c55cf2db1112ba95e6cbb50377'
+  version '3.7.5'
+  sha256 '46934ff9794a42b8c9d0f5797aa17ec0ee59845994ab4e843d95fd5c3cd6e6ae'
 
   url 'https://mac.wiz.money/MoneyWiz_Mac_Free.dmg'
   appcast 'https://macdistribution.wiz.money/version_info_free.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.