### PR TITLE
Update shift from 4.0.25 to 4.0.28

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,5 +1,5 @@
 cask 'shift' do
-  version '4.0.25'
+  version '4.0.28'
   sha256 '95142435a998148050282cf5a1f36937ea4e6386f1c137ae79b894afa3e9c332'
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.