### PR TITLE
Update cloudmounter from 3.5.585 to 3.6.611

### DIFF
--- a/Casks/cloudmounter.rb
+++ b/Casks/cloudmounter.rb
@@ -1,6 +1,6 @@
 cask 'cloudmounter' do
-  version '3.5.585'
-  sha256 'b231bce984fbdcd183cfde6573a11e4c56e11015c4e1e08e387e7320d04d889c'
+  version '3.6.611'
+  sha256 'b9b90d9e634c63377b080f1b242c912213ad0f502f614951dcbe867d05fb010e'
 
   url 'https://cdn.eltima.com/download/cloudmounter.dmg'
   appcast 'https://cdn.eltima.com/download/cloudmounter-update/settings.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.