### PR TITLE
Update chessx from 1.5.2 to 1.5.0

### DIFF
--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -1,6 +1,6 @@
 cask 'chessx' do
-  version '1.5.2'
-  sha256 '922bde3748dfb78738f7007fbb768e9b42d997d5fb991d6b8f110c3a7e40b611'
+  version '1.5.0'
+  sha256 'c75ef2f58f6eb99816b2ceecbb80073b9e3b3b79fa4376d65118928db02469b0'
 
   # downloads.sourceforge.net/chessx/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/chessx/chessx/#{version}/chessx-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`https://sourceforge.net/projects/chessx/files/latest/download` points to `https://sourceforge.net/projects/chessx/files/chessx/1.5.0/chessx-1.5.0.dmg/download`, and the download link for version `1.5.2` is `https://sourceforge.net/projects/chessx/files/chessx/beta/chessx-1.5.2.dmg` -- note the `beta`.

Closes https://github.com/Homebrew/homebrew-cask/issues/81211