### PR TITLE
Update telegram from 6.1.2.198002 to 6.1.3.200067

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask 'telegram' do
-  version '6.1.2.198002'
-  sha256 'd535ded4d81e6e6c5bc982ed2e260a7025777e38ac187f57448aa13b9d777650'
+  version '6.1.3.200067'
+  sha256 '0f89d7bcc2b5fe0d536ec8fdc5d010b0e08d83fcb727c4c9d8cd52b69bbbfd2d'
 
   url "https://osx.telegram.org/updates/Telegram-#{version}.app.zip"
   appcast 'https://osx.telegram.org/updates/versions.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.