### PR TITLE
Update glip from 20.2.10 to 20.2.11

### DIFF
--- a/Casks/glip.rb
+++ b/Casks/glip.rb
@@ -1,6 +1,6 @@
 cask 'glip' do
-  version '20.2.10'
-  sha256 '86ad5690a059c1bb329bc7577ab05e1e00fe9b9b3c6079fd7db1782a0500dc6d'
+  version '20.2.11'
+  sha256 '62a113e78ba94144fcf7d0aac43b603b6502771f4304695bd14392c27c0cd835'
 
   # downloads.ringcentral.com/glip/rc/ was verified as official when first introduced to the cask
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.