### PR TITLE
Update webcatalog from 20.15.1 to 21.0.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask 'webcatalog' do
-  version '20.15.1'
-  sha256 '26937746828ba80e7e8fc5eb70059cc0364449f95f1cc1af352722f03eb3a886'
+  version '21.0.0'
+  sha256 'c062891f534018a9bde36ca52206a03cf44126531fdcca5f835a47f4a2571e65'
 
   # github.com/quanglam2807/webcatalog/ was verified as official when first introduced to the cask
   url "https://github.com/quanglam2807/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.