### PR TITLE
Update mission-control-plus from 1.13 to 1.14

### DIFF
--- a/Casks/mission-control-plus.rb
+++ b/Casks/mission-control-plus.rb
@@ -1,6 +1,6 @@
 cask 'mission-control-plus' do
-  version '1.13'
-  sha256 'cc56395c2d836ae141f6da7e0db4f84a01375d6097b9b11b5fc5707fc8ed6b24'
+  version '1.14'
+  sha256 '8a89794c85dfab931d07bd309058064d6e3cf664057239d4cc75ce6b72276df4'
 
   # github.com/ronyfadel/MissionControlPlusReleases was verified as official when first introduced to the cask
   url "https://github.com/ronyfadel/MissionControlPlusReleases/releases/download/#{version}/Mission.Control.Plus.tgz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.