### PR TITLE
Update tagspaces from 3.4.2 to 3.5.2

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask 'tagspaces' do
-  version '3.4.2'
-  sha256 '8fa1d9ab15887f142d125a450c368bd6275a96a377c560076ed5bc83e9c849ba'
+  version '3.5.2'
+  sha256 'e7ba6bf22185fb4f2e21082e5b5bbb81c93e1d98847ab633883d800765033254'
 
   # github.com/tagspaces/tagspaces/ was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.