### PR TITLE
Update skyfonts from 5.9.5.5 to 5.9.5.6

### DIFF
--- a/Casks/skyfonts.rb
+++ b/Casks/skyfonts.rb
@@ -1,6 +1,6 @@
 cask 'skyfonts' do
-  version '5.9.5.5'
-  sha256 'facb1bf918780eecf7111a9957f277a77de114e92f599c8101a68518345b63fb'
+  version '5.9.5.6'
+  sha256 'b2526d96898895db1c3f2caf3b1ab825898408b097e1efd88fbf33dd6bf9515f'
 
   url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
   appcast 'https://api.skyfonts.com/api/SkyFontsAppCast?osid=3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.