### PR TITLE
Update baidunetdisk from 3.0.6.2 to 3.1.0

### DIFF
--- a/Casks/baidunetdisk.rb
+++ b/Casks/baidunetdisk.rb
@@ -1,9 +1,9 @@
 cask 'baidunetdisk' do
-  version '3.0.6.2'
-  sha256 '644bee905013bbc7c967819656441ba343850a168611cb80a4b5fedcfb792134'
+  version '3.1.0'
+  sha256 'c6017603268449774bcea61a9385ba7fc913614121ef75da047e793de5fba125'
 
   # baidupcs.com/issue/netdisk/MACguanjia was verified as official when first introduced to the cask
-  url "https://issuecdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
+  url "http://wppkg.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
   appcast 'https://pan.baidu.com/disk/cmsdata?do=client'
   name 'Baidu NetDisk'
   name '百度网盘'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.