### PR TITLE
Update flash-ppapi from 32.0.0.371 to 32.0.0.387

### DIFF
--- a/Casks/flash-ppapi.rb
+++ b/Casks/flash-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-ppapi' do
-  version '32.0.0.371'
-  sha256 'cc6796eea07c403a658057d4ea3601a86ed193ac009a8f5de8c75c07f48c68d3'
+  version '32.0.0.387'
+  sha256 '9848e7baf922bea5660822fd3eb89a24bdd246f6a5dd7a9f8428abc53b187a84'
 
   url "https://fpdownload.adobe.com/pub/flashplayer/pdc/#{version}/install_flash_player_osx_ppapi.dmg"
   appcast 'https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).