### PR TITLE
Update flock from 2.2.361 to 2.2.374

### DIFF
--- a/Casks/flock.rb
+++ b/Casks/flock.rb
@@ -1,6 +1,6 @@
 cask 'flock' do
-  version '2.2.361'
-  sha256 '63e7e578904729c61880f3422190d585f3ff5640b347975787bd3467f6c01167'
+  version '2.2.374'
+  sha256 '4318e5ba5f0156f6eea503a93b04bcc2393339a6d910ea7443e4cb82d0431e96'
 
   # flock.co was verified as official when first introduced to the cask
   url "https://updates.flock.co/fl_mac_electron/Flock-macOS-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.