### PR TITLE
Update katalon-studio from 7.4.6 to 7.5.0

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.4.6'
-  sha256 'fbf172e3451a9cf256a3587b9a8c581db3f40d8b8d90c93884bd4cb2e27d242b'
+  version '7.5.0'
+  sha256 '2c9c34507e4631ef9648bcd9fa5b79d1e86f765c67db243b0cc86a61a7c62910'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.