### PR TITLE
Update qownnotes from 20.4.12,b5533-170634 to 20.4.13,b5538-175357

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.4.12,b5533-170634'
-  sha256 'dfb1dd89f9d8e7f77c1fd3ee0aab82b795d5125f21266fc3d58d55d45a3b12c5'
+  version '20.4.13,b5538-175357'
+  sha256 '093e324f1e69a0bef3247b8a15121439c391eb0e157984b95fc00c92c74b93df'
 
   # github.com/pbek/QOwnNotes/ was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.