### PR TITLE
Link Filebot bash completion plugin into bash_completion.d

### DIFF
--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -9,6 +9,7 @@ cask 'filebot' do
 
   app 'FileBot.app'
   binary "#{appdir}/FileBot.app/Contents/MacOS/filebot.sh", target: 'filebot'
+  binary "#{appdir}/FileBot.app/Contents/Resources/bash_completion.d/filebot_completion", target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/filebot"
 
   zap trash: '~/Library/Preferences/net.filebot.ui.plist'
 end


### PR DESCRIPTION
This change will make the `filebot` command auto-completion work with `Bash 4` (installed via `brew`) but won't affect the default macOS `bash 3` or `zsh` tools.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
