### PR TITLE
Update hstracker from 1.6.30 to 1.6.31

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,6 @@
 cask 'hstracker' do
-  version '1.6.30'
-  sha256 '73ec8da77feb6d7cbd22ce5b75262cf1056e24122e10aa86674f2c8dff0431ec'
+  version '1.6.31'
+  sha256 '351e70c9d21a7a4cc420b1c184b6c24625ca73117fe80de32fbd8555efa403a4'
 
   # github.com/HearthSim/HSTracker/ was verified as official when first introduced to the cask
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.