### PR TITLE
Update ipepresenter from 7.2.15 to 7.2.16

### DIFF
--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -1,6 +1,6 @@
 cask 'ipepresenter' do
-  version '7.2.15'
-  sha256 '897a4bdce476aa563b5560ffea307cd5409dd948d52ba25d08ac12e53533ac8f'
+  version '7.2.16'
+  sha256 'e4510a7ac6408518db2453e3ddfb5d6e6a55af88010e2597ed64cf4bbefadee7'
 
   # bintray.com/otfried/ was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.