### PR TITLE
Update avocode from 4.5.1 to 4.6.1

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.5.1'
-  sha256 '0b5d2508de73f37b7dad8eec3b707b461a5e23e5ad909f731d15fe5391823ad7'
+  version '4.6.1'
+  sha256 '705a2c11394379929699f8175b2e6d1c84749c01a9a8621a15dd39a558905cf8'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.