### PR TITLE
Update virtualc64 from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,7 +1,7 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '3.3.1'
-  sha256 '1867a341c6f92ae2ac441821d6b65c011093decf42bdd23e40c31b429bd19a71'
+  version '3.3.2'
+  sha256 'ffe82a07306c56065e6e76b212ee4918308c93b72ba73e3ef7be8f6b5cd579ac'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.