### PR TITLE
Switch to subdomain-style S3 URLs

### DIFF
--- a/Casks/aviatrix-vpn-client.rb
+++ b/Casks/aviatrix-vpn-client.rb
@@ -2,8 +2,8 @@ cask 'aviatrix-vpn-client' do
   version :latest
   sha256 :no_check
 
-  # s3-us-west-2.amazonaws.com/aviatrix-download/ was verified as official when first introduced to the cask
-  url 'https://s3-us-west-2.amazonaws.com/aviatrix-download/AviatrixVPNClient/AVPNC_mac.pkg'
+  # aviatrix-download.s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url 'https://aviatrix-download.s3.amazonaws.com/AviatrixVPNClient/AVPNC_mac.pkg'
   name 'Aviatrix VPN Client'
   homepage 'https://docs.aviatrix.com/Downloads/samlclient.html'
 

--- a/Casks/bubo.rb
+++ b/Casks/bubo.rb
@@ -2,8 +2,8 @@ cask 'bubo' do
   version '1.0'
   sha256 '25c50797d1397b0e4ae02346d6179c9c8ec3fbd129dad759100fb3f598109630'
 
-  # s3-us-west-2.amazonaws.com/jguice/mac-bt-headset-fix-beta/ was verified as official when first introduced to the cask
-  url 'https://s3-us-west-2.amazonaws.com/jguice/mac-bt-headset-fix-beta/bubo.app.zip'
+  # jguice.s3.amazonaws.com/mac-bt-headset-fix-beta/ was verified as official when first introduced to the cask
+  url 'https://jguice.s3.amazonaws.com/mac-bt-headset-fix-beta/bubo.app.zip'
   name 'Bubo'
   name 'Spotify Bluetooth Headset Listener'
   homepage 'https://github.com/jguice/mac-bt-headset-fix'

--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -2,8 +2,8 @@ cask 'qgroundcontrol' do
   version :latest
   sha256 :no_check
 
-  # s3-us-west-2.amazonaws.com/qgroundcontrol/ was verified as official when first introduced to the cask
-  url 'https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.dmg'
+  # qgroundcontrol.s3.amazonaws.com/latest was verified as official when first introduced to the cask
+  url 'https://qgroundcontrol.s3.amazonaws.com/latest/QGroundControl.dmg'
   name 'QGroundControl'
   homepage 'http://qgroundcontrol.com/'
 

--- a/Casks/vip-access.rb
+++ b/Casks/vip-access.rb
@@ -2,8 +2,8 @@ cask 'vip-access' do
   version :latest
   sha256 :no_check
 
-  # s3-us-east-2.amazonaws.com/ was verified as official when first introduced to the cask
-  url 'https://s3-us-east-2.amazonaws.com/com-symantec-vip-us-east-2-prd-idcenter-downloads-v2/VIPAccessSecurityCode.dmg'
+  # com-symantec-vip-us-east-2-prd-idcenter-downloads-v2.s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url 'https://com-symantec-vip-us-east-2-prd-idcenter-downloads-v2.s3.amazonaws.com/VIPAccessSecurityCode.dmg'
   name 'Symantec VIP Access'
   homepage 'https://vip.symantec.com/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

For URLs that had a redundant region specifier in their subdomain.
```
1 file inspected, no offenses detected
==> Downloading https://aviatrix-download.s3.amazonaws.com/AviatrixVPNClient/AVP
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'aviatrix-vpn-client', skipping verific
audit for aviatrix-vpn-client: passed

1 file inspected, no offenses detected
==> Downloading https://jguice.s3.amazonaws.com/mac-bt-headset-fix-beta/bubo.app
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'bubo'.
audit for bubo: passed

1 file inspected, no offenses detected
==> Downloading https://qgroundcontrol.s3.amazonaws.com/latest/QGroundControl.dm
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'qgroundcontrol', skipping verification
audit for qgroundcontrol: passed

1 file inspected, no offenses detected
==> Downloading https://com-symantec-vip-us-east-2-prd-idcenter-downloads-v2.s3.
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'vip-access', skipping verification.
audit for vip-access: passed
```