### PR TITLE
Update emby-server from 4.4.1.0 to 4.4.2.0

### DIFF
--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -1,6 +1,6 @@
 cask 'emby-server' do
-  version '4.4.1.0'
-  sha256 'e07a356f694911ff905e84ece89f9156145f6c9db1051d8473bf0faa825374dd'
+  version '4.4.2.0'
+  sha256 'c090d6ce02554fb44f498364f6d6abe8f8e7fce64ddef7f87c6f01ff331ac9bd'
 
   # github.com/MediaBrowser/Emby.Releases was verified as official when first introduced to the cask
   url "https://github.com/MediaBrowser/Emby.Releases/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.