### PR TITLE
Update setapp from 2.5.1,1579269411 to 2.5.7,1586177549

### DIFF
--- a/Casks/setapp.rb
+++ b/Casks/setapp.rb
@@ -1,6 +1,6 @@
 cask 'setapp' do
-  version '2.5.1,1579269411'
-  sha256 '9852a47b798f7c46ca8c2610f6035f60d99cd6ba23bb74a2e2586e0039854e97'
+  version '2.5.7,1586177549'
+  sha256 'c4ee02059b5a239631f5b935f2b6c72b3711309138ae4c8dba4421acbed51fdc'
 
   # devmate.com/com.setapp.InstallSetapp was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.setapp.InstallSetapp/#{version.before_comma}/#{version.after_comma}/InstallSetapp-#{version.before_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.