### PR TITLE
Update melodics from 2.1.4290 to 2.1.4295

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.4290'
-  sha256 'f947dee37324d69f24026cb16be6d8e3c5aa36095f5df939cebdeb128d91c3c7'
+  version '2.1.4295'
+  sha256 'f39592c43e262987c1c7143feed161213cba6dde110c41e7e5bef264c7b31718'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.