### PR TITLE
Update photoninja from 1.3.8b to 1.3.9

### DIFF
--- a/Casks/photoninja.rb
+++ b/Casks/photoninja.rb
@@ -1,6 +1,6 @@
 cask 'photoninja' do
-  version '1.3.8b'
-  sha256 '40709d2711ab780054efccc5550941e4f31240311ed62fdf418378eb558a48cb'
+  version '1.3.9'
+  sha256 'f08dcb13709460e94898176bc0276716026974326eca24efc3927ecef24de0a9'
 
   # picturecode.cachefly.net/ was verified as official when first introduced to the cask
   url "https://picturecode.cachefly.net/photoninja/downloads/Install_PhotoNinja_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.