### PR TITLE
Update icq url to include version and auto_updates

### DIFF
--- a/Casks/icq.rb
+++ b/Casks/icq.rb
@@ -2,11 +2,13 @@ cask 'icq' do
   version '3.0.27060'
   sha256 '54f277c93995f1c4ba70b524c040d8cc0539fe63c9e18787dddd2d768f57e1fc'
 
-  # hb.bizmrg.com/icq-www/ was verified as official when first introduced to the cask
-  url 'https://hb.bizmrg.com/icq-www/mac/x64/icq.dmg'
+  # icq-www.hb.bizmrg.com was verified as official when first introduced to the cask
+  url "https://icq-www.hb.bizmrg.com/mac/x64/#{version}/icq.dmg"
   appcast "https://icq-www.hb.bizmrg.com/mac/x64/#{version}/version.xml"
   name 'ICQ'
-  homepage 'https://icq.com/mac/en'
+  homepage 'https://icq.com/desktop'
+
+  auto_updates true
 
   app 'ICQ.app'
 


### PR DESCRIPTION
ICQ uses Sparkle framework with auto-updates (it updates itself, doesn't just open webpage to download new version).
Also, URL in cask linked to latest stable version instead of cask version, so on when ICQ releases an update sha mismatch errors would occur.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

