### PR TITLE
Update cutbox from 1.4.5 to 1.4.8

### DIFF
--- a/Casks/cutbox.rb
+++ b/Casks/cutbox.rb
@@ -1,6 +1,6 @@
 cask 'cutbox' do
-  version '1.4.5'
-  sha256 '1288203c2fbcbff806ca4aa1d237ef24edd5771a24aecf497f09cd023d6dd461'
+  version '1.4.8'
+  sha256 '99d189593f421fb1a230de2dacede9140f13930d462a8e986ba8c42ff2978ecb'
 
   url "https://github.com/cutbox/CutBox/releases/download/#{version}/CutBox.dmg"
   appcast 'https://github.com/cutbox/CutBox/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.