### PR TITLE
Update keybase from 5.4.2-20200424204055,7b0bbf1e3c to 5.5.0-20200526170801,139bb348af

### DIFF
--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -1,6 +1,6 @@
 cask 'keybase' do
-  version '5.4.2-20200424204055,7b0bbf1e3c'
-  sha256 '49ab4da30db7c46f1a1c2c06312f07f7ba5f82e5449de73470247d2bbb268968'
+  version '5.5.0-20200526170801,139bb348af'
+  sha256 'ccee4d6e971a265f411a841695cd19e2a040b27d11484850f02b432d7e931d51'
 
   url "https://prerelease.keybase.io/darwin-updates/Keybase-#{version.before_comma}%2B#{version.after_comma}.zip"
   appcast 'https://prerelease.keybase.io/update-darwin-prod-v2.json'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).