### PR TITLE
Update cabal from 5.0.2 to 5.0.4

### DIFF
--- a/Casks/cabal.rb
+++ b/Casks/cabal.rb
@@ -1,6 +1,6 @@
 cask 'cabal' do
-  version '5.0.2'
-  sha256 'a9672daf7b5137513ab959a85bfc345fa52ffd76529b4f329a95a64af643ffc1'
+  version '5.0.4'
+  sha256 'bd055e31b578db97e6d47757b6d7e186000fe554df63158d1451309614aabbc3'
 
   # github.com/cabal-club/cabal-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/cabal-club/cabal-desktop/releases/download/v#{version}/cabal-desktop-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.