### PR TITLE
Update duefocus from 2.4.6 to 2.5.0

### DIFF
--- a/Casks/duefocus.rb
+++ b/Casks/duefocus.rb
@@ -1,6 +1,6 @@
 cask 'duefocus' do
-  version '2.4.6'
-  sha256 'aca41b8d798e207c9a579bda6670aaca9db5248bc24038947ff806d2cd9c59b9'
+  version '2.5.0'
+  sha256 '41cb010236fce73f91ad0e55a14d29c7fe1451984aba6be3b6a5de3f1f789271'
 
   url "https://web.duefocus.com/distribution/darwin/v3/DueFocus-#{version}-mac.zip"
   appcast 'https://web.duefocus.com/distribution/darwin/v3/appcast.html'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).