### PR TITLE
Update manico from 2.7.2,386 to 2.7.3,388

### DIFF
--- a/Casks/manico.rb
+++ b/Casks/manico.rb
@@ -1,6 +1,6 @@
 cask 'manico' do
-  version '2.7.2,386'
-  sha256 '209fd0cb5e5b72d7b1876ab4c80b045ab34bf069a04dbce52d1432da9aa30e5f'
+  version '2.7.3,388'
+  sha256 '2a8863cfc6af313e3c79875fc3bff7bbf20813f13c25101b45963a2a436b0d98'
 
   url "https://manico.im/api/release_manager/downloads/im.manico.Manico/#{version.after_comma}.zip"
   appcast 'https://manico.im/api/release_manager/im.manico.Manico.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.