### PR TITLE
Update navicat-for-postgresql from 15.0.15 to 15.0.16

### DIFF
--- a/Casks/navicat-for-postgresql.rb
+++ b/Casks/navicat-for-postgresql.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-postgresql' do
-  version '15.0.15'
-  sha256 'cbd7a43956780e9160b3dd78e94385c89da9663ea2ebc3b39e1b08f51fdb12e2'
+  version '15.0.16'
+  sha256 'a9d02bc77652b045b780664f23e6f7e83b406b9b52614f5c27a19f93e7cf07e3'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_pgsql_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20PostgreSQL&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.