### PR TITLE
Update unity-webgl-support-for-editor from 2019.3.12f1,84b23722532d to 2019.3.13f1,d4ddf0d95db9

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.3.12f1,84b23722532d'
-  sha256 '868f13d2e6b311e0e664c29184c07843d306bf9b471484d0227b35fdb06e0ad7'
+  version '2019.3.13f1,d4ddf0d95db9'
+  sha256 '2fc47df3f0bcc13513079d2d1e5f823f166b59a901515e19cba00ae3c6e21694'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.