### PR TITLE
Update catlight from 2.31.0 to 2.32.2

### DIFF
--- a/Casks/catlight.rb
+++ b/Casks/catlight.rb
@@ -1,9 +1,8 @@
 cask 'catlight' do
-  version '2.31.0'
-  sha256 'd06c54aed7e0c10f51245a039c64cb26e5006db8b8b0e8bb0a588384bdf04c5e'
+  version '2.32.2'
+  sha256 'b3f6a4027813ab8f4549243fd7fab85cdb4a3ff2a2059af4f05b772d12af78fb'
 
-  # de2nac35bcll0.cloudfront.net/ was verified as official when first introduced to the cask
-  url "https://de2nac35bcll0.cloudfront.net/dl/mac/beta/CatLightSetup-#{version}.zip"
+  url "https://download.catlight.io/rel/mac/beta/CatLightSetup-#{version}.zip"
   appcast 'https://catlight.io/downloads'
   name 'catlight'
   homepage 'https://catlight.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.