### PR TITLE
Update sound-siphon from 3.2.2,5876 to 3.2.3,5876

### DIFF
--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -1,6 +1,6 @@
 cask 'sound-siphon' do
-  version '3.2.2,5876'
-  sha256 '2808036adb72a247af9115eb2ea731574345acfea5cd0694c049f3fe89d4a6b6'
+  version '3.2.3,5876'
+  sha256 '0e5e955a2976963580d14d1711263a8d0688a1160e4cbd147f848fa2e098e8f7'
 
   # staticz.net/ was verified as official when first introduced to the cask
   url "https://staticz.com/download/#{version.after_comma}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.