### PR TITLE
Update alt-tab from 3.23.0 to 3.23.1

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask 'alt-tab' do
-  version '3.23.0'
-  sha256 'a58d7dddd1b298aec545a07bb7650ab484a8f5cffcf8befa7ef129ac46515bba'
+  version '3.23.1'
+  sha256 '72db485e12a93bd354799d5854f3c68220009587c504f4dbf8fd982953ccfce3'
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast 'https://github.com/lwouis/alt-tab-macos/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.