### PR TITLE
Update tidepool-uploader from 2.30.1 to 2.31.0

### DIFF
--- a/Casks/tidepool-uploader.rb
+++ b/Casks/tidepool-uploader.rb
@@ -1,6 +1,6 @@
 cask 'tidepool-uploader' do
-  version '2.30.1'
-  sha256 '6fb4dbadf0a42b3956a7d5adec90e35690eaa6437e1c157125b51ce6c5728b98'
+  version '2.31.0'
+  sha256 '535a9e087a5447061e12eb9913a98f507870e785a740eb52ba00f817331c0283'
 
   # github.com/tidepool-org/chrome-uploader/ was verified as official when first introduced to the cask
   url "https://github.com/tidepool-org/chrome-uploader/releases/download/v#{version}/tidepool-uploader-#{version}.dmg/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).