### PR TITLE
Update turbovnc-viewer from 2.2.4 to 2.2.5

### DIFF
--- a/Casks/turbovnc-viewer.rb
+++ b/Casks/turbovnc-viewer.rb
@@ -1,6 +1,6 @@
 cask 'turbovnc-viewer' do
-  version '2.2.4'
-  sha256 '84e7dc130f4500d8dff327cad7831fccdf7933fd308329f9a4e5f2fc9f0533e4'
+  version '2.2.5'
+  sha256 '912277534d5df0e648c19b27e9c3a23380a71a9d6ad5cef2fb87f3e65a77185a'
 
   # sourceforge.net/turbovnc/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/turbovnc/#{version}/TurboVNC-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.