### PR TITLE
Update tiled from 1.3.4 to 1.3.5

### DIFF
--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -1,6 +1,6 @@
 cask 'tiled' do
-  version '1.3.4'
-  sha256 '23e97468fbacac9521508f5370076e00ec40d2562da9c24da3181f71c1fc960b'
+  version '1.3.5'
+  sha256 'eee141430f29d2b1427afc70ecd0c215cd04308406da9fa22469636e4122ffde'
 
   # github.com/bjorn/tiled/ was verified as official when first introduced to the cask
   url "https://github.com/bjorn/tiled/releases/download/v#{version}/Tiled-#{version}-macos.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.