### PR TITLE
Update classroom-assistant from 1.0.5 to 2.0.0

### DIFF
--- a/Casks/classroom-assistant.rb
+++ b/Casks/classroom-assistant.rb
@@ -1,6 +1,6 @@
 cask 'classroom-assistant' do
-  version '1.0.5'
-  sha256 '78ec7624e3fc92f7e9d90d768cd8e6fbbc981ac187af7a36fb195d59e6feb62a'
+  version '2.0.0'
+  sha256 '9af87976ab74f131a3486329229ffdd40ecdb3ebff082cdc2c2fac08a22394c5'
 
   url "https://github.com/education/classroom-assistant/releases/download/v#{version}/Classroom.Assistant-darwin-x64-#{version}.zip"
   appcast 'https://github.com/education/classroom-assistant/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.