### PR TITLE
Update lifesize from 2.210.2639 to 2.210.2648

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,6 +1,6 @@
 cask 'lifesize' do
-  version '2.210.2639'
-  sha256 '142514768b655e6600b55b1ee0361733b4cab3ba5c0400aa270ac31b4c4b5497'
+  version '2.210.2648'
+  sha256 '26106c4badbe2948687eda43a356561297179eb60ac55b12b70965bd47b6c506'
 
   # download.lifesizecloud.com/Lifesize- was verified as official when first introduced to the cask
   url "https://download.lifesizecloud.com/Lifesize-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.