### PR TITLE
Update freesmug-chromium from 81.0.4044.129 to 81.0.4044.138

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask 'freesmug-chromium' do
-  version '81.0.4044.129'
-  sha256 'e9c6179819c504264dba32660da7bfba87d44270e8e95b09acb486bc96f0a515'
+  version '81.0.4044.138'
+  sha256 'a6854b83eb8966063fa966466e99911e7e0c19a82cbcf58ad17fee5c9c458419'
 
   # sourceforge.net/osxportableapps/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.