### PR TITLE
Mark ipfs as auto-updating

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -7,5 +7,7 @@ cask 'ipfs' do
   name 'IPFS Desktop'
   homepage 'https://github.com/ipfs-shipyard/ipfs-desktop'
 
+  auto_updates true
+
   app 'IPFS Desktop.app'
 end


### PR DESCRIPTION
IPFS Desktop does auto-updates, so it should not be updated by Homebrew Cask.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
