### PR TITLE
Update opensesame from 3.3.0 to 3.3.1

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,6 +1,6 @@
 cask 'opensesame' do
-  version '3.3.0'
-  sha256 'a5dd6944c3350863865ac150a15ee80db6748501a485c51adeb9e1c1d81ff882'
+  version '3.3.1'
+  sha256 'ef20883bf06ad3786a074531803fab34efc88a9061847480e3d12a8507166aef'
 
   # github.com/smathot/OpenSesame/ was verified as official when first introduced to the cask
   url "https://github.com/smathot/OpenSesame/releases/download/release%2F#{version}/opensesame_#{version}-py37-macos-1.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.