### PR TITLE
Update thebrain from 10.0.66.0 to 11.0.80.0

### DIFF
--- a/Casks/thebrain.rb
+++ b/Casks/thebrain.rb
@@ -1,9 +1,9 @@
 cask 'thebrain' do
-  version '10.0.66.0'
-  sha256 '2a9a7b6f08a2694e2ee94e4dd7217a4aaf7b53042557fd77b6b304909f3d1383'
+  version '11.0.80.0'
+  sha256 '4944417d06c264676718e82d698affe8396045015a4dd915c4f439e7ac86f5ed'
 
   url "https://updater.thebrain.com/files/TheBrain#{version}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=10000'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://salesapi.thebrain.com/?a=doDirectDownload%26id=11000'
   name 'TheBrain'
   homepage 'https://www.thebrain.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.