### PR TITLE
Update kodelife from 0.9.1.132 to 0.9.2.134

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,6 +1,6 @@
 cask 'kodelife' do
-  version '0.9.1.132'
-  sha256 'a4782eeefc7c4a91d81fc36925ee4465dea471eeaa53feae934480bacf40d92d'
+  version '0.9.2.134'
+  sha256 '99059e98f5cdc60ecc2d298fb791506811653be9481dee49d84ef7ef53db2cd2'
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-macos.zip"
   appcast 'https://hexler.net/pub/kodelife/appcast.hex'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.