### PR TITLE
Update firecamp from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask 'firecamp' do
   version '1.2.2'
-  sha256 '1241c4ee06ff845cf4b2dfdeba73b77d54e01854f959f4e55d15b2f9b91caac2'
+  sha256 '3d42d0d2793c283f5b7f86179790b6c77f5fbdab5615a48aab61a04bcec5c572'
 
   # firecamp.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg"

--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,5 +1,5 @@
 cask 'firecamp' do
-  version '1.2.1'
+  version '1.2.2'
   sha256 '1241c4ee06ff845cf4b2dfdeba73b77d54e01854f959f4e55d15b2f9b91caac2'
 
   # firecamp.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask

--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask 'firecamp' do
-  version '1.2.0'
-  sha256 'f37e3df03a759d77ead93e3ab09f3b6365b876c3ef83febc914528ed629e58df'
+  version '1.2.1'
+  sha256 '1241c4ee06ff845cf4b2dfdeba73b77d54e01854f959f4e55d15b2f9b91caac2'
 
   # firecamp.ams3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.