### PR TITLE
Update maccy from 0.10.0 to 0.11.0

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -9,7 +9,6 @@ cask 'maccy' do
   homepage 'https://maccy.app/'
 
   auto_updates true
-
   depends_on macos: '>= :high_sierra'
 
   app 'Maccy.app'

--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask 'maccy' do
-  version '0.10.0'
-  sha256 '0d53b3f61ce6f3e3817015568b853397d1520fa00e068c20cb14a4e55da25858'
+  version '0.11.0'
+  sha256 '6aa9f596ee23a420f37a94ba9f2dc7f260d0f9d4e2974a79b3207daf8041d145'
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"

--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -7,6 +7,7 @@ cask 'maccy' do
   appcast 'https://github.com/p0deje/Maccy/releases.atom'
   name 'Maccy'
   homepage 'https://maccy.app/'
+
   auto_updates true
 
   depends_on macos: '>= :high_sierra'

--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -7,6 +7,7 @@ cask 'maccy' do
   appcast 'https://github.com/p0deje/Maccy/releases.atom'
   name 'Maccy'
   homepage 'https://maccy.app/'
+  auto_updates true
 
   depends_on macos: '>= :high_sierra'
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).