### PR TITLE
Update fontgoggles from 1.1.12 to 1.1.13

### DIFF
--- a/Casks/fontgoggles.rb
+++ b/Casks/fontgoggles.rb
@@ -1,6 +1,6 @@
 cask 'fontgoggles' do
-  version '1.1.12'
-  sha256 'e90b0e63800a6baa06709bc4630bf17ae29bd8363c458a983aa721d6f5ff3e81'
+  version '1.1.13'
+  sha256 'b888dd0ee4330ef2b58fa6919202fab66aa26608cdcc95595c029ee6430e224d'
 
   # github.com/justvanrossum/fontgoggles was verified as official when first introduced to the cask
   url "https://github.com/justvanrossum/fontgoggles/releases/download/v#{version}/FontGoggles.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.