### PR TITLE
Update qownnotes from 20.5.8,b5618-154723 to 20.5.9,b5623-170206

### DIFF
--- a/Casks/qownnotes.rb
+++ b/Casks/qownnotes.rb
@@ -1,6 +1,6 @@
 cask 'qownnotes' do
-  version '20.5.8,b5618-154723'
-  sha256 'd66652ce37b8557a37dee34c6710cbe24feba43e91aba21afaf18c31f9d6fa7c'
+  version '20.5.9,b5623-170206'
+  sha256 '18310926b5a705414dbe1cdafd5eb0b8b0051b2d09549bcc8ccb7ca4355a97a4'
 
   # github.com/pbek/QOwnNotes/ was verified as official when first introduced to the cask
   url "https://github.com/pbek/QOwnNotes/releases/download/macosx-#{version.after_comma}/QOwnNotes-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.