### PR TITLE
Update gdlauncher from 1.0.5 to 1.0.6

### DIFF
--- a/Casks/gdlauncher.rb
+++ b/Casks/gdlauncher.rb
@@ -1,6 +1,6 @@
 cask 'gdlauncher' do
-  version '1.0.5'
-  sha256 '93bb5cdf7808be4582b4bf05eec59a0e20225a3fcb9ff7a385dc92fb8174d171'
+  version '1.0.6'
+  sha256 '1163ce4f4db5d08a8cc59a48fe1e5a2ac93a97d26d4e7b42a749ad6f46e87f99'
 
   # github.com/gorilla-devs/GDLauncher/ was verified as official when first introduced to the cask
   url "https://github.com/gorilla-devs/GDLauncher/releases/download/v#{version}/GDLauncher-mac-setup.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).