### PR TITLE
Update Pext to 0.30

### DIFF
--- a/Casks/pext.rb
+++ b/Casks/pext.rb
@@ -1,6 +1,6 @@
 cask 'pext' do
-  version '0.29'
-  sha256 '858f0ee1686f606629c0d0253c7f69165dbc621b49e63487d7f47c721c6bd28b'
+  version '0.30'
+  sha256 'b4ed7401c253ea747f92c7f32f10f3703901501513b7ec437b9117061d4ff958'
 
   # github.com/Pext/Pext was verified as official when first introduced to the cask
   url "https://github.com/Pext/Pext/releases/download/v#{version}/Pext-#{version}.dmg"


### PR DESCRIPTION
As usual, not on my Macbook, so can't run the commands right now.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).