### PR TITLE
Update arq from 6.1.15 to 6.2.0

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '6.1.15'
-  sha256 'a09c5d0e3c490c8510a9ab0ad8bdf2cd896b7277f0a50bb670aa3586dd30fe0c'
+  version '6.2.0'
+  sha256 'bd127a45d3c6635340883618f9eec8cc876ef201d52b289aa7906392cab30698'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"
   appcast 'https://www.arqbackup.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.