### PR TITLE
Update schism-tracker from 20190805 to 20200412

### DIFF
--- a/Casks/schism-tracker.rb
+++ b/Casks/schism-tracker.rb
@@ -1,6 +1,6 @@
 cask 'schism-tracker' do
-  version '20190805'
-  sha256 'e33fa9be548245e300c1e1b2da3e42eb10834462bc58abae1a3edc16333fe92c'
+  version '20200412'
+  sha256 '0f43b52949d60787eecc4fd5679f01694f114c17f6ee05a20d49ac995bfa6445'
 
   url "https://github.com/schismtracker/schismtracker/releases/download/#{version}/schismtracker-#{version}-osx.tar.gz"
   appcast 'https://github.com/schismtracker/schismtracker/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.