### PR TITLE
Update ipepresenter from 7.2.13 to 7.2.14

### DIFF
--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -1,9 +1,9 @@
 cask 'ipepresenter' do
-  version '7.2.13'
-  sha256 'ad10ad1afbef8ef9a632a48976534623a3af3a23536765674142d15d10d1c3ce'
+  version '7.2.14'
+  sha256 '01425a521034711305f28c43a713d83ab96793f54be5a87a24de89ac8c242fbf'
 
   # bintray.com/otfried was verified as official when first introduced to the cask
-  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"
+  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac-10.10.dmg"
   appcast 'http://ipepresenter.otfried.org/'
   name 'IpePresenter'
   homepage 'http://ipepresenter.otfried.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.