### PR TITLE
Update bzflag from 2.4.18 to 2.4.20

### DIFF
--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -1,6 +1,6 @@
 cask 'bzflag' do
-  version '2.4.18'
-  sha256 '268151bebde80144c3fc6cb742e8024b822b3cf97e822e278cb4e2f546681e65'
+  version '2.4.20'
+  sha256 'c20c5ed67a68017e8e65bef1f1581fe7019ecfc203ec370f9484beabe5e14f45'
 
   url "https://download.bzflag.org/bzflag/macos/#{version}/BZFlag-#{version}-macOS.zip"
   appcast 'https://github.com/BZFlag-Dev/bzflag/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.