### PR TITLE
Update unity-lumin-support-for-editor from 2019.3.8f1,4ba98e9386ed to 2019.3.9f1,e6e740a1c473

### DIFF
--- a/Casks/unity-lumin-support-for-editor.rb
+++ b/Casks/unity-lumin-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-lumin-support-for-editor' do
-  version '2019.3.8f1,4ba98e9386ed'
-  sha256 '4b67c1b4eb2b2b9af31f27bacfbf1ce9f5ce8b86211c53baf330212895113551'
+  version '2019.3.9f1,e6e740a1c473'
+  sha256 '04560d0e9d1ef058eeb5cd89fb2302a0166e6ac760ea63e676ae13cd648152e8'
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Lumin-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.