### PR TITLE
Update preform from 3.4.4,250 to 3.4.5,289

### DIFF
--- a/Casks/preform.rb
+++ b/Casks/preform.rb
@@ -1,6 +1,6 @@
 cask 'preform' do
-  version '3.4.4,250'
-  sha256 '581267791d5a793e69792b1721ae4f768e484f9eb5477a02336288fdedebaec7'
+  version '3.4.5,289'
+  sha256 '599235b62eb4faeeb9a046de551eb73c40be06d3d665b5e1854bd90b8b6540a6'
 
   # s3.amazonaws.com/FormlabsReleases/ was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/FormlabsReleases/Release/#{version.before_comma}/PreForm_#{version.before_comma}_release_origin_testing_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.