### PR TITLE
Update strongvpn from 2.2.1,44950 to 2.2.2,45556

### DIFF
--- a/Casks/strongvpn.rb
+++ b/Casks/strongvpn.rb
@@ -1,6 +1,6 @@
 cask 'strongvpn' do
-  version '2.2.1,44950'
-  sha256 '6431ed45898870497f92bfa4192314e7dcd68b6e59065b5473dade12e096a042'
+  version '2.2.2,45556'
+  sha256 'a86e394249155fdca02f65ebad8bc269274b69aee6134b9b41e0abaff69030bc'
 
   # static.colomovers.com was verified as official when first introduced to the cask
   url 'https://static.colomovers.com/mac/StrongVPN.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.