### PR TITLE
Update pdfpen from 1201.3,1588210263 to 1202.4,1589250891

### DIFF
--- a/Casks/pdfpen.rb
+++ b/Casks/pdfpen.rb
@@ -1,6 +1,6 @@
 cask 'pdfpen' do
-  version '1201.3,1588210263'
-  sha256 'c8a33457165afd07f75fa1e9d714b7b9b43d802b8993efb0a88c8ec7e5c58971'
+  version '1202.4,1589250891'
+  sha256 '4b9eb4880c5625a76af874734cc8034b56f8cfe0415cb5e9d06ea307da0512e7'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpen/#{version.before_comma}/#{version.after_comma}/PDFpen-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpen.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.