### PR TITLE
Update keep-it from 1.8.5 to 1.8.6

### DIFF
--- a/Casks/keep-it.rb
+++ b/Casks/keep-it.rb
@@ -1,6 +1,6 @@
 cask 'keep-it' do
-  version '1.8.5'
-  sha256 '8d38683b97f4fa982a7954342abe287eee48fa6d0a2dd02073760354a25cb9a1'
+  version '1.8.6'
+  sha256 'a4698b1a9b0a24c25568a67cef04f09ef0a7584ce6a879b5ebde4cadec42cd76'
 
   url "https://reinventedsoftware.com/keepit/downloads/KeepIt_#{version}.dmg"
   appcast 'https://reinventedsoftware.com/keepit/downloads/keepit.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.