### PR TITLE
Update battlescribe from 2.03.20 to 2.03.21

### DIFF
--- a/Casks/battlescribe.rb
+++ b/Casks/battlescribe.rb
@@ -1,6 +1,6 @@
 cask 'battlescribe' do
-  version '2.03.20'
-  sha256 '4f858e184a47d42b973e7fe9cd89cce3540cfb0f7309707e3c92f92ffa8c32f8'
+  version '2.03.21'
+  sha256 '2d89e5d84b6c321db9ff46f73486e40dc93209efefb7ee663158d840831667bc'
 
   url "https://battlescribe.net/files/BattleScribe_#{version}_Installer.pkg"
   appcast 'https://battlescribe.net/?tab=downloads'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).