### PR TITLE
Update corona-tracker

### DIFF
--- a/Casks/corona-tracker.rb
+++ b/Casks/corona-tracker.rb
@@ -8,8 +8,12 @@ cask 'corona-tracker' do
   name 'Corona Tracker'
   homepage 'https://coronatracker.samabox.com/'
 
-  auto_updates true
   depends_on macos: '>= :catalina'
 
   app 'Corona Tracker.app'
+
+  zap trash: [
+               '~/Library/Containers/maccatalyst.com.samabox.corona',
+               '~/Library/Application Scripts/maccatalyst.com.samabox.corona',
+             ]
 end


### PR DESCRIPTION
Added `zap` stanza and removed `auto_update` because the app does not artifacts auto-update.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name.