### PR TITLE
Update epichrome from 2.3.0 to 2.3.1

### DIFF
--- a/Casks/epichrome.rb
+++ b/Casks/epichrome.rb
@@ -1,6 +1,6 @@
 cask 'epichrome' do
-  version '2.3.0'
-  sha256 'a1967f9cb554893a2745cb14a4853106341891d4a40c4b97f58cc3d544dc90f1'
+  version '2.3.1'
+  sha256 '3d8a582b44e3a67497281d11c109f6fa7b4a5cdf9f5433a8a90762f9a4ebbdf3'
 
   url "https://github.com/dmarmor/epichrome/releases/download/v#{version}/epichrome-#{version}.pkg"
   appcast 'https://github.com/dmarmor/epichrome/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.