### PR TITLE
Update navicat-for-sqlite from 15.0.14 to 15.0.15

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.14'
-  sha256 'f7eb30f484ce0d9f9e069fc504a43471ef2fe16c9fb324922439afa0e09f3c98'
+  version '15.0.15'
+  sha256 '248c85e9069de5125d67ecbccac4ab1f3c1a24a39bcee8e4f119273dfd4b95ff'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.