### PR TITLE
Update pocket-casts from 1.3.2 to 1.4

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,6 +1,6 @@
 cask 'pocket-casts' do
-  version '1.3.2'
-  sha256 '2846ab178c671147838497426952ef8160daab8acc0c16e8abdb578efb5e7d20'
+  version '1.4'
+  sha256 '905436b8221a7b514ebf713a278a96a389b3991183c5e2fd284b7d71b996c22e'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
   appcast 'https://static2.pocketcasts.com/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.