### PR TITLE
Update tower from 4.4,226:0cf82b91 to 4.5,231:61814c2f

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,6 +1,6 @@
 cask 'tower' do
-  version '4.4,226:0cf82b91'
-  sha256 '44db0182143c5eb5b9265b6c02b97f14fe211212a8ba0ab5896256bcc6b31286'
+  version '4.5,231:61814c2f'
+  sha256 '99aab3bedeeac9a3fc736d2313bfad7e4cb07a099cee59e4bd92e18da731cd52'
 
   # fournova-app-updates.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma.before_colon}-#{version.after_colon}/Tower-#{version.before_comma}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.