### PR TITLE
Update fl-studio from 20.6.2.880 to 20.7.0.988

### DIFF
--- a/Casks/fl-studio.rb
+++ b/Casks/fl-studio.rb
@@ -1,6 +1,6 @@
 cask 'fl-studio' do
-  version '20.6.2.880'
-  sha256 'd01cc74d9031efd4c7e9dc08a2740b583730db47856465fcad53f42745843edd'
+  version '20.7.0.988'
+  sha256 '3f321984517de9d4d8fe13921f0bff245b201e625bf39ebc3ce8f405ddb6639f'
 
   url "http://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.image-line.com/redirect/flstudio20_mac_installer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.