### PR TITLE
Update firefox from 77.0 to 77.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '77.0'
+  version '77.0.1'
 
   language 'cs' do
-    sha256 'f073faad3b4dc982f47bb478af49a3e5e5209a2f5812757f5bab10e8f94f95d0'
+    sha256 'db339fd0c9198a06b4fea425db4090cd0a23169bff0ad2a90ae8965a9906e1da'
     'cs'
   end
 
   language 'de' do
-    sha256 '6ac652d614c6eafd66ca3dc56730d959f7990bf47966ce586873d70b0e62489a'
+    sha256 '91baccd3b1f1a03294f44c2cf87c12a732a89592974552ea4a33269e3029ae84'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '680e634266dc189df8f332fe5ca537a06809cd5d11e5ed3170c149322091a9aa'
+    sha256 '278facb713b60b82dab6d8eb7fbcdf8699967e515691c2f639921742fe332737'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'be1735b3ee7fcb49e86689dcdf7c84d4832c5a188304bb7604a8c8f2df456670'
+    sha256 '8816d93824644733682ed4544c9730012fde0d46d51f5d050fe7968f2bf22ec5'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '4c8aa32dcd8418e81f45781f2b7d053c2193d32239a8f74d5f26b02a96c1ced7'
+    sha256 '5531758a0b879ca4f324b89f3bcee8f2aa5c66d77698b5b7f806cc508ab00169'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '0099203b1c3df0ecfa13ee4b38f54f95abc70e0a13532394d3cac9575b5a36ec'
+    sha256 '1cfa70b43bfcc74ff5d158484407db797cc699d59bbc5edc147e5f09f007855e'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '2d3db4b4569df710189db6ac28d462132b6ed9a2741d3b25f82814b5179b9263'
+    sha256 '0fb92f103723d40833d89bc6a8271a59cc8c5f6b934b66ac3db41ca8c92d0e28'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 '7e8b1659ffa4235c763d6e125c22a185d7ec015a23003a79e1a67cbbe48161d9'
+    sha256 'fd97ae5ce1e8c514a570edfe77669904b8b08c11f496a5cc3d2ae63d076d57cc'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '76491718651de0d788c3d85f8604f5136f7b938ae138dfccddfa3b4c6c8fe87d'
+    sha256 'c32c6a21ce5eaa5ce64ff6fbf9740b982513ae948d86a6e1bf8b2341b0e1b7e8'
     'fi'
   end
 
   language 'fr' do
-    sha256 '28011ebfe15a0ea992c1cc6430919a2770323f3f77ac0bc87e3ada819096cf55'
+    sha256 '2b0fbecc6aac220dcafe0f5c974e7e1d0574857c29fb947625daaac53b9bbff2'
     'fr'
   end
 
   language 'gl' do
-    sha256 '091a819b2f2a118c5bbb0c119404cb7746fd13f6fa7d71fe12b29ff70ec5835a'
+    sha256 'e6289a860391d939b8e9b037f0dbb77e005eec8796c5b2ce1d099e4b15d88145'
     'gl'
   end
 
   language 'in' do
-    sha256 '2a29004ee38a133dfe749ab3868dddd041cafaa901cff3540810a272f94cc7b2'
+    sha256 '69977fc1a4707423a746a0b4b490ecb1108962fbfe7100ed71610740ef0cccee'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 'b8301499dfe67a4bbb55d051622defa545bdc7e6c94a567a38ccc9203e19454c'
+    sha256 '951a4a1243feeee3b9c8fa199d5c5d05b7050ed1cee1caeda624549fcc338b70'
     'it'
   end
 
   language 'ja' do
-    sha256 'ac6ec25ec6fee5371d786c47654aaf6211714258d9a1ad722dcf1008d39c4645'
+    sha256 'aa2b0baf5b468a7d8c989453fc68050ba38236d9a1ade58e13f1048131ae473e'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '7a34977d17ca03c77fef2a3faa2944ace161b0182a424a3f9a276fb6d62e245b'
+    sha256 '9d687faa3d6fd004e31d156564e2708cd3ddb4d8da21dea3273c7c36c0903b50'
     'ko'
   end
 
   language 'nl' do
-    sha256 '8ad92542ef8363a6904645fa7dd24835dee1757c533c9b890133c81f985f43cb'
+    sha256 'd9db813c514ccca4d2ec65b860004bad18d8ea7138c78b244e285762f323ac25'
     'nl'
   end
 
   language 'pl' do
-    sha256 'bff64769d997b14f3442898e0a200154c5c2c6ff19452149834a444badc91d48'
+    sha256 '37bdd02f819eababe0106d3238953f59c2d12c0cf08934ec4baec3dec88110cc'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '5dc8a08efea4410c3c76ae9df0d05cc675e7100bcac20ccaff9853e4570135af'
+    sha256 '2b5f4f269352bc02cc9a51514a476c094626957589c79e53cd263aa03b53675f'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 '5bffe28a18309af837ff7e246f5053aeb11245e85c20857e1f7c365c09913a5b'
+    sha256 'fd70be0b91021dec4d403f72392b93e511497461de8084300b7b4aa8d675a489'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '76203d9bbf7171fad8d7cbd9041006b5b3f43e64cf8484252d38fd45dd10604c'
+    sha256 '1a5cf91a5cdfbe634ce3f7f62b96d51f99c75767fc0938eab4654bae6c57427c'
     'ru'
   end
 
   language 'tr' do
-    sha256 '58c64f1358dd9a9d294b0b7166663e36534dc006fa8d4571f9a9bea07d9041d9'
+    sha256 'd40c5d773c260283fa944a21c6f1e45ceabef29b2e908e31217c4085e8de6bbc'
     'tr'
   end
 
   language 'uk' do
-    sha256 'd855313f591105a9d0c2f11b56887649c139baa840fe6097150670faedee6b5b'
+    sha256 'f4a0b8aae8a655f6e39ba6edb738f551ac55b52c38e3bbc768225cf0756c8d0a'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '1cd50adb9b781e560fea3c04ec05f09da56135480e8c03f541fe7e3115e5039a'
+    sha256 'd54696a8657b758728df2573f05769465edb614c53d956dfa510ac774259b634'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '9f91cde780d9ed79ad5ba4194d2133e9740b60accf102f8be4a7739d00e031b7'
+    sha256 'a7592d80af3b7bda655a37f9779f7357872c6ec1a4dea708f0aab02e7f344375'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).