### PR TITLE
Update qbittorrent from 4.2.4 to 4.2.5

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'qbittorrent' do
-  version '4.2.4'
-  sha256 '384fe7d1c7bd35747829f39a0a679378a6f1ec89bc1a3e27e1809c12b69ee73a'
+  version '4.2.5'
+  sha256 '52f86aa8f0e3f5c15013d40ff7789861dc6afdce077dfa461ccff2a56ff0d8f7'
 
   # sourceforge.net/qbittorrent/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.