### PR TITLE
Update sidequest from 0.10.2 to 0.10.3

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,6 +1,6 @@
 cask 'sidequest' do
-  version '0.10.2'
-  sha256 '0fd6d6174b05714e79f46e561a70b70aeabd6ee77f2ce4ae497c5298dfe07197'
+  version '0.10.3'
+  sha256 '8c15622687e491b02705edc96df9924114669890e7d8f781e1016dbcd9dc3ea7'
 
   # github.com/the-expanse/SideQuest/ was verified as official when first introduced to the cask
   url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.