### PR TITLE
Update mailbutler from 2,2708-13157 to 2,2715-13158

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2,2708-13157'
-  sha256 '04d8406b5e0de5c7ae8415a01dbad1668e047972181a155c683ed33e657d1cc5'
+  version '2,2715-13158'
+  sha256 'e6fc2874b5f800386e654f91fec9e51892cde417338d818c449b677ef109a641'
 
   url "https://downloads.mailbutler.io/sparkle/public/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.