### PR TITLE
Update microsoft-teams from 1.3.00.8663 to 1.3.00.9271

### DIFF
--- a/Casks/microsoft-teams.rb
+++ b/Casks/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-teams' do
-  version '1.3.00.8663'
-  sha256 '50f34a948fa0e1e71af89c126fc44380aa58f533389215beafa12fecf6357d95'
+  version '1.3.00.9271'
+  sha256 '6da9d7d11baf17a3900bd8394b3d92edc2849ab3cea748daa0fccc1ffc3371fb'
 
   url "https://statics.teams.microsoft.com/production-osx/#{version}/Teams_osx.pkg"
   appcast 'https://teams.microsoft.com/downloads/DesktopUrl?env=production&plat=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.