### PR TITLE
Update nosqlbooster-for-mongodb from 6.0.2 to 6.0.3

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask 'nosqlbooster-for-mongodb' do
-  version '6.0.2'
-  sha256 '479139ea54cc9cd16e426f743b742ca26dea9172b1e5b1fd47260f1f892528d5'
+  version '6.0.3'
+  sha256 '9088acf80b38cda79b74e38e7b9ba18dd2e94013154661567853faf556ec20d7'
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   appcast 'https://nosqlbooster.com/downloads'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).