### PR TITLE
Update scrutiny from 9.6.5 to 9.6.6

### DIFF
--- a/Casks/scrutiny.rb
+++ b/Casks/scrutiny.rb
@@ -1,6 +1,6 @@
 cask 'scrutiny' do
-  version '9.6.5'
-  sha256 'a58cc8be24f1f0c15a1bd7d52696c0931fc882ff522328b662a3df065997ffa5'
+  version '9.6.6'
+  sha256 '056e694811826705b6b5bf0714841dd5c77d723700587b27283092d6d9c8678f'
 
   url 'https://peacockmedia.software/mac/scrutiny/scrutiny.dmg'
   appcast 'https://peacockmedia.software/mac/scrutiny/version_history.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.