### PR TITLE
Update mp3gain-express from 2.3.3 to 2.4.0

### DIFF
--- a/Casks/mp3gain-express.rb
+++ b/Casks/mp3gain-express.rb
@@ -1,8 +1,8 @@
 cask 'mp3gain-express' do
-  version '2.3.3'
-  sha256 'c96da91165873e4adce960aac50bd78f787c0d8c482fe08829a13f3362e21fd3'
+  version '2.4.0'
+  sha256 '43725242307dc7bee59c133f0fcef1acf64cfeb7d209b833d72cbe930697d32e'
 
-  url "https://projects.sappharad.com/mp3gain/mp3gain_mac#{version.no_dots}.zip"
+  url "https://projects.sappharad.com/mp3gain/mp3gain_mac#{version.chomp('.0').no_dots}.zip"
   appcast 'https://projects.sappharad.com/mp3gain/updates.xml'
   name 'MP3Gain Express'
   homepage 'https://projects.sappharad.com/mp3gain/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.