### PR TITLE
Update front from 3.20.21 to 3.21.7

### DIFF
--- a/Casks/front.rb
+++ b/Casks/front.rb
@@ -1,6 +1,6 @@
 cask 'front' do
-  version '3.20.21'
-  sha256 '81680f4b27171e9a3e6bf9f7f9db9972a34931e0b92ab702c4f168e978d98631'
+  version '3.21.7'
+  sha256 '9089e1faf406e94bc7da27579b994d12681e9ed2ffd937c631282c7f22d72917'
 
   url "https://dl.frontapp.com/desktop/builds/#{version}/Front-#{version}.zip"
   appcast 'https://dl.frontapp.com/desktop/updates/latest/mac/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.