### PR TITLE
Update imaging-edge from 2.0.2_1911a,DqbvQuTn2u to 1_0_02,2BqD6b8EKL

### DIFF
--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,9 +1,9 @@
 cask 'imaging-edge' do
-  version '2.0.2_1911a,DqbvQuTn2u'
-  sha256 '8ccb39c6f716a388cd825b084fb83c85e73865a3397fd1badd034157d4b64b09'
+  version '1_0_02,2BqD6b8EKL'
+  sha256 'b4eab497dc35974f9d56261c326ef2af538153b27455b93756d980d5786bb379'
 
-  # ids.update.sony.net/IDC/ was verified as official when first introduced to the cask
-  url "http://ids.update.sony.net/IDC/#{version.after_comma}/IE#{version.before_comma.no_dots}.dmg"
+  # di.update.sony.net/NEX/ was verified as official when first introduced to the cask
+  url "https://di.update.sony.net/NEX/#{version.after_comma}/ied_#{version.before_comma}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/imagingedge_DL/mac?fm=en',
           configuration: version.after_comma
   name 'Sony Imaging Edge'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -9,7 +9,7 @@ cask 'imaging-edge' do
   name 'Sony Imaging Edge'
   homepage 'https://support.d-imaging.sony.co.jp/app/imagingedge/'
 
-  pkg 'IE_INST.pkg'
+  pkg "ied_#{version.before_comma}.pkg"
 
   uninstall pkgutil: 'com.sony.ImagingEdgeVer.1.pkg',
             delete:  '/Applications/Imaging Edge'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -1,9 +1,9 @@
 cask 'imaging-edge' do
-  version '1_0_02,2BqD6b8EKL'
+  version '1.0.02,2BqD6b8EKL'
   sha256 'b4eab497dc35974f9d56261c326ef2af538153b27455b93756d980d5786bb379'
 
   # di.update.sony.net/NEX/ was verified as official when first introduced to the cask
-  url "https://di.update.sony.net/NEX/#{version.after_comma}/ied_#{version.before_comma}.dmg"
+  url "https://di.update.sony.net/NEX/#{version.after_comma}/ied_#{version.before_comma.dots_to_underscores}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/desktop_DL/mac?fm=en',
           configuration: version.after_comma
   name 'Sony Imaging Edge'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -2,7 +2,6 @@ cask 'imaging-edge' do
   version '1.0.02,2BqD6b8EKL'
   sha256 'b4eab497dc35974f9d56261c326ef2af538153b27455b93756d980d5786bb379'
 
-  # di.update.sony.net/NEX/ was verified as official when first introduced to the cask
   url "https://di.update.sony.net/NEX/#{version.after_comma}/ied_#{version.before_comma.dots_to_underscores}.dmg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/desktop_DL/mac?fm=en',
           configuration: version.after_comma

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -8,7 +8,7 @@ cask 'imaging-edge' do
   name 'Sony Imaging Edge'
   homepage 'https://imagingedge.sony.net/en-us/ie-desktop.html'
 
-  pkg "ied_#{version.before_comma}.pkg"
+  pkg "ied_#{version.before_comma.dots_to_underscores}.pkg"
 
   uninstall pkgutil: 'com.sony.ImagingEdgeVer.1.pkg',
             delete:  '/Applications/Imaging Edge'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -4,7 +4,7 @@ cask 'imaging-edge' do
 
   # di.update.sony.net/NEX/ was verified as official when first introduced to the cask
   url "https://di.update.sony.net/NEX/#{version.after_comma}/ied_#{version.before_comma}.dmg"
-  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/imagingedge_DL/mac?fm=en',
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/desktop_DL/mac?fm=en',
           configuration: version.after_comma
   name 'Sony Imaging Edge'
   homepage 'https://support.d-imaging.sony.co.jp/app/imagingedge/'

--- a/Casks/imaging-edge.rb
+++ b/Casks/imaging-edge.rb
@@ -7,7 +7,7 @@ cask 'imaging-edge' do
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.d-imaging.sony.co.jp/disoft_DL/desktop_DL/mac?fm=en',
           configuration: version.after_comma
   name 'Sony Imaging Edge'
-  homepage 'https://support.d-imaging.sony.co.jp/app/imagingedge/'
+  homepage 'https://imagingedge.sony.net/en-us/ie-desktop.html'
 
   pkg "ied_#{version.before_comma}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.