### PR TITLE
Update exodus from 20.5.9 to 20.5.10

### DIFF
--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -1,6 +1,6 @@
 cask 'exodus' do
-  version '20.5.9'
-  sha256 '5475fe1ac642c725c4e2f29c67ee4b7486afa8b1c271f24895fc359a9c5a8507'
+  version '20.5.10'
+  sha256 '16dd29dcd85518d07166f39c72fb07bcac73b006e116f392ca8f69594efbc1ba'
 
   url "https://downloads.exodus.io/releases/exodus-macos-#{version}.dmg"
   appcast 'https://www.exodus.io/releases/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.