### PR TITLE
Update rsyncosx from 6.2.6 to 6.3.0

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,8 +1,8 @@
 cask 'rsyncosx' do
-  version '6.2.6'
-  sha256 'bfd6f4d62d8540b9c35ba0e51f2065e30eaf12c776487bbcb0b1b76326a6d6cf'
+  version '6.3.0'
+  sha256 '29490d351ac673355a08f6cdf229dbd54851206f93f329dda98278fd4a5bd90f'
 
-  url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX-#{version}.dmg"
+  url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom'
   name 'RsyncOSX'
   homepage 'https://github.com/rsyncOSX/RsyncOSX'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.