### PR TITLE
Update feishu from 3.21.8 to 3.22.2

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,6 +1,6 @@
 cask 'feishu' do
-  version '3.21.8'
-  sha256 'bae4bbd8dfb37843402d8e75f051612a11cd247f9b696c6e2adbc623374ecac9'
+  version '3.22.2'
+  sha256 'e9361b0853b0bb4c01125d61accc9605be6b8ebfb35f5e4a06f166b6d5f7b9e3'
 
   # sf3-ttcdn-tos.pstatp.com was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.