### PR TITLE
Update electerm from 1.3.35 to 1.3.36

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.35'
-  sha256 '7b585b2946cd8a948b4c73ec9c52475176cd7043f60a2a66f06a14c05017033a'
+  version '1.3.36'
+  sha256 'c551123867e175b4fccbc21092e29b8125852d224d160860db776b2287e283a5'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).