### PR TITLE
Update termius from 5.7.2 to 5.9.2

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '5.7.2'
-  sha256 'a586d858aa7bf7c62d845c0387a05841bd5550289b43e5208508a7d18eb855c9'
+  version '5.9.2'
+  sha256 'a78bc672ed6891a6c7c50b77c432965c188390864fbe403abc643a5cf4537317'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.