### PR TITLE
Update exodus from 20.3.27 to 20.4.9

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '20.3.27'
-  sha256 'c6a2eb14639d576e3238e2450e39d3b86fa19fabdb84497fd7c9f5077fbd1a02'
+  version '20.4.9'
+  sha256 '335d6e71259f7d57b3747b9d6aed8b0b87d840fe51c857b02e0085a752c6f471'
 
   url "https://downloads.exodus.io/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.