### PR TITLE
Update edfbrowser from 1.74 to 1.75

### DIFF
--- a/Casks/edfbrowser.rb
+++ b/Casks/edfbrowser.rb
@@ -1,6 +1,6 @@
 cask 'edfbrowser' do
-  version '1.74,04a7ca44345f889cc84b1c0d33732a58'
-  sha256 '70a5728eacacd45c7d6a5bd956687f3ccef8907c713521f4d341ba951505fd1d'
+  version '1.75,17cf821fec8dc9b27e9632c055307117'
+  sha256 'a0ac2209b2e4372964ba9b4d2e26bdd0b5fad86316fbd982f7b759b2b4305bb4'
 
   # gitlab.com/whitone/EDFbrowser/ was verified as official when first introduced to the cask
   url "https://gitlab.com/whitone/EDFbrowser/uploads/#{version.after_comma}/EDFbrowser-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.