### PR TITLE
Update ipfs from 0.11.1 to 0.11.2

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -1,6 +1,6 @@
 cask 'ipfs' do
-  version '0.11.1'
-  sha256 '494cd86647e13fb3bf8f4886c210e1fc609d7a9d555b28d4c273665ca4bcae9b'
+  version '0.11.2'
+  sha256 'f7aeb45e76d74de07e15b5ec9ddb692d00df143375996c344227221ac53a205e'
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/ipfs-desktop-#{version}.dmg"
   appcast 'https://github.com/ipfs-shipyard/ipfs-desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.