### PR TITLE
Update macvim from 8.2.319,162 to 8.2.539,163

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -1,6 +1,6 @@
 cask 'macvim' do
-  version '8.2.319,162'
-  sha256 'be142e63ecc4266e139c894e373cdba5e0c10cd93ac13f9d3105de8ce266064a'
+  version '8.2.539,163'
+  sha256 '5ab07a704909b52fa2b28ffa69b06389447d8a013242354bae6c185b6df1da37'
 
   url "https://github.com/macvim-dev/macvim/releases/download/snapshot-#{version.after_comma}/MacVim.dmg"
   appcast 'https://github.com/macvim-dev/macvim/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.