### PR TITLE
Update thingsmacsandboxhelper from 3.20 to 3.21

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -1,6 +1,6 @@
 cask 'thingsmacsandboxhelper' do
-  version '3.20'
-  sha256 '0f140b820a77afeb33d449691e8a5e5f1e36b52e48447336dbf4c45eed0da497'
+  version '3.21'
+  sha256 'adcc57f686125fa7670fa9d20193f1704c5eb0eb2c70863257007c785940374c'
 
   # culturedcode.cachefly.net/ was verified as official when first introduced to the cask
   url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.