### PR TITLE
Update thedesk from 21.0.0 to 21.0.1

### DIFF
--- a/Casks/thedesk.rb
+++ b/Casks/thedesk.rb
@@ -1,6 +1,6 @@
 cask 'thedesk' do
-  version '21.0.0'
-  sha256 '6c29a124f010082f66c3717be67a74951f93015e12241ad299d77399fd52803e'
+  version '21.0.1'
+  sha256 'd20701fe9ad7a26dd062f3a6a592e4c68339a8119be908205962b76e6757b2e3'
 
   # github.com/cutls/TheDesk/ was verified as official when first introduced to the cask
   url "https://github.com/cutls/TheDesk/releases/download/v#{version}/TheDesk-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.