### PR TITLE
Update geph from 3.5.4 to 3.6.0

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.5.4'
-  sha256 'f4ef8fe1bc5e194ad34ecd917f7e6f4a7229d89fd181342561135d55fd71e145'
+  version '3.6.0'
+  sha256 '2490f4a82ca7233b9f43a238338dd94a86c7a22a91b1bddb8aaac629fc71d57d'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.