### PR TITLE
Update loom from 0.36.5 to 0.36.7

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.36.5'
-  sha256 'f5d1855ec1bd3434fecd21e0661ee68f3ac4461b66141b076c6272977cc89992'
+  version '0.36.7'
+  sha256 'df1929d32a8c0440cfaaf28c90c55b47bd0dde8812e89fc395c0bec397f92602'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.