### PR TITLE
framer-x.rb: discontinued

### DIFF
--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -11,4 +11,14 @@ cask 'framer-x' do
   depends_on macos: '>= :high_sierra'
 
   app 'Framer X.app'
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      This software has been deprecated in favor of Framer Desktop (framer cask).
+      Your Framer X license will be honoured on the new software:
+
+        https://www.framer.com/support/using-framer/framer-x/
+    EOS
 end

--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -21,4 +21,5 @@ cask 'framer-x' do
 
         https://www.framer.com/support/using-framer/framer-x/
     EOS
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

We don’t usually deprecate in this manner, but in this case there’s a clear path users should take.