### PR TITLE
Update eclipse-cpp from 4.14.0,2019-12:R to 4.15.0,2020-03:R

### DIFF
--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-cpp' do
-  version '4.14.0,2019-12:R'
-  sha256 'ffa629dd7fa06e3d3228acb0c5545bb044d7e5f0de4160a8d6ad370b07139442'
+  version '4.15.0,2020-03:R'
+  sha256 'bcc179ea9391f925a1843ae62910de654b191b5347384f64fb8f01ad3abeffa2'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-cpp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for C/C++ Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.