### PR TITLE
Update noxappplayer from 3.0.0.0,20200315:b101bb5a99074327abab2da0bafd2a74 to 3.0.1.0,20200414:e34827a24f3b4c16b3d61a88eda7fc43

### DIFF
--- a/Casks/noxappplayer.rb
+++ b/Casks/noxappplayer.rb
@@ -1,6 +1,6 @@
 cask 'noxappplayer' do
-  version '3.0.0.0,20200315:b101bb5a99074327abab2da0bafd2a74'
-  sha256 'adf67436ef9561598aa3a4d60a1b445b209a3c5ea1b047a2ccd304b68e340890'
+  version '3.0.1.0,20200414:e34827a24f3b4c16b3d61a88eda7fc43'
+  sha256 '77c35b79a6ee1225f15c806bcbbfbaf35de88a249e21867cd231529da74c8ade'
 
   url "https://res06.bignox.com/full/#{version.after_comma.before_colon}/#{version.after_colon}.dmg?filename=Nox_installer_for_mac_intl_#{version.before_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.bignox.com/en/download/fullPackage/mac_fullzip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.