### PR TITLE
Update activedock from 1.56 to 1.60

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '1.56'
-  sha256 '5c560b8da108a0152cb96abf139d48c811da4ea501fc7fe27edbcd93001d5f1b'
+  version '1.60'
+  sha256 'bdbd55b5914bb858e87a590328b8d0c075c984ec007c71ae42d190909d52e22e'
 
   url 'https://noteifyapp.com/download/ActiveDock.dmg'
   appcast 'https://macplus-software.com/downloads/ActiveDock.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).