### PR TITLE
Update pycharm-with-anaconda-plugin from 2020.1,201.6668.115 to 2020.1.1

### DIFF
--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -2,7 +2,7 @@ cask 'pycharm-with-anaconda-plugin' do
   version '2020.1.1'
   sha256 '6a3db1131ca312a12ad0fc68369103c3e9c77e97486c63c8717b29dbdc3b06b4'
 
-  url "https://download.jetbrains.com/python/pycharm-community-anaconda-#{version}.dmg"
+  url "https://download-cf.jetbrains.com/python/pycharm-professional-anaconda-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release'
   name 'Jetbrains PyCharm with Anaconda plugin'
   homepage 'https://www.jetbrains.com/pycharm/promo/anaconda'

--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -1,8 +1,8 @@
 cask 'pycharm-with-anaconda-plugin' do
-  version '2020.1,201.6668.115'
-  sha256 'db98e30cc1c16c6cc68ca89949b4eb55dd36e03cbd2b7452b9be06a6ed0c16f4'
+  version '2020.1.1'
+  sha256 '6a3db1131ca312a12ad0fc68369103c3e9c77e97486c63c8717b29dbdc3b06b4'
 
-  url "https://download.jetbrains.com/python/pycharm-professional-anaconda-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-community-anaconda-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release'
   name 'Jetbrains PyCharm with Anaconda plugin'
   homepage 'https://www.jetbrains.com/pycharm/promo/anaconda'

--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -2,7 +2,7 @@ cask 'pycharm-with-anaconda-plugin' do
   version '2020.1.1'
   sha256 '6a3db1131ca312a12ad0fc68369103c3e9c77e97486c63c8717b29dbdc3b06b4'
 
-  url "https://download-cf.jetbrains.com/python/pycharm-professional-anaconda-#{version}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-professional-anaconda-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release'
   name 'Jetbrains PyCharm with Anaconda plugin'
   homepage 'https://www.jetbrains.com/pycharm/promo/anaconda'

--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -1,6 +1,6 @@
 cask 'pycharm-with-anaconda-plugin' do
   version '2020.1.1'
-  sha256 '6a3db1131ca312a12ad0fc68369103c3e9c77e97486c63c8717b29dbdc3b06b4'
+  sha256 'aaaab145b0a84e81dd2d2bd6caee2da2315e8667fcf24faa4adefa493093620f'
 
   url "https://download.jetbrains.com/python/pycharm-professional-anaconda-#{version}.dmg"
   appcast 'https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.