### PR TITLE
Update mongodb-compass-readonly from 1.21.1 to 1.21.2

### DIFF
--- a/Casks/mongodb-compass-readonly.rb
+++ b/Casks/mongodb-compass-readonly.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-readonly' do
-  version '1.21.1'
-  sha256 '3b3d09f91d2c8f553a2e747cb288ba35a9fbbab52886529acf277035a10b62fe'
+  version '1.21.2'
+  sha256 '404162d4be0a17c49ca6c43f1875e3b43b31ea8001359962fbb09078a8cb61f8'
 
   url "https://downloads.mongodb.com/compass/mongodb-compass-readonly-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.