### PR TITLE
Update asciidocfx from 1.7.1 to 1.7.2

### DIFF
--- a/Casks/asciidocfx.rb
+++ b/Casks/asciidocfx.rb
@@ -1,6 +1,6 @@
 cask 'asciidocfx' do
-  version '1.7.1'
-  sha256 '4043aa0f6288e80be48ed9e086cce459085fa1cd30fe5bba900ad04aa61986ba'
+  version '1.7.2'
+  sha256 '8849be62e8f771b3f1700821b84dce90160f2cdff12da26a0ecb0cce5612688e'
 
   # github.com/asciidocfx/AsciidocFX was verified as official when first introduced to the cask
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.