### PR TITLE
Update odrive from 6683 to 6696

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,10 +1,10 @@
 cask 'odrive' do
-  version '6683'
-  sha256 '7825ae0d8b603b4a879d4d46551b29562d0b30d3765f98b8b0506a16958c786d'
+  version '6696'
+  sha256 '7deec3397c326b96d898d4bec8a386e336421c61fdf4e24335f4f5fb28752452'
 
   # downloads can be found at https://www.odrive.com/downloaddesktop
   # d3huse1s6vwzq6.cloudfront.net/ was verified as official when first introduced to the cask
-  url "https://d3huse1s6vwzq6.cloudfront.net/odrivesync.#{version}.dmg"
+  url "https://d3huse1s6vwzq6.cloudfront.net/odrivesync.#{version}.pkg"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.odrive.com/downloaddesktop?platform=mac'
   name 'odrive'
   homepage 'https://www.odrive.com/'

--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -9,7 +9,7 @@ cask 'odrive' do
   name 'odrive'
   homepage 'https://www.odrive.com/'
 
-  pkg "odrive.#{version}.pkg"
+  pkg "odrivesync.#{version}.pkg"
 
   uninstall quit:    'com.oxygencloud.odrive',
             pkgutil: 'com.oxygen.odrive.*'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.