### PR TITLE
Update folding-at-home from 7.5.1 to 7.6.9

### DIFF
--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -4,9 +4,9 @@ cask 'folding-at-home' do
 
   # download.foldingathome.org/releases/public/release/fah-installer was verified as official when first introduced to the cask
   url "https://download.foldingathome.org/releases/public/release/fah-installer/osx-10.11-64bit/v#{version.major_minor}/fah-installer_#{version}_x86_64.mpkg.zip"
-  appcast 'https://download.foldingathome.org/releases/public/release/fah-installer/'
+  appcast 'https://foldingathome.org/alternative-downloads/'
   name 'Folding@home'
-  homepage 'https://folding.stanford.edu/'
+  homepage 'https://foldingathome.org/'
 
   pkg "fah-installer_#{version}_x86_64.pkg"
 

--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -2,9 +2,8 @@ cask 'folding-at-home' do
   version '7.6.9'
   sha256 '9475e8aef3614daf92e3cfc8748be5e10e1c5b38a5c5da30ce3fe60f754de16b'
 
-  # download.foldingathome.org/releases/public/release/fah-installer was verified as official when first introduced to the cask
   url "https://download.foldingathome.org/releases/public/release/fah-installer/osx-10.11-64bit/v#{version.major_minor}/fah-installer_#{version}_x86_64.mpkg.zip"
-  appcast 'https://foldingathome.org/alternative-downloads/'
+  appcast 'https://download.foldingathome.org/js/fah-downloads.js'
   name 'Folding@home'
   homepage 'https://foldingathome.org/'
 

--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -1,6 +1,6 @@
 cask 'folding-at-home' do
-  version '7.5.1'
-  sha256 '94fd47ff55120c1c869d0dfbf366ae418406a3b47b0fa1bcf94014777abb72a6'
+  version '7.6.9'
+  sha256 '9475e8aef3614daf92e3cfc8748be5e10e1c5b38a5c5da30ce3fe60f754de16b'
 
   # download.foldingathome.org/releases/public/release/fah-installer was verified as official when first introduced to the cask
   url "https://download.foldingathome.org/releases/public/release/fah-installer/osx-10.11-64bit/v#{version.major_minor}/fah-installer_#{version}_x86_64.mpkg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.