### PR TITLE
Update universal-media-server from 9.4.0 to 9.4.1

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -1,6 +1,6 @@
 cask 'universal-media-server' do
-  version '9.4.0'
-  sha256 '17aadd9dc96fda358d06505dcd3eaa92f66aededaa29bb2895cd4f1acace29b2'
+  version '9.4.1'
+  sha256 '109efe4930f30c9c2c086ad436a77a7ba35fbd57c190358c7ce1d5b223fcddf9'
 
   # github.com/UniversalMediaServer/UniversalMediaServer was verified as official when first introduced to the cask
   url "https://github.com/UniversalMediaServer/UniversalMediaServer/releases/download/#{version}/UMS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.