### PR TITLE
Update dcp-o-matic-encode-server from 2.14.32 to 2.14.33

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-encode-server' do
-  version '2.14.32'
-  sha256 '7e457019145d7f2fcede8d2a76f5c438a0f241e2b217fbec7b559b4ac48733f0'
+  version '2.14.33'
+  sha256 'd9e6aed8351fd4c8417dc97e31982ee4a2983fb9778bc86cf384a3ecbf86ab51'
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-server&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.