### PR TITLE
Update algodoo from 2.1.0 to 2.1.3

### DIFF
--- a/Casks/algodoo.rb
+++ b/Casks/algodoo.rb
@@ -1,8 +1,8 @@
 cask 'algodoo' do
-  version '2.1.0'
-  sha256 'f7582c715c489861aeb210f40a8930fb172da8e3b2f04c3c2c6049892488fb5e'
+  version '2.1.3'
+  sha256 '9f3419d0da9cca0f0f5abc0b8a228197221c92fcbc35138ed2bb0b9251820a66'
 
-  url "https://www.algodoo.com/download/Algodoo_#{version.dots_to_underscores}-MacOS.dmg"
+  url "http://www.algodoo.com/download/Algodoo_#{version.dots_to_underscores}-MacOS.dmg"
   appcast 'https://www.algodoo.com/download/'
   name 'Algodoo'
   homepage 'https://www.algodoo.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.