### PR TITLE
Update lehreroffice from 2020.3.1 to 2020.4.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2020.3.1'
-  sha256 '475ec4d99c97e7add31ec20b5c5d030a1b3906b4cdf1d21d38883944b38bd106'
+  version '2020.4.0'
+  sha256 '0b7af2851ef8628f4812723d106478bbe8ebabcec9a591b5ede315cbfa7d2bfb'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.