### PR TITLE
Update fontlab from 7.1.1.7383 to 7.1.2.7432

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,6 +1,6 @@
 cask 'fontlab' do
-  version '7.1.1.7383'
-  sha256 '4c22cafad1e9d3575d0eb354aa615c24053617fcac3b14cbda535c3b15664776'
+  version '7.1.2.7432'
+  sha256 '95c0a72b0094f337e2bb540d1aee75d6d4320a25d28bbefe36c637292b608ab1'
 
   # fontlab.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://fontlab.s3.amazonaws.com/fontlab-#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.