### PR TITLE
Update podman

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -7,8 +7,7 @@ cask 'podman' do
   name 'podman'
   homepage 'https://github.com/containers/libpod/'
 
-  # Renamed for consistency with previous releases
-  binary 'podman-remote-darwin', target: 'podman'
+  binary 'podman-remote-darwin'
 
   zap trash: '~/.config/containers/podman-remote.config'
 end


### PR DESCRIPTION
@vitorgalvao I accidentally merged #83504 without my push on the PR to remove the binary rename, because (to my knowledge) we don't allow that sort of thing. This fixes it. However, if you to allow it (`podman-remote-darwin` is pretty terrible), feel free to close this PR. Thanks.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.