### PR TITLE
Update thunder from 3.4.0.4338 to 3.4.1.4368

### DIFF
--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -1,6 +1,6 @@
 cask 'thunder' do
-  version '3.4.0.4338'
-  sha256 '2f8d60050084687c9abac55a40e2c314791e8c448b11c6e07902af4e281bef1f'
+  version '3.4.1.4368'
+  sha256 'a732b748d95005fbf7ecfe3373be037940b10127dc1adf3de30a4a05d46a97f2'
 
   # down.sandai.net was verified as official when first introduced to the cask
   url "https://down.sandai.net/mac/thunder_#{version}.dmg"

--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -7,7 +7,7 @@ cask 'thunder' do
   appcast 'https://static-xl9-ssl.xunlei.com/json/mac_download_url.json'
   name 'Thunder'
   name '迅雷'
-  homepage 'https://mac.xunlei.com/'
+  homepage 'https://www.xunlei.com/'
 
   auto_updates true
   depends_on macos: '>= :yosemite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.