### PR TITLE
Update wickrme from 5.51.2 to 5.52.9

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.51.2'
-  sha256 '42fa023fead5b3cd0f4a183c595b85d771d8d8f274f0d65178692322d457bd77'
+  version '5.52.9'
+  sha256 '3b71dd0f38d047980281ea452649f4983759187881e1500d195dd3d9dcac4e9b'
 
   # s3.amazonaws.com/static.wickr.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.