### PR TITLE
Update brave-browser from 81.1.7.98,107.98 to 81.1.8.86,108.86

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser' do
-  version '81.1.7.98,107.98'
-  sha256 'ed7e64d60992664c1b4dc694df3ea5fddd3206eb3c0df93b4f7765f0984f39bc'
+  version '81.1.8.86,108.86'
+  sha256 '90f660b432f9a80d6e4b818fc5b3c416e455f5a365d94a54ef6f7f7c84f9286d'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/#{version.after_comma}/Brave-Browser.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.