### PR TITLE
Update pritunl from 1.0.2404.6 to 1.0.2418.61

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,6 +1,6 @@
 cask 'pritunl' do
-  version '1.0.2404.6'
-  sha256 '90e83ac8762694204aa9092ccf0ad951800314c98b2e07c1d092c6805e02ba5d'
+  version '1.0.2418.61'
+  sha256 '6d74aee65804189a5f03cbb968d7f78c383a6f2dc0eccf205df178f97e0d99bf'
 
   # github.com/pritunl/pritunl-client-electron/ was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.