### PR TITLE
Update winds from 3.1.16 to 3.2.0

### DIFF
--- a/Casks/winds.rb
+++ b/Casks/winds.rb
@@ -1,6 +1,6 @@
 cask 'winds' do
-  version '3.1.16'
-  sha256 '8b69823278849f87a73f7573efe64d2b4fbdf94b8bb5d46d8a8f7be53d85cd74'
+  version '3.2.0'
+  sha256 'a7ce55d4082b043771683eb69a7c1f8c7b635e6f4fbc190bf8200fc733ed1576'
 
   # s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/winds-2.0-releases/releases/Winds-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.