### PR TITLE
Update unity from 2019.3.7f1,6437fd74d35d to 2019.3.9f1,e6e740a1c473

### DIFF
--- a/Casks/noxappplayer.rb
+++ b/Casks/noxappplayer.rb
@@ -1,6 +1,6 @@
 cask 'noxappplayer' do
   version '2.0.0.0,0117'
-  sha256 '489a57f1399bf8a026abd5c7a802ffeb5024753534dfa9afbe48ba300bbe0d7b'
+  sha256 'adf67436ef9561598aa3a4d60a1b445b209a3c5ea1b047a2ccd304b68e340890'
 
   url "https://res06.bignox.com/full/2020#{version.after_comma}/7fc81e345aff4ac394d6c188c67e4cf1.dmg?filename=Nox_installer_for_mac_v#{version.before_comma}_en_#{version.after_comma}.dmg"
   appcast 'https://www.bignox.com/blog/category/releasenote/'

--- a/Casks/noxappplayer.rb
+++ b/Casks/noxappplayer.rb
@@ -1,8 +1,8 @@
 cask 'noxappplayer' do
-  version '2.0.0.0,0117'
+  version '3.0.0.0'
   sha256 'adf67436ef9561598aa3a4d60a1b445b209a3c5ea1b047a2ccd304b68e340890'
 
-  url "https://res06.bignox.com/full/2020#{version.after_comma}/7fc81e345aff4ac394d6c188c67e4cf1.dmg?filename=Nox_installer_for_mac_v#{version.before_comma}_en_#{version.after_comma}.dmg"
+  url "http://res06.bignox.com/full/20200315/b101bb5a99074327abab2da0bafd2a74.dmg?filename=Nox_installer_for_mac_intl_#{version}.dmg"
   appcast 'https://www.bignox.com/blog/category/releasenote/'
   name 'NoxAppPlayer'
   homepage 'https://www.bignox.com/'

--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.3.7f1,6437fd74d35d'
-  sha256 '09fe5b135bc4563750ab20cc7cfd35d66fe30815647eae5c5678f7c2d11acff8'
+  version '2019.3.9f1,e6e740a1c473'
+  sha256 '04cb4d805e7c80985188772c4b7d95f55e5c9ce8ade6a2f19d6c55961cbc846d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.