### PR TITLE
Update alt-tab from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.6.1'
-  sha256 '1abd2a34cb9d153356bbd009c050c200ffd2a8553fc0a7556bffab14e9365441'
+  version '3.6.2'
+  sha256 '5728b468b9002d07e6b83df9f2a0d10c5b61b03e9cc1cca2169264b66d51ceb6'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.