### PR TITLE
Update dust3d from 1.0.0-rc.5 to 1.0.0-rc.6

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -1,6 +1,6 @@
 cask 'dust3d' do
-  version '1.0.0-rc.5'
-  sha256 'ece43219f8a1dba79261c71a3b0ec24b2e59e03de3cb52a19f59a88758638adc'
+  version '1.0.0-rc.6'
+  sha256 'bc2714e22a9c1ad712a9dc8fca806b50d1f47142da7e02e5a74ff95c402959aa'
 
   # github.com/huxingyi/dust3d was verified as official when first introduced to the cask
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.