### PR TITLE
Update aircall from 2.4.3 to 2.4.4

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,6 +1,6 @@
 cask 'aircall' do
-  version '2.4.3'
-  sha256 'd424d5937c1140efbb2d745ce57c8306d813a8f161df91bcd63d52b30d76530f'
+  version '2.4.4'
+  sha256 'd4396268dda9645c3804a7b876087a37e4025821f5caee938766e6469cc94324'
 
   # aircall-electron-releases.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://aircall-electron-releases.s3.amazonaws.com/production/Aircall-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.