### PR TITLE
Update psi-plus from 1.4.1375-macOS10.13 to 1.4.1399-macOS10.13

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.1375-macOS10.13'
-  sha256 '30b4866b6cfcfc358f0baea8dadab3ee8aea2979b695933659c55bdeed5e415b'
+  version '1.4.1399-macOS10.13'
+  sha256 '79a2f4c584678f1883a883b43cd43bf330d59da6cc0e871486234d7dce0ea10c'
 
   # downloads.sourceforge.net/psiplus/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).