### PR TITLE
Update popchar from 8.9 to 8.10

### DIFF
--- a/Casks/popchar.rb
+++ b/Casks/popchar.rb
@@ -1,6 +1,6 @@
 cask 'popchar' do
-  version '8.9'
-  sha256 '670f7ea6329bcd0fa760ca33042e09f7866b5f69170a658bbd0c79fd2b8da549'
+  version '8.10'
+  sha256 'cac9830de0ac9d1fa01b44e91315be2c60d68978b61968c3a8b9211e983e1f4b'
 
   url "https://www.ergonis.com/downloads/products/popcharx/PopCharX#{version.no_dots}-Install.dmg",
       user_agent: :fake


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.