### PR TITLE
Update xact from 2.48 to 2.49

### DIFF
--- a/Casks/xact.rb
+++ b/Casks/xact.rb
@@ -1,6 +1,6 @@
 cask 'xact' do
-  version '2.48'
-  sha256 'c42998dfc1c5fcfec5c81cf3a8715e257aa23232324e102c3d6a644b2188ae0c'
+  version '2.49'
+  sha256 'b54d15865424964670720b58d8b3a68a51d536ad9f0b286dae99668b94811c00'
 
   url "http://xact.scottcbrown.org/xACT#{version}.zip"
   appcast 'http://xactupdate.scottcbrown.org/xACT.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.