### PR TITLE
Update tuxguitar from 1.5.3 to 1.5.4

### DIFF
--- a/Casks/tuxguitar.rb
+++ b/Casks/tuxguitar.rb
@@ -1,6 +1,6 @@
 cask 'tuxguitar' do
-  version '1.5.3'
-  sha256 '806f16487fa6f8329db53698d588662fcb208fc4e8fdf4c7d04e2d724e7b9870'
+  version '1.5.4'
+  sha256 'af2d3bee09057c9716eaf4a13d11898945f0431a3c84739a51a39cea49497f6e'
 
   url "https://downloads.sourceforge.net/tuxguitar/tuxguitar-#{version}-macosx-cocoa-64.app.tar.gz"
   appcast 'https://sourceforge.net/projects/tuxguitar/rss?path=/TuxGuitar'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.