### PR TITLE
Update catlight from 2.30.0 to 2.31.0

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,6 +1,6 @@
 cask 'catlight' do
-  version '2.30.0'
-  sha256 '7a514b392b2d1e4c12717c5a981eb5e8a10ae53acb29b74a4d5a43f3318b4065'
+  version '2.31.0'
+  sha256 'd06c54aed7e0c10f51245a039c64cb26e5006db8b8b0e8bb0a588384bdf04c5e'
 
   # de2nac35bcll0.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://de2nac35bcll0.cloudfront.net/dl/mac/beta/CatLightSetup-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.