### PR TITLE
Update rcloneosx from 2.1.9 to 2.2.0

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask 'rcloneosx' do
-  version '2.1.9'
-  sha256 'c2a99eb930a31136251b16d3f4b5f22aea963a88996f3eb3ca6d3d0cde9d8ea1'
+  version '2.2.0'
+  sha256 '405adaf55c0e22cc3942cab7ba88fe44a5937f4ec3d1cc517281de92687fb679'
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/rcloneosx.#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/rcloneosx/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.