### PR TITLE
Update powder-player from 1.55 to 1.60

### DIFF
--- a/Casks/powder-player.rb
+++ b/Casks/powder-player.rb
@@ -1,6 +1,6 @@
 cask 'powder-player' do
-  version '1.55'
-  sha256 '8b52dc9772d255c753693c95ff4ca381dc4da8a897f7d3b51ff51728bf01c002'
+  version '1.60'
+  sha256 '66f532b975c12f3d5343e7589dcc6746e1a555416494bd8f6b80642464b7b66a'
 
   # github.com/jaruba/PowderPlayer/ was verified as official when first introduced to the cask
   url "https://github.com/jaruba/PowderPlayer/releases/download/v#{version}/PowderPlayer_v#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).