### PR TITLE
Update freeyourmusic from 5.1.2 to 5.1.3

### DIFF
--- a/Casks/freeyourmusic.rb
+++ b/Casks/freeyourmusic.rb
@@ -1,6 +1,6 @@
 cask 'freeyourmusic' do
-  version '5.1.2'
-  sha256 'b90d7100a91fbe040e3cc00eaec5ba42ee82b698c246bc35d29bc378a5ab6c6c'
+  version '5.1.3'
+  sha256 '66f6078a1a338d35d840bfe1307de331af72a33e30cb92dcf89020b88bc16226'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/FreeYourMusic-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.