### PR TITLE
Update bdash from 1.8.2 to 1.8.3

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask 'bdash' do
-  version '1.8.2'
-  sha256 'b4893236b613ca9d56df1de050cc0c37c597e7ee914a379ad41d66adbfddd7b3'
+  version '1.8.3'
+  sha256 '7d93babc7bdf2a1cad6e6083d2b52a55141fc5e6c24c41c96585357e84da5f04'
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   appcast 'https://github.com/bdash-app/bdash/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.