### PR TITLE
Update wings3d from 2.2.5 to 2.2.6.1

### DIFF
--- a/Casks/wings3d.rb
+++ b/Casks/wings3d.rb
@@ -1,6 +1,6 @@
 cask 'wings3d' do
-  version '2.2.5'
-  sha256 'c0a86eeeac4ad00c61d4add386b092cf1595a3412dd6b92312d85f727f97340c'
+  version '2.2.6.1'
+  sha256 'b2d4a1ad6fc66d8efbd88cbe761c3612913323bd173b45eb47be5db385f1c30f'
 
   # sourceforge.net/wings/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wings/wings-#{version}-macosx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.