### PR TITLE
Update telavox-flow from 1.97.0 to 1.98.1

### DIFF
--- a/Casks/telavox-flow.rb
+++ b/Casks/telavox-flow.rb
@@ -1,6 +1,6 @@
 cask 'telavox-flow' do
-  version '1.97.0'
-  sha256 'ade8f6b0d925db3eb38443815609e7390d78da9af9a97be17c6811744647d17c'
+  version '1.98.1'
+  sha256 '653b6648bd49a6f4f3d30a8b4b5f64a604d2844ed83362a4afdce42952700087'
 
   # s3.eu-west-2.amazonaws.com/flow-desktop/ was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/flow-desktop/Flow-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.