### PR TITLE
Update mono-mdk from 6.8.0.105 to 6.8.0.123

### DIFF
--- a/Casks/mono-mdk.rb
+++ b/Casks/mono-mdk.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk' do
-  version '6.8.0.105'
-  sha256 'a585985ef908fe0ee4329255f761ff608824296219d2be44e3aca664fc988637'
+  version '6.8.0.123'
+  sha256 '93b7a3ec17d1d1f888f1c1c824a4b8529fb8d8da13df81daedba445222cc9f8e'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://www.mono-project.com/download/stable/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.