### PR TITLE
Update unity-android-support-for-editor from 2019.3.12f1,84b23722532d to 2019.3.13f1,d4ddf0d95db9

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.12f1,84b23722532d'
-  sha256 'c1620b8d1437729caf3bdc27b8af1612e592f2156786bf0b6bcede970f377d04'
+  version '2019.3.13f1,d4ddf0d95db9'
+  sha256 '7a7cb009ff8332142dfaac636354997df5695be91bac28ebfe7cf5c946574c3d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.