### PR TITLE
Update alt-tab from 3.22.2 to 3.22.3

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.22.2'
-  sha256 '7dc7835d2b04e89511b9aafeb040d689d27fae5ba7999706be12c80be52f5d74'
+  version '3.22.3'
+  sha256 '7ba8092eaa220d80028507bb24882d6d81456c3aa24ac7f76ee1379ab0538fea'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.