### PR TITLE
Update jump from 8.5.10 to 8.5.15

### DIFF
--- a/Casks/jump.rb
+++ b/Casks/jump.rb
@@ -1,6 +1,6 @@
 cask 'jump' do
-  version '8.5.10'
-  sha256 '9991fa64892e8cfe7f302925cb28885bc3d431a4888a92fa6babb0866e46141d'
+  version '8.5.15'
+  sha256 'e90e0211481a52bc74dac39bb9847bfe605fdce628225d87ef9c8961985bfed9'
 
   url "https://mirror.jumpdesktop.com/downloads/JumpDesktopMac-#{version}.zip"
   appcast 'https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.