### PR TITLE
Update signal from 1.33.0 to 1.33.1

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.33.0'
-  sha256 'debd956851098ced478de88d70c0f827f10248f78c4c0fcf1cb0dc3e6ddd906c'
+  version '1.33.1'
+  sha256 '05601f19e35b7defe9ae9291ba21ccc4d65f363841b0dc18fbabd27cedbad27d'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.