### PR TITLE
Update backuploupe from 3.0 to 3.0.1

### DIFF
--- a/Casks/backuploupe.rb
+++ b/Casks/backuploupe.rb
@@ -1,6 +1,6 @@
 cask 'backuploupe' do
-  version '3.0'
-  sha256 '128d2e74227784063bdf64b1bfe62476dcd0a8154cf0bd121547c86d92773eb8'
+  version '3.0.1'
+  sha256 '674247a93782b4ad22ccfeb32ebaf48a1d0cd50152a632248a21a131ca192f26'
 
   url "https://www.soma-zone.com/download/files/BackupLoupe-#{version}.tar.bz2"
   appcast "https://www.soma-zone.com/BackupLoupe/a/appcast-update-#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.