### PR TITLE
Update insync from 3.1.5.40801 to 3.1.6.40808

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '3.1.5.40801'
-  sha256 'e6e336cd3ce6971e797c6e2a8cb2c8bfea510a4b33c812b820c6242af88d187e'
+  version '3.1.6.40808'
+  sha256 'e8331f76941c7dacf13a10d07b037639b1c69a430ecc976dabb4df4ce5faecf3'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   appcast 'https://www.insynchq.com/downloads?start=true'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.