### PR TITLE
Update zoc from 7.25.6 to 7.25.7

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask 'zoc' do
-  version '7.25.6'
-  sha256 '6dba650cadc3cb7511870aa2e500f687a09d4948b4fe8253958fa52a6cb00c8a'
+  version '7.25.7'
+  sha256 'c0e1a69c367f2de768609e9eec0dbe58b59056b89963a48f783557362e44dec1'
 
   url "https://www.emtec.com/downloads/zoc/zoc#{version.no_dots}.dmg"
   appcast 'https://www.emtec.com/downloads/zoc/zoc_changes.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.