### PR TITLE
Update eqmac from 2.2 to 0.0.1

### DIFF
--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -1,26 +1,26 @@
 cask 'eqmac' do
-  version '2.2'
-  sha256 'ff60579197b52571d9686bbfaec695dfa75797b8a9314fbf69a673bbeb12e1fc'
+  version '0.0.1'
+  sha256 '00538e305f4ad90c688fc4fd9dd07969f713e35051ef98971cda53368996f918'
 
   url "https://github.com/bitgapp/eqMac/releases/download/v#{version}/eqMac.dmg"
   appcast 'https://github.com/bitgapp/eqMac/releases.atom'
   name 'eqMac'
   homepage 'https://github.com/bitgapp/eqMac/releases/'
 
-  app "eqMac#{version.major}.app"
+  app "eqMac.app"
   installer script: {
-                      executable: "#{staged_path}/eqMac#{version.major}.app/Contents/Resources/install_driver.sh",
+                      executable: "#{staged_path}/eqMac.app/Contents/Resources/install_driver.sh",
                       sudo:       true,
                     }
 
-  uninstall quit:   "com.bitgapp.eqMac#{version.major}",
+  uninstall quit:   "com.bitgapp.eqMac#{version}",
             script: {
-                      executable: "#{appdir}/eqMac#{version.major}.app/Contents/Resources/uninstall_driver.sh",
+                      executable: "#{appdir}/eqMac.app/Contents/Resources/uninstall_driver.sh",
                       sudo:       true,
                     }
 
   zap trash: [
-               "~/Library/Caches/com.bitgapp.eqMac#{version.major}",
-               "~/Library/Cookies/com.bitgapp.eqMac#{version.major}.binarycookies",
+               "~/Library/Caches/com.bitgapp.eqMac",
+               "~/Library/Cookies/com.bitgapp.eqMac.binarycookies",
              ]
 end

--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -7,7 +7,7 @@ cask 'eqmac' do
   name 'eqMac'
   homepage 'https://github.com/bitgapp/eqMac/releases/'
 
-  app "eqMac.app"
+  app 'eqMac.app'
   installer script: {
                       executable: "#{staged_path}/eqMac.app/Contents/Resources/install_driver.sh",
                       sudo:       true,
@@ -20,7 +20,7 @@ cask 'eqmac' do
                     }
 
   zap trash: [
-               "~/Library/Caches/com.bitgapp.eqMac",
-               "~/Library/Cookies/com.bitgapp.eqMac.binarycookies",
+               '~/Library/Caches/com.bitgapp.eqMac',
+               '~/Library/Cookies/com.bitgapp.eqMac.binarycookies',
              ]
 end

--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -2,7 +2,7 @@ cask 'eqmac' do
   version '2.2'
   sha256 'ff60579197b52571d9686bbfaec695dfa75797b8a9314fbf69a673bbeb12e1fc'
 
-  url "https://github.com/bitgapp/eqMac/releases/download/V#{version}/eqMac#{version.major}.dmg"
+  url "https://github.com/bitgapp/eqMac/releases/download/v#{version}/eqMac.dmg"
   appcast 'https://github.com/bitgapp/eqMac/releases.atom'
   name 'eqMac'
   homepage 'https://github.com/bitgapp/eqMac/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.