### PR TITLE
Update tuple from 0.70.1,2020-04-19-22d584e5 to 0.71.0,2020-04-27-992dbc4e

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -1,6 +1,6 @@
 cask 'tuple' do
-  version '0.70.1,2020-04-19-22d584e5'
-  sha256 'ab81ab1b48a4b2bb9b485f8d1c228683a2436640ad2e285d951d5ff0c09f2347'
+  version '0.71.0,2020-04-27-992dbc4e'
+  sha256 'eaee08d73d43bdd99d31b90b62118109326e6eaff8bf9029dff1641d75c951f6'
 
   # s3.us-east-2.amazonaws.com/tuple-releases/ was verified as official when first introduced to the cask
   url "https://s3.us-east-2.amazonaws.com/tuple-releases/production/sparkle/tuple-#{version.before_comma}-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.