### PR TITLE
Update lando from 3.0.0-rrc.3 to 3.0.0-rrc.4

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.0-rrc.3'
-  sha256 '01f93f409725fa892ddc9aca7bee95603ec92f3b35adfe7efd4a7f553fb094a3'
+  version '3.0.0-rrc.4'
+  sha256 '1d4536d817c0c73720e1c63143914b12b7d337b8e30350c1269924854fcfede2'
 
   # github.com/lando/lando was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.