### PR TITLE
Update opensesame from 3.2.8 to 3.3.0

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,9 +1,9 @@
 cask 'opensesame' do
-  version '3.2.8'
-  sha256 '1f660ce97518c904153ce8a50a57102166c8991f3ed65fb24f87ff69fb2cc0e8'
+  version '3.3.0'
+  sha256 'a5dd6944c3350863865ac150a15ee80db6748501a485c51adeb9e1c1d81ff882'
 
   # github.com/smathot/OpenSesame/ was verified as official when first introduced to the cask
-  url "https://github.com/smathot/OpenSesame/releases/download/release/#{version}/opensesame_#{version}-py2.7-macos-1.dmg"
+  url "https://github.com/smathot/OpenSesame/releases/download/release%2F#{version}/opensesame_#{version}-py37-macos-1.dmg"
   appcast 'https://github.com/smathot/OpenSesame/releases.atom'
   name 'OpenSesame'
   homepage 'https://osdoc.cogsci.nl/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.