### PR TITLE
Update spectacle

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -12,6 +12,8 @@ cask 'spectacle' do
 
   app 'Spectacle.app'
 
+  uninstall quit: 'com.divisiblebyzero.Spectacle'
+
   zap trash: [
                '~/Library/Application Support/Spectacle',
                '~/Library/Caches/com.divisiblebyzero.Spectacle',
@@ -21,6 +23,11 @@ cask 'spectacle' do
              ]
 
   caveats do
+    puts <<~EOS
+      Spectacle users have recommended Rectangle as an open source
+      alternative. It can also be installed using Homebrew Cask:
+        brew cask install rectangle
+    EOS
     discontinued
   end
 end

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -23,11 +23,6 @@ cask 'spectacle' do
              ]
 
   caveats do
-    puts <<~EOS
-      Spectacle users have recommended Rectangle as an open source
-      alternative. It can also be installed using Homebrew Cask:
-        brew cask install rectangle
-    EOS
     discontinued
   end
 end


### PR DESCRIPTION
Quit on uninstall. Suggest Rectangle as recommended
alternative.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.