### PR TITLE
Update pdfpenpro from 1201.3,1588210072 to 1202.4,1589250721

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,6 +1,6 @@
 cask 'pdfpenpro' do
-  version '1201.3,1588210072'
-  sha256 '08ad689ad4d210a1116ae9ba1beae8f8eccf014b3b6b57cf7426216e41afb238'
+  version '1202.4,1589250721'
+  sha256 '13f51f7c547b28019c024ea2491f097bbb4b0f4a4066cea38bd8c37427241a05'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.