### PR TITLE
Update timecamp from 1.4.6.2 to 1.5.4.1

### DIFF
--- a/Casks/timecamp.rb
+++ b/Casks/timecamp.rb
@@ -1,6 +1,6 @@
 cask 'timecamp' do
-  version '1.4.6.2'
-  sha256 '74dee429fabfcdd3f6a9d0d755bbe1ca056433392d73f4b64e14182fdfb70c0c'
+  version '1.5.4.1'
+  sha256 'b4ae19f187fadec3ca58975baec55364ca01622ac77b2e57a29f95a68724eb5b'
 
   # timecamp.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://timecamp.s3.amazonaws.com/downloadsoft/#{version}/TimeCampSetup_macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.