### PR TITLE
Update meld from 3.19.2-r6,osx-15 to 3.21.0-r2,osx-18

### DIFF
--- a/Casks/meld.rb
+++ b/Casks/meld.rb
@@ -1,12 +1,14 @@
 cask 'meld' do
-  version '3.19.2-r6,osx-15'
-  sha256 '81f79f708346ffc489001fb54562d5ed7226f9d660fa225dc4f253fe3b01075b'
+  version '3.21.0-r2,osx-18'
+  sha256 'febb42a00c97b37be6c50168ebfdf33e67eb2ec07e5e5d1e75e75efcad7d394b'
 
   # github.com/yousseb/meld was verified as official when first introduced to the cask
   url "https://github.com/yousseb/meld/releases/download/#{version.after_comma}/meldmerge.dmg"
   appcast 'https://github.com/yousseb/meld/releases.atom'
   name 'Meld for OSX'
   homepage 'https://yousseb.github.io/meld/'
+
+  depends_on macos: '>= :high_sierra'
 
   app 'Meld.app'
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.