### PR TITLE
Secure/improve URLs

### DIFF
--- a/Casks/deploystudio.rb
+++ b/Casks/deploystudio.rb
@@ -2,10 +2,10 @@ cask 'deploystudio' do
   version '1.7.8'
   sha256 'a7d71ed8e72498c8f7b37349458afd0cd74ba7a95313f26ea1ba05f4d1362071'
 
-  url "http://www.deploystudio.com/Downloads/DeployStudioServer_v#{version}.dmg"
-  appcast 'http://www.deploystudio.com/category/downloads/'
+  url "https://www.deploystudio.com/Downloads/DeployStudioServer_v#{version}.dmg"
+  appcast 'https://www.deploystudio.com/category/downloads/'
   name 'DeployStudio Server'
-  homepage 'http://www.deploystudio.com/'
+  homepage 'https://www.deploystudio.com/'
 
   pkg "DeployStudioServer_v#{version}.pkg"
 

--- a/Casks/gpower.rb
+++ b/Casks/gpower.rb
@@ -2,10 +2,10 @@ cask 'gpower' do
   version '3.1.9.6'
   sha256 '841390e00110ccdd5201f334af985b54837b9f9b4ffb3151d49e28efb9bb3964'
 
-  url "http://www.psychologie.hhu.de/fileadmin/redaktion/Fakultaeten/Mathematisch-Naturwissenschaftliche_Fakultaet/Psychologie/AAP/gpower/GPowerMac_#{version}.zip"
-  appcast 'http://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower.html'
+  url "https://www.psychologie.hhu.de/fileadmin/redaktion/Fakultaeten/Mathematisch-Naturwissenschaftliche_Fakultaet/Psychologie/AAP/gpower/GPowerMac_#{version}.zip"
+  appcast 'https://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower.html'
   name 'G*Power'
-  homepage 'http://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower.html'
+  homepage 'https://www.psychologie.hhu.de/arbeitsgruppen/allgemeine-psychologie-und-arbeitspsychologie/gpower.html'
 
   app 'G*Power.app'
 end

--- a/Casks/stack-stack.rb
+++ b/Casks/stack-stack.rb
@@ -2,9 +2,9 @@ cask 'stack-stack' do
   version '2.13.0'
   sha256 'e324a48e7c73791977c832583a5fc6229b7b9907597cc27d5a490a1215660e63'
 
-  # s3.eu-central-1.amazonaws.com/stack-v1 was verified as official when first introduced to the cask
-  url "https://s3.eu-central-1.amazonaws.com/stack-v1/builds/prod/Stack-#{version}.dmg"
-  appcast 'https://s3.eu-central-1.amazonaws.com/stack-v1'
+  # stack-v1.s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url "https://stack-v1.s3.amazonaws.com/builds/prod/Stack-#{version}.dmg"
+  appcast 'https://stack-v1.s3.amazonaws.com/'
   name 'Stack'
   homepage 'https://stackers.app/'
 

--- a/Casks/wacom-inkspace.rb
+++ b/Casks/wacom-inkspace.rb
@@ -3,7 +3,7 @@ cask 'wacom-inkspace' do
   sha256 'f405de898bb43622b07a86c42a244cc27c462eaca0d85deae76e4271adebc4cc'
 
   url "https://cdn.wacom.com/i/m/mac/WacomInkspaceApp_#{version}.zip"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=http://link.wacom.com/i/m?os=mac'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://link.wacom.com/i/m?os=mac'
   name 'Wacom Inkspace'
   homepage 'https://www.wacom.com/en-us/products/apps-services/inkspace'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---

`deploystudio` issue was pre-existing, the content is not on the page anymore, regardless of protocol:
```
1 file inspected, no offenses detected
==> Downloading https://www.deploystudio.com/Downloads/DeployStudioServer_v1.7.8

curl: (22) The requested URL returned error: 404 
audit for deploystudio: failed
 - download not possible: Download failed on Cask 'deploystudio' with message: Download failed: https://www.deploystudio.com/Downloads/DeployStudioServer_v1.7.8.dmg
 - The URL https://www.deploystudio.com/Downloads/DeployStudioServer_v1.7.8.dmg is not reachable (HTTP status code 404)
 - The URL https://www.deploystudio.com/category/downloads/ is not reachable (HTTP status code 404)
Error: audit failed for casks: deploystudio

1 file inspected, no offenses detected
==> Downloading https://www.psychologie.hhu.de/fileadmin/redaktion/Fakultaeten/M
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'gpower'.
audit for gpower: passed

1 file inspected, no offenses detected
==> Downloading https://stack-v1.s3.amazonaws.com/builds/prod/Stack-2.13.0.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'stack-stack'.
audit for stack-stack: passed

1 file inspected, no offenses detected
==> Downloading https://cdn.wacom.com/i/m/mac/WacomInkspaceApp_2.7.4.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'wacom-inkspace'.
audit for wacom-inkspace: passed
```
