### PR TITLE
Update thought-train from 1.2 to 1.3

### DIFF
--- a/Casks/thought-train.rb
+++ b/Casks/thought-train.rb
@@ -1,6 +1,6 @@
 cask 'thought-train' do
-  version '1.2'
-  sha256 'cc8ed67924f2a30c54922a525e3f983afd2745f89db45abdb90ae1c9a12a631c'
+  version '1.3'
+  sha256 '33460d0028807d1875a5e2ee0a197286dbfcc1f1bfab4f14fe63cbdd41686699'
 
   url "https://thoughttrain.cc/downloads/thought-train-#{version}.pkg"
   appcast 'https://github.com/marcperel/thought-train-production/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.