### PR TITLE
Update termius from 5.9.3 to 5.10.0

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '5.9.3'
-  sha256 'b618f8f89b12c26f5f2ba15371046a3d41acd21dbf720ef151c406bb8f19a169'
+  version '5.10.0'
+  sha256 'f0ee11152d3e2ba9bdf72b514a74f1f437ecb6bf5f38fdeb493442adced4ce6e'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac/ was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.