### PR TITLE
Update dyn-updater from 5.4.8 to 5.5.0

### DIFF
--- a/Casks/dyn-updater.rb
+++ b/Casks/dyn-updater.rb
@@ -1,6 +1,6 @@
 cask 'dyn-updater' do
-  version '5.4.8'
-  sha256 'be4b02a43ca968df9715975930480cea599fc5ecb3e34798f38139ff209dd1ee'
+  version '5.5.0'
+  sha256 '70cb2600907b05adf5a912baaee7512b6d70331405c551414889a49608a1fab9'
 
   url "http://cdn.dyn.com/dynupdater/DynUpdater-#{version}.zip"
   appcast 'http://cdn.dyn.com/dynupdater/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.