### PR TITLE
Update zoomus from 4.6.20615.0421 to 5.0.23186.0427

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -1,6 +1,6 @@
 cask 'zoomus' do
-  version '4.6.20615.0421'
-  sha256 '5730265a55c81a3d1fc573dd52972c9ed31aabbc8b460de42f5f41f4976c34d8'
+  version '5.0.23186.0427'
+  sha256 '9d64ce7c7331556f14677e7ad126557c35b1eb2e98c19127fbfe8b7e5d48237a'
 
   # d11yldzmag5yn.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d11yldzmag5yn.cloudfront.net/prod/#{version}/Zoom.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.