### PR TITLE
Update whatsapp from 0.4.2088 to 2.2017.6

### DIFF
--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,6 +1,6 @@
 cask 'whatsapp' do
-  version '0.4.2088'
-  sha256 '8a4f5aad337ed94b08bc87e9b9ebff168b703be3dcd3de0469274c9d3241c326'
+  version '2.2017.6'
+  sha256 '85f4f788847e11c1f2df0de9ab3ae62a80a7861ddfa00ebced069f2fdca9e47b'
 
   url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
   appcast 'https://web.whatsapp.com/desktop/mac/releases?platform=darwin&arch=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.