### PR TITLE
Update unity-ios-support-for-editor from 2019.3.11f1,ceef2d848e70 to 2019.3.12f1,84b23722532d

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.11f1,ceef2d848e70'
-  sha256 '541e430ade29d1f3e7c33a68d167150b9c774c7a419341b1d5b135297410fee4'
+  version '2019.3.12f1,84b23722532d'
+  sha256 '3ec8114e4589a1e6760b393ed3fda6694acacfa928e37bd31ba61f2e5d3fa536'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.