### PR TITLE
Update Axe Electrum to 3.3.8.6

### DIFF
--- a/Casks/axe-electrum.rb
+++ b/Casks/axe-electrum.rb
@@ -1,6 +1,6 @@
 cask 'axe-electrum' do
-  version '3.3.8.5'
-  sha256 '8e71de1959c8306c8f3ae24d3eb74a2d8430ffa322939aac14328712a6d13124'
+  version '3.3.8.6'
+  sha256 '0bedd0d20de4468888fde78e91bf23fd127aac6d5478d5b26c74c13baad899d9'
 
   url "https://github.com/axerunners/electrum-axe/releases/download/#{version}/axe-electrum-#{version}-macosx.dmg"
   appcast 'https://github.com/axerunners/electrum-axe/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).