### PR TITLE
Update tuple from 0.69.0,2020-04-04-576f0166 to 0.69.2,2020-04-08-2dce3177

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.69.0,2020-04-04-576f0166'
-  sha256 'f2a51c266d865803627ccc58e2d6d9213dae1826a428f9e45199432001825743'
+  version '0.69.2,2020-04-08-2dce3177'
+  sha256 '7963b34473137a7ca647aa5e85872f8cc5c35ced06efcd47656fec72fa82f403'
 
   # s3.us-east-2.amazonaws.com/tuple-releases was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.