### PR TITLE
Update Engine Prime from 1.3.4 to 1.5.0

### DIFF
--- a/Casks/engine-prime.rb
+++ b/Casks/engine-prime.rb
@@ -1,9 +1,9 @@
 cask 'engine-prime' do
-  version '1.3.4'
-  sha256 '6d2a9f9387951b242a03b842ec00aa7069f263e04b0466885b9c6d4759d0a35a'
+  version '1.5.0'
+  sha256 'ee4de365448da76640758eb70cbb0af06a99ae9ddb14a9d6d7fa8550ac6713d2'
 
   # inmusicbrands.com/ was verified as official when first introduced to the cask
-  url "https://cdn.inmusicbrands.com/denondj/EnginePrime/Engine_Prime_#{version}_Setup.dmg"
+  url "https://cdn.inmusicbrands.com/denondj/EnginePrime/15/Engine_Prime_#{version}_Setup.dmg"
   name 'Engine Prime'
   homepage 'https://www.denondj.com/engineprime'
 


### PR DESCRIPTION
Update Engine Prime to the newly released version 1.5.0
https://djworx.com/denon-djs-engine-prime-v1-5-fingers-crossed/

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).