### PR TITLE
Update perforce from 19.2,1942501 to 20.1,1953492

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask 'perforce' do
-  version '19.2,1942501'
-  sha256 'd7d665d1e9ff538790ae17fbe38c2d54597a9ea36bbe0e0b4ef9e178cd8e896d'
+  version '20.1,1953492'
+  sha256 'e93b556b4824afa3b9c1b7e328a53c605c8953cc9facd6c12d7a3b3451434ea6'
 
   url "https://cdist2.perforce.com/perforce/r#{version.before_comma}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.