### PR TITLE
Update ghost-browser from 2.1.1.11 to 2.1.1.12

### DIFF
--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -1,6 +1,6 @@
 cask 'ghost-browser' do
-  version '2.1.1.11'
-  sha256 '39c151fe69e451bd76d7765cc29eb470deb04c836376483c54d3641b91f9fdf5'
+  version '2.1.1.12'
+  sha256 '81c1e2da47c5f7b1d1892cebe91b5fd755699110d2ae9ab7248e8bc7a3853780'
 
   # ghostbrowser.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://ghostbrowser.s3.amazonaws.com/downloads/GhostBrowser-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.