### PR TITLE
Update netron from 4.1.0 to 4.1.1

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.1.0'
-  sha256 '219d10f85ec0d0d25753e817f4ebc451486a617de4246c7cb183430cafd9d962'
+  version '4.1.1'
+  sha256 '1a13cf7a09b22ce12ea1157788d885309a2cde1bcae2f0954e78eac85baab4ce'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.