### PR TITLE
Update michaelvillar-timer from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/michaelvillar-timer.rb
+++ b/Casks/michaelvillar-timer.rb
@@ -1,6 +1,6 @@
 cask 'michaelvillar-timer' do
-  version '1.5.2'
-  sha256 'f7adbf0f04ecdfb6cf914774859bc187d2ae944a51b748ddc82de4ecd34e9252'
+  version '1.5.3'
+  sha256 'db4aa47e11b557dc4733153b452e7acb6bd67c9836e3bc829fb751e07db075b1'
 
   url "https://github.com/michaelvillar/timer-app/releases/download/#{version}/Timer.app.zip"
   appcast 'https://github.com/michaelvillar/timer-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.