### PR TITLE
Update michaelvillar-timer from 1.5.1 to 1.5.2

### DIFF
--- a/Casks/michaelvillar-timer.rb
+++ b/Casks/michaelvillar-timer.rb
@@ -1,6 +1,6 @@
 cask 'michaelvillar-timer' do
-  version '1.5.1'
-  sha256 'c5f1bbbad6df63152cc0955a6bdc1c19f6caa570fd517a742a75e5453f01d9a3'
+  version '1.5.2'
+  sha256 'f7adbf0f04ecdfb6cf914774859bc187d2ae944a51b748ddc82de4ecd34e9252'
 
   url "https://github.com/michaelvillar/timer-app/releases/download/#{version}/Timer.app.zip"
   appcast 'https://github.com/michaelvillar/timer-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.