### PR TITLE
copyq: add caveat about Accessibility preferences

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -19,4 +19,16 @@ cask 'copyq' do
       exec '#{appdir}/CopyQ.app/Contents/MacOS/CopyQ' "$@"
     EOS
   end
+
+  caveats <<~EOS
+    As the CopyQ app is not signed, you will have to re-grant Accessibility
+    access every time the app is updated:
+
+    Run:
+      open /System/Library/PreferencePanes/Security.prefPane
+    or go to:
+      System Preferences -> Security & Privacy -> Accessibility
+    then:
+      Untick and retick CopyQ.app
+  EOS
 end


### PR DESCRIPTION
As every user will hit this on every upgrade, we should document this in
the cask itself so it shows on `brew cask upgrade` when CopyQ is
updated.

Refs: https://github.com/hluk/CopyQ/issues/1030
Refs: https://github.com/hluk/CopyQ/issues/1245

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).