### PR TITLE
Update iridium from 2020.01-0 to 2020.04.81.0

### DIFF
--- a/Casks/iridium.rb
+++ b/Casks/iridium.rb
@@ -3,7 +3,8 @@ cask 'iridium' do
   sha256 'd7295ffde57bb18057fd61f8458c01a16a062658448a96c87db5ec75ed1977eb'
 
   url "https://downloads.iridiumbrowser.de/macos/#{version.major_minor}-0/iridiumbrowser-#{version}.dmg"
-  appcast 'https://iridiumbrowser.de/news/'
+  appcast 'https://iridiumbrowser.de/news/',
+          configuration: version.major_minor
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'
 

--- a/Casks/iridium.rb
+++ b/Casks/iridium.rb
@@ -1,8 +1,8 @@
 cask 'iridium' do
-  version '2020.01-0'
-  sha256 '304e5f434adc70ff6afd30ce133415907db066d5427c18801fe7168ac8c4b4e4'
+  version '2020.04.81.0'
+  sha256 'd7295ffde57bb18057fd61f8458c01a16a062658448a96c87db5ec75ed1977eb'
 
-  url "https://downloads.iridiumbrowser.de/macos/#{version}/iridium-browser_#{version}_macos.dmg"
+  url "https://downloads.iridiumbrowser.de/macos/#{version.major_minor}-0/iridiumbrowser-#{version}.dmg"
   appcast 'https://iridiumbrowser.de/news/'
   name 'Iridium Browser'
   homepage 'https://iridiumbrowser.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.