### PR TITLE
Add `auto_updates` flag to adguard 2.4.8.795

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -7,6 +7,8 @@ cask 'adguard' do
   name 'Adguard'
   homepage 'https://adguard.com/'
 
+  auto_updates true
+
   pkg 'AdGuard.pkg'
 
   uninstall pkgutil: 'com.adguard.mac.adguard-pkg'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).