### PR TITLE
Update shotcut from 20.02.17 to 20.04.12

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,6 +1,6 @@
 cask 'shotcut' do
-  version '20.02.17'
-  sha256 'bfeff968a40e9a0e13016ba3f12627417281f95bf8e6cd0134668988bb11d3af'
+  version '20.04.12'
+  sha256 '8a11c1bb20fed5afcb134d77321a2b7dc2693146440b6228c1e3354c9e89413c'
 
   # github.com/mltframework/shotcut was verified as official when first introduced to the cask
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.