### PR TITLE
Update patchwork from 3.17.6 to 3.17.7

### DIFF
--- a/Casks/patchwork.rb
+++ b/Casks/patchwork.rb
@@ -1,6 +1,6 @@
 cask 'patchwork' do
-  version '3.17.6'
-  sha256 '96c576fe6619f5b81053313a689ca9fdda5b9debffb5c0b6f495893305428803'
+  version '3.17.7'
+  sha256 'e3ece220cba7931adc6a879d3f2dadcb358cc3cdfeed63b745383e5021244469'
 
   url "https://github.com/ssbc/patchwork/releases/download/v#{version}/Patchwork-#{version}.dmg"
   appcast 'https://github.com/ssbc/patchwork/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.