### PR TITLE
Update min from 1.14.0 to 1.14.1

### DIFF
--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -1,6 +1,6 @@
 cask 'min' do
-  version '1.14.0'
-  sha256 '0fed724d415d2d428cddc96b15d8add5acb8a71fdcefe15b8bd49ceba37ce57f'
+  version '1.14.1'
+  sha256 '6f6e19d5fff750f8ca47a78bd75fc13c07a7e60f80698bb2f0d5975ecc29d452'
 
   # github.com/minbrowser/min/ was verified as official when first introduced to the cask
   url "https://github.com/minbrowser/min/releases/download/v#{version}/Min-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.