### PR TITLE
Update vv from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/vv.rb
+++ b/Casks/vv.rb
@@ -1,6 +1,6 @@
 cask 'vv' do
-  version '2.2.1'
-  sha256 'be2c837b078ac2199f1c2a4862a94ed4f71aacdf0012ee784907a650abe88972'
+  version '2.2.2'
+  sha256 'e30e8481930809ae5ac18f69c88d39a3b516bc1b3054ed06d55cd754fed31677'
 
   url "https://github.com/vv-vim/vv/releases/download/v#{version}/VV-#{version}.dmg"
   appcast 'https://github.com/vv-vim/vv/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.