### PR TITLE
Docs: Define notable in rejected_casks.md

### DIFF
--- a/doc/faq/rejected_casks.md
+++ b/doc/faq/rejected_casks.md
@@ -15,7 +15,7 @@ Common reasons to reject a Cask entirely:
 + The download URL for the app is both behind a login/registration form and from a host that differs from the homepage, meaning users can’t easily verify its authenticity. [alehouse/homebrew-unofficial](https://github.com/alehouse/homebrew-unofficial) is a sister repo where you may wish to submit your cask.
 + The Cask is for an app that is unmaintained (no releases in the last year, or [explicitly discontinued](https://github.com/Homebrew/homebrew-cask/pull/22699)).
 + The Cask is for an app that is too obscure. Examples:
-  + An app from a GitHub repository that is [not notable enough](https://github.com/Homebrew/homebrew-cask/pull/28103). To quailifiy as notable the repository needs to be 30 days or older and have either:
+  + An app from a GitHub repository that is [not notable enough](https://github.com/Homebrew/homebrew-cask/pull/28103). To quailifiy as notable, the repository needs to be 30 days or older and have either:
     + ≥ 75 stars, or
     + ≥ 30 watchers, or
     + ≥ 30 forks

--- a/doc/faq/rejected_casks.md
+++ b/doc/faq/rejected_casks.md
@@ -15,7 +15,10 @@ Common reasons to reject a Cask entirely:
 + The download URL for the app is both behind a login/registration form and from a host that differs from the homepage, meaning users can’t easily verify its authenticity. [alehouse/homebrew-unofficial](https://github.com/alehouse/homebrew-unofficial) is a sister repo where you may wish to submit your cask.
 + The Cask is for an app that is unmaintained (no releases in the last year, or [explicitly discontinued](https://github.com/Homebrew/homebrew-cask/pull/22699)).
 + The Cask is for an app that is too obscure. Examples:
-  + A self-submitted app from a GitHub repository that is [not notable enough](https://github.com/Homebrew/homebrew-cask/pull/28103) (under 50 stars).
+  + An app from a GitHub repository that is [not notable enough](https://github.com/Homebrew/homebrew-cask/pull/28103). To quailifiy as notable the repository needs to be 30 days or older and have either:
+    + ≥ 75 stars, or
+    + ≥ 30 watchers, or
+    + ≥ 30 forks
   + [Electronic Identification (eID) software](https://github.com/Homebrew/homebrew-cask/issues/59021).
 + The Cask is for an app with no information on the homepage (example: a GitHub repository without a README).
 + The author has [specifically asked us not to include it](https://github.com/Homebrew/homebrew-cask/pull/5342).


### PR DESCRIPTION
Added definition of "notable" to `rejected_casks.md`.

Taken from [Homebrew audit.rb](https://github.com/Homebrew/brew/blob/8e984d621d222eed5b39c118a1271af11db70f6f/Library/Homebrew/dev-cmd/audit.rb#L570-L577).