### PR TITLE
Update swifty from 0.4.5 to 0.4.7

### DIFF
--- a/Casks/swifty.rb
+++ b/Casks/swifty.rb
@@ -1,6 +1,6 @@
 cask 'swifty' do
-  version '0.4.5'
-  sha256 '7c2acae4490b96b1c64fcecb23d3c39ebc8b5dd761508e635dc491db1bdaa93b'
+  version '0.4.7'
+  sha256 'b72e09dad1ed345832b029180a74848469d832f22aa30493415292ba0e874909'
 
   # github.com/swiftyapp/swifty/ was verified as official when first introduced to the cask
   url "https://github.com/swiftyapp/swifty/releases/download/v#{version}/Swifty-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.