### PR TITLE
Update miro-formerly-realtimeboard

### DIFF
--- a/Casks/miro-formerly-realtimeboard.rb
+++ b/Casks/miro-formerly-realtimeboard.rb
@@ -2,13 +2,12 @@ cask 'miro-formerly-realtimeboard' do
   version :latest
   sha256 :no_check
 
-  # desktop.realtimeboard.com/ was verified as official when first introduced to the cask
-  url 'https://desktop.realtimeboard.com/platforms/darwin/Miro%20-%20formerly%20RealtimeBoard.dmg'
+  url 'https://desktop.miro.com/platforms/darwin/Miro.dmg'
   name 'Miro'
   name 'RealtimeBoard'
   homepage 'https://miro.com/'
 
-  app 'Miro - formerly RealtimeBoard.app'
+  app 'Miro.app'
 
   zap trash: [
                '~/Library/Preferences/com.electron.realtimeboard.plist',

--- a/Casks/miro.rb
+++ b/Casks/miro.rb
@@ -1,4 +1,4 @@
-cask 'miro-formerly-realtimeboard' do
+cask 'miro' do
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.