### PR TITLE
Update navicat-for-sql-server from 15.0.15 to 15.0.16

### DIFF
--- a/Casks/navicat-for-sql-server.rb
+++ b/Casks/navicat-for-sql-server.rb
@@ -1,6 +1,6 @@
 cask 'navicat-for-sql-server' do
-  version '15.0.15'
-  sha256 '3d61a5e507ce8f17f71b065f7a37eac5639b14b7f2b1d73810d7112028e370d6'
+  version '15.0.16'
+  sha256 '5fb8bcfbf2a7034d1c3735648ecf008703e425d3d7f8b8aa81baffb09d6a91fa'
 
   url "http://download.navicat.com/download/navicat#{version.major_minor.no_dots}_sqlserver_en.dmg"
   appcast 'https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20for%20SQL%20Server&appLang=en'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.