### PR TITLE
Update kode54-cog from 1135,f5c7c4d49 to 1137,05386bce3

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '1135,f5c7c4d49'
-  sha256 '5844e1e35fdb0b6b986514d74d8545bc5778775edd0f2a79fc06313ae464cc55'
+  version '1137,05386bce3'
+  sha256 '69a6d17a9bf73cefd726466a828b724dc9a8e2ffaf8b64afc812aad8944d9962'
 
   # losno.co/cog/ was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.