### PR TITLE
Update rotato from 97.1585820352 to 98.1586761954

### DIFF
--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -1,6 +1,6 @@
 cask 'rotato' do
-  version '97.1585820352'
-  sha256 '92902d4626441dc406877f5c53d27084c3467aed28005da51fbe50e97dcf69fb'
+  version '98.1586761954'
+  sha256 '7f03318c8593e31393c272a2f581c39815362ac8b55176955c23501e31f1b6ce'
 
   # dl.devmate.com/com.mortenjust.Rendermock was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.mortenjust.Rendermock/#{version.major}/#{version.minor}/DesignCamera-#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.