### PR TITLE
Update nosql-workbench-for-amazon-dynamodb from 1.0.0 to 1.1.0

### DIFF
--- a/Casks/nosql-workbench-for-amazon-dynamodb.rb
+++ b/Casks/nosql-workbench-for-amazon-dynamodb.rb
@@ -1,6 +1,6 @@
 cask 'nosql-workbench-for-amazon-dynamodb' do
-  version '1.0.0'
-  sha256 'aee4e9daa7925f01385490678e0d852719fa3b845a7522dc0a98fceba61c8043'
+  version '1.1.0'
+  sha256 '5b3a3862feeece47ea798111c33dc9c63da94309c6425a8d45b4d3d286fd683f'
 
   # nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://nosql-workbench-for-amazon-dynamodb.s3.amazonaws.com/NoSQL+Workbench+for+Amazon+DynamoDB-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.