### PR TITLE
Update pritunl from 1.0.2418.61 to 1.0.2428.78

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,6 +1,6 @@
 cask 'pritunl' do
-  version '1.0.2418.61'
-  sha256 '6d74aee65804189a5f03cbb968d7f78c383a6f2dc0eccf205df178f97e0d99bf'
+  version '1.0.2428.78'
+  sha256 '50431e23ea402265c80044222c1cfe6dc7d1e01795465cd9b0e0e4fd82373a08'
 
   # github.com/pritunl/pritunl-client-electron/ was verified as official when first introduced to the cask
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.