### PR TITLE
Update pd-l2ork from 2.10.1 to 2.11.0

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,9 +1,9 @@
 cask 'pd-l2ork' do
-  version '2.10.1'
-  sha256 '3c899164df5bd753bb9fecf0c406af318a611acdb75c9175407aa304ff02e432'
+  version '2.11.0'
+  sha256 'b30ee278d8417ee0edab353004e9f4b47edeb725357ca1598d2a0117b0c8c95b'
 
   # github.com/agraef/purr-data/ was verified as official when first introduced to the cask
-  url "https://github.com/agraef/purr-data/releases/download/#{version}/pd-l2ork-#{version}-osx_10.11-x86_64-dmg.zip"
+  url "https://github.com/agraef/purr-data/releases/download/#{version}/osx_10.11-x86_64-dmg.zip"
   appcast 'https://github.com/agraef/purr-data/releases.atom'
   name 'Pd-l2ork'
   name 'Purr Data'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.