### PR TITLE
Update unity-download-assistant from 2019.3.11f1,ceef2d848e70 to 2019.3.12f1,84b23722532d

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.11f1,ceef2d848e70'
-  sha256 '609ab83b9b6a7d24c8ad3ad9400c6f34c65ca023a0aa5e8a034c17c3d21cd42c'
+  version '2019.3.12f1,84b23722532d'
+  sha256 'a5f4933205e402339c6b94c64c505e93c72e62221e1dffdab3eb3ef5a19f026c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.