### PR TITLE
Update querious from 3.0.3 to 3.0.4

### DIFF
--- a/Casks/querious.rb
+++ b/Casks/querious.rb
@@ -1,6 +1,6 @@
 cask 'querious' do
-  version '3.0.3'
-  sha256 'f65a2ca31954c6dfb83e78be65450c830b32ae638ad02c18c3f71bc8a694dc1c'
+  version '3.0.4'
+  sha256 '464c028f30d88f840dc52cc9fb0401e0283c28754dfc3e0f89dd960960209fcc'
 
   url "https://www.araelium.com/querious/downloads/versions/Querious#{version}.zip"
   appcast 'https://arweb-assets.s3.amazonaws.com/downloads/querious/updates.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.