### PR TITLE
Update SciHubEVA from v4.0.0 to v4.0.1

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -1,6 +1,6 @@
 cask 'scihubeva' do
-  version 'v4.0.0'
-  sha256 'cf3857084f4a78092621bb7e836e4db16b26e3c10551f77a3ead7ed40b9fb5e9'
+  version 'v4.0.1'
+  sha256 '5ba4ea891fa3781612d8c47c550920194e44bb0d4f49a724ab111d3aed35ebd0'
 
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast 'https://github.com/leovan/SciHubEVA/releases.atom'


### PR DESCRIPTION
Update SciHubEVA from v4.0.0 to v4.0.1

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).