### PR TITLE
Update gitfiend from 0.22.8 to 0.23.1

### DIFF
--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -1,6 +1,6 @@
 cask 'gitfiend' do
-  version '0.22.8'
-  sha256 '8d0eaaf47074c28d97f8fca7780e11f868adb8ab97f18c8e196f54817a86237d'
+  version '0.23.1'
+  sha256 '2b231a127c92857fa46d3832cf3bdde4486e75fad48e248cf1696474b1357394'
 
   url "https://gitfiend.com/resources/GitFiend-#{version}.dmg"
   appcast 'https://gitfiend.com/app-info'
@@ -17,9 +17,7 @@ cask 'gitfiend' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      node() { ELECTRON_RUN_AS_NODE=1 "#{appdir}/GitFiend.app/Contents/MacOS/GitFiend" "${@}"; }
-      readonly project="$(node -e 'console.log(path.resolve(process.argv[1]))' "${1}")"
-      open -a "#{appdir}/GitFiend.app" --args "${project}"
+      exec '#{appdir}/GitFiend.app/Contents/MacOS/GitFiend' "$@"
     EOS
   end
 

--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -10,6 +10,16 @@ cask 'gitfiend' do
   auto_updates true
 
   app 'GitFiend.app'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/gitfiend.wrapper.sh"
+  binary shimscript, target: 'gitfiend'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      nohup #{appdir}/GitFiend.app/Contents/MacOS/GitFiend "$@" > /dev/null 2>&1 &
+    EOS
+  end
 
   zap trash: [
                '~/Library/Application Support/GitFiend',

--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -17,9 +17,9 @@ cask 'gitfiend' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      node() { ELECTRON_RUN_AS_NODE=1 #{appdir}/GitFiend.app/Contents/MacOS/GitFiend "$@"; }
-      project=$(node -e 'console.log(path.resolve(process.argv[1]))' "$1")
-      open -a #{appdir}/GitFiend.app --args "$project"
+      node() { ELECTRON_RUN_AS_NODE=1 "#{appdir}/GitFiend.app/Contents/MacOS/GitFiend" "${@}"; }
+      project="$(node -e 'console.log(path.resolve(process.argv[1]))' "${1}")"
+      open -a "#{appdir}/GitFiend.app" --args "${project}"
     EOS
   end
 

--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -18,7 +18,7 @@ cask 'gitfiend' do
     IO.write shimscript, <<~EOS
       #!/bin/sh
       node() { ELECTRON_RUN_AS_NODE=1 "#{appdir}/GitFiend.app/Contents/MacOS/GitFiend" "${@}"; }
-      project="$(node -e 'console.log(path.resolve(process.argv[1]))' "${1}")"
+      readonly project="$(node -e 'console.log(path.resolve(process.argv[1]))' "${1}")"
       open -a "#{appdir}/GitFiend.app" --args "${project}"
     EOS
   end

--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -17,7 +17,9 @@ cask 'gitfiend' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      nohup #{appdir}/GitFiend.app/Contents/MacOS/GitFiend "$@" > /dev/null 2>&1 &
+      node() { ELECTRON_RUN_AS_NODE=1 #{appdir}/GitFiend.app/Contents/MacOS/GitFiend "$@"; }
+      project=$(node -e 'console.log(path.resolve(process.argv[1]))' "$1")
+      open -a #{appdir}/GitFiend.app --args "$project"
     EOS
   end
 


### PR DESCRIPTION
Add `gitfiend` binary & shimscript.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.