### PR TITLE
Update dbvisualizer from 11.0 to 11.0.1

### DIFF
--- a/Casks/dbvisualizer.rb
+++ b/Casks/dbvisualizer.rb
@@ -1,6 +1,6 @@
 cask 'dbvisualizer' do
-  version '11.0'
-  sha256 '79394fd6358ff8f2f88c436dea781cb713cc9abe34e263e84cdb33c07eb2a545'
+  version '11.0.1'
+  sha256 '84d53806ba9b22c3163f2c09d8d60127893fddc0e9a71377b675994f7bacf4c6'
 
   url "https://www.dbvis.com/product_download/dbvis-#{version}/media/dbvis_macos_#{version.dots_to_underscores}_jre.dmg"
   appcast "https://www.dbvis.com/download/#{version.major}.0"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.