### PR TITLE
Update liteide from 37 to 37.1

### DIFF
--- a/Casks/liteide.rb
+++ b/Casks/liteide.rb
@@ -1,6 +1,6 @@
 cask 'liteide' do
-  version '37'
-  sha256 'f012e101e6746725ea564ef55eac1e5d124e2cbe26887e897f8a63e44f0cfb35'
+  version '37.1'
+  sha256 'f739a15d05c227dc53c9501bfa8de917b1b2b7dcc8517c156a49bc55b75e8e67'
 
   url "https://github.com/visualfc/liteide/releases/download/x#{version}/liteidex#{version}.macos-qt5.12.5.zip"
   appcast 'https://github.com/visualfc/liteide/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.