### PR TITLE
Update kite from 0.20200512.1 to 0.20200513.0

### DIFF
--- a/Casks/kite.rb
+++ b/Casks/kite.rb
@@ -1,6 +1,6 @@
 cask 'kite' do
-  version '0.20200512.1'
-  sha256 '66fbb7de0908917752014fbc82504c3bee8c779b03ee0c776f272620a12e87f9'
+  version '0.20200513.0'
+  sha256 'fab0f9591a2f9dd530881aab48f33054f276223d19c66e2044831e7c9eed38d2'
 
   # draqv87tt43s0.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://draqv87tt43s0.cloudfront.net/mac/#{version}/Kite.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.