### PR TITLE
Update scaleft from 1.44.4 to 1.44.6

### DIFF
--- a/Casks/scaleft.rb
+++ b/Casks/scaleft.rb
@@ -1,6 +1,6 @@
 cask 'scaleft' do
-  version '1.44.4'
-  sha256 'ecd73c5d0fd2262282ed5cf7e93f85ba86aeec4171078be5e4f7ee0b38402b98'
+  version '1.44.6'
+  sha256 '67f54555b58cdc8165f9c40bc903ee5d706a60f058e27ace20a03a6a93a242fb'
 
   url "https://dist.scaleft.com/client-tools/mac/v#{version}/ScaleFT-#{version}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.