### PR TITLE
Update ipepresenter from 7.2.16 to 7.2.17

### DIFF
--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -1,6 +1,6 @@
 cask 'ipepresenter' do
-  version '7.2.16'
-  sha256 'e4510a7ac6408518db2453e3ddfb5d6e6a55af88010e2597ed64cf4bbefadee7'
+  version '7.2.17'
+  sha256 '40c25dec534beb35f9cccb0202885a5ce1408fde109a031c6af4d0acc391a1bd'
 
   # bintray.com/otfried/ was verified as official when first introduced to the cask
   url "https://dl.bintray.com/otfried/generic/ipe/#{version.major_minor}/ipepresenter-#{version}-mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.