### PR TITLE
Update aether from 2.0.0-dev.13,1906191901.7eaf250 to 2.0.0-dev.14,1912161354.a1a015e

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -1,6 +1,6 @@
 cask 'aether' do
-  version '2.0.0-dev.13,1906191901.7eaf250'
-  sha256 '2a6f02a5e4255d15e57225a76d26ae8d0063dcbf96a6a74848eea26e6d392f95'
+  version '2.0.0-dev.14,1912161354.a1a015e'
+  sha256 'cd3a722137891601cd2f2103f2ea57f76b88bd1b930f28ba5877b26372abde06'
 
   url "https://static.getaether.net/Releases/Aether-#{version.before_comma}/#{version.after_comma}/mac/Aether-#{version.before_comma}%2B#{version.after_comma}.dmg"
   appcast 'https://static.getaether.net/WebsiteReleaseLinks/Latest/LatestReleaseLinks.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.