### PR TITLE
Update jalbum from 19.3.6 to 20.0.0

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,8 +1,8 @@
 cask 'jalbum' do
-  version '19.3.6'
-  sha256 'd6ed48947e5735f4ab137259ad0f9dd0b38b463999494fd3d9eda5576bf50071'
+  version '20.0.0'
+  sha256 '4c2ee25138bda78479601cd4d1e7ebfd6227967adb4b09876f46d209017a94c3'
 
-  url "https://download.jalbum.net/download/#{version}/MacOSX/jAlbum.dmg"
+  url "https://download.jalbum.net/download/#{version.major}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',
           configuration: version.major_minor.chomp('.0')
   name 'jAlbum'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.