### PR TITLE
Update 4k-youtube-to-mp3 from 3.11.1.3500 to 3.12.0.3590

### DIFF
--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask '4k-youtube-to-mp3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '3.11.1.3500'
-  sha256 '80bd85468d48b28bc5b6cc0a80af96c11df48eecb4e072544356f9553bdfd7ca'
+  version '3.12.0.3590'
+  sha256 'd54eac913939d7e56ec942943a6a078640b1d2778a3b7e778ee268164145b529'
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.