### PR TITLE
Updated SeaMonkey from 2.53.1 to 2.53.2

### DIFF
--- a/Casks/seamonkey.rb
+++ b/Casks/seamonkey.rb
@@ -1,33 +1,33 @@
 cask 'seamonkey' do
-  version '2.53.1'
+  version '2.53.2'
 
   language 'de' do
-    sha256 '7227a9b9a428ba18eaaede58841ca5ad082d60dd73151d84f465613594781e47'
+    sha256 '06dd692e8debe3d8c64f34659f675ae207bf4f1d60b2a9810ab2a389d37c691f'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '8d3b5c90d39d6ab5aa2079a6289d6cede27eb468d9bb97a2b5a7d85972d90124'
+    sha256 '46fdc10bc29f757bccd9cb3cf933490d06a59c63c2fbc572ca626d7bd25e00dd'
     'en-GB'
   end
 
   language 'en-US', default: true do
-    sha256 'c4fab248ee30709b462a9c04ed8ca6e3443ae486c40210d2e521bedf050289bc'
+    sha256 '4ed0131465029c5e6403bf881fd7469f7f7d002b436703166275fa131cab073e'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '74cf24fca6550cb6c27bb33cc115549212ff055befbbf8b49a86f8341088affc'
+    sha256 '075f2fb8f3b2195c8475132054ac9a3d429b575349d6592b16943fedfed9ee68'
     'fr'
   end
 
   language 'it' do
-    sha256 '7a32c5b2e9da21beed987e6cd0a33801cdeab504582a5d0391006bd33eb2de97'
+    sha256 'b3fd64c5dfd7417a54415ce92c20b53ac98be784f263069c1f9d3ca654cc70b7'
     'it'
   end
 
   language 'ru' do
-    sha256 '7ff97c53c2cec5e08e32557cff36e603ba73ec9ac412cc5a7636685630cc464f'
+    sha256 '796867c304b411d07c9f0bf92a9f7330ae97ff830da461386855efc756def3f1'
     'ru'
   end
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [✓] `brew cask audit --download {{cask_file}}` is error-free. (see [1] below)
- [✓] `brew cask style --fix {{cask_file}}` reports no offenses. (see [2] below)
- [✓] The commit message includes the cask’s name and version.
- [✓] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

**This is my (second) first pull request for [Homebrew / homebrew-cask](https://github.com/Homebrew/homebrew-cask). (I thought I made a [pull request](https://github.com/alexkoster/homebrew-cask/pull/1) in the past but I must have sent it to my own [repo](https://github.com/alexkoster/homebrew-cask/pull/1) 🤦‍♂️) Above commands ran successfully (see [1] and [2] below for details). Please don't hesitate to suggest any changes I should make. Thanks! 😀**

Additionally, if **adding a new cask**:**

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

[1] output of command `brew cask audit --download Casks/seamonkey.rb`
```
$ brew cask audit --download Casks/seamonkey.rb
==> Auditing language: 'de'
==> Downloading https://archive.mozilla.org/pub/seamonkey/releases/2.53.2/mac/de/seamonkey-2.53.2.de.mac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'seamonkey'.
audit for seamonkey: passed
==> Auditing language: 'en-GB'
==> Downloading https://archive.mozilla.org/pub/seamonkey/releases/2.53.2/mac/en-GB/seamonkey-2.53.2.en-GB.mac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'seamonkey'.
audit for seamonkey: passed
==> Auditing language: 'en-US'
==> Downloading https://archive.mozilla.org/pub/seamonkey/releases/2.53.2/mac/en-US/seamonkey-2.53.2.en-US.mac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'seamonkey'.
audit for seamonkey: passed
==> Auditing language: 'fr'
==> Downloading https://archive.mozilla.org/pub/seamonkey/releases/2.53.2/mac/fr/seamonkey-2.53.2.fr.mac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'seamonkey'.
audit for seamonkey: passed
==> Auditing language: 'it'
==> Downloading https://archive.mozilla.org/pub/seamonkey/releases/2.53.2/mac/it/seamonkey-2.53.2.it.mac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'seamonkey'.
audit for seamonkey: passed
==> Auditing language: 'ru'
==> Downloading https://archive.mozilla.org/pub/seamonkey/releases/2.53.2/mac/ru/seamonkey-2.53.2.ru.mac.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'seamonkey'.
audit for seamonkey: passed
```
[2] output of `brew cask style --fix Casks/seamonkey.rb`
```
$ brew cask style --fix Casks/seamonkey.rb
Fetching gem metadata from https://rubygems.org/.........
Using concurrent-ruby 1.1.6
Using minitest 5.14.0
Using ast 2.4.0
Using bundler 1.17.2
Using thread_safe 0.3.6
Using json 2.3.0
Using connection_pool 2.2.2
Using simplecov-html 0.10.2
Using docile 1.3.2
Using sync 0.5.0
Using diff-lcs 1.3
Using zeitwerk 2.3.0
Using unf_ext 0.0.7.7
Using jaro_winkler 1.5.4
Using thor 1.0.1
Using net-http-digest_auth 1.4.1
Using hpricot 0.8.6
Using mini_portile2 2.4.0
Using ntlm-http 0.1.1
Using mustache 1.1.1
Fetching mime-types-data 3.2020.0425
Using webrobots 0.1.2
Using parallel 1.19.1
Using plist 3.5.0
Using rdiscount 2.2.0.1
Using rexml 3.2.4
Using rainbow 3.0.0
Using ruby-progressbar 1.10.1
Fetching rspec-support 3.9.3
Using unicode-display_width 1.7.0
Using ruby-macho 2.2.0
Using i18n 1.8.2
Fetching parser 2.7.1.2
Installing rspec-support 3.9.3
Installing mime-types-data 3.2020.0425
Installing parser 2.7.1.2
Using tzinfo 1.2.7
Fetching net-http-persistent 4.0.0
Using simplecov 0.16.1
Using tins 1.24.1
Using unf 0.1.4
Using nokogiri 1.10.9
Using parallel_tests 2.32.0
Using ronn 0.7.3
Fetching rspec-core 3.9.2
Installing net-http-persistent 4.0.0
Using rspec-expectations 3.9.1
Using rspec-mocks 3.9.1
Using activesupport 6.0.2.2
Using mime-types 3.3.1
Using term-ansicolor 1.7.1
Using domain_name 0.5.20190701
Using coveralls 0.8.23
Using http-cookie 1.0.3
Using mechanize 2.7.6
Installing rspec-core 3.9.2
Fetching rubocop 0.82.0
Using rspec 3.9.0
Using rspec-its 1.3.0
Using rspec-retry 0.6.2
Using rspec-wait 0.0.9
Installing rubocop 0.82.0
Using rubocop-performance 1.5.2
Fetching rubocop-rspec 1.39.0
Installing rubocop-rspec 1.39.0
Bundle complete! 16 Gemfile dependencies, 58 gems now installed.
Bundled gems are installed into `../../../Homebrew/vendor/bundle`
Removing rubocop (0.81.0)
Removing rspec-support (3.9.2)
Removing parser (2.7.1.0)
Removing net-http-persistent (3.1.0)
Removing rspec-core (3.9.1)
Removing mime-types-data (3.2019.1009)
Removing rubocop-rspec (1.38.1)

1 file inspected, no offenses detected
```