### PR TITLE
Update cacher from 2.26.0 to 2.27.1

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.26.0'
-  sha256 'cea50dcb15fcb8b453be09dad5c19968cdcfa623731eb92a2638030743774dbc'
+  version '2.27.1'
+  sha256 '8b178a779d385f5dbc987982736448616536a2d575cec4fe977b304d36312e16'
 
   # cacher-download.nyc3.digitaloceanspaces.com/ was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.