### PR TITLE
Update bitrix24 from 8.1.0.44 to 8.2.69.48

### DIFF
--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -1,7 +1,7 @@
 cask 'bitrix24' do
   # note: "24" is not a version number, but an intrinsic part of the product name
-  version '8.1.0.44'
-  sha256 '4494265baf3a9927d929131274f7f75d1b05f9bb3c6f1a81ecb7882288a7ca7d'
+  version '8.2.69.48'
+  sha256 '6fbfa5c12a18e3b2eec15e765991d008f47a20026632b6eb6881bf555aaaf30c'
 
   url 'https://dl.bitrix24.com/b24/bitrix24_desktop.dmg'
   appcast 'https://www.bitrix24.com/osx_version.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.