### PR TITLE
Revert "Update tiled from 1.3.4 to 1.3.5"

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,6 +1,6 @@
 cask 'tiled' do
-  version '1.3.5'
-  sha256 'fafbd343242b70e4d1e6d8c775f71817e1ddce7caba98a4d6784424549220418'
+  version '1.3.4'
+  sha256 '23e97468fbacac9521508f5370076e00ec40d2562da9c24da3181f71c1fc960b'
 
   # github.com/bjorn/tiled/ was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/Tiled-#{version}-macos.zip"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#83311

in reference to https://github.com/Homebrew/homebrew-cask/pull/83311#issuecomment-635241903