### PR TITLE
Update tidepool-uploader from 2.28.0 to 2.28.1

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.28.0'
-  sha256 '239c308e760f2d7977ef810325e66b84460a17fabb5d90a6286906d83e7fac21'
+  version '2.28.1'
+  sha256 '7f7b0642a8b0e72d1931409c63cec0af8e15f88d9e1aabbff240c31fed6b720a'
 
   # github.com/tidepool-org/chrome-uploader was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.