### PR TITLE
Update vnote from 2.9 to 2.9.1

### DIFF
--- a/Casks/vnote.rb
+++ b/Casks/vnote.rb
@@ -1,6 +1,6 @@
 cask 'vnote' do
-  version '2.9'
-  sha256 'dabeb8bca928965a3c90f35025ea5b62a8e48470248e5200841ce16b59e9e9d8'
+  version '2.9.1'
+  sha256 '7611fca118e2b5894b1530ae049db9ede91ebbabdd6fc5f135cb61d724f8f12d'
 
   # github.com/tamlok/vnote was verified as official when first introduced to the cask
   url "https://github.com/tamlok/vnote/releases/download/v#{version}/VNote-#{version}-x64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.