### PR TITLE
Update studio-3t from 2020.3.1 to 2020.4.0

### DIFF
--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -1,6 +1,6 @@
 cask 'studio-3t' do
-  version '2020.3.1'
-  sha256 '7ef08f40592bd0194cd4c78d87f9a2bc31f63d64525e97c7f55d5320c8c8c418'
+  version '2020.4.0'
+  sha256 'bc17df00dcf156a160ab318ccacdf2e0157b89b875ab9b651233889bc0fd5cc2'
 
   url "https://download.studio3t.com/studio-3t/mac/#{version}/Studio-3T.dmg"
   appcast 'https://files.studio3t.com/changelog/changelog.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.