### PR TITLE
Update c0re100-qbittorrent from 4.2.3.10 to 4.2.5.10

### DIFF
--- a/Casks/c0re100-qbittorrent.rb
+++ b/Casks/c0re100-qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'c0re100-qbittorrent' do
-  version '4.2.3.10'
-  sha256 '5fa2b179191e1d6b6193d1edc247364502a7930494da645598fdbd71d52dedd3'
+  version '4.2.5.10'
+  sha256 '1fec5c9b300d6dadc250ff15f2e7acdd28f062153aef2a02b9cffad0059923f2'
 
   url "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-#{version}/qBittorrent-#{version}.dmg"
   appcast 'https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.