### PR TITLE
Update strawberry from 0.6.11 to 0.6.12

### DIFF
--- a/Casks/strawberry.rb
+++ b/Casks/strawberry.rb
@@ -1,6 +1,6 @@
 cask 'strawberry' do
-  version '0.6.11'
-  sha256 'aadc433133da034ad3dfb4d67cf5f7ac09b4fe669f285cc2a11c0e66f7adf0be'
+  version '0.6.12'
+  sha256 '15305bd63efbdee5004b1c2749c1674737587a88a5baf6f2915463fe0c12f04d'
 
   # github.com/strawberrymusicplayer/strawberry/ was verified as official when first introduced to the cask
   url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).