### PR TITLE
Update droplr from 5.6.2,235 to 5.7.2,426

### DIFF
--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -1,8 +1,8 @@
 cask 'droplr' do
-  version '5.6.2,235'
-  sha256 '20313d3b60a42fa94ef014ba09d0cc071bbae0022efc72f79be61fba93f088e6'
+  version '5.7.2,426'
+  sha256 '69ff334f9ec2925dc1b1e30dc562042435b736bbf03f3de9fcf511dcc302c176'
 
-  url "https://files.droplr.com/apps/mac/Droplr+#{version.after_comma}.zip"
+  url "https://files.droplr.com/apps/mac/Droplr-#{version.before_comma.no_dots}.dmg"
   appcast 'https://droplr.com/appcast/appcast-sandbox.xml'
   name 'Droplr'
   homepage 'https://droplr.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.