### PR TITLE
Add XcodeClangFormat v1.1.0

### DIFF
--- a/Casks/xcodeclangformat.rb
+++ b/Casks/xcodeclangformat.rb
@@ -1,0 +1,19 @@
+cask 'xcodeclangformat' do
+  version '1.1.0'
+  sha256 'd6fd1a1af949bbc99e0e0a3e15c8c5b3ce4d138b6b8943ee17459dc2dbc4f583'
+
+  url "https://github.com/mapbox/XcodeClangFormat/releases/download/v#{version}/XcodeClangFormat-v#{version}.zip"
+  appcast 'https://github.com/mapbox/XcodeClangFormat/releases.atom'
+  name 'XcodeClangFormat'
+  homepage 'https://github.com/mapbox/XcodeClangFormat'
+
+  app 'XcodeClangFormat.app'
+
+  zap trash: [
+               '~/Library/Application Scripts/com.mapbox.XcodeClangFormat',
+               '~/Library/Application Scripts/com.mapbox.XcodeClangFormat.clang-format',
+               '~/Library/Containers/com.mapbox.XcodeClangFormat',
+               '~/Library/Containers/com.mapbox.XcodeClangFormat.clang-format',
+               '~/Library/Group Containers/XcodeClangFormat',
+             ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download xcode-clang-format` is error-free.
- [x] `brew cask style --fix xcode-clang-format` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install xcode-clang-format` worked successfully.
- [x] `brew cask uninstall xcode-clang-format` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

**Note:** This extension is developed by @mapbox, mainly by @kkaefer