### PR TITLE
Update teamwire from 2.1.0 to 2.2.0

### DIFF
--- a/Casks/teamwire.rb
+++ b/Casks/teamwire.rb
@@ -1,6 +1,6 @@
 cask 'teamwire' do
-  version '2.1.0'
-  sha256 'd099950489fd7f97d5c9648d774e8a6b9585da7e19ad99cfb24d3be539a37878'
+  version '2.2.0'
+  sha256 '43b0c9bee9f07f4262a04a1563339c80b0b3899e10c91ae5725f67db494d775f'
 
   url "https://desktop.teamwire.eu/dist/#{version}/Teamwire-macos64_#{version}.dmg"
   name 'Teamwire'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.