### PR TITLE
Update odrive from 6624 to 6642

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,6 +1,6 @@
 cask 'odrive' do
-  version '6624'
-  sha256 '9baf2588d72e0979939874b8235aa8fa26cfd180f32970e453e17cc17122a1e8'
+  version '6642'
+  sha256 '5544c9b6f8a1b574d1d1ddd3c9d7ea102fac6a8c451e3d38b51e5067d3e659cf'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net/ was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.