### PR TITLE
Update fontgoggles from 1.1.13 to 1.1.14

### DIFF
--- a/Casks/fontgoggles.rb
+++ b/Casks/fontgoggles.rb
@@ -1,6 +1,6 @@
 cask 'fontgoggles' do
-  version '1.1.13'
-  sha256 'b888dd0ee4330ef2b58fa6919202fab66aa26608cdcc95595c029ee6430e224d'
+  version '1.1.14'
+  sha256 '609287874d2a288b69a146e670fea2521b6d23b18940f777fc835ad981c10296'
 
   # github.com/justvanrossum/fontgoggles/ was verified as official when first introduced to the cask
   url "https://github.com/justvanrossum/fontgoggles/releases/download/v#{version}/FontGoggles.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.