### PR TITLE
Update stack-stack from 3.0.0 to 3.2.0

### DIFF
--- a/Casks/stack-stack.rb
+++ b/Casks/stack-stack.rb
@@ -1,6 +1,6 @@
 cask 'stack-stack' do
-  version '3.0.0'
-  sha256 '2bcc8053c63fe22cc340e5922068f641bfec931a9effbfc9aaddfa7e31abc926'
+  version '3.2.0'
+  sha256 '58d5c2ad6b521e8c0dfdffb204a4d7b89acc2215845b9920920aecafb56b8978'
 
   # stack-v1.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://stack-v1.s3.amazonaws.com/builds/prod/Stack-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.