### PR TITLE
Update openttd from 1.10.0 to 1.10.1

### DIFF
--- a/Casks/openttd.rb
+++ b/Casks/openttd.rb
@@ -1,6 +1,6 @@
 cask 'openttd' do
-  version '1.10.0'
-  sha256 'f4999e8676568ad87f933ba868e97dbe92fd6e47d4d821a3d33775b5d1c8dd39'
+  version '1.10.1'
+  sha256 'f35cef401dc3872d0e7cfb34cef24cd62cdaca0998d514905f8f8389986e2316'
 
   url "https://proxy.binaries.openttd.org/openttd-releases/#{version}/openttd-#{version}-macosx.zip"
   appcast 'https://www.openttd.org/downloads/openttd-releases/latest.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.