### PR TITLE
Update dcv-viewer from 2020.0.1710 to 2020.0.1716

### DIFF
--- a/Casks/dcv-viewer.rb
+++ b/Casks/dcv-viewer.rb
@@ -1,6 +1,6 @@
 cask 'dcv-viewer' do
-  version '2020.0.1710'
-  sha256 'e31300784ba7a1069426b2c359db25848e4d47dbb0aa2d0cbe0f8692d6ec3b51'
+  version '2020.0.1716'
+  sha256 'e4ddae68e8c827d3ec28ef7c557883d901058a8d17460495a456da7e15e1a4d0'
 
   # d1uj6qtbmh3dt5.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d1uj6qtbmh3dt5.cloudfront.net/#{version.major_minor}/Clients/nice-dcv-viewer-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.