### PR TITLE
Update trilium-notes from 0.41.5 to 0.41.6

### DIFF
--- a/Casks/trilium-notes.rb
+++ b/Casks/trilium-notes.rb
@@ -1,6 +1,6 @@
 cask 'trilium-notes' do
-  version '0.41.5'
-  sha256 '64ecea14a53af6e371af4029f5b4abf85c93ea8e88f985ef34a72fa0d4d7c55e'
+  version '0.41.6'
+  sha256 'f8790538fac69cf3421f455b80d1bedea56140888347eb0cdeb5c0fce5177230'
 
   url "https://github.com/zadam/trilium/releases/download/v#{version}/trilium-mac-x64-#{version}.zip"
   appcast 'https://github.com/zadam/trilium/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.