### PR TITLE
Update gdisk from 1.0.4 to 1.0.5

### DIFF
--- a/Casks/gdisk.rb
+++ b/Casks/gdisk.rb
@@ -1,6 +1,6 @@
 cask 'gdisk' do
-  version '1.0.4'
-  sha256 '67fa54f927439f969f08a093e9c2f85485b1f7015ea399632f5891b1694c9372'
+  version '1.0.5'
+  sha256 '1c2ba083d943f71c67b6af1e2a42364cfa4e4c618e38841c90018f03ba5cd293'
 
   url "https://downloads.sourceforge.net/gptfdisk/gdisk-#{version}.pkg"
   appcast 'https://sourceforge.net/projects/gptfdisk/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.