### PR TITLE
Update arq from 6.2.16 to 6.2.19

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask 'arq' do
-  version '6.2.16'
-  sha256 '76ba8edd5ddbf9e2315f71bf7a58cf125e56a38d26ee35d79b72f880e929ed93'
+  version '6.2.19'
+  sha256 '3787aafd4d89395dddc412ff5bdada311903bded4a29f3f0a79fa3c8d3dae9aa'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"
   appcast "https://www.arqbackup.com/download/arqbackup/arq#{version.major}_release_notes.html"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.