### PR TITLE
Update pyfa from 2.19.0 to 2.18.1

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.19.0'
-  sha256 '7ea8afa615f8c8f1b8be4d50c9cced6f219d85fa1c357e3d1f6982ca6c46ea89'
+  version '2.18.1'
+  sha256 'b271c0b5b3ac57799159888fb6e6a414e1995c221af5ab979906ec5cb7e5b02c'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.