### PR TITLE
Update league-of-legends.rb

### DIFF
--- a/Casks/league-of-legends.rb
+++ b/Casks/league-of-legends.rb
@@ -15,10 +15,11 @@ cask 'league-of-legends' do
                '~/Library/Saved Application State/com.riotgames.LeagueofLegends.LeagueClientUx.savedState',
                '~/Library/Preferences/com.riotgames.LeagueofLegends.LeagueClientUxHelper.plist',
                '~/Library/Caches/com.riotgames.LeagueofLegends.LeagueClient',
-               '/Users/Shared/Riot Games/RiotClientInstalls.json',
-               '/Users/Shared/Riot Games/com.riot.riotclient.checkinstalls-lock',
+               '/Users/Shared/Riot Games',
              ],
-      rmdir: '~/Documents/League of Legends',
-      rmdir: '~/../Shared/Riot Games/Riot Client.app',
-      rmdir: '~/../Shared/Riot Games/Metadata'
+      rmdir: [
+               '~/Documents/League of Legends',
+               '/Users/Shared/Riot Games/Riot Client.app',
+               '/Users/Shared/Riot Games/Metadata',
+             ]
 end

--- a/Casks/league-of-legends.rb
+++ b/Casks/league-of-legends.rb
@@ -15,6 +15,10 @@ cask 'league-of-legends' do
                '~/Library/Saved Application State/com.riotgames.LeagueofLegends.LeagueClientUx.savedState',
                '~/Library/Preferences/com.riotgames.LeagueofLegends.LeagueClientUxHelper.plist',
                '~/Library/Caches/com.riotgames.LeagueofLegends.LeagueClient',
+               '/Users/Shared/Riot Games/RiotClientInstalls.json',
+               '/Users/Shared/Riot Games/com.riot.riotclient.checkinstalls-lock',
              ],
-      rmdir: '~/Documents/League of Legends'
+      rmdir: '~/Documents/League of Legends',
+      rmdir: '~/../Shared/Riot Games/Riot Client.app',
+      rmdir: '~/../Shared/Riot Games/Metadata'
 end


### PR DESCRIPTION
The Riot Client is stored in the Shared users directory, in a sub-directory called 'Riot Games'.   I have added that to the zap stanza.
- [✓] `brew cask audit --download {{cask_file}}` is error-free.
- [ X ] `brew cask style --fix {{cask_file}}` reports no offenses.
   ```
   W: 22:  7: Duplicated key in hash literal.
   W: 23:  7: Duplicated key in hash literal.

   1 file inspected, 2 offenses detected
   Error: Style check failed.
   ```
- [✓] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [✓] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
