### PR TITLE
Update jumpshare from 2.6.0 to 2.6.1

### DIFF
--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -1,6 +1,6 @@
 cask 'jumpshare' do
-  version '2.6.0'
-  sha256 '832ca3b54e6c33d1d1986143bdb4c763257071544a089342095131e287833f5d'
+  version '2.6.1'
+  sha256 'b11d1f979c1262d2e059e76d74775af9ea65d5a0bc45caabbea45781437b5837'
 
   url "https://apps.jumpshare.com/desktop/mac/updates/Jumpshare-#{version}.tar.bz2"
   appcast 'https://apps.jumpshare.com/desktop/mac/updates/appcast.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).