### PR TITLE
Update tableplus from 3.4.0,304 to 3.5.0,308

### DIFF
--- a/Casks/tableplus.rb
+++ b/Casks/tableplus.rb
@@ -1,6 +1,6 @@
 cask 'tableplus' do
-  version '3.4.0,304'
-  sha256 'a9a3c7464b2e4cec4c5a8deb3e6159a2d5447c38954aa17278a8e7a978ac7807'
+  version '3.5.0,308'
+  sha256 '3cbca4a55ad07bdf78ef9af7b390a3da23bf86b398e355d0261ea7d82c34d7da'
 
   # tableplus-osx-builds.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://tableplus-osx-builds.s3.amazonaws.com/#{version.after_comma}/TablePlus.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.