### PR TITLE
Update openaudible from 2.0.1 to 2.0.2

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,6 +1,6 @@
 cask 'openaudible' do
-  version '2.0.1'
-  sha256 '456d94493940f77a22d277137cae06bf53d073c2239eb5905d25d1222e450ba9'
+  version '2.0.2'
+  sha256 'faf0749eab80c267b9ea3a56c38c9966954dae47c737ce547ef432bf9f4b48d9'
 
   # github.com/openaudible/ was verified as official when first introduced to the cask
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.