### PR TITLE
Update banking-4 from 7.3.0 to 7.3.1

### DIFF
--- a/Casks/banking-4.rb
+++ b/Casks/banking-4.rb
@@ -1,7 +1,7 @@
 cask 'banking-4' do
   # note: "4" is not a version number, but an intrinsic part of the product name
-  version '7.3.0'
-  sha256 '475e48c91e554958921e5d3603d20c887f019ce62d33b2ae2b062bc0d119666d'
+  version '7.3.1'
+  sha256 '60905a28048f18679199c20dd8db684fe73478af5b0a5ceb8e0df9deb4be7849'
 
   url 'https://subsembly.com/download/MacBanking4.pkg'
   appcast 'https://subsembly.com/banking4-macos-updates.php'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.