### PR TITLE
Update dbngin from 30 to 32

### DIFF
--- a/Casks/dbngin.rb
+++ b/Casks/dbngin.rb
@@ -1,6 +1,6 @@
 cask 'dbngin' do
-  version '30'
-  sha256 '4971854fd6d6098de0142729b5dfdff8e6bfd49b94915b577edf062f17f9ecba'
+  version '32'
+  sha256 '11f06e7fc877392f70860cbbf86191271233d74de325ff5d3916bcb77bff7c14'
 
   # dbngin-osx-builds.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://dbngin-osx-builds.s3.amazonaws.com/#{version}/DBngin.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.