### PR TITLE
Update busycontacts from 1.4.7,140703 to 1.4.7,140801

### DIFF
--- a/Casks/busycontacts.rb
+++ b/Casks/busycontacts.rb
@@ -1,6 +1,6 @@
 cask 'busycontacts' do
-  version '1.4.7,140703'
-  sha256 '6a64c3b3d16e52fba144d9e2058b24a801bfc8eff5d4f892ee77b6b36bfd116f'
+  version '1.4.7,140801'
+  sha256 'b0b002345254928a960155810898399184b293ac400008d206bd50d3ab3267e0'
 
   url 'https://www.busymac.com/download/BusyContacts.zip'
   appcast 'https://www.busymac.com/busycontacts/news.plist'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.