### PR TITLE
Add nomachine-enterprise-client v6.10.12_8

### DIFF
--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -1,0 +1,17 @@
+cask 'nomachine-enterprise-client' do
+  version '6.10.12_8'
+  sha256 '1cc40bccd4b86f789177d213f9a7be4fb19a48d794f56885064176ad58f7f21e'
+
+  url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine-enterprise-client_#{version}.dmg"
+  appcast 'https://www.nomachine.com/download/download&id=15'
+  name 'NoMachine Enterprise Client'
+  homepage 'https://www.nomachine.com/'
+
+  pkg 'NoMachine.pkg'
+
+  # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
+  uninstall delete:  '/Applications/NoMachine.app',
+            pkgutil: 'com.nomachine.nomachine.NoMachine*.pkg'
+
+  zap trash: '~/Library/Preferences/com.nomachine.nxdock.plist'
+end

--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -10,8 +10,9 @@ cask 'nomachine-enterprise-client' do
   pkg 'NoMachine.pkg'
 
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
-  uninstall delete:  '/Applications/NoMachine.app',
-            pkgutil: 'com.nomachine.nomachine.NoMachine*.pkg'
+  uninstall delete:    '/Applications/NoMachine.app',
+            pkgutil:   'com.nomachine.nomachine.NoMachine*.pkg',
+            launchctl: 'com.nomachine.uninstall'
 
   zap trash: '~/Library/Preferences/com.nomachine.nxdock.plist'
 end

--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -16,6 +16,4 @@ cask 'nomachine-enterprise-client' do
                          'com.nomachine.uninstall',
                          'com.nomachine.nxlaunchconf',
                        ]
-
-  zap trash: '~/Library/Preferences/com.nomachine.nxdock.plist'
 end

--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -12,7 +12,10 @@ cask 'nomachine-enterprise-client' do
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
   uninstall delete:    '/Applications/NoMachine.app',
             pkgutil:   'com.nomachine.nomachine.NoMachine*.pkg',
-            launchctl: 'com.nomachine.uninstall'
+            launchctl: [
+                         'com.nomachine.uninstall',
+                         'com.nomachine.nxlaunchconf',
+                       ]
 
   zap trash: '~/Library/Preferences/com.nomachine.nxdock.plist'
 end

--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -9,6 +9,7 @@ cask 'nomachine-enterprise-client' do
 
   pkg 'NoMachine.pkg'
 
+  # A launchctl job ordinarily manages uninstall once the app bundle is removed
   # To ensure it ran, verify if /Library/Application Support/NoMachine/nxuninstall.sh no longer exists
   uninstall delete:    '/Applications/NoMachine.app',
             pkgutil:   'com.nomachine.nomachine.NoMachine*.pkg',


### PR DESCRIPTION
In comparison to the default NoMachine application this cask only installs the client software without the server part.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download nomachine-enterprise-client` is error-free.
- [x] `brew cask style --fix nomachine-enterprise-client` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install nomachine-enterprise-client` worked successfully.
- [x] `brew cask uninstall nomachine-enterprise-client` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
