### PR TITLE
Update rectangle from 0.28 to 0.29

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -1,6 +1,6 @@
 cask 'rectangle' do
-  version '0.28'
-  sha256 '5b0d3347c65f569a33e9031e6d749ed5a8df65288da5ab32625e18fa455ff92b'
+  version '0.29'
+  sha256 'e9e259d6b27e378b9a197164ce19c1a9d180861c01691f07642ef568927268a7'
 
   url "https://rectangleapp.com/downloads/Rectangle#{version}.dmg"
   appcast 'https://www.rectangleapp.com/downloads/updates.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.