### PR TITLE
Update oracle-jdk-javadoc from 14,36:076bab302c7b4508975440c56f6cc26a to 14.0.1,7:664493ef4a6946b186ff29eb326336a2

### DIFF
--- a/Casks/oracle-jdk-javadoc.rb
+++ b/Casks/oracle-jdk-javadoc.rb
@@ -1,6 +1,6 @@
 cask 'oracle-jdk-javadoc' do
-  version '14,36:076bab302c7b4508975440c56f6cc26a'
-  sha256 '7134633321d30fa6be8eecd403900ac71d93bdaa2d330e701a87f21ef7131ff7'
+  version '14.0.1,7:664493ef4a6946b186ff29eb326336a2'
+  sha256 'ec3e41df14e63ee111a716126191464bc8791f98e50c3188e258aab3010fdc9d'
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.