### PR TITLE
Update kotlin-native from 1.3.61 to 1.3.72

### DIFF
--- a/Casks/kotlin-native.rb
+++ b/Casks/kotlin-native.rb
@@ -1,6 +1,6 @@
 cask 'kotlin-native' do
-  version '1.3.61'
-  sha256 'e026f5286e2f8853c49ebac1c57b2e76f5fab67a431013442ada84347bf24415'
+  version '1.3.72'
+  sha256 'c5742382cf42def4b59b583f9b04b06928bbebf1aa090ea3ea03bfea5570dcc2'
 
   # github.com/JetBrains/kotlin/ was verified as official when first introduced to the cask
   url "https://github.com/JetBrains/kotlin/releases/download/v#{version}/kotlin-native-macos-#{version}.tar.gz"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).