### PR TITLE
Update middle from 1.3.5 to 1.3.6

### DIFF
--- a/Casks/middle.rb
+++ b/Casks/middle.rb
@@ -1,6 +1,6 @@
 cask 'middle' do
-  version '1.3.5'
-  sha256 '384fc0c49b4fd11d22adee82fee53d148484c2a86eeabe0ce9a5e63ee1018c0a'
+  version '1.3.6'
+  sha256 '1ef92309ca6da66b42408fd1931d10ca64689bd10c474021b83687cf8b1eb600'
 
   url "https://middleclick.app/downloads/Middle#{version}.dmg"
   appcast 'https://middleclick.app/downloads/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.