### PR TITLE
Update frhelper from 3.9.6,2020-02-25 to 3.9.6,2020-04-05

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,9 +1,10 @@
 cask 'frhelper' do
-  version '3.9.6,2020-02-25'
+  version '3.9.6,2020-04-05'
   sha256 'ec638576b929dfd9c2637b5dd152c59fc05812bdfa670c2419d056e329c6e44b'
 
   # static.frdic.com/ was verified as official when first introduced to the cask
-  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_comma}"
+  url "https://static.frdic.com/pkg/fhmac.dmg?v=#{version.after_comma}",
+      user_agent: :fake
   appcast 'https://www.eudic.net/v4/fr/app/download',
           configuration: version.after_comma
   name 'Frhelper'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.