### PR TITLE
Added cask for Strawberry music player, v0.6.9

### DIFF
--- a/Casks/strawberry.rb
+++ b/Casks/strawberry.rb
@@ -1,0 +1,19 @@
+cask 'strawberry' do
+  version '0.6.9'
+  sha256 'ce9c6ca46a86b7b7f9456e9351d181ca33400508263f44dde91c3e495d994d20'
+
+  # github.com/strawberrymusicplayer/strawberry was verified as official when first introduced to the cask
+  url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}.dmg"
+  appcast 'https://github.com/strawberrymusicplayer/strawberry/releases.atom'
+  name 'Strawberry'
+  homepage 'https://www.strawberrymusicplayer.org/'
+
+  app 'strawberry.app'
+
+  zap trash: [
+               '~/Library/Application Support/Strawberry',
+               '~/Library/Caches/Strawberry',
+               '~/Library/Preferences/org.strawberrymusicplayer.Strawberry.plist',
+               '~/Library/Saved Application State/org.strawberrymusicplayer.strawberry.savedState',
+             ]
+end


### PR DESCRIPTION
[Strawberry music player](https://www.strawberrymusicplayer.org/) is a fork of [Clementine](https://www.clementine-player.org/). There is no stable version yet, most notably the media keys are not "captured" by Strawberry, i.e. the music plays/pauses but iTunes is also started. There seems to be some GUI issue switching between the different sections in the settings window as well.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or **[documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version)**.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
