### PR TITLE
Update trilium-notes from 0.40.7 to 0.41.5

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.40.7'
-  sha256 '0ad1621ff9efa71ab77ba3184bb2be87931f655198a6b524c2cba04fb3f0ceda'
+  version '0.41.5'
+  sha256 '64ecea14a53af6e371af4029f5b4abf85c93ea8e88f985ef34a72fa0d4d7c55e'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.