### PR TITLE
Update graphicconverter from 11.2,4376 to 11.2.1,4400

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -1,6 +1,6 @@
 cask 'graphicconverter' do
-  version '11.2,4376'
-  sha256 'd786ffde76832be3b39111bc62857d463e1f99cfd572b998a618b5342c94909e'
+  version '11.2.1,4400'
+  sha256 'd03bb3c8e7676b034e2e8bffdc9323357593634ecb83054a60d1f4791716b2d0'
 
   # lemkesoft.info/ was verified as official when first introduced to the cask
   url "https://www.lemkesoft.info/files/graphicconverter/gc#{version.major}_build#{version.after_comma}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.