### PR TITLE
Update alt-tab from 3.21.1 to 3.21.2

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.21.1'
-  sha256 'b34ee519481baba68eaf86ebeae2b1ea094de582b8343a2faf72af46061f6042'
+  version '3.21.2'
+  sha256 '7d32894c544d9723e7545f721064d64ccfa46e768041e9f3f203cb92dc43520c'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.