### PR TITLE
Update altserver from 1.2.1 to 1.3

### DIFF
--- a/Casks/altserver.rb
+++ b/Casks/altserver.rb
@@ -1,6 +1,6 @@
 cask 'altserver' do
-  version '1.2.1'
-  sha256 '6dcbcd514d6d9bd0c0332a2d6e392680e292dd3d2b494d68bcb2ad25ccbc6420'
+  version '1.3'
+  sha256 'c83d5076435d88260ae99674776274bb3f23aa6dc54e717ad65a0c26c66f88f4'
 
   # f000.backblazeb2.com/file was verified as official when first introduced to the cask
   url "https://f000.backblazeb2.com/file/altstore/altserver/#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.