### PR TITLE
Update electerm from 1.3.21 to 1.3.28

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.21'
-  sha256 '3a53a8075abb93cb66c876c5c0b2506fe75a90366e2110a61b25f0aed581d933'
+  version '1.3.28'
+  sha256 'd8f5d5d22e1f0a74ea5a85b6ae98a1237546cb41e9bbe74b4574bb15d1e8170c'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.