### PR TITLE
Update electerm from 1.3.18 to 1.3.21

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.18'
-  sha256 '813880b59f7525c5f6fca39d1c364f49d3ffe766310ae2ceb2b0fd255a982cca'
+  version '1.3.21'
+  sha256 '3a53a8075abb93cb66c876c5c0b2506fe75a90366e2110a61b25f0aed581d933'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.