### PR TITLE
Update encryptme from 4.2.0 to 4.2.1

### DIFF
--- a/Casks/encryptme.rb
+++ b/Casks/encryptme.rb
@@ -1,6 +1,6 @@
 cask 'encryptme' do
-  version '4.2.0'
-  sha256 '23b9e7f15eeacc7e24f4301585e391371b95fa643150b1b84edaac0ee64adcd9'
+  version '4.2.1'
+  sha256 '3971992f81456f13d35b1781fae84b4776a3a64128c1e4507a79da3c967a2963'
 
   url "https://static.encrypt.me/downloads/osx/updates/Release/EncryptMe-#{version}.dmg"
   appcast 'https://www.getcloak.com/updates/osx/public/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.