### PR TITLE
Update delicious-library from 3.9 to 3.9.1

### DIFF
--- a/Casks/delicious-library.rb
+++ b/Casks/delicious-library.rb
@@ -1,11 +1,11 @@
 cask 'delicious-library' do
-  version '3.9'
-  sha256 '6b13093e40164d376f5b29f196406014b06761b4d4d2b5cc2dffc5bc2e48fc27'
+  version '3.9.1'
+  sha256 'c306034b7f0915adc3b83689923913db88f0f0fbc9fe7a1c70d6814eab758193'
 
-  url "https://delicious-monster.com/downloads/DeliciousLibrary#{version.major}/v#{version}/DeliciousLibrary#{version.major}.zip"
+  url "https://www.delicious-monster.com/downloads/DeliciousLibrary#{version.major}/v#{version}/DeliciousLibrary#{version.major}.zip"
   appcast "https://www.delicious-monster.com/downloads/DeliciousLibrary#{version.major}.xml"
   name 'Delicious Library'
-  homepage 'https://delicious-monster.com/'
+  homepage 'https://www.delicious-monster.com/'
 
   app "Delicious Library #{version.major}.app"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Delicious Monster certificate only valid for www.delicious-monster.com, updated URLs