### PR TITLE
Update cloudapp from 6.1.2.2002 to 6.1.5.2037

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -1,6 +1,6 @@
 cask 'cloudapp' do
-  version '6.1.2.2002'
-  sha256 '357fa5e50ced82cf213b8b88d25d4296284e6a032a0224ed03a52547902a861f'
+  version '6.1.5.2037'
+  sha256 '4674b17accde177e88ef486348ff18bc37320d28abec7af6b46f7d9a5ba21d90'
 
   url "http://downloads.getcloudapp.com/mac/CloudApp-#{version}.zip"
   appcast 'https://d2plwz9jdz9z5d.cloudfront.net/mac/latest/appcast.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).