### PR TITLE
Update angry-ip-scanner from 3.7.1 to 3.7.2

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -1,6 +1,6 @@
 cask 'angry-ip-scanner' do
-  version '3.7.1'
-  sha256 'e6e45b8cce5e26017e9c4033b2c9d21a32a30c850f13c39095f8aa2571241c81'
+  version '3.7.2'
+  sha256 '229e1c2dcb1fcccacd2816c7a0e1ad43733f7a09cf76df4ecd53ccdafee8bdda'
 
   # github.com/angryip/ipscan/ was verified as official when first introduced to the cask
   url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).