### PR TITLE
Update toontown-rewritten from latest to 1.2.4

### DIFF
--- a/Casks/toontown-rewritten.rb
+++ b/Casks/toontown-rewritten.rb
@@ -1,8 +1,9 @@
 cask 'toontown-rewritten' do
-  version :latest
-  sha256 :no_check
+  version '1.2.4'
+  sha256 '56cd2178be0ea7a1c49ba688c9da2d1f0b1644cd41f1343d15e6e770576beba4'
 
-  url 'https://download.toontownrewritten.com/launcher/mac/toontown_launcher_latest.dmg'
+  url "https://cdn.toontownrewritten.com/launcher/mac/updates/#{version}/ttr_launcher_#{version}.zip"
+  appcast 'https://www.toontownrewritten.com/play'
   name 'Toontown Rewritten'
   name 'Toontown Launcher'
   homepage 'https://www.toontownrewritten.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.