### PR TITLE
Update fsnotes from 4.2.4 to 4.2.6

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask 'fsnotes' do
-  version '4.2.4'
-  sha256 'ba6a07655f44fc92f2be968b66068f364e7de354e56a1001c1d2db86bd254e0c'
+  version '4.2.6'
+  sha256 'aadde0d269ffc9d86c21b4368ff5c546bbfab70963ede916a67d380e58333602'
 
   # github.com/glushchenko/fsnotes/ was verified as official when first introduced to the cask
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.