### PR TITLE
Update gdlauncher from 0.12.4 to 1.0.3

### DIFF
--- a/Casks/gdlauncher.rb
+++ b/Casks/gdlauncher.rb
@@ -1,9 +1,9 @@
 cask 'gdlauncher' do
-  version '0.12.4'
-  sha256 'd73f751659443117b0bf8948e3e74494f96a1c2060cdb1dcaa21854d270209f3'
+  version '1.0.3'
+  sha256 'ccf9cd4d7ffb03a0717c344e64c95db71f687becf27e15770c57a43552881b15'
 
   # github.com/gorilla-devs/GDLauncher/ was verified as official when first introduced to the cask
-  url "https://github.com/gorilla-devs/GDLauncher/releases/download/v#{version}/GDLauncher-mac-setup.zip"
+  url "https://github.com/gorilla-devs/GDLauncher/releases/download/v#{version}/GDLauncher-mac-setup.dmg"
   appcast 'https://github.com/gorilla-devs/GDLauncher/releases.atom'
   name 'GDLauncher'
   homepage 'https://gdevs.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.