### PR TITLE
Update cacher from 2.24.0 to 2.25.0

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.24.0'
-  sha256 '2553f91a55ba12ef4f27816ba17f558afa5d31bfe712e304c8bd7d3905b2ea78'
+  version '2.25.0'
+  sha256 'c9bdf143761f553ed32e843eafd699fc61dc3d077f2fcfcd466c23c50210f717'
 
   # cacher-download.nyc3.digitaloceanspaces.com was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.