### PR TITLE
Update nheko from 0.7.1 to 0.7.2

### DIFF
--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -1,6 +1,6 @@
 cask 'nheko' do
-  version '0.7.1'
-  sha256 '29e96ae7368744d813ea38c7bee99099859f59cc977f8ba128ec701f72e3aa84'
+  version '0.7.2'
+  sha256 '75bc8fe8fbaed333a205ca37bd64d8f69dc419197d26c7e7017f2cadc622cc8a'
 
   # github.com/Nheko-Reborn/nheko/ was verified as official when first introduced to the cask
   url "https://github.com/Nheko-Reborn/nheko/releases/download/v#{version}/nheko-v#{version}.dmg"


### PR DESCRIPTION
Nheko-reborn is [updated to 0.7.2](https://github.com/Nheko-Reborn/nheko/releases/tag/v0.7.2).

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

_Nope, not adding a new cask._