### PR TITLE
Update masscode from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/masscode.rb
+++ b/Casks/masscode.rb
@@ -1,6 +1,6 @@
 cask 'masscode' do
-  version '1.2.0'
-  sha256 'eb2b26b44eba15fa735d8dbbac6e5ca8838766f471ccd4ef4d3685766b43a4b4'
+  version '1.2.1'
+  sha256 'b0c94f5f3db37cd4d7305fa1e6c42dc6e3c9651fce621fe4263849c9994252ed'
 
   # github.com/antonreshetov/massCode was verified as official when first introduced to the cask
   url "https://github.com/antonreshetov/massCode/releases/download/v#{version}/massCode-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.