### PR TITLE
Update alt-tab from 3.7.1 to 3.7.2

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.7.1'
-  sha256 'd6ccf7dbac67277512b6ceaca28cb9a3fe117cf3e0e616bb681cd267be498cc5'
+  version '3.7.2'
+  sha256 '7e739abbab761fbd666aaaf57e13f661a2e1c07a72ccfd0f5b042ca5b1edfe14'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.