### PR TITLE
Add Beekeeper-Studio v1.2.0

### DIFF
--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,0 +1,24 @@
+cask 'beekeeper-studio' do
+    version '1.2.0'
+    sha256 '43dd9b9a6952e152335dc695d44881f9a4488d5f7d7fade4e7d6e3c55d892e6d'
+  
+    # github.com/beekeeper-studio/beekeeper-studio/ was verified as official when first introduced to the cask
+    url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg"
+    appcast 'https://github.com/beekeeper-studio/beekeeper-studio/releases.atom'
+    name 'Beekeeper Studio'
+    homepage 'https://www.beekeeperstudio.io/'
+  
+    auto_updates true
+  
+    app 'Beekeeper Studio.app'
+  
+    zap trash: [
+                 '~/Library/Application Support/Caches/beekeeper-studio-updater',
+                 '~/Library/Application Support/beekeeper-studio',
+                 '~/Library/Caches/io.beekeeperstudio.desktop',
+                 '~/Library/Caches/io.beekeeperstudio.desktop.ShipIt',
+                 '~/Library/Preferences/ByHost/io.beekeeperstudio.desktop.ShipIt.*.plist',
+                 '~/Library/Preferences/io.beekeeperstudio.desktop.plist',
+                 '~/Library/Saved Application State/io.beekeeperstudio.desktop.savedState',
+               ]
+  end

--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,24 +1,24 @@
 cask 'beekeeper-studio' do
-    version '1.2.0'
-    sha256 '43dd9b9a6952e152335dc695d44881f9a4488d5f7d7fade4e7d6e3c55d892e6d'
-  
-    # github.com/beekeeper-studio/beekeeper-studio/ was verified as official when first introduced to the cask
-    url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg"
-    appcast 'https://github.com/beekeeper-studio/beekeeper-studio/releases.atom'
-    name 'Beekeeper Studio'
-    homepage 'https://www.beekeeperstudio.io/'
-  
-    auto_updates true
-  
-    app 'Beekeeper Studio.app'
-  
-    zap trash: [
-                 '~/Library/Application Support/Caches/beekeeper-studio-updater',
-                 '~/Library/Application Support/beekeeper-studio',
-                 '~/Library/Caches/io.beekeeperstudio.desktop',
-                 '~/Library/Caches/io.beekeeperstudio.desktop.ShipIt',
-                 '~/Library/Preferences/ByHost/io.beekeeperstudio.desktop.ShipIt.*.plist',
-                 '~/Library/Preferences/io.beekeeperstudio.desktop.plist',
-                 '~/Library/Saved Application State/io.beekeeperstudio.desktop.savedState',
-               ]
-  end
+  version '1.2.0'
+  sha256 '43dd9b9a6952e152335dc695d44881f9a4488d5f7d7fade4e7d6e3c55d892e6d'
+
+  # github.com/beekeeper-studio/beekeeper-studio/ was verified as official when first introduced to the cask
+  url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg"
+  appcast 'https://github.com/beekeeper-studio/beekeeper-studio/releases.atom'
+  name 'Beekeeper Studio'
+  homepage 'https://www.beekeeperstudio.io/'
+
+  auto_updates true
+
+  app 'Beekeeper Studio.app'
+
+  zap trash: [
+               '~/Library/Application Support/Caches/beekeeper-studio-updater',
+               '~/Library/Application Support/beekeeper-studio',
+               '~/Library/Caches/io.beekeeperstudio.desktop',
+               '~/Library/Caches/io.beekeeperstudio.desktop.ShipIt',
+               '~/Library/Preferences/ByHost/io.beekeeperstudio.desktop.ShipIt.*.plist',
+               '~/Library/Preferences/io.beekeeperstudio.desktop.plist',
+               '~/Library/Saved Application State/io.beekeeperstudio.desktop.savedState',
+             ]
+end


### PR DESCRIPTION
Adds Beekeeper Studio.app, an open source SQL client.

After making all changes to the cask:

* [x]  `brew cask audit --download {{cask_file}}` is error-free.
* [x]  `brew cask style --fix {{cask_file}}` reports no offenses.
* [x]  The commit message includes the cask’s name and version.
* [x]  The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

* [x]  Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
* [x]  `brew cask install {{cask_file}}` worked successfully.
* [x]  `brew cask uninstall {{cask_file}}` worked successfully.
* [x]  Checked there are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same cask.
* [ ]  Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
* [x]  Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Cask [was refused](https://github.com/Homebrew/homebrew-cask/pull/81133) but rejection conditions changed since then.
