### PR TITLE
Update java from 14,36:076bab302c7b4508975440c56f6cc26a to 14.0.1,7:664493ef4a6946b186ff29eb326336a2

### DIFF
--- a/Casks/java.rb
+++ b/Casks/java.rb
@@ -1,6 +1,6 @@
 cask 'java' do
-  version '14,36:076bab302c7b4508975440c56f6cc26a'
-  sha256 'f3e7439e19ea22f71a96b5563e0e0967e7df1563f2f9d7922209793498ca4698'
+  version '14.0.1,7:664493ef4a6946b186ff29eb326336a2'
+  sha256 'd8aa6806e6cc99724395563bf02fc6907a7c801f4caef85b96ad44927193da07'
 
   url "https://download.java.net/java/GA/jdk#{version.before_comma}/#{version.after_colon}/#{version.after_comma.before_colon}/GPL/openjdk-#{version.before_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Java Development Kit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.