### PR TITLE
Update kite from 0.20200411.0 to 0.20200416.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200411.0'
-  sha256 '6f8bde03416a8183fb63e8b6aae316359ed41748e8ac0171d6f3dcd2e403cce5'
+  version '0.20200416.0'
+  sha256 '79f15e1d234ff970551a3470bbc0cbef860bccc9893cb235063705998547ddbd'
 
   # draqv87tt43s0.cloudfront.net was verified as official when first introduced to the cask
   url "https://draqv87tt43s0.cloudfront.net/mac/#{version}/Kite.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.