### PR TITLE
Update mongodb-compass-community from 1.20.5 to 1.21.0

### DIFF
--- a/Casks/mongodb-compass-community.rb
+++ b/Casks/mongodb-compass-community.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-community' do
-  version '1.20.5'
-  sha256 '38ed4d47bc6998f05cf3f5326e970102b70a783d168d7d385288789d4645083b'
+  version '1.21.0'
+  sha256 'faa147d5c2d76f697820e784d7d8c51b5f6e9df8632386b3390b7c7dcc4fc06c'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-community-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.