### PR TITLE
Update visual-paradigm from 16.1,20200401 to 16.1,20200501

### DIFF
--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -1,6 +1,6 @@
 cask 'visual-paradigm' do
-  version '16.1,20200401'
-  sha256 'e39ef74b20582753a91b56ed53976d251e141d251b81f1633108f54187bd2316'
+  version '16.1,20200501'
+  sha256 'a63e822167096d7dbf485f9a66d09921a4f2d188bc9c677e07931a88dc2e0ebf'
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.visual-paradigm.com/downloads/vp/checksum.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.