### PR TITLE
Update openttd from 1.10.1 to 1.10.2

### DIFF
--- a/Casks/openttd.rb
+++ b/Casks/openttd.rb
@@ -1,6 +1,6 @@
 cask 'openttd' do
-  version '1.10.1'
-  sha256 'f35cef401dc3872d0e7cfb34cef24cd62cdaca0998d514905f8f8389986e2316'
+  version '1.10.2'
+  sha256 'b655cd2109f9b1feb551694a7a4f25dc3f1cc13b04685e5d07cade4a35823179'
 
   url "https://proxy.binaries.openttd.org/openttd-releases/#{version}/openttd-#{version}-macosx.zip"
   appcast 'https://www.openttd.org/downloads/openttd-releases/latest.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.