### PR TITLE
Update coconutbattery

### DIFF
--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -9,7 +9,7 @@ cask 'coconutbattery' do
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
   else
     version '3.9.0'
-    sha256 '2d260655182d52cec044c3b0c3d8ab8cd387fda0284b9944396bcb2bb569919b'
+    sha256 '764110af9aff6cec1caa485aae0cb7b180dcf484213db82cbf1b15dfacf37ac5'
     url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.delete('.')}.zip"
     appcast 'https://coconut-flavour.com/updates/coconutBattery.xml'
   end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Version 3.9 is available for download on the homepage, but is not yet in the appcast. The checksum has changed again.