### PR TITLE
Update gloomhaven-helper checksum

### DIFF
--- a/Casks/gloomhaven-helper.rb
+++ b/Casks/gloomhaven-helper.rb
@@ -1,6 +1,6 @@
 cask 'gloomhaven-helper' do
   version '8.3.6'
-  sha256 'f49fbbd1b230da0c7be001efda41c573f588a0e866f6bdb941f28d7f89757f93'
+  sha256 'c02ee7e43bc16f780b6c168b9735328a8cef69731c993c57ece88557ec94ea4d'
 
   url "https://esotericsoftware.com/files/ghh/GloomhavenHelper-#{version}.zip"
   name 'Gloomhaven Helper'


### PR DESCRIPTION
The developer has updated the download from the 8.3.6 link, which was done after I contacted them concerning a crash during startup. This makes an update to the checksum required, as the installation now fails with

```
==> Verifying SHA-256 checksum for Cask 'gloomhaven-helper'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
Error: Checksum for Cask 'gloomhaven-helper' does not match.
Expected: f49fbbd1b230da0c7be001efda41c573f588a0e866f6bdb941f28d7f89757f93
  Actual: c02ee7e43bc16f780b6c168b9735328a8cef69731c993c57ece88557ec94ea4d
```

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.