### PR TITLE
Update plex from 1.9.0.1203-00f2b4d9 to 1.10.0.1208-daa6b641

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask 'plex' do
-  version '1.9.0.1203-00f2b4d9'
-  sha256 '79d445e5ad203b811bbcc487601252937de894946fc691eb76777eb7dd6a0263'
+  version '1.10.0.1208-daa6b641'
+  sha256 'ff31321d4d63d7859a0e7ed834284bd50c5baba60c44d542553f9063550ef5b6'
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast 'https://plex.tv/api/downloads/6.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.