### PR TITLE
Update unity-android-support-for-editor from 2019.3.7f1,6437fd74d35d to 2019.3.8f1,4ba98e9386ed

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.7f1,6437fd74d35d'
-  sha256 'f0bfd98820233ccce1d091f80077e1a91444de58274a28ddab3f77b4ef5b153f'
+  version '2019.3.8f1,4ba98e9386ed'
+  sha256 '7244a5ef6dbe3a583acf0933bae4732c087469240502be24fee2aca7d1280387'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.