### PR TITLE
Update lyx from 2.3.4.2 to 2.3.5.1

### DIFF
--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -1,6 +1,6 @@
 cask 'lyx' do
-  version '2.3.4.2'
-  sha256 '37c390de4405f3ee9ce4e2feba6ba8f66bc937f4fe4c67573b747215e1843551'
+  version '2.3.5.1'
+  sha256 'b4186192cec8f84f5140f88d42d49b1b03f31f58e534a0b575fa4d039e56eea2'
 
   # ftp.lip6.fr/pub/lyx/ was verified as official when first introduced to the cask
   url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.