### PR TITLE
Update wwdc from 6.1.2 to 6.2

### DIFF
--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -1,6 +1,6 @@
 cask 'wwdc' do
-  version '6.1.2'
-  sha256 'ed6e653493ffba3fb05488f0123e7f6f66f823b6401ff34ee8e420e8c0cdcf1a'
+  version '6.2'
+  sha256 '9477a50f1ec984bb1474fc72246d9e095241360cc66d43bbd737fff6a7761a6b'
 
   # github.com/insidegui/WWDC was verified as official when first introduced to the cask
   url "https://github.com/insidegui/WWDC/releases/download/#{version}/WWDC_v#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.