### PR TITLE
Update mongodb-compass-isolated-edition from 1.20.5 to 1.21.0

### DIFF
--- a/Casks/mongodb-compass-isolated-edition.rb
+++ b/Casks/mongodb-compass-isolated-edition.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-isolated-edition' do
-  version '1.20.5'
-  sha256 '4470d107785f6a39f9fbd73976d3d94b2572de2ab925fba05f621272c474aef0'
+  version '1.21.0'
+  sha256 '9c600542300556db42c69d5fc02c04d9e607bf5280ec48ee4f35af71c45cbf74'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-isolated-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.