### PR TITLE
Update webcatalog from 20.8.0 to 20.9.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.8.0'
-  sha256 'ebec3a0e89e11c701ed4391adbc5d1c57ebdb3493b477aa8b0a6121edbe2a112'
+  version '20.9.0'
+  sha256 '903eccd54f79f5a2828fbee89c396af296098caee2f81299338cb72de68531b8'
 
   # github.com/quanglam2807/webcatalog/ was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.