### PR TITLE
Update hyperbackupexplorer from 2.2.1-0133 to 2.2.2-0141

### DIFF
--- a/Casks/hyperbackupexplorer.rb
+++ b/Casks/hyperbackupexplorer.rb
@@ -1,8 +1,8 @@
 cask 'hyperbackupexplorer' do
-  version '2.2.1-0133'
-  sha256 'b11ad0a60d3cbac84e9a39dff5b602591daa075c959c072e46e8f205aeac96ef'
+  version '2.2.2-0141'
+  sha256 'e5dc0c7bbe11782e69d602c11b373354fb64a82689e33eba73433d91bd8de15d'
 
-  url "https://global.download.synology.com/download/Tools/HyperBackupExplorer/#{version}/Mac/x86_64/HyperBackupExplorer-#{version}-mac.zip"
+  url "https://archive.synology.com/download/Tools/HyperBackupExplorer/#{version}/Mac/x86_64/HyperBackupExplorer-#{version}-mac.dmg"
   appcast 'https://archive.synology.com/download/Tools/HyperBackupExplorer/'
   name 'HyperBackupExplorer'
   homepage 'https://www.synology.com/en-us/dsm/feature/hyper_backup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.