### PR TITLE
Update devolo-cockpit from 5.1.2 to 5.1.3

### DIFF
--- a/Casks/devolo-cockpit.rb
+++ b/Casks/devolo-cockpit.rb
@@ -1,6 +1,6 @@
 cask 'devolo-cockpit' do
-  version '5.1.2'
-  sha256 'ebec71ac589ac0fd8b9bf7c0209b8fba01203d52b7009c3073441592b2c4bd97'
+  version '5.1.3'
+  sha256 '713dfba5edfed8349f31d0434643de7421bbda190533c23393e78c4d750aa714'
 
   url "https://www.devolo.com/fileadmin/Web-Content/DE/products/hnw/devolo-cockpit/software/devolo-cockpit-v#{version.dots_to_hyphens}.dmg"
   appcast 'https://www.devolo.com/support/downloads/download/devolo-cockpit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.