### PR TITLE
Update strawberry from 0.6.9 to 0.6.10

### DIFF
--- a/Casks/strawberry.rb
+++ b/Casks/strawberry.rb
@@ -1,6 +1,6 @@
 cask 'strawberry' do
-  version '0.6.9'
-  sha256 'ce9c6ca46a86b7b7f9456e9351d181ca33400508263f44dde91c3e495d994d20'
+  version '0.6.10'
+  sha256 '17b11068f088f17773886eed4c50dea2367dc4efd3f8bc4d8a8f3af3bbc9911c'
 
   # github.com/strawberrymusicplayer/strawberry/ was verified as official when first introduced to the cask
   url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.