### PR TITLE
Update github from 2.4.2-aee5caae to 2.4.3-539849ed

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,8 +1,9 @@
 cask 'github' do
-  version '2.4.3'
-  sha256 '217ea716e2e460ef84ecf3c1c789fd08ecf2196bb56dbcbaf16acd58747152cf'
+  version '2.4.2-aee5caae'
+  sha256 'b6692dd0cf91aff5db7ef62728bbf082534253b548119778e63f3c65db0b987e'
 
-  url "https://codeload.github.com/desktop/desktop/zip/release-#{version}"
+  # githubusercontent.com/ was verified as official when first introduced to the cask
+  url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'

--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,9 +1,8 @@
 cask 'github' do
-  version '2.4.2-aee5caae'
-  sha256 'b6692dd0cf91aff5db7ef62728bbf082534253b548119778e63f3c65db0b987e'
+  version '2.4.3'
+  sha256 '217ea716e2e460ef84ecf3c1c789fd08ecf2196bb56dbcbaf16acd58747152cf'
 
-  # githubusercontent.com/ was verified as official when first introduced to the cask
-  url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
+  url "https://codeload.github.com/desktop/desktop/zip/release-#{version}"
   appcast 'https://github.com/desktop/desktop/releases.atom'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'

--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,6 +1,6 @@
 cask 'github' do
-  version '2.4.2-aee5caae'
-  sha256 'b6692dd0cf91aff5db7ef62728bbf082534253b548119778e63f3c65db0b987e'
+  version '2.4.3-539849ed'
+  sha256 '912ef5946987bba2332d656503970f6250d6e1caeb18178b43ab1633003ba468'
 
   # githubusercontent.com/ was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.