### PR TITLE
Update sitebulb from 3.6.3 to 3.6.4

### DIFF
--- a/Casks/sitebulb.rb
+++ b/Casks/sitebulb.rb
@@ -1,6 +1,6 @@
 cask 'sitebulb' do
-  version '3.6.3'
-  sha256 'fcf7ed70115cdd1ec2d4bb59b38a566d43177b449c298d5b5d8a03db81f7f12d'
+  version '3.6.4'
+  sha256 'f3ec327d9261a70a376c1ce49555599e17e5be53e1cb7136764569e71fc75a35'
 
   url "https://downloads.sitebulb.com/#{version}/macOS/Sitebulb.dmg"
   appcast 'https://sitebulb.com/download/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).