### PR TITLE
Update navicat-data-modeler-essentials from 3.0.8 to 3.0.9

### DIFF
--- a/Casks/navicat-data-modeler-essentials.rb
+++ b/Casks/navicat-data-modeler-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-data-modeler-essentials' do
-  version '3.0.8'
-  sha256 '76d9ba97576a78dbed5df40ea8eb6126d72878ce64e6163260d4330ac9e3af47'
+  version '3.0.9'
+  sha256 'd7d3550c645352af43b3a68f87a8725c4d4880cce93703d47434bcebd7679f3a'
 
   url "http://download3.navicat.com/updater/modeler0#{version.major_minor.no_dots}_ess_mac_en.zip"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Data%20Modeler%20Essentials'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.