### PR TITLE
Update arq from 6.2.11 to 6.2.16

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '6.2.11'
-  sha256 '116842dab5c794bf44e8d9c0010ecf0e9f1bad1cd2fcd2f1d0682816856c939d'
+  version '6.2.16'
+  sha256 '76ba8edd5ddbf9e2315f71bf7a58cf125e56a38d26ee35d79b72f880e929ed93'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"
   appcast "https://www.arqbackup.com/download/arqbackup/arq#{version.major}_release_notes.html"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.