### PR TITLE
Update arq from 6.2.1 to 6.2.3

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '6.2.1'
-  sha256 'd649bef9f3a26fd26fa13c3c0bb71f03987c1d01c08a91101783d02175504f2e'
+  version '6.2.3'
+  sha256 'fb74c9b26d994e08984fa28e51811ebcff701eebe7a2a97d115fbdb4c009459a'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"
   appcast 'https://www.arqbackup.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.