### PR TITLE
Update moneywiz from 3.7.5 to 3.7.6

### DIFF
--- a/Casks/moneywiz.rb
+++ b/Casks/moneywiz.rb
@@ -1,6 +1,6 @@
 cask 'moneywiz' do
-  version '3.7.5'
-  sha256 '46934ff9794a42b8c9d0f5797aa17ec0ee59845994ab4e843d95fd5c3cd6e6ae'
+  version '3.7.6'
+  sha256 '5636ae8ae534ceb3dc6297b6a45bb7610cc8e4ac6dc9c36c050245671061dd6d'
 
   url 'https://mac.wiz.money/MoneyWiz_Mac_Free.dmg'
   appcast 'https://macdistribution.wiz.money/version_info_free.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.