### PR TITLE
Update exodus from 20.4.23 to 20.5.9

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '20.4.23'
-  sha256 'f1f1b43e69e02f8070d96170bf6104fcf2b170199ec69829b506f1a682f3e755'
+  version '20.5.9'
+  sha256 '5475fe1ac642c725c4e2f29c67ee4b7486afa8b1c271f24895fc359a9c5a8507'
 
   url "https://downloads.exodus.io/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.