### PR TITLE
Update blitz from 1.6.43 to 1.6.47

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.6.43'
-  sha256 'bea3d5a1cb79c2a810e1d37d78d45f1fb219c231a473f2a85ab763cf080c2f51'
+  version '1.6.47'
+  sha256 '6b8dd84ea1343d9717b1954c8663e602dee1596d821b659bfef24fa8de800623'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.