### PR TITLE
Update jalbum from 20.0.0 to 20.1.0

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,5 +1,5 @@
 cask 'jalbum' do
-  version '20.0.0'
+  version '20.1.0'
   sha256 '115e3ab0d02564a9a59f25d25a16cfebd2344e2e71843d558575685a10a376c3'
 
   url "https://download.jalbum.net/download/#{version.major}/MacOSX/jAlbum.dmg"

--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -2,7 +2,7 @@ cask 'jalbum' do
   version '20.1.0'
   sha256 '643a96cc60b8d6b9497283270a6230c1602eb1e574e6a2aa4d7a95293be84ecd'
 
-  url "https://download.jalbum.net/download/#{version.major.minor}/MacOSX/jAlbum.dmg"
+  url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',
           configuration: version.major_minor.chomp('.0')
   name 'jAlbum'

--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,8 +1,8 @@
 cask 'jalbum' do
   version '20.1.0'
-  sha256 '115e3ab0d02564a9a59f25d25a16cfebd2344e2e71843d558575685a10a376c3'
+  sha256 '643a96cc60b8d6b9497283270a6230c1602eb1e574e6a2aa4d7a95293be84ecd'
 
-  url "https://download.jalbum.net/download/#{version.major}/MacOSX/jAlbum.dmg"
+  url "https://download.jalbum.net/download/#{version.major.minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',
           configuration: version.major_minor.chomp('.0')
   name 'jAlbum'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.