### PR TITLE
Update glyphs from 2.6.5,1320 to 2.6.5,1322

### DIFF
--- a/Casks/glyphs.rb
+++ b/Casks/glyphs.rb
@@ -1,6 +1,6 @@
 cask 'glyphs' do
-  version '2.6.5,1320'
-  sha256 '6689fbb9adf8a75495ba0757f6c36e1526dfb7c449573ca938841b3060a5a6e2'
+  version '2.6.5,1322'
+  sha256 '5846030f7f13675418d2e74082f4a90cddacd0743767d432f2c5d799294485db'
 
   url "https://updates.glyphsapp.com/Glyphs#{version.major_minor_patch}-#{version.after_comma}.zip"
   appcast "https://updates.glyphsapp.com/appcast#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.