### PR TITLE
Update stay from 1.2.8 to 1.3

### DIFF
--- a/Casks/stay.rb
+++ b/Casks/stay.rb
@@ -1,6 +1,6 @@
 cask 'stay' do
-  version '1.2.8'
-  sha256 '754b02b07af6da1383f59751448cab76d18b1ffc9c7dca8047f7fccc37650076'
+  version '1.3'
+  sha256 'fc20518adc53aba6856cc5b3149889f046ab640134a9876952c5a0cb61e9b6a2'
 
   url "https://cordlessdog.com/stay/versions/Stay%20#{version}.dmg"
   appcast 'https://cordlessdog.com/stay/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.