### PR TITLE
Update geph from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -1,6 +1,6 @@
 cask 'geph' do
-  version '3.6.0'
-  sha256 '2490f4a82ca7233b9f43a238338dd94a86c7a22a91b1bddb8aaac629fc71d57d'
+  version '3.6.1'
+  sha256 '279b8935ecc0ee69cf74db2e8fa9141982e0333d10248840d16d025aab07de83'
 
   url "https://dl.geph.io/desktop-builds/geph-macos-#{version}.dmg"
   appcast 'https://geph.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.