### PR TITLE
Update mochi from 1.4.16 to 1.4.17

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask 'mochi' do
-  version '1.4.16'
-  sha256 'dafc1340cca9300d6bd9edc138a5775407f163c60083aa5fdbd82eaff43e0957'
+  version '1.4.17'
+  sha256 '1ccbf347d17b63273e81227d87596482823c2e070afb19b74ac03656ca7800ae'
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   appcast 'https://mochi.cards/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.