### PR TITLE
Update flipper from 0.37.0 to 0.39.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.37.0'
-  sha256 '8e685143a7d933a8a6211efcedb0e689dc3d0a4faf564919548c15aabe5c3a48'
+  version '0.39.0'
+  sha256 '79a1be3f7bd95b22d1f2fb05be1cd88991001607e860b1d409cc8f5bd471d1f2'
 
   # github.com/facebook/flipper/ was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.