### PR TITLE
Update kode54-cog from 1137,05386bce3 to 1143,cbe7dcfd4

### DIFF
--- a/Casks/kode54-cog.rb
+++ b/Casks/kode54-cog.rb
@@ -1,6 +1,6 @@
 cask 'kode54-cog' do
-  version '1137,05386bce3'
-  sha256 '69a6d17a9bf73cefd726466a828b724dc9a8e2ffaf8b64afc812aad8944d9962'
+  version '1143,cbe7dcfd4'
+  sha256 '15b637fff835cec53e3792179b590c2fd424b8fee86dad84aa5c9cf7a435ea4e'
 
   # losno.co/cog/ was verified as official when first introduced to the cask
   url "https://f.losno.co/cog/Cog-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.