### PR TITLE
Update c0re100-qbittorrent from 4.2.5.10 to 4.2.5.11

### DIFF
--- a/Casks/c0re100-qbittorrent.rb
+++ b/Casks/c0re100-qbittorrent.rb
@@ -1,6 +1,6 @@
 cask 'c0re100-qbittorrent' do
-  version '4.2.5.10'
-  sha256 '1fec5c9b300d6dadc250ff15f2e7acdd28f062153aef2a02b9cffad0059923f2'
+  version '4.2.5.11'
+  sha256 '8dd2d4b70b3af1bcec83023eb85c130d25e1e0c05fb759d77d876752e7ad6d84'
 
   url "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-#{version}/qBittorrent-#{version}.dmg"
   appcast 'https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).