### PR TITLE
Update segger-embedded-studio-for-arm from 4.52b to 4.52c

### DIFF
--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -1,6 +1,6 @@
 cask 'segger-embedded-studio-for-arm' do
-  version '4.52b'
-  sha256 '3f55cf1242d59fcf65797a2d785efa363ea8fc7299e475d167b8c9cc16a53ea2'
+  version '4.52c'
+  sha256 '3a380781029296cfbe11121971743afc96659ccae109c8ea746c9a138fe3998e'
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_x64.dmg"
   appcast 'https://studio.segger.com/arm_segger_studio_release_notes.htm'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.