### PR TITLE
Update proclaim from 2.12.0.0037 to 2.12.0.0038

### DIFF
--- a/Casks/proclaim.rb
+++ b/Casks/proclaim.rb
@@ -1,6 +1,6 @@
 cask 'proclaim' do
-  version '2.12.0.0037'
-  sha256 'bdb2bb63c4c32582c0c470a0f4958ff5c74f4b086d64fd8d8a97ad5446f5e966'
+  version '2.12.0.0038'
+  sha256 'c182891d4f68fae54b3cdfb953848e733294ba466f7004b9df1f3857589e4998'
 
   # logoscdn.com/Proclaim/ was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/Proclaim/Installer/#{version}/Proclaim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.