### PR TITLE
Update plex-media-server from 1.19.1.2630-72c16a276 to 1.19.1.2645-ccb6eb67e

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask 'plex-media-server' do
-  version '1.19.1.2630-72c16a276'
-  sha256 '8d4b4b6da0730e595e3b073a51ea6e20884263729a2b798e158d6ca41ae2cd6b'
+  version '1.19.1.2645-ccb6eb67e'
+  sha256 '606dcb1c1c62f3f1388437cb5591fee623f4c7b29e6d66fec1733e290d0c1360'
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/5.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.