### PR TITLE
Update paperspace from 8.4.0.4 to 8.4.1.0

### DIFF
--- a/Casks/paperspace.rb
+++ b/Casks/paperspace.rb
@@ -1,6 +1,6 @@
 cask 'paperspace' do
-  version '8.4.0.4'
-  sha256 '0d37f2d87b4a772a44a63e9a6467e2dc290e3e134691aff497df7e14996fc942'
+  version '8.4.1.0'
+  sha256 '99defd065b5d9afc8838934cc7b3e84792f967aacab5f81ace3b3e0f7da8e0b0'
 
   # ps-receiver.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://ps-receiver.s3.amazonaws.com/darwin/Paperspace-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).