### PR TITLE
Update tiger-trade from 5.3.1,20191224:BACCCE to 5.6.3,20200409:3E708C + add appcast

### DIFF
--- a/Casks/tiger-trade.rb
+++ b/Casks/tiger-trade.rb
@@ -1,6 +1,6 @@
 cask 'tiger-trade' do
-  version '5.3.1,20191224:BACCCE'
-  sha256 '34153f46fc100964934cdadc0a4ea751315d270da0834e4b8324f07d730b0797'
+  version '5.6.3,20200409:3E708C'
+  sha256 'd1056c280ef73996f863e93350a5e76bd0f4aebd5074034ce1073b17382eec83'
 
   # s.tigerfintech.com was verified as official when first introduced to the cask
   url "https://s.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version.before_comma}_#{version.after_comma.before_colon}_#{version.after_colon}.dmg"

--- a/Casks/tiger-trade.rb
+++ b/Casks/tiger-trade.rb
@@ -4,10 +4,10 @@ cask 'tiger-trade' do
 
   # s.tigerfintech.com was verified as official when first introduced to the cask
   url "https://s.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version.before_comma}_#{version.after_comma.before_colon}_#{version.after_colon}.dmg"
-  appcast 'https://www.itiger.com/download/mac'
+  appcast 'https://up.play-analytics.com/app/upgrade/latest?lang=zh_CN&platform=darwin&appVer=1'
   name 'Tiger Trade'
   name '老虎证券'
-  homepage 'https://www.itiger.com/'
+  homepage 'https://www.itiger.com/download/mac'
 
   depends_on macos: '>= :sierra'
 

--- a/Casks/tiger-trade.rb
+++ b/Casks/tiger-trade.rb
@@ -4,6 +4,7 @@ cask 'tiger-trade' do
 
   # s.tigerfintech.com was verified as official when first introduced to the cask
   url "https://s.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version.before_comma}_#{version.after_comma.before_colon}_#{version.after_colon}.dmg"
+  appcast 'https://www.itiger.com/download/mac'
   name 'Tiger Trade'
   name '老虎证券'
   homepage 'https://www.itiger.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.