### PR TITLE
Update fastrawviewer from 1.5.5.1599 to 1.5.6.1615

### DIFF
--- a/Casks/fastrawviewer.rb
+++ b/Casks/fastrawviewer.rb
@@ -1,6 +1,6 @@
 cask 'fastrawviewer' do
-  version '1.5.5.1599'
-  sha256 '08d2226cd9f8184ddac0fd5ddd50014c54d33eb74dcc39d6bc531482de42d73e'
+  version '1.5.6.1615'
+  sha256 'c46b9905f80628dc22e079368cf85726a6dcee9348a70a267bb2a16d8a2a97a2'
 
   url "https://updates.fastrawviewer.com/data/FastRawViewer-#{version}.dmg"
   appcast 'https://www.fastrawviewer.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.