### PR TITLE
Update freeyourmusic from 5.2.0 to 5.2.1

### DIFF
--- a/Casks/freeyourmusic.rb
+++ b/Casks/freeyourmusic.rb
@@ -1,6 +1,6 @@
 cask 'freeyourmusic' do
-  version '5.2.0'
-  sha256 '4aeece4686144f0a1d5b49112867e64d196c2e9c3aae9d1bb424a0881e974dd2'
+  version '5.2.1'
+  sha256 '0dbfe2a4f77b1b7712a99976f4b9f9d9dc15a3511c750393447780528caa0f8a'
 
   # dzqeytqqx888.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://dzqeytqqx888.cloudfront.net/FreeYourMusic-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.