### PR TITLE
Update keepassxc from 2.5.3 to 2.5.4

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,9 +1,9 @@
 cask 'keepassxc' do
-  version '2.5.3'
-  sha256 'e278f02466e3fb294c5c676d7b0ba3c60302d0b08273b8088ff39ca2e97e79af'
+  version '2.5.4'
+  sha256 '3d56ebbcb3471a2f6116abe884d1e7b662347b80e18cc0a12ca9fdf2c9a14d7a'
 
   # github.com/keepassxreboot/keepassxc was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-2.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
   appcast 'https://github.com/keepassxreboot/keepassxc/releases.atom'
   name 'KeePassXC'
   homepage 'https://keepassxc.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.