### PR TITLE
Update zulip from 5.1.0 to 5.2.0

### DIFF
--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -1,6 +1,6 @@
 cask 'zulip' do
-  version '5.1.0'
-  sha256 'c0c6cd9bc0aa0c5f7854aad2bb31ac7e3beeca591dd06b47321c262fb4a60f22'
+  version '5.2.0'
+  sha256 'b8828c9d69750f504541ec793dbc66880fcfa403d979ac960c7ffa9e5408d387'
 
   # github.com/zulip/zulip-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/zulip/zulip-desktop/releases/download/v#{version}/Zulip-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.