### PR TITLE
Update sirimote from 1.3.6 to 1.3.7

### DIFF
--- a/Casks/sirimote.rb
+++ b/Casks/sirimote.rb
@@ -1,6 +1,6 @@
 cask 'sirimote' do
-  version '1.3.6'
-  sha256 'cb989843fd1798d3c41d6d4d512015ae984d3867e3892d98230cd5f684063f50'
+  version '1.3.7'
+  sha256 '1a4c7fbf5476215278a26dedfdec6a81860fbf5ec53c157f2cf0466a645d8d35'
 
   url 'https://eternalstorms.at/sirimote/SiriMote.zip'
   appcast 'https://eternalstorms.at/sirimote/updatefeed.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.