### PR TITLE
Update anydo from 4.2.85 to 4.2.86

### DIFF
--- a/Casks/anydo.rb
+++ b/Casks/anydo.rb
@@ -1,6 +1,6 @@
 cask 'anydo' do
-  version '4.2.85'
-  sha256 '0268fb5801134344f855ec6a1819a5e207bd9b3b10e88e305729bd4fa59cf751'
+  version '4.2.86'
+  sha256 '968818816795fc966787de892923d93e70e192fba7f34b60f501511a896e22eb'
 
   url 'https://electron-app.any.do/Any.do.dmg'
   appcast 'https://electron-app.any.do/latest-mac.yml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.