### PR TITLE
Update rectangle from 0.25 to 0.26

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -1,6 +1,6 @@
 cask 'rectangle' do
-  version '0.25'
-  sha256 '9c5f8009ea024712b88e53e3d75735363b5367f060f6d59475ff97a79a80ba01'
+  version '0.26'
+  sha256 'ac811ef13f84cf07c4071adcf74d5d11d702c52bc183ac09cf260680681839a5'
 
   url "https://rectangleapp.com/downloads/Rectangle#{version}.dmg"
   appcast 'https://www.rectangleapp.com/downloads/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.