### PR TITLE
Update another-redis-desktop-manager from 1.3.3 to 1.3.4

### DIFF
--- a/Casks/another-redis-desktop-manager.rb
+++ b/Casks/another-redis-desktop-manager.rb
@@ -1,6 +1,6 @@
 cask 'another-redis-desktop-manager' do
-  version '1.3.3'
-  sha256 '19c7d5639611c8e988df1c114453b06c0bd071ef2593a51443fba3c64ed6db07'
+  version '1.3.4'
+  sha256 'b50b0afdabc280c31f5aea81a0b439e9dbea9741a64f3579a44026272566a703'
 
   url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another.Redis.Desktop.Manager.#{version}.dmg"
   appcast 'https://github.com/qishibo/AnotherRedisDesktopManager/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.