### PR TITLE
Update back-in-time from 5 to 5.1.2

### DIFF
--- a/Casks/back-in-time.rb
+++ b/Casks/back-in-time.rb
@@ -1,10 +1,11 @@
 cask 'back-in-time' do
-  version '5'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '5.1.2'
+  sha256 '7a7bc1c0cead6f4b06320e571363364ff279e874f3880701310296242c3bce9c'
 
-  url "https://www.tri-edre.com/pub/files/backintime#{version}.dmg"
+  url "https://www.tri-edre.com/pub/files/backintime#{version.major}.dmg"
+  appcast 'https://www.tri-edre.com/news/backintimeen.html'
   name 'Back-In-Time'
   homepage 'https://www.tri-edre.com/english/backintime.html'
 
-  app "Back-In-Time #{version}.app"
+  app "Back-In-Time #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.