### PR TITLE
Update pkg.md documentation

### DIFF
--- a/doc/cask_language_reference/stanzas/pkg.md
+++ b/doc/cask_language_reference/stanzas/pkg.md
@@ -24,7 +24,7 @@ pkg 'AlinofTimer.pkg', allow_untrusted: true
 
 ## `pkg choices:`
 
-`pkg choices:` can be used to override `.pkg`’s default install options via `-applyChoiceChangesXML`. It uses a deserialized version of the `choiceChanges` property list (refer to the `CHOICE CHANGES FILE` section of the [`installer` man page](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/installer.8.html) for further information).
+`pkg choices:` can be used to override `.pkg`’s default install options via `-applyChoiceChangesXML`. It uses a deserialized version of the `choiceChanges` property list (refer to the `CHOICE CHANGES FILE` section of the `installer` manual page by running the command `man installer` for further information).
 
 Running the  macOS command:
 


### PR DESCRIPTION
Discovered this while preparing https://github.com/Homebrew/homebrew-cask/pull/80371 and https://github.com/Homebrew/homebrew-cask/pull/80372.

The [original link](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/installer.8.html) no longer exists, and it appears that [Apple has removed many of these links](https://apple.stackexchange.com/questions/239484/does-apple-provide-a-web-site-with-content-of-man-pages-for-the-command-line-c), so I just replaced it with a suggestion to run `man installer`. 