### PR TITLE
Update couchbase-server-enterprise from 6.5.0 to 6.5.1

### DIFF
--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -11,6 +11,7 @@ cask 'couchbase-server-enterprise' do
     sha256 'c2f6969d60658d2873153627b23385c92109f88a36e45889fc39e26599f6fa0f'
 
     url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.dmg"
+    appcast 'http://appcast.couchbase.com/membasex.xml'
 
     app 'Couchbase Server.app'
   end

--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -7,8 +7,8 @@ cask 'couchbase-server-enterprise' do
 
     app "couchbase-server-enterprise_#{version}/Couchbase Server.app"
   else
-    version '6.5.0'
-    sha256 'd6eec86d867dd0ffc39bd9e4ac8832fa607076bc9446105a063d1a7e2ca7c0ee'
+    version '6.5.1'
+    sha256 'c2f6969d60658d2873153627b23385c92109f88a36e45889fc39e26599f6fa0f'
 
     url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.dmg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.