### PR TITLE
Update openaudible from 2.0 to 2.0.1

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,6 +1,6 @@
 cask 'openaudible' do
-  version '2.0'
-  sha256 '050f6335c938e1372e703f789ccb570c0dc7a87efae7e5cbf0c596afcf5d1ae1'
+  version '2.0.1'
+  sha256 '456d94493940f77a22d277137cae06bf53d073c2239eb5905d25d1222e450ba9'
 
   # github.com/openaudible was verified as official when first introduced to the cask
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.