### PR TITLE
Update gzdoom from 4.4.0 to 4.4.1

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask 'gzdoom' do
-  version '4.4.0'
-  sha256 '40cf781f2246666c0b3312a262dd538bef0e52cf3dcc85b7cf099c6d7e3548ba'
+  version '4.4.1'
+  sha256 '9dd083cc8f65060698f300c274eefea8364987a4a548524a446f703330b91fb6'
 
   # github.com/coelckers/gzdoom/ was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).