### PR TITLE
Update colorsnapper from 1.6.2 to 1.6.3

### DIFF
--- a/Casks/colorsnapper.rb
+++ b/Casks/colorsnapper.rb
@@ -1,6 +1,6 @@
 cask 'colorsnapper' do
-  version '1.6.2'
-  sha256 '687cfc23035804db63bca7fff606ab512c1297d057e0da6d7424f1e29ec427de'
+  version '1.6.3'
+  sha256 'a8e99b92276cc085c2dbddb406760480c77d95e9518eda4aa6c9b94f7793db13'
 
   # cs2-binaries.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://cs2-binaries.s3.amazonaws.com/ColorSnapper2-#{version.dots_to_underscores}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).