### PR TITLE
Update krisp from 1.11.8 to 1.12.13

### DIFF
--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -1,6 +1,6 @@
 cask 'krisp' do
-  version '1.11.8'
-  sha256 'b91a9a2cc7a04db75120d001b5b2981bf57a6ffee403a808cfe15aa7b6b5c00b'
+  version '1.12.13'
+  sha256 'c84e78637f5861adfc194b75f3cbed889f6628b0c5dae3651d8f5d46382e672f'
 
   url "https://cdn.krisp.ai/mac/release/v#{version.major}.#{version.minor}/krisp_#{version}.pkg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://api.krisp.ai/v2/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.