### PR TITLE
Update wechat from 2.3.31.18 to 2.3.31.19

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,5 +1,5 @@
 cask 'wechat' do
-  version '2.3.31.18'
+  version '2.3.31.19'
   sha256 '91dbbdfcb5b9eacdbe5b813e868f0bba4ed3435b85533dd0af0ba179ba480408'
 
   url 'https://dldir1.qq.com/weixin/mac/WeChatMac.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.