### PR TITLE
Update qutebrowser from 1.10.2 to 1.11.0

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,6 @@
 cask 'qutebrowser' do
-  version '1.10.2'
-  sha256 '616c38a96bb24f1fd1d5a332709124bdcac249397cc1370fbaee381a7d55a352'
+  version '1.11.0'
+  sha256 'a53e20cf7991cea36f8e6f486e42c6da7704d838676d98f5acafc08707cb1b8b'
 
   # github.com/qutebrowser/qutebrowser/ was verified as official when first introduced to the cask
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.