### PR TITLE
Update curio from 13020.9 to 14002.2

### DIFF
--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -1,6 +1,6 @@
 cask 'curio' do
-  version '13020.9'
-  sha256 '09b500dcfa6e2bb1ff93c0ac6eacd83dbd8ad23f611ba1ec93f3fdff8888c003'
+  version '14002.2'
+  sha256 '4d10db218b453769925c9c357463e58676bd26e7b66aa8a326fa40836e590d24'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
   appcast 'https://www.zengobi.com/appcasts/Curio13HLwLK2C84LaKptcz.xml'

--- a/Casks/curio.rb
+++ b/Casks/curio.rb
@@ -3,7 +3,7 @@ cask 'curio' do
   sha256 '4d10db218b453769925c9c357463e58676bd26e7b66aa8a326fa40836e590d24'
 
   url "https://www.zengobi.com/downloads/Curio#{version.no_dots}.zip"
-  appcast 'https://www.zengobi.com/appcasts/Curio13HLwLK2C84LaKptcz.xml'
+  appcast 'https://www.zengobi.com/appcasts/Curio14-2ZaxaUUlKorRS4Hf.xml'
   name 'Curio'
   homepage 'https://zengobi.com/curio/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.