### PR TITLE
Update jamovi.rb

### DIFF
--- a/Casks/jamovi.rb
+++ b/Casks/jamovi.rb
@@ -4,7 +4,7 @@ cask 'jamovi' do
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos.dmg"
   appcast 'https://www.jamovi.org/download.html',
-          configuration: "#{version.chomp('.0')} solid"
+          configuration: "solid</td><td>.dmg</td><td>#{version.chomp('.0')}"
   name 'jamovi'
   homepage 'https://www.jamovi.org/'
 

--- a/Casks/jamovi.rb
+++ b/Casks/jamovi.rb
@@ -3,7 +3,8 @@ cask 'jamovi' do
   sha256 'edc430dd3c3be63b2e7a4ea42a09c2c7cb3d34d747f0e8b4742c37c08c00af44'
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.jamovi.org/download.html&splitter_1=macos.dmg&index_1=0&splitter_2=download-button&index_2=-1'
+  appcast 'https://www.jamovi.org/download.html', 
+          configuration: "#{version.chomp('.0')} solid"
   name 'jamovi'
   homepage 'https://www.jamovi.org/'
 

--- a/Casks/jamovi.rb
+++ b/Casks/jamovi.rb
@@ -3,7 +3,7 @@ cask 'jamovi' do
   sha256 'edc430dd3c3be63b2e7a4ea42a09c2c7cb3d34d747f0e8b4742c37c08c00af44'
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos.dmg"
-  appcast 'https://www.jamovi.org/download.html', 
+  appcast 'https://www.jamovi.org/download.html',
           configuration: "#{version.chomp('.0')} solid"
   name 'jamovi'
   homepage 'https://www.jamovi.org/'


### PR DESCRIPTION
revert appcast to direct download URL as the CGI didn't work anymore

also, add 'configuration' so that only 'solid' releases pass