### PR TITLE
Update hstracker from 1.6.22 to 1.6.25

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.22'
-  sha256 '9e6a1a91978551639af16a00011fb0c97e0f8132f2b1753e3063d359aa1eafa3'
+  version '1.6.25'
+  sha256 '15a9bbad8b176a22405cfe929a5728863ae2a8241b82bebe936692d244d945e5'
 
   # github.com/HearthSim/HSTracker was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.