### PR TITLE
Update free-download-manager from 5.1 to 5.1.38

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,8 +1,8 @@
 cask 'free-download-manager' do
-  version '5.1'
+  version '5.1.38'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://dn3.freedownloadmanager.org/#{version.major}/#{version}-latest/fdm.dmg"
+  url "https://dn3.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
   appcast 'https://www.freedownloadmanager.org/download.htm'
   name 'Free Download Manager'
   homepage 'https://www.freedownloadmanager.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.