### PR TITLE
Update refined-github-safari from 2.0.31 to 2.0.32

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask 'refined-github-safari' do
-  version '2.0.31'
-  sha256 'a558d0a6d31adf50644eadeaa2c260bff8e7a1b12698f3bb67e3143371e9fbb9'
+  version '2.0.32'
+  sha256 'b970846bcdbf44c1a80194a929c394556e3123376486430e067aee5426443201'
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast 'https://github.com/lautis/refined-github-safari/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.