### PR TITLE
Update gitify from 3.0.2 to 3.0.4

### DIFF
--- a/Casks/gitify.rb
+++ b/Casks/gitify.rb
@@ -1,6 +1,6 @@
 cask 'gitify' do
-  version '3.0.2'
-  sha256 '141d7795a04488b34607d127b330435bc8b2ce85f227c68597a3dba411c6cd94'
+  version '3.0.4'
+  sha256 'dea73ad39b76543b46a6a172f63b855aa6824df82ce5ccc182ff500948f21189'
 
   url "https://github.com/manosim/gitify/releases/download/v#{version}/Gitify-#{version}-mac.zip"
   appcast 'https://github.com/manosim/gitify/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.