### PR TITLE
Remove auto-update browserosaurus

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -8,7 +8,5 @@ cask 'browserosaurus' do
   name 'Browserosaurus'
   homepage 'https://will-stone.github.io/browserosaurus/'
 
-  auto_updates true
-
   app 'Browserosaurus.app'
 end


### PR DESCRIPTION
Cask no longer auto updates

From Version 10.0.0 the cask no longer auto updates As stated with [the release](https://github.com/will-stone/browserosaurus/releases/tag/v10.0.0)
Version 10.2.0 also confirms that 

> Improved update checker: previously B would only check for an update on load, it will now check once a day too. As before, this will not download anything and will still simply prompt the user to visit browserosaurus.com to download the new version.

https://github.com/will-stone/browserosaurus/releases/tag/v10.2.0

---


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
