### PR TITLE
Update tor-browser.rb

### DIFF
--- a/Casks/tor-browser.rb
+++ b/Casks/tor-browser.rb
@@ -36,12 +36,12 @@ cask 'tor-browser' do
     'en-US'
   end
 
-  language 'es-ar' do
+  language 'es-AR' do
     sha256 '69c6050f2b5ac00e3ce5a981e99d72b3479b0d90f9c606b415b1b66da6fa1658'
     'es-AR'
   end
 
-  language 'es-es' do
+  language 'es-ES' do
     sha256 'f9f27b74fcbacc9ff9ae5c267a7b10030f357a13caa5c6e3d0cfdb6c88f697be'
     'es-ES'
   end
@@ -151,12 +151,12 @@ cask 'tor-browser' do
     'vi'
   end
 
-  language 'zh-cn' do
+  language 'zh-CN' do
     sha256 '96574251b885c12b48a3495e843e434f9174e02bb83121b578e17d9dbebf1ffb'
     'zh-CN'
   end
 
-  language 'zh-tw' do
+  language 'zh-TW' do
     sha256 'd03b2cd5ebd7ef1dc215944253d1070ec64b402389c210081cf95c1e270925b7'
     'zh-TW'
   end


### PR DESCRIPTION
mistakenly spelling the countrycode in lowercase creates an interesting bug here. trying to install on spanish systems will install the argentianian version and trying to install in taiwan will install the chinese version:

```
% brew cask fetch  --language=zh-TW tor-browser

==> Downloading external files for Cask tor-browser
==> Downloading https://dist.torproject.org/torbrowser/9.0.9/TorBrowser-9.0.9-osx64_zh-CN.dmg

% brew cask fetch  --language=es-ES tor-browser

==> Downloading external files for Cask tor-browser
==> Downloading https://dist.torproject.org/torbrowser/9.0.9/TorBrowser-9.0.9-osx64_es-AR.dmg
```

i think what is going on here is that if the country-code is in lowercase, it won't match and then it will fallback to the uppermost version where at least the language matches.