### PR TITLE
Update cryo from 0.5.3 to 0.5.5

### DIFF
--- a/Casks/cryo.rb
+++ b/Casks/cryo.rb
@@ -1,6 +1,6 @@
 cask 'cryo' do
-  version '0.5.3'
-  sha256 'b04b7d98d2af12e07d77313a48d06e4abbc9220799ddf476c3a351ecd6ee8b23'
+  version '0.5.5'
+  sha256 'fb518e89e770218b26721947d93759aac7c4f18a77acc43cd90a64c01ea13ff8'
 
   url "https://cryonet.io/downloads/macos/cryo_#{version}_macos.zip"
   appcast 'https://cryonet.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.