### PR TITLE
Update lbry from 0.45.2 to 0.46.2

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask 'lbry' do
-  version '0.45.2'
-  sha256 '75b184db304d898bdea1ccf55fab13cd98bb8cea7bad501809c2f1587cce7988'
+  version '0.46.2'
+  sha256 'fd64bd1aae3a19d141dd4b1e2257b09c0b2cb9beda0560bc39e989d5d6554f12'
 
   # github.com/lbryio/lbry-desktop/ was verified as official when first introduced to the cask
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.