### PR TITLE
Update intel-power-gadget

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -15,4 +15,9 @@ cask 'intel-power-gadget' do
 
   uninstall pkgutil: 'com.intel.pkg.PowerGadget.*',
             kext:    'EnergyDriver'
+
+  zap trash: [
+               '~/Library/Caches/com.intel.PowerGadget',
+               '~/Library/Preferences/com.intel.PowerGadget.plist',
+             ]
 end

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -3,8 +3,7 @@ cask 'intel-power-gadget' do
   sha256 '22ed3fe050c3b965841ccc5590a3a03bb9498f8620e01ba4dea5557dcd24fe43'
 
   url "https://software.intel.com/file/#{version.after_comma}/download"
-  appcast 'https://software.intel.com/en-us/articles/intel-power-gadget',
-          configuration: version.after_comma
+  appcast 'https://software.intel.com/sites/landingpage/powergadget/?app=IntelPowerGadgetMac'
   name 'Intel Power Gadget'
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget'
 

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -12,7 +12,7 @@ cask 'intel-power-gadget' do
   depends_on macos: '>= :high_sierra'
 
   pkg 'Install Intel Power Gadget.pkg'
-  
+
   uninstall_preflight do
     system_command '/usr/sbin/installer',
                    args: [

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -3,7 +3,8 @@ cask 'intel-power-gadget' do
   sha256 '22ed3fe050c3b965841ccc5590a3a03bb9498f8620e01ba4dea5557dcd24fe43'
 
   url "https://software.intel.com/file/#{version.after_comma}/download"
-  appcast 'https://software.intel.com/sites/landingpage/powergadget/?app=IntelPowerGadgetMac'
+  appcast 'https://software.intel.com/en-us/articles/intel-power-gadget',
+          configuration: version.after_comma
   name 'Intel Power Gadget'
   homepage 'https://software.intel.com/en-us/articles/intel-power-gadget'
 
@@ -12,16 +13,6 @@ cask 'intel-power-gadget' do
 
   pkg 'Install Intel Power Gadget.pkg'
 
-  uninstall_preflight do
-    system_command '/usr/sbin/installer',
-                   args: [
-                           '-pkg', '/Applications/Intel Power Gadget/Uninstaller.pkg',
-                           '-target', '/'
-                         ],
-                   sudo: true
-  end
-
-  uninstall pkgutil: 'com.intel.pkg.PowerGadget.*'
-
-  zap trash: '~/Library/Caches/com.intel.PowerGadget'
+  uninstall pkgutil: 'com.intel.pkg.PowerGadget.*',
+            kext:    'EnergyDriver'
 end

--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -12,7 +12,17 @@ cask 'intel-power-gadget' do
   depends_on macos: '>= :high_sierra'
 
   pkg 'Install Intel Power Gadget.pkg'
+  
+  uninstall_preflight do
+    system_command '/usr/sbin/installer',
+                   args: [
+                           '-pkg', '/Applications/Intel Power Gadget/Uninstaller.pkg',
+                           '-target', '/'
+                         ],
+                   sudo: true
+  end
 
-  uninstall pkgutil: 'com.intel.pkg.PowerGadget.*',
-            kext:    'EnergyDriver'
+  uninstall pkgutil: 'com.intel.pkg.PowerGadget.*'
+
+  zap trash: '~/Library/Caches/com.intel.PowerGadget'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

Similarly to #81081, `intel-power-gadget` comes with an `Uninstaller.pkg` provided by Intel itself.
Maybe it could be preferable to use that instead of manually replicate its function?
Correct me if I'm wrong, so that I can adjust the PR to just remove the config files in the `zap` stanza