### PR TITLE
Update jamf-migrator from 5.2.1 to 5.2.2

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '5.2.1'
-  sha256 '868310c4540a91cab3864749243d34a91c54d38be0bc532046d8a9d62686e491'
+  version '5.2.2'
+  sha256 'a7fb2930b41d52a49cc9a509e0fd9aea4ce6e5d0c3c2f9d3b1e3aa4880d9f1a6'
 
   url 'https://github.com/jamf/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamf/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.