### PR TITLE
Update flash-ppapi from 32.0.0.363 to 32.0.0.371

### DIFF
--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-ppapi' do
-  version '32.0.0.363'
-  sha256 '439843742880498083eef38840859667940283155e909d256aad07910bb769eb'
+  version '32.0.0.371'
+  sha256 'cc6796eea07c403a658057d4ea3601a86ed193ac009a8f5de8c75c07f48c68d3'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.