### PR TITLE
Update lightproxy from 1.1.15 to 1.1.16

### DIFF
--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -2,7 +2,7 @@ cask 'lightproxy' do
   version '1.1.16'
   sha256 'a5d324bd39a2c21b0c8d0c21cf94e8e4c189dc36b52be4118463e1ac99181b77'
 
-  # github.com/alibaba/ was verified as official when first introduced to the cask
+  # github.com/alibaba/lightproxy/ was verified as official when first introduced to the cask
   url "https://github.com/alibaba/lightproxy/releases/download/v#{version}/LightProxy-#{version}.dmg"
   appcast 'https://github.com/alibaba/lightproxy/releases.atom'
   name 'LightProxy'

--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -1,10 +1,10 @@
 cask 'lightproxy' do
-  version '1.1.15'
-  sha256 '0d6a265c05f6cfc97dcd39a17137934dcfc7cc249d04e9cdb9f7a91416842d0b'
+  version '1.1.16'
+  sha256 'a5d324bd39a2c21b0c8d0c21cf94e8e4c189dc36b52be4118463e1ac99181b77'
 
-  # gw.alipayobjects.com/os/LightProxy/ was verified as official when first introduced to the cask
-  url 'https://gw.alipayobjects.com/os/LightProxy/a6d8f427-0b65-4967-9354-21a0d66cf4dd/LightProxy.dmg'
-  appcast 'https://github.com/alibaba/lightproxy/tree/master/CHANGELOG'
+  # github.com/alibaba/ was verified as official when first introduced to the cask
+  url "https://github.com/alibaba/lightproxy/releases/download/v#{version}/LightProxy-#{version}.dmg"
+  appcast 'https://github.com/alibaba/lightproxy/releases.atom'
   name 'LightProxy'
   homepage 'https://alibaba.github.io/lightproxy/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.