### PR TITLE
Update lando from 3.0.5 to 3.0.6

### DIFF
--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -1,6 +1,6 @@
 cask 'lando' do
-  version '3.0.5'
-  sha256 'f150ae913f17f889712a62f9225e7791139b0d210b8541409a8ed7d2a6841943'
+  version '3.0.6'
+  sha256 'caf941cb932c71b94853c8f46d40bac623be178d2065c3b1a38b056b03bbe689'
 
   # github.com/lando/lando/ was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.