### PR TITLE
Update darwindumper from 3.0.4 to 3.1.0

### DIFF
--- a/Casks/darwindumper.rb
+++ b/Casks/darwindumper.rb
@@ -1,6 +1,6 @@
 cask 'darwindumper' do
-  version '3.0.4'
-  sha256 '29286070dd7f91d9289afa7fa7b52703252b255106934c8800b2db57edd3fa8b'
+  version '3.1.0'
+  sha256 '0cf0807b3c1e9bb8df1c8563271e48db84e50f06572506954e32b360f005728c'
 
   url "https://bitbucket.org/blackosx/darwindumper/downloads/DarwinDumper_v#{version}.zip"
   appcast 'https://bitbucket.org/blackosx/darwindumper/wiki/DD_AppCast.xml'

--- a/Casks/datovka.rb
+++ b/Casks/datovka.rb
@@ -1,9 +1,9 @@
 cask 'datovka' do
-  version '4.15.0'
-  sha256 'b7b76c092252a45f66b11b43a049ce062ff58b2a9d0d5b027081ac6e3f5131e8'
+  version '4.15.1'
+  sha256 'f9e7e8699d49f87581a737da20124344f4275bf5999a362c4c778c4838537eb7'
 
   # secure.nic.cz/files/datove_schranky/ was verified as official when first introduced to the cask
-  url "https://secure.nic.cz/files/datove_schranky/#{version}/datovka-#{version}-64bit-osx10.7.dmg"
+  url "https://secure.nic.cz/files/datove_schranky/#{version}/datovka-#{version}-64bit-macos10.12.dmg"
   appcast 'https://www.datovka.cz/cs/pages/instalace.html'
   name 'Datovka'
   homepage 'https://www.datovka.cz/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.