### PR TITLE
Update vsee from 4.7.3,40556 to 4.8.0,40948

### DIFF
--- a/Casks/vsee.rb
+++ b/Casks/vsee.rb
@@ -1,6 +1,6 @@
 cask 'vsee' do
-  version '4.7.3,40556'
-  sha256 '604de91563fc23859f14d0974a77611106c6a659e4a438f28f841da6d6623ffe'
+  version '4.8.0,40948'
+  sha256 '2d95b055d95aea74c92c27cb52d572af7ff080e554181c4149c02337facb6ae0'
 
   # d2q5hugz2rti4w.cloudfront.net was verified as official when first introduced to the cask
   url "https://d2q5hugz2rti4w.cloudfront.net/mac/#{version.after_comma}/vseemac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.