### PR TITLE
Update zappy from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,6 +1,6 @@
 cask 'zappy' do
-  version '2.2.0'
-  sha256 '41945a082193d1bd8b32856cb81ce083e0c42f48c4ab2aca626b64c93d6f3c8a'
+  version '2.2.1'
+  sha256 '1c79699988294aa8637f619fc97429a297515d2f5dbf5a80f238ea90ced80de5'
 
   url "https://zappy.zapier.com/releases/zappy-#{version}.zip"
   appcast 'https://zappy.zapier.com/releases/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.