### PR TITLE
Update opencore-configurator from 1.21.0.0 to 1.22.0.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '1.21.0.0'
-  sha256 '0e8caed753e4915f33f8d0ba500197003b8c604f96d3052c0bcb4f01fa484cf1'
+  version '1.22.0.0'
+  sha256 '71ccbcceb4d9627690994bd6d2f318e55c22fea84ac0d09ab7423b6f3521ad29'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.