### PR TITLE
Update lbry from 0.44.0 to 0.45.0

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.44.0'
-  sha256 '362595f1addbed00c6dd9cae0ea4322de48f5d75b253b7da23c2185cf7c081ea'
+  version '0.45.0'
+  sha256 '7017cea0fcb7a9d7da3813c39e4f59b13e1ff121826fe6bef8e1e5af3a41cbb8'
 
   # github.com/lbryio/lbry-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.