### PR TITLE
Update Motrix from 1.5.13 to 1.5.15

### DIFF
--- a/Casks/motrix.rb
+++ b/Casks/motrix.rb
@@ -1,6 +1,6 @@
 cask 'motrix' do
-  version '1.5.13'
-  sha256 '98f760fe64159adce7de6bf401c68ba8653f754f7c966bb7770e596f4e9e94b0'
+  version '1.5.15'
+  sha256 'f918e23d01fabe75d1970d7839e80a2a2b220b9f66b9ae69d056734e8bb9046c'
 
   # github.com/ was verified as official when first introduced to the cask
   url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}.dmg"


### PR DESCRIPTION
Update Motrix from 1.5.13 to 1.5.15

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
