### PR TITLE
Update trader-workstation from 972 to 972.1z

### DIFF
--- a/Casks/trader-workstation.rb
+++ b/Casks/trader-workstation.rb
@@ -1,19 +1,19 @@
 cask 'trader-workstation' do
-  version '972'
-  sha256 '2ee63659a030c7ffef553836e8ab7d504c8513d26b771ef845b382aaa4d6ed74'
+  version '972.1z'
+  sha256 '0b215cc07400e495218c149acd324f49cb94b90f9b2ab6559c89340555a811da'
 
   url 'https://download2.interactivebrokers.com/installers/tws/stable-standalone/tws-stable-standalone-macosx-x64.dmg'
   name 'Trader Workstation'
   homepage 'https://www.interactivebrokers.com/'
 
   installer script: {
-                      executable: "#{staged_path}/Trader Workstation #{version} Installer.app/Contents/MacOS/JavaApplicationStub",
+                      executable: "#{staged_path}/Trader Workstation #{version.major} Installer.app/Contents/MacOS/JavaApplicationStub",
                       args:       ['-q'],
                     }
 
   uninstall quit:   'com.install4j.5889-6375-8446-2021.22',
             script: {
-                      executable: "#{ENV['HOME']}/Applications/Trader Workstation #{version}/Trader Workstation #{version} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+                      executable: "#{ENV['HOME']}/Applications/Trader Workstation #{version.major}/Trader Workstation #{version.major} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
                       args:       ['-q'],
                     }
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask/pull/81737