### PR TITLE
Cask suggestion: StoryMill (by Mariner Software)

### DIFF
--- a/Casks/storymill.rb
+++ b/Casks/storymill.rb
@@ -1,0 +1,20 @@
+cask 'storymill' do
+  version '4.0.5'
+  sha256 :no_check
+
+  # s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/MarinerDownloads/StoryMill/StoryMill_Mac_4_0_5.dmg'
+  name 'StoryMill'
+  homepage 'https://marinersoftware.com/'
+
+  app 'StoryMill'
+
+  zap trash: [
+               '~/Library/Caches/com.marinersoftware.StoryMill',
+               '~/Library/Preferences/com.marinersoftware.StoryMill.plist',
+               '~/Library/Application Support/.StoryMill.plist',
+             ],
+      rmdir: [
+               '~/Library/Application Support/StoryMill/',
+             ]
+end

--- a/Casks/storymill.rb
+++ b/Casks/storymill.rb
@@ -1,20 +1,19 @@
 cask 'storymill' do
   version '4.0.5'
-  sha256 :no_check
+  sha256 'd16e6609df0530f08c7da830744602ca060dc40375bcc76b143056f58501fa8a'
 
-  # s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/MarinerDownloads/StoryMill/StoryMill_Mac_4_0_5.dmg'
+  # s3.amazonaws.com/MarinerDownloads/StoryMill/ was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/MarinerDownloads/StoryMill/StoryMill_Mac_#{version.dots_to_underscores}.dmg"
+  appcast 'http://www.marinersoftware.com/sparkle/StoryMill/StoryMill.xml'
   name 'StoryMill'
   homepage 'https://marinersoftware.com/'
 
-  app 'StoryMill'
+  app 'StoryMill.app'
 
   zap trash: [
                '~/Library/Caches/com.marinersoftware.StoryMill',
                '~/Library/Preferences/com.marinersoftware.StoryMill.plist',
                '~/Library/Application Support/.StoryMill.plist',
              ],
-      rmdir: [
-               '~/Library/Application Support/StoryMill/',
-             ]
+      rmdir: '~/Library/Application Support/StoryMill/'
 end


### PR DESCRIPTION
There is no doubt that the Mariner Software team makes intuitive and efficient-to-use software (though I think it is personally overpriced, but it certainly works for some).  I don't own any of their other software (future endeavour to put on `homebrew-cask` by those who do?) but I think that it'd be nice to have this as an installable cask.  

Keep in mind that **this is available on the app store**.  What do y'all think?  Is there any point if you can get it from the app store?  It is *paid software* but *downloadable for free*.

---

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).

❌ `brew cask install {{cask_file}}` worked successfully.
    Everything worked except:
    ```
    Error: It seems the App source '/usr/local/Caskroom/storymill/4.0.5/StoryMill' is not there.
    ```

❌ `brew cask uninstall {{cask_file}}` worked successfully.
    Due to the above error:
    ```
    Error: Cask 'storymill' is not installed.
    ```
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
