### PR TITLE
wireshark: Remove config directory on zap

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -37,5 +37,6 @@ cask 'wireshark' do
                '~/Library/Cookies/org.wireshark.Wireshark.binarycookies',
                '~/Library/Preferences/org.wireshark.Wireshark.plist',
                '~/Library/Saved Application State/org.wireshark.Wireshark.savedState',
+               '~/.config/wireshark',
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

No cask version included, since this PR amends the zap stanza only.