### PR TITLE
Update natron from 2.3.14 to 2.3.15

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,6 +1,6 @@
 cask 'natron' do
   version '2.3.15'
-  sha256 '7afe4ab02f2538b695e6d36f26fade558a9625fd4d228f587cff38dd5478b804'
+  sha256 '9ac24bb154aea1d65813c2a8451237f02b77dd68a39619c91a671ab897eebde9'
 
   # github.com/NatronGitHub/Natron/ was verified as official when first introduced to the cask
   url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-OSX-64.dmg"

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,9 +1,9 @@
 cask 'natron' do
-  version '2.3.14'
+  version '2.3.15'
   sha256 '7afe4ab02f2538b695e6d36f26fade558a9625fd4d228f587cff38dd5478b804'
 
   # github.com/NatronGitHub/Natron/ was verified as official when first introduced to the cask
-  url "https://github.com/NatronGitHub/Natron/releases/latest/download/Natron-#{version}.dmg"
+  url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-OSX-64.dmg"
   appcast 'https://github.com/NatronGitHub/Natron/releases.atom'
   name 'Natron'
   homepage 'https://NatronGitHub.github.io/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.