### PR TITLE
Update qtox from 1.16.3 to 1.17.2

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,6 +1,6 @@
 cask 'qtox' do
-  version '1.16.3'
-  sha256 'c11fb1063b4985a42d19f07ee8704b30b287a2a88a37752c102bf8a91a81f209'
+  version '1.17.2'
+  sha256 'bfe2033d42b78e8b1f40a0276c806df33e221b208b15eb5ce6dda445f764cc6d'
 
   # github.com/qTox/qTox/ was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.