### PR TITLE
Update loom from 0.33.5 to 0.33.7

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.33.5'
-  sha256 'f0dc266f5a3f6d3501fd39cc612d67ad3080d1e4a42e4d60938ba9edd586c554'
+  version '0.33.7'
+  sha256 '54e14bb854f83e10c49ae061c1a158e4bbe620ed8aa89e079e63c5ebc14c2d2b'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.