### PR TITLE
Update soulver from 3.4.0.1-111 to 3.4.1-114

### DIFF
--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -1,6 +1,6 @@
 cask 'soulver' do
-  version '3.4.0.1-111'
-  sha256 'f2269af8e35ae06a833fc1629048578f1fec8d69256f5a2d2b56684d1e3be911'
+  version '3.4.1-114'
+  sha256 '9662e94f92e9dfef449198aa84da22210d9c6ee64cf345d127a1e063328b60cc'
 
   url "https://soulver.app/mac/sparkle/soulver-#{version}.zip"
   appcast 'https://soulver.app/mac/sparkle/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.