### PR TITLE
Update sidequest from 0.10.6 to 0.10.7

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,6 +1,6 @@
 cask 'sidequest' do
-  version '0.10.6'
-  sha256 '68b6cddbaca60656f4fe819738918d11fe0916f0c856acb3f836a7dbb1dc1855'
+  version '0.10.7'
+  sha256 '676212d49ad915a03486583eb5ab6445a883dde27d757a47246d648b23b5e3be'
 
   # github.com/the-expanse/SideQuest/ was verified as official when first introduced to the cask
   url "https://github.com/the-expanse/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.