### PR TITLE
Update endless-sky from 0.9.11 to 0.9.12

### DIFF
--- a/Casks/endless-sky.rb
+++ b/Casks/endless-sky.rb
@@ -1,6 +1,6 @@
 cask 'endless-sky' do
-  version '0.9.11'
-  sha256 'c7f34a7a99ac70184914c8c43b4e8f3ac42c870d69fb680ca8d5e3dd14409ba3'
+  version '0.9.12'
+  sha256 '4b6a4e45b173fd986ae9fab775267795361befb3f68ac6b9cb6517f69eee22aa'
 
   # github.com/endless-sky/endless-sky/ was verified as official when first introduced to the cask
   url "https://github.com/endless-sky/endless-sky/releases/download/v#{version}/endless-sky-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.