### PR TITLE
Update macx-dvd-ripper-pro from 6.5.1,20191223 to 6.5.2,20200420

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask 'macx-dvd-ripper-pro' do
-  version '6.5.1,20191223'
-  sha256 '291758ace70b0a11c3bef51f442d8ee93ce1a2f8b5fed9ead186b093803e6f4c'
+  version '6.5.2,20200420'
+  sha256 '251255fe5432e5f4576d0a17a1b7f8bec6cec6ff8dbaf7d518f3f9dcf2fe32a4'
 
   url 'https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg'
   appcast 'https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.