### PR TITLE
Update losslesscut from 3.21.0 to 3.22.0

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '3.21.0'
-  sha256 '8b1791511611dbe7411a0f2fc56e88797cb267748b49ec9bd390cb1460286c13'
+  version '3.22.0'
+  sha256 'c88135a5e34c76487a933a61c9909733d3324bece1f56c94aa009618d8e67b11'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.