### PR TITLE
Update dosbox-x from 0.83.0,20200229182835 to 0.83.1,20200502171747

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,6 +1,6 @@
 cask 'dosbox-x' do
-  version '0.83.0,20200229182835'
-  sha256 '7a208a72f9bd10279d562714ba3b6b176aa9a95a4acd016058fb2179df841b76'
+  version '0.83.1,20200502171747'
+  sha256 '87b2d3803acabf5e3a2acd74e2a8f116369e78b886063cb47c26926adead044d'
 
   # github.com/joncampbell123/dosbox-x/ was verified as official when first introduced to the cask
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x64-#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.