### PR TITLE
MacTex 2020.0407 - Making it clear you need to restart your terminal to use

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -77,6 +77,7 @@ cask 'mactex' do
              ]
 
   caveats do
-    'You must restart your terminal window for the installation of MacTex CLI tools to take effect.'
+    'You must restart your terminal window for the installation of MacTex CLI tools to take effect.  Bash or zsh users can run the command:
+      eval "$(/usr/libexec/path_helper)"'
   end
 end

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -75,4 +75,7 @@ cask 'mactex' do
                '/usr/local/texlive',
                '~/Library/texlive',
              ]
+  caveats do
+    'You must restart your terminal window for the installation of MacTex CLI tools to take effect.'
+  end
 end

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -76,8 +76,10 @@ cask 'mactex' do
                '~/Library/texlive',
              ]
 
-  caveats do
-    'You must restart your terminal window for the installation of MacTex CLI tools to take effect.  Bash or zsh users can run the command:
-      eval "$(/usr/libexec/path_helper)"'
-  end
+  caveats <<~EOS
+    You must restart your terminal window for the installation of MacTex CLI tools to take effect.
+    Alternatively, Bash and Zsh users can run the command:
+
+      eval "$(/usr/libexec/path_helper)"
+  EOS
 end

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -75,6 +75,7 @@ cask 'mactex' do
                '/usr/local/texlive',
                '~/Library/texlive',
              ]
+
   caveats do
     'You must restart your terminal window for the installation of MacTex CLI tools to take effect.'
   end


### PR DESCRIPTION
MacTex registers itself in the PATH via writing to  /etc/paths.d .  This file is only read on terminal startup, so once MaxTex is installed, I'm adding a message telling users to restart their terminal so they can use the CLI tools.

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).