### PR TITLE
Update ckan from 1.27.0 to 1.27.2

### DIFF
--- a/Casks/ckan.rb
+++ b/Casks/ckan.rb
@@ -1,6 +1,6 @@
 cask 'ckan' do
-  version '1.27.0'
-  sha256 '34b131cec535445ef9759ef669fe3250ec65f4ba0047cf0bba9e2f8410c5052c'
+  version '1.27.2'
+  sha256 '094a9ad8535bed7ffcd9138108f213627f9829707ef927ed8dba72250cfe35de'
 
   url "https://github.com/KSP-CKAN/CKAN/releases/download/v#{version}/CKAN.dmg"
   appcast 'https://github.com/KSP-CKAN/CKAN/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.