### PR TITLE
calibre 4.15.0: Switch download URL from calibre-ebook.com to GitHub

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -6,7 +6,7 @@ cask 'calibre' do
   else
     version '4.15.0'
     sha256 '335d84d46c3f01dec853516c73974756a92b177e7926c2776c612fb08d098aeb'
-    url "https://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"
+    url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"
     appcast 'https://github.com/kovidgoyal/calibre/releases.atom'
   end
 

--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -2,10 +2,12 @@ cask 'calibre' do
   if MacOS.version <= :high_sierra
     version '3.48.0'
     sha256 '68829cd902b8e0b2b7d5cf7be132df37bcc274a1e5720b4605d2dd95f3a29168'
-    url "https://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"
+    # github.com/kovidgoyal/calibre/ was verified as official when first introduced to the cask
+    url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"
   else
     version '4.15.0'
     sha256 '335d84d46c3f01dec853516c73974756a92b177e7926c2776c612fb08d098aeb'
+    # github.com/kovidgoyal/calibre/ was verified as official when first introduced to the cask
     url "https://github.com/kovidgoyal/calibre/releases/download/v#{version}/calibre-#{version}.dmg"
     appcast 'https://github.com/kovidgoyal/calibre/releases.atom'
   end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

The download server for calibre (calibre-ebook.com) is consistently too slow. I propose switching the release URL to GitHub to speed this up.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
