### PR TITLE
Update sha256 for kekadefaultapp 1.1.22,1.0.1-r.7

### DIFF
--- a/Casks/kekadefaultapp.rb
+++ b/Casks/kekadefaultapp.rb
@@ -1,6 +1,6 @@
 cask 'kekadefaultapp' do
   version '1.1.22,1.0.1-r.7'
-  sha256 '64a9ba60d5fdf7e8e72b21e9bdec0c2804b07f83599de61368f2ecebdcb65eb1'
+  sha256 '14a6150bf81907b54430ab93b1963c16f1fb56a212f36a01da2a44de945299d4'
 
   url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}/KekaDefaultApp.v#{version.after_comma}.zip"
   appcast 'https://github.com/aonez/Keka/releases.atom'


### PR DESCRIPTION
The sha256 value in the cask does not match the value of the file that
is downloaded from github. This updates the cask to match the correct
sha256 checksum.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
