### PR TITLE
Update diskcatalogmaker from 8.1.1 to 8.1.2

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask 'diskcatalogmaker' do
-  version '8.1.1'
-  sha256 '35e60670630458554608826feccfdbe2f775595f7dc408ca92b7bc7a271595e1'
+  version '8.1.2'
+  sha256 'e3ddf2eafd428f5e5ae2408fd61cddbd77fa1cdb21c20d542585f0e9b860822c'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.