### PR TITLE
Update juicebar from 1.0.57 to 1.0.60

### DIFF
--- a/Casks/juicebar.rb
+++ b/Casks/juicebar.rb
@@ -1,6 +1,6 @@
 cask 'juicebar' do
-  version '1.0.57'
-  sha256 'acbaa1eb19e1658de4d0024b355eb47d889eab87fcd8a28ea727578a94e71568'
+  version '1.0.60'
+  sha256 '9a640ac759f9cb3e0768ecdafe382bf90afd8015c03ef2061ec6f5ddc30e204f'
 
   url "https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.