### PR TITLE
Update terminus from 1.0.110 to 1.0.111

### DIFF
--- a/Casks/terminus.rb
+++ b/Casks/terminus.rb
@@ -1,6 +1,6 @@
 cask 'terminus' do
-  version '1.0.110'
-  sha256 '6ea5b2ce3995e9999280ffe3be84e70a6feb6dd9301f3f482887aec8d5d8b2f7'
+  version '1.0.111'
+  sha256 'e1be1201f08c98861b34f20380cb7dcde3d5d0b14c8a2ba1566650df7e54339a'
 
   # github.com/Eugeny/terminus/ was verified as official when first introduced to the cask
   url "https://github.com/Eugeny/terminus/releases/download/v#{version}/terminus-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.