### PR TITLE
Update cabal from 5.0.1 to 5.0.2

### DIFF
--- a/Casks/cabal.rb
+++ b/Casks/cabal.rb
@@ -1,6 +1,6 @@
 cask 'cabal' do
-  version '5.0.1'
-  sha256 '0ca563c84fb7536f0d0f8eb2011a2175d68183cb89d139573a5004d2c0e60075'
+  version '5.0.2'
+  sha256 'a9672daf7b5137513ab959a85bfc345fa52ffd76529b4f329a95a64af643ffc1'
 
   # github.com/cabal-club/cabal-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/cabal-club/cabal-desktop/releases/download/v#{version}/cabal-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.