### PR TITLE
Update amazon-workspaces from 2.5.11 to 3.0.6

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,10 +1,10 @@
 cask 'amazon-workspaces' do
-  version '2.5.11'
-  sha256 'd217cceaecb28cb8d2c4f99f2f84c0aa4696f91dfb779c2cacf0c51e1b93c6a1'
+  version '3.0.6'
+  sha256 'fe6eb189569ead45ef69b1826eb6a9bbd07498067b243855b56f5aeeb2691584'
 
-  # d2td7dqidlhjx7.cloudfront.net/ was verified as official when first introduced to the cask
-  url 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg'
-  appcast 'https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpacesAppCast_macOS_20171023.xml'
+  # workspaces-client-updates.s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url 'https://workspaces-client-updates.s3.amazonaws.com/prod/iad/osx/WorkSpaces.pkg'
+  appcast 'https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpacesAppCast_macOS_20171023.xml'
   name 'Amazon Workspaces'
   homepage 'https://clients.amazonworkspaces.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.