### PR TITLE
Update lark from 3.21.3 to 3.21.4

### DIFF
--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -1,6 +1,6 @@
 cask 'lark' do
-  version '3.21.3'
-  sha256 'e819ee0108f4d351f3246a8f57f6eb1d43e4241c5be2cd90d720af9284d40832'
+  version '3.21.4'
+  sha256 '7e0cd2c94e727fd259f73b12c21244ce7bd062bbaa23d38d5b04777ee001d005'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Lark-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.