### PR TITLE
Update navicat-for-mariadb from 15.0.15 to 15.0.16

### DIFF
--- a/Casks/navicat-for-mariadb.rb
+++ b/Casks/navicat-for-mariadb.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-mariadb' do
-  version '15.0.15'
-  sha256 '914006594c4f94553ca050a8c814bb37e5b485ffbe18eefd21acf513826348af'
+  version '15.0.16'
+  sha256 '1cc640ed441c0daec57153625c9dfd67b3959ba96040f46aa982f0a050bd1142'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_mariadb_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20MariaDB&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.