### PR TITLE
Update telavox-flow from 1.99.0 to 1.100.2

### DIFF
--- a/Casks/telavox-flow.rb
+++ b/Casks/telavox-flow.rb
@@ -1,6 +1,6 @@
 cask 'telavox-flow' do
-  version '1.99.0'
-  sha256 'e2c4acf4ebd26d76631a05897c69e9f7589d23f2fbdec275817deb2fc39e637f'
+  version '1.100.2'
+  sha256 'fec82dac93701ebd57389743674ea190a549e45133a0d79cbb30d4421b2829b6'
 
   # s3.eu-west-2.amazonaws.com/flow-desktop/ was verified as official when first introduced to the cask
   url "https://s3.eu-west-2.amazonaws.com/flow-desktop/Flow-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.