### PR TITLE
sonic-visualiser: Add zap stanza

### DIFF
--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -11,4 +11,11 @@ cask 'sonic-visualiser' do
   depends_on macos: '>= :sierra'
 
   app 'Sonic Visualiser.app'
+
+  zap trash: [
+               '~/Library/Saved Application State/org.sonicvisualiser.SonicVisualiser.savedState',
+               '~/Library/Preferences/org.sonicvisualiser.Sonic Visualiser.plist',
+               '~/Library/Preferences/org.sonicvisualiser.SonicVisualiser.plist',
+               '~/Library/Application Support/sonic-visualiser/',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Adding zap stanze for a cask, hence no version in commit message.