### PR TITLE
Update free-download-manager from 5.1.38 to 6.9.1

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -2,7 +2,7 @@ cask 'free-download-manager' do
   version '6.9.1'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://dn3.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
+  url "https://dn3.freedownloadmanager.org/#{version.major}/latest/fdm.dmg"
   appcast 'https://www.freedownloadmanager.org/download-fdm-for-mac.htm'
   name 'Free Download Manager'
   homepage 'https://www.freedownloadmanager.org/'

--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,9 +1,9 @@
 cask 'free-download-manager' do
-  version '5.1.38'
+  version '6.9.1'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dn3.freedownloadmanager.org/#{version.major}/#{version.major_minor}-latest/fdm.dmg"
-  appcast 'https://www.freedownloadmanager.org/download.htm'
+  appcast 'https://www.freedownloadmanager.org/download-fdm-for-mac.htm'
   name 'Free Download Manager'
   homepage 'https://www.freedownloadmanager.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.