### PR TITLE
Update rcloneosx from 2.1.5 to 2.1.9

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,8 +1,8 @@
 cask 'rcloneosx' do
-  version '2.1.5'
-  sha256 'be9e0baeb95f20e3ad1fc69ec2f33eca9bdbcd930744bab9082354a9bbb3bb94'
+  version '2.1.9'
+  sha256 'c2a99eb930a31136251b16d3f4b5f22aea963a88996f3eb3ca6d3d0cde9d8ea1'
 
-  url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/RcloneOSX-#{version}.dmg"
+  url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/rcloneosx.#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'
   name 'RcloneOSX'
   homepage 'https://github.com/rsyncOSX/rcloneosx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.