### PR TITLE
Update katalon-studio from 7.4.0 to 7.4.2

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.4.0'
-  sha256 'b5b5a8be023db821394bfeaeca6b4a109c101486237fcaa959488950a3ece57c'
+  version '7.4.2'
+  sha256 '8d36697a959a7661ff5a0de8bd80917e972e3973765398eb903ef762df663550'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.