### PR TITLE
Add version for AWS Session Manager

### DIFF
--- a/Casks/session-manager-plugin.rb
+++ b/Casks/session-manager-plugin.rb
@@ -1,9 +1,9 @@
 cask 'session-manager-plugin' do
-  version :latest
-  sha256 :no_check
+  version '1.1.61.0'
+  sha256 '426615b12b2d7728504ee7896c60fa330534314d6cb64ee8cb3ea0488e7d66e4'
 
   # session-manager-downloads.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url 'https://session-manager-downloads.s3.amazonaws.com/plugin/latest/mac/sessionmanager-bundle.zip'
+  url "https://session-manager-downloads.s3.amazonaws.com/plugin/#{version}/mac/sessionmanager-bundle.zip"
   name 'Session Manager Plugin for the AWS CLI'
   homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
 

--- a/Casks/session-manager-plugin.rb
+++ b/Casks/session-manager-plugin.rb
@@ -4,6 +4,7 @@ cask 'session-manager-plugin' do
 
   # session-manager-downloads.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://session-manager-downloads.s3.amazonaws.com/plugin/#{version}/mac/sessionmanager-bundle.zip"
+  appcast 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
   name 'Session Manager Plugin for the AWS CLI'
   homepage 'https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html'
 


### PR DESCRIPTION
Switches from the `latest` versioning to using proper version URLs under the same domain/S3 bucket.

===

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


```
$ brew cask audit --download session-manager-plugin
==> Downloading https://session-manager-downloads.s3.amazonaws.com/plugin/1.1.61.0/mac/sessionmanager-bundle.zip
Already downloaded: /Users/luke8639/Library/Caches/Homebrew/downloads/e5755a17827b7ced85e1908bb4096c80c0e6481ac9a3c480f88e07a1a1c7df6c--sessionmanager-bundle.zip
==> Verifying SHA-256 checksum for Cask 'session-manager-plugin'.
audit for session-manager-plugin: passed

$ brew cask style --fix session-manager-plugin

1 file inspected, no offenses detected
```

Version is current per [documented version/release history](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#plugin-version-history)


