### PR TITLE
Update tikzit from 2.1.4 to 2.1.5

### DIFF
--- a/Casks/tikzit.rb
+++ b/Casks/tikzit.rb
@@ -1,6 +1,6 @@
 cask 'tikzit' do
-  version '2.1.4'
-  sha256 'aa3024cb27f89127661c701efad7737edd9739b52c1d7008d8d32ddb5793ee2b'
+  version '2.1.5'
+  sha256 'a4e191e65462f46a2aa92ab08f136f4f799c2d43f062564bdff833c9b2fb3ce5'
 
   # github.com/tikzit/tikzit was verified as official when first introduced to the cask
   url "https://github.com/tikzit/tikzit/releases/download/v#{version}/tikzit-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.