### PR TITLE
Update zeebe-modeler from 0.9.0 to 0.9.1

### DIFF
--- a/Casks/zeebe-modeler.rb
+++ b/Casks/zeebe-modeler.rb
@@ -1,6 +1,6 @@
 cask 'zeebe-modeler' do
-  version '0.9.0'
-  sha256 '0e5635e92d0301de2c5c41ddf34faf0f647d62586ae3d16941b4d661951bee32'
+  version '0.9.1'
+  sha256 '773b4caef62317d2500499af299e8c35d560972b68780d9f36e659864959931c'
 
   # github.com/zeebe-io/zeebe-modeler/ was verified as official when first introduced to the cask
   url "https://github.com/zeebe-io/zeebe-modeler/releases/download/v#{version}/zeebe-modeler-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.