### PR TITLE
Update electron from 8.2.1 to 8.2.3

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,6 +1,6 @@
 cask 'electron' do
-  version '8.2.1'
-  sha256 '3dd2e09883b1ae2fac361c59fc671473889c6dbaecc0998cc35914ea76ddf0e4'
+  version '8.2.3'
+  sha256 '31bd214c587f3b56d49e33fa86e8d8dd25f83712088a06ac6cf135994c97c3bf'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.