### PR TITLE
Update toptracker from 1.6.1.6521 to 1.6.2.6524

### DIFF
--- a/Casks/toptracker.rb
+++ b/Casks/toptracker.rb
@@ -1,6 +1,6 @@
 cask 'toptracker' do
-  version '1.6.1.6521'
-  sha256 '2dab586d95fd0b853b23ead7c4ad2752c53adb09a80e76e28e8be232dc80c0ea'
+  version '1.6.2.6524'
+  sha256 '3b626f3a4761b6fd8678da4dfed5beabdf1ea198478a8a5f3a06585de56804b0'
 
   # d101nvfmxunqnl.cloudfront.net was verified as official when first introduced to the cask
   url "https://d101nvfmxunqnl.cloudfront.net/desktop/builds/mac/toptracker_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.