### PR TITLE
Update zappy from 2.4.0 to 2.5.0

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,6 +1,6 @@
 cask 'zappy' do
-  version '2.4.0'
-  sha256 '41ceeb3bb893585b4e75021ad774640af8618565079c333acb392c520d18865c'
+  version '2.5.0'
+  sha256 'fa7b19b1d0cfdaf22027a81f851b4b130cff068af6e6abb670a44895b10e1f84'
 
   url "https://zappy.zapier.com/releases/zappy-#{version}.zip"
   appcast 'https://zappy.zapier.com/releases/appcast.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).