### PR TITLE
Update keyshot from 9.2.86 to 9.3.14

### DIFF
--- a/Casks/keyshot.rb
+++ b/Casks/keyshot.rb
@@ -1,6 +1,6 @@
 cask 'keyshot' do
-  version '9.2.86'
-  sha256 '2e1c3f0bfa0b330e3f67cbdd17689e23f1426fdba3a923079368bfc79522e71e'
+  version '9.3.14'
+  sha256 '30973fc28828b19187f9653566b135b39720c9e551ccef848f1f3efd13285ef9'
 
   url "https://download.keyshot.com/keyshot#{version.major}/keyshot_mac64_#{version}.pkg"
   name 'KeyShot'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.