### PR TITLE
Added Glance.app v1.1

### DIFF
--- a/Casks/glance.rb
+++ b/Casks/glance.rb
@@ -1,6 +1,6 @@
 cask 'glance' do
-  version '1.0.0'
-  sha256 '8ef7ba4a5130955e213fdfcc2bf43cba47c742d5f02e0e9c62405acaf19626b5'
+  version '1.1.0'
+  sha256 'bd14584dd7f81fa13217e02f6d6cbdc24344f553059abc7dc2d037e54680fbdb'
 
   url "https://github.com/samuelmeuli/glance/releases/download/v#{version}/Glance.dmg"
   appcast 'https://github.com/samuelmeuli/glance/releases.atom'

--- a/Casks/glance.rb
+++ b/Casks/glance.rb
@@ -1,0 +1,25 @@
+cask 'glance' do
+  version '1.0.0'
+  sha256 '8ef7ba4a5130955e213fdfcc2bf43cba47c742d5f02e0e9c62405acaf19626b5'
+
+  url "https://github.com/samuelmeuli/glance/releases/download/v#{version}/Glance.dmg"
+  appcast 'https://github.com/samuelmeuli/glance/releases.atom'
+  name 'Glance'
+  homepage 'https://github.com/samuelmeuli/glance'
+
+  depends_on macos: '>= :catalina'
+
+  app 'Glance.app'
+
+  zap trash: [
+               '~/Library/Application\ Scripts/com.samuelmeuli.Glance/',
+               '~/Library/Application\ Scripts/com.samuelmeuli.Glance.QLPlugin/',
+               '~/Library/Containers/com.samuelmeuli.Glance/',
+               '~/Library/Containers/com.samuelmeuli.Glance.QLPlugin/',
+               '~/Library/Group\ Containers/group.com.samuelmeuli.glance/',
+             ]
+
+  caveats <<~EOS
+    You must start #{appdir}/Glance.app once manually to setup the QuickLook plugin.
+  EOS
+end

--- a/Casks/glance.rb
+++ b/Casks/glance.rb
@@ -12,11 +12,11 @@ cask 'glance' do
   app 'Glance.app'
 
   zap trash: [
-               '~/Library/Application\ Scripts/com.samuelmeuli.Glance/',
-               '~/Library/Application\ Scripts/com.samuelmeuli.Glance.QLPlugin/',
-               '~/Library/Containers/com.samuelmeuli.Glance/',
-               '~/Library/Containers/com.samuelmeuli.Glance.QLPlugin/',
-               '~/Library/Group\ Containers/group.com.samuelmeuli.glance/',
+               '~/Library/Application Scripts/com.samuelmeuli.Glance',
+               '~/Library/Application Scripts/com.samuelmeuli.Glance.QLPlugin',
+               '~/Library/Containers/com.samuelmeuli.Glance',
+               '~/Library/Containers/com.samuelmeuli.Glance.QLPlugin',
+               '~/Library/Group Containers/group.com.samuelmeuli.glance',
              ]
 
   caveats <<~EOS


### PR DESCRIPTION
Adds [Glance](https://github.com/samuelmeuli/glance) which is an All-In-One Quick Look plugin that uses the new Quick Look API. Since a lot of the Quick Look plugins use the outdated API and are not sandboxed `Glance` is gaining quite some traction.

The caveat that you have to start the app once manually to set up the Quick look plugin is a request by the author:

@samuelmeuli writes in https://github.com/samuelmeuli/glance/issues/11#issuecomment-630335561 
> I think the user should open the app by themselves. Automatically executing a binary that was downloaded from the internet seems a bit problematic to me. And the user might want to verify that the app is sandboxed before opening it. Maybe a note in caveats is enough?

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
