### PR TITLE
Update ledger-live from 2.2.4 to 2.3.2

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,6 +1,6 @@
 cask 'ledger-live' do
-  version '2.2.4'
-  sha256 '18178170144c0a25edf06e7901911a7009d51db71ff1b1ff5fc9929dda793ff2'
+  version '2.3.2'
+  sha256 '889b83c5dd9b16819fef31598bf99fd0f9809fc716ca492bfd487a4ab533f079'
 
   # github.com/LedgerHQ/ledger-live-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.