### PR TITLE
Update unity-android-support-for-editor from 2019.3.9f1,e6e740a1c473 to 2019.3.10f1,5968d7f82152

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.9f1,e6e740a1c473'
-  sha256 '280807504b9b2d2a610893f544ccbc2249f9c609314a9e63206a183b6f5f0356'
+  version '2019.3.10f1,5968d7f82152'
+  sha256 '3e0cb3ce56b2930f4b93e2cf6ea9dfe714fc7bbeffa3b32733ac44022adabca8'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.