### PR TITLE
Update mochi from 1.4.15 to 1.4.16

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask 'mochi' do
-  version '1.4.15'
-  sha256 'bfd6a5b8968e28a26e55b3a603e07c546168c8af439580f8245e1d4a0e3e7766'
+  version '1.4.16'
+  sha256 'dafc1340cca9300d6bd9edc138a5775407f163c60083aa5fdbd82eaff43e0957'
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   appcast 'https://mochi.cards/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.