### PR TITLE
Update freesmug-chromium from 80.0.3987.116 to 81.0.4044.122

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -7,6 +7,11 @@ cask 'freesmug-chromium' do
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
+  
+  conflicts_with cask: [
+                         'chromium',
+                         'eloston-chromium',
+                       ]
 
   app 'Chromium.app'
 end

--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -7,7 +7,7 @@ cask 'freesmug-chromium' do
   appcast 'https://sourceforge.net/projects/osxportableapps/rss?path=/Chromium'
   name 'Chromium'
   homepage 'http://www.freesmug.org/chromium'
-  
+
   conflicts_with cask: [
                          'chromium',
                          'eloston-chromium',

--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '80.0.3987.116'
-  sha256 '7257979a6fd92c3e34101de0be34d237557e59d496b41f3f791c7e61e51d29be'
+  version '81.0.4044.122'
+  sha256 'cd7f8da4517b7627411d45bf5057def3bb4a4489172e953e5249eb3003e7d241'
 
   # sourceforge.net/osxportableapps/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.