### PR TITLE
Update dcp-o-matic-batch-converter from 2.14.32 to 2.14.33

### DIFF
--- a/Casks/dcp-o-matic-batch-converter.rb
+++ b/Casks/dcp-o-matic-batch-converter.rb
@@ -1,6 +1,6 @@
 cask 'dcp-o-matic-batch-converter' do
-  version '2.14.32'
-  sha256 'f08af591098d5fc8d3e8e2990c9afc97377a4fc1e79f24fabf78585dace22bc0'
+  version '2.14.33'
+  sha256 'caef7930cd780dda292e5b0986cf8b46b4c67e2b4be2a2032f73b4fe28cbbf9e'
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-batch&version=#{version}"
   appcast 'https://dcpomatic.com/download'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.