### PR TITLE
Add chef-workstation @ 0.17.5

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,0 +1,45 @@
+cask 'chef-workstation' do
+  version '0.17.5'
+  sha256 'e9b9165a80222900a1e421f7ad72d2f8252bc0f46175162e43b8cf271b2d2207'
+
+  url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.13/chef-workstation-#{version}-1.dmg"
+  name 'Chef Workstation'
+  homepage 'https://docs.chef.io/workstation/'
+
+  depends_on macos: '>= :high_sierra'
+
+  pkg "chef-workstation-#{version}-1.pkg"
+
+  uninstall quit:      'sh.chef.chef-workstation',
+            pkgutil:   'com.getchef.pkg.chef-workstation',
+            launchctl: 'io.chef.chef-workstation.app',
+            delete:    [
+                         '/Applications/Chef Workstation App.app',
+                         '/opt/chef-workstation/',
+                         '/usr/local/bin/berks',
+                         '/usr/local/bin/chef',
+                         '/usr/local/bin/chef-cli',
+                         '/usr/local/bin/chef-analyze',
+                         '/usr/local/bin/chef-apply',
+                         '/usr/local/bin/chef-client',
+                         '/usr/local/bin/chef-run',
+                         '/usr/local/bin/chef-shell',
+                         '/usr/local/bin/chef-solo',
+                         '/usr/local/bin/chef-vault',
+                         '/usr/local/bin/chefx',
+                         '/usr/local/bin/cookstyle',
+                         '/usr/local/bin/dco',
+                         '/usr/local/bin/delivery',
+                         '/usr/local/bin/foodcritic',
+                         '/usr/local/bin/inspec',
+                         '/usr/local/bin/kitchen',
+                         '/usr/local/bin/knife',
+                         '/usr/local/bin/ohai',
+                         '/usr/local/bin/push-apply',
+                         '/usr/local/bin/pushy-client',
+                         '/usr/local/bin/pushy-service-manager',
+                         '/usr/local/bin/uninstall_chef_workstation',
+                       ]
+
+  zap trash: '~/.chef-workstation/'
+end

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -3,6 +3,7 @@ cask 'chef-workstation' do
   sha256 'e9b9165a80222900a1e421f7ad72d2f8252bc0f46175162e43b8cf271b2d2207'
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.13/chef-workstation-#{version}-1.dmg"
+  appcast 'https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.14&m=x86_64&v=latest'
   name 'Chef Workstation'
   homepage 'https://docs.chef.io/workstation/'
 
@@ -13,33 +14,10 @@ cask 'chef-workstation' do
   uninstall quit:      'sh.chef.chef-workstation',
             pkgutil:   'com.getchef.pkg.chef-workstation',
             launchctl: 'io.chef.chef-workstation.app',
-            delete:    [
-                         '/Applications/Chef Workstation App.app',
-                         '/opt/chef-workstation/',
-                         '/usr/local/bin/berks',
-                         '/usr/local/bin/chef',
-                         '/usr/local/bin/chef-cli',
-                         '/usr/local/bin/chef-analyze',
-                         '/usr/local/bin/chef-apply',
-                         '/usr/local/bin/chef-client',
-                         '/usr/local/bin/chef-run',
-                         '/usr/local/bin/chef-shell',
-                         '/usr/local/bin/chef-solo',
-                         '/usr/local/bin/chef-vault',
-                         '/usr/local/bin/chefx',
-                         '/usr/local/bin/cookstyle',
-                         '/usr/local/bin/dco',
-                         '/usr/local/bin/delivery',
-                         '/usr/local/bin/foodcritic',
-                         '/usr/local/bin/inspec',
-                         '/usr/local/bin/kitchen',
-                         '/usr/local/bin/knife',
-                         '/usr/local/bin/ohai',
-                         '/usr/local/bin/push-apply',
-                         '/usr/local/bin/pushy-client',
-                         '/usr/local/bin/pushy-service-manager',
-                         '/usr/local/bin/uninstall_chef_workstation',
-                       ]
+            script:    {
+                         executable: '/opt/chef-workstation/bin/uninstall_chef_workstation',
+                         sudo:       true,
+                       }
 
   zap trash: '~/.chef-workstation/'
 end


### PR DESCRIPTION

Chef Workstation is the successor to ChefDK, which was previously in homebrew-cask.  It was removed because it was open source, cli-only [1]  Since that time, we have added a GUI component "Chef Workstation App" to Chef Workstation. 

[1] #47905

Signed-off-by: Marc A. Paradise <marc@chef.io>

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused]. (It was previously removed, see note above)
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
