### PR TITLE
Update opencore-configurator from 2.1.0.0 to 2.2.0.0

### DIFF
--- a/Casks/opencore-configurator.rb
+++ b/Casks/opencore-configurator.rb
@@ -1,6 +1,6 @@
 cask 'opencore-configurator' do
-  version '2.1.0.0'
-  sha256 '4fd2919743797e45519cb1aea7245eaff66ba6bf280eec98bd1d324ac856901b'
+  version '2.2.0.0'
+  sha256 '05c08eef93632ff1a8d27b6a39e4035358b787cb32440f2bbf2106f3183395a2'
 
   url 'https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last'
   appcast 'https://mackie100projects.altervista.org/category/opencore-configurator-changelog/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.