### PR TITLE
Update gpxsee from 7.28 to 7.29

### DIFF
--- a/Casks/gpxsee.rb
+++ b/Casks/gpxsee.rb
@@ -1,6 +1,6 @@
 cask 'gpxsee' do
-  version '7.28'
-  sha256 '8cf9cf5910758774b9e4f98cacd1cba5aeb544dee25cee113bad5d193ac4984a'
+  version '7.29'
+  sha256 '2e8553952193e3b0b3c5b5d625a77cdefb8ec28e0b8072b57eb2b665cb2c5c0e'
 
   # sourceforge.net/gpxsee/Mac%20OS%20X was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/gpxsee/Mac%20OS%20X/GPXSee-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.