### PR TITLE
added all other available languages  (4.1.7)

### DIFF
--- a/Casks/openoffice.rb
+++ b/Casks/openoffice.rb
@@ -1,9 +1,74 @@
 cask 'openoffice' do
   version '4.1.7'
 
-  language 'en', default: true do
+  language 'ast' do
+    sha256 '02b10f509b578dfb14527a835634dd64b7def04adc9f3fb994d09974f0885e7d'
+    'ast'
+  end
+
+  language 'eu' do
+    sha256 '67b27691b7d026f44e0e802efb689ca9ca641fe79291d8e8146b2b808e90742a'
+    'eu'
+  end
+
+  language 'bg' do
+    sha256 '915153c86c056024fa4896a7fd8d93582f5e6138c2ca9dedd3f34573277459a4'
+    'bg'
+  end
+
+  language 'ca' do
+    sha256 '2e26fc5920454c46538ce57361c4a9061ec8be648a5ad635a0a80d2c92679118'
+    'ca'
+  end
+
+  language 'ca-XV' do
+    sha256 '78f6b51c22f3b4b47dc8a711e18dde743e3ab0f19be5b1de303bd79b2cbed891'
+    'ca-XV'
+  end
+
+  language 'ca-XR' do
+    sha256 '982b482b2efa66100c2797e1c7eb5d776375013d42467a239e00765bc14f4598'
+    'ca-XR'
+  end
+
+  language 'zh-CN' do
+    sha256 'd5ed7547efcdd951e6776f4e37d8b27e6a65d2a3ab76a52b96915bf0ab042a19'
+    'zh-CN'
+  end
+
+  language 'zh-TW' do
+    sha256 'b4770bd8629034d451e92dff96b43986bf0c8a8aeb47bbd7837905de9ab828f6'
+    'zh-TW'
+  end
+
+  language 'cs' do
+    sha256 '0ccfd9a138e689c8cfeee310c4bc60353e43b9b4c0289a5285f7939ed016098e'
+    'cs'
+  end
+
+  language 'da' do
+    sha256 'e3238e4cd5e58b6482ab88b0ed39d855181580a82c9c234b4645e867d6ca664c'
+    'da'
+  end
+
+  language 'nl' do
+    sha256 '2644242b26ee7ad486ad06308ddf7828af3f454c40fe11bcb22e44df935b3e30'
+    'nl'
+  end
+
+  language 'en-GB' do
+    sha256 '4c52eca9b82cc859f469e975bf8f351a772cd95aade0156e32db61af30aa745c'
+    'en-GB'
+  end
+
+  language 'en-US', default: true do
     sha256 '615d6fa38ef78e99e30f515ce3f61fd9e228408a425c91afc5e587d662e18f99'
     'en-US'
+  end
+
+  language 'fi' do
+    sha256 '6d2fb9b16a4ae374b85feb97aff9708658ded7b0eceac7bc6c25503b3883de09'
+    'fi'
   end
 
   language 'fr' do
@@ -16,9 +81,64 @@ cask 'openoffice' do
     'gl'
   end
 
+  language 'de' do
+    sha256 '9e787312d4937652736905d987d9912f95c4bd2646e47525c6321efa4bef767d'
+    'de'
+  end
+
+  language 'el' do
+    sha256 '06374139227433e9e253fac920679a6c3d8ddeea3fe7cce26fde93f2ab4a409e'
+    'el'
+  end
+
+  language 'he' do
+    sha256 '1208af02f3d16e6d32c257b6001f3f169245ce26ae1d2fe23f2f8c301a847112'
+    'he'
+  end
+
+  language 'hi' do
+    sha256 'c46c7d8f7b03107220e4038dbe0d509ff3ac51a08a3fc9820332b444006b9516'
+    'hi'
+  end
+
+  language 'hu' do
+    sha256 'bfa1e1ad6f4da9eaed665a462f1e7bab36c281715bac183cefad8498df96e8eb'
+    'hu'
+  end
+
+  language 'it' do
+    sha256 '6f85beb9b43d45f6392628dd519cf7861bcd0e1e4369d674580cb93dbbb10ff4'
+    'it'
+  end
+
+  language 'ja' do
+    sha256 'b3ef845182210ac90112a4e88f40ab9c203421f54cc4b2e7a8c277be3a20df42'
+    'ja'
+  end
+
+  language 'km' do
+    sha256 '0bab72ac51fb2e6ff48d757c2b2cf102b3c5fe4492848fdf369219a066e9d3fd'
+    'km'
+  end
+
   language 'ko' do
     sha256 'fbac79978daa873c6d60592221d7f8f1b3d9bf50f6cabfd1e8396495ee035fb4'
     'ko'
