### PR TITLE
Update avocode from 4.6.4 to 4.7.0

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask 'avocode' do
-  version '4.6.4'
-  sha256 '63b03f08ff34cc558a72f3df92d01fddac48645258e4907424c51bb5ff384bb7'
+  version '4.7.0'
+  sha256 'a1c5daf330a3359c2307e26f356cf7cf378d07baf6018ae07e5b11a0492a0552'
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).