### PR TITLE
Update ring from 2.5.0 to 2.6.0

### DIFF
--- a/Casks/ring.rb
+++ b/Casks/ring.rb
@@ -1,6 +1,6 @@
 cask 'ring' do
-  version '2.5.0'
-  sha256 'eab1d877c8812017e416683c2ceea4e5b8a200e662ea84c5109817d8799c5c47'
+  version '2.6.0'
+  sha256 'c598a87f10bf41926d67e7aa8a43bc1a0f1f50b9d2d07a5184e397ec727e118d'
 
   # ring-mac-app-assets.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://ring-mac-app-assets.s3.amazonaws.com/production/Ring_#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).