### PR TITLE
Update chalk from 1.4.2 to 1.5.1

### DIFF
--- a/Casks/chalk.rb
+++ b/Casks/chalk.rb
@@ -1,6 +1,6 @@
 cask 'chalk' do
-  version '1.4.2'
-  sha256 '040d6cb7891121fd16f1628632bfd94537483bd4e28bc05b8c831e8de734374c'
+  version '1.5.1'
+  sha256 'c813ced44061d77e351abdbcdc798bce034eff18d120d3f7ed0277cda4c0c89c'
 
   url "https://www.chachatelier.fr/chalk/downloads/Chalk-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.