### PR TITLE
Update appzapper from 2.0.2 to 2.0.3

### DIFF
--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -1,6 +1,6 @@
 cask 'appzapper' do
-  version '2.0.2'
-  sha256 'bc05e7b2290ffdbfba23fcb445d57237eef258fea679aff902aa135ee302d297'
+  version '2.0.3'
+  sha256 'bb541a89fd513c4fa95eeefe46ebac6b985ac6498a46da4e4622089a15ef6bcd'
 
   url "https://appzapper.com/downloads/appzapper#{version.no_dots}.zip"
   appcast "https://www.appzapper.com/az#{version.major}appcast.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.