### PR TITLE
Update clip-studio-paint from 1.9.7 to 1.9.9

### DIFF
--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -4,6 +4,7 @@ cask 'clip-studio-paint' do
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
   appcast 'https://www.clipstudio.net/en/dl'
+          configuration: version.no_dots
   name 'CLIP STUDIO PAINT'
   homepage 'https://www.clipstudio.net/en'
 

--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -3,7 +3,7 @@ cask 'clip-studio-paint' do
   sha256 'ea3cca466ec6b253e84661a6a3f8c8ffdae36d5382a94acf08e1c58316e1261e'
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
-  appcast 'https://www.clipstudio.net/en/dl'
+  appcast 'https://www.clipstudio.net/en/dl',
           configuration: version.no_dots
   name 'CLIP STUDIO PAINT'
   homepage 'https://www.clipstudio.net/en'

--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -1,6 +1,6 @@
 cask 'clip-studio-paint' do
-  version '1.9.7'
-  sha256 '819d929b0a9ce948f1df75c563ac8d19b9f9b70b2cc91d79f8a597cd4629deb4'
+  version '1.9.9'
+  sha256 'ea3cca466ec6b253e84661a6a3f8c8ffdae36d5382a94acf08e1c58316e1261e'
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
   appcast 'https://www.clipstudio.net/en/dl'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.