### PR TITLE
Update folding-at-home from 7.6.9 to 7.6.13

### DIFF
--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -1,6 +1,6 @@
 cask 'folding-at-home' do
-  version '7.6.9'
-  sha256 '9475e8aef3614daf92e3cfc8748be5e10e1c5b38a5c5da30ce3fe60f754de16b'
+  version '7.6.13'
+  sha256 'ee96f4f1b724db46f9a37f7d805095a16b24f1ef7e9b9a1615a56e94e4119a36'
 
   url "https://download.foldingathome.org/releases/public/release/fah-installer/osx-10.11-64bit/v#{version.major_minor}/fah-installer_#{version}_x86_64.mpkg.zip"
   appcast 'https://download.foldingathome.org/js/fah-downloads.js'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.