### PR TITLE
Update refined-github-safari from 2.0.28 to 2.0.29

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask 'refined-github-safari' do
-  version '2.0.28'
-  sha256 'e01c30935b789a5fa3c61579bfe50e67d8c654cce6cc48e01dff5a0f64c77c36'
+  version '2.0.29'
+  sha256 '999fc29c0642a0be54f25782172c2f58a5952b56026097059cdda3794623301b'
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast 'https://github.com/lautis/refined-github-safari/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.