### PR TITLE
Update marvel from 9.1.2 to 9.1.3

### DIFF
--- a/Casks/marvel.rb
+++ b/Casks/marvel.rb
@@ -1,6 +1,6 @@
 cask 'marvel' do
-  version '9.1.2'
-  sha256 '92713ebaa974e60f253566da27d76ef90056d378c1376d501e0918a7156cf2a0'
+  version '9.1.3'
+  sha256 '6550fb4b187b326e5fef61268882b1f703e25910f08f847fd8dc165cb4f10844'
 
   # storage.googleapis.com/sketch-plugin was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/sketch-plugin/#{version}/Marvel.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.