### PR TITLE
Update tla-plus-toolbox from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,6 +1,6 @@
 cask 'tla-plus-toolbox' do
-  version '1.6.0'
-  sha256 'ecf63a0676f381946e4438032b9ce97481a3dc89114713bab566585be28f1507'
+  version '1.7.0'
+  sha256 '66ee35f952fd80239cbf3c7e869bd0315234165677efc2a0f00d2a00ac1c6512'
 
   # github.com/tlaplus/tlaplus/ was verified as official when first introduced to the cask
   url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.