### PR TITLE
Update splashtop-streamer from 3.3.6.0 to 3.3.8.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-streamer' do
-  version '3.3.6.0'
-  sha256 'a1028216e88edd1ea34a35cdf0213451250f9fc994bba4df4e153a90afe48bdc'
+  version '3.3.8.0'
+  sha256 '37e9c3bc2ea19f078b010e2c0c2dd897981dd649cbbd0d55a39c6f3de36ebae5'
 
   # d17kmd0va0f0mp.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.