### PR TITLE
Update flipper from 0.41.0 to 0.42.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.41.0'
-  sha256 '5671e995c808fec6335709017e8f9f60e1d29af6d91a7d50cbef738107aac349'
+  version '0.42.0'
+  sha256 '3db7d206b4b7d02695cceebf3f1acccbf3eb2d099edd0374abfafffa6c15a021'
 
   # github.com/facebook/flipper/ was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.