### PR TITLE
Update amadeus-pro from 2.8.1 to 2.8.2

### DIFF
--- a/Casks/amadeus-pro.rb
+++ b/Casks/amadeus-pro.rb
@@ -1,6 +1,6 @@
 cask 'amadeus-pro' do
-  version '2.8.1'
-  sha256 'f93390018cd4ec8792a040aeaab419eea08f23dac7b7f5e3b6f94f08dfd50c75'
+  version '2.8.2'
+  sha256 '252dde81287c609ad3e6c7c1a84774164cdb3fd569487d2d8f2b769037fbddc7'
 
   # s3.amazonaws.com/AmadeusPro2/ was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/AmadeusPro2/AmadeusPro.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.