### PR TITLE
Update mailbutler from 2,2718-13159 to 2,2721-13245

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2,2718-13159'
-  sha256 '94d1b744590a6e39d082d1cc7e5e5920d9782f4bc82a66a27f727c341627d140'
+  version '2,2721-13245'
+  sha256 '20f2deb7b1f8bc8404640c225ab4e9c003410939d15680f5b870a6003feff9bd'
 
   url "https://downloads.mailbutler.io/sparkle/public/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.