### PR TITLE
Update unity from 2019.3.8f1,4ba98e9386ed to 2019.3.9f1,e6e740a1c473

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.3.8f1,4ba98e9386ed'
-  sha256 '0834335acad9909397f089031130c150a55e5d867727617fac50c75c06518dcb'
+  version '2019.3.9f1,e6e740a1c473'
+  sha256 '04cb4d805e7c80985188772c4b7d95f55e5c9ce8ade6a2f19d6c55961cbc846d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.