### PR TITLE
Update ganache from 2.3.2 to 2.4.0

### DIFF
--- a/Casks/ganache.rb
+++ b/Casks/ganache.rb
@@ -1,6 +1,6 @@
 cask 'ganache' do
-  version '2.3.2'
-  sha256 '19191f2f5457e981451899df3724032015c8259f0390fb1efae12c7403c2febb'
+  version '2.4.0'
+  sha256 '24a706730c006bb5a5c70fe6c167a0371300891c38096985455ac45e762e14fb'
 
   # github.com/trufflesuite/ganache/ was verified as official when first introduced to the cask
   url "https://github.com/trufflesuite/ganache/releases/download/v#{version}/Ganache-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.