### PR TITLE
Update astropad-studio from 3.3.0 to 3.4.0

### DIFF
--- a/Casks/astropad-studio.rb
+++ b/Casks/astropad-studio.rb
@@ -1,6 +1,6 @@
 cask 'astropad-studio' do
-  version '3.3.0'
-  sha256 '55d6d08f5b70a1ffd89dd5864312bddc3c3df1784a848d0ba408dff1dec775fd'
+  version '3.4.0'
+  sha256 '0e6020a293d3e1ea48082afc0b8b3148f79b9b7f260f653e3d0a1b63e0235e68'
 
   # s3.amazonaws.com/astropad.com/ was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/astropad.com/downloads/AstropadStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.