### PR TITLE
Update freeyourmusic from 5.1.4 to 5.1.5

### DIFF
--- a/Casks/freeyourmusic.rb
+++ b/Casks/freeyourmusic.rb
@@ -1,6 +1,6 @@
 cask 'freeyourmusic' do
-  version '5.1.4'
-  sha256 '330056bcf2be7cd69a6f077d0466d081e5e3b86a6006ddba1a7a96f6f3133ffa'
+  version '5.1.5'
+  sha256 'c7f96d1063061a850aba4eb2d8d5887e6f17cee8d379bb70a3fcf697c15c9aff'
 
   # dzqeytqqx888.cloudfront.net was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/FreeYourMusic-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.