### PR TITLE
Update bisq from 1.3.1 to 1.3.2

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask 'bisq' do
-  version '1.3.1'
-  sha256 'db42438d0e8d5c8d243bff23f7f1ae0685e007d22042ba6debb29e56d225733d'
+  version '1.3.2'
+  sha256 'c1a70e0511ae9ee3dbf26946321e2df22d7930670826526cb5ef8b40605b9ac0'
 
   # github.com/bisq-network/bisq/ was verified as official when first introduced to the cask
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.