### PR TITLE
Update chef-workstation from 0.17.5 to 0.18.3

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask 'chef-workstation' do
-  version '0.17.5'
-  sha256 'e9b9165a80222900a1e421f7ad72d2f8252bc0f46175162e43b8cf271b2d2207'
+  version '0.18.3'
+  sha256 '53312b80cfd0bbc29b3be73cfc0a6c438fd1873c60c0752ac3b636c62fdcbab3'
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.13/chef-workstation-#{version}-1.dmg"
   appcast 'https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.14&m=x86_64&v=latest'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.