### PR TITLE
Update malwarebytes from 4.3.5.3517 to 4.3.6.3518

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '4.3.5.3517'
-  sha256 '7558291665fde852c98005d653e3ed4ba4f40da38ea02cd2b0c42519e28bc89e'
+  version '4.3.6.3518'
+  sha256 'c8ed7d5fa7fc40f431d68c668980b6556ca744e5ca78b20cafa0bed4d1e66ca9'
 
   # data-cdn.mbamupdates.com/web was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.