### PR TITLE
Update tiddly from 0.0.13 to 0.0.14

### DIFF
--- a/Casks/tiddly.rb
+++ b/Casks/tiddly.rb
@@ -1,6 +1,6 @@
 cask 'tiddly' do
-  version '0.0.13'
-  sha256 '8125475c3c18fdd029c38361287d64abb4ced1552bf8b60fb9ae86e98e9bddbe'
+  version '0.0.14'
+  sha256 '5b311671ae872e34bc96b4ac96d69ce96b9910e38af9d4722cf01f192ab5e6b2'
 
   url "https://github.com/Jermolene/TiddlyDesktop/releases/download/v#{version}/tiddlydesktop-mac64-v#{version}.zip"
   appcast 'https://github.com/Jermolene/TiddlyDesktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.