### PR TITLE
Update Multipass to 1.3.0

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask 'multipass' do
-  version '1.2.1'
-  sha256 '3bad64bb06a04aacf03fa6db4022a3212d159ed1400e0dad59935404b90fa352'
+  version '1.3.0'
+  sha256 '10334a00061e2fb09c3d134b307b762166811f889d9f477c7ba35acf2e50eb41'
 
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast 'https://github.com/CanonicalLtd/multipass/releases.atom'


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.

NB: this will fail CI due to missing CPU features (it's a VM manager).