### PR TITLE
Update ganache from 2.1.2 to 2.3.0

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,6 +1,6 @@
 cask 'ganache' do
-  version '2.1.2'
-  sha256 '6ad434dc1fab941ac40e86acb2c755348974c84a2a543ee9ec0be16f192bb230'
+  version '2.3.0'
+  sha256 '17740bbe33bb9db80ae3dd2d6b825b0b20836749845b51deb4c70cc1ec8fdb71'
 
   # github.com/trufflesuite/ganache was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.