### PR TITLE
Update chromium from 761197 to 762311

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '761197'
-  sha256 'eaa769e827fe839c75cf28adbe8411bfece7a8258179a9daa1a01238fee263d6'
+  version '761663'
+  sha256 'efc538b8239224b870b654b47129ad02450a60c7801a5c31b9e0699f359b6c3f'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
@@ -9,7 +9,16 @@ cask 'chromium' do
   homepage 'https://www.chromium.org/Home'
 
   app 'chrome-mac/Chromium.app'
-  binary "#{appdir}/Chromium.app/Contents/MacOS/Chromium", target: 'chromium'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/chromium.wrapper.sh"
+  binary shimscript, target: 'chromium'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      '#{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
+    EOS
+  end
 
   zap trash: [
                '~/Library/Preferences/org.chromium.Chromium.plist',

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '761663'
-  sha256 'efc538b8239224b870b654b47129ad02450a60c7801a5c31b9e0699f359b6c3f'
+  version '762126'
+  sha256 '30f8b666815f1eb54900dff038ae5d6a419a48bdf883e63f3fdce6a9f0b1e611'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
@@ -21,9 +21,9 @@ cask 'chromium' do
   end
 
   zap trash: [
-               '~/Library/Preferences/org.chromium.Chromium.plist',
-               '~/Library/Caches/Chromium',
                '~/Library/Application Support/Chromium',
+               '~/Library/Caches/Chromium',
+               '~/Library/Preferences/org.chromium.Chromium.plist',
                '~/Library/Saved Application State/org.chromium.Chromium.savedState',
              ]
 end

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,12 +1,17 @@
 cask 'chromium' do
-  version '762126'
-  sha256 '30f8b666815f1eb54900dff038ae5d6a419a48bdf883e63f3fdce6a9f0b1e611'
+  version '762311'
+  sha256 '1ceb7992244fc0eced6abe79415e24c20e497674b215f7ff2b1e00ca7b1e616e'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
   appcast 'https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2FLAST_CHANGE?alt=media'
   name 'Chromium'
   homepage 'https://www.chromium.org/Home'
+
+  conflicts_with cask: [
+                         'eloston-chromium',
+                         'freesmug-chromium',
+                       ]
 
   app 'chrome-mac/Chromium.app'
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.