### PR TITLE
fsnotes: fix sha256 for 4.1.3 download

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
   version '4.1.3'
-  sha256 '7d96b80c539ac1d291161f40344dbe192be790538cb02bf0a738303705bb441f'
+  sha256 'c17f9a93af86404b991ea1439d26b4550641292d2c600e1071c728af5ae467d7'
 
   # github.com/glushchenko/fsnotes was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
I am not sure if it was modified in-place since the 4.1.3 update was issued, 
but the asset downloaded to my machine has a different SHA-256 checksum
than the expected value here.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Before:

```text
$ brew cask install fsnotes
==> Downloading https://github.com/glushchenko/fsnotes/releases/download/4.1.3/FSNotes_4.1.3.zip
Already downloaded: /Users/parkr/Library/Caches/Homebrew/downloads/3018171411972c08b9323f997d16c11e472a4001c9feb6797247854353986b27--FSNotes_4.1.3.zip
==> Verifying SHA-256 checksum for Cask 'fsnotes'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
Error: Checksum for Cask 'fsnotes' does not match.
Expected: 7d96b80c539ac1d291161f40344dbe192be790538cb02bf0a738303705bb441f
  Actual: c17f9a93af86404b991ea1439d26b4550641292d2c600e1071c728af5ae467d7
    File: /Users/parkr/Library/Caches/Homebrew/downloads/3018171411972c08b9323f997d16c11e472a4001c9feb6797247854353986b27--FSNotes_4.1.3.zip
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/master/doc/reporting_bugs/checksum_does_not_match_error.md
```
