### PR TITLE
Update cryo from 0.5.1 to 0.5.2

### DIFF
--- a/Casks/cryo.rb
+++ b/Casks/cryo.rb
@@ -1,6 +1,6 @@
 cask 'cryo' do
-  version '0.5.1'
-  sha256 'e73397dd0ccf3e1ef95165cdfc36c2f9cb523986f5c61f09c014bc3bb48f266e'
+  version '0.5.2'
+  sha256 'fd2a0311d5e503a77881fd693817a8f6d5863ff8d3dc0485b294f8d5c561a59b'
 
   url "https://cryonet.io/downloads/macos/cryo_#{version}_macos.zip"
   appcast 'https://cryonet.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
