### PR TITLE
Update hbuilderx from 2.6.9.20200403 to 2.6.11.20200409

### DIFF
--- a/Casks/hbuilderx.rb
+++ b/Casks/hbuilderx.rb
@@ -1,6 +1,6 @@
 cask 'hbuilderx' do
-  version '2.6.9.20200403'
-  sha256 '38e85e181806f54198da56cd70c2fa877b5df176a1277e74e89326c2267f01ef'
+  version '2.6.11.20200409'
+  sha256 '6084ac251c01f4a75ae553b95b2d1a7af2033741b70d79006a596133b04366cb'
 
   # download.dcloud.net.cn was verified as official when first introduced to the cask
   url "https://download.dcloud.net.cn/HBuilderX.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.