### PR TITLE
Update visicut from 1.9-36-g6537f945 to 1.9-68-gf9e37c5e

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask 'visicut' do
-  version '1.9-36-g6537f945'
-  sha256 'd368607b84ad2a14fbe99d4390a8320cb4283b02309f8d8c67ab4b5f56ea6bfd'
+  version '1.9-68-gf9e37c5e'
+  sha256 'fb5f35b0cdd7fca48012949a636ff91b231ff57e55662aeaf42e9899b0d7b665'
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast 'https://download.visicut.org'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.