### PR TITLE
trezor-bridge: clean up a few leftovers

### DIFF
--- a/Casks/trezor-bridge.rb
+++ b/Casks/trezor-bridge.rb
@@ -10,5 +10,8 @@ cask 'trezor-bridge' do
   pkg "trezor-bridge-#{version}.pkg"
 
   uninstall pkgutil:   'com.bitcointrezor.pkg.TREZORBridge*',
-            launchctl: 'com.bitcointrezor.trezorBridge.trezord'
+            launchctl: 'com.bitcointrezor.trezorBridge.trezord',
+            delete:    '/Applications/Utilities/TREZOR Bridge'
+
+  zap trash: '~/Library/Logs/trezord.log'
 end


### PR DESCRIPTION
This PR cleans up a leftover directory, which the vendor’s
uninstaller doesn’t cover.

The commit also make sure the default log file is removed on `zap`.

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version. **Does not bump version**
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
