### PR TITLE
Update lifesize from 2.210.2637 to 2.210.2639

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,6 +1,6 @@
 cask 'lifesize' do
-  version '2.210.2637'
-  sha256 '28acaaad991223a48cc80ec3804dc63a0ee5bfdc5557e2877b5bfcd3a77e9c0a'
+  version '2.210.2639'
+  sha256 '142514768b655e6600b55b1ee0361733b4cab3ba5c0400aa270ac31b4c4b5497'
 
   # download.lifesizecloud.com/Lifesize- was verified as official when first introduced to the cask
   url "https://download.lifesizecloud.com/Lifesize-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.