### PR TITLE
Update cityofzion-neon from 2.4.0 to 2.5.0

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,8 +1,8 @@
 cask 'cityofzion-neon' do
-  version '2.4.0'
-  sha256 'cf469cb239902fcf07c94a15ea575bca48279fbd46084730b64c98384f43caac'
+  version '2.5.0'
+  sha256 '511208e87d3bf45e61ca943686f09bd8b79a6c4fdd8c66480bc3693840fb6c86'
 
-  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.dmg"
+  url "https://github.com/CityOfZion/neon-wallet/releases/download/#{version}/Neon-#{version}.Mac.dmg"
   appcast 'https://github.com/CityOfZion/neon-wallet/releases.atom'
   name 'Neon Wallet'
   homepage 'https://github.com/CityOfZion/neon-wallet'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.