### PR TITLE
update sencha cmd to 7.2.0.66 required to build latest ExtJS 7.2.0

### DIFF
--- a/Casks/sencha.rb
+++ b/Casks/sencha.rb
@@ -1,6 +1,6 @@
 cask 'sencha' do
-  version '6.7.0.63'
-  sha256 '3e888afb613223a7584376fc63c68f06eb6010a996eca82ee7a2e0d78b6658f3'
+  version '7.2.0.66'
+  sha256 'e93272a168b7afcd64eaa373d93e9d356b2cf03bd19b56b6a976a3c816ef5614'
 
   url "https://cdn.sencha.com/cmd/#{version}/jre/SenchaCmd-#{version}-osx.app.zip"
   name 'Sencha Cmd'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).