### PR TITLE
Update stack-stack from 2.11.0 to 2.13.0

### DIFF
--- a/Casks/stack-stack.rb
+++ b/Casks/stack-stack.rb
@@ -1,6 +1,6 @@
 cask 'stack-stack' do
-  version '2.11.0'
-  sha256 'd8addd413cc6a86c7421b3119476107ff582756adf3f691b31e60294daf372ef'
+  version '2.13.0'
+  sha256 'e324a48e7c73791977c832583a5fc6229b7b9907597cc27d5a490a1215660e63'
 
   # s3.eu-central-1.amazonaws.com/stack-v1 was verified as official when first introduced to the cask
   url "https://s3.eu-central-1.amazonaws.com/stack-v1/builds/prod/Stack-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.