### PR TITLE
Update memory from 2019.31 to 2020.08

### DIFF
--- a/Casks/memory.rb
+++ b/Casks/memory.rb
@@ -1,5 +1,5 @@
 cask 'memory' do
-  version '2019.31'
+  version '2020.08'
   sha256 '5313247b3c80ff9cebfc0cb9411d9a8d8b3d27b1aec046b9514f2698ce1bfa4b'
 
   # timelytimetracking.s3.amazonaws.com/ was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.