### PR TITLE
Update jump from 8.5.0 to 8.5.8

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.5.0'
-  sha256 '7ae6338d9d1e30fc9694ecf820abfa0776f1a28690b68e83c68307e48dfe6905'
+  version '8.5.8'
+  sha256 '74166bdcd41e03b12979a900d89d75c1bdce233c8e8354133f811154b600eaff'
 
   url "https://mirror.jumpdesktop.com/downloads/JumpDesktopMac-#{version}.zip"
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.