### PR TITLE
Update auristor-client from 0.192 to 0.194

### DIFF
--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -1,5 +1,5 @@
 cask 'auristor-client' do
-  version '0.192'
+  version '0.194'
 
   if MacOS.version <= :el_capitan
     sha256 'e813336062adf2d40acfb1c268498e074ec5f3d514e93efe53afd1368a3e0aee'
@@ -14,7 +14,7 @@ cask 'auristor-client' do
     sha256 '38fe71d60379c09954631994f52286fab0d601b9ee561c21757a56e3c29d90f3'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.14/Auristor-client-#{version}-Mojave.dmg"
   else
-    sha256 'a399d4815bfda945ecbde924feef758ec20768fd252bf9f19fcc00f9174fcf86'
+    sha256 '734da14030894e4f866f59f6aa4f4b7094aba3779956211b8699ec16ace3eab1'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.15/Auristor-client-#{version}-Catalina.dmg"
   end
 

--- a/Casks/auristor-client.rb
+++ b/Casks/auristor-client.rb
@@ -1,17 +1,14 @@
 cask 'auristor-client' do
   version '0.194'
 
-  if MacOS.version <= :el_capitan
-    sha256 'e813336062adf2d40acfb1c268498e074ec5f3d514e93efe53afd1368a3e0aee'
-    url "https://www.auristor.com/downloads/auristor/osx/macos-10.11/AuriStor-client-#{version}-ElCapitan.dmg"
-  elsif MacOS.version <= :sierra
-    sha256 '2062e2a601202ff55af57b3f59ca28abb489060e7abfa8545cf3e8e56bb40166'
+  if MacOS.version <= :sierra
+    sha256 '909f53f46b1dcfe627fd421f3b91f0e62010b35891d4407100780a5c52cc1704'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.12/AuriStor-client-#{version}-Sierra.dmg"
   elsif MacOS.version <= :high_sierra
-    sha256 '4233f8a82a03b73d09a2048ae1acd82a87367a6f0e20209e64f7e9a0e7b3bab2'
+    sha256 'f0d2e9c4f94e9178e790174b24a6c0e4b9593cafd0d6191ef0321c69cc141c24'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.13/AuriStor-client-#{version}-HighSierra.dmg"
   elsif MacOS.version <= :mojave
-    sha256 '38fe71d60379c09954631994f52286fab0d601b9ee561c21757a56e3c29d90f3'
+    sha256 '47830671ce3b5cb7253b9554701ec81bf61d4b4153c2a882e86774868c5dbad9'
     url "https://www.auristor.com/downloads/auristor/osx/macos-10.14/Auristor-client-#{version}-Mojave.dmg"
   else
     sha256 '734da14030894e4f866f59f6aa4f4b7094aba3779956211b8699ec16ace3eab1'
@@ -23,7 +20,6 @@ cask 'auristor-client' do
 
   # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
   depends_on macos: [
-                      :el_capitan,
                       :sierra,
                       :high_sierra,
                       :mojave,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.