### PR TITLE
Update firefox from 76.0 to 76.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '76.0'
+  version '76.0.1'
 
   language 'cs' do
-    sha256 '2beedffec79b7c701cd03d722de437b96af3abe9bf72a6aa0ee911892969445a'
+    sha256 'a7a586aee36804a2aab8c89ae3e6295fc3cec647c410d1f853f865e5e6c4ccb1'
     'cs'
   end
 
   language 'de' do
-    sha256 'cf8af096d03a7c3b7e0cd3e2cf40dfb4899de29b6296a8cd042d029350173892'
+    sha256 'ee281674bcc375d71546ab6c21f85db1a04b4ef999c5e2a15c3d5e569a67b3b6'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '6dfe49037f67e96454b42915579cb0b67c3b4adcb80aae1b00a4286c90be65fe'
+    sha256 '6a8381fe0b1019fea221a6fb661ed9139422c3451504e2d9ac67dd7286f575cf'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'c71f44c038bc78cd9e310f367bcccb1e1dffdda2e3196491ffea1cd456e86b0d'
+    sha256 'a0a0c23abb829807c5d10b6a9423bbc9c0445fe27fff69eb8ec1caef766d4451'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '1c237ba3e8cdee862ebf3a8a4e4a07cbd981cbfe8bc738670671f61276f57b52'
+    sha256 'a751fb770543dc1688041e11813070b5e012a3dbb2e0cb774cca63f5ae935282'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 'fc3ef3c2ddcad9b006029bd8e7b7695de3c5080cdd24c444f565ca123965875e'
+    sha256 'bfa6e3282de83ebd447352c2845ea38224a5047c9ddd63a03335fa8f38af8867'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '133b64d7f3ed915a06e4ce5bd3d7d9230341dfd6983c25b4edbe9330441e9439'
+    sha256 '88a99908eeba6183312d5ee2d7d4a47459d565eac3bce76572d1592267112e34'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '03e5fdbd2eac21e43fad69604a20ac6cbde86b214a5d0731109d976adc8133c8'
+    sha256 '93ec59e7da6633e336176797b80ce7e9feee9b750fc1be13cb7d9b393513246d'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 'fb76ca24a7d7944eb63306d494976fcf02dd41fe3cd84fe66503fa92b092f699'
+    sha256 '51385737a7f325044e021fbedebf1c37fe37c9d9002f404c6a1ab1d5b1db143e'
     'fi'
   end
 
   language 'fr' do
-    sha256 '5e8f9c0c671e86d115ede1351b3553763644894f13a5a109c9b56634a6a42006'
+    sha256 '7fbb2343f96fdb0d810de8a71a94a69ec6c4fb0cefaede9d8cd910675ca9b382'
     'fr'
   end
 
   language 'gl' do
-    sha256 'a5935853812fb9673f344e4b4539c5ee3d10b96feed230494ba5085ba9d264af'
+    sha256 '2855bfe1f6b992cd7b306817d1c103f1f3aa76c512c3f3679109c2a998d9be00'
     'gl'
   end
 
   language 'in' do
-    sha256 'c75598ad5cbb1fd373786ee830f748db633773eedcd5bb47cc1044d71c3abd21'
+    sha256 '463ea0574f004c61eadcb370ebc7b2c7373286c1b9be6ff46c7cf3c873d69597'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '4df55e236762f5e42d189e6e7ebf434528a546ad388fa111bd3865381d34010d'
+    sha256 'f1fbae8e011c07ac738a5abbcb7caa05845095ef7823c0dbbcbf88df0d023c31'
     'it'
   end
 
   language 'ja' do
-    sha256 'fb07c442adfa9d36dd1c43c1cf7b60ddb2a9db281dc10d691a4acd76c352bcf3'
+    sha256 '343938f5774012b817417e8887f71491c18736ed728752c9a95c274ff2d06d4e'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 'cb6642452b1c4504df2f3a7ea2809c2ade407eb0f2abe15db5bb62a0e109034c'
+    sha256 '7b34ac3eb2d5bcb20359ef3bd843c506ce88119c15e4c2119b049c0467964e6c'
     'ko'
   end
 
   language 'nl' do
-    sha256 '66016542088aeda5b45cd8377772836bc6ae4367000d34f76945933a1fb1bab3'
+    sha256 '8fcdee473631845c56e489d14b1ef3f5d12fd7d3e45a9f40338bd1acc6ed1057'
     'nl'
   end
 
   language 'pl' do
-    sha256 '6b571b594148fa3102b7409e0359d9a5f9d45bd3656a9cd2df1c08b476fa492e'
+    sha256 'c370ccaea3f8aa436313bb64e5e213b62b767b5521aa82f3e341709fba29c601'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 'c2e042014c878163792b93beedc4a80f75cc15c77a99c183c45c4bac2ec943ac'
+    sha256 '293005eb71fd83dca3f2b7c059f980f34bbb9e46220613630469663e32b5c971'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '909672a859d4180c9e20b7845390e25f5e46381e1bfa35ed6cf198f4ad7d7419'
+    sha256 '6087f1aa0180c300f2617e799afa6ca57fc4dea5e036c9a26550a6bd335260ce'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'df839c878ec0ed68b5c319c677adc15990ed1f5931edc871f7e441893a5ab252'
+    sha256 '54d1342c1351bfbe06416ffad9920e3e2ad3247e998175af67a170dc4fb7b742'
     'ru'
   end
 
   language 'tr' do
-    sha256 'ab684957ad99661ae9352ab5bcc24d53e7c9f8c290b4c3a10a2ad76ef504f6d0'
+    sha256 '7ba1bfc03b444da821c0833be1803aaf12430a6afafdde0b928c17436e0f925e'
     'tr'
   end
 
   language 'uk' do
-    sha256 'fc9242cbb0b76c15658c3bea88f44e19176704a539345def70886f1aee0bb41a'
+    sha256 '5075a5dece0671a78d48cac8cda0eaf5f12d786549ed2048c9c34da14d976573'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'fffa110190f715de05947b08064ea8ce0e61b118702edeb7fd8c50dae05dd2ff'
+    sha256 '6604118cde03121f1d9ed14873844e704174ea55ead5959ea510d4861cc36768'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '57e138a9586e5e7ce1490e0352bd4923ed44fe8b7ca4d7fdda633f6dc21cc1a9'
+    sha256 '9ff0c97bcc696d6956d547c72f6b5c86fc4a4eab155bdb15dbb2c9cd88f29746'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
