### PR TITLE
Update marginnote from 3.6.7 to 3.6.8

### DIFF
--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -1,6 +1,6 @@
 cask 'marginnote' do
-  version '3.6.7'
-  sha256 '6495892ed0d10aa02fa7dde830aa6a1759158ee4386dd77c3ec486238972e97c'
+  version '3.6.8'
+  sha256 '689bfed0228fe0782a831e9530303b890fcaa645c01ae245eb73e36990d5925b'
 
   # marginstudy.com/ was verified as official when first introduced to the cask
   url "https://marginstudy.com/mac/MarginNote#{version.major}.dmg"

--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -4,7 +4,7 @@ cask 'marginnote' do
 
   # marginstudy.com/ was verified as official when first introduced to the cask
   url "https://marginstudy.com/mac/MarginNote#{version.major}.dmg"
-  appcast 'https://api.appcenter.ms/v0.1/public/sparkle/apps/1451f4f6-9214-4d46-b91c-d5898c7e42cb'
+  appcast 'https://dist.marginnote.cn/marginnote3.xml'
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'
 

--- a/Casks/marginnote.rb
+++ b/Casks/marginnote.rb
@@ -4,7 +4,7 @@ cask 'marginnote' do
 
   # marginstudy.com/ was verified as official when first introduced to the cask
   url "https://marginstudy.com/mac/MarginNote#{version.major}.dmg"
-  appcast 'https://dist.marginnote.cn/marginnote3.xml'
+  appcast "https://dist.marginnote.cn/marginnote#{version.major}.xml"
   name 'MarginNote'
   homepage 'https://www.marginnote.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.