### PR TITLE
Update electron from 8.2.0 to 8.2.1

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '8.2.0'
-  sha256 '84422f2f2711f27944dac8d6f33c7bfddc67264615866ac6c8887c65b73793e7'
+  version '8.2.1'
+  sha256 '3dd2e09883b1ae2fac361c59fc671473889c6dbaecc0998cc35914ea76ddf0e4'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.