### PR TITLE
Update cabal from 4.1.1 to 5.0.0

### DIFF
--- a/Casks/cabal.rb
+++ b/Casks/cabal.rb
@@ -1,6 +1,6 @@
 cask 'cabal' do
-  version '4.1.1'
-  sha256 '9b0c959135674663839cc0b80533a7a94603dda8977f817fa954e4d1ca5e40d3'
+  version '5.0.0'
+  sha256 '897ddafb13ca78488490ac572b2da0400a5084d5a4a19efa21e22e82526c02ef'
 
   # github.com/cabal-club/cabal-desktop was verified as official when first introduced to the cask
   url "https://github.com/cabal-club/cabal-desktop/releases/download/v#{version}/cabal-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.