### PR TITLE
inkscape.rb: keep only 1.0.0

### DIFF
--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -3,6 +3,8 @@ cask 'inkscape' do
   sha256 '9b42468815b4bcbc8ccb76a239aea48a2965dbd2f3ae7c3b560c7f2a7e48a955'
 
   url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}.dmg"
+  appcast 'https://gitlab.com/inkscape/inkscape/-/tags?format=atom',
+          configuration: version.major_minor
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -1,44 +1,28 @@
 cask 'inkscape' do
-  if MacOS.version <= :mojave
-    version '0.92.2-1'
-    sha256 'faece7a9a5fa9db7724b0c761f7f2014676d00ef8b90a0ef506fa39d09209fea'
+  version '1.0.0'
+  sha256 '9b42468815b4bcbc8ccb76a239aea48a2965dbd2f3ae7c3b560c7f2a7e48a955'
 
-    url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}-x11-10.7-x86_64.dmg"
-
-    depends_on x11: true
-
-    binary "#{appdir}/Inkscape.app/Contents/Resources/bin/inkscape"
-
-    zap trash: '~/.inkscape-etc'
-  else
-    version '1.0.0'
-    sha256 '9b42468815b4bcbc8ccb76a239aea48a2965dbd2f3ae7c3b560c7f2a7e48a955'
-
-    url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}.dmg"
-
-    # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-    shimscript = "#{staged_path}/inkscape.wrapper.sh"
-
-    binary shimscript, target: 'inkscape'
-
-    preflight do
-      IO.write shimscript, <<~EOS
-        #!/bin/sh
-        exec '#{staged_path}/Inkscape.app/Contents/MacOS/Inkscape' "$@"
-      EOS
-    end
-
-    zap trash: [
-                 '~/.config/inkscape',
-                 '~/Library/Application Support/Inkscape',
-                 '~/Library/Application Support/org.inkscape.Inkscape',
-                 '~/Library/Preferences/org.inkscape.Inkscape.plist',
-                 '~/Library/Saved Application State/org.inkscape.Inkscape.savedState',
-               ]
-  end
-
+  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}.dmg"
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 
   app 'Inkscape.app'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/inkscape.wrapper.sh"
+  binary shimscript, target: 'inkscape'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{staged_path}/Inkscape.app/Contents/MacOS/Inkscape' "$@"
+    EOS
+  end
+
+  zap trash: [
+               '~/.config/inkscape',
+               '~/Library/Application Support/Inkscape',
+               '~/Library/Application Support/org.inkscape.Inkscape',
+               '~/Library/Preferences/org.inkscape.Inkscape.plist',
+               '~/Library/Saved Application State/org.inkscape.Inkscape.savedState',
+             ]
 end

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -3,7 +3,8 @@ cask 'inkscape' do
   sha256 '9b42468815b4bcbc8ccb76a239aea48a2965dbd2f3ae7c3b560c7f2a7e48a955'
 
   url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://inkscape.org/release'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://inkscape.org/release',
+          configuration: version.major_minor
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -3,8 +3,7 @@ cask 'inkscape' do
   sha256 '9b42468815b4bcbc8ccb76a239aea48a2965dbd2f3ae7c3b560c7f2a7e48a955'
 
   url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}.dmg"
-  appcast 'https://gitlab.com/inkscape/inkscape/-/tags?format=atom',
-          configuration: version.major_minor
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://inkscape.org/release'
   name 'Inkscape'
   homepage 'https://inkscape.org/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

According to the website, version `1.0.0` is supported from macOS `10.11`.