### PR TITLE
Update gfortran.rb to v8.2

### DIFF
--- a/Casks/gfortran.rb
+++ b/Casks/gfortran.rb
@@ -6,13 +6,20 @@ cask 'gfortran' do
     # github.com/fxcoudert/gfortran-for-macOS/ was verified as official when first introduced to the cask
     url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-ElCapitan.dmg"
     pkg "gfortran-#{version}-ElCapitan/gfortran.pkg"
-  else
+  elsif MacOS.version == :sierra
     version '6.3'
     sha256 '38b81bc878dba41cfdbb0c335aec5a97554a5d1766fb3e3ca6be7da0df9e8e09'
 
     # github.com/fxcoudert/gfortran-for-macOS/ was verified as official when first introduced to the cask
     url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-Sierra.dmg"
-    pkg 'gfortran.pkg'
+    pkg "gfortran-#{version}-Sierra/gfortran.pkg"
+  else
+    version '8.2'
+    sha256 '81d379231ba5671a5ef1b7832531f53be5a1c651701a61d87e1d877c4f06d369'
+
+    # github.com/fxcoudert/gfortran-for-macOS/ was verified as official when first introduced to the cask
+    url "https://github.com/fxcoudert/gfortran-for-macOS/releases/download/#{version}/gfortran-#{version}-Mojave.dmg"
+    pkg "gfortran-#{version}-Mojave/gfortran.pkg"
   end
 
   appcast 'https://github.com/fxcoudert/gfortran-for-macOS/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

Conditioned older version on their respective minimum OS version.
v8.2 is out since October 2018.

cc @jimhester
