### PR TITLE
Update shutter-encoder from 13.7 to 13.8

### DIFF
--- a/Casks/shutter-encoder.rb
+++ b/Casks/shutter-encoder.rb
@@ -1,6 +1,6 @@
 cask 'shutter-encoder' do
-  version '13.7'
-  sha256 '154d3fcaa1977243f956672bc5f7d1b0a99e4202326713a5501b5ffcf81ff89f'
+  version '13.8'
+  sha256 '96e4970477763130a2a4859b95f5f42552a772aad2ec42627af780808081d566'
 
   url "https://www.shutterencoder.com/Shutter%20Encoder%20(MAC%20Version%20#{version}).zip"
   appcast 'https://www.shutterencoder.com/changelog.txt'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).