### PR TITLE
Update postbox from 7.0.15 to 7.0.16

### DIFF
--- a/Casks/postbox.rb
+++ b/Casks/postbox.rb
@@ -1,6 +1,6 @@
 cask 'postbox' do
-  version '7.0.15'
-  sha256 '225ee55929526f83b41507f50411e79a0dadb8d08179daf6a7fe37c716c6352e'
+  version '7.0.16'
+  sha256 'e8afa465889a9d9d902465fcb0295c45613f6e77d1efb0c23dff5c73f02ffadc'
 
   # d3nx85trn0lqsg.cloudfront.net/mac/ was verified as official when first introduced to the cask
   url "https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-#{version}-mac64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.