### PR TITLE
Update remember-the-milk from 1.1.22 to 1.2.0

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.1.22'
-  sha256 '4646be465ed1be07254806f7c74f98e708adcfbb9441208d0183f4a17946dbe4'
+  version '1.2.0'
+  sha256 '3d8ad4dc8f58a13246550defb6d3efd46d739981ecae958a2f3419f0fc7acdbf'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   appcast 'https://www.rememberthemilk.com/services/mac/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).