### PR TITLE
Update breaktimer from 0.7.2 to 0.7.3

### DIFF
--- a/Casks/breaktimer.rb
+++ b/Casks/breaktimer.rb
@@ -1,6 +1,6 @@
 cask 'breaktimer' do
-  version '0.7.2'
-  sha256 '0ce13c043622e9d5e60b531adf2cd3eb13d07a7227d9e7e804723ea47c0dd8b4'
+  version '0.7.3'
+  sha256 '07f2ce6e31304dabd0b35a0b4897d08d4ac462e814d3c4ffbd8bc765d8ccbaea'
 
   # github.com/tom-james-watson/breaktimer-app was verified as official when first introduced to the cask
   url "https://github.com/tom-james-watson/breaktimer-app/releases/download/v#{version}/BreakTimer.dmg"
@@ -8,10 +8,21 @@ cask 'breaktimer' do
   name 'BreakTimer'
   homepage 'https://breaktimer.app/'
 
+  auto_updates true
+
   app 'BreakTimer.app'
+  binary "#{appdir}/BreakTimer.app/Contents/MacOS/BreakTimer", target: 'breaktimer'
+
+  uninstall quit:      'com.tomjwatson.breaktimer',
+            launchctl: 'com.tomjwatson.breaktimer.ShipIt'
 
   zap trash: [
                '~/Library/Application Support/BreakTimer',
+               '~/Library/Caches/com.tomjwatson.breaktimer',
+               '~/Library/Caches/com.tomjwatson.breaktimer.ShipIt',
+               '~/Library/Logs/BreakTimer',
+               '~/Library/Preferences/ByHost/com.tomjwatson.breaktimer.ShipIt.*.plist',
                '~/Library/Preferences/com.tomjwatson.breaktimer.plist',
+               '~/Library/Saved Application State/com.tomjwatson.breaktimer.savedState',
              ]
 end


### PR DESCRIPTION
Add binary, `uninstall` stanza & update `zap` stanza.
Continuation of #80775 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
