### PR TITLE
Update massreplaceit from 3.1.1 to 3.1.2

### DIFF
--- a/Casks/massreplaceit.rb
+++ b/Casks/massreplaceit.rb
@@ -1,6 +1,6 @@
 cask 'massreplaceit' do
-  version '3.1.1'
-  sha256 'e44e97787a45b0ae52346f833c0ba3bf1383b407e0fc327d536347eb3eef5509'
+  version '3.1.2'
+  sha256 '784170af5de041adf04808ca3ab40d087051b59c6fde451b90e176ac883d5663'
 
   url 'http://www.hexmonkeysoftware.com/files/MassReplaceIt.dmg'
   appcast 'http://www.hexmonkeysoftware.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.