### PR TITLE
Update lando from 3.0.3 to 3.0.4

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.3'
-  sha256 'a89a3919b6d95cdf15d92dd12234936477593e18f748ad1aeb4217fd6e6624a5'
+  version '3.0.4'
+  sha256 '176a1afe7a638a0fae25c8e9b3d6122d403ac7f5e67c0eaac1548460a3d281a0'
 
   # github.com/lando/lando/ was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.