### PR TITLE
Update nvidia-geforce-now from 2.0.18.79,81293F to 2.0.19.65,43B1E3

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.18.79,81293F'
-  sha256 'd690c5b8d00d23a4c79617a47cd5f059fed108d99f6b33a2a669dd84ebfebe22'
+  version '2.0.19.65,43B1E3'
+  sha256 '3e788092bc0ed74fddb5fd21fee785992d89e70ff8598e49701a46e15f140863'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.