### PR TITLE
Update battlescribe from 2.03.17 to 2.03.18

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.17'
-  sha256 '5f398233ffac363a3fe23cd70b9629f001ee07d62ab47d4a5ebfc9f63590218a'
+  version '2.03.18'
+  sha256 '3cd4c152c59497500abc327d7cea8897e3dd16e7668da35bfda325634703c22a'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.pkg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.