### PR TITLE
Update battlescribe from 2.03.14 to 2.03.15

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -7,6 +7,7 @@ cask 'battlescribe' do
   name 'BattleScribe'
   homepage 'https://battlescribe.net/'
 
-  suite 'BattleScribe Tools'
-  app 'BattleScribe.app'
+  pkg "BattleScribe_#{version}_Installer.pkg"
+  
+  uninstall pkgutil: 'dunno'  
 end

--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,8 +1,8 @@
 cask 'battlescribe' do
-  version '2.03.14'
-  sha256 '91c4bfaf47137608bf71c14aecc2e5e5a7df61797de5d013c7fdaa5b54980650'
+  version '2.03.15'
+  sha256 'e4ad9f59538835d49d953549e8f00b210367f7db363b7a66aad8aa57e5c4e7f8'
 
-  url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.dmg"
+  url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.pkg"
   appcast 'https://battlescribe.net/?tab=downloads'
   name 'BattleScribe'
   homepage 'https://battlescribe.net/'

--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -8,6 +8,11 @@ cask 'battlescribe' do
   homepage 'https://battlescribe.net/'
 
   pkg "BattleScribe_#{version}_Installer.pkg"
-  
-  uninstall pkgutil: 'dunno'  
+
+  uninstall pkgutil: [
+                       'net.battlescribe.desktop.dataeditor',
+                       'net.battlescribe.desktop.dataindexer',
+                       'net.battlescribe.desktop.jre',
+                       'net.battlescribe.desktop.rostereditor',
+                     ]
 end

--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -14,5 +14,9 @@ cask 'battlescribe' do
                        'net.battlescribe.desktop.dataindexer',
                        'net.battlescribe.desktop.jre',
                        'net.battlescribe.desktop.rostereditor',
+                     ],
+            delete:  [
+                       '/Applications/BattleScribe Tools/',
+                       '/Applications/BattleScribe.app',
                      ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.