### PR TITLE
Update kext-updater from 3.4.5 to 3.4.6

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,6 +1,6 @@
 cask 'kext-updater' do
-  version '3.4.5'
-  sha256 '6be1c25fb1ab0c0bfe6c5365e4988e183add53ea386c81943f8965d28dcded4e'
+  version '3.4.6'
+  sha256 '959ac756ecd13d694f35e195a5b0853187a6678d793a73fd82031e1d059ddc47'
 
   url 'https://update.kextupdater.de/kextupdater/kextupdaterng.zip'
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.