### PR TITLE
Update dash to 5.1.5

### DIFF
--- a/Casks/dash.rb
+++ b/Casks/dash.rb
@@ -3,8 +3,8 @@ cask 'dash' do
     version '4.6.7'
     sha256 'e2b5eb996645b25f12ccae15e24b1b0d8007bc5fed925e14ce7be45a2b693fb6'
   else
-    version '5.1.4'
-    sha256 '4032cee2661d20112bb22d2d19c0f6ba50b86b6fdaec798ac395b5f93cb2a632'
+    version '5.1.5'
+    sha256 '696a95ae708d717eef279610c7d94008914cd35d5bbb5a1302439205cf2d2dff'
   end
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.