### PR TITLE
Create android-clt.rb

### DIFF
--- a/Casks/android-clt.rb
+++ b/Casks/android-clt.rb
@@ -16,11 +16,11 @@ cask 'android-clt' do
   binary "#{staged_path}/tools/bin/sdkmanager"
 
   postflight do
-    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/android-sdk")
+    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/android-clt")
   end
 
   uninstall_postflight do
-    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-sdk")
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-clt")
   end
 
   caveats do
@@ -28,7 +28,7 @@ cask 'android-clt' do
     <<~EOS
       You can control android sdk packages via the sdkmanager command.
       You may want to add to your profile:
-        'export ANDROID_SDK_ROOT="#{HOMEBREW_PREFIX}/share/android-sdk"'
+        'export ANDROID_SDK_ROOT="#{HOMEBREW_PREFIX}/share/android-clt"'
     EOS
   end
 end

--- a/Casks/android-clt.rb
+++ b/Casks/android-clt.rb
@@ -1,0 +1,34 @@
+cask 'android-clt' do
+  version '6200805'
+  sha256 '23f0626336a98d70aff7311a73292026af31bc577c6f06b509cd4ad33752313e'
+
+  # dl.google.com/android/repository was verified as official when first introduced to the cask
+  url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
+  name 'android-clt'
+  homepage 'https://developer.android.com/'
+  
+  conflicts_with cask: 'android-sdk'
+
+  binary "#{staged_path}/tools/bin/apkanalyzer"
+  binary "#{staged_path}/tools/bin/avdmanager"
+  binary "#{staged_path}/tools/bin/lint"
+  binary "#{staged_path}/tools/bin/screenshot2"
+  binary "#{staged_path}/tools/bin/sdkmanager"
+
+  postflight do
+    FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/android-sdk")
+  end
+
+  uninstall_postflight do
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-sdk")
+  end
+
+  caveats do
+    depends_on_java '8'
+    <<~EOS
+      You can control android sdk packages via the sdkmanager command.
+      You may want to add to your profile:
+        'export ANDROID_SDK_ROOT="#{HOMEBREW_PREFIX}/share/android-sdk"'
+    EOS
+  end
+end

--- a/Casks/android-clt.rb
+++ b/Casks/android-clt.rb
@@ -1,28 +1,28 @@
 cask 'android-clt' do
   version '6200805'
   sha256 '23f0626336a98d70aff7311a73292026af31bc577c6f06b509cd4ad33752313e'
-  
+
   # dl.google.com/android/repository was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
   name 'android-clt'
   homepage 'https://developer.android.com/'
-  
+
   conflicts_with cask: 'android-sdk'
-  
+
   binary "#{staged_path}/tools/bin/apkanalyzer"
   binary "#{staged_path}/tools/bin/avdmanager"
   binary "#{staged_path}/tools/bin/lint"
   binary "#{staged_path}/tools/bin/screenshot2"
   binary "#{staged_path}/tools/bin/sdkmanager"
-  
+
   postflight do
     FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/android-sdk")
   end
-  
+
   uninstall_postflight do
     FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-sdk")
   end
-  
+
   caveats do
     depends_on_java '8'
     <<~EOS

--- a/Casks/android-clt.rb
+++ b/Casks/android-clt.rb
@@ -1,28 +1,28 @@
 cask 'android-clt' do
   version '6200805'
   sha256 '23f0626336a98d70aff7311a73292026af31bc577c6f06b509cd4ad33752313e'
-
+  
   # dl.google.com/android/repository was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
   name 'android-clt'
   homepage 'https://developer.android.com/'
   
   conflicts_with cask: 'android-sdk'
-
+  
   binary "#{staged_path}/tools/bin/apkanalyzer"
   binary "#{staged_path}/tools/bin/avdmanager"
   binary "#{staged_path}/tools/bin/lint"
   binary "#{staged_path}/tools/bin/screenshot2"
   binary "#{staged_path}/tools/bin/sdkmanager"
-
+  
   postflight do
     FileUtils.ln_sf(staged_path.to_s, "#{HOMEBREW_PREFIX}/share/android-sdk")
   end
-
+  
   uninstall_postflight do
     FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-sdk")
   end
-
+  
   caveats do
     depends_on_java '8'
     <<~EOS

--- a/Casks/android-commandlinetools.rb
+++ b/Casks/android-commandlinetools.rb
@@ -1,11 +1,12 @@
-cask 'android-clt' do
+cask 'android-commandlinetools' do
   version '6200805'
   sha256 '23f0626336a98d70aff7311a73292026af31bc577c6f06b509cd4ad33752313e'
 
   # dl.google.com/android/repository was verified as official when first introduced to the cask
   url "https://dl.google.com/android/repository/commandlinetools-mac-#{version}_latest.zip"
+  appcast 'https://developer.android.com/studio#cmdline-tools'
   name 'android-clt'
-  homepage 'https://developer.android.com/'
+  homepage 'https://developer.android.com/studio'
 
   conflicts_with cask: 'android-sdk'
 
@@ -21,14 +22,5 @@ cask 'android-clt' do
 
   uninstall_postflight do
     FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/android-clt")
-  end
-
-  caveats do
-    depends_on_java '8'
-    <<~EOS
-      You can control android sdk packages via the sdkmanager command.
-      You may want to add to your profile:
-        'export ANDROID_SDK_ROOT="#{HOMEBREW_PREFIX}/share/android-clt"'
-    EOS
   end
 end


### PR DESCRIPTION
The Android SDK Tools package has been deprecated and replaced by the Command Line Tools. Because of conflicts/removals/additions to each package for specific binaries, then this may be a better alternative to creating a cask for the command line tools. Perhaps, moving the cask 'android-sdk' to the homebrew-cask-versions tap because of deprecation would be better.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
