### PR TITLE
Update unity-webgl-support-for-editor from 2019.3.10f1,5968d7f82152 to 2019.3.11f1,ceef2d848e70

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.3.10f1,5968d7f82152'
-  sha256 'df2ab0f241115659bef80a1db4aa6202cfe90e9eb67e9764e7574aedb275a058'
+  version '2019.3.11f1,ceef2d848e70'
+  sha256 '9bf4a977dccdc7d04623fc18d427148c990fecbfa689d6479728581015689c4d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.