### PR TITLE
Update airtame from 4.0.0 to 4.0.1

### DIFF
--- a/Casks/airtame.rb
+++ b/Casks/airtame.rb
@@ -1,6 +1,6 @@
 cask 'airtame' do
-  version '4.0.0'
-  sha256 '90d315fbacca451e88171bce3156ac6859b2078bcb7846e6af1b0c91c994be0e'
+  version '4.0.1'
+  sha256 '159e7ccbebbe9028256422ac7e33b27b0daf45876be0a11c87393aae2d3c87a6'
 
   url "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://downloads-cdn.airtame.com/get.php?platform=osx_x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.