### PR TITLE
Update wordpresscom from 5.1.1 to 5.2.0

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask 'wordpresscom' do
-  version '5.1.1'
-  sha256 'b606966c9ad16318166b5d500299b10a33d3e550278a425e5bbfb6d8230e8b3a'
+  version '5.2.0'
+  sha256 '4c40595a2220f5fa38e98e9fc108b9344009989fd3e33f03879c4742017d5b12'
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast 'https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).