### PR TITLE
Update praat from 6.1.11 to 6.1.12

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask 'praat' do
-  version '6.1.11'
-  sha256 '020ad9d9addea38c8b34f4076059d6c8ccee210ace3102d11cbe08eb848b2aac'
+  version '6.1.12'
+  sha256 'c3da9f39833f923f40f91e3842cf5730f72b17fb06eb365df807a06a7a108c06'
 
   # github.com/praat/praat was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.