### PR TITLE
Update classroom-assistant from 2.0.0 to 2.0.1

### DIFF
--- a/Casks/classroom-assistant.rb
+++ b/Casks/classroom-assistant.rb
@@ -1,6 +1,6 @@
 cask 'classroom-assistant' do
-  version '2.0.0'
-  sha256 '9af87976ab74f131a3486329229ffdd40ecdb3ebff082cdc2c2fac08a22394c5'
+  version '2.0.1'
+  sha256 'b3e13813d5895cb115a44714d24a0a279efc7c6e04b59922de3dd3cd7bfeeac2'
 
   url "https://github.com/education/classroom-assistant/releases/download/v#{version}/Classroom.Assistant-darwin-x64-#{version}.zip"
   appcast 'https://github.com/education/classroom-assistant/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.