### PR TITLE
Update hstracker from 1.6.29 to 1.6.30

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.29'
-  sha256 '51c22a56aca450cc6de47587d272c9c9e6c693550fb2479eeb102de9e52bf8be'
+  version '1.6.30'
+  sha256 '73ec8da77feb6d7cbd22ce5b75262cf1056e24122e10aa86674f2c8dff0431ec'
 
   # github.com/HearthSim/HSTracker/ was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.