### PR TITLE
Update kaleidoscope from 2.3,1438-feb-21-2020 to 2.3.1,1441-apr-7-2020

### DIFF
--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -1,10 +1,10 @@
 cask 'kaleidoscope' do
-  version '2.3,1438-feb-21-2020'
-  sha256 '347d7fb5e36e0c50ffac56d99b3853b61cf2cf7ed82eb3f55768a2554f90d9a2'
+  version '2.3.1,1441-apr-7-2020'
+  sha256 '720abc4bc1a5cdb0d58fb1794d16c9d4e00d82a570d428ff7b44e36fa45212bd'
 
   # appcasts.hypergiant.com/ks/prod was verified as official when first introduced to the cask
   url "https://appcasts.hypergiant.com/ks/prod/Kaleidoscope-#{version.before_comma}-build-#{version.after_comma}.zip"
-  appcast 'https://updates.blackpixel.com/updates?app=ks'
+  appcast 'https://appcasts.hypergiant.com/ks/prod/updates'
   name 'Kaleidoscope'
   homepage 'https://www.kaleidoscopeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.