### PR TITLE
Update omnigraffle from 7.15 to 7.15.1

### DIFF
--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -8,8 +8,8 @@ cask 'omnigraffle' do
     sha256 '83ef24af2dbd7977b9922e992f17f23e102562f0589d28bc37d5579b4a4d4938'
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
   else
-    version '7.15'
-    sha256 '08c8de14907994dfee0a178b8da897603552c904737547d36e5d9b7448d6d278'
+    version '7.15.1'
+    sha256 'cc5b5798320ff94cc05d38ee8612f1ac217bb9a2d7e18b99a6808e814065f169'
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.