### PR TITLE
Add Kui v8.9.1 with caveat

### DIFF
--- a/Casks/kui.rb
+++ b/Casks/kui.rb
@@ -1,0 +1,42 @@
+cask 'kui' do
+  version '8.9.1'
+  sha256 '41778159c8fe32d77ca84449d81ccb2674656a5bbe3a1d45eea187543e572b9e'
+
+  # github.com/IBM/kui was verified as official when first introduced to the cask
+  url "https://github.com/IBM/kui/releases/download/v#{version}/Kui-darwin-x64.tar.bz2"
+  appcast 'https://github.com/IBM/kui/releases.atom'
+  name 'Kui'
+  homepage 'https://kui.tools/'
+
+  app 'Kui-darwin-x64/Kui.app'
+
+  # binary 'Kui-darwin-x64/kubectl-kui'
+
+  # TODO: Uncomment the line above and adjust caveats
+  # when kubectl-kui can find Kui.app in /Applications on Mac.
+  # https://github.com/IBM/kui/pull/4878
+  #
+  # The following is based on https://github.com/ibm/kui#installation
+  caveats <<~EOS
+    Kui installs as an app in /Applications, but the kubectl plugin
+    (for kubectl 1.12+) does not look there. 
+
+    See https://github.com/IBM/kui/pull/4878 for updates, but for now
+    temporarily add #{staged_path}/Kui-darwin-x64 to your PATH:
+
+    In ~/.zprofile or ~/.bash_profile:
+
+      export PATH="#{staged_path}/Kui-darwin-x64:${PATH}"
+    
+    Then to test it out, run:
+
+      kubectl kui get pods
+    
+    After that command, you should see a popup window listing pods 
+    in your current namespace and context. 
+    
+    If kubectl is not found, you can install it with:
+
+      brew install kubernetes-cli
+  EOS
+end


### PR DESCRIPTION
Added Kui but in testing the binary in /usr/local/bin, I found I needed to make an upstream PR to have it look for Kui in /Applications.

So I opened a PR at https://github.com/IBM/kui/pull/4878 and temporarily added a PR with a workaround.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
