### PR TITLE
Update joplin from 1.0.200 to 1.0.201

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask 'joplin' do
-  version '1.0.200'
-  sha256 'fec1143e536ae668e5c075c62818115ae1e1ae17f621cb501467a7b30cc88949'
+  version '1.0.201'
+  sha256 '5903df1076160376fac4b575f71e435b9fbfa5907d5896430883ff6c73d5dbf5'
 
   # github.com/laurent22/joplin was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.