### PR TITLE
Update gearsystem from 3.0.2 to 3.0.3

### DIFF
--- a/Casks/gearsystem.rb
+++ b/Casks/gearsystem.rb
@@ -1,6 +1,6 @@
 cask 'gearsystem' do
-  version '3.0.2'
-  sha256 '23559909818aaa99f8e1d87cc944583bd9ffaa8ad77a1e2f6a284a465700ee4f'
+  version '3.0.3'
+  sha256 '2988d659b30332655d2012de15bca3027adb5e705708a47f3f605aa01b9c79aa'
 
   url "https://github.com/drhelius/Gearsystem/releases/download/gearsystem-#{version}/Gearsystem-#{version}-macOS.zip"
   appcast 'https://github.com/drhelius/Gearsystem/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.