### PR TITLE
Update webcatalog from 20.3.1 to 20.4.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.3.1'
-  sha256 '7c4ee20c7e275221455e1157920fe0bde2de5b98c59c2eac7576406588be5228'
+  version '20.4.0'
+  sha256 'da748311bbf568e67c2278b50ac5f33bff7e5d3b8dc325e421a2a49f34a1cd4f'
 
   # github.com/quanglam2807/webcatalog was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.