### PR TITLE
Update menumeters from 2.0.5 to 2.0.6

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,6 +1,6 @@
 cask 'menumeters' do
-  version '2.0.5'
-  sha256 '2c378fa96a4bba46ce2c4fd5fcf00c79c0c802d0d483ab21eeee2cf2ce10e927'
+  version '2.0.6'
+  sha256 'e9d976c2e75e2b4c81ae67af8ff5ac50a1bdc5ceea5f8eb6343f388c190081fb'
 
   url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version.major_minor_patch}.zip"
   appcast 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.