### PR TITLE
rar.rb: remove caveat

### DIFF
--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -12,10 +12,4 @@ cask 'rar' do
   binary 'rar/unrar'
   artifact 'rar/default.sfx', target: "#{HOMEBREW_PREFIX}/lib/default.sfx"
   artifact 'rar/rarfiles.lst', target: "#{HOMEBREW_PREFIX}/etc/rarfiles.lst"
-
-  caveats <<~EOS
-    Instructions on using rar and unrar are available in
-
-      #{staged_path}/rar/rar.txt
-  EOS
 end


### PR DESCRIPTION
Good example of a bad `caveat`.