### PR TITLE
Update rocket from 1.7.3,68 to 1.7.4,69

### DIFF
--- a/Casks/rocket.rb
+++ b/Casks/rocket.rb
@@ -1,6 +1,6 @@
 cask 'rocket' do
-  version '1.7.3,68'
-  sha256 '58db49ed05a0f4cbebe39c0f8dc9f0287133d4383321b1a8a8eeb5667533beda'
+  version '1.7.4,69'
+  sha256 'af589098cad82a5e84a9212410d4b98cd2904ad38472c8feb5291374aca33971'
 
   url "https://macrelease.matthewpalmer.net/distribution/appcasts/Rocket-#{version.after_comma}.dmg"
   appcast 'https://macrelease.matthewpalmer.net/distribution/appcasts/rocket.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.