### PR TITLE
Update surge from 3.5.0-1039 to 3.5.1-1069

### DIFF
--- a/Casks/surge.rb
+++ b/Casks/surge.rb
@@ -1,6 +1,6 @@
 cask 'surge' do
-  version '3.5.0-1039'
-  sha256 'f6c4f111c05831edff5e328f225c3ec1771522867250e849bfd65bdbb583056d'
+  version '3.5.1-1069'
+  sha256 'cb1e9151efcf211530aafb77415e9f55be59685ffbf3bdf3e9021075a3219d91'
 
   url "https://www.nssurge.com/mac/v#{version.major}/Surge-#{version}.zip"
   appcast "https://www.nssurge.com/mac/v#{version.major}/appcast-signed.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.