### PR TITLE
Update alt-tab from 3.21.0 to 3.21.1

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.21.0'
-  sha256 'add3f4d2aa52eec5cb5c5f7c56dd7b3c6e9270d5908c9a887c20acf80167795d'
+  version '3.21.1'
+  sha256 'b34ee519481baba68eaf86ebeae2b1ea094de582b8343a2faf72af46061f6042'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.