### PR TITLE
Update SciHubEVA from v3.2.3 to v4.0.0

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -1,6 +1,6 @@
 cask 'scihubeva' do
-  version 'v3.2.3'
-  sha256 'b3020cd58e943ff2b4c5d7c834c3d2e1801b7e262df4ae08fadde6df0e6383b9'
+  version 'v4.0.0'
+  sha256 'cf3857084f4a78092621bb7e836e4db16b26e3c10551f77a3ead7ed40b9fb5e9'
 
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast 'https://github.com/leovan/SciHubEVA/releases.atom'


### PR DESCRIPTION
Update SciHubEVA from v3.2.3 to v4.0.0

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).