### PR TITLE
Update webcatalog from 20.13.0 to 20.13.1

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.13.0'
-  sha256 '1772a6d02bda74ac07d578d6b5d2bc6feb7e1f311982ed49e947ccc796625b72'
+  version '20.13.1'
+  sha256 '77f371b9b858ed8edcd52bc6124fbe0731b14e0250e162558791599ec91c2a66'
 
   # github.com/quanglam2807/webcatalog/ was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.