### PR TITLE
Update megahertz-knotes from 2.3.0 to 2.4.0

### DIFF
--- a/Casks/megahertz-knotes.rb
+++ b/Casks/megahertz-knotes.rb
@@ -1,6 +1,6 @@
 cask 'megahertz-knotes' do
-  version '2.3.0'
-  sha256 'e8db95db9226e8301fed77b405d24e82eced142f560ee79ed16f84bb9c1a814a'
+  version '2.4.0'
+  sha256 '2c15b74006e17a04603cf7d8a802636d4e8fbbd1078ffd4a216f6eadc2d87f67'
 
   url "http://cdn.knotesapp.cn/download/%e7%b3%af%e8%af%8d%e7%ac%94%e8%ae%b0-#{version}.dmg"
   appcast "https://knotes#{version.major}-release-cn.s3.amazonaws.com/mac/latest-mac.yml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.