### PR TITLE
Revert "Update utools from 1.0.0-beta to 1.0.2-beta"

### DIFF
--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -1,6 +1,6 @@
 cask 'utools' do
-  version '1.0.2-beta'
-  sha256 'e6288cf846a733ef67d3fe87ab0454f0b9f44de1830daafa7f0ddbd7f00fbb16'
+  version '1.0.0-beta'
+  sha256 '7ba4b6574f6ebab5a83e3639ca8bef03a7f5135787e5f400b0ab566c1638ff50'
 
   # resource.u-tools.cn/ was verified as official when first introduced to the cask
   url "https://resource.u-tools.cn/currentversion/uTools-#{version}.dmg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#82112
the app was downgraded (appcast changed to 1.0.0 and the 1.0.2 download doesn't work)