### PR TITLE
Update unicodechecker from 1.21.1,755 to 1.22,776

### DIFF
--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -2,7 +2,7 @@ cask 'unicodechecker' do
   version '1.22,776'
   sha256 '3c173ef1984cc42baa0dd03cfbd4d07cf18c75e3699b2c2a3a24250ac77fbe4f'
 
-  url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
+  url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker%20#{version.before_comma}%20(#{version.after_comma}).zip'
   appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml'
   name 'UnicodeChecker'
   homepage 'https://earthlingsoft.net/UnicodeChecker/'

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -1,6 +1,6 @@
 cask 'unicodechecker' do
   version '1.22,776'
-  sha256 '0b6019277bade20ccd2904adf0fd29c7395ab495e02ace8c5b58d4e33ebd6587'
+  sha256 '3c173ef1984cc42baa0dd03cfbd4d07cf18c75e3699b2c2a3a24250ac77fbe4f'
 
   url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'
   appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml'

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -2,8 +2,8 @@ cask 'unicodechecker' do
   version '1.22,776'
   sha256 '3c173ef1984cc42baa0dd03cfbd4d07cf18c75e3699b2c2a3a24250ac77fbe4f'
 
-  url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker%20#{version.before_comma}%20(#{version.after_comma}).zip"
-  appcast "https://earthlingsoft.net/UnicodeChecker/appcast.xml'
+  url "https://earthlingsoft.net/UnicodeChecker/UnicodeChecker%20#{version.before_comma}%20(#{version.after_comma}).zip"
+  appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml'
   name 'UnicodeChecker'
   homepage 'https://earthlingsoft.net/UnicodeChecker/'
 

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -1,5 +1,5 @@
 cask 'unicodechecker' do
-  version '1.21.1,755'
+  version '1.22,776'
   sha256 '0b6019277bade20ccd2904adf0fd29c7395ab495e02ace8c5b58d4e33ebd6587'
 
   url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker.zip'

--- a/Casks/unicodechecker.rb
+++ b/Casks/unicodechecker.rb
@@ -2,8 +2,8 @@ cask 'unicodechecker' do
   version '1.22,776'
   sha256 '3c173ef1984cc42baa0dd03cfbd4d07cf18c75e3699b2c2a3a24250ac77fbe4f'
 
-  url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker%20#{version.before_comma}%20(#{version.after_comma}).zip'
-  appcast 'https://earthlingsoft.net/UnicodeChecker/appcast.xml'
+  url 'https://earthlingsoft.net/UnicodeChecker/UnicodeChecker%20#{version.before_comma}%20(#{version.after_comma}).zip"
+  appcast "https://earthlingsoft.net/UnicodeChecker/appcast.xml'
   name 'UnicodeChecker'
   homepage 'https://earthlingsoft.net/UnicodeChecker/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.