### PR TITLE
Update second-life-viewer from 6.3.8.538264 to 6.3.9.538719

### DIFF
--- a/Casks/second-life-viewer.rb
+++ b/Casks/second-life-viewer.rb
@@ -1,6 +1,6 @@
 cask 'second-life-viewer' do
-  version '6.3.8.538264'
-  sha256 'ef11c50eb92310d8b5043d5b4911fba7ae0d4fbce323799b24d12df66fe9237b'
+  version '6.3.9.538719'
+  sha256 '4b2ca8f11645df40ee14997d260e7eadf02cce4d1d49066226c77ffb909af9f7'
 
   url "http://download.cloud.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://secondlife.com/support/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.