### PR TITLE
fix shasum for switchresx 4.9.2

### DIFF
--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -1,6 +1,6 @@
 cask 'switchresx' do
   version '4.9.2'
-  sha256 'c15d6f6e6a72c99894620e0a2a9a80b8302729fc59b8efaa411d4a43c2d078bc'
+  sha256 '983e239abced6fc50e9b7f97806b0af2b37a71e6c752a084d45898b8579cb69b'
 
   url "https://www.madrau.com/data/switchresx/SwitchResX#{version.major}.zip"
   appcast "https://www.madrau.com/SRXCurrentVersion#{version.major}"


### PR DESCRIPTION
Shasum wasn't updated in #81393

audit for switchresx: passed
1 file inspected, no offenses detected