### PR TITLE
Update loom from 0.33.4 to 0.33.5

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.33.4'
-  sha256 '6d4dea090ff2fc910a3e48d44763b36c21562514932a8f2cf47bd7a80902eb49'
+  version '0.33.5'
+  sha256 'f0dc266f5a3f6d3501fd39cc612d67ad3080d1e4a42e4d60938ba9edd586c554'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.