### PR TITLE
Update tinypng4mac from 1.0.3 to 1.0.4

### DIFF
--- a/Casks/tinypng4mac.rb
+++ b/Casks/tinypng4mac.rb
@@ -1,6 +1,6 @@
 cask 'tinypng4mac' do
-  version '1.0.3'
-  sha256 '723a9e0b63b69a5b3c0d20cbe2199ff5dea7ac06ae511ec827b6bb82cf5af112'
+  version '1.0.4'
+  sha256 'f3605f5974eab8fbe6ec461a2a79365698162e4f96159bf803074536a624e31e'
 
   url "https://github.com/kyleduo/TinyPNG4Mac/releases/download/v#{version}/TinyPNG4Mac_#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/kyleduo/TinyPNG4Mac/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.