### PR TITLE
Update libreoffice from 6.4.2 to 6.4.3

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice' do
-  version '6.4.2'
-  sha256 '2b60da51282204cb581bd5a91bcb38256385098e5d29f77c82bc246695d6068b'
+  version '6.4.3'
+  sha256 'ea61587defa5e7cb9025aa6857eb760c9c2be1c5ba88f07c3c623ff139330b27'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.