### PR TITLE
Update syncovery from 8.65c to 8.68a

### DIFF
--- a/Casks/syncovery.rb
+++ b/Casks/syncovery.rb
@@ -1,6 +1,6 @@
 cask 'syncovery' do
-  version '8.65c'
-  sha256 '1f35f9036553808607934906921295dd5cb2d938d087598e1af7eeb0b00a71e6'
+  version '8.68a'
+  sha256 'f99b0d208bff8a563cb994674b75634b01a27daf0fadf0b4a17a42973820ef15'
 
   url "https://www.syncovery.com/release/SyncoveryMac#{version}.dmg"
   appcast 'https://www.syncovery.com/download/mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.