### PR TITLE
Update wavesurfer from 1.8.8p6 to 1.8.8p6.1

### DIFF
--- a/Casks/wavesurfer.rb
+++ b/Casks/wavesurfer.rb
@@ -1,6 +1,6 @@
 cask 'wavesurfer' do
-  version '1.8.8p6'
-  sha256 '612cede095ffd6eee9b53bf29246ad8af778753cba907300db42770e4631e56a'
+  version '1.8.8p6.1'
+  sha256 'ef1aacab25f37d595e87e5638cd9ef5b3b2af22a05c6aa06585795915a8ae6ea'
 
   url "https://downloads.sourceforge.net/wavesurfer/wavesurfer-#{version}-macos.dmg"
   appcast 'https://sourceforge.net/projects/wavesurfer/rss'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.