### PR TITLE
Update freeplane from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,6 +1,6 @@
 cask 'freeplane' do
-  version '1.8.1'
-  sha256 '0f985264250e39d145f8762ab0c9d7e99908a1b1aa20eb0970d50876089df50d'
+  version '1.8.2'
+  sha256 '4dffa2932b640675d4df9bd742e735c5cee5983fafd51c49dfb39e9c90235d54'
 
   # downloads.sourceforge.net/freeplane was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/freeplane/freeplane%20stable/Freeplane-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.