### PR TITLE
Update amadeus-pro from 2.7.5 to 2.8

### DIFF
--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -1,5 +1,5 @@
 cask 'amadeus-pro' do
-  version '2.7.5'
+  version '2.8'
   sha256 'c8362dc9eb44dcf1dc1cdb57a57c44f161d1f18b12a1b1b15b11cbd4e4cfcc6a'
 
   # s3.amazonaws.com/AmadeusPro2 was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.