### PR TITLE
Update another-redis-desktop-manager from 1.3.5 to 1.3.6

### DIFF
--- a/Casks/another-redis-desktop-manager.rb
+++ b/Casks/another-redis-desktop-manager.rb
@@ -1,8 +1,8 @@
 cask 'another-redis-desktop-manager' do
-  version '1.3.5'
-  sha256 '7da22ee2d677bf9e52bf92478b8c7968abfb97bbcb8033cf4edc81af2b97d997'
+  version '1.3.6'
+  sha256 '22f8ca81cb5f19c3eceacf8494191db07709ff93608051a164f52b967430cf0d'
 
-  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another.Redis.Desktop.Manager.#{version}.dmg"
+  url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another-Redis-Desktop-Manager.#{version}.dmg"
   appcast 'https://github.com/qishibo/AnotherRedisDesktopManager/releases.atom'
   name 'Another Redis Desktop Manager'
   homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'

--- a/Casks/another-redis-desktop-manager.rb
+++ b/Casks/another-redis-desktop-manager.rb
@@ -7,5 +7,5 @@ cask 'another-redis-desktop-manager' do
   name 'Another Redis Desktop Manager'
   homepage 'https://github.com/qishibo/AnotherRedisDesktopManager/'
 
-  app 'Another.Redis.Desktop.Manager.app'
+  app 'Another Redis Desktop Manager.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.