### PR TITLE
Update mycrypto from 1.7.8 to 1.7.9

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.7.8'
-  sha256 'ed19f40387698eec24d05100d9c570bcc93560265cc1310359fbd0dc0c58a4a9'
+  version '1.7.9'
+  sha256 'b3fdba4dd5a9e17ec468970e30360bd993412b750a68d9580d95d515fff3e49a'
 
   # github.com/MyCryptoHQ/MyCrypto was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.