### PR TITLE
Update menutube from 1.5.0 to 1.6.1

### DIFF
--- a/Casks/menutube.rb
+++ b/Casks/menutube.rb
@@ -1,9 +1,9 @@
 cask 'menutube' do
-  version '1.5.0'
-  sha256 '1661d6b690a619eda8e394b9328ca5db8eea980fab5cb2c5c68b220d16798935'
+  version '1.6.1'
+  sha256 'b50a106a88b96e9ce98feb99502446ad9ce8fcd610dfb3f479e40030e16a7d42'
 
   # github.com/edanchenkov/MenuTube/ was verified as official when first introduced to the cask
-  url "https://github.com/edanchenkov/MenuTube/releases/download/#{version}/MenuTube.zip"
+  url "https://github.com/edanchenkov/MenuTube/releases/download/#{version}/MenuTube-#{version}.dmg"
   appcast 'https://github.com/edanchenkov/MenuTube/releases.atom'
   name 'MenuTube'
   homepage 'https://edanchenkov.github.io/MenuTube/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.