### PR TITLE
Update virtualbox-extension-pack from 6.1.6 to 6.1.8

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-extension-pack' do
-  version '6.1.6'
-  sha256 '80b96b4b51a502141f6a8981f1493ade08a00762622c39e48319e5b122119bf3'
+  version '6.1.8'
+  sha256 'e609c012305e4ff3c520f36b46d19dab50ecac65228a983fe85c918a1534e490'
 
   url "https://download.virtualbox.org/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   appcast 'https://download.virtualbox.org/virtualbox/LATEST.TXT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.