### PR TITLE
Update permute from 3.4.7,2252 to 3.4.8,2259

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask 'permute' do
-  version '3.4.7,2252'
-  sha256 '769f9f76b6cfc0a0381ecf0a3660fd7ddcbbb2c58596442e0d0ef525e28a8319'
+  version '3.4.8,2259'
+  sha256 '7c9c7cb0c9e52d8afb6cd9e8af8ff9856d4e0f6eb2bf517502856892e3537c14'
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.