### PR TITLE
Update ganttproject from 2.8.11,r2393 to 2.8.11,r2396

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,6 +1,6 @@
 cask 'ganttproject' do
-  version '2.8.11,r2393'
-  sha256 '08b11da6a4cf8d354b0ae4f6c1f1e38a7df7be4706f35699fcbcd527376378be'
+  version '2.8.11,r2396'
+  sha256 'b8f64286ca9c04f606336994785c5ed3995c1842f8b1d82199f7ad0bb01d2851'
 
   # github.com/bardsoftware/ganttproject/ was verified as official when first introduced to the cask
   url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.before_comma}/ganttproject-#{version.before_comma}-#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.