### PR TITLE
Fix `Formula#installed` error in `brewcask-ci.rb`

### DIFF
--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -132,7 +132,7 @@ module Cask
             ensure
               cask_and_formula_dependencies.reverse.each do |cask_or_formula|
                 next unless cask_or_formula.is_a?(Cask)
-                Installer.new(cask_or_formula, verbose: true).uninstall if cask_or_formula.installed?
+                Installer.new(cask_or_formula, verbose: true).uninstall if cask_or_formula.any_version_installed?
               end
             end
 


### PR DESCRIPTION
Fixes `Error: Calling Formula#installed? is deprecated! Use Formula#latest_version_installed? (or Formula#any_version_installed? ) instead.`, as encounted on  #83274 and #83510. Ping @vitorgalvao 