### PR TITLE
Update toptracker from 1.6.0.6502 to 1.6.1.6521

### DIFF
--- a/Casks/toptracker.rb
+++ b/Casks/toptracker.rb
@@ -1,6 +1,6 @@
 cask 'toptracker' do
-  version '1.6.0.6502'
-  sha256 'a4e2734c14d2d1b138650b4728f8bd8a5462547a038e7e206d6de57c8ba17003'
+  version '1.6.1.6521'
+  sha256 '2dab586d95fd0b853b23ead7c4ad2752c53adb09a80e76e28e8be232dc80c0ea'
 
   # d101nvfmxunqnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d101nvfmxunqnl.cloudfront.net/desktop/builds/mac/toptracker_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.