### PR TITLE
Update sentinel from 0.15.1 to 0.15.2

### DIFF
--- a/Casks/sentinel.rb
+++ b/Casks/sentinel.rb
@@ -1,6 +1,6 @@
 cask 'sentinel' do
-  version '0.15.1'
-  sha256 '235205161ed2ab38e7795de7d709f49755faf98ec5c9d161dbd4a46477119c27'
+  version '0.15.2'
+  sha256 '76c30e1d8bc3955eda794d6b37e0174d016ad876bd8a96ba38e274b8f310bd7b'
 
   url "https://releases.hashicorp.com/sentinel/#{version}/sentinel_#{version}_darwin_amd64.zip"
   appcast 'https://docs.hashicorp.com/sentinel/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.