### PR TITLE
Update miktex-console from 2.9.7350-1 to 2.9.7400-1

### DIFF
--- a/Casks/miktex-console.rb
+++ b/Casks/miktex-console.rb
@@ -1,6 +1,6 @@
 cask 'miktex-console' do
-  version '2.9.7350-1'
-  sha256 '4d4bf5fcbe70cc3aca8d36c96df8101a1301ae0f7369742f91262266633c71dd'
+  version '2.9.7400-1'
+  sha256 'c73f5f41eb62346e553fad584e897e157c0a4abd27eea1d01f0bbcf0f920fad5'
 
   url "https://miktex.org/download/ctan/systems/win32/miktex/setup/darwin-x86_64/miktex-#{version}-darwin-x86_64.dmg"
   appcast 'https://miktex.org/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.