### PR TITLE
Update suspicious-package from 3.5.2 to 3.5.3

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -1,6 +1,6 @@
 cask 'suspicious-package' do
-  version '3.5.2'
-  sha256 'e84b090d3956edaec646a588c48a250608f4f8fbb5a24b07008cbf62eea04c16'
+  version '3.5.3'
+  sha256 'fad69db99a60058f8136954653fa2de81667f12cb731957a6d921d36ceaf195d'
 
   url 'https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg'
   appcast 'https://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.