### PR TITLE
Update browserosaurus from 10.4.1 to 10.4.2

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask 'browserosaurus' do
-  version '10.4.1'
-  sha256 '07ef1a1c5a554f311ec9d80ccc1a1682183a5aaabd05c3404e75384167605205'
+  version '10.4.2'
+  sha256 '74a725aa6ce9557249b8d56185d61437a7d4e5fc959bc4f9156ff71d92687810'
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.