### PR TITLE
Update wickrme from 5.53.6 to 5.54.11

### DIFF
--- a/Casks/wickrme.rb
+++ b/Casks/wickrme.rb
@@ -1,6 +1,6 @@
 cask 'wickrme' do
-  version '5.53.6'
-  sha256 'b71528827fbfa25d13f1f8006ac13fbdb5e191849ab4c794d1debf1bad9f9e18'
+  version '5.54.11'
+  sha256 '6444441d7b61418b63c3cebc2af5a23933cdf4929c799722cb152b22c2375b50'
 
   # s3.amazonaws.com/static.wickr.com/ was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/static.wickr.com/downloads/mac/me/WickrMe-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.