### PR TITLE
Updated RingCentral 20.2.20

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -5,12 +5,13 @@ cask 'ringcentral' do
   url 'https://app.ringcentral.com/downloads/RingCentral.pkg'
   appcast 'https://app.ringcentral.com/download/latest-mac.yml'
   name 'RingCentral'
-  homepage 'https://www.ringcentral.com/apps/rc-app'
+  homepage 'https://www.ringcentral.com/rcapp.html'
 
   pkg 'RingCentral.pkg'
 
-  uninstall quit:   'RingCentral',
-            delete: '/Applications/RingCentral.app'
+  uninstall delete:  '/Applications/RingCentral.app',
+            quit:    'RingCentral',
+            pkgutil: 'com.ringcentral.glip'
 
   zap trash: [
                '~/Library/Application Support/RingCentral',

--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,11 +1,21 @@
 cask 'ringcentral' do
-  version '20.1.0'
-  sha256 '2a16143b8b167783c19bd47e79fa7fd94d6d942efdc6a41e19b2cb0c4fbcd816'
+  version '20.2.20'
+  sha256 'a737aa8920c71f3c112f12a4e31b484e6f39660a609b13d8ee64094307591321'
 
-  url "https://downloads.ringcentral.com/sp/RingCentralPhone-#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads.ringcentral.com/sp/RingCentralForMac'
-  name 'RingCentral for Mac'
-  homepage 'https://www.ringcentral.com/apps/rc-phone'
+  url 'https://app.ringcentral.com/downloads/RingCentral.pkg'
+  appcast 'https://app.ringcentral.com/download/latest-mac.yml'
+  name 'RingCentral'
+  homepage 'https://www.ringcentral.com/apps/rc-app'
 
-  app 'RingCentral for Mac.app'
+  pkg 'RingCentral.pkg'
+
+  uninstall quit:   'RingCentral',
+            delete: '/Applications/RingCentral.app'
+
+  zap trash: [
+               '~/Library/Application Support/RingCentral',
+               '~/Library/Logs/RingCentral',
+               '~/Library/Preferences/com.ringcentral.glip.plist',
+               '~/Library/Saved Application State/com.ringcentral.glip.savedState',
+             ]
 end


### PR DESCRIPTION
Updated information to download the new Electron App released with
20.2.20, as opposed to RingCentral Classic (Glip)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
