### PR TITLE
Update rowmote-helper from 4.2 to 4.2.2

### DIFF
--- a/Casks/rowmote-helper.rb
+++ b/Casks/rowmote-helper.rb
@@ -1,6 +1,6 @@
 cask 'rowmote-helper' do
-  version '4.2'
-  sha256 'a3dba1835b34abf08a33f4c02c875cf4ef181b534615a25021b024a4cdda568f'
+  version '4.2.2'
+  sha256 '705223df2b4a655a1d414a369e1d68176617a4a2819a4d6faa615ff7cef040b1'
 
   url "https://regularrateandrhythm.com/rowmote-pro/rh/rowmote-helper-#{version}.zip"
   appcast 'https://www.regularrateandrhythm.com/apps/rowmote-pro/rowmote-appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.