### PR TITLE
Update anydo from 4.2.80 to 4.2.81

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.80'
-  sha256 'c2bf48ad6b2d9dfeaafa1aed50806c2fb791f48c3a173d9276d6d1d196c17479'
+  version '4.2.81'
+  sha256 '405c59007d0fa550daa80843070efcca371c6ff0b57dfa2268c27b1c69497807'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.