### PR TITLE
Update arq from 6.2.11 to 6.2.14

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,5 +1,5 @@
 cask 'arq' do
-  version '6.2.11'
+  version '6.2.14'
   sha256 '116842dab5c794bf44e8d9c0010ecf0e9f1bad1cd2fcd2f1d0682816856c939d'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.