### PR TITLE
Update gretl from 2020a to 2020b

### DIFF
--- a/Casks/gretl.rb
+++ b/Casks/gretl.rb
@@ -1,6 +1,6 @@
 cask 'gretl' do
-  version '2020a'
-  sha256 '00ee333c92caf9542498d1891d505e47029329a84f3cce9e4478739c8056184e'
+  version '2020b'
+  sha256 'a6537914d2e221b372c12261d224f14825563fe0bb69c7f980b16b277e09939e'
 
   # downloads.sourceforge.net/gretl was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gretl/gretl-#{version}-quartz.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.