### PR TITLE
Update aircall from 2.4.4 to 2.4.7

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,6 +1,6 @@
 cask 'aircall' do
-  version '2.4.4'
-  sha256 'd4396268dda9645c3804a7b876087a37e4025821f5caee938766e6469cc94324'
+  version '2.4.7'
+  sha256 '5063958d9b84036997218821b5a8d54c974c963faa2d07d5a2e14a1f4dcee93c'
 
   # aircall-electron-releases.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://aircall-electron-releases.s3.amazonaws.com/production/Aircall-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.