### PR TITLE
Update sqlpro-for-mysql from 2020.08 to 2020.44

### DIFF
--- a/Casks/sqlpro-for-mysql.rb
+++ b/Casks/sqlpro-for-mysql.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-mysql' do
-  version '2020.08'
-  sha256 '3ba64e00d07c137a53eb35db6f95e02278130bef7415ca79d3586e31ba2b5c0b'
+  version '2020.44'
+  sha256 'cd111f96d61173d53b0220fd4d79c94d0b10247b83268fad9e1bec7d5cb22865'
 
   # d3fwkemdw8spx3.cloudfront.net/mysql/ was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mysql/SQLProMySQL.#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.