### PR TITLE
Update latexit from 2.14.6 to 2.14.7

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,6 +1,6 @@
 cask 'latexit' do
-  version '2.14.6'
-  sha256 '612e586bf07709a08c1f53cb014596ddea11d5f3f62fa0f4727dc6f22100eb62'
+  version '2.14.7'
+  sha256 '24c7f911c9f1e25fed25e1131b0511843da77ca5e9707021bf4fe96798b5f7a7'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.