### PR TITLE
Update qlfits from 3.1.2 to 3.2.2

### DIFF
--- a/Casks/qlfits.rb
+++ b/Casks/qlfits.rb
@@ -1,6 +1,6 @@
 cask 'qlfits' do
-  version '3.1.2'
-  sha256 '52748bb989d86132e77b302e9ec5e9949295899292bb817ee30ab14ae02395ff'
+  version '3.2.2'
+  sha256 '95320c8fcdf02681d592122ef75ab8e1b0ee8d6f394760b3c25f8485a3e6c130'
 
   url "https://github.com/onekiloparsec/QLFits/releases/download/#{version}/QLFits#{version.major}.qlgenerator.zip"
   appcast 'https://github.com/onekiloparsec/QLFits/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.