### PR TITLE
Update pdf-squeezer from 3.10.5 to 4.0.2

### DIFF
--- a/Casks/pdf-squeezer.rb
+++ b/Casks/pdf-squeezer.rb
@@ -1,9 +1,9 @@
 cask 'pdf-squeezer' do
-  version '3.10.5'
-  sha256 '30ed7389586cad83a9702e2f5f311fc1aab24dc1d8cf4f038b5bfa629c36c92a'
+  version '4.0.2'
+  sha256 'd8b0ad35f63e5f8aa1017342c6b02b3652057c3a4c49143cf0a2d4ac52d0a12f'
 
-  url 'https://witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
-  appcast 'https://witt-software.com/downloads/pdfsqueezer/appcast.xml'
+  url 'https://www.witt-software.com/downloads/pdfsqueezer/PDF%20Squeezer.dmg'
+  appcast 'https://www.witt-software.com/downloads/pdfsqueezer/pdfsq4-appcast.xml'
   name 'PDF Squeezer'
   homepage 'https://witt-software.com/pdfsqueezer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.