### PR TITLE
Update melodics from 2.1.4374 to 2.1.4423

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,6 +1,6 @@
 cask 'melodics' do
-  version '2.1.4374'
-  sha256 '5a6a0a44522c8c463a5a44bce832fcb0374fcc85be11b66a34e79a44d688dbfa'
+  version '2.1.4423'
+  sha256 'a1d334f563f729ef41d00b407537b0f3329e54a9e1a8f777d0c462d2856d2bba'
 
   url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
   appcast "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.