### PR TITLE
Update flipper from 0.40.0 to 0.41.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.40.0'
-  sha256 '6f9e08f1bf40c147e73cc67f4a13241a90fa4e3913c247a5ddda0f97a880e7d4'
+  version '0.41.0'
+  sha256 '5671e995c808fec6335709017e8f9f60e1d29af6d91a7d50cbef738107aac349'
 
   # github.com/facebook/flipper/ was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.