### PR TITLE
Update gifox from 2.1.3,020103.00 to 2.1.4,020104.00

### DIFF
--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -1,6 +1,6 @@
 cask 'gifox' do
-  version '2.1.3,020103.00'
-  sha256 '88c324cc28d26b2014600f609bffccd63c105ca1114dc89777f7ea8cd4abe2f3'
+  version '2.1.4,020104.00'
+  sha256 '846695e5e5e563d9982033c4dafb990a954ec31f29b94ad408c382097a894d37'
 
   # d3si16icyi9iar.cloudfront.net/gifox was verified as official when first introduced to the cask
   url "https://d3si16icyi9iar.cloudfront.net/gifox/#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.