### PR TITLE
Update dcp-o-matic-player from 2.14.32 to 2.14.33

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-player' do
-  version '2.14.32'
-  sha256 '50056fd444d1d3e6d623530d207ea85f6de49ad4e3a6f15e38075e499c83e663'
+  version '2.14.33'
+  sha256 '4e824c415f379ff7752a81f92e00271bd785ab7b80359451c861654badd5827e'
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-player&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.