### PR TITLE
Update zappy from 2.3.1 to 2.4.0

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,6 +1,6 @@
 cask 'zappy' do
-  version '2.3.1'
-  sha256 '8d08341c337781236c428fb546dc719fb9cd0a91a12f10dd88ce35f8e966388f'
+  version '2.4.0'
+  sha256 '41ceeb3bb893585b4e75021ad774640af8618565079c333acb392c520d18865c'
 
   url "https://zappy.zapier.com/releases/zappy-#{version}.zip"
   appcast 'https://zappy.zapier.com/releases/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.