### PR TITLE
Update netron from 4.1.3 to 4.1.4

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.1.3'
-  sha256 '672e58afe2d7d6587754d3f3dc87b10afc9de145421fd985e6797ba95867b4fc'
+  version '4.1.4'
+  sha256 '64ac077583782e4fdcbf1a2d098736cbb34a4cfec9bd6ebb06c9de3d19760f8a'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.