### PR TITLE
Update bricklink studio 2.0 – change URL to same as manual download button

### DIFF
--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -1,13 +1,14 @@
 cask 'bricklink-studio' do
-  version :latest
-  sha256 :no_check
+  version '2.1.4_2'
+  sha256 'f63a924d4f0349322e298c68691ce080046995c59b8dfa02d803a3af03bf0a1b'
 
-  # blstudio.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url 'https://blstudio.s3.amazonaws.com/Studio2.0/Studio+2.0.pkg'
-  name 'Stud.io'
-  homepage 'https://studio.bricklink.com/v2/build/studio.page'
+  # s3.amazonaws.com/blstudio/ was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/blstudio/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg"
+  appcast 'https://www.bricklink.com/v3/studio/download.page'
+  name 'Studio'
+  homepage 'https://www.bricklink.com/v3/studio/download.page'
 
-  pkg 'Studio+2.0.pkg'
+  pkg "Studio+#{version.major}.0.pkg"
 
-  uninstall pkgutil: 'com.bricklink.pkg.Studio'
+  uninstall pkgutil: "com.bricklink.pkg.Studio#{version.major}.0"
 end

--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -3,7 +3,7 @@ cask 'bricklink-studio' do
   sha256 :no_check
 
   # blstudio.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/blstudio/Studio2.0/Studio+2.0.pkg'
+  url 'https://blstudio.s3.amazonaws.com/Studio2.0/Studio+2.0.pkg'
   name 'Stud.io'
   homepage 'https://studio.bricklink.com/v2/build/studio.page'
 

--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -7,7 +7,7 @@ cask 'bricklink-studio' do
   name 'Stud.io'
   homepage 'https://studio.bricklink.com/v2/build/studio.page'
 
-  pkg 'Stud.io.pkg'
+  pkg 'Studio+2.0.pkg'
 
   uninstall pkgutil: 'com.bricklink.pkg.Studio'
 end

--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -3,7 +3,7 @@ cask 'bricklink-studio' do
   sha256 :no_check
 
   # blstudio.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url 'https://blstudio.s3.amazonaws.com/Stud.io.pkg'
+  url 'https://s3.amazonaws.com/blstudio/Studio2.0/Studio+2.0.pkg'
   name 'Stud.io'
   homepage 'https://studio.bricklink.com/v2/build/studio.page'
 


### PR DESCRIPTION
I noticed the current version installed was a v2.0 of 2016. Let's point the URL to the current location behind download link on the page of BrickLink STUDIO 2.0

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
