### PR TITLE
Update ipepresenter from 7.2.14 to 7.2.15

### DIFF
--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -1,9 +1,9 @@
 cask 'ipepresenter' do
-  version '7.2.14'
-  sha256 '01425a521034711305f28c43a713d83ab96793f54be5a87a24de89ac8c242fbf'
+  version '7.2.15'
+  sha256 '897a4bdce476aa563b5560ffea307cd5409dd948d52ba25d08ac12e53533ac8f'
 
   # bintray.com/otfried/ was verified as official when first introduced to the cask
-  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac-10.10.dmg"
+  url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"
   appcast 'http://ipepresenter.otfried.org/'
   name 'IpePresenter'
   homepage 'http://ipepresenter.otfried.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.