### PR TITLE
Update brackets from 1.14.1 to 1.14.2

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,6 +1,6 @@
 cask 'brackets' do
-  version '1.14.1'
-  sha256 '9e95b89544796ef959b6acb36db77a712f1cf55d09294cff4b6dde648f055160'
+  version '1.14.2'
+  sha256 '716be1a75099079aa1a22dedab403c9839155c4b99aab6677d8a24589f7f9a15'
 
   # github.com/adobe/brackets was verified as official when first introduced to the cask
   url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.