### PR TITLE
Update keka.rb

### DIFF
--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -14,6 +14,7 @@ cask 'keka' do
   app 'Keka.app'
 
   zap trash: [
+               '~/Library/Containers/com.aone.keka',
                '~/Library/Application Support/Keka',
                '~/Library/Caches/com.aone.keka',
                '~/Library/Preferences/com.aone.keka.plist',


### PR DESCRIPTION
Since version 1.1 Keka is sandboxed so it uses `~/Library/Containers/com.aone.keka`.
