### PR TITLE
Update basictex from 2019.1011 to 2020.0407

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -1,6 +1,6 @@
 cask 'basictex' do
-  version '2019.1011'
-  sha256 'b40998a06132364b4e58ca1be77c4b86d3e9514a4a59d8712a912b78593620cd'
+  version '2020.0407'
+  sha256 'c6a27c95a8af3bc26121cc3be415f3fc7120ffaa4ff4c1a860a7fe9fe78ac31e'
 
   # mirror.ctan.org/systems/mac/mactex was verified as official when first introduced to the cask
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

May take time for all mirrors around the world to update.