### PR TITLE
Update lazarus from 2.0.6 to 2.0.8

### DIFF
--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -1,6 +1,6 @@
 cask 'lazarus' do
-  version '2.0.6'
-  sha256 '9bb74062462775cf325288f2e42361d7287ad8dd9c0150ef79710442a05389f0'
+  version '2.0.8'
+  sha256 '7cacde9e30ca5055acaa54f28793e2c5c296ac440b3d27594340caf26c25150a'
 
   # sourceforge.net/lazarus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lazarus/LazarusIDE-#{version}-macos-x86_64.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.