### PR TITLE
Update lingo from 10.4,111 to 10.5,111

### DIFF
--- a/Casks/lingo.rb
+++ b/Casks/lingo.rb
@@ -1,6 +1,6 @@
 cask 'lingo' do
-  version '10.4,111'
-  sha256 'c51761046995900485b90ec09a8f06dc7e5ae2db9f6b22fbeb025aecef5f3d30'
+  version '10.5,111'
+  sha256 'a92fa560723151dbb6a9a2450e6c73dcca43c4b1103153c519d2a258c2608197'
 
   # rink.hockeyapp.net/api/2/apps was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/7d71478daf6447bda4094e216e97b0cf/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.