### PR TITLE
Update meshlab from 2020.04 to 2020.05

### DIFF
--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -1,6 +1,6 @@
 cask 'meshlab' do
-  version '2020.04'
-  sha256 '875651a5f5614084ffee654c1b47ef1cb74d760910215946f33d13b8b9b6d503'
+  version '2020.05'
+  sha256 '5ecc2fadb9b1b13d9c9c0d276a9785b4093c05ddd5cee1413727cb7264a7f6c6'
 
   # github.com/cnr-isti-vclab/meshlab/ was verified as official when first introduced to the cask
   url "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-#{version}/MeshLab#{version}-macos.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.