### PR TITLE
Update anydo from 4.2.83 to 2.4.84

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.83'
-  sha256 '36cd2d0bdcd4c3a714b77cf2e45e81283e7b9c4dc365e2ed38c8a61e8e2b58eb'
+  version '2.4.84'
+  sha256 'c9ed4199c6de5a19ff910619821e7d930e1ac26af2fabcfb012e1bde4bb7aa44'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.