### PR TITLE
Update sizzy from 0.21.1 to 0.22.0

### DIFF
--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -1,6 +1,6 @@
 cask 'sizzy' do
-  version '0.21.1'
-  sha256 'b7a7ac60ea151d4629673d2de0baf52ad99129003fac05b8d55e3f955f83930a'
+  version '0.22.0'
+  sha256 '531149423c97d2d2d0d8c7d4cfdf878b8f4ea46b4fe4e6cfa3d02fa27c00ddb0'
 
   url 'https://sizzy.co/get-app'
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://sizzy.co/get-app&user_agent=Intel%20Mac%20OS%20X'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.