### PR TITLE
Update mindjet-mindmanager from 12.1.190 to 13.0.181

### DIFF
--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -5,10 +5,10 @@ cask 'mindjet-mindmanager' do
   url "https://download.mindjet.com/MindManager_Mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.mindjet.com/latest-release-notes-mac-english',
           configuration: version.dots_to_underscores
-  name 'Mindjet Mindmanager'
+  name 'Mindmanager'
   homepage 'https://www.mindjet.com/mindmanager/'
 
   depends_on macos: '>= :high_sierra'
 
-  app 'Mindjet MindManager.app'
+  app 'MindManager.app'
 end

--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -1,8 +1,8 @@
 cask 'mindjet-mindmanager' do
-  version '12.1.190'
-  sha256 '06a68a50fda70bf9d270a9a02ad69441e359b4a0eb63b8217610f08e1998048a'
+  version '13.0.181'
+  sha256 '8820a1cd65a8452d0965516c7fcb21ac11a4530481aec694c9ce8da67bf8ce4f'
 
-  url "https://download.mindjet.com/Mindjet_MindManager_Mac_#{version}.dmg"
+  url "https://download.mindjet.com/MindManager_Mac_#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.mindjet.com/latest-release-notes-mac-english',
           configuration: version.dots_to_underscores
   name 'Mindjet Mindmanager'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.