### PR TITLE
Update tandem from 1.5.1 to 1.5.3

### DIFF
--- a/Casks/tandem.rb
+++ b/Casks/tandem.rb
@@ -1,6 +1,6 @@
 cask 'tandem' do
-  version '1.5.1'
-  sha256 'c1ca526b4efb9c412b40cf2054e6102f3bb57d9aab9c48e8f25143d5bde00ff2'
+  version '1.5.3'
+  sha256 '0abc760ab09f98867d53d67013961d1eaa6348b8c95a17190aac24e1360e3798'
 
   # tandem-app.sfo2.cdn.digitaloceanspaces.com/ was verified as official when first introduced to the cask
   url "https://tandem-app.sfo2.cdn.digitaloceanspaces.com/Tandem-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.