### PR TITLE
Update praat from 6.1.13 to 6.1.14

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,9 +1,9 @@
 cask 'praat' do
-  version '6.1.13'
-  sha256 'b1de1e489d2a923b3ef0aaa1103486a8a6dbc574645af3bfa8964618d3269412'
+  version '6.1.14'
+  sha256 '08fbd3f4878d2312f92542ce7d604d398b2506c851c0bb072bd884b6d6846f8a'
 
   # github.com/praat/praat/ was verified as official when first introduced to the cask
-  url "https://github.com/praat/praat/releases/download/v#{version}a/praat#{version.no_dots}_mac64.dmg"
+  url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac64.dmg"
   appcast 'https://github.com/praat/praat/releases.atom'
   name 'Praat'
   homepage 'http://www.fon.hum.uva.nl/praat/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.