### PR TITLE
Update glyphs from 2.6.5,1313 to 2.6.5,1318

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.5,1313'
-  sha256 '5d5f58fe2cb3ed215fbd2f4989575f426600be1dd3eb64113428982c30e94325'
+  version '2.6.5,1318'
+  sha256 '2aad709a72e51b80158a701455d44d3337808244f1648f438e5d90b5de556138'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.