### PR TITLE
Update masterway-note from 1.0.0.84528265 to 1.1.0.88242909

### DIFF
--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -1,9 +1,9 @@
 cask 'masterway-note' do
-  version '1.0.0.84528265'
-  sha256 'a6e92d580121dc74c96c3392f6e5c4e11fb08fce73a5b4f0368726fa1395be60'
+  version '1.1.0.88242909'
+  sha256 'f6a7e718f7f1c18dc5302ee1f9b320b9ef64d926dc2980f470529cd948c819c4'
 
   # prota.oss-cn-beijing.aliyuncs.com/ was verified as official when first introduced to the cask
-  url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/#{version.major_minor_patch}/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0-#{version}.dmg"
+  url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/#{version.major_minor}/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0-#{version}.dmg"
   appcast 'https://masterwaynote.com/mac',
           configuration: version.major_minor
   name 'Masterway Note'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.