### PR TITLE
Update wavebox from 10.0.128.1 to 10.0.142.1

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '10.0.128.1'
-  sha256 'fb8b2cb2a8563767116f72a001cdd0f3dba7b0fc5052831c138705c81311f8ab'
+  version '10.0.142.1'
+  sha256 '040e689e64cc61ffa00f13dc09fab3db11f6873053e55871d8ac73f78dc43a4b'
 
   # download.wavebox.app/ was verified as official when first introduced to the cask
   url "https://download.wavebox.app/core/mac/Install%20Wavebox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.