### PR TITLE
Update simply-fortran from 3.11.3230 to 3.11.3231

### DIFF
--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -1,11 +1,11 @@
 cask 'simply-fortran' do
-  version '3.11.3230'
+  version '3.11.3231'
 
   if MacOS.version <= :mojave
     sha256 '88e0c516534aa344b31eb2beba99df48a7ddabde6a819da3acc29130ef3befd7'
     url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}.legacy.dmg"
   else
-    sha256 '370fec665d116014235998085ddc6b4d9a068c2443c91eeb7b2cc1c34448464e'
+    sha256 'dd390a2edd4c2c029872c48bd29fc7cf9a7d3ece7e71623566f1db9cbbff4a11'
     url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}.dmg"
   end
   appcast 'https://simplyfortran.com/download/?platform=macos',

--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -2,7 +2,7 @@ cask 'simply-fortran' do
   version '3.11.3231'
 
   if MacOS.version <= :mojave
-    sha256 '88e0c516534aa344b31eb2beba99df48a7ddabde6a819da3acc29130ef3befd7'
+    sha256 '753e3435c5311bb61edc422f7fe909ab608e38a1259b7a88a3397a3393c96fe9'
     url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}.legacy.dmg"
   else
     sha256 'dd390a2edd4c2c029872c48bd29fc7cf9a7d3ece7e71623566f1db9cbbff4a11'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.