### PR TITLE
Bumped concourse fly to the latest release (6.0.0)

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,6 +1,6 @@
 cask 'fly' do
-  version '5.8.0'
-  sha256 '8e1b4e3a6fdc29878010ba9ee59f8df182e0a33c0551f0ad77f65e242a4fe769'
+  version '6.0.0'
+  sha256 'adf5925e0f13d392e034035b6efd063df680515aa984c237f85725570b69ff72'
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/concourse/concourse/releases.atom'


### PR DESCRIPTION

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).