### PR TITLE
Update freedom from 2.3.1 to 2.3.2

### DIFF
--- a/Casks/freedom.rb
+++ b/Casks/freedom.rb
@@ -1,6 +1,6 @@
 cask 'freedom' do
-  version '2.3.1'
-  sha256 '2c5ec899f0cb40aa27f4da48a5f19c1f0d9a8937056e4486d416ccb539d30523'
+  version '2.3.2'
+  sha256 'eebeb9c90f356b46dbe6e7fe2fbb90390e110e2d0fae265ecb0f31ba081d59bc'
 
   url "https://cdn.freedom.to/installers/updates/mac/#{version}/Freedom.zip"
   appcast 'https://cdn.freedom.to/installers/updates/mac/Appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.