### PR TITLE
Update raven-reader from 0.7.6 to 0.7.7

### DIFF
--- a/Casks/raven-reader.rb
+++ b/Casks/raven-reader.rb
@@ -1,6 +1,6 @@
 cask 'raven-reader' do
-  version '0.7.6'
-  sha256 'e3c2350da9b5e7f2f17a4f55063be3303b5a2527ec2137231fb446eaa484a6a4'
+  version '0.7.7'
+  sha256 'f8b8ea1c8b2ad6218c88a05ab32f782f1af904a587bb8ebd56f9d1ccb3aa7bde'
 
   url "https://download.ravenreader.app/ravenreader/Raven%20Reader-#{version}-mac.zip"
   appcast 'https://download.ravenreader.app/ravenreader/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.