### PR TITLE
Update endurance from 2.0,36 to 3.0,45

### DIFF
--- a/Casks/endurance.rb
+++ b/Casks/endurance.rb
@@ -1,8 +1,8 @@
 cask 'endurance' do
-  version '2.0,36'
-  sha256 '3879bdd612c2e5c89c8f308424d2c65f91858621f2ecc70e6c2b742849b19d45'
+  version '3.0,45'
+  sha256 '84a1d401fc7575fa0e34f0ea7292a97e7f8e51fa87036273b169c2ec31ff437a'
 
-  url "https://enduranceapp.com/beta/Endurance#{version.after_comma}.zip"
+  url "https://enduranceapp.com/prerelease/Endurance#{version.before_comma}r#{version.after_comma}.zip"
   appcast 'https://enduranceapp.com/appcast'
   name 'Endurance'
   homepage 'https://enduranceapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.