### PR TITLE
Update pocket-casts from 1.4 to 1.4.1

### DIFF
--- a/Casks/pocket-casts.rb
+++ b/Casks/pocket-casts.rb
@@ -1,6 +1,6 @@
 cask 'pocket-casts' do
-  version '1.4'
-  sha256 '905436b8221a7b514ebf713a278a96a389b3991183c5e2fd284b7d71b996c22e'
+  version '1.4.1'
+  sha256 'a64d7b6d8826b2ce51d8f436a4d8f48d20aa4e00f00d4bc4aee1dac888b325a6'
 
   url 'https://static.pocketcasts.com/mac/PocketCasts.zip'
   appcast 'https://static2.pocketcasts.com/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.