### PR TITLE
Update tinkerwell from 2.6.0 to 2.7.0

### DIFF
--- a/Casks/tinkerwell.rb
+++ b/Casks/tinkerwell.rb
@@ -1,6 +1,6 @@
 cask 'tinkerwell' do
-  version '2.6.0'
-  sha256 '390550d9cd65b6ab0c32533e23f0a7638403d4c28327a1e4c79089fca507d5dd'
+  version '2.7.0'
+  sha256 'ce6ef09d64c5b16a82d1f6f507a696e6c17bf7c47335438a73db44aaf3561e96'
 
   # tinkerwell.fra1.digitaloceanspaces.com/ was verified as official when first introduced to the cask
   url "https://tinkerwell.fra1.digitaloceanspaces.com/tinkerwell/Tinkerwell-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.