### PR TITLE
Update gearboy from 3.0.2 to 3.0.3

### DIFF
--- a/Casks/gearboy.rb
+++ b/Casks/gearboy.rb
@@ -1,6 +1,6 @@
 cask 'gearboy' do
-  version '3.0.2'
-  sha256 '598f69b65f5ff99352f01328b5106b3bb41d109057854a9490f58c7933a57226'
+  version '3.0.3'
+  sha256 'd940227966e3500a9fc3d612b00ca52cab58e03e1aa70d4ec97f1884a2b0686a'
 
   url "https://github.com/drhelius/Gearboy/releases/download/gearboy-#{version}/Gearboy-#{version}-macOS.zip"
   appcast 'https://github.com/drhelius/Gearboy/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.