### PR TITLE
Update sqlpro-for-mssql from 2020.43 to 2020.47

### DIFF
--- a/Casks/sqlpro-for-mssql.rb
+++ b/Casks/sqlpro-for-mssql.rb
@@ -1,6 +1,6 @@
 cask 'sqlpro-for-mssql' do
-  version '2020.43'
-  sha256 '09f6bc8acc4af133c72bfe7017e543401b33c930589e6e1af07a32fd90661514'
+  version '2020.47'
+  sha256 '044a95d344b2dc8720914cdc35e5f4b884f9bff8bebc85d30f30501ac84690e0'
 
   # d3fwkemdw8spx3.cloudfront.net/mssql/ was verified as official when first introduced to the cask
   url "https://d3fwkemdw8spx3.cloudfront.net/mssql/SQLProMSSQL.#{version}.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.