### PR TITLE
Update segger-embedded-studio-for-arm from 4.52 to 4.52a

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.52'
-  sha256 '6fe1344a72c64c136e8825705b5e8f6bfc4e2e21c8264e7f14bce0448bffa478'
+  version '4.52a'
+  sha256 'a769acbb5a2445e55dfd9f464ca8bbc2d689fe773c5018e35ad88039ad77da75'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   appcast 'https://studio.segger.com/arm_segger_studio_release_notes.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.