### PR TITLE
Update prepros from 7.2.20 to 7.2.21

### DIFF
--- a/Casks/prepros.rb
+++ b/Casks/prepros.rb
@@ -1,6 +1,6 @@
 cask 'prepros' do
-  version '7.2.20'
-  sha256 '7b243c2168375bf87660a3c4fefdfaee23b9fca507269909dc4b6340b18c8398'
+  version '7.2.21'
+  sha256 'e0a13adef2ebb62663edb5950dc55b86852d18f2b7d07d8625221dbc7b1a2f4b'
 
   url "https://downloads.prepros.io/v#{version.major}/Prepros-#{version}.zip"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://prepros.io/downloads/stable/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.