### PR TITLE
Update blocs from 3.4.9 to 3.4.10

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,6 +1,6 @@
 cask 'blocs' do
-  version '3.4.9'
-  sha256 'dcc8cbdebb063246190ede47d6ee770757b32fc8556042590accce3c432f6779'
+  version '3.4.10'
+  sha256 '23775539f9c78318065db2bcbfa00590835a2b9d746514eb26897f47d3d3d063'
 
   url "https://blocsapp.com/download/Blocs#{version.major}.zip"
   appcast 'https://blocsapp.com/release-notes.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.