### PR TITLE
Update hands-off from 4.4.1 to 4.4.2

### DIFF
--- a/Casks/hands-off.rb
+++ b/Casks/hands-off.rb
@@ -1,6 +1,6 @@
 cask 'hands-off' do
-  version '4.4.1'
-  sha256 '76f796f04ad39b6c70e7f8306ef917fc88d0a663c2a6d6b8e3f51376c0a066bc'
+  version '4.4.2'
+  sha256 'a7f1f82d70900f766b6d2a4e6bd33add78a71b3ee8145e5e426086b7a0a39a84'
 
   url "https://www.oneperiodic.com/files/Hands%20Off!%20v#{version}.dmg"
   appcast "https://www.oneperiodic.com/handsoff#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.