### PR TITLE
Update google-earth-pro from 7.3.3.7673 to 7.3.3.7692

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask 'google-earth-pro' do
-  version '7.3.3.7673'
-  sha256 'be3e67eb81e14febad41f173abc7ba514d188a50105606d0e3d30e9b8b66b87a'
+  version '7.3.3.7692'
+  sha256 '79006bd4ce7237051822c5034a259216252443e815006f8a2a3804420205c8ee'
 
   url 'https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg'
   name 'Google Earth Pro'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.