### PR TITLE
Update obs-virtualcam from 1.1.0,0e62cec to 1.1.2,a70ec47

### DIFF
--- a/Casks/obs-virtualcam.rb
+++ b/Casks/obs-virtualcam.rb
@@ -1,6 +1,6 @@
 cask 'obs-virtualcam' do
-  version '1.1.0,0e62cec'
-  sha256 'e0ad314f6e635c4e79d78bb75c694263f80ce524e5f084f4fcfba155042e0d51'
+  version '1.1.2,a70ec47'
+  sha256 '38a59fd4a75374c2fe101d796006e210647ae4dae6825b80720e495ed6219ac5'
 
   url "https://github.com/johnboiles/obs-mac-virtualcam/releases/download/v#{version.before_comma}/obs-mac-virtualcam-#{version.after_comma}-v#{version.before_comma}.pkg"
   appcast 'https://github.com/johnboiles/obs-mac-virtualcam/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).