### PR TITLE
Update kap from 3.2.0 to 3.2.1

### DIFF
--- a/Casks/kap.rb
+++ b/Casks/kap.rb
@@ -1,6 +1,6 @@
 cask 'kap' do
-  version '3.2.0'
-  sha256 '3944d7a0ec9ad386e26c10f7e49827ad099e33a8afb5f82f110e48b315a7b017'
+  version '3.2.1'
+  sha256 'ae5f3c3f408467edd5981b89a363dbc5a6b1df1cfaa143880b93e0a6638599d0'
 
   # github.com/wulkano/kap/ was verified as official when first introduced to the cask
   url "https://github.com/wulkano/kap/releases/download/v#{version.major_minor_patch}/Kap-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.