### PR TITLE
Add Thorium Reader App

### DIFF
--- a/Casks/thorium-reader.rb
+++ b/Casks/thorium-reader.rb
@@ -1,0 +1,12 @@
+cask 'thorium-reader' do
+  version '1.3.0'
+  sha256 '058d0dddd3217cb72afc5131b621782e2f4116d3a7405f63f747c011b87b6601'
+
+  # github.com/edrlab/thorium-reader was verified as official when first introduced to the cask
+  url "https://github.com/edrlab/thorium-reader/releases/download/v#{version}/Thorium-#{version}.dmg"
+  appcast 'https://github.com/edrlab/thorium-reader/releases'
+  name 'Thorium Reader'
+  homepage 'https://edrlab.org/software/thorium-reader/'
+
+  app 'Thorium.app'
+end

--- a/Casks/thorium.rb
+++ b/Casks/thorium.rb
@@ -9,4 +9,9 @@ cask 'thorium' do
   homepage 'https://edrlab.org/software/thorium-reader/'
 
   app 'Thorium.app'
+
+  zap trash: [
+               '~/Library/Application Support/EDRLab.ThoriumReader',
+               '~/Library/Preferences/io.github.edrlab.thorium.plist',
+             ]
 end

--- a/Casks/thorium.rb
+++ b/Casks/thorium.rb
@@ -1,4 +1,4 @@
-cask 'thorium-reader' do
+cask 'thorium' do
   version '1.3.0'
   sha256 '058d0dddd3217cb72afc5131b621782e2f4116d3a7405f63f747c011b87b6601'
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Note: this app is referred to as 'Thorium Reader' pretty much everywhere (including their website, their GitHub page, and the Microsoft store), with the exception of the .app name itself. I followed the reference strictly and dropped 'reader', but I'm not sure if exceptions are made in cases like this.