### PR TITLE
Update waterfox-current from 2020.04,6820.4.7 to 2020.05,6820.5.5

### DIFF
--- a/Casks/waterfox-current.rb
+++ b/Casks/waterfox-current.rb
@@ -1,6 +1,6 @@
 cask 'waterfox-current' do
-  version '2020.04,6820.4.7'
-  sha256 'fc410c4ed1d1151daffae0b8b77d612adaef1115db738b1049f1271daa9fd69a'
+  version '2020.05,6820.5.5'
+  sha256 '80608f12658c63074e7f6067d6646dc4998584dac2302f4cac88005ae5753bc1'
 
   # storage-waterfox.netdna-ssl.com/ was verified as official when first introduced to the cask
   url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Current%20#{version.before_comma}%20Setup.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.