### PR TITLE
Update unity-download-assistant from 2019.3.9f1,e6e740a1c473 to 2019.3.10f1,5968d7f82152

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.9f1,e6e740a1c473'
-  sha256 'c12ad7bcfc323d86bc933bb2bb7e03e99d560e18028ad54c24c3ae95cd8d8880'
+  version '2019.3.10f1,5968d7f82152'
+  sha256 'c4c6a4c71071e0c0db8e26684a6555b35f441dcedf5a21c1263d654e2fe6d882'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.