### PR TITLE
Update zeplin from 3.2,875 to 3.2.2,885

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '3.2,875'
-  sha256 '344cea49579a44ee82589e4a876aff1a1f663b0c4b59d2c757a75e67eccf9aa0'
+  version '3.2.2,885'
+  sha256 '96dc6c48659790ae1fba411e17e4a2e45dfeac5297c73234b0110362e4d80920'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.