### PR TITLE
Update doxygen from 1.8.17 to 1.8.18

### DIFF
--- a/Casks/doxygen.rb
+++ b/Casks/doxygen.rb
@@ -1,6 +1,6 @@
 cask 'doxygen' do
-  version '1.8.17'
-  sha256 'bf051b2c26ad5569efe9ca09396199340d03c6c96d61b730d50d5cd8f547425b'
+  version '1.8.18'
+  sha256 '472d6bbf61621a3c3a7f9492ae604c2befb58a4b18d144166a674f398734864b'
 
   url "http://doxygen.nl/files/Doxygen-#{version}.dmg"
   appcast 'http://www.doxygen.nl/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.