### PR TITLE
Update rstudio from 1.2.5033 to 1.2.5042

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -1,6 +1,6 @@
 cask 'rstudio' do
-  version '1.2.5033'
-  sha256 'b67c987569e4638f14d64178ce34201e036f7dd318917f99a7624036c3f56885'
+  version '1.2.5042'
+  sha256 '74ea68eb92a02f6ced3172b8571a76ed3b1568668d6001d196aaafd826952746'
 
   # rstudio.org was verified as official when first introduced to the cask
   url "https://download1.rstudio.org/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.