### PR TITLE
Update iconjar from 2.3.0,38894 to 2.4.0,39240

### DIFF
--- a/Casks/iconjar.rb
+++ b/Casks/iconjar.rb
@@ -1,6 +1,6 @@
 cask 'iconjar' do
-  version '2.3.0,38894'
-  sha256 'fec801ec023b211a5685075bcf8e6209190aee6dd5e8f35e62db16a604f8d815'
+  version '2.4.0,39240'
+  sha256 '9419851556f62ebbce43d0af26541e58519df3279a238ae2e5ca4e81b8c73e77'
 
   url "https://geticonjar.com/releases/IconJar.app.#{version.after_comma}.zip"
   appcast 'https://geticonjar.com/releases/stable.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.