### PR TITLE
Update screenflick from 2.7.45 to 2.7.49

### DIFF
--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -3,7 +3,8 @@ cask 'screenflick' do
   sha256 '76bceb692c9910c8213b0b5c554e7ca3ec215c7e9860176c56b6ef746ccf1c4a'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
-  appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"
+  appcast 'https://arweb-assets.s3.amazonaws.com/downloads/screenflick/updates.json'
+ 
   name 'Screenflick'
   homepage 'https://www.araelium.com/screenflick/'
 

--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -1,6 +1,6 @@
 cask 'screenflick' do
-  version '2.7.45'
-  sha256 'da4e78c232804e48e64919a244dd5ddee70365e56bc2646ce78333a7aeff63ce'
+  version '2.7.49'
+  sha256 '76bceb692c9910c8213b0b5c554e7ca3ec215c7e9860176c56b6ef746ccf1c4a'
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast "https://arweb-assets.s3.amazonaws.com/downloads/screenflick/screenflick#{version.major}.xml"

--- a/Casks/screenflick.rb
+++ b/Casks/screenflick.rb
@@ -4,7 +4,6 @@ cask 'screenflick' do
 
   url "https://store.araelium.com/screenflick/downloads/versions/Screenflick#{version}.zip"
   appcast 'https://arweb-assets.s3.amazonaws.com/downloads/screenflick/updates.json'
- 
   name 'Screenflick'
   homepage 'https://www.araelium.com/screenflick/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.