### PR TITLE
Update arq from 6.2.4 to 6.2.9

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '6.2.4'
-  sha256 '8032deaf250be93e627288794ed92a9e7ee9da35ea07312bfe15d91fb997d707'
+  version '6.2.9'
+  sha256 'c26e4cf9f4b6c552960cfb6f11eb1ce829a2b10a8cfed8d90b1525e72546d97b'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"
   appcast 'https://www.arqbackup.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.