### PR TITLE
Update ishowu-instant from 1.3.3 to 1.3.4

### DIFF
--- a/Casks/ishowu-instant.rb
+++ b/Casks/ishowu-instant.rb
@@ -1,6 +1,6 @@
 cask 'ishowu-instant' do
-  version '1.3.3'
-  sha256 '916992d89b97f9ab543bee8035146dfc267550a31d8d2bf5a34039cefc309708'
+  version '1.3.4'
+  sha256 'e02a00862ea0bf6e4855942b8ed285b0c743d0bb6fd387cc8a29157415240d38'
 
   url "https://www.shinywhitebox.com/downloads/instant/iShowU_Instant_#{version}.dmg"
   appcast 'https://www.shinywhitebox.com/store/appcast.php?p=14'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.