### PR TITLE
Update kode54-cog from 1127,5fbf722f2 to 1131,6c7b7f721

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '1127,5fbf722f2'
-  sha256 'ad19b4283aaacd15a5e5135ceecc9eb2de17012d1849de55d406cf000d952d2c'
+  version '1131,6c7b7f721'
+  sha256 'bc21961d2404d2b100ddb6daf825ab74f07dbeb7f6c2b8b030627a6a199dce4b'
 
   # losno.co/cog was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.