### PR TITLE
Update electerm from 1.3.15 to 1.3.18

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.15'
-  sha256 'cd84821e9334094a136dd1c3b619eb570eb95f96f618a2cf4506f826e31f3ec0'
+  version '1.3.18'
+  sha256 '813880b59f7525c5f6fca39d1c364f49d3ffe766310ae2ceb2b0fd255a982cca'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.