### PR TITLE
Update xamarin-ios from 13.16.0.11 to 13.16.0.13

### DIFF
--- a/Casks/xamarin-ios.rb
+++ b/Casks/xamarin-ios.rb
@@ -13,6 +13,7 @@ cask 'xamarin-ios' do
   uninstall pkgutil: [
                        'com.xamarin.xamarin.ios.pkg',
                        'com.xamarin.xamarin-ios-build-host.pkg',
+                       'com.xamarin.monotouch.pkg',
                      ]
 
   zap trash: [

--- a/Casks/xamarin-ios.rb
+++ b/Casks/xamarin-ios.rb
@@ -1,6 +1,6 @@
 cask 'xamarin-ios' do
-  version '13.16.0.11'
-  sha256 'a203f227b1887ab26695ca03c349674a146b82faf450315520521741e058dfa7'
+  version '13.16.0.13'
+  sha256 '9d66f137177d826f45feceb47e0654cc9412e621387e3b307030118b494a69fa'
 
   url "https://dl.xamarin.com/MonoTouch/Mac/xamarin.ios-#{version}.pkg"
   appcast 'https://docs.microsoft.com/en-us/xamarin/ios/release-notes/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.