### PR TITLE
Update keka from 1.1.26 to 1.1.27

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,6 +1,6 @@
 cask 'keka' do
-  version '1.1.26'
-  sha256 '78842a355218276627866cd0b5ab7c54ba07bb4a2d13d9013589af0cc255eeb7'
+  version '1.1.27'
+  sha256 'fa3a5fba127a265544d4e017faa62d4529eb1f1110723e32508e038d25964b50'
 
   # github.com/aonez/Keka/ was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.