### PR TITLE
Update microsoft-outlook from 16.36.20041300 to 16.37.20051002

### DIFF
--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-outlook' do
-  version '16.36.20041300'
-  sha256 '285aade67991dc10d7f5fe183ad751f414ff14afa5eb45b1343771f0f6900080'
+  version '16.37.20051002'
+  sha256 '21d9ef144fd964a6972ff4dd81b2cd47c768f365dc249d1604755c2c03b182ca'
 
   # officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/ was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.