### PR TITLE
Update wey from 0.3.5 to 0.3.6

### DIFF
--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,6 +1,6 @@
 cask 'wey' do
-  version '0.3.5'
-  sha256 'baa4b7446bacfda9e24d6cc64306757b77341a7ef0d4dbb4f557dce1f3c94d03'
+  version '0.3.6'
+  sha256 '8a1f3bd436b4d837ea2f586b5a96904bf6de02db5a25922cefd23b1f4e7e0b05'
 
   url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.