### PR TITLE
Update kext-updater from 3.4.6 to 3.4.7

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,8 +1,9 @@
 cask 'kext-updater' do
-  version '3.4.6'
-  sha256 '959ac756ecd13d694f35e195a5b0853187a6678d793a73fd82031e1d059ddc47'
+  version '3.4.7'
+  sha256 '733a7751788a3a05ab8bcb8835c0fb56457b4982d79fb1c9b62d696930a25e0d'
 
-  url 'https://update.kextupdater.de/kextupdater/kextupdaterng.zip'
+  # bitbucket.org/profdrluigi/kextupdater was verified as official when first introduced to the cask
+  url "https://bitbucket.org/profdrluigi/kextupdater/downloads/Kext_Updater_#{version}.zip"
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'
   name 'Kext Updater'
   homepage 'https://kextupdater.de/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.