### PR TITLE
Update ringcentral-classic from 20.2.20 to 20.2.21

### DIFF
--- a/Casks/ringcentral-classic.rb
+++ b/Casks/ringcentral-classic.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral-classic' do
-  version '20.2.20'
-  sha256 'f7da52b2c132240a93e3fbff0bd92a0276288703ea2e2a7b9d54474be3f489cc'
+  version '20.2.21'
+  sha256 'd28982a802c531469779a9912fca10a4f97c1c1684b1c18339d4d8de8ef28d36'
 
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral%20Classic-#{version}.dmg"
   name 'RingCentral Classic'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.