### PR TITLE
Update ha-menu from 2.2.0 to 2.2.1

### DIFF
--- a/Casks/ha-menu.rb
+++ b/Casks/ha-menu.rb
@@ -1,6 +1,6 @@
 cask 'ha-menu' do
-  version '2.2.0'
-  sha256 '4f21987a13f4de87fd8b738027b182ea29b2d02747b5bc610250ce3ae973978a'
+  version '2.2.1'
+  sha256 'f82a100f4c1a69984ddcc3f86e033b1c12fb5ba4defe94a8ae26b5be0f5e8a4b'
 
   # github.com/codechimp-org/ha-menu/ was verified as official when first introduced to the cask
   url "https://github.com/codechimp-org/ha-menu/releases/download/#{version}/HA.Menu.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.