### PR TITLE
Update Flux to remove version from URL

### DIFF
--- a/Casks/flux.rb
+++ b/Casks/flux.rb
@@ -2,7 +2,7 @@ cask 'flux' do
   version '40.1'
   sha256 '1844305519b450cfe3c5475e99f6c06fb2eea51e65c1b0ee25f6671a49fff75d'
 
-  url "https://justgetflux.com/mac/Flux#{version}.zip"
+  url "https://justgetflux.com/mac/Flux.zip"
   appcast 'https://justgetflux.com/mac/macflux.xml'
   name 'f.lux'
   homepage 'https://justgetflux.com/'


### PR DESCRIPTION
The url does not actually have a version. This causes the following failures:
```
> brew cask install flux
==> Downloading https://justgetflux.com/mac/Flux40.1.zip
##O#- #
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
Error: Download failed on Cask 'flux' with message: Download failed: https://justgetflux.com/mac/Flux40.1.zip
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
