### PR TITLE
Update kext-updater from 3.4.0 to 3.4.1

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,6 +1,6 @@
 cask 'kext-updater' do
-  version '3.4.0'
-  sha256 '12512493bc73190fe1e2d8f3660f19a49f14f304f60f8e8e10f0f5eee0566a8e'
+  version '3.4.1'
+  sha256 'fe45dfc65ea3d55ee412e0be9a389365aa7e6b46e42e92dd98743f471667d26e'
 
   url 'https://update.kextupdater.de/kextupdater/kextupdaterng.zip'
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.