### PR TITLE
Update sha in houdahspot.rb

### DIFF
--- a/Casks/houdahspot.rb
+++ b/Casks/houdahspot.rb
@@ -2,7 +2,7 @@ cask 'houdahspot' do
   version '5.1.1'
   sha256 '38587dee264c7bae0b5370a60c6175d2471e24de4804f592c12864965bfbf32e'
 
-  url "https://www.houdah.com/houdahSpot/download_assets/HoudahSpot#{version}.zip"
+  url "https://dl.houdah.com/houdahSpot/updates/cast#{version.major}_assets/HoudahSpot#{version}.zip"
   appcast "https://www.houdah.com/houdahSpot/updates/cast#{version.major}.xml"
   name 'HoudahSpot'
   homepage 'https://www.houdah.com/houdahSpot/'

--- a/Casks/houdahspot.rb
+++ b/Casks/houdahspot.rb
@@ -1,6 +1,6 @@
 cask 'houdahspot' do
   version '5.1.1'
-  sha256 'e353651fbcdb972432798102edce6b6395d1e401abc2183fb69be5a9302bc43f'
+  sha256 '38587dee264c7bae0b5370a60c6175d2471e24de4804f592c12864965bfbf32e'
 
   url "https://www.houdah.com/houdahSpot/download_assets/HoudahSpot#{version}.zip"
   appcast "https://www.houdah.com/houdahSpot/updates/cast#{version.major}.xml"


### PR DESCRIPTION
this is quite strange - the download url redirects to the latest download:

```
==> Downloading https://www.houdah.com/houdahSpot/download_assets/HoudahSpot5.1.1.zip
==> Downloading from https://www.houdah.com/houdahSpot/download_assets/HoudahSpot_latest.zip
```
and downloads version 5.1
but if you use the original url directly you get the right version (5.1.1)

The new sha belongs to version 5.1.1 (which you can download from the website)

@vitorgalvao - do you have an idea why this is happening?
