### PR TITLE
Update jalbum from 20.2.0 to 20.2.3

### DIFF
--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -3,8 +3,8 @@ cask 'jalbum' do
   sha256 '91f60902b1df36744f3b86ef630dad95e8fd2f8fbaad1dcf441b21b3da2a9e78'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
-  appcast 'https://jalbum.net/en/software/download/previous',
-          configuration: version.major_minor.chomp('.0')
+  appcast 'https://jalbum.net/en/software/release-notes',
+          must_contain: version.major_minor.chomp('.0')
   name 'jAlbum'
   homepage 'https://jalbum.net/'
 

--- a/Casks/jalbum.rb
+++ b/Casks/jalbum.rb
@@ -1,6 +1,6 @@
 cask 'jalbum' do
-  version '20.2.0'
-  sha256 '42a5b95dbfc6b4e73a4c6598bd81f678a15c97c2426e603e125831ac4727986c'
+  version '20.2.3'
+  sha256 '91f60902b1df36744f3b86ef630dad95e8fd2f8fbaad1dcf441b21b3da2a9e78'
 
   url "https://download.jalbum.net/download/#{version.major_minor}/MacOSX/jAlbum.dmg"
   appcast 'https://jalbum.net/en/software/download/previous',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.