### PR TITLE
Update weiyun from 3.0.3.403_ce6a9d to 3.0.4.406_2dc389

### DIFF
--- a/Casks/weiyun.rb
+++ b/Casks/weiyun.rb
@@ -1,6 +1,6 @@
 cask 'weiyun' do
-  version '3.0.3.403_ce6a9d'
-  sha256 'd8ae1a7cb20b9367cd14e4e4f52e56dacd1fc72c69e6cbaee0efba4d79c17f95'
+  version '3.0.4.406_2dc389'
+  sha256 'be41ee57871992cb4ecfd477ecbb2bb6c264512c531d92c7f4ddf356b48bd64e'
 
   # dldir1.qq.com/weiyun was verified as official when first introduced to the cask
   url "https://dldir1.qq.com/weiyun/Weiyun_Mac_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.