### PR TITLE
Update balenaetcher from 1.5.87 to 1.5.88

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,6 +1,6 @@
 cask 'balenaetcher' do
-  version '1.5.87'
-  sha256 '864e6e6b3db6bd889641ccbcd3e9ebcea215a54ecbc38d3cdaeaedade21a56c0'
+  version '1.5.88'
+  sha256 'e1a8357d076c11e3fb889c6fcba659f8aa9245f52d59e2a5b32398d111b53c91'
 
   # github.com/balena-io/etcher/ was verified as official when first introduced to the cask
   url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.