### PR TITLE
Update accessmenubarapps from 2.6.1 to 2.6.19

### DIFF
--- a/Casks/accessmenubarapps.rb
+++ b/Casks/accessmenubarapps.rb
@@ -1,5 +1,5 @@
 cask 'accessmenubarapps' do
-  version '2.6.1'
+  version '2.6.19'
   sha256 'fe8a08d721af4b9e5e71bb71f3b876169fecde8219b53c01938861c2781fb16c'
 
   url "https://www.ortisoft.de/resources/AccessMenuBarApps#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.