### PR TITLE
Update loom from 0.37.0 to 0.37.1

### DIFF
--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -1,6 +1,6 @@
 cask 'loom' do
-  version '0.37.0'
-  sha256 'dc5760cdd27ae01ddc8cb2be421e5628eb52308cb47c1de684be246af1bcef10'
+  version '0.37.1'
+  sha256 'b8d49b9d64accb9f9c9fbec4aa63f47560698adb64b2e55473fa5b6d1173667d'
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}.dmg"
   appcast 'https://s3-us-west-2.amazonaws.com/loom.desktop.packages/loom-inc-production/desktop-packages/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.