### PR TITLE
Update webcatalog from 20.4.1 to 20.5.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.4.1'
-  sha256 '60220ca0e54b43e4c0e2dbbb9314f77e7e7018b13cba32d481e883c82ba746d3'
+  version '20.5.0'
+  sha256 'de526d1960b0193fc3d10a7b0f2f84b53cd9f82d8c23e6bfbfb41fd24b455c0a'
 
   # github.com/quanglam2807/webcatalog was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.