### PR TITLE
Add cask-pr-inspect-download.rb

### DIFF
--- a/developer/bin/cask-pr-inspect-download.rb
+++ b/developer/bin/cask-pr-inspect-download.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'open-uri'
+require 'optparse'
+require 'tmpdir'
+
+# Options
+ARGV.push('--help') if ARGV.empty?
+
+OptionParser.new do |opt|
+  opt.banner = <<~BANNER
+    `fetch` the `url` from a cask PR, to inspect its contents.
+    Archives will be opened as soon as the download finishes.
+    Useful to check for appcasts or renamed artifacts.
+
+    Usage:
+      #{File.basename($PROGRAM_NAME)} <pr url>
+
+    Options:
+  BANNER
+
+  opt.on('-h', '--help', 'Show this help.') do
+    puts opt
+    exit 0
+  end
+end.parse!
+
+pr_url = ARGV[0]
+
+abort 'URL is not from an official Homebrew Cask tap' if pr_url !~ %r{^https://github.com/Homebrew/homebrew-cask.*}
+
+pr_api = pr_url.sub(%r{^https://github.com/([^/]+)/([^/]+)/pull/([^/]+).*}, 'https://api.github.com/repos/\1/\2/pulls/\3/files')
+pr_json = JSON.parse(URI.open(pr_api).read)
+
+abort 'PR needs to have a single file' if pr_json.count != 1
+
+file_raw_url = pr_json[0]['raw_url']
+file_name = File.basename(file_raw_url)
+local_file = File.join(Dir.mktmpdir, file_name)
+tmp_cache_dir = Dir.mktmpdir
+tmp_download_dir = File.join(tmp_cache_dir, 'downloads')
+
+ENV['HOMEBREW_CACHE'] = tmp_cache_dir
+File.write(local_file, URI.open(file_raw_url).read)
+system('brew', 'cask', 'fetch', local_file)
+
+downloaded_file = File.join(tmp_download_dir, Dir.children(tmp_download_dir).first)
+downloaded_file_ext = File.extname(downloaded_file)
+
+case downloaded_file_ext
+when '.dmg', '.zip', '.tar.gz', '.tgz'
+  system('open', downloaded_file)
+else
+  system('open', tmp_download_dir)
+end


### PR DESCRIPTION
Wold benefit from cleaning up and improvements (like using `pathname`), but it works. It’s an old script to quickly inspect the contents of cask PRs. I may do the cleaning up later, but as it is it might be useful to someone else.