### PR TITLE
Update 4k-video-downloader from 4.12.0.3570 to 4.12.1.3580

### DIFF
--- a/Casks/4k-video-downloader.rb
+++ b/Casks/4k-video-downloader.rb
@@ -1,6 +1,6 @@
 cask '4k-video-downloader' do
-  version '4.12.0.3570'
-  sha256 '056c752167d4deaa38d1f21fcb67dfdfb438e4dfc681ed16e088ab080d3feb1f'
+  version '4.12.1.3580'
+  sha256 '7fbef86431188b16136fcc6d5b334f7e4828248933b4b7fb532d2b30b3cb3b38'
 
   url "https://dl.4kdownload.com/app/4kvideodownloader_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.