### PR TITLE
Update rapidweaver from 8.6,20829 to 8.6.1,20831

### DIFF
--- a/Casks/rapidweaver.rb
+++ b/Casks/rapidweaver.rb
@@ -1,6 +1,6 @@
 cask 'rapidweaver' do
-  version '8.6,20829'
-  sha256 'b76ca9c1fd7614b5a72b5556ce3371cc91a5d7b27ab278d3a0e02b00187c463f'
+  version '8.6.1,20831'
+  sha256 '7d5f1d8a3f71bcfdbb5ad15eb733d2b4173e37237571020212ee204811fa1d08'
 
   # github.com/realmacsoftware was verified as official when first introduced to the cask
   url "https://github.com/realmacsoftware/RapidWeaver#{version.major}-releases/releases/download/#{version.before_comma}-%28#{version.after_comma}%29/RapidWeaver#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.