### PR TITLE
Update chirp from 20200521 to 20200603

### DIFF
--- a/Casks/chirp.rb
+++ b/Casks/chirp.rb
@@ -1,6 +1,6 @@
 cask 'chirp' do
-  version '20200521'
-  sha256 'f5115b5bffd3a2c931a4bd8ce45d62def44e2000899ba8738e8591d38557b8f9'
+  version '20200603'
+  sha256 '30fefb6b520f08fbbcfac7a0d43bf8b0c108f60542e843affafaac8a62fa8694'
 
   url "https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-unified-daily-#{version}.app.zip"
   appcast 'https://trac.chirp.danplanet.com/chirp_daily/LATEST/SHA1SUM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.