### PR TITLE
Update microsoft-edge from 80.0.361.109 to 80.0.361.111

### DIFF
--- a/Casks/microsoft-edge.rb
+++ b/Casks/microsoft-edge.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge' do
-  version '80.0.361.109'
-  sha256 '5075c5d8862a4ac7fe3c580c29ac4dbc8b5763b8595d015f17e2134cacc74ec3'
+  version '80.0.361.111'
+  sha256 'f0f76eb2329e71ac4153d982cf9797edc38b4858d0fbb345280420a1f112d426'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdge-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.