### PR TITLE
Update mycrypto from 1.7.7 to 1.7.8

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.7.7'
-  sha256 'c7bbcee32f7ac9831ca4db1f091ad154181ed2e5ada3e1f9895e674b218e2df4'
+  version '1.7.8'
+  sha256 'ed19f40387698eec24d05100d9c570bcc93560265cc1310359fbd0dc0c58a4a9'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.