### PR TITLE
Update airdisplay from 3.2.1 to 3.3.3

### DIFF
--- a/Casks/airdisplay.rb
+++ b/Casks/airdisplay.rb
@@ -1,6 +1,6 @@
 cask 'airdisplay' do
-  version '3.2.1'
-  sha256 'ddb653f912b5f437ed269d84ca01f7b9e9ac09b9b26cb66608dac48716c52ed2'
+  version '3.3.3'
+  sha256 '773b71d4a572d7af79dc9812f77f2299c73ba5045a0d29cbdf5943d2505a4025'
 
   url "https://www.avatron.com/updates/software/airdisplay/ad#{version.no_dots}.zip"
   appcast 'https://www.avatron.com/updates/software/airdisplay/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.