### PR TITLE
Update remember-the-milk from 1.1.19 to 1.1.20

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.1.19'
-  sha256 'd7159d21d4975501551a5fa740e895bb7299820ab3ded07e11909aebb568ac60'
+  version '1.1.20'
+  sha256 'ab319267db20a6eaf6384c72a8f53fe27134ad4ddc1e2a96ceedc16942aba5d8'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   appcast 'https://www.rememberthemilk.com/services/mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.