### PR TITLE
Update ultimate from 3.0.12.412 to 3.0.12.428

### DIFF
--- a/Casks/ultimate.rb
+++ b/Casks/ultimate.rb
@@ -1,6 +1,6 @@
 cask 'ultimate' do
-  version '3.0.12.412'
-  sha256 '0cf5deed4e068ceac642e3cea0b06b93bc8e1cac5ff7206b5d41a24f4cee9044'
+  version '3.0.12.428'
+  sha256 '74ac9b13b38d88b8e5e5b955b04130d2a56a4871f21d8e1ccce607d1006f88db'
 
   url 'https://download.epubor.com/epubor_ultimate.zip'
   appcast 'https://www.epubor.com/ultimate.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.