### PR TITLE
Update zoho-mail from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.1.5'
-  sha256 'dc1f1b9cbb556e9dda51d08820d702cc4aa1cc50c3678166949606fe0de28172'
+  version '1.1.6'
+  sha256 '966d7d372fc8a4857072fc77079c59fe81d0ab9113c25b5525bf52230968dd17'
 
   # downloads.zohocdn.com/zmail-desktop/mac was verified as official when first introduced to the cask
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.