### PR TITLE
created zap stanza for Mountain Duck 3.4.0.15624

### DIFF
--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -14,6 +14,6 @@ cask 'mountain-duck' do
   zap trash: [
                '~/Library/Application Scripts/io.mountainduck.findersync',
                '~/Library/Containers/io.mountainduck.findersync',
-               # '~/Library/Group Containers/*.duck',
+               '~/Library/Group Containers/G69SCX94XU.duck',
              ]
 end

--- a/Casks/mountain-duck.rb
+++ b/Casks/mountain-duck.rb
@@ -10,4 +10,10 @@ cask 'mountain-duck' do
   auto_updates true
 
   app 'Mountain Duck.app'
+
+  zap trash: [
+               '~/Library/Application Scripts/io.mountainduck.findersync',
+               '~/Library/Containers/io.mountainduck.findersync',
+               # '~/Library/Group Containers/*.duck',
+             ]
 end


### PR DESCRIPTION
There's a folder created by Mountain Duck that I _think_ may be shared with Cyberduck if it's installed. That folder shouldn't be zapped, unless there's a way to check if Cyberduck is or isn't installed. Or maybe there could be a message saying "you'll have to delete this yourself, but this is where to find it," or maybe a prompt for confirmation. But I have no idea how to do that, and I'm not sure how this is typically handled.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
