### PR TITLE
Update tower from 4.2,222:270499c7 to 4.3,225:9e4b22dd

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,6 +1,6 @@
 cask 'tower' do
-  version '4.2,222:270499c7'
-  sha256 'c651d1a2c302dbf5bba76babb12a8924229f5454e881e9a22fcea3735fb89d6e'
+  version '4.3,225:9e4b22dd'
+  sha256 'c41c366d05b61132556f05819ee0aa8682cba6d95c2fe27885089f0852ad2f0f'
 
   # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma.before_colon}-#{version.after_colon}/Tower-#{version.before_comma}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.