### PR TITLE
Update navicat-premium-essentials from 15.0.15 to 15.0.16

### DIFF
--- a/Casks/navicat-premium-essentials.rb
+++ b/Casks/navicat-premium-essentials.rb
@@ -1,6 +1,6 @@
 cask 'navicat-premium-essentials' do
-  version '15.0.15'
-  sha256 'd4f96b65e179c4635cba1a97ab04de34ee29a1f7180f5ebec95bdbea62ecac42'
+  version '15.0.16'
+  sha256 'c9c771ab581d46c677b87cd992a77da64ae4a589b58f2a72daf9045434c33d6a'
 
   url "http://download.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Premium%20Essentials&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.