### PR TITLE
Update yyets from 3.2.2 to 3.2.5

### DIFF
--- a/Casks/yyets.rb
+++ b/Casks/yyets.rb
@@ -1,6 +1,6 @@
 cask 'yyets' do
-  version '3.2.2'
-  sha256 '3d45291ea48a234fe838c18c9253b3be4c97a0dca351e86287fe8a7bd41bf3aa'
+  version '3.2.5'
+  sha256 '6a7f508a79d1c7888349e0c6241ada4293fe879183f202645d8fe0f2c1c5b27c'
 
   url "http://appdown.rrys.tv/RRShare_#{version}.dmg"
   appcast 'http://app.rrys.tv/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.