### PR TITLE
Update utools from 0.8.9-beta to 1.0.0-beta

### DIFF
--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -1,6 +1,6 @@
 cask 'utools' do
-  version '0.8.9-beta'
-  sha256 'f4c206ee440974d1b3386333f28533d603bbfd0a0878f00c6721b74765a1c967'
+  version '1.0.0-beta'
+  sha256 '7ba4b6574f6ebab5a83e3639ca8bef03a7f5135787e5f400b0ab566c1638ff50'
 
   # resource.u-tools.cn/ was verified as official when first introduced to the cask
   url "https://resource.u-tools.cn/currentversion/uTools-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.