### PR TITLE
Update tableplus from 3.3.0,300 to 3.4.0,304

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '3.3.0,300'
-  sha256 'ed8e8add50d60df29ee775d5296c6842b134f3f767984d3afea5ee46555f6b9a'
+  version '3.4.0,304'
+  sha256 'a9a3c7464b2e4cec4c5a8deb3e6159a2d5447c38954aa17278a8e7a978ac7807'
 
   # tableplus-osx-builds.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.