### PR TITLE
Update navicat-for-mysql from 15.0.14 to 15.0.15

### DIFF
--- a/Casks/navicat-for-mysql.rb
+++ b/Casks/navicat-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mysql' do
-  version '15.0.14'
-  sha256 '983d2a2f831f65f06146cc4c6f1e465944d87ba0d6a022d4667af36f0b3a38a9'
+  version '15.0.15'
+  sha256 'afdeade6985bc97c143102a3c7161eb17e6d8411403d07fa469ac077f5ac9773'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mysql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MySQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.