### PR TITLE
Update packages from 1.2.8 to 1.2.9

### DIFF
--- a/Casks/packages.rb
+++ b/Casks/packages.rb
@@ -1,6 +1,6 @@
 cask 'packages' do
-  version '1.2.8'
-  sha256 '8fdbd3355ac4b347b3097261e2ec0c4076486229051e80169f3ede0ca50cfa51'
+  version '1.2.9'
+  sha256 '70ac111417728c17b1f27d5520afd87c33f899f12de8ace0f703e3e1c500b28e'
 
   url 'http://s.sudre.free.fr/Software/files/Packages.dmg'
   appcast 'http://s.sudre.free.fr/Software/documentation/RemoteVersion.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.