### PR TITLE
fix(audit): update renamed token_conflicts argument

### DIFF
--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -89,7 +89,7 @@ module Cask
           overall_success &= step "brew cask audit #{cask.token}", "audit" do
             Auditor.audit(cask, audit_download: true,
                                 audit_appcast: true,
-                                check_token_conflicts: added_cask_files.include?(path),
+                                audit_token_conflicts: added_cask_files.include?(path),
                                 commit_range: @commit_range)
           end
 


### PR DESCRIPTION
Attempting to fix `cask ci` command to reflect change introduced by Homebrew/brew#7427.

New arguments were introduced by the above PR which I have not added, only addressing the renamed argument. Happy to add the additional checks if necessary.