### PR TITLE
Update use-engine from 2.2.4.1 to 2.2.5

### DIFF
--- a/Casks/use-engine.rb
+++ b/Casks/use-engine.rb
@@ -1,6 +1,6 @@
 cask 'use-engine' do
-  version '2.2.4.1'
-  sha256 '6077d7f7a1ae417acb6257443a9db9ebe7803db7f9ef4125b57bc7ded999763e'
+  version '2.2.5'
+  sha256 '7ec4d9da00b7c9637bd092fb14a3d24d24bc66aff5bfd91da08c58ed8c824a95'
 
   url "https://repository.use-together.com/stable/use-engine/macos/#{version.major}.x/#{version}/use-engine.dmg"
   name 'USE Engine'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.