### PR TITLE
Update angry-ip-scanner from 3.7.0 to 3.7.1

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -1,6 +1,6 @@
 cask 'angry-ip-scanner' do
-  version '3.7.0'
-  sha256 '9b473206df119def590d2f515c19cb3db7084c1d3a2ec1199313f551bd6013ec'
+  version '3.7.1'
+  sha256 'e6e45b8cce5e26017e9c4033b2c9d21a32a30c850f13c39095f8aa2571241c81'
 
   # github.com/angryip/ipscan/ was verified as official when first introduced to the cask
   url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.