### PR TITLE
Update latexit from 2.14.8 to 2.14.9

### DIFF
--- a/Casks/latexit.rb
+++ b/Casks/latexit.rb
@@ -1,6 +1,6 @@
 cask 'latexit' do
-  version '2.14.8'
-  sha256 'eead7d0145b6dffb298898a2495d99537bafec6c0aff3ce9fdef69d8ea893fd5'
+  version '2.14.9'
+  sha256 '991f41c1541c08cf0970ea82d21ec1a4c74c164a286d6c980b980bd44c9deacf'
 
   url "https://www.chachatelier.fr/latexit/downloads/LaTeXiT-#{version.dots_to_underscores}.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.