### PR TITLE
Update dingtalk from 5.1.1.2 to 5.1.5.0

### DIFF
--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,6 +1,6 @@
 cask 'dingtalk' do
-  version '5.1.1.2'
-  sha256 'ad389bf052aa2225f41bfbbf0c92befd36cd39b3e41ed4a315e35d356495832a'
+  version '5.1.5.0'
+  sha256 'e65d9fdaf4be5537b43b8614a2509ee0ab0b4eb205ac738f3ae9b25d11c8b186'
 
   url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version}.dmg"
   appcast 'https://im.dingtalk.com/manifest/appcast_en.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).