### PR TITLE
secure URLs

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -6,7 +6,7 @@ cask 'aquamacs' do
   url "https://github.com/davidswelt/aquamacs-emacs/releases/download/Aquamacs-#{version}/Aquamacs-Emacs-#{version}.dmg"
   appcast 'https://github.com/davidswelt/aquamacs-emacs/releases.atom'
   name 'Aquamacs'
-  homepage 'http://aquamacs.org/'
+  homepage 'https://aquamacs.org/'
 
   app 'Aquamacs.app'
 

--- a/Casks/astah-professional.rb
+++ b/Casks/astah-professional.rb
@@ -3,7 +3,7 @@ cask 'astah-professional' do
   sha256 '5c2a2931bb682e71c422d2b3abd16e53106fcc571f85c3f0a7f3a2f00ed3998e'
 
   # cdn.change-vision.com/files was verified as official when first introduced to the cask
-  url "http://cdn.change-vision.com/files/astah-professional-#{version.before_comma.dots_to_underscores}-#{version.after_comma}-MacOs.dmg"
+  url "https://cdn.change-vision.com/files/astah-professional-#{version.before_comma.dots_to_underscores}-#{version.after_comma}-MacOs.dmg"
   appcast 'https://astah.net/download'
   name 'Change Vision Astah Professional'
   homepage 'https://astah.net/editions/professional'

--- a/Casks/baidunetdisk.rb
+++ b/Casks/baidunetdisk.rb
@@ -3,7 +3,7 @@ cask 'baidunetdisk' do
   sha256 'c6017603268449774bcea61a9385ba7fc913614121ef75da047e793de5fba125'
 
   # baidupcs.com/issue/netdisk/MACguanjia was verified as official when first introduced to the cask
-  url "http://wppkg.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
+  url "https://wppkg.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_#{version}.dmg"
   appcast 'https://pan.baidu.com/disk/cmsdata?do=client'
   name 'Baidu NetDisk'
   name '百度网盘'

--- a/Casks/detexify.rb
+++ b/Casks/detexify.rb
@@ -5,7 +5,7 @@ cask 'detexify' do
   # s3.amazonaws.com/detexify.kirelabs.org was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/detexify.kirelabs.org/Detexify.zip'
   name 'Detexify'
-  homepage 'http://detexify.kirelabs.org/classify.html'
+  homepage 'https://detexify.kirelabs.org/classify.html'
 
   app 'Detexify.app'
 

--- a/Casks/ebmac.rb
+++ b/Casks/ebmac.rb
@@ -3,7 +3,7 @@ cask 'ebmac' do
   sha256 '91f454e709607ae8b397b13e4201adc4add8e80394969918218fc097831f3c73'
 
   # ftp.vector.co.jp/72/54/938 was verified as official when first introduced to the cask
-  url "http://ftp.vector.co.jp/72/54/938/EBMac#{version}.dmg"
+  url "https://ftp.vector.co.jp/72/54/938/EBMac#{version}.dmg"
   appcast 'http://ebstudio.info/manual/EBMac/'
   name 'EBMac'
   homepage 'http://ebstudio.info/manual/EBMac/'

--- a/Casks/empoche.rb
+++ b/Casks/empoche.rb
@@ -2,9 +2,9 @@ cask 'empoche' do
   version '0.2.1'
   sha256 '0d2a4183c909db3c8e7ab8d051179d0ac135fc8d62b7cf85a11b73d1b14f172f'
 
-  # empoche-desktop.s3.eu-central-1.amazonaws.com was verified as official when first introduced to the cask
-  url "https://empoche-desktop.s3.eu-central-1.amazonaws.com/Empoche-#{version}-mac.zip"
-  appcast 'https://empoche-desktop.s3.eu-central-1.amazonaws.com/latest-mac.yml'
+  # empoche-desktop.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://empoche-desktop.s3.amazonaws.com/Empoche-#{version}-mac.zip"
+  appcast 'https://empoche-desktop.s3.amazonaws.com/latest-mac.yml'
   name 'Empoche'
   homepage 'https://empoche.com/'
 

--- a/Casks/firestormos.rb
+++ b/Casks/firestormos.rb
@@ -2,7 +2,7 @@ cask 'firestormos' do
   version '6.0.2.56680'
   sha256 'f8e5fa3b1a72aff67ce91d44f82f536d898a9b4c3a818414799ccb8d288e7e97'
 
-  url "http://downloads.firestormviewer.org/mac/Phoenix-FirestormOS-Releasex64_#{version.dots_to_underscores}_x86_64.dmg"
+  url "https://downloads.firestormviewer.org/mac/Phoenix-FirestormOS-Releasex64_#{version.dots_to_underscores}_x86_64.dmg"
   appcast 'https://www.firestormviewer.org/mac-for-open-simulator/'
   name 'Phoenix Firestorm viewer for OpenSim'
   homepage 'https://www.firestormviewer.org/'
@@ -14,6 +14,6 @@ cask 'firestormos' do
     This version is only needed if you visit OpenSim grids; should not be used for uploading mesh to Second Life.
     Most problems that crop up during updates can be resolved or fixed by performing a clean install:
 
