### PR TITLE
Update losslesscut from 3.22.2 to 3.22.3

### DIFF
--- a/Casks/losslesscut.rb
+++ b/Casks/losslesscut.rb
@@ -1,6 +1,6 @@
 cask 'losslesscut' do
-  version '3.22.2'
-  sha256 '788ad7e1de7461260daea6a78df1c5edd0fb276de6cce999a48e503940158710'
+  version '3.22.3'
+  sha256 '02a250c8a3ebf6ad675960d78678433dde41bd66e8e5e88697e7786cb30b6590'
 
   url "https://github.com/mifi/lossless-cut/releases/download/v#{version}/LosslessCut-mac.dmg"
   appcast 'https://github.com/mifi/lossless-cut/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.