### PR TITLE
Update seashore from 2.5.7 to 2.5.8

### DIFF
--- a/Casks/seashore.rb
+++ b/Casks/seashore.rb
@@ -1,6 +1,6 @@
 cask 'seashore' do
-  version '2.5.7'
-  sha256 '05e94d6842093948a4f0f0d65f7b58973b6d741af59394f7df0a664eea95e394'
+  version '2.5.8'
+  sha256 '96818260017d4f73bceffa69bb8a19476c118366c9355d7b175e6c41dfdd9f71'
 
   url "https://github.com/robaho/seashore/releases/download/v#{version}/seashore-bin-#{version}.dmg"
   appcast 'https://github.com/robaho/seashore/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.