### PR TITLE
Update cctalk from 7.6.6-1036 to 7.6.7.9

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask 'cctalk' do
-  version '7.6.6-1036'
-  sha256 '06e92cfb8ffca6cc5ba06405f081c93684e5bf09ada2b86254b50f825b4c8760'
+  version '7.6.7.9'
+  sha256 '82983490f55ab5b4e37c184d47a5e59bf6376cc742f7a6c2aaba1f18668f6d78'
 
   # cc.hjfile.cn/ was verified as official when first introduced to the cask
-  url "https://cc.hjfile.cn/cc/CCtalk.#{version}/8/1/103/CCtalk.#{version}.dmg"
+  url "http://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103'
   name 'CCtalk'
   homepage 'https://www.cctalk.com/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.