### PR TITLE
Update wavebox from 10.0.148.1 to 10.0.158.1

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,6 +1,6 @@
 cask 'wavebox' do
-  version '10.0.148.1'
-  sha256 '269be18b3d238c8d7a14b3711ca9a3098644a7c120720e35783d49a36dd41fb5'
+  version '10.0.158.1'
+  sha256 '0ec011c75c290406a7fbeebdfe104b791e65b307dede51e67cf4c8210950bf13'
 
   # download.wavebox.app/ was verified as official when first introduced to the cask
   url "https://download.wavebox.app/core/mac/Install%20Wavebox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.