### PR TITLE
Update path-finder from 9.2 to 9.3

### DIFF
--- a/Casks/path-finder.rb
+++ b/Casks/path-finder.rb
@@ -1,6 +1,6 @@
 cask 'path-finder' do
-  version '9.2'
-  sha256 '52377e15877656fae5b3ba0685204be39cdf3c257324618fcd1267f7ebb9cc8b'
+  version '9.3'
+  sha256 'ef0fb9d17b709a725d37d8a58bcd03a1971fdecc726fbadf601544b357e9bab2'
 
   url "https://get.cocoatech.com/PF#{version.major}.dmg"
   appcast 'https://get.cocoatech.com/releasecast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.