### PR TITLE
Update github from 2.4.0-568b4113 to 2.4.1-aae6e805

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,6 +1,6 @@
 cask 'github' do
-  version '2.4.0-568b4113'
-  sha256 'eb51e1af32078616f730c7161f46a17a0dbbd73a998837fa3dda59a2546cd31a'
+  version '2.4.1-aae6e805'
+  sha256 '579ae9918179ef884f8bd22c50375cef9310fd81f87b3b4462f8a95e03176878'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.