### PR TITLE
Update intel-power-gadget

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -14,7 +14,7 @@ cask 'intel-power-gadget' do
   pkg 'Install Intel Power Gadget.pkg'
 
   uninstall pkgutil: 'com.intel.pkg.PowerGadget.*',
-            kext:    'EnergyDriver'
+            kext:    'com.intel.driver.EnergyDriver'
 
   zap trash: [
                '~/Library/Caches/com.intel.PowerGadget',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

I apologize for immediately submitting another PR for the same cask, but I've discovered that the kext ID previously used in the formula is not correct and consequently the kext is not unloaded until the next reboot.

NOTE:
The tests are going to fail due to some unmet CPU requirements from Intel