### PR TITLE
Update signal from 1.34.0 to 1.34.1

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,6 +1,6 @@
 cask 'signal' do
-  version '1.34.0'
-  sha256 'ae80d7d04064f5057f989910aae8720dc73ca9e4ee5485a7954d2dbd66a55df3'
+  version '1.34.1'
+  sha256 '89d30105c2e9e13525dba26036c71549b53c395de5d32e8951921f93d50795fa'
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.