### PR TITLE
add Objektiv.app v0.6.3

### DIFF
--- a/Casks/objektiv.rb
+++ b/Casks/objektiv.rb
@@ -1,0 +1,11 @@
+cask 'objektiv' do
+  version '0.6.3'
+  sha256 '93f4f31712144c3225a45e69dc251a5db727b299dc7511f4f38004936c396d7a'
+
+  url "https://github.com/Vorror/Objektiv/releases/download/v#{version}/Objektiv.zip"
+  appcast 'https://github.com/Vorror/Objektiv/releases.atom'
+  name 'Objektiv'
+  homepage 'https://github.com/Vorror/Objektiv'
+
+  app 'Objektiv.app'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

---

This cask is based on [a fork](https://github.com/Vorror/Objektiv) of the original [Objektiv](https://github.com/nthloop/Objektiv) application that even came with [a website](https://nthloop.github.io/Objektiv/). The developer [Vorror](https://github.com/Vorror) has contributed substantial fixes and polish. I chose name the cask without a fork prefix and to submit it to stable because:

* The last commit on the original repository was more than 7 years ago.
* It was [proposed to define new maintainers](https://github.com/nthloop/Objektiv/issues/10), without response from the original developers.
* The original developers [have not reacted](https://github.com/nthloop/Objektiv/issues/10#issue-128844222) to communication.
* The [two](http://ankitsolanki.com/) [websites](https://www.xrivatsan.com/) referenced in the original developer's profiles are both defunct, suggesting they might have left the industry.

Additional information about notability:
* While the fork only has 25 stars, the original repository has 104.
* The application has seen media coverage in 2013: [Cult of Mac: Quickly Switch Default Browsers On Your Mac With Objektiv [OS X Tips]](https://www.cultofmac.com/217631/quickly-switch-default-browsers-on-your-mac-with-objektiv-os-x-tips/)
