### PR TITLE
Update mactracker from 7.9.1 to 7.9.2

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -1,6 +1,6 @@
 cask 'mactracker' do
-  version '7.9.1'
-  sha256 'fb811b503fd16580299cf56195b20a50c46fce07e332b1a73a759df6f4c6d116'
+  version '7.9.2'
+  sha256 'f9fc3a163d33ae08c34a3efcda61cfeaee7f764123fb559a362a476f04a520d1'
 
   url "https://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
   appcast 'https://update.mactracker.ca/appcast-b.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.