### PR TITLE
Update unity-download-assistant from 2019.3.13f1,d4ddf0d95db9 to 2019.4.0f1,0af376155913

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask 'unity-download-assistant' do
-  version '2019.3.13f1,d4ddf0d95db9'
-  sha256 'cb24357b4a4581dfa84ddadcd05715ae3c36b8fe1f05d370eb2f65ba4c9700f3'
+  version '2019.4.0f1,0af376155913'
+  sha256 'c2b0f79e87472cc38191c17da1c817578fa1557270dfa22783d17d35d8f8535d'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.