### PR TITLE
Update davmail from 5.4.0-3135 to 5.5.1-3299

### DIFF
--- a/Casks/davmail.rb
+++ b/Casks/davmail.rb
@@ -1,6 +1,6 @@
 cask 'davmail' do
-  version '5.4.0-3135'
-  sha256 '32a10f0885a7fca671c67a3f2f55b6f2f91d9e76db5b2a8ec3827921c547af70'
+  version '5.5.1-3299'
+  sha256 'd906cc113a055bd3c494fe917907df2562c4bee94726aa08ed13cdb519b9dbe9'
 
   # downloads.sourceforge.net/davmail was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/davmail/DavMail-MacOSX-#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.