### PR TITLE
torguard.rb: depends on <= mojave

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -8,6 +8,8 @@ cask 'torguard' do
   name 'TorGuard'
   homepage 'https://torguard.net/'
 
+  depends_on macos: '<= :mojave'
+
   pkg 'Install TorGuard.pkg'
 
   uninstall pkgutil: 'net.torguard.TorGuardDesktopQt',


### PR DESCRIPTION
Looks like this does not run on Catalina (no reports yet on previous macOS versions).

https://github.com/Homebrew/homebrew-cask/issues/80086