### PR TITLE
Update bdash from 1.8.0 to 1.8.2

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.8.0'
-  sha256 'b7c1bbdc4796b28f9b1415aae78b2a0d3b019e9d142732e60b074180daacf79f'
+  version '1.8.2'
+  sha256 'b4893236b613ca9d56df1de050cc0c37c597e7ee914a379ad41d66adbfddd7b3'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.