### PR TITLE
Update openrct2 from 0.2.5 to 0.2.6

### DIFF
--- a/Casks/openrct2.rb
+++ b/Casks/openrct2.rb
@@ -1,6 +1,6 @@
 cask 'openrct2' do
-  version '0.2.5'
-  sha256 '788ea7345c8d52ab4feda3ba7d8d5d67cf5c049ccae5c255727011e23b320efa'
+  version '0.2.6'
+  sha256 '0073933b486da10b181bc8a226a140badc64c7cd93f681d769c17b5715221a85'
 
   # github.com/OpenRCT2/OpenRCT2 was verified as official when first introduced to the cask
   url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.