### PR TITLE
Update yammer from 3.4.5 to 3.4.6

### DIFF
--- a/Casks/yammer.rb
+++ b/Casks/yammer.rb
@@ -1,6 +1,6 @@
 cask 'yammer' do
-  version '3.4.5'
-  sha256 'd26bdb80f1f054494b8fa271df6008d86be526b734cc997264062f9a6ca2165c'
+  version '3.4.6'
+  sha256 '6262e7e485862adacff57518da1c7bda129cc77515d15c9ce7980cfc7f033eae'
 
   # yammerdesktopapp.blob.core.windows.net/binaries/dist/ was verified as official when first introduced to the cask
   url "https://yammerdesktopapp.blob.core.windows.net/binaries/dist/darwin/x64/#{version}/Yammer-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.