### PR TITLE
Update http-toolkit from 0.1.21 to 0.1.22

### DIFF
--- a/Casks/http-toolkit.rb
+++ b/Casks/http-toolkit.rb
@@ -1,6 +1,6 @@
 cask 'http-toolkit' do
-  version '0.1.21'
-  sha256 '54ccdb363ebfa55a55452c68b66106476701fb2e1bc63e4336565e65189c10ae'
+  version '0.1.22'
+  sha256 '85c4b4252a581d79ac01cf1e9ba8e08ea2edba663a20d7869925056a4e117cf8'
 
   # github.com/httptoolkit/httptoolkit-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/httptoolkit/httptoolkit-desktop/releases/download/v#{version}/HTTP.Toolkit.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.