### PR TITLE
Update ghost-browser from 2.1.1.10 to 2.1.1.11

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.10'
-  sha256 'a664883c68f881bf2d3c85278543f355ab263fc2fac68dc829354d675ce1c095'
+  version '2.1.1.11'
+  sha256 '39c151fe69e451bd76d7765cc29eb470deb04c836376483c54d3641b91f9fdf5'
 
   # ghostbrowser.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.