### PR TITLE
Update reunion from 12.0.0.200127 to 12.0.0.200421

### DIFF
--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -1,6 +1,6 @@
 cask 'reunion' do
-  version '12.0.0.200127'
-  sha256 '9655c949b744ba3e1571b3de55d9a3c35a7391bd3d4a4591098a2e9812b3dd83'
+  version '12.0.0.200421'
+  sha256 'fd3124f41a71ea853fef079784cce8db07a06261367630eb0763064f1ab5395a'
 
   url "https://store.leisterpro.com/updates/reunion#{version.major}/Reunion-#{version.dots_to_hyphens}.zip"
   appcast "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.