### PR TITLE
Update superproductivity from 5.0.7 to 5.0.8

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '5.0.7'
-  sha256 '16200fabc87d5d0f2201c285a446ce4bdc552eb6bca2ecc6fcabdb52e140d379'
+  version '5.0.8'
+  sha256 '9fcc799ae5049c9bb6cfb7220a461f31527a2b2c594658dec0446920fd32b500'
 
   # github.com/johannesjo/super-productivity was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.