### PR TITLE
Update eagle from 9.6.0 to 9.6.1

### DIFF
--- a/Casks/eagle.rb
+++ b/Casks/eagle.rb
@@ -1,6 +1,6 @@
 cask 'eagle' do
-  version '9.6.0'
-  sha256 '8c833b3457d4135dc08520507ff5a28bcc5849fe726761efc6a6b769f3b5ac11'
+  version '9.6.1'
+  sha256 '8c548955927feefec3bfd9ee28a1e0288ada549e371c01a25a139be91486ace7'
 
   url "https://trial2.autodesk.com/NET17SWDLD/2017/EGLPRM/ESD/Autodesk_EAGLE_#{version}_English_Mac_64bit.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.autodesk.com/eagle-download-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.