### PR TITLE
Update nvidia-geforce-now from 2.0.19.72,0586BA to 2.0.19.78,F3C0AE

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.19.72,0586BA'
-  sha256 '741b864a15adeea10b05380366f49f07d1936a47ecbe536a68b24550074ebe7c'
+  version '2.0.19.78,F3C0AE'
+  sha256 'c540be6e68648d7a20b922fa6656435f184a684e7216195eacc54d8218338105'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.