### PR TITLE
Update menumeters from 2.0.6 to 2.0.6.1

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,8 +1,8 @@
 cask 'menumeters' do
-  version '2.0.6'
-  sha256 'e9d976c2e75e2b4c81ae67af8ff5ac50a1bdc5ceea5f8eb6343f388c190081fb'
+  version '2.0.6.1'
+  sha256 '2959fbd4474738afec9172127701e3c1f47fa6f7db0ff1bdb90ec745c500ebce'
 
-  url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version.major_minor_patch}.zip"
+  url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
   appcast 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml'
   name 'MenuMeters for El Capitan (and later)'
   homepage 'https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.