### PR TITLE
Update metabase from 0.35.1 to 0.35.2

### DIFF
--- a/Casks/metabase.rb
+++ b/Casks/metabase.rb
@@ -1,6 +1,6 @@
 cask 'metabase' do
-  version '0.35.1'
-  sha256 '967bd3806a455b56b8f22df35e77f765e5b0abb0aefd7a31572c230d669a1fe3'
+  version '0.35.2'
+  sha256 '06d56f3e81b9647c6c150c4406d4d340861c4e93ea332fe2e2f45e19110e2cb3'
 
   # s3.amazonaws.com/downloads.metabase.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/downloads.metabase.com/v#{version}/Metabase.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.