### PR TITLE
Update psi-plus from 1.4.1147-macOS10.13 to 1.4.1209-macOS10.13

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.1147-macOS10.13'
-  sha256 '5b3ce37d4babb6d684169e71c5ba6a0a7c934b4746f388b64c1bc337ea103c36'
+  version '1.4.1209-macOS10.13'
+  sha256 '1cd69e575538f052d3183d816ff4f3c63fca42ffb76c0160bcdba14e51fb2fd4'
 
   # downloads.sourceforge.net/psiplus/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.