-      http://wiki.phoenixviewer.com/fs_clean_install for instructions.
+      https://wiki.firestormviewer.org/fs_clean_install for instructions.
   EOS
 end

--- a/Casks/gpower.rb
+++ b/Casks/gpower.rb
@@ -2,10 +2,10 @@ cask 'gpower' do
   version '3.1.9.6'
   sha256 '841390e00110ccdd5201f334af985b54837b9f9b4ffb3151d49e28efb9bb3964'
 
-  url "http://www.gpower.hhu.de/fileadmin/redaktion/Fakultaeten/Mathematisch-Naturwissenschaftliche_Fakultaet/Psychologie/AAP/gpower/GPowerMac_#{version}.zip"
-  appcast 'http://www.gpower.hhu.de/'
+  url "https://www.gpower.hhu.de/fileadmin/redaktion/Fakultaeten/Mathematisch-Naturwissenschaftliche_Fakultaet/Psychologie/AAP/gpower/GPowerMac_#{version}.zip"
+  appcast 'https://www.gpower.hhu.de/'
   name 'G*Power'
-  homepage 'http://www.gpower.hhu.de/'
+  homepage 'https://www.gpower.hhu.de/'
 
   app 'G*Power.app'
 end

--- a/Casks/monogame.rb
+++ b/Casks/monogame.rb
@@ -6,7 +6,7 @@ cask 'monogame' do
   url "https://github.com/MonoGame/MonoGame/releases/download/v#{version}/MonoGame.pkg"
   appcast 'https://github.com/MonoGame/MonoGame/releases.atom'
   name 'MonoGame'
-  homepage 'http://www.monogame.net/'
+  homepage 'https://www.monogame.net/'
 
   pkg 'MonoGame.pkg'
 

--- a/Casks/slimbatterymonitor.rb
+++ b/Casks/slimbatterymonitor.rb
@@ -3,9 +3,9 @@ cask 'slimbatterymonitor' do
   sha256 '587ce35b534c26b489b60d7f4ca71a96c1dcd83193a30c58676ae8d4665c6aff'
 
   url "http://quux.orange-carb.org/dist/SlimBatteryMonitor-#{version}.dmg"
-  appcast 'http://www.orange-carb.org/SBM/updates/sbm.xml'
+  appcast 'https://www.orange-carb.org/SBM/updates/sbm.xml'
   name 'SlimBatteryMonitor'
-  homepage 'http://www.orange-carb.org/SBM/'
+  homepage 'https://www.orange-carb.org/SBM/'
 
   app 'SlimBatteryMonitor.app'
 end

--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -2,7 +2,7 @@ cask 'thebrain' do
   version '10.0.66.0'
   sha256 '2a9a7b6f08a2694e2ee94e4dd7217a4aaf7b53042557fd77b6b304909f3d1383'
 
-  url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
+  url "https://updater.thebrain.com/files/TheBrain#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'
   name 'TheBrain'
   homepage 'https://www.thebrain.com/'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
1 file inspected, no offenses detected
==> Downloading https://github.com/davidswelt/aquamacs-emacs/releases/download/A
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'aquamacs'.
audit for aquamacs: passed

1 file inspected, no offenses detected
==> Downloading https://cdn.change-vision.com/files/astah-professional-8_2_0-b74
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'astah-professional'.
audit for astah-professional: passed

1 file inspected, no offenses detected
==> Downloading https://wppkg.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'baidunetdisk'.
audit for baidunetdisk: passed

1 file inspected, no offenses detected
==> Downloading https://s3.amazonaws.com/detexify.kirelabs.org/Detexify.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'detexify', skipping verification.
audit for detexify: passed

1 file inspected, no offenses detected
==> Downloading https://ftp.vector.co.jp/72/54/938/EBMac1.45.1.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'ebmac'.
audit for ebmac: passed

1 file inspected, no offenses detected
==> Downloading https://empoche-desktop.s3.amazonaws.com/Empoche-0.2.1-mac.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'empoche'.
audit for empoche: passed

1 file inspected, no offenses detected
==> Downloading https://downloads.firestormviewer.org/mac/Phoenix-FirestormOS-Re
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'firestormos'.
audit for firestormos: passed

1 file inspected, no offenses detected
==> Downloading https://www.gpower.hhu.de/fileadmin/redaktion/Fakultaeten/Mathem
==> Downloading from http://www.gpower.hhu.de/fileadmin/redaktion/Fakultaeten/Ma
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'gpower'.
audit for gpower: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/MonoGame/MonoGame/releases/download/v3.7.1/Mo
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'monogame'.
audit for monogame: passed

1 file inspected, no offenses detected
==> Downloading http://quux.orange-carb.org/dist/SlimBatteryMonitor-1.5.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'slimbatterymonitor'.
audit for slimbatterymonitor: passed

1 file inspected, no offenses detected
==> Downloading https://updater.thebrain.com/files/TheBrain10.0.66.0.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'thebrain'.
audit for thebrain: passed
```