### PR TITLE
Update navicat-for-sql-server from 15.0.12 to 15.0.14

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.12'
-  sha256 '953c9e149f7ad50bc614cc8964f1529f8b31276960fee2876e88fe8b637561da'
+  version '15.0.14'
+  sha256 '3bcbe21610791e73773e3a968019b8415b8cf56f6ca3ae8ed943c50b69957ce6'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.