### PR TITLE
Add Play! latest formula

### DIFF
--- a/Casks/purei-play.rb
+++ b/Casks/purei-play.rb
@@ -1,0 +1,10 @@
+cask 'purei-play' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://purei.org/download_latest.php?platform=macos'
+  name 'Play! - PS2 Emulator'
+  homepage 'https://purei.org/'
+
+  app 'Play.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

Few extra note:

- app name is `Play!`, and by the token rules, and the fact that ! is a problematic shell character, it would be removed, however there is already an app by the name `Play` in here, thus the purei prefix
- note this is the official emu repo https://github.com/jpd002/Play- not the name `Play-` is what GitHub simplifies ! to, if this is the preferred name, I can amend this PR 
- `Play!` is only provided as latest/development release, as its an emu, and is in constant development, thus fits the exception rule
- dmg image is official build, and can be verified here https://purei.org/downloads.php note, "weekly builds" on the website are outdated since the automated builds have been introduced
