### PR TITLE
Update ipe from 7.2.14 to 7.2.15

### DIFF
--- a/Casks/ipe.rb
+++ b/Casks/ipe.rb
@@ -1,9 +1,9 @@
 cask 'ipe' do
-  version '7.2.14'
-  sha256 '4421ef4d8804cac9e87c16c6ded4e5e8d5fe4e710eb10d79408f701343f23aa2'
+  version '7.2.15'
+  sha256 '6c73b330ce2b093265fe92c551b836c61a8e9c2b5b202a7e5e740a40eca5f667'
 
   # bintray.com/otfried/ was verified as official when first introduced to the cask
-  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac-10.10.dmg"
+  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipe-#{version}-mac.dmg"
   appcast 'http://ipe.otfried.org/'
   name 'Ipe'
   homepage 'http://ipe.otfried.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.