### PR TITLE
Update youdaonote from 3.5.9 to 3.6.0

### DIFF
--- a/Casks/youdaonote.rb
+++ b/Casks/youdaonote.rb
@@ -1,6 +1,6 @@
 cask 'youdaonote' do
-  version '3.5.9'
-  sha256 'b529384109007f86be688206d077b60e9367bfe0bdd1ecc917104da424b6d914'
+  version '3.6.0'
+  sha256 '0382e5edaec5c3871469a0e4389a97b032d2e4c5d9369a1822d20179b1f48369'
 
   # download.ydstatic.com/notewebsite/downloads/ was verified as official when first introduced to the cask
   url 'https://download.ydstatic.com/notewebsite/downloads/YoudaoNote.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.