+  end
+
+  language 'lt' do
+    sha256 '3cfee4725788da7abfff40aa728bda6016be6092f2d70c57ecf3bcedefee1f4d'
+    'lt'
+  end
+
+  language 'nb' do
+    sha256 '114ff0c8f3512c568a500cd22c96777772edba6e7d87ef078cdac73bb5d49e6b'
+    'nb'
+  end
+
+  language 'pl' do
+    sha256 '8938b8313aa14f7adeaaf708c2deb8b2899d7bdf04b4341fddcd8592695a41f7'
+    'pl'
   end
 
   language 'pt-BR' do
@@ -36,13 +156,65 @@ cask 'openoffice' do
     'ru'
   end
 
+  language 'gd' do
+    sha256 'a95667ad1df581ecce25a1d4d8d035f461253e1ee013c95c060fe3e2b2d4bdf5'
+    'gd'
+  end
+
+  language 'sr' do
+    sha256 'f74d1dc0559fd69fbebec0a7bc61f308d5abf129996840c9840fb1536ca6055c'
+    'sr'
+  end
+
+  language 'sk' do
+    sha256 'a0c93a1302edd9a915f63069fb38f2ffbe54369452577feac1eef3ec232b5b98'
+    'sk'
+  end
+
+  language 'sl' do
+    sha256 '8a245ba63d0039f2905eafb3b9a26b7a3af469a7bf2e85265baabde0f7ba20eb'
+    'sl'
+  end
+
+  language 'es' do
+    sha256 'da281609082dc0e7cdf0dfb553a6b3a2b6a875a159e4a63a7a41bd92ab6fc53b'
+    'es'
+  end
+
+  language 'sv' do
+    sha256 '93bd515c16753bed508a79c54e919190f453e39f4bf2f60f8e15cb3243e93bec'
+    'sv'
+  end
+
+  language 'ta' do
+    sha256 '3a5f523d2eda28092466d11c3c2f2ae9ff51d4a643fa917e0dff84e6f618cf43'
+    'ta'
+  end
+
+  language 'th' do
+    sha256 '80419d495fc24b5eeb9eee143329516abac093c1e1c3dbf4988fd32bf26a626b'
+    'th'
+  end
+
+  language 'tr' do
+    sha256 '3de54dc39b8635b8e150467aa9336dfc6d52b9759df3ec391b914e2665090e77'
+    'tr'
+  end
+
+  language 'vi' do
+    sha256 '3d996ef050af264bf4bce11a2906ef289c9e7f4ed439b934bc995c595997bfb6'
+    'vi'
+  end
+
   # sourceforge.net/openofficeorg.mirror/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_#{language}.dmg"
+
   appcast 'https://sourceforge.net/projects/openofficeorg.mirror/rss'
+
   name 'Apache OpenOffice'
   homepage 'https://www.openoffice.org/'
 
   app 'OpenOffice.app'
-
   zap trash: '~/Library/Application Support/OpenOffice'
+
 end


### PR DESCRIPTION
I wrote a script to create the `openoffice.rb` which tries to get the latest version number and belonging SHA256 hashes from official website. https://github.com/emsspree/Homebrew_helpers/blob/master/create_Formula_for_OpenOffice

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
