### PR TITLE
Update blocs from 3.4.7 to 3.4.8

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,6 +1,6 @@
 cask 'blocs' do
-  version '3.4.7'
-  sha256 'd3c1336923baf9c81d6ca493259a1afcdf4f5010213e04e6a700ac4a0c0a6999'
+  version '3.4.8'
+  sha256 '277fe6f5c00a7312575bf184ef03f252a2de491bfc0d7edef9a89883a49c62c3'
 
   url "https://blocsapp.com/download/Blocs#{version.major}.zip"
   appcast 'https://blocsapp.com/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.