### PR TITLE
Update zoho-mail from 1.1.7 to 1.1.9

### DIFF
--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -1,6 +1,6 @@
 cask 'zoho-mail' do
-  version '1.1.7'
-  sha256 'ad47481a7b2d699c3143299c32e77b44f938c5ae0f8d68c856c339ac54f1fdc1'
+  version '1.1.9'
+  sha256 'abcab0c3711cdf108286631836b11f0921fa63901f742400992ba6d41264bad0'
 
   # downloads.zohocdn.com/zmail-desktop/mac/ was verified as official when first introduced to the cask
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.