### PR TITLE
Update sound-control from 2.4.1,5156 to 2.4.2,5156

### DIFF
--- a/Casks/sound-control.rb
+++ b/Casks/sound-control.rb
@@ -1,6 +1,6 @@
 cask 'sound-control' do
-  version '2.4.1,5156'
-  sha256 '8cd697bc1879eb36fb2e6dde5e64e06b927adea52f2c664d839864c129a0bffa'
+  version '2.4.2,5156'
+  sha256 '16597cf39c91b1bdd012684e09d68050ac117ba812336651ce9d704e303816e6'
 
   # staticz.net was verified as official when first introduced to the cask
   url "https://staticz.com/download/#{version.after_comma}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.