### PR TITLE
Update gopass-ui from 0.6.0 to 0.7.0

### DIFF
--- a/Casks/gopass-ui.rb
+++ b/Casks/gopass-ui.rb
@@ -1,6 +1,6 @@
 cask 'gopass-ui' do
-  version '0.6.0'
-  sha256 '8fd4845d3ae4e4f0caa92f2f8140e09d9538736a5f61f402959f6909b7b1c4b6'
+  version '0.7.0'
+  sha256 '43f14b79004b32eb081d39752f34b09639993a039cff4691ad69eb82b562b6b0'
 
   url "https://github.com/codecentric/gopass-ui/releases/download/v#{version}/Gopass.UI-#{version}.dmg"
   appcast 'https://github.com/codecentric/gopass-ui/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.