### PR TITLE
Update masscode from 1.1.0 to 1.2.0

### DIFF
--- a/Casks/masscode.rb
+++ b/Casks/masscode.rb
@@ -1,9 +1,9 @@
 cask 'masscode' do
-  version '1.1.0'
-  sha256 'c57809663fdfd919de72d03793ab0af7078bb795ae05b11730cbcccb0abf3f76'
+  version '1.2.0'
+  sha256 'eb2b26b44eba15fa735d8dbbac6e5ca8838766f471ccd4ef4d3685766b43a4b4'
 
   # github.com/antonreshetov/massCode was verified as official when first introduced to the cask
-  url "https://github.com/antonreshetov/massCode/releases/download/v#{version}/massCode-#{version}-mac.zip"
+  url "https://github.com/antonreshetov/massCode/releases/download/v#{version}/massCode-#{version}.dmg"
   appcast 'https://github.com/antonreshetov/massCode/releases.atom'
   name 'massCode'
   homepage 'https://masscode.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.