### PR TITLE
Update unity-windows-support-for-editor from 2019.3.8f1,4ba98e9386ed to 2019.3.9f1,e6e740a1c473

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.3.8f1,4ba98e9386ed'
-  sha256 'bd8590ce30be8369be387f7ac335e1365baeef1e2008e4a027fbd0dc5948f8c9'
+  version '2019.3.9f1,e6e740a1c473'
+  sha256 'bc05589d4fdc12164a80a993e828acfba12982ac5c14a44a106c4b8bb54e4632'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.