### PR TITLE
Update pomotroid from 0.7.1 to 0.8.0

### DIFF
--- a/Casks/pomotroid.rb
+++ b/Casks/pomotroid.rb
@@ -1,6 +1,6 @@
 cask 'pomotroid' do
-  version '0.7.1'
-  sha256 '4cb6e9092299b726133971601cff969ba0958e198372ecc4a13c85b40f32edcb'
+  version '0.8.0'
+  sha256 '502c177b3d2820001cad64de5dcbf9f7af4cd9206670ee6298abd0820e93c538'
 
   url "https://github.com/Splode/pomotroid/releases/download/v#{version}/pomotroid-#{version}-macos.dmg"
   appcast 'https://github.com/Splode/pomotroid/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.