### PR TITLE
Extend MacPass name string to include 'KeePass'

### DIFF
--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -5,7 +5,7 @@ cask 'macpass' do
   # github.com/MacPass/MacPass/ was verified as official when first introduced to the cask
   url "https://github.com/MacPass/MacPass/releases/download/#{version}/MacPass-#{version}.zip"
   appcast 'https://github.com/MacPass/MacPass/releases.atom'
-  name 'MacPass'
+  name 'MacPass KeePass-compatible password manager'
   homepage 'https://macpass.github.io/'
 
   auto_updates true


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.