### PR TITLE
Update darktable to 3.0.2

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask 'darktable' do
-  version '3.0.1.2'
-  sha256 'a737973ad2ad619676874d86a599a2805431cd2a4e18169792d66c1746440d3c'
+  version '3.0.2'
+  sha256 'b71dab1b4f0ad796055f6d725a82913ad08f609de6ca96d65dbe6ffbeecb6416'
 
   # github.com/darktable-org/darktable was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).