### PR TITLE
Update quiterss from 0.19.3 to 0.19.4

### DIFF
--- a/Casks/quiterss.rb
+++ b/Casks/quiterss.rb
@@ -1,8 +1,8 @@
 cask 'quiterss' do
-  version '0.19.3'
-  sha256 '841dbf3105681eb789d63f98dde850bc9b8582aa7df96f595fbdb5fecc6a52b6'
+  version '0.19.4'
+  sha256 '58c7517860252e60521d5681ce1f6220c7d4bedb4841a0d1e41236695085627e'
 
-  url "https://quiterss.org/files/#{version}/QuiteRSS-#{version}.dmg"
+  url "https://quiterss.org/files/#{version}_/QuiteRSS-#{version}.dmg"
   appcast 'https://github.com/QuiteRSS/quiterss/releases.atom'
   name 'QuiteRSS'
   homepage 'https://quiterss.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.