### PR TITLE
Update instant-articles-builder from 0.2.1 to 0.2.2

### DIFF
--- a/Casks/instant-articles-builder.rb
+++ b/Casks/instant-articles-builder.rb
@@ -1,6 +1,6 @@
 cask 'instant-articles-builder' do
-  version '0.2.1'
-  sha256 'b60edd847e10a48b20750be53ce04de8dcb4fbaf7405feea40dde5aae3c14c32'
+  version '0.2.2'
+  sha256 '2332bb4ce57f025871a393f78f48451f68b34b65a70f43db4e5065074818da1e'
 
   # github.com/facebook/instant-articles-builder/ was verified as official when first introduced to the cask
   url "https://github.com/facebook/instant-articles-builder/releases/download/#{version}/Instant.Articles.Builder.for.Mac-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.