### PR TITLE
Update zoomus from 4.6.20561.0413 to 4.6.20615.0421

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.6.20561.0413'
-  sha256 '6c88d261f7784f1278f9aa7edcaa438cd919e7525cd66a17f019a2bcfae30eea'
+  version '4.6.20615.0421'
+  sha256 '5730265a55c81a3d1fc573dd52972c9ed31aabbc8b460de42f5f41f4976c34d8'
 
   # d11yldzmag5yn.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d11yldzmag5yn.cloudfront.net/prod/#{version}/Zoom.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.