### PR TITLE
Update cursorsense from 2.0.1 to 2.1.2

### DIFF
--- a/Casks/cursorsense.rb
+++ b/Casks/cursorsense.rb
@@ -1,6 +1,6 @@
 cask 'cursorsense' do
-  version '2.0.1'
-  sha256 'c7567d46ae2fde4d80d9713c1323da543ec1b26753996b37624993bcbd32a9c1'
+  version '2.1.2'
+  sha256 '393168677f5958ffef36fdf010db84fc3144a34f450497f6a04f176129ef8651'
 
   url "https://plentycom.jp/ctrl/files_cs/CursorSense#{version}.dmg"
   appcast 'https://plentycom.jp/en/cursorsense/download.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.