### PR TITLE
Update gswitch from 1.9.6 to 1.9.7

### DIFF
--- a/Casks/gswitch.rb
+++ b/Casks/gswitch.rb
@@ -1,6 +1,6 @@
 cask 'gswitch' do
-  version '1.9.6'
-  sha256 '431660ba4f7971f00d5d4648a96b4ac2326dbde366486f6fbbb4727f3d575e48'
+  version '1.9.7'
+  sha256 '5d212c1bd39f6bfae588797fa09b959051dc4eefd26ec05fbd26b798125b976a'
 
   # github.com/CodySchrank/gSwitch/ was verified as official when first introduced to the cask
   url "https://github.com/CodySchrank/gSwitch/releases/download/#{version}/gSwitch.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.