### PR TITLE
Update macdown from 0.7.3 to 0.7.2

### DIFF
--- a/Casks/macdown.rb
+++ b/Casks/macdown.rb
@@ -1,6 +1,6 @@
 cask 'macdown' do
-  version '0.7.3'
-  sha256 '57a0568354ee7af694e825f19f9f03b9844c6301c70ea04fb324b6efdf7fdcd0'
+  version '0.7.2'
+  sha256 '271f11eb64c19fccee2615e092067cdecc29adf0c2ed0703dae9acda8fa0a672'
 
   # github.com/MacDownApp/macdown was verified as official when first introduced to the cask
   url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.