### PR TITLE
Update gitfiend from 0.22.8 to 0.23.1

### DIFF
--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -1,6 +1,6 @@
 cask 'gitfiend' do
-  version '0.22.8'
-  sha256 '8d0eaaf47074c28d97f8fca7780e11f868adb8ab97f18c8e196f54817a86237d'
+  version '0.23.1'
+  sha256 '2b231a127c92857fa46d3832cf3bdde4486e75fad48e248cf1696474b1357394'
 
   url "https://gitfiend.com/resources/GitFiend-#{version}.dmg"
   appcast 'https://gitfiend.com/app-info'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.