### PR TITLE
Update katalon-studio from 7.5.0 to 7.3.5

### DIFF
--- a/Casks/katalon-studio.rb
+++ b/Casks/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask 'katalon-studio' do
-  version '7.5.0'
-  sha256 '2c9c34507e4631ef9648bcd9fa5b79d1e86f765c67db243b0cc86a61a7c62910'
+  version '7.3.5'
+  sha256 '34d17687622c9e1ef92bdeb5742d92269d63b1678a8a95e59122993d04956bab'
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   appcast 'https://github.com/katalon-studio/katalon-studio/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.