### PR TITLE
Update jami from 20200409.1452 to 20200422.0842

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,6 +1,6 @@
 cask 'jami' do
-  version '20200409.1452'
-  sha256 '9ddcc103a78ff9e63a922faa218d276372f602b73a30c0af8eda7342b3df192d'
+  version '20200422.0842'
+  sha256 'fa519a3ae48ec487bdd8142b79f5c5191c8525b09911fa9c4dc19f085257e1bb'
 
   url "https://dl.jami.net/mac_osx/jami-#{version.no_dots}.dmg"
   appcast 'https://dl.jami.net/mac_osx/sparkle-ring.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.