### PR TITLE
Update unity-ios-support-for-editor from 2019.3.8f1,4ba98e9386ed to 2019.3.9f1,e6e740a1c473

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.8f1,4ba98e9386ed'
-  sha256 'c38fb7146b4354c56236853557ccff3fa66851c5db6bcd6a20412788beee6d83'
+  version '2019.3.9f1,e6e740a1c473'
+  sha256 '08d708acfdd427d89a5d705fb00b0f2c6079342ac0dd2730a4d0f86d1bed29c0'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.