### PR TITLE
Update icq from 3.0.26705 to 3.0.27060

### DIFF
--- a/Casks/icq.rb
+++ b/Casks/icq.rb
@@ -1,6 +1,6 @@
 cask 'icq' do
-  version '3.0.26705'
-  sha256 '81843ac755b43f9ef51da787840d5fbab7b175515da319a42dab576d8a59cb0e'
+  version '3.0.27060'
+  sha256 '54f277c93995f1c4ba70b524c040d8cc0539fe63c9e18787dddd2d768f57e1fc'
 
   # hb.bizmrg.com/icq-www/ was verified as official when first introduced to the cask
   url 'https://hb.bizmrg.com/icq-www/mac/x64/icq.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.