### PR TITLE
Update zappy from 2.1.4 to 2.2.0

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,6 +1,6 @@
 cask 'zappy' do
-  version '2.1.4'
-  sha256 '32f5687a00c3b0ccb0721dc1d1d2be9e1531dcdba73be870a2da692c10e9febc'
+  version '2.2.0'
+  sha256 '41945a082193d1bd8b32856cb81ce083e0c42f48c4ab2aca626b64c93d6f3c8a'
 
   url "https://zappy.zapier.com/releases/zappy-#{version}.zip"
   appcast 'https://zappy.zapier.com/releases/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.