### PR TITLE
Update pingplotter from 5.15.1 to 5.15.8

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -1,6 +1,6 @@
 cask 'pingplotter' do
-  version '5.15.1'
-  sha256 '865e2377a655c0a04f042a0f6687721bf054b15a00723252ab3aa98096f90374'
+  version '5.15.8'
+  sha256 'dcc7eed17dc815c76c3a974837d154f82be6f361ed449f9a904239f0cf0d912c'
 
   url 'https://www.pingplotter.com/downloads/pingplotter_osx.zip'
   appcast 'https://www.pingplotter.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.