### PR TITLE
Update script-debugger from 7.0.11-7A110 to 7.0.12-7A112

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,6 +1,6 @@
 cask 'script-debugger' do
-  version '7.0.11-7A110'
-  sha256 'eaf7852be5b0595128f484ae9d97b81079feb62349ab7a8fed28cfa09b65ec38'
+  version '7.0.12-7A112'
+  sha256 '3be99ccffadebf5d876cfd0dddc5f81bd4ae36c93f1913a633c0bb36fbfa41c9'
 
   # s3.amazonaws.com/latenightsw.com/ was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.