### PR TITLE
Update pdfpen from 1122.2,1585609793 to 1200.19,1588022122

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,6 +1,6 @@
 cask 'pdfpen' do
-  version '1122.2,1585609793'
-  sha256 '750590c70ca8400244b8d7cfbcef94d9ae275d54f7a070e5b7d9f8424769f580'
+  version '1200.19,1588022122'
+  sha256 '06a3336c8a51de4ea38351a71c91ae6fb1da070656eb564499d044bac3004fad'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.