### PR TITLE
Update videostream from 0.3.6 to 0.4.0

### DIFF
--- a/Casks/videostream.rb
+++ b/Casks/videostream.rb
@@ -1,6 +1,6 @@
 cask 'videostream' do
-  version '0.3.6'
-  sha256 'd1f65c33c075709c1890aca871602baffdef22ae810a07c5a4f59d88a0383071'
+  version '0.4.0'
+  sha256 'ac74c9b20fa53ce49ba5b2e36f55456363107d02c58fcb4579d10f8441954771'
 
   url 'https://cdn.getvideostream.com/videostream-native-updates/macOS/Videostream.pkg'
   appcast 'https://videostream-cdn.s3.amazonaws.com/videostream-native-updates/macOS/manifest.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.