### PR TITLE
Update tiger-trade from 5.6.7,20200422:406BE1 to 5.7.0,20200429:4175FA

### DIFF
--- a/Casks/tiger-trade.rb
+++ b/Casks/tiger-trade.rb
@@ -1,6 +1,6 @@
 cask 'tiger-trade' do
-  version '5.6.7,20200422:406BE1'
-  sha256 '5f2c06dc0050de3f01b9dcfe77321973e07f1cb75b06ace7f18207b31cb582f7'
+  version '5.7.0,20200429:4175FA'
+  sha256 'e46fe10cb58efd073ab3139c48703b155155115fa3a0428d00044ee855094d82'
 
   # s.tigerfintech.com/ was verified as official when first introduced to the cask
   url "https://s.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version.before_comma}_#{version.after_comma.before_colon}_#{version.after_colon}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.