### PR TITLE
Update aws-vault from 5.4.0 to 5.4.1

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,6 +1,6 @@
 cask 'aws-vault' do
-  version '5.4.0'
-  sha256 '1df607d555cefc7d14c8b508f251e039ab1b849800497746a642844552d4ecc2'
+  version '5.4.1'
+  sha256 '411fd34b28891d9ef95f9e5ec454daf6f5e7f64a08a64d5395e214c89cd9d1be'
 
   url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
   appcast 'https://github.com/99designs/aws-vault/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.