### PR TITLE
Update katalon-studio from 7.3.0 to 7.3.1

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.3.0'
-  sha256 'af9a1480d080209958c54579e717f8c79a8d618cd698592dbe8eb6dd24be1459'
+  version '7.3.1'
+  sha256 '0e7cfe03b1d1dc3ef273a6784aeefc9477c588817ef89689a28485ca164d2292'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.