### PR TITLE
Update amazon-music from 7.10.1.2195,2003272195 to 7.11.3.2198,20200415

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,9 +1,9 @@
 cask 'amazon-music' do
-  version '7.10.1.2195,2003272195'
-  sha256 'a7a9e303646f1cb85b5bbb4fc19be91d1b817aa5e0c3270eab9546b5182774d7'
+  version '7.11.3.2198,20200415'
+  sha256 'dfc5cfb4ed0e1fc6bbb974fdbea2a4ff5079dc6096a7b7edd3d7e967d5556a35'
 
   # morpho-releases.s3-us-west-2.amazonaws.com/mac/ was verified as official when first introduced to the cask
-  url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.after_comma}/AmazonMusicInstaller.dmg"
+  url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.before_comma}_#{version.after_comma}/AmazonMusicInstaller.dmg"
   appcast 'https://www.amazon.com/gp/dmusic/desktop/downloadPlayer',
           configuration: version.after_comma
   name 'Amazon Music'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.