### PR TITLE
Update psi-plus from 1.4.1275-macOS10.13 to 1.4.1303-macOS10.13

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
   version '1.4.1303-macOS10.13'
-  sha256 '55c34b2efaba60b16707022e84d71cf19a342b4d6368250083284513126281ba'
+  sha256 '1832916899883698fb764348c1e4e51e5bafbc29053b090b7ebde6048155b0de'
 
   # downloads.sourceforge.net/psiplus/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"

--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.1275-macOS10.13'
-  sha256 '6eb00b7ee9c899dd2fde272d9b0b611b392c4b9e8dabe5a4333c13628523ecac'
+  version '1.4.1303-macOS10.13'
+  sha256 '8b192c47bf8ae521368bac85d3421d024c8db7a1e2f130751143c8a1e391bae6'
 
   # downloads.sourceforge.net/psiplus/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"

--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
   version '1.4.1303-macOS10.13'
-  sha256 '8b192c47bf8ae521368bac85d3421d024c8db7a1e2f130751143c8a1e391bae6'
+  sha256 '55c34b2efaba60b16707022e84d71cf19a342b4d6368250083284513126281ba'
 
   # downloads.sourceforge.net/psiplus/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).