### PR TITLE
Update gzdoom from 4.3.3 to 4.4.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '4.3.3'
-  sha256 '8f474455af2c5cdcf2dd9087d94d5f718ffa1ed50a291b6361f846b30f6d1d16'
+  version '4.4.0'
+  sha256 '40cf781f2246666c0b3312a262dd538bef0e52cf3dcc85b7cf099c6d7e3548ba'
 
   # github.com/coelckers/gzdoom/ was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).