### PR TITLE
Update exodus from 20.4.14 to 20.4.18

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '20.4.14'
-  sha256 '2d7de4a83acba3aada3a180b8b38e4ec51fac4c3f516ef28aee3606f4fa7584e'
+  version '20.4.18'
+  sha256 '11997f6a9993c75db025caabbbad5837faef225ec9ec39a3ad36006d76541b19'
 
   url "https://downloads.exodus.io/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.