### PR TITLE
Update navicat-for-sqlite from 15.0.15 to 15.0.16

### DIFF
--- a/Casks/navicat-for-sqlite.rb
+++ b/Casks/navicat-for-sqlite.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sqlite' do
-  version '15.0.15'
-  sha256 '248c85e9069de5125d67ecbccac4ab1f3c1a24a39bcee8e4f119273dfd4b95ff'
+  version '15.0.16'
+  sha256 '36f60cc34a27bd2d039b0cb88dc969b83a3676e50d8691a98ef0496ac6471a8d'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlite_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQLite&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.