### PR TITLE
Update unity from 2019.3.14f1,2b330bf6d2d8 to 2019.4.0f1,0af376155913

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.3.14f1,2b330bf6d2d8'
-  sha256 '13f988b63314a9087ff17666deb5a86252aaceddc7428c1b62dfa0fa68c74abd'
+  version '2019.4.0f1,0af376155913'
+  sha256 '643e08d88c737f2c1326aac3802593fd0ffa774ebb3edf6384e8b0c96f22bbe3'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.