### PR TITLE
Update unity-android-support-for-editor from 2019.3.13f1,d4ddf0d95db9 to 2019.4.0f1,0af376155913

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-android-support-for-editor' do
-  version '2019.3.13f1,d4ddf0d95db9'
-  sha256 '7a7cb009ff8332142dfaac636354997df5695be91bac28ebfe7cf5c946574c3d'
+  version '2019.4.0f1,0af376155913'
+  sha256 '02be1d2b75e1b271ebec9a32c9b178e6f852988916987549574bcd06f4f93f1c'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.