### PR TITLE
Update mattermost from 4.4.1 to 4.4.2

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,6 +1,6 @@
 cask 'mattermost' do
-  version '4.4.1'
-  sha256 'd1b9f80f8c21ae4cdc5e52697ce49b3a7eedb33896ee2d9fdd5567b69bbff8e6'
+  version '4.4.2'
+  sha256 '90b70d659b39097fc49bb67fc323ec95b18c62229a6978c4b4f9a2328b6c8e84'
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
   appcast 'https://github.com/mattermost/desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.