### PR TITLE
Update motrix from 1.4.1 to 1.5.10

### DIFF
--- a/Casks/motrix.rb
+++ b/Casks/motrix.rb
@@ -1,6 +1,6 @@
 cask 'motrix' do
-  version '1.4.1'
-  sha256 'e2250db04b7dcb93fb5fde90ea82fee2cfd6c621c6253cd7535a2630b9a5632c'
+  version '1.5.10'
+  sha256 '14a52d68ace85c6c644c5d7406b0c5ec9acd13cd75bc714ad975c0832ac6f9cc'
 
   # github.com/ was verified as official when first introduced to the cask
   url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.