### PR TITLE
Update ipe from 7.2.13 to 7.2.14

### DIFF
--- a/Casks/ipe.rb
+++ b/Casks/ipe.rb
@@ -1,9 +1,9 @@
 cask 'ipe' do
-  version '7.2.13'
-  sha256 '3003343719f3b17f32a321fff64f10e60e92b4d9550e136c65838c761c23fe55'
+  version '7.2.14'
+  sha256 '4421ef4d8804cac9e87c16c6ded4e5e8d5fe4e710eb10d79408f701343f23aa2'
 
   # bintray.com/otfried was verified as official when first introduced to the cask
-  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac.dmg"
+  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac-10.10.dmg"
   appcast 'http://ipe.otfried.org/'
   name 'Ipe'
   homepage 'http://ipe.otfried.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.