### PR TITLE
Update signal from 1.33.1 to 1.33.3

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.33.1'
-  sha256 '05601f19e35b7defe9ae9291ba21ccc4d65f363841b0dc18fbabd27cedbad27d'
+  version '1.33.3'
+  sha256 '1f5061ae70fd12af7a81e47b75e0c7c8fc66a0f67edb27e3fc117d8c3f47e56c'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.