### PR TITLE
Update blitz from 1.8.8 to 1.8.12

### DIFF
--- a/Casks/blitz.rb
+++ b/Casks/blitz.rb
@@ -1,6 +1,6 @@
 cask 'blitz' do
-  version '1.8.8'
-  sha256 '8fa073bbcacd2a2e15f4dcf8bb869a3f5d50ea2243c24274e2a1af031a7d880d'
+  version '1.8.12'
+  sha256 'bac72248811fe4d538ffd97369daecc461e801acdc791d7ad2820ec553a8dbc9'
 
   url "https://dl.blitz.gg/download/Blitz-#{version}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://dl.blitz.gg/download/mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.