### PR TITLE
Update michaelvillar-timer from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/michaelvillar-timer.rb
+++ b/Casks/michaelvillar-timer.rb
@@ -1,6 +1,6 @@
 cask 'michaelvillar-timer' do
-  version '1.5.0'
-  sha256 '42f96d58b3c3f80b6f4e3aa92ce5894b7c8bbe0b91ec8c3ca1fef1f333d0b261'
+  version '1.5.1'
+  sha256 'c5f1bbbad6df63152cc0955a6bdc1c19f6caa570fd517a742a75e5453f01d9a3'
 
   url "https://github.com/michaelvillar/timer-app/releases/download/#{version}/Timer.app.zip"
   appcast 'https://github.com/michaelvillar/timer-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.