### PR TITLE
Update fontexplorer-x-pro from 7.0.0 to 7.0.1

### DIFF
--- a/Casks/fontexplorer-x-pro.rb
+++ b/Casks/fontexplorer-x-pro.rb
@@ -1,6 +1,6 @@
 cask 'fontexplorer-x-pro' do
-  version '7.0.0'
-  sha256 '5bda8425468f98efb8db458358df9abc6096a0f2dbdfa41afad177d9823e32a5'
+  version '7.0.1'
+  sha256 '3edf5cd6f7cb9312dee1b5bc74959419dcb842f5ad669d496df1e1c6d193b8ab'
 
   url "https://fast.fontexplorerx.com/FontExplorerXPro#{version.no_dots}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://fex.linotype.com/download/mac/FontExplorerXPro.dmg',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.