### PR TITLE
Update keeweb from 1.15.0 to 1.15.1

### DIFF
--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -1,6 +1,6 @@
 cask 'keeweb' do
-  version '1.15.0'
-  sha256 '832f3643886a038651804157e6d7e4985e65911449050f4a43ec2e6e9f3efa79'
+  version '1.15.1'
+  sha256 'e9c08df636a94f54adc12118fb5491a5b084100dc1f39255ba9bc51f7a7d4dfc'
 
   # github.com/keeweb/keeweb/ was verified as official when first introduced to the cask
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).