### PR TITLE
Update mellow from 0.1.18 to 0.1.19

### DIFF
--- a/Casks/mellow.rb
+++ b/Casks/mellow.rb
@@ -1,6 +1,6 @@
 cask 'mellow' do
-  version '0.1.18'
-  sha256 '72bc3938c6c83918168474f4b27d812b2eea08b2c370472e71bd3af709321518'
+  version '0.1.19'
+  sha256 '72d752b3abd8299f3e95df215f9659638c0bb3b0f57c1c8d4fa0e69a624a5106'
 
   url "https://github.com/mellow-io/mellow/releases/download/v#{version}/Mellow-#{version}.dmg"
   appcast 'https://github.com/mellow-io/mellow/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.