### PR TITLE
Update corretto from 11.0.6.10.1-2 to 11.0.7.10.1

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -3,7 +3,7 @@ cask 'corretto' do
   sha256 'efd6cba4404041ef6ac3e882042f12c76b844d918f83b56493187df3bae3815e'
 
   url "https://corretto.aws/downloads/resources/#{version.sub(%r{-\d+}, '')}/amazon-corretto-#{version}-macosx-x64.pkg"
-  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.pkg"
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.pkg'
   name 'Amazon Corretto'
   homepage 'https://corretto.aws/'
 

--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -3,7 +3,7 @@ cask 'corretto' do
   sha256 'efd6cba4404041ef6ac3e882042f12c76b844d918f83b56493187df3bae3815e'
 
   url "https://corretto.aws/downloads/resources/#{version.sub(%r{-\d+}, '')}/amazon-corretto-#{version}-macosx-x64.pkg"
-  appcast "https://docs.aws.amazon.com/en_us/corretto/latest/corretto-#{version.major}-ug/corretto-#{version.major}-ug.rss"
+  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.pkg"
   name 'Amazon Corretto'
   homepage 'https://corretto.aws/'
 

--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,6 +1,6 @@
 cask 'corretto' do
-  version '11.0.6.10.1-2'
-  sha256 '401d569df7771aacaf8ea3a1ceadf38c1044ab9737ddb21685b375f395adbf50'
+  version '11.0.7.10.1'
+  sha256 'efd6cba4404041ef6ac3e882042f12c76b844d918f83b56493187df3bae3815e'
 
   url "https://corretto.aws/downloads/resources/#{version.sub(%r{-\d+}, '')}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://docs.aws.amazon.com/en_us/corretto/latest/corretto-#{version.major}-ug/corretto-#{version.major}-ug.rss"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.