### PR TITLE
Update unity-ios-support-for-editor from 2019.3.7f1,6437fd74d35d to 2019.3.8f1,4ba98e9386ed

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.7f1,6437fd74d35d'
-  sha256 'f5f035ddd273f04807038e9484b377766750f579bb9ef9f4351f13ed2b8dc2cb'
+  version '2019.3.8f1,4ba98e9386ed'
+  sha256 'c38fb7146b4354c56236853557ccff3fa66851c5db6bcd6a20412788beee6d83'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.