### PR TITLE
Update qownnotes from 20.5.5,b5587-050034 to 20.5.6,b5595-131948

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.5.5,b5587-050034'
-  sha256 '7ce9932011637ccb447ba3b057cb2d44bc189b651a651735d6db7bcc16e14314'
+  version '20.5.6,b5595-131948'
+  sha256 'db44f79c30273d841841af73b2f0ac6e159bfb3a187746c642db82b251d58357'
 
   # github.com/pbek/QOwnNotes/ was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.