### PR TITLE
Update netron from 4.1.5 to 4.1.6

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,6 +1,6 @@
 cask 'netron' do
-  version '4.1.5'
-  sha256 '2d3ac9295d5bb4a9e8dd9533f7272d1a20f01e0e240a6b14dc51ddd8e3828a57'
+  version '4.1.6'
+  sha256 'b47ede6b2921b21e90e1e86d1e2c9430f6e7f0832aea111b1459c181e205b282'
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
   appcast 'https://github.com/lutzroeder/netron/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.