### PR TITLE
Update realm-studio from 3.11.0 to 3.10.0

### DIFF
--- a/Casks/realm-studio.rb
+++ b/Casks/realm-studio.rb
@@ -1,6 +1,6 @@
 cask 'realm-studio' do
-  version '3.11.0'
-  sha256 'cb849642b1da4a690bd2c50d2be2bf67abc5e343f2792f31bbd3807dfd5580d7'
+  version '3.10.0'
+  sha256 'd22bdd203bab653fe4a87e1ced7c54d150e6a44e79bdf050b12dcd8ccc2ba45d'
 
   url "https://static.realm.io/downloads/realm-studio/Realm%20Studio-#{version}-mac.zip"
   appcast 'https://static.realm.io/downloads/realm-studio/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.