### PR TITLE
Update vidrio from 1.12 to 1.14

### DIFF
--- a/Casks/vidrio.rb
+++ b/Casks/vidrio.rb
@@ -1,6 +1,6 @@
 cask 'vidrio' do
-  version '1.12'
-  sha256 '40bb941acbca1a2ffd4c6d974c8402c88d27a95a4968ec98a83c5deab7bba77d'
+  version '1.14'
+  sha256 '3d9b0a5b0fb5e7505b9f69b100cfbb811fa7a5a30b65dea5549d8b44a586214a'
 
   url "https://vidr.io/releases/Vidrio-#{version}.dmg"
   appcast 'https://vidr.io/latest-version'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.