### PR TITLE
Update cacher from 2.27.1 to 2.27.2

### DIFF
--- a/Casks/cacher.rb
+++ b/Casks/cacher.rb
@@ -1,6 +1,6 @@
 cask 'cacher' do
-  version '2.27.1'
-  sha256 '8b178a779d385f5dbc987982736448616536a2d575cec4fe977b304d36312e16'
+  version '2.27.2'
+  sha256 '7381aa594f225c2148d9d8c4799731a66e2c8af5d06ec176d89c1ec61d9efea7'
 
   # cacher-download.nyc3.digitaloceanspaces.com/ was verified as official when first introduced to the cask
   url "https://cacher-download.nyc3.digitaloceanspaces.com/Cacher-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.