### PR TITLE
Update racket-cs from 7.6 to 7.7

### DIFF
--- a/Casks/racket-cs.rb
+++ b/Casks/racket-cs.rb
@@ -1,6 +1,6 @@
 cask 'racket-cs' do
-  version '7.6'
-  sha256 'aca037891573cdfe829edf98c1d5c044d934355f11a150bce32f993233a2111f'
+  version '7.7'
+  sha256 '00400bfd66f42b25b2302591d5d5f0b8a30bd34d5222b1c4a560c10c5a0335d4'
 
   url "https://mirror.racket-lang.org/installers/#{version}/racket-#{version}-x86_64-macosx-cs.dmg"
   appcast 'https://download.racket-lang.org/all-versions.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.