### PR TITLE
Update ocenaudio from 3.7.14 to 3.7.15

### DIFF
--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,12 +1,12 @@
 cask 'ocenaudio' do
-  version '3.7.14'
+  version '3.7.15'
 
   if MacOS.version <= :high_sierra
     sha256 '47553175f53633a9f03a3a12fff44b27335d7223555f398d92ffa09aa6ee3776'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else
-    sha256 'eb1cf21d2eba25d07406fbe5deb8e92885738070172642594256c0ed6ecfdcf9'
+    sha256 '3cb388b0a3694aa54794a90ba93e58033db7d27bd8786491b7acd9df68ac548e'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg'
   end

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,7 +2,7 @@ cask 'ocenaudio' do
   version '3.7.15'
 
   if MacOS.version <= :high_sierra
-    sha256 '47553175f53633a9f03a3a12fff44b27335d7223555f398d92ffa09aa6ee3776'
+    sha256 '52a544285a93d41c5ef41aaeaf1a82585f4e77085faeeff92dabaa710356a6ce'
 
     url 'https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg'
   else


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.