### PR TITLE
Use vendor provided shim for p4merge

### DIFF
--- a/Casks/p4v.rb
+++ b/Casks/p4v.rb
@@ -24,7 +24,11 @@ cask 'p4v' do
       #!/bin/bash
       set -euo pipefail
       COMMAND=$(basename "$0")
-      exec "#{appdir}/${COMMAND}.app/Contents/MacOS/${COMMAND}" "$@" 2> /dev/null
+      if [[ "$COMMAND" == "p4merge" ]]; then
+        exec "#{appdir}/${COMMAND}.app/Contents/Resources/launch${COMMAND}" "$@" 2> /dev/null
+      else
+        exec "#{appdir}/${COMMAND}.app/Contents/MacOS/${COMMAND}" "$@" 2> /dev/null
+      fi
     EOS
   end
 


### PR DESCRIPTION
P4Merge comes with a vendor provided shim that interacts with the main P4Merge
application and that terminates when the window is closed. This helps e.g.
merging several files in a row when P4Merge is launched from a SCM tool like
Git

See https://community.perforce.com/s/article/2848

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
  → It doesn't as it doesn't update the app per se, just fixes the shim provided by Homebrew 
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
