### PR TITLE
Update mia-for-gmail from 2.4.0 to 2.4.1

### DIFF
--- a/Casks/mia-for-gmail.rb
+++ b/Casks/mia-for-gmail.rb
@@ -1,6 +1,6 @@
 cask 'mia-for-gmail' do
-  version '2.4.0'
-  sha256 '89d2ce22341c38fa08310bc9a3a58b1d521e9757c6aa03cc009d8716e77e87ac'
+  version '2.4.1'
+  sha256 '0bc3cc3c641d6f5b2dcdc5962f3b3c504595c767d9388e34cfe9821a43be6b5e'
 
   url 'https://www.miaforgmail.com/application/notifier-pro-for-gmail/MiaForGmail.dmg'
   appcast 'https://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.