### PR TITLE
Update preform from 3.4.3,195 to 3.4.4,250

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,9 +1,9 @@
 cask 'preform' do
-  version '3.4.3,195'
-  sha256 'b7da31eb8325fbafee78b4f4a7850eed064c934d6fe54baf0eb75f8475e2918d'
+  version '3.4.4,250'
+  sha256 '581267791d5a793e69792b1721ae4f768e484f9eb5477a02336288fdedebaec7'
 
   # s3.amazonaws.com/FormlabsReleases was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_release_#{version.before_comma}_build_#{version.after_comma}.dmg"
+  url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://formlabs.com/download-preform-mac/'
   name 'PreForm'
   homepage 'https://formlabs.com/tools/preform/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.