### PR TITLE
Update openaudible from 2.0.7 to 2.0.8

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,6 +1,6 @@
 cask 'openaudible' do
-  version '2.0.7'
-  sha256 '642b067614c120bdfc8378c0fd1b16f303ae508c988df72c807a87ac15550dd8'
+  version '2.0.8'
+  sha256 '46ee778e429e1b7b5896227513afc357a38df369c1daadd8a08a0981113c8520'
 
   # github.com/openaudible/ was verified as official when first introduced to the cask
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_mac.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).