### PR TITLE
Update unity-windows-support-for-editor from 2019.3.10f1,5968d7f82152 to 2019.3.11f1,ceef2d848e70

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.3.10f1,5968d7f82152'
-  sha256 '008006c153bf688ef198a914b90cae7b5f5ed25b85134172b85a0d5acaefaac0'
+  version '2019.3.11f1,ceef2d848e70'
+  sha256 'd2c22cafd5a3b054e38511802b581e8ffacc4ad1ed34139b4e6432b7d48328b5'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.