### PR TITLE
Update wechatwork from 3.0.16.2129 to 3.0.20.2254

### DIFF
--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,6 +1,6 @@
 cask 'wechatwork' do
-  version '3.0.16.2129'
-  sha256 '79896edf2f77e6d409cbb772d95c35b97e580a3a9fcb67371fe892f932e03bdd'
+  version '3.0.20.2254'
+  sha256 'd95788121a921c68f81ec68143ff6cb89757074426b0c8b2c875225f5c50ad35'
 
   url "https://dldir1.qq.com/wework/work_weixin/WXWork_#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://work.weixin.qq.com/wework_admin/commdownload?platform=mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.