### PR TITLE
Update pdf-converter-master from 6.2.1 to 6.2.0

### DIFF
--- a/Casks/pdf-converter-master.rb
+++ b/Casks/pdf-converter-master.rb
@@ -1,6 +1,6 @@
 cask 'pdf-converter-master' do
-  version '6.2.1'
-  sha256 '11110406915ad5a3c657e876adb000260d939cd3cffa91ef2b4476a84cd128d6'
+  version '6.2.0'
+  sha256 '3134b19c8f234b1d0e948fec3115008ada48973f3a8c48ccdd8fd4e8bad7b923'
 
   url "https://www.lightenpdf.com/upload/download/pdf-converter-master-#{version.no_dots}.dmg"
   appcast 'https://www.lightenpdf.com/pdf-converter-mac.html',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Version 6.2.1 seems to have been pulled:
```
-bash-5.0.17- /Users/miccal (33) [> brew cask fetch pdf-converter-master

==> Downloading external files for Cask pdf-converter-master
==> Downloading https://www.lightenpdf.com/upload/download/pdf-converter-master-621.dmg
curl: (22) The requested URL returned error: 404 Not Found                    

Error: Download failed on Cask 'pdf-converter-master' with message: Download failed: https://www.lightenpdf.com/upload/download/pdf-converter-master-621.dmg
```