### PR TITLE
Update app-tamer from 2.5 to 2.5.1

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,6 +1,6 @@
 cask 'app-tamer' do
-  version '2.5'
-  sha256 '9b65803e106af3a2cb0f0e05dd1c95a4cf45d904fa5a44c57d142b6eeb31812d'
+  version '2.5.1'
+  sha256 'dc705190efa7658652202e0cb50293b2c8fa02443da943d61641405db7ecd4b0'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.