### PR TITLE
Update robofont from 3.3 to 3.4

### DIFF
--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -1,6 +1,6 @@
 cask 'robofont' do
-  version '3.3'
-  sha256 '2ee6460201abe754710188c0a18ff725af1599c49d38ffa6ca5828f33bd04683'
+  version '3.4'
+  sha256 'df986128e4630f93ef38fb9245f04f0b0fd2b603b0caa1753a6d62015e8b98a8'
 
   # static.typemytype.com/robofont/ was verified as official when first introduced to the cask
   url 'https://static.typemytype.com/robofont/RoboFont.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.