### PR TITLE
Update loginputmac from 2.3.3 to 2.3.4

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '2.3.3'
-  sha256 '70ad6061bd453292cecd8d90fa3b10a22ae17eeb41a2462323b5e15b3a0c3f36'
+  version '2.3.4'
+  sha256 'b9a26081560a57be59697479ec82f07ef8254ce9d1acffc9f5e3ffff53413af2'
 
   # loginput-mac2.content-delivery.top/ was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.