### PR TITLE
Update lehreroffice from 2020.4.0 to 2020.5.0

### DIFF
--- a/Casks/lehreroffice.rb
+++ b/Casks/lehreroffice.rb
@@ -1,6 +1,6 @@
 cask 'lehreroffice' do
-  version '2020.4.0'
-  sha256 '0b7af2851ef8628f4812723d106478bbe8ebabcec9a591b5ede315cbfa7d2bfb'
+  version '2020.5.0'
+  sha256 '42ed7e4b68dedd224d8b39d3984b31ecff32ac2c6f2364ce86692f622208a537'
 
   url 'https://www.lehreroffice.ch/lo/dateien/easy/lo_desktop_macos.dmg'
   appcast 'https://www.lehreroffice.ch/services/update/getcurrentversion.php?app=Desktop'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.