### PR TITLE
Update delicious-library from 3.9.1 to 3.9.2

### DIFF
--- a/Casks/delicious-library.rb
+++ b/Casks/delicious-library.rb
@@ -1,6 +1,6 @@
 cask 'delicious-library' do
-  version '3.9.1'
-  sha256 'c306034b7f0915adc3b83689923913db88f0f0fbc9fe7a1c70d6814eab758193'
+  version '3.9.2'
+  sha256 'b7cd5d5e4a410f7191b7cfcda3433818797787cc73507c5672a3502326dc2590'
 
   url "https://www.delicious-monster.com/downloads/DeliciousLibrary#{version.major}/v#{version}/DeliciousLibrary#{version.major}.zip"
   appcast "https://www.delicious-monster.com/downloads/DeliciousLibrary#{version.major}.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).