### PR TITLE
Update smlnj from 110.96 to 110.97

### DIFF
--- a/Casks/smlnj.rb
+++ b/Casks/smlnj.rb
@@ -1,6 +1,6 @@
 cask 'smlnj' do
-  version '110.96'
-  sha256 '41e0cf5fff767ee2455f8ff318aad6b75d3821f8bb8d3a21de0a2a9016273716'
+  version '110.97'
+  sha256 '200ab32a192a34a24923d1bc61e18365108b9ab83fa0549f495c1621db49a80f'
 
   # smlnj.cs.uchicago.edu/ was verified as official when first introduced to the cask
   url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-amd64-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.