### PR TITLE
Update stella from 6.1.1 to 6.1.2

### DIFF
--- a/Casks/stella.rb
+++ b/Casks/stella.rb
@@ -1,6 +1,6 @@
 cask 'stella' do
-  version '6.1.1'
-  sha256 'e5500dbbb5773a7d30158e43c71e656e61ee3f82cd243c1a0daa667a4d5f835f'
+  version '6.1.2'
+  sha256 'f9b7222bd21d4b00b45dc7917e40f9b936eaf2946246fc36a7671d409bea53ff'
 
   # github.com/stella-emu/stella/ was verified as official when first introduced to the cask
   url "https://github.com/stella-emu/stella/releases/download/#{version}/Stella-#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.