### PR TITLE
Update wire from 3.17.3666 to 3.18.3728

### DIFF
--- a/Casks/wire.rb
+++ b/Casks/wire.rb
@@ -1,6 +1,6 @@
 cask 'wire' do
-  version '3.17.3666'
-  sha256 'f646b364a448686dd88c5aa6ef6ab5427945030e3112332c375081deb29b6c64'
+  version '3.18.3728'
+  sha256 'b4f87f375552ea498089a36232be115f72da797c8131bb95d33d15ee4b9a2376'
 
   # github.com/wireapp/wire-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/wireapp/wire-desktop/releases/download/macos%2F#{version}/Wire.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).