### PR TITLE
Update mmex from 1.3.3 to 1.3.4

### DIFF
--- a/Casks/mmex.rb
+++ b/Casks/mmex.rb
@@ -1,9 +1,9 @@
 cask 'mmex' do
-  version '1.3.3'
-  sha256 '49eeb6b50a51bfa09da7f4bb063ad75c5695eeeac410ae13d4c8e8844ac43505'
+  version '1.3.4'
+  sha256 '3d094573241527ab8c578c4dd879373df5ff662d528cb329ab74f36f4836efe2'
 
   # github.com/moneymanagerex/moneymanagerex/ was verified as official when first introduced to the cask
-  url "https://github.com/moneymanagerex/moneymanagerex/releases/download/v#{version}/mmex_#{version}_macos10.9-wx3.0.2build.dmg"
+  url "https://github.com/moneymanagerex/moneymanagerex/releases/download/v#{version}-Release/mmex-#{version}-Darwin.dmg"
   appcast 'https://github.com/moneymanagerex/moneymanagerex/releases.atom'
   name 'Money Manager Ex'
   homepage 'https://www.moneymanagerex.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.