### PR TITLE
Update spectacle

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -19,4 +19,8 @@ cask 'spectacle' do
                '~/Library/Cookies/com.divisiblebyzero.Spectacle.binarycookies',
                '~/Library/Preferences/com.divisiblebyzero.Spectacle.plist',
              ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Mark as discontinued according to:
https://github.com/eczarny/spectacle#important-note


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.