### PR TITLE
Update gdlauncher from 1.0.4 to 1.0.5

### DIFF
--- a/Casks/gdlauncher.rb
+++ b/Casks/gdlauncher.rb
@@ -1,6 +1,6 @@
 cask 'gdlauncher' do
-  version '1.0.4'
-  sha256 '9b72e85aee15c00746f18959702e549ec8cedc32bf5a2ae98145015809ad642e'
+  version '1.0.5'
+  sha256 '93bb5cdf7808be4582b4bf05eec59a0e20225a3fcb9ff7a385dc92fb8174d171'
 
   # github.com/gorilla-devs/GDLauncher/ was verified as official when first introduced to the cask
   url "https://github.com/gorilla-devs/GDLauncher/releases/download/v#{version}/GDLauncher-mac-setup.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).