### PR TITLE
Update cutter from 1.10.2 to 1.10.3

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.10.2'
-  sha256 'c999722f7ba4442c3cd9aa619baec2389459526a243c0af48697e18de5893eba'
+  version '1.10.3'
+  sha256 'af01ca5da120afbc8666c5a029996435226ac3d72448cb48b02fd8a4853e6c80'
 
   # github.com/radareorg/cutter/ was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).