### PR TITLE
Update wey from 0.3.6 to 0.3.7

### DIFF
--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,6 +1,6 @@
 cask 'wey' do
   version '0.3.7'
-  sha256 'a98359f3a1ce34c0e45887628b37fad2949a273d0dd814a0ae37ad3f3b59f3aa'
+  sha256 '5ebbfad23a598d64c2fa1c311877546ae9b9c4e41e4040395496231fc70f68ec'
 
   url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom'

--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -2,7 +2,7 @@ cask 'wey' do
   version '0.3.7'
   sha256 'a98359f3a1ce34c0e45887628b37fad2949a273d0dd814a0ae37ad3f3b59f3aa'
 
-  url "https://github.com/yue/wey/releases/download/v#{version}/wey-v0.3.6-darwin-x64.zip"
+  url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom'
   name 'Wey'
   homepage 'https://github.com/yue/wey'

--- a/Casks/wey.rb
+++ b/Casks/wey.rb
@@ -1,8 +1,8 @@
 cask 'wey' do
-  version '0.3.6'
-  sha256 '8a1f3bd436b4d837ea2f586b5a96904bf6de02db5a25922cefd23b1f4e7e0b05'
+  version '0.3.7'
+  sha256 'a98359f3a1ce34c0e45887628b37fad2949a273d0dd814a0ae37ad3f3b59f3aa'
 
-  url "https://github.com/yue/wey/releases/download/v#{version}/wey-v#{version}-darwin-x64.zip"
+  url "https://github.com/yue/wey/releases/download/v#{version}/wey-v0.3.6-darwin-x64.zip"
   appcast 'https://github.com/yue/wey/releases.atom'
   name 'Wey'
   homepage 'https://github.com/yue/wey'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.