### PR TITLE
Update termius from 5.9.2 to 5.9.3

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,5 +1,5 @@
 cask 'termius' do
-  version '5.9.2'
+  version '5.9.3'
   sha256 'b618f8f89b12c26f5f2ba15371046a3d41acd21dbf720ef151c406bb8f19a169'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac/ was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.