### PR TITLE
Update vitamin-r from 3.15 to 3.16

### DIFF
--- a/Casks/vitamin-r.rb
+++ b/Casks/vitamin-r.rb
@@ -3,8 +3,8 @@ cask 'vitamin-r' do
     version '2.58'
     sha256 'c6c631430b44359aa022d9ca5ca6e98dbdf7258f2ceae0353f344a035682661e'
   else
-    version '3.15'
-    sha256 'd194732284f22982b53e1f26d57a5706fd1fcccda9a6fd892d74760c65b1a13a'
+    version '3.16'
+    sha256 '261cf2a9c92597dc2a87ce91868de60bf5e44c25e73bb1ed6bb98fc563c97125'
   end
 
   url "https://www.publicspace.net/download/signedVitamin#{version.major}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.