### PR TITLE
Update vivi from 2.18.4 to 2.19.0

### DIFF
--- a/Casks/vivi.rb
+++ b/Casks/vivi.rb
@@ -1,6 +1,6 @@
 cask 'vivi' do
-  version '2.18.4'
-  sha256 '3a1c34e2bf120c32d4b7f5e4bec40e47ec06cebb7126bcdd11746f42cbf60a93'
+  version '2.19.0'
+  sha256 '1c5570600243fa9e91735f42a33e686e0f6bfb5fe7c441f9a4eaea90b04f31fa'
 
   url "https://downloads.vivi.io/app/#{version}/Vivi.pkg"
   name 'Vivi'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.