### PR TITLE
Update timely from 1.0.10 to 1.1.0

### DIFF
--- a/Casks/timely.rb
+++ b/Casks/timely.rb
@@ -1,9 +1,9 @@
 cask 'timely' do
-  version '1.0.10'
-  sha256 '121e5b3075c9de953c2fa0b585ec45824a8dc08668992c444143ca6af5d73152'
+  version '1.1.0'
+  sha256 'e1e56f6ebcea702ab4bb71f9fe74eeb3c2ca4f866f59caa5a44952df84f2809a'
 
   # github.com/Timely was verified as official when first introduced to the cask
-  url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-v#{version}/Timely-#{version}.dmg"
+  url "https://github.com/Timely/desktop-releases/releases/download/darwin-x64-prod-#{version}/Timely-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://app.timelyapp.com/download/mac'
   name 'Timely'
   homepage 'https://timelyapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.