### PR TITLE
Update frescobaldi from 3.1.1 to 3.1.2

### DIFF
--- a/Casks/frescobaldi.rb
+++ b/Casks/frescobaldi.rb
@@ -1,6 +1,6 @@
 cask 'frescobaldi' do
-  version '3.1.1'
-  sha256 '06703429004db47b44b1743ef63e740b3d25048f254e6a27f4b4627bd3671bca'
+  version '3.1.2'
+  sha256 'd70c9004c6745c46b04bc28cda9bc1e6e664d4208090dd92e29f65cf10135d7f'
 
   # github.com/frescobaldi/frescobaldi was verified as official when first introduced to the cask
   url "https://github.com/frescobaldi/frescobaldi/releases/download/v#{version}/Frescobaldi-#{version}-x86_64.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

**I don't use Homebrew and haven't tested the change.**

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).