### PR TITLE
Update licecap from 1.29 to 1.30

### DIFF
--- a/Casks/licecap.rb
+++ b/Casks/licecap.rb
@@ -1,6 +1,6 @@
 cask 'licecap' do
-  version '1.29'
-  sha256 '9d12df4946d3247483a1e050279b032320799ee96918f44628b92d862866250f'
+  version '1.30'
+  sha256 'de2af536ced4a81ef6c89c237741037bd12a4532a231d1fc2f3bc456d175c382'
 
   url "https://www.cockos.com/licecap/licecap#{version.no_dots}.dmg"
   appcast 'https://www.cockos.com/licecap/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.