### PR TITLE
Update lifesize from 2.210.2648 to 2.210.2652

### DIFF
--- a/Casks/lifesize.rb
+++ b/Casks/lifesize.rb
@@ -1,6 +1,6 @@
 cask 'lifesize' do
-  version '2.210.2648'
-  sha256 '26106c4badbe2948687eda43a356561297179eb60ac55b12b70965bd47b6c506'
+  version '2.210.2652'
+  sha256 '341b0240098c849c601b9183fc4baf4f670ae3f904a9a673f2b745ee8623c6a6'
 
   # download.lifesizecloud.com/ was verified as official when first introduced to the cask
   url "https://download.lifesizecloud.com/Lifesize-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.