### PR TITLE
Update adobe-dng-converter from 12.2 to 12.2.1

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -3,8 +3,8 @@ cask 'adobe-dng-converter' do
     version '9.6.1'
     sha256 '087eac5026667e4e6e3c156fd13243c9ea00f6c0238cbbb94d3099ae8772603f'
   else
-    version '12.2'
-    sha256 'cc2962dd051c29bb2c4737a831477be5b0f35531f0fbc1ea2c10c2449201f0f7'
+    version '12.2.1'
+    sha256 '96f19bfea04bfca361c3a0c61605a818aad2cbb9f42eeee0c1c6b96bc41521d1'
   end
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.