### PR TITLE
Update superproductivity from 5.0.10 to 5.0.12

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,6 +1,6 @@
 cask 'superproductivity' do
-  version '5.0.10'
-  sha256 '06cc23fbff5d35cfe6a3e007127e069455d0e6721ea4d8b46a5c83e390cdc53e'
+  version '5.0.12'
+  sha256 '7a5fc306b52f26dda3662845af9668253509078df9f562cd9a4c241e87a02005'
 
   # github.com/johannesjo/super-productivity/ was verified as official when first introduced to the cask
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.