### PR TITLE
Revert vlc from 3.0.9.2 to 3.0.8 + update appcast 

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -3,7 +3,7 @@ cask 'vlc' do
   sha256 '422aaf37cd12cdc49f27a5f8fa9a16d287ea8ae8f451cedc8b7a2e0b5d39c068'
 
   url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
-  appcast 'https://download.videolan.org/pub/videolan/vlc/'
+  appcast 'https://www.videolan.org/vlc/download-macosx.html'
   name 'VLC media player'
   homepage 'https://www.videolan.org/vlc/'
 

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,6 +1,6 @@
 cask 'vlc' do
-  version '3.0.9.2'
-  sha256 'a30ca5f664c27c64f0df8ed64e85844a3422ba8dcf9b962e02acfbdd63a17190'
+  version '3.0.8'
+  sha256 '422aaf37cd12cdc49f27a5f8fa9a16d287ea8ae8f451cedc8b7a2e0b5d39c068'
 
   url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}.dmg"
   appcast 'https://download.videolan.org/pub/videolan/vlc/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.