### PR TITLE
Update igdm from 2.8.1 to 3.0.0

### DIFF
--- a/Casks/igdm.rb
+++ b/Casks/igdm.rb
@@ -1,6 +1,6 @@
 cask 'igdm' do
-  version '2.8.1'
-  sha256 '252ea2e15861484fd086be49d22fd104b96764dcc4f244cfcce520ecfd281543'
+  version '3.0.0'
+  sha256 'f33d07228be63d68bc532a6bb1aab74e452a1a079356c0fcc1b04a49f8f7652e'
 
   # github.com/ifedapoolarewaju/igdm/ was verified as official when first introduced to the cask
   url "https://github.com/ifedapoolarewaju/igdm/releases/download/v#{version}/IGdm-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.