### PR TITLE
Update astropad from 3.3.0 to 3.4.0

### DIFF
--- a/Casks/astropad.rb
+++ b/Casks/astropad.rb
@@ -1,6 +1,6 @@
 cask 'astropad' do
-  version '3.3.0'
-  sha256 'c72f14f1969477a28dd7de5380dca5a0510d09bb1e64ff04c7f6d6b3c72a7ea1'
+  version '3.4.0'
+  sha256 'bc90d1888452a08d48e52b5ef298bcc4e5ab67fc29fef5aa8b8a95ffbea23f02'
 
   url "https://downloads.astropad.com/standard/Astropad-#{version}.dmg"
   appcast 'https://astropad.com/downloads/sparkle.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.