### PR TITLE
Update chromium from 762311 to 762671

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '762311'
-  sha256 '1ceb7992244fc0eced6abe79415e24c20e497674b215f7ff2b1e00ca7b1e616e'
+  version '762671'
+  sha256 '98b64cb71cbfd502f73853dae27f5e364f5a7a16e8fb8a577d25107831e6fbbc'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.