### PR TITLE
Update polymail from 2.1.8 to 2.1.9

### DIFF
--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -1,6 +1,6 @@
 cask 'polymail' do
-  version '2.1.8'
-  sha256 '4f532c6e76869362f9b1334b34ebfbdf211ed03e25a1d6f1ac2bfff077b60f75'
+  version '2.1.9'
+  sha256 '92b91d488ec409887e90ce2a4ad864e3e066ab5cbbc6be496e8c7beffb79df64'
 
   url "https://sparkle-updater.polymail.io/macos/builds/Polymail-v#{version}.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sparkle-updater.polymail.io/osx/Polymail-Latest.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.