### PR TITLE
Update focuswriter from 1.7.5 to 1.7.6

### DIFF
--- a/Casks/focuswriter.rb
+++ b/Casks/focuswriter.rb
@@ -1,6 +1,6 @@
 cask 'focuswriter' do
-  version '1.7.5'
-  sha256 '80b1892c72073a6ab225408fc0942b172a702212ab5bcd9ee87140857e389386'
+  version '1.7.6'
+  sha256 '3431642e61cf11c3d0993fd6b70880cba2cca23043e22b2b2f68f8f8a02ff1bc'
 
   url "https://gottcode.org/focuswriter/FocusWriter_#{version}.dmg"
   appcast 'https://gottcode.org/focuswriter/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.