### PR TITLE
Update puppetry from 3.2.2 to 3.2.3

### DIFF
--- a/Casks/puppetry.rb
+++ b/Casks/puppetry.rb
@@ -1,6 +1,6 @@
 cask 'puppetry' do
-  version '3.2.2'
-  sha256 '0383632428ff83b3f0950cd1ed394ba752602956910c052b9bf491fff3e72b68'
+  version '3.2.3'
+  sha256 '5aeb72cba43719837942de823f665eb91632631ef06d34c5e19d57a4c60121cf'
 
   # github.com/dsheiko/puppetry/ was verified as official when first introduced to the cask
   url "https://github.com/dsheiko/puppetry/releases/download/v#{version}/puppetry-mac-v#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).