### PR TITLE
Update netron from 4.0.7 to 4.0.8

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.0.7'
-  sha256 '63738fdf9bbb5a67e8ea2320ae307d51b2450aa230a662337b348bf463ec9cb4'
+  version '4.0.8'
+  sha256 'b39712ecffbb39db6ba27cb48de8051f5beb3b6bf98c21eed561536430bb81be'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.