### PR TITLE
Update navicat-premium from 15.0.14 to 15.0.15

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium' do
-  version '15.0.14'
-  sha256 'e801355513419d1075a254d517093ec75a6146ff2a7d80310c40b7efbc203cb1'
+  version '15.0.15'
+  sha256 '626609232cce4b67420ed66d68d0a6dd798ec8e40e1783a666f1bf281e875146'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Premium&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.