### PR TITLE
Update unity-download-assistant from 2019.3.10f1,5968d7f82152 to 2019.3.11f1,ceef2d848e70

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.10f1,5968d7f82152'
-  sha256 'c4c6a4c71071e0c0db8e26684a6555b35f441dcedf5a21c1263d654e2fe6d882'
+  version '2019.3.11f1,ceef2d848e70'
+  sha256 '609ab83b9b6a7d24c8ad3ad9400c6f34c65ca023a0aa5e8a034c17c3d21cd42c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.