### PR TITLE
Update popo from 3.3.6 to 3.3.7

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask 'popo' do
-  version '3.3.6'
-  sha256 '87f91d1bd230fa2b34ae08856688b4b8a1230f9550963e729ab5306f2e76f456'
+  version '3.3.7'
+  sha256 '659f48e919a0b307f0aecff7ba712ca7637fb9b4823700330aadc56ab92505a1'
 
   url "http://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   appcast 'http://popo.netease.com/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.