### PR TITLE
Update pyfa from 2.19.0 to 2.20.0

### DIFF
--- a/Casks/pyfa.rb
+++ b/Casks/pyfa.rb
@@ -1,6 +1,6 @@
 cask 'pyfa' do
-  version '2.19.0'
-  sha256 '7ea8afa615f8c8f1b8be4d50c9cced6f219d85fa1c357e3d1f6982ca6c46ea89'
+  version '2.20.0'
+  sha256 '36a1aa25e7b5cbc385e21749fc13a3f1629d7b05a3a1c7c072e79ae92cae700a'
 
   url "https://github.com/pyfa-org/Pyfa/releases/download/v#{version}/pyfa-v#{version}-mac.zip"
   appcast 'https://github.com/pyfa-org/Pyfa/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

(Hopefully) closes https://github.com/Homebrew/homebrew-cask/pull/80214