### PR TITLE
Update bloodhound from 3.0.3 to 3.0.4

### DIFF
--- a/Casks/bloodhound.rb
+++ b/Casks/bloodhound.rb
@@ -1,6 +1,6 @@
 cask 'bloodhound' do
-  version '3.0.3'
-  sha256 '13694645a7643abaa67d282782fdb6f7e246ab06436ff22f6a4dae55c65af5df'
+  version '3.0.4'
+  sha256 'a0411b1b8ea64d342813eefa92371a40ea46ae27bcfca61b72a66950322ecd3f'
 
   url "https://github.com/BloodHoundAD/BloodHound/releases/download/#{version}/BloodHound-darwin-x64.zip"
   appcast 'https://github.com/BloodHoundAD/BloodHound/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.