### PR TITLE
Update timemator from 2.5.1 to 2.5.2

### DIFF
--- a/Casks/timemator.rb
+++ b/Casks/timemator.rb
@@ -1,6 +1,6 @@
 cask 'timemator' do
-  version '2.5.1'
-  sha256 '8b8f2b3ed391f6976ef6f397b4faa3d1982319679befd56b5d2b9915416fedcb'
+  version '2.5.2'
+  sha256 'f4e6ee06818a24dc6bc1de943518c0aade50a2175729fe985f1b6774607749a9'
 
   # catforce-timemator.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url 'https://catforce-timemator.s3.amazonaws.com/releases/Timemator.dmg'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).