### PR TITLE
Update dropshare from 5.6,5128 to 5.6.1,5139

### DIFF
--- a/Casks/dropshare.rb
+++ b/Casks/dropshare.rb
@@ -1,6 +1,6 @@
 cask 'dropshare' do
-  version '5.6,5128'
-  sha256 '23bbe1e64965bb7cfd07511c0b05e7ed125eef8e9283e3fee9ed634487ac6704'
+  version '5.6.1,5139'
+  sha256 '4dcb419f38a06d856dde1033b5eec54f831048335206eff87590defff754824f'
 
   # d2wvuuix8c9e48.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d2wvuuix8c9e48.cloudfront.net/Dropshare#{version.major}-#{version.after_comma}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.