### PR TITLE
Update macpilot from 11.1.3 to 11.1.4

### DIFF
--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -1,13 +1,13 @@
 cask 'macpilot' do
-  version '11.1.3'
-  sha256 '1990b04414896ef24767e58cd9b56901460375ee8fb805572ca34da019bcda58'
+  version '11.1.4'
+  sha256 '75fc421d51ebd172ebdf149400fbcd010cf1224529e2e7d3fdf1915e62757f64'
 
   url 'https://www.koingosw.com/products/macpilot/download/macpilot.dmg'
   appcast 'https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle'
   name 'MacPilot'
   homepage 'https://www.koingosw.com/products/macpilot/'
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :mojave'
 
   app 'MacPilot.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.