### PR TITLE
Sets auto_updates to true for tuple version 0.69.0,2020-04-04-576f0166

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -8,5 +8,7 @@ cask 'tuple' do
   name 'Tuple'
   homepage 'https://tuple.app/'
 
+  auto_updates true
+
   app 'Tuple.app'
 end


### PR DESCRIPTION
I have used auto update to get to the latest version of this app without updating via homebrew cask. Here is a screenshot of the app and its auto-update menu item on the latest version:

<img width="211" alt="Screen Shot 2020-04-06 at 10 15 48 AM" src="https://user-images.githubusercontent.com/1747920/78570786-6b596380-77f3-11ea-8b49-4597f613982c.png">

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
