### PR TITLE
Update stand from 1.0.4 to 2.0

### DIFF
--- a/Casks/stand.rb
+++ b/Casks/stand.rb
@@ -1,11 +1,10 @@
 cask 'stand' do
-  version '1.0.4'
-  sha256 '8919e43c9c591657d8d6961b25e8dc5f77d706d71eb246839be22522a82bb0ec'
+  version '2.0'
+  sha256 'eb0555f6376757105e1faea1fd1f9e4afae21eef73fdd5c7d0fb0c76a8cd9702'
 
-  # get-stand-app.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://get-stand-app.s3.amazonaws.com/#{version.patch}/Stand.zip"
-  appcast 'https://standapp-sparkle-updater.herokuapp.com/',
-          configuration: version.major_minor
+  # f001.backblazeb2.com/file/stand-app/ was verified as official when first introduced to the cask
+  url "https://f001.backblazeb2.com/file/stand-app/#{version}/Stand.zip"
+  appcast 'https://standapp-sparkle-updater.herokuapp.com/'
   name 'Stand'
   homepage 'https://getstandapp.com/'
 

--- a/Casks/stand.rb
+++ b/Casks/stand.rb
@@ -2,7 +2,7 @@ cask 'stand' do
   version '2.0'
   sha256 'eb0555f6376757105e1faea1fd1f9e4afae21eef73fdd5c7d0fb0c76a8cd9702'
 
-  # f001.backblazeb2.com/file/stand-app was verified as official when first introduced to the cask
+  # f001.backblazeb2.com/file/stand-app/ was verified as official when first introduced to the cask
   url "https://f001.backblazeb2.com/file/stand-app/#{version}/Stand.zip"
   appcast 'https://standapp-sparkle-updater.herokuapp.com/'
   name 'Stand'

--- a/Casks/stand.rb
+++ b/Casks/stand.rb
@@ -2,7 +2,7 @@ cask 'stand' do
   version '2.0'
   sha256 'eb0555f6376757105e1faea1fd1f9e4afae21eef73fdd5c7d0fb0c76a8cd9702'
 
-  # f001.backblazeb2.com/file/stand-app/ was verified as official when first introduced to the cask
+  # f001.backblazeb2.com/file/stand-app was verified as official when first introduced to the cask
   url "https://f001.backblazeb2.com/file/stand-app/#{version}/Stand.zip"
   appcast 'https://standapp-sparkle-updater.herokuapp.com/'
   name 'Stand'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.