### PR TITLE
Update psi-plus from 1.4.1024-macOS10.13 to 1.4.1050-macOS10.13

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.1024-macOS10.13'
-  sha256 '8693dd320ab0304137c348e98b3e4d7c215676561d7aad886ec402e00206ba42'
+  version '1.4.1050-macOS10.13'
+  sha256 'f9ffa7fbc92d102f1d76d19b506f400571d16d399068ad07be11559b631cea4b'
 
   # downloads.sourceforge.net/psiplus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.