### PR TITLE
Update expressvpn from 7.5.6.4 to 7.8.3.4

### DIFF
--- a/Casks/expressvpn.rb
+++ b/Casks/expressvpn.rb
@@ -1,6 +1,6 @@
 cask 'expressvpn' do
-  version '7.5.6.4'
-  sha256 '0d2c6e4072b543315662e874908c402932d2d09c06fdeb0bd7521b2d858aa681'
+  version '7.8.3.4'
+  sha256 'accf6ac3426161ec00fb525ea8e341e53571165ddfd06cad98aace6aef464365'
 
   url "https://download.expressvpn.xyz/clients/mac/expressvpn_mac_#{version}_release.pkg"
   appcast 'https://www.expressvpn.xyz/vpn-software/vpn-mac'


### PR DESCRIPTION
Seems this was downgraded a week ago (https://github.com/Homebrew/homebrew-cask/pull/82491) from 7.8.2.2 to 7.5.6.4. The reason for the downgrade was that they linked to version 7.5.6.4 on their homepage. The link now points to 7.8.3.4, so I see no reason for this to remain on an old version.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).