### PR TITLE
Update waterfox-current from 2020.05,6820.5.5 to 2020.06,6820.6.2

### DIFF
--- a/Casks/waterfox-current.rb
+++ b/Casks/waterfox-current.rb
@@ -1,9 +1,8 @@
 cask 'waterfox-current' do
-  version '2020.05,6820.5.5'
-  sha256 '80608f12658c63074e7f6067d6646dc4998584dac2302f4cac88005ae5753bc1'
+  version '2020.06,6820.6.2'
+  sha256 '945e3a87cfd1eb194ee5fd5dcb751ba16dc7eb6c1ffbf9637c7c28d2c4e2729f'
 
-  # storage-waterfox.netdna-ssl.com/ was verified as official when first introduced to the cask
-  url "https://storage-waterfox.netdna-ssl.com/releases/osx64/installer/Waterfox%20Current%20#{version.before_comma}%20Setup.dmg"
+  url "https://cdn.waterfox.net/releases/osx64/installer/Waterfox%20Current%20#{version.before_comma}%20Setup.dmg"
   appcast 'https://www.waterfox.net/download/'
   name 'Waterfox Current'
   homepage 'https://www.waterfox.net/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.