### PR TITLE
Update netxms-console from 3.2.484 to 3.2.493

### DIFF
--- a/Casks/netxms-console.rb
+++ b/Casks/netxms-console.rb
@@ -1,6 +1,6 @@
 cask 'netxms-console' do
-  version '3.2.484'
-  sha256 '5e6e5adeee6295ad6358caec7d9f53b1dec459e1b50951fa5cbc9c29fdb56432'
+  version '3.2.493'
+  sha256 '4b719422be4cfaf46d2a5ce243e9282aa8edf6aa030f72a6770e00d2896be7bb'
 
   url "https://netxms.org/download/releases/#{version.major_minor}/nxmc-#{version}.dmg"
   appcast "https://netxms.org/download/releases/#{version.major_minor}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.