### PR TITLE
Update qbittorrent from 4.2.3 to 4.2.4

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'qbittorrent' do
-  version '4.2.3'
-  sha256 '422ecaaedf610eb359ea1042ea57d0fb92d87754f66b432b3f2b17d1d21607c2'
+  version '4.2.4'
+  sha256 '384fe7d1c7bd35747829f39a0a679378a6f1ec89bc1a3e27e1809c12b69ee73a'
 
   # sourceforge.net/qbittorrent/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.