### PR TITLE
Add AirtestIDE 1.2.3

### DIFF
--- a/Casks/airtest-ide.rb
+++ b/Casks/airtest-ide.rb
@@ -4,7 +4,7 @@ cask 'airtest-ide' do
 
   url 'https://airtestproject.s3.netease.com/downloads/AirtestIDE/AirtestIDE_2020-01-20_py3_Mac10-12.dmg'
   name 'AirtestIDE'
-  homepage 'https://airtest.netease.com'
+  homepage 'https://airtest.netease.com/'
 
   app 'AirtestIDE.app'
 end

--- a/Casks/airtest-ide.rb
+++ b/Casks/airtest-ide.rb
@@ -1,0 +1,10 @@
+cask 'airtest-ide' do
+  version '1.2.3'
+  sha256 '8998233963fb07e9c74185575294a88089ac2349839450722280466b2464b7b7'
+
+  url 'https://airtestproject.s3.netease.com/downloads/AirtestIDE/AirtestIDE_2020-01-20_py3_Mac10-12.dmg'
+  name 'AirtestIDE'
+  homepage 'https://airtest.netease.com'
+
+  app 'AirtestIDE.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

-------

When brew download the cask dmg file, may raise error:
```
curl: (18) transfer closed with 263019584 bytes remaining to read
```

But if use `wget` to download it or try a few more times, download will be succeed.

Download via Safari is no problem also.