### PR TITLE
Update jamovi from 1.1.9.0 to 1.2.16.0

### DIFF
--- a/Casks/jamovi.rb
+++ b/Casks/jamovi.rb
@@ -1,6 +1,6 @@
 cask 'jamovi' do
-  version '1.1.9.0'
-  sha256 'edc430dd3c3be63b2e7a4ea42a09c2c7cb3d34d747f0e8b4742c37c08c00af44'
+  version '1.2.16.0'
+  sha256 'e0c4e1ae1dcea84062952d00d510e68866330ea60834be3f62cfc873852566fb'
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.jamovi.org/download.html&splitter_1=macos.dmg&index_1=0&splitter_2=download-button&index_2=-1'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.