### PR TITLE
Update openaudible from 2.0.6 to 2.0.7

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,6 +1,6 @@
 cask 'openaudible' do
-  version '2.0.6'
-  sha256 'bd61fcac52d077c5a53db6df576313a9cff50acbf52a95821233769b61c5b88f'
+  version '2.0.7'
+  sha256 '642b067614c120bdfc8378c0fd1b16f303ae508c988df72c807a87ac15550dd8'
 
   # github.com/openaudible/ was verified as official when first introduced to the cask
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.