### PR TITLE
Update goodsync from 11.1.6.8 to 11.1.7.7

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask 'goodsync' do
-  version '11.1.6.8'
-  sha256 '9b2cff74afa6672714e06637779070edb49f7a48c817988af04b366a7c3bec7e'
+  version '11.1.7.7'
+  sha256 'defb18d018ddeef00363700544a798cd6ffbe63d90c6e88d13fe8a11a8fac040'
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast 'https://www.goodsync.com/download?os=macos',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.