### PR TITLE
Update mycrypto from 1.7.9 to 1.7.10

### DIFF
--- a/Casks/mycrypto.rb
+++ b/Casks/mycrypto.rb
@@ -1,6 +1,6 @@
 cask 'mycrypto' do
-  version '1.7.9'
-  sha256 'b3fdba4dd5a9e17ec468970e30360bd993412b750a68d9580d95d515fff3e49a'
+  version '1.7.10'
+  sha256 '235918375040f575eb466f6761feab9ee8501ec2887fe866938d8d02ab1c2da8'
 
   # github.com/MyCryptoHQ/MyCrypto/ was verified as official when first introduced to the cask
   url "https://github.com/MyCryptoHQ/MyCrypto/releases/download/#{version}/mac_#{version}_MyCrypto.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.