### PR TITLE
Update scrutiny from 9.6.3 to 9.6.4

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '9.6.3'
-  sha256 '48cc1ac7787806a1e23a33a175f57244f1f183702d8ca6bcb94480d68c0ae497'
+  version '9.6.4'
+  sha256 '38dc5a4771a0ac50bdc061bdcedcf79331d0c385a83d574a3843acca2ef8679c'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.