### PR TITLE
Update jupyter-notebook-viewer from 0.1.3 to 0.1.4

### DIFF
--- a/Casks/jupyter-notebook-viewer.rb
+++ b/Casks/jupyter-notebook-viewer.rb
@@ -1,6 +1,6 @@
 cask 'jupyter-notebook-viewer' do
-  version '0.1.3'
-  sha256 '4748a12553ff8b3ad9fb6d27560d7045cbfadb7d35b212b432c00e64b002b966'
+  version '0.1.4'
+  sha256 '6f5fc66aeb71b07430338446ff438963fd6a5ccc00067a059e18a1819b5a5f0d'
 
   url "https://github.com/tuxu/nbviewer-app/releases/download/#{version}/nbviewer-app.zip"
   appcast 'https://github.com/tuxu/nbviewer-app/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.