### PR TITLE
Update gnucash from 3.9,1 to 3.10,1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask 'gnucash' do
-  version '3.9,1'
-  sha256 '121ccd52e49e27fd998ae8d2a34d65b3afd0ea184a5d752143008406a5e99053'
+  version '3.10,1'
+  sha256 '053764da1b4f87e2851372912ad503447bf96cd111b819a92f02319343f592f6'
 
   # github.com/Gnucash/gnucash was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.before_comma}/Gnucash-Intel-#{version.before_comma.chomp('b')}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.