### PR TITLE
Update crystalmaker from 10.5.0 to 10.5.1

### DIFF
--- a/Casks/crystalmaker.rb
+++ b/Casks/crystalmaker.rb
@@ -1,6 +1,6 @@
 cask 'crystalmaker' do
-  version '10.5.0'
-  sha256 '7bc6cd2498989ef7886cd17d7af24d30229b78998aefabf8e026301d42caf05e'
+  version '10.5.1'
+  sha256 'a0d0a2b1363514c24f03b7ffc85441a774275e00b48eeb25138f9929698e0b80'
 
   url 'http://crystalmaker.com/downloads/crystalmaker_mac.zip'
   appcast "http://crystalmaker.com/crystalmaker/release-notes/mac/#{version.major}/index.html"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.