### PR TITLE
Update zappy from 2.1.3 to 2.1.4

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,6 +1,6 @@
 cask 'zappy' do
-  version '2.1.3'
-  sha256 '1ca6c8f602e85a0ebd2987df4e6e409a2a42a713daafd1ac3d2d0d0c27b7ad48'
+  version '2.1.4'
+  sha256 '32f5687a00c3b0ccb0721dc1d1d2be9e1531dcdba73be870a2da692c10e9febc'
 
   url "https://zappy.zapier.com/releases/zappy-#{version}.zip"
   appcast 'https://zappy.zapier.com/releases/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.