### PR TITLE
Update mattermost from 4.4.0 to 4.4.1

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
-  version '4.4.0'
-  sha256 'd66a567eda191d35db89d098b564d65d5629f08269a9c0584363df813639b2a6'
+  version '4.4.1'
+  sha256 'd1b9f80f8c21ae4cdc5e52697ce49b3a7eedb33896ee2d9fdd5567b69bbff8e6'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
   appcast 'https://github.com/mattermost/desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.