### PR TITLE
Update juicebar from 1.0.61 to 1.0.62

### DIFF
--- a/Casks/juicebar.rb
+++ b/Casks/juicebar.rb
@@ -1,6 +1,6 @@
 cask 'juicebar' do
-  version '1.0.61'
-  sha256 '2eb8e3a184acd86982f620db08b8c304046b6e0941cdaf3666fc776b03e94a2f'
+  version '1.0.62'
+  sha256 '3bac0d3df6cd68bf29813b4e2abf7cc730a106998ddd45071d386d773c1b56ed'
 
   url "https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.