### PR TITLE
Update rhinoceros from 6.24.20079.23332 to 6.25.20114.03572

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,6 +1,6 @@
 cask 'rhinoceros' do
-  version '6.24.20079.23332'
-  sha256 '199c6047a7a35926b3776237e3acfcb1f53ff9e6a2ada0e421e58077a782e88c'
+  version '6.25.20114.03572'
+  sha256 '32155191878621b7877439a3d349303a7e2fc793434e21efd0dd0151dad0db1f'
 
   # mcneel.com/ was verified as official when first introduced to the cask
   url "https://files.mcneel.com/rhino/#{version.major}/mac/releases/rhino_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.