### PR TITLE
Update polymail from 2.1.6 to 2.1.7

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,6 +1,6 @@
 cask 'polymail' do
-  version '2.1.6'
-  sha256 'e5c8a7e5fbeb201dbf42752af50313aa7e06f9bdbd2d08c2f013bdcbba6fb843'
+  version '2.1.7'
+  sha256 'f1364e5e4c8d87ab383e355cb7c49ce012604ea21cabd210d9076846e03cae43'
 
   url "https://sparkle-updater.polymail.io/macos/builds/Polymail-v#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sparkle-updater.polymail.io/osx/Polymail-Latest.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.