### PR TITLE
Update itunes-volume-control from 1.6.7 to 1.6.8

### DIFF
--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -1,6 +1,6 @@
 cask 'itunes-volume-control' do
-  version '1.6.7'
-  sha256 '2a86efdfd9fc1f911cbb94f81294d0e5cf4aa673e5ba6537977c4452a201c759'
+  version '1.6.8'
+  sha256 '93386a0ffcc7f96fbb6de42c2d1f04339e3e62f9ce7bc99e106ff73c7345440c'
 
   # uni-bonn.de/alberti/iTunesVolumeControl/ was verified as official when first introduced to the cask
   url "http://quantum-technologies.iap.uni-bonn.de/alberti/iTunesVolumeControl/iTunesVolumeControl-v#{version}.zip"
@@ -9,7 +9,7 @@ cask 'itunes-volume-control' do
   homepage 'https://github.com/alberti42/iTunes-Volume-Control'
 
   auto_updates true
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :mojave'
 
   app 'iTunes Volume Control.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.