### PR TITLE
Update lightproxy from 1.1.16 to 1.1.20

### DIFF
--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -1,6 +1,6 @@
 cask 'lightproxy' do
-  version '1.1.16'
-  sha256 'a5d324bd39a2c21b0c8d0c21cf94e8e4c189dc36b52be4118463e1ac99181b77'
+  version '1.1.20'
+  sha256 '4b69141f296a10858b20b3be2de21a4c5c67421ac575e4175d8d16daea89e3d7'
 
   # github.com/alibaba/lightproxy/ was verified as official when first introduced to the cask
   url "https://github.com/alibaba/lightproxy/releases/download/v#{version}/LightProxy-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).