### PR TITLE
Update onlyoffice from 5.4.2 to 5.5.1

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,6 +1,6 @@
 cask 'onlyoffice' do
-  version '5.4.2'
-  sha256 '88bd9b6bfa4e2121c02702fb53e64a495b569512f0d118e1238ee255f2315da4'
+  version '5.5.1'
+  sha256 '7090144f0d06328a7a1de43ea779c3db32b1afd7358295ca71ff2fbddb03601b'
 
   url "https://download.onlyoffice.com/install/desktop/editors/mac/updates/onlyoffice/ONLYOFFICE-#{version}.zip"
   appcast 'https://download.onlyoffice.com/install/desktop/editors/mac/onlyoffice.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.