### PR TITLE
Update visicut from 1.9-68-gf9e37c5e to 1.9-70-g2c0db535

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask 'visicut' do
-  version '1.9-68-gf9e37c5e'
-  sha256 'fb5f35b0cdd7fca48012949a636ff91b231ff57e55662aeaf42e9899b0d7b665'
+  version '1.9-70-g2c0db535'
+  sha256 '7549aec494c173d94b8210ed5ac49a779d62e99cbe556a3101490a717b987dda'
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast 'https://download.visicut.org'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.