### PR TITLE
Update badlion-client from 2.13.1 to 2.13.2

### DIFF
--- a/Casks/badlion-client.rb
+++ b/Casks/badlion-client.rb
@@ -1,6 +1,6 @@
 cask 'badlion-client' do
-  version '2.13.1'
-  sha256 '98ad9066ebf9d5b8010be2a30675600cb5b0063c406e337160dac5a46bda7ee1'
+  version '2.13.2'
+  sha256 '6ba0f70fb07d8559c171b5682ed6a1c9f444909b5c790683da4a8a10b87c2dda'
 
   url "https://client-updates.badlion.net/Badlion%20Client-#{version}.dmg"
   appcast 'https://client-updates.badlion.net/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.