### PR TITLE
Update loginputmac from 2.3.4_1 to 2.3.5

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '2.3.4_1'
-  sha256 '1f4e65a1048282daf93d0d551013209e6fd87bd184df3b43750a7368617f5bae'
+  version '2.3.5'
+  sha256 '7c6cdd1276f328b049666e9f3e27cca39c2524959ba72c7ffcfcead4bf67ab20'
 
   # loginput-mac2.content-delivery.top/ was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.