### PR TITLE
Update blitz from 1.6.47 to 1.7.8

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.6.47'
-  sha256 '6b8dd84ea1343d9717b1954c8663e602dee1596d821b659bfef24fa8de800623'
+  version '1.7.8'
+  sha256 'f8be47c0d7608d6db024ee1dd325ea29cadc3488d2a97eae75d8a27108eb7125'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.