### PR TITLE
Update wireshark-chmodbpf from 3.2.2 to 3.2.3

### DIFF
--- a/Casks/wireshark-chmodbpf.rb
+++ b/Casks/wireshark-chmodbpf.rb
@@ -1,6 +1,6 @@
 cask 'wireshark-chmodbpf' do
-  version '3.2.2'
-  sha256 'c6bda7aba34c441dc8b3998ffbe938ea37a98cf9e4cbf0136a8b65229ce0887f'
+  version '3.2.3'
+  sha256 '066a05b20dce30f55a9ae8543cdf62771250352ab74c93186b8fb8a37a3aaf18'
 
   url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   appcast 'https://www.wireshark.org/download/osx/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.