### PR TITLE
Update nvidia-geforce-now from 2.0.19.78,F3C0AE to 2.0.20.86,57612F

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask 'nvidia-geforce-now' do
-  version '2.0.19.78,F3C0AE'
-  sha256 'c540be6e68648d7a20b922fa6656435f184a684e7216195eacc54d8218338105'
+  version '2.0.20.86,57612F'
+  sha256 'a3128cf9cf7137bf03c35ab0e5fb3e2f984c8605e7b62534ddbcaaa81aff6aa3'
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).