### PR TITLE
Update torguard from 3.98.2 to 3.98.3

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,6 +1,6 @@
 cask 'torguard' do
-  version '3.98.2'
-  sha256 '86a718f93539410cad509aaf6e3cb8efc88c8ca3d3da2d879aeca396eb7b0553'
+  version '3.98.3'
+  sha256 '13a6e84034798effcedfb0204275e24803684e73b8dd615bc90d89719ef45bbe'
 
   # torguard.biz was verified as official when first introduced to the cask
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.