### PR TITLE
copyq: add caveat about Accessibility preferences

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -19,4 +19,8 @@ cask 'copyq' do
       exec '#{appdir}/CopyQ.app/Contents/MacOS/CopyQ' "$@"
     EOS
   end
+
+  caveats do
+    unsigned_accessibility
+  end
 end

--- a/doc/cask_language_reference/stanzas/caveats.md
+++ b/doc/cask_language_reference/stanzas/caveats.md
@@ -43,7 +43,8 @@ The following methods may be called to generate standard warning messages:
 | `discontinued`                     | all software development has been officially discontinued upstream.
 | `free_license 'web_page'`          | users may get an official license to use the software at `web_page`.
 | `kext`                             | users may need to enable their kexts in System Preferences → Security & Privacy → General.
-| `license 'web_page'`               | software has a usage license at `web_page`.
+| `unsigned_accessibility`           | users will need to re-enable the app on each update in System Preferences → Security & Privacy → Privacy as it is unsigned.
+| `license 'web_page'`               | software has a usage license at `web_page`.
 
 Example:
 


### PR DESCRIPTION
Previously https://github.com/Homebrew/homebrew-cask/pull/83157. cc/ @vitorgalvao 

As every user will hit this on every upgrade (e.g. [0][], [1][]), we
should document this in the cask itself.

Uses the caveat defined in [2][], and adds documentation for it.

[0]: https://github.com/hluk/CopyQ/issues/1030
[1]: https://github.com/hluk/CopyQ/issues/1245
[2]: https://github.com/Homebrew/brew/pull/7652

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).