### PR TITLE
Update ticktick from 3.5.10,138 to 3.5.11,139

### DIFF
--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -1,6 +1,6 @@
 cask 'ticktick' do
-  version '3.5.10,138'
-  sha256 'a9f846e872c474d05e822e31de6383acb2dc6c4984041c8514ad4610c13e01b3'
+  version '3.5.11,139'
+  sha256 'aeb3da17db243e38913dde13515ad01ef3628977264e8c783253bdd9e0b35d48'
 
   # appest-public.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.before_comma}_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.