### PR TITLE
Update lando from 3.0.1 to 3.0.3

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.1'
-  sha256 '280eff6b2a9b262c122d6cc705f80bdea8dcf3d229400248ffedd7868bbd9ac4'
+  version '3.0.3'
+  sha256 'a89a3919b6d95cdf15d92dd12234936477593e18f748ad1aeb4217fd6e6624a5'
 
   # github.com/lando/lando/ was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.