### PR TITLE
Update kstars from 3.4.1 to 3.4.2

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask 'kstars' do
-  version '3.4.1'
-  sha256 '688c7eb9a8ccd3ad41179ca4d935f42551b12969d966e7e157c470a819914855'
+  version '3.4.2'
+  sha256 'fea23b50fb903fc56b048f8ea36470325f32ca967d01b6f410b0f89ac564b215'
 
   # indilib.org/jdownloads/kstars/ was verified as official when first introduced to the cask
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.