### PR TITLE
podman: Update to 1.9.3

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -1,30 +1,14 @@
 cask 'podman' do
-  version '1.6.0,28-gdac7889d'
-  sha256 '10aa54e65084a6db98aa46b90fdcdec7b4ae0eb5d241e65dd360859e43bb1236'
+  version '1.9.3'
+  sha256 '221bab2f343252aaa465712a3873faad958f24bd66436ba09c36e329a74de030'
 
-  url "https://github.com/containers/libpod/releases/download/v#{version.before_comma}/podman-remote-v#{version.before_comma}-#{version.after_comma}-master-darwin-amd64.tgz"
+  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-remote-darwin.tar.gz"
   appcast 'https://github.com/containers/libpod/releases.atom'
   name 'podman'
   homepage 'https://github.com/containers/libpod/'
 
-  binary "podman-v#{version.before_comma}-#{version.after_comma}/podman"
-
-  postflight do
-    man1 = Dir["#{staged_path}/podman-*/docs/*.1"]
-    FileUtils.mv(man1, "#{HOMEBREW_PREFIX}/share/man/man1/")
-
-    man5 = Dir["#{staged_path}/podman-*/docs/*.5"]
-    FileUtils.mkdir("#{HOMEBREW_PREFIX}/share/man/man5/") unless File.exist?("#{HOMEBREW_PREFIX}/share/man/man5/")
-    FileUtils.mv(man5, "#{HOMEBREW_PREFIX}/share/man/man5/")
-  end
-
-  uninstall_postflight do
-    man1 = Dir["#{HOMEBREW_PREFIX}/share/man/man1/podman*.1"]
-    FileUtils.rm(man1)
-
-    man5 = Dir["#{HOMEBREW_PREFIX}/share/man/man5/podman*.5"]
-    FileUtils.rm(man5)
-  end
+  # Renamed for consistency with previous releases
+  binary 'podman-remote-darwin', target: 'podman'
 
   zap trash: '~/.config/containers/podman-remote.config'
 end


### PR DESCRIPTION
- Update to new version number scheme
- Remove man docs because they are no longer provided in tarball

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
