### PR TITLE
Update 115browser from 12.0.0.4 to 13.0.0.2

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,6 +1,6 @@
 cask '115browser' do
-  version '12.0.0.4'
-  sha256 'd287e072b6a419606e67e4c19747b95918b0c2e578cb6e465edaa5c9083276c1'
+  version '13.0.0.2'
+  sha256 '7f3760fe29d741b73b844083ce430c1aa09475ba0e475bc61101cb7d6acbddbd'
 
   url "https://down.115.com/client/mac/115pc_#{version}.dmg"
   appcast 'https://appversion.115.com/1/web/1.0/api/chrome?callback=get_version'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.