### PR TITLE
Update vscodium from 1.44.0 to 1.44.1

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.44.0'
-  sha256 '676ec94b36c9740caf8b08c845c0fde4ec4020ee0444178a56cee18a95d73031'
+  version '1.44.1'
+  sha256 '4bfa6261e7d95c6457ebc49d6928a00f13c7f2d36954eebcecf26683b151fe31'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{version}.dmg"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
