### PR TITLE
Update forecast from 0.9_125 to 0.9.1_128

### DIFF
--- a/Casks/forecast.rb
+++ b/Casks/forecast.rb
@@ -1,6 +1,6 @@
 cask 'forecast' do
-  version '0.9_125'
-  sha256 '533baab40ab6bc7cef9ebfaa60804caffcdd3ff2915a7456733e5503ac7a64d4'
+  version '0.9.1_128'
+  sha256 '8d3200143ba11ca407953879d280f1d57b3b25c4c3769a58824b2a03f354dd2b'
 
   # d2uzvmey2c90kn.cloudfront.net/appcast_download/ was verified as official when first introduced to the cask
   url "https://d2uzvmey2c90kn.cloudfront.net/appcast_download/Forecast_#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.