### PR TITLE
Update sofa-server from 1.3.4 to 2.0

### DIFF
--- a/Casks/sofa-server.rb
+++ b/Casks/sofa-server.rb
@@ -1,5 +1,5 @@
 cask 'sofa-server' do
-  version '1.3.4'
+  version '2.0'
   sha256 '14860aa797c3ef39c9c81d829e77b63f36a7dc4c1190b90542a7e614a37e7ed5'
 
   url 'https://flavio.tordini.org/files/sofa/sofa-server.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.