### PR TITLE
Update sqlpro-studio from 2020.35 to 2020.39

### DIFF
--- a/Casks/sqlpro-studio.rb
+++ b/Casks/sqlpro-studio.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-studio' do
-  version '2020.35'
-  sha256 '46ff97867ad6b15794d89802e84d13aba6e61006a038ce1b7cf933daf310ba2a'
+  version '2020.39'
+  sha256 '8d578529ce7430ee8b81b75d7f9df094d5a6ca0d9ab18e0b06bc141141da9616'
 
   # d3fwkemdw8spx3.cloudfront.net/studio/ was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/studio/SQLProStudio.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.