### PR TITLE
Update hubstaff from 1.5.9,2025 to 1.5.10,2223

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask 'hubstaff' do
-  version '1.5.9,2025'
-  sha256 '51da121d85af776bca859e2b27ccba4a44675b0d7bd7acbe11febebbe89c5d5d'
+  version '1.5.10,2223'
+  sha256 '3c32fe638b6a9e6ac7c44dc7050993579a323cafe9be975ec94c6409a96807e3'
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast 'https://app.hubstaff.com/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.