### PR TITLE
Update toggl from 7.5.85 to 7.5.123

### DIFF
--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -4,7 +4,7 @@ cask 'toggl' do
 
   # github.com/toggl-open-source/toggldesktop/ was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
-  appcast 'https://toggl.github.io/toggldesktop/#mac'
+  appcast 'https://toggl-open-source.github.io/toggldesktop/assets/releases/darwin_stable_appcast.xml'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/toggl-desktop/'
 

--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -1,6 +1,6 @@
 cask 'toggl' do
-  version '7.5.85'
-  sha256 '8ad2f539abaebe77083e92c1ea0d608d4d174e8c7fd1aa6f2475eda30949fbc3'
+  version '7.5.123'
+  sha256 'cb6a0c92d32b545fa17a9faa1294b774dc193b624961910dfe3d92ae714f5f6e'
 
   # github.com/toggl-open-source/toggldesktop/ was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"

--- a/Casks/toggl.rb
+++ b/Casks/toggl.rb
@@ -4,7 +4,7 @@ cask 'toggl' do
 
   # github.com/toggl-open-source/toggldesktop/ was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
-  appcast 'https://assets.toggl.com/installers/darwin_stable_appcast.xml'
+  appcast 'https://toggl.github.io/toggldesktop/#mac'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/toggl-desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.