### PR TITLE
Update subsurface from 4.9.3 to 4.9.4

### DIFF
--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -1,6 +1,6 @@
 cask 'subsurface' do
-  version '4.9.3'
-  sha256 '00f6b59d75c6435f64045d0b452be9e61223592761a0d88c4f93c45330308fab'
+  version '4.9.4'
+  sha256 'c129cedf74c4c8d22bc965310fe1eb2ccb7eb69decbf690f2b7ab3ef190bcf5b'
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}.dmg"
   appcast 'https://subsurface-divelog.org/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.