### PR TITLE
Update red-eye from 1.0 to 1.1

### DIFF
--- a/Casks/red-eye.rb
+++ b/Casks/red-eye.rb
@@ -1,6 +1,6 @@
 cask 'red-eye' do
-  version '1.0'
-  sha256 'af58a4b8aa5c08c77f6a5a7b1242a094d1e52f7f74311bfff04ec0ca99bf87ed'
+  version '1.1'
+  sha256 '12dd416b0c9e7ef1f8ff49b1bb7adc7bc98d6135c233bfd5d832d3307ba08b72'
 
   url 'https://www.hexedbits.com/downloads/redeye.zip'
   appcast 'https://www.hexedbits.com/redeye/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.