### PR TITLE
Update sizzy from 0.19.0 to 0.20.0

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
   version '0.20.0'
-  sha256 'bca61723d744dbdfb58a85419faba265fe3c92f3b69167b31b204c435bf560f4'
+  sha256 'f9780d350b9e69666069af63cdeadec2ecea960c988e02df0a4e01b51f1a00ec'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'

--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.19.0'
-  sha256 'c71a6d3a4c04a0fb7a0100bfd6652446010bca527c3952d95fe2f5427614ffc8'
+  version '0.20.0'
+  sha256 'bca61723d744dbdfb58a85419faba265fe3c92f3b69167b31b204c435bf560f4'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.