### PR TITLE
Update androidtool to 1.70.0

### DIFF
--- a/Casks/androidtool.rb
+++ b/Casks/androidtool.rb
@@ -1,11 +1,11 @@
 cask 'androidtool' do
-  version '1.66'
-  sha256 '4f432ad45660071a1f36c4878bd444dd8bedd520c7c70096e5d7a7907ff7c86a'
+  version '1.70.0'
+  sha256 'd643136a0694e922701305c7bc0c14302ba6652fc20a21defb41300f49a731d4'
 
-  url "https://github.com/mortenjust/androidtool-mac/releases/download/#{version}/AndroidTool.zip"
-  appcast 'https://github.com/mortenjust/androidtool-mac/releases.atom'
+  url "https://github.com/muandrew/androidtool-mac/releases/download/release%2F#{version}/AndroidTool-#{version}.zip"
+  appcast 'https://github.com/muandrew/androidtool-mac/releases.atom'
   name 'AndroidTool'
-  homepage 'https://github.com/mortenjust/androidtool-mac'
+  homepage 'https://github.com/muandrew/androidtool-mac'
 
   app 'AndroidTool.app'
 end


### PR DESCRIPTION
The project repository was changed because the original
author `mortenjust` is no longer maintaining this project.

Thanks `mortenjust` for starting this excellent tool!

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
