### PR TITLE
Update openwebstart from 1.1.6 to 1.1.7

### DIFF
--- a/Casks/openwebstart.rb
+++ b/Casks/openwebstart.rb
@@ -1,6 +1,6 @@
 cask 'openwebstart' do
-  version '1.1.6'
-  sha256 '426a31642a853a48c2cf6e5d96358013ed61cb1139b746366474e555153560da'
+  version '1.1.7'
+  sha256 'eae6a2490be2d015e6d697692ee47364ed15bd238a3780ebfb62a8719e4f3626'
 
   # github.com/karakun/OpenWebStart was verified as official when first introduced to the cask
   url "https://github.com/karakun/OpenWebStart/releases/download/v#{version}/OpenWebStart_macos_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.