### PR TITLE
Update kodelife from 0.9.0.129 to 0.9.1.132

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,6 +1,6 @@
 cask 'kodelife' do
-  version '0.9.0.129'
-  sha256 '7442e62ba5628fcaf65db987677acc7ff361ee9abca8296af751ff3eaab11b39'
+  version '0.9.1.132'
+  sha256 'a4782eeefc7c4a91d81fc36925ee4465dea471eeaa53feae934480bacf40d92d'
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-macos.zip"
   appcast 'https://hexler.net/pub/kodelife/appcast.hex'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.