### PR TITLE
Update workflowy from 1.3.5-7075 to 1.3.5-7218

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.5-7075'
-  sha256 'c2b0b62d7cbd0dae3dde52808d9c8de64ebb84b1c685ca3ca595b0b47e2b44d4'
+  version '1.3.5-7218'
+  sha256 '5f3a118dc980a568f812bcd520d0ba7880badf40bb80ff8c89d867dea8a432c8'
 
   # github.com/workflowy/desktop/ was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.