### PR TITLE
Update noxappplayer from 3.0.1.0,20200414:e34827a24f3b4c16b3d61a88eda7fc43 to 3.0.2.0,20200422:02062aa2192b4490aa121f60ba82cf3b

### DIFF
--- a/Casks/noxappplayer.rb
+++ b/Casks/noxappplayer.rb
@@ -7,5 +7,7 @@ cask 'noxappplayer' do
   name 'NoxAppPlayer'
   homepage 'https://www.bignox.com/'
 
+  container nested: 'NoxAppPlayerInstaller.app/Contents/MacOS/NoxAppPlayer.zip'
+
   app 'NoxAppPlayer.app'
 end

--- a/Casks/noxappplayer.rb
+++ b/Casks/noxappplayer.rb
@@ -1,6 +1,6 @@
 cask 'noxappplayer' do
-  version '3.0.1.0,20200414:e34827a24f3b4c16b3d61a88eda7fc43'
-  sha256 '77c35b79a6ee1225f15c806bcbbfbaf35de88a249e21867cd231529da74c8ade'
+  version '3.0.2.0,20200422:02062aa2192b4490aa121f60ba82cf3b'
+  sha256 'cc401e478c833ad16a4adfbbde30b40a705be6ce6cf1ec4ff9062ceb2d9a0078'
 
   url "https://res06.bignox.com/full/#{version.after_comma.before_colon}/#{version.after_colon}.dmg?filename=Nox_installer_for_mac_intl_#{version.before_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.bignox.com/en/download/fullPackage/mac_fullzip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.