### PR TITLE
Update Sabaki from 0.50.0 to 0.50.1

### DIFF
--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,6 +1,6 @@
 cask 'sabaki' do
-  version '0.43.3'
-  sha256 '8d3a9eec8b6330ebf9d321dc6ddfe26e56e046bbe7ec581a998403ba508c9284'
+  version '0.50.0'
+  sha256 '567a3c93720915508766fd03f939487765d8a5da941dabf41bb9abdcc0f861f1'
 
   # github.com/SabakiHQ/Sabaki was verified as official when first introduced to the cask
   url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-x64.7z"

--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,6 +1,6 @@
 cask 'sabaki' do
   version '0.51.1'
-  sha256 '8d2085b7dd90add0f20e3e77d81f85337bff803d22fe828b90b340c3e9b55099'
+  sha256 '61a4843666fdc6d21d262f47bf5b2b5b13a9f41a2d89667eaab4f13f6728729d'
 
   # github.com/SabakiHQ/Sabaki/ was verified as official when first introduced to the cask
   url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-x64.7z"

--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,5 +1,5 @@
 cask 'sabaki' do
-  version '0.51.0'
+  version '0.51.1'
   sha256 '8d2085b7dd90add0f20e3e77d81f85337bff803d22fe828b90b340c3e9b55099'
 
   # github.com/SabakiHQ/Sabaki/ was verified as official when first introduced to the cask

--- a/Casks/sabaki.rb
+++ b/Casks/sabaki.rb
@@ -1,6 +1,6 @@
 cask 'sabaki' do
-  version '0.50.1'
-  sha256 'c0d29e889de6d885d7ed7d6f6ace6c5ae7346889c5255a30b6b72af52f800a95'
+  version '0.51.0'
+  sha256 '8d2085b7dd90add0f20e3e77d81f85337bff803d22fe828b90b340c3e9b55099'
 
   # github.com/SabakiHQ/Sabaki was verified as official when first introduced to the cask
   url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-x64.7z"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).