### PR TITLE
Update altair-graphql-client from 2.4.7 to 2.4.8

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask 'altair-graphql-client' do
-  version '2.4.7'
-  sha256 'fab4b53d84c4e35761e24ef6271a09790f321dd8c42530a3384c2824ceccbdcd'
+  version '2.4.8'
+  sha256 'f81a23350ad4ae0d1384ccf97fc93a80830c58c2cad206991d70c5e00653db79'
 
   # github.com/imolorhe/altair/ was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair_#{version}_mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).