### PR TITLE
Update 4k-stogram from 3.0.1.3150 to 3.0.2.3160

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask '4k-stogram' do
-  version '3.0.1.3150'
-  sha256 '33582f743f6b897ef88d2e0219196b4a5131bd888e46c7ed3351f4422958bb50'
+  version '3.0.2.3160'
+  sha256 '6f6d7381967733cf9d94ae5cbb06bea3bbf929c717e71556175f2c1e5077f31a'
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version.major_minor_patch}.dmg"
   appcast 'https://www.4kdownload.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.