### PR TITLE
Update listen1 from 2.7.1 to 2.7.2

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask 'listen1' do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version '2.7.1'
-  sha256 '6679a19de87bb0f80da01d49f4d083a69587d3a06693ee5aa6ed93c57c7b4a96'
+  version '2.7.2'
+  sha256 'b64cae4a4ae91292d18167418e2edf7ec663c08481ba601852911f3c5a1de6fc'
 
   # github.com/listen1/listen1_desktop/ was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.