### PR TITLE
Update 4k-stogram from 3.0.0.3140 to 3.0.1.3150

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask '4k-stogram' do
-  version '3.0.0.3140'
-  sha256 'd4d69f78a8dd078259c0f60a831872eab0d52d64609c73c57b42949d5958e858'
+  version '3.0.1.3150'
+  sha256 '33582f743f6b897ef88d2e0219196b4a5131bd888e46c7ed3351f4422958bb50'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.