### PR TITLE
Update jaxx-liberty from 2.4.1 to 2.4.3

### DIFF
--- a/Casks/jaxx-liberty.rb
+++ b/Casks/jaxx-liberty.rb
@@ -1,6 +1,6 @@
 cask 'jaxx-liberty' do
-  version '2.4.1'
-  sha256 '941a96226a4c3d73fafd5b8063b3455df1ecff9a366d2b7f6118838a886a8684'
+  version '2.4.3'
+  sha256 'f0225db3007a0e207fbdc908f601be97522cb69759665f2e5e5fdbac7115a179'
 
   url "https://download-liberty.jaxx.io/Jaxx.Liberty-#{version}.dmg"
   appcast 'https://jaxx.io/downloads.html'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).