### PR TITLE
Update sound-siphon from 3.2.1,5876 to 3.2.2,5876

### DIFF
--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -1,6 +1,6 @@
 cask 'sound-siphon' do
-  version '3.2.1,5876'
-  sha256 'a3e28bdb4e848b43a84834ad1c07db3ddfc6c4970cd1624f7fa6133531971619'
+  version '3.2.2,5876'
+  sha256 '2808036adb72a247af9115eb2ea731574345acfea5cd0694c049f3fe89d4a6b6'
 
   # staticz.net was verified as official when first introduced to the cask
   url "https://staticz.com/download/#{version.after_comma}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.