### PR TITLE
Update imgotv from 6.2.2,2 to 6.2.3,1

### DIFF
--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -1,6 +1,6 @@
 cask 'imgotv' do
-  version '6.2.2,2'
-  sha256 'a79c48c642060ec35b721c57f29d3b6ec6ebe701f23b66e811619c0d88b71223'
+  version '6.2.3,1'
+  sha256 '1eed3c0703d7ea3de9276501d271e8edf7cd8cdc3882843cf03d54401a355c9e'
 
   # download.imgo.tv was verified as official when first introduced to the cask
   url "https://download.imgo.tv/app/pc/newmac/#{version.before_comma}-#{version.after_comma}/mgtv-mango2-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.