### PR TITLE
Update outline-manager from 1.5.0 to 1.5.1

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -1,6 +1,6 @@
 cask 'outline-manager' do
-  version '1.5.0'
-  sha256 '84328bbb820aa9743d0c7cb5cc77242858315dd11ca7bade7f802c036e64d09f'
+  version '1.5.1'
+  sha256 'dbe7779589367f5b402390c9fb25c0b0253af35f80d4042992d1ebe87cf5c716'
 
   # github.com/Jigsaw-Code/outline-server/ was verified as official when first introduced to the cask
   url "https://github.com/Jigsaw-Code/outline-server/releases/download/v#{version}/Outline-Manager.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.