### PR TITLE
Update cutbox from 1.4.8 to 1.4.10

### DIFF
--- a/Casks/cutbox.rb
+++ b/Casks/cutbox.rb
@@ -1,6 +1,6 @@
 cask 'cutbox' do
-  version '1.4.8'
-  sha256 '99d189593f421fb1a230de2dacede9140f13930d462a8e986ba8c42ff2978ecb'
+  version '1.4.10'
+  sha256 '2e13489d6de9cd5e13e53776c86460719047fb4db6ff822a19df75df9a6a23e9'
 
   url "https://github.com/cutbox/CutBox/releases/download/#{version}/CutBox.dmg"
   appcast 'https://github.com/cutbox/CutBox/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.