### PR TITLE
Update unity-android-support-for-editor from 2019.3.11f1,ceef2d848e70 to 2019.3.12f1,84b23722532d

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.11f1,ceef2d848e70'
-  sha256 'f91856c7494e9b0000e97198b9df5c2aaf53fd4d716ea619a8aad79a61ac3a5b'
+  version '2019.3.12f1,84b23722532d'
+  sha256 'c1620b8d1437729caf3bdc27b8af1612e592f2156786bf0b6bcede970f377d04'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.