### PR TITLE
Update tiny-player from 1.2.11 to 1.2.12

### DIFF
--- a/Casks/tiny-player.rb
+++ b/Casks/tiny-player.rb
@@ -1,6 +1,6 @@
 cask 'tiny-player' do
-  version '1.2.11'
-  sha256 '462e68f8dfe317a88f649ab71308790dc397a11e2b61b6153cb80e3d15bc4897'
+  version '1.2.12'
+  sha256 'b0163d8bf55e32d634ea1f04dc1453c1d927d2c418c8479caf0911286f6ac52a'
 
   url "https://download.catnapgames.com/TinyPlayer-#{version}.zip"
   appcast 'https://download.catnapgames.com/TinyPlayerAppcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.