### PR TITLE
Update gitup from 1.1.2 to 1.1.3

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,6 +1,6 @@
 cask 'gitup' do
-  version '1.1.2'
-  sha256 '78b10d8e489d7ff0ddd5f7c3bbbdcbecf4c9896619eaf6a3a268e9debef28203'
+  version '1.1.3'
+  sha256 'c9e885a010d30ac9a2fae05475f4be68b722585ba64fb486ae8bde08c1cb7620'
 
   # gitup-builds.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url 'https://gitup-builds.s3.amazonaws.com/stable/GitUp.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.