### PR TITLE
Update electron-fiddle from 0.13.1 to 0.14.0

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask 'electron-fiddle' do
-  version '0.13.1'
-  sha256 'a5e81613379d900af275bd57f34b45dc860335a6a5bf5a812647c745fd70a52c'
+  version '0.14.0'
+  sha256 'd32a51e72e8646c6cd21348ad439dad0a7ffb14e842e58182aced42c48c79e2f'
 
   # github.com/electron/fiddle was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.