### PR TITLE
Update url and hompage in eqmac.rb

### DIFF
--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -3,10 +3,10 @@ cask 'eqmac' do
   sha256 'ff60579197b52571d9686bbfaec695dfa75797b8a9314fbf69a673bbeb12e1fc'
 
   # github.com/nodeful/eqMac was verified as official when first introduced to the cask
-  url "https://github.com/nodeful/eqMac#{version.major}/releases/download/V#{version}/eqMac#{version.major}.dmg"
-  appcast "https://github.com/nodeful/eqMac#{version.major}/releases.atom"
+  url "https://github.com/nodeful/eqMac/releases/download/V#{version}/eqMac#{version.major}.dmg"
+  appcast "https://github.com/nodeful/eqMac/releases.atom"
   name 'eqMac'
-  homepage 'https://www.bitgapp.com/eqmac/'
+  homepage 'https://github.com/bitgapp/eqMac/releases/'
 
   app "eqMac#{version.major}.app"
   installer script: {

--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -2,9 +2,8 @@ cask 'eqmac' do
   version '2.2'
   sha256 'ff60579197b52571d9686bbfaec695dfa75797b8a9314fbf69a673bbeb12e1fc'
 
-  # github.com/nodeful/eqMac was verified as official when first introduced to the cask
-  url "https://github.com/nodeful/eqMac/releases/download/V#{version}/eqMac#{version.major}.dmg"
-  appcast "https://github.com/nodeful/eqMac/releases.atom"
+  url "https://github.com/bitgapp/eqMac/releases/download/V#{version}/eqMac#{version.major}.dmg"
+  appcast 'https://github.com/bitgapp/eqMac/releases.atom'
   name 'eqMac'
   homepage 'https://github.com/bitgapp/eqMac/releases/'
 


### PR DESCRIPTION
the official website just offers the beta version as download - version 2.2 is only available on github - so I think the website should also link to this site … 