### PR TITLE
Update navicat-for-postgresql from 15.0.14 to 15.0.15

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.14'
-  sha256 '5da2a8bc49aab4d1c5f4fcde93bac1ed51acd7d0da514b9e9198efef51b59035'
+  version '15.0.15'
+  sha256 'cbd7a43956780e9160b3dd78e94385c89da9663ea2ebc3b39e1b08f51fdb12e2'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.