### PR TITLE
Upgrade Plexamp to v3

### DIFF
--- a/Casks/plexamp.rb
+++ b/Casks/plexamp.rb
@@ -2,7 +2,9 @@ cask 'plexamp' do
   version '3.0.0'
   sha256 '96781e3924c523a85a9017fdb1a403269d3afcb8576e443f8f29669eb838bbd1'
 
+  # plexamp.plex.tv was verified as official when first introduced to the cask
   url "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-#{version}.dmg"
+  appcast 'https://plexamp.plex.tv/plexamp.plex.tv/desktop/latest-mac.yml'
   name 'Plexamp'
   homepage 'https://plexamp.com/'
 

--- a/Casks/plexamp.rb
+++ b/Casks/plexamp.rb
@@ -1,11 +1,10 @@
 cask 'plexamp' do
-  version '1.1.0'
-  sha256 'f48bf6ee4a7353ed457501ce0d3cdfb4e736c1ea9b223011b6ba8d32f5f6daab'
+  version '3.0.0'
+  sha256 '96781e3924c523a85a9017fdb1a403269d3afcb8576e443f8f29669eb838bbd1'
 
-  url "https://plexamp.plex.tv/plexamp.plex.tv/Plexamp-#{version}.dmg"
-  appcast 'https://www.plex.tv/plex-labs/#modal-plexamp-downloads'
+  url "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-#{version}.dmg"
   name 'Plexamp'
-  homepage 'https://www.plex.tv/plex-labs/#plexamp'
+  homepage 'https://plexamp.com/'
 
   app 'Plexamp.app'
 end


### PR DESCRIPTION
Upgrades the cask to v3.0.0 of Plexamp including the new domain and download locations.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

I had to remove the appcast URL, not sure what to do with the following error:
```
❯ "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/developer/bin/find-appcast" /Applications/Plexamp.app
Looking for Sparkle appcast… Not found.
Looking for electron-builder appcast… Not found.

An "app-update.yml" file was found, but we could not parse it.
Please report this on https://github.com/Homebrew/homebrew-cask/
Provide this info:

provider: s3
bucket: plexamp.plex.tv
endpoint: 'https://plexamp.plex.tv'
path: desktop
updaterCacheDirName: plexamp-updater
```

Style also yells at me with:
```
C:  5:  3: plexamp.plex.tv does not match plexamp.com, a comment has to be added above the url stanza. For details, see https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment
```

Should I add the comment:
```
# plexamp.plex.tv was verified as official when first introduced to the cask
```

If we go to https://plexamp.com/#downloads, that is the provided domain (looks like an alias to the S3 bucket they are using from what I can see). 