### PR TITLE
Update loginputmac from 2.3.5 to 2.3.5_1

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,5 +1,5 @@
 cask 'loginputmac' do
-  version '2.3.5_1'
+  version '2.3.5'
   sha256 '91c5e011792f3ab2ee7f3e69ff7ea3a45c156f02b574cba2c57dbcfec82dd4a6'
 
   # loginput-mac2.content-delivery.top/ was verified as official when first introduced to the cask

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask 'loginputmac' do
-  version '2.3.5'
-  sha256 '7c6cdd1276f328b049666e9f3e27cca39c2524959ba72c7ffcfcead4bf67ab20'
+  version '2.3.5_1'
+  sha256 '91c5e011792f3ab2ee7f3e69ff7ea3a45c156f02b574cba2c57dbcfec82dd4a6'
 
   # loginput-mac2.content-delivery.top/ was verified as official when first introduced to the cask
   url "https://loginput-mac2.content-delivery.top/loginputmac#{version.major}_latest.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.