### PR TITLE
Update wpsoffice from 2.1.0,3464 to 2.1.1,3493

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask 'wpsoffice' do
-  version '2.1.0,3464'
-  sha256 'f46ec300e8129c6c1972eee79b0e2208f5b93b7048d6fd43dca8b35752a09c65'
+  version '2.1.1,3493'
+  sha256 '1a0ebd021833034051bc241ba71dd37969fa3c388fb4d8906a053bb4c4ae4751'
 
   # wdl1.pcfg.cache.wpscdn.com was verified as official when first introduced to the cask
   url "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/macwpsoffice/download/#{version.before_comma}.#{version.after_comma}/WPSOffice_#{version.before_comma}(#{version.after_comma}).dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.