### PR TITLE
Update sonic-pi from 3.2.1 to 3.2.2

### DIFF
--- a/Casks/sonic-pi.rb
+++ b/Casks/sonic-pi.rb
@@ -1,6 +1,6 @@
 cask 'sonic-pi' do
-  version '3.2.1'
-  sha256 '17e32ea392b3f324022bbdab8ecdb7d7f159b06e922ca65cf26ed41090c349cd'
+  version '3.2.2'
+  sha256 '52828a3132ed8657a30a64f995dfe72b32f0a3b718886c3ac7e6d41d846ab441'
 
   url "https://sonic-pi.net/files/releases/v#{version}/sonic-pi-for-mac-v#{version}.zip"
   appcast 'https://github.com/samaaron/sonic-pi/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.