### PR TITLE
Update chromium from 761197 to 761635

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '761197'
-  sha256 'eaa769e827fe839c75cf28adbe8411bfece7a8258179a9daa1a01238fee263d6'
+  version '761635'
+  sha256 '9feb76e2b483c7e27026bd69b0d63ba695b6997c66d6466992baca180c5d3a6d'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
@@ -9,7 +9,16 @@ cask 'chromium' do
   homepage 'https://www.chromium.org/Home'
 
   app 'chrome-mac/Chromium.app'
-  binary "#{appdir}/Chromium.app/Contents/MacOS/Chromium", target: 'chromium'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/Chromium.wrapper.sh"
+  binary shimscript, target: 'chromium'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      '#{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
+    EOS
+  end
 
   zap trash: [
                '~/Library/Preferences/org.chromium.Chromium.plist',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.