### PR TITLE
Update zettelkasten from 3.3.0 to 3.3.1

### DIFF
--- a/Casks/zettelkasten.rb
+++ b/Casks/zettelkasten.rb
@@ -1,9 +1,9 @@
 cask 'zettelkasten' do
-  version '3.3.0'
-  sha256 '0249695dd3742819624720e457559f707131d6864c76c911fd553e06781cc2f9'
+  version '3.3.1'
+  sha256 '1f12515ac2943f0fc8083cf737f1216a35c2ee9249ecad2be02b99f7ebda8964'
 
   # github.com/sjPlot/Zettelkasten was verified as official when first introduced to the cask
-  url "https://github.com/sjPlot/Zettelkasten/releases/download/v#{version}/Zettelkasten_#{version}.dmg"
+  url "https://github.com/sjPlot/Zettelkasten/releases/download/v#{version}/Zettelkasten_#{version}_Mac-Java9+.dmg"
   appcast 'https://github.com/sjPlot/Zettelkasten/releases.atom'
   name 'zettelkasten'
   homepage 'http://zettelkasten.danielluedecke.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.