### PR TITLE
Update mimecast from 2.10,87301327:6013e89f434a2ce2aeb6 to 2.11

### DIFF
--- a/Casks/mimecast.rb
+++ b/Casks/mimecast.rb
@@ -1,9 +1,8 @@
 cask 'mimecast' do
-  version '2.10,87301327:6013e89f434a2ce2aeb6'
-  sha256 '0c57d1daf2298dc067c73b09ee556b894111d0afd978dd5743b306f02e9782dd'
+  version '2.11'
+  sha256 '4213e910eecddcf8784696d45c718b0ef9fa071ef98a82f45cbdbf4abda59cc1'
 
-  # system.na3.netsuite.com/ was verified as official when first introduced to the cask
-  url "https://system.na3.netsuite.com/core/media/media.nl?id=#{version.after_comma.before_colon}&c=601905&h=#{version.after_colon}"
+  url 'https://us-api.mimecast.com/update/bin/msm/eNptjMtuwjAURP_F6xb5mdjsoBWL8lBVhKqyiRzfa7CKkxYnoaTqv9fsWY00c-b8koSuP2MAMiVvzUn4xerA5gv_8RKfr5fd97haDj-7i9ovj-YwcjsPfP36rrd-vTzqbR2LYTOmzQJmcF2RB-JOAZuu_wLb4cSHE04aGzG71yGis6mbQDzc5SKojIG3SjrNlRGqMKIUvHRgwDHuCi50cbv2qWsjnl0LN_HTbjtjM2nuSlMYbwyjrDSS6swMeE6hbciU3eO79hPzRuqqT5RVSlUDKPUoKk45pSpXkjOBhlFEB-C8LrUsTAFSuZLpmqI33tKS5dRWc5_7GmovbQ1WGecY-fsHKkl1eg'
   appcast 'http://updates-us.mimecast.com/update/descriptors/msm/latest'
   name 'Mimecast for Mac'
   homepage 'https://community.mimecast.com/community/knowledge-base/mimecast-for-mac'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.