### PR TITLE
kitty: Remove symlink from /usr/local/bin

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -9,8 +9,10 @@ cask 'kitty' do
 
   depends_on macos: '>= :sierra'
 
+  # Symlinking the kitty binary is known to cause problems. It should also be
+  # unnecessary because the kitty binary should already be in PATH when using
+  # kitty. https://github.com/kovidgoyal/kitty/issues/1950
   app 'kitty.app'
-  binary "#{appdir}/kitty.app/Contents/MacOS/kitty"
 
   zap trash: [
                '~/.config/kitty',


### PR DESCRIPTION
Placing a symlink to the kitty CLI in /usr/local/bin causes segfaults[1]. It's also redundant because the kitty CLI can be accessed from within kitty without having to do anything.

[1]: https://github.com/kovidgoyal/kitty/issues/1950

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
