### PR TITLE
Update kext-updater from 3.4.7 to 3.4.8

### DIFF
--- a/Casks/kext-updater.rb
+++ b/Casks/kext-updater.rb
@@ -1,6 +1,6 @@
 cask 'kext-updater' do
-  version '3.4.7'
-  sha256 '733a7751788a3a05ab8bcb8835c0fb56457b4982d79fb1c9b62d696930a25e0d'
+  version '3.4.8'
+  sha256 'aee1f48c4955016d4041c7dcc4d1f72f6cd1e021229345da198807159e13ea32'
 
   url 'https://update.kextupdater.de/kextupdater/kextupdaterng.zip'
   appcast 'https://update.kextupdater.de/kextupdater/appcastng.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.