### PR TITLE
Update droplr from 5.6.2,235 to 5.7.2,425

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -10,5 +10,5 @@ cask 'droplr' do
   auto_updates true
   depends_on macos: '>= :sierra'
 
-  app 'Droplr.app'
+  pkg "Droplr#{version.before_comma.no_dots}-#{version.after_comma}.pkg"
 end

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,6 +1,6 @@
 cask 'droplr' do
-  version '5.6.2,235'
-  sha256 '20313d3b60a42fa94ef014ba09d0cc071bbae0022efc72f79be61fba93f088e6'
+  version '5.7.2,425'
+  sha256 'fd38fb8d49ec6d8d84a9d402154a5a5c6ace8defcae8e063525703bf651cec4c'
 
   url "https://files.droplr.com/apps/mac/Droplr+#{version.after_comma}.zip"
   appcast 'https://droplr.com/appcast/appcast-sandbox.xml'

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -11,4 +11,7 @@ cask 'droplr' do
   depends_on macos: '>= :sierra'
 
   pkg "Droplr#{version.before_comma.no_dots}-#{version.after_comma}.pkg"
+
+  uninstall pkgutil: 'com.droplr.droplr-mac',
+            quit:    'com.droplr.droplr-mac'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.