### PR TITLE
Update qt-creator from 4.11.2 to 4.12.0

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.11.2'
-  sha256 'c3633a1ca1d79693172e624395e609d658d99d16f5b3d8bdfb6ebe4f51efe3e8'
+  version '4.12.0'
+  sha256 '831121c8bffda3642bfce35da82c425a7159b55d60b7968a9ddff96a84662810'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qtcreator/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.