### PR TITLE
Update bluefish from 2.2.10-2 to 2.2.11

### DIFF
--- a/Casks/bluefish.rb
+++ b/Casks/bluefish.rb
@@ -1,6 +1,6 @@
 cask 'bluefish' do
-  version '2.2.10-2'
-  sha256 '018eacd5bb2d8fcd2f2ffc01aff65c0f49f98ad9bf921045975d4c5f8e3e0633'
+  version '2.2.11'
+  sha256 'c28ba47d9fbc29e185879ce96f4f8ee9a88f0fb903dbc49bf7477c1ac0c373ac'
 
   # bennewitz.com was verified as official when first introduced to the cask
   url "https://www.bennewitz.com/bluefish/stable/binaries/macosx/Bluefish-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.