### PR TITLE
Update sitebulb from 3.5.2 to 3.6.3

### DIFF
--- a/Casks/sitebulb.rb
+++ b/Casks/sitebulb.rb
@@ -1,6 +1,6 @@
 cask 'sitebulb' do
-  version '3.5.2'
-  sha256 '40837fa3ebf3e5e4bce4d8690554f2c225df1a8cdf33f23869dc559a9d556c90'
+  version '3.6.3'
+  sha256 'fcf7ed70115cdd1ec2d4bb59b38a566d43177b449c298d5b5d8a03db81f7f12d'
 
   url "https://downloads.sitebulb.com/#{version}/macOS/Sitebulb.dmg"
   appcast 'https://sitebulb.com/download/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).