### PR TITLE
Update depends on stanza from sierra to high sierra in rstudio.rb

### DIFF
--- a/Casks/rstudio.rb
+++ b/Casks/rstudio.rb
@@ -8,7 +8,7 @@ cask 'rstudio' do
   name 'RStudio'
   homepage 'https://www.rstudio.com/'
 
-  depends_on macos: '>= :sierra'
+  depends_on macos: '>= :high_sierra'
 
   app 'RStudio.app'
 


### PR DESCRIPTION
the website says that the min version is 10.13 (see https://rstudio.com/products/rstudio/download/)
although the app still contains 10.12 as min version in the info.plist