### PR TITLE
Update jubler from 7.0.0-alpha3 to 7.0.0

### DIFF
--- a/Casks/jubler.rb
+++ b/Casks/jubler.rb
@@ -1,6 +1,6 @@
 cask 'jubler' do
-  version '7.0.0-alpha3'
-  sha256 '8c316e6f2fef9070b7481011522f80136990a8cf987ba0b3ace7c5a8746af8d8'
+  version '7.0.0'
+  sha256 '9d535ff444638804719d04010018c2b4ac620a7004866e5a9b7c3e5136fb798a'
 
   # github.com/teras/Jubler/ was verified as official when first introduced to the cask
   url "https://github.com/teras/Jubler/releases/download/v#{version}/Jubler-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.