### PR TITLE
Update mailbutler from 2,2715-13158 to 2,2718-13159

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2,2715-13158'
-  sha256 'e6fc2874b5f800386e654f91fec9e51892cde417338d818c449b677ef109a641'
+  version '2,2718-13159'
+  sha256 '94d1b744590a6e39d082d1cc7e5e5920d9782f4bc82a66a27f727c341627d140'
 
   url "https://downloads.mailbutler.io/sparkle/public/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.