### PR TITLE
Update publii from 0.35.3 to 0.36.0

### DIFF
--- a/Casks/publii.rb
+++ b/Casks/publii.rb
@@ -1,8 +1,8 @@
 cask 'publii' do
-  version '0.35.3'
-  sha256 '4cd6883223e9fe6f4aada12dded4657f408670c70ff51c1e3fe3cafc4e5a1f3d'
+  version '0.36.0'
+  sha256 '4765d425ddf94c11ef73176a13a162453bbb74c23180277642209fe8c62c2e58'
 
-  url "https://cdn.getpublii.com/Publii__#{version}.dmg"
+  url "https://cdn.getpublii.com/Publii-#{version}.dmg"
   appcast 'https://getpublii.com/download/'
   name 'Publii'
   homepage 'https://getpublii.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.