### PR TITLE
Update knuff from 1.2 to 1.3

### DIFF
--- a/Casks/knuff.rb
+++ b/Casks/knuff.rb
@@ -1,6 +1,6 @@
 cask 'knuff' do
-  version '1.2'
-  sha256 '3e2aae3b80ec53d70a6f68fc309d6e54d09b38cdf97638885f70e3e8eb86ad53'
+  version '1.3'
+  sha256 '06c6bb6d2254211f4369a9903aefb61eb894c706b08635091f457d1730b79c69'
 
   url "https://github.com/KnuffApp/Knuff/releases/download/v#{version}/Knuff.app.zip"
   appcast 'https://github.com/KnuffApp/Knuff/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.