### PR TITLE
Update mongodb-compass-readonly from 1.21.0 to 1.21.1

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.21.0'
-  sha256 '80ef5e017c6100e9013930643a587e2e149e082637f80ddf30ac617f11bd9611'
+  version '1.21.1'
+  sha256 '3b3d09f91d2c8f553a2e747cb288ba35a9fbbab52886529acf277035a10b62fe'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.