### PR TITLE
Update yate from 5.1.3 to 5.1.3.1

### DIFF
--- a/Casks/yate.rb
+++ b/Casks/yate.rb
@@ -1,6 +1,6 @@
 cask 'yate' do
-  version '5.1.3'
-  sha256 'b436eee807b6cfa47216de5834a135d9a1818614a43fe2a770df0b90353b5a9e'
+  version '5.1.3.1'
+  sha256 '57c2f9e33a83bb6b3685b4c9bbe70058374774ce489b23a10310dc787dce616a'
 
   url 'https://2manyrobots.com/Updates/Yate/Yate.zip'
   appcast 'https://2manyrobots.com/Updates/Yate/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.