### PR TITLE
Update gns3 from 2.2.7 to 2.2.8

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,7 +1,7 @@
 cask 'gns3' do
   # note: "3" is not a version number, but an intrinsic part of the product name
-  version '2.2.7'
-  sha256 'dc7fa25f531623e58d2e084ce0dc2389f6b5b01390a12fc8358b216581fc1236'
+  version '2.2.8'
+  sha256 'e86154915c869e65b277846b12b68cc34df62daf04ba7cfa54b6ea37020cfc51'
 
   # github.com/GNS3/gns3-gui/ was verified as official when first introduced to the cask
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.