### PR TITLE
nextcloud: also install the command-line client

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -15,6 +15,7 @@ cask 'nextcloud' do
   depends_on macos: '>= :yosemite'
 
   pkg "Nextcloud-#{version}.pkg"
+  binary "#{appdir}/nextcloud.app/Contents/MacOS/nextcloudcmd"
 
   uninstall pkgutil: 'com.nextcloud.desktopclient'
 end


### PR DESCRIPTION
Ref: https://docs.nextcloud.com/desktop/2.6/advancedusage.html#nextcloud-command-line-client

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
