### PR TITLE
Secure/improve URLs

### DIFF
--- a/Casks/knotes.rb
+++ b/Casks/knotes.rb
@@ -2,11 +2,11 @@ cask 'knotes' do
   version '1.6.0'
   sha256 '8884b6a67f1c43b7880ff5da957f2c0684f3afb12a6f1fc24b960d72e2f9bae9'
 
-  # s3.ap-northeast-2.amazonaws.com/ was verified as official when first introduced to the cask
-  url "https://s3.ap-northeast-2.amazonaws.com/knotes-release-cn/mac/Knotes-#{version}-mac.zip"
-  appcast 'http://knotesapp.com/'
+  # knotes-release-cn.s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url "https://knotes-release-cn.s3.amazonaws.com/mac/Knotes-#{version}-mac.zip"
+  appcast 'https://knotesapp.com/'
   name 'Knotes'
-  homepage 'http://knotesapp.com/'
+  homepage 'https://knotesapp.com/'
 
   app 'Knotes.app'
 

--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -2,10 +2,10 @@ cask 'porting-kit' do
   version '3.0.21'
   sha256 '1d2d30262259af326de22f330bda4f9b35a563d8c2bc35da13bb473ab68264a8'
 
-  url "http://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
-  appcast 'http://portingkit.com/kit/updatecast.xml'
+  url "https://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
+  appcast 'https://portingkit.com/kit/updatecast.xml'
   name 'Porting Kit'
-  homepage 'http://portingkit.com/'
+  homepage 'https://portingkit.com/'
 
   auto_updates true
   conflicts_with cask: 'porting-kit-legacy'

--- a/Casks/rssowl.rb
+++ b/Casks/rssowl.rb
@@ -6,7 +6,7 @@ cask 'rssowl' do
   url "https://github.com/rssowl/RSSOwl/releases/download/#{version}/RSSOwl.#{version}.dmg"
   appcast 'https://github.com/rssowl/RSSOwl/releases.atom'
   name 'RSSOwl'
-  homepage 'http://www.rssowl.org/'
+  homepage 'https://www.rssowl.org/'
 
   app 'RSSOwl.app'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
1 file inspected, no offenses detected
==> Downloading https://knotes-release-cn.s3.amazonaws.com/mac/Knotes-1.6.0-mac.
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'knotes'.
audit for knotes: passed

1 file inspected, no offenses detected
==> Downloading https://portingkit.com/kit/Porting%20Kit%203.0.21.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'porting-kit'.
audit for porting-kit: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/rssowl/RSSOwl/releases/download/2.2.1/RSSOwl.
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'rssowl'.
audit for rssowl: passed
```