### PR TITLE
Update proclaim from 2.12.0.0038 to 2.12.0.0040

### DIFF
--- a/Casks/proclaim.rb
+++ b/Casks/proclaim.rb
@@ -1,6 +1,6 @@
 cask 'proclaim' do
-  version '2.12.0.0038'
-  sha256 'c182891d4f68fae54b3cdfb953848e733294ba466f7004b9df1f3857589e4998'
+  version '2.12.0.0040'
+  sha256 '9896ab9a6498b9d20cd56f2e11bbc9f44cc41dc021ecf356354d28d83cf9472a'
 
   # logoscdn.com/Proclaim/ was verified as official when first introduced to the cask
   url "https://downloads.logoscdn.com/Proclaim/Installer/#{version}/Proclaim.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.