### PR TITLE
Update phocus from 3.4.8 to 3.5

### DIFF
--- a/Casks/phocus.rb
+++ b/Casks/phocus.rb
@@ -1,6 +1,6 @@
 cask 'phocus' do
-  version '3.4.8'
-  sha256 'c1fe13b000a913ee8aa65f451a1d99be07d76c099fedcbb2f392f979f986c856'
+  version '3.5'
+  sha256 'e271c1f50fe4e8c2273be7a0b5babca61ab731ad65bdac62e6a4651ff64bbd10'
 
   url "https://cdn.hasselblad.com/software/Phocus-for-Mac/#{version}/Phocus-#{version}.dmg"
   name 'Hasselblad Phocus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.