### PR TITLE
Update thedesk from 20.3.1 to 20.3.2

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '20.3.1'
-  sha256 '683d647acf94dbd3220c0e0f0c9934e39673a8875747b9fac002c372c4519fb9'
+  version '20.3.2'
+  sha256 'b018837ce830c6b9318fec32c6425495c041c315e05646b8e019a95bc626a326'
 
   # github.com/cutls/TheDesk was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.