### PR TITLE
Update webcatalog from 20.12.0 to 20.12.1

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.12.0'
-  sha256 '3e03e90a83b9510cb1252c770234ab39ee2405f846f06aa68c9787c13ff603bf'
+  version '20.12.1'
+  sha256 '131759b0d49c7f521168d6f701d030f689eff1ef1447480d0cb2bde2cd2ac40d'
 
   # github.com/quanglam2807/webcatalog/ was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.