### PR TITLE
Update malwarebytes from 4.3.6.3518 to 4.4.11.3637

### DIFF
--- a/Casks/malwarebytes.rb
+++ b/Casks/malwarebytes.rb
@@ -1,6 +1,6 @@
 cask 'malwarebytes' do
-  version '4.3.6.3518'
-  sha256 'c8ed7d5fa7fc40f431d68c668980b6556ca744e5ca78b20cafa0bed4d1e66ca9'
+  version '4.4.11.3637'
+  sha256 '11304835c5ebe292624762cfb37e532795b19c1fee842da7ae02d73dcb54012a'
 
   # data-cdn.mbamupdates.com/web/ was verified as official when first introduced to the cask
   url "https://data-cdn.mbamupdates.com/web/mb#{version.major}_mac/Malwarebytes-Mac-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.