### PR TITLE
Update jamf-migrator from 5.2.3 to 5.2.5

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask 'jamf-migrator' do
-  version '5.2.3'
-  sha256 '0c5d532cadc609bbffea6f857b0729f50d81bc2abb1b4e7ce644009bbbe40fb5'
+  version '5.2.5'
+  sha256 '4d7fe507e11e2b428425e59d7c336853e61fe60842dac98a13065bcf71d6d7d1'
 
   url 'https://github.com/jamf/JamfMigrator/releases/download/current/jamf-migrator.zip'
   appcast 'https://github.com/jamf/JamfMigrator/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.