### PR TITLE
Update netron from 4.0.8 to 4.0.9

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.0.8'
-  sha256 'b39712ecffbb39db6ba27cb48de8051f5beb3b6bf98c21eed561536430bb81be'
+  version '4.0.9'
+  sha256 'd5f6262bbb595ecf372b572ac7af5782ed90010734b1e7bde8fa2bc99d6ed920'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.