### PR TITLE
Update mendeley-reference-manager from 2.24.0 to 2.25.0

### DIFF
--- a/Casks/mendeley-reference-manager.rb
+++ b/Casks/mendeley-reference-manager.rb
@@ -1,6 +1,6 @@
 cask 'mendeley-reference-manager' do
-  version '2.24.0'
-  sha256 '5e89c6d4d56f5885ac764325c97980d6b526d651777cac2be433ca4f3075196a'
+  version '2.25.0'
+  sha256 '25bd3feb8005383f16f379b33532f7d08190a2cdb93bfc74798f22e50da72c23'
 
   url "https://static.mendeley.com/bin/desktop/mendeley-reference-manager-#{version}.dmg"
   appcast 'https://static.mendeley.com/bin/desktop/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.