### PR TITLE
Update flightgear.rb

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,7 +1,7 @@
 cask 'flightgear' do
   version '2018.3.2'
   sha256 'dc7a40e19f64b80fdf7171be1516fd877dc7934981268ee72dfb974b53849b9a'
-  
+
   # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss'

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,7 +1,7 @@
 cask 'flightgear' do
-  version '2020.1.2'
-  sha256 'e8dee2cb5b1b2747a15fb06fbf90f8b71813b8da5c5e82d4f2777eea36c491e2'
-
+  version '2018.3.2'
+  sha256 'dc7a40e19f64b80fdf7171be1516fd877dc7934981268ee72dfb974b53849b9a'
+  
   # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/flightgear/rss'


### PR DESCRIPTION
according to the homepage the last stable version is '2018.3.2'

the last two submitted-and-merged versions are labeled 'beta'
