### PR TITLE
Update edfbrowser from 1.75 to 1.76

### DIFF
--- a/Casks/edfbrowser.rb
+++ b/Casks/edfbrowser.rb
@@ -1,6 +1,6 @@
 cask 'edfbrowser' do
-  version '1.75,17cf821fec8dc9b27e9632c055307117'
-  sha256 'a0ac2209b2e4372964ba9b4d2e26bdd0b5fad86316fbd982f7b759b2b4305bb4'
+  version '1.76,87e7b6e7565cce3453f85e78bebfd759'
+  sha256 '9cbbf181604f10628242f720732cf730a90d04244864a94dc296be1340613cc7'
 
   # gitlab.com/whitone/EDFbrowser/ was verified as official when first introduced to the cask
   url "https://gitlab.com/whitone/EDFbrowser/uploads/#{version.after_comma}/EDFbrowser-#{version.before_comma}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).