### PR TITLE
Update wasabi-wallet from 1.1.11 to 1.1.11.1

### DIFF
--- a/Casks/wasabi-wallet.rb
+++ b/Casks/wasabi-wallet.rb
@@ -1,6 +1,6 @@
 cask 'wasabi-wallet' do
-  version '1.1.11'
-  sha256 '5c3ff915d734d0576ced43fcce5b2898a1ccc6ba1f309b70b121de5f2f3abf26'
+  version '1.1.11.1'
+  sha256 'c91d55efd49d109d3360b2047ba9b5302e1505ebee418deaae88e6d1b564c49e'
 
   # github.com/zkSNACKs/WalletWasabi/ was verified as official when first introduced to the cask
   url "https://github.com/zkSNACKs/WalletWasabi/releases/download/v#{version}/Wasabi-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.