### PR TITLE
Update cabal from 5.0.0 to 5.0.1

### DIFF
--- a/Casks/cabal.rb
+++ b/Casks/cabal.rb
@@ -1,6 +1,6 @@
 cask 'cabal' do
-  version '5.0.0'
-  sha256 '897ddafb13ca78488490ac572b2da0400a5084d5a4a19efa21e22e82526c02ef'
+  version '5.0.1'
+  sha256 '0ca563c84fb7536f0d0f8eb2011a2175d68183cb89d139573a5004d2c0e60075'
 
   # github.com/cabal-club/cabal-desktop was verified as official when first introduced to the cask
   url "https://github.com/cabal-club/cabal-desktop/releases/download/v#{version}/cabal-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.