### PR TITLE
Update wire from 3.16.3630 to 3.17.3666

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,6 +1,6 @@
 cask 'wire' do
-  version '3.16.3630'
-  sha256 '2573bf02530a3cde44549f64a3459e7b47fe1e4bbd9bfe7ab26634b80ab1d2d2'
+  version '3.17.3666'
+  sha256 'f646b364a448686dd88c5aa6ef6ab5427945030e3112332c375081deb29b6c64'
 
   # github.com/wireapp/wire-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.