### PR TITLE
Update obsidian from 0.6.5 to 0.6.7

### DIFF
--- a/Casks/obsidian.rb
+++ b/Casks/obsidian.rb
@@ -1,6 +1,6 @@
 cask 'obsidian' do
-  version '0.6.5'
-  sha256 'ff50dd63c01efc7d59cd48d5a387be813bbebead1b79f696943bfa7a54f1471b'
+  version '0.6.7'
+  sha256 '15110ee8f5a30c3c75de9302740d0b3009dd06723f5b3d220d484fa5c7c7c4a3'
 
   # github.com/obsidianmd/ was verified as official when first introduced to the cask
   url "https://github.com/obsidianmd/obsidian-releases/releases/download/v#{version}/Obsidian-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).