### PR TITLE
Update tableau-reader from 2020.1.2 to 2020.1.3

### DIFF
--- a/Casks/tableau-reader.rb
+++ b/Casks/tableau-reader.rb
@@ -1,6 +1,6 @@
 cask 'tableau-reader' do
-  version '2020.1.2'
-  sha256 '4641c749fa2d3d7199ba5f0efe52225ed3e7505f09e76867463198da41e3ad48'
+  version '2020.1.3'
+  sha256 '90ebbec9b869cdc4a180bb2c7a93a8257ed7a52bdcd0bc84044a7a59ec66bf67'
 
   url "https://downloads.tableau.com/tssoftware/TableauReader-#{version.dots_to_hyphens}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.tableau.com/downloads/reader/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.