### PR TITLE
Upgrade Phoenix to 2.6.4

### DIFF
--- a/Casks/phoenix.rb
+++ b/Casks/phoenix.rb
@@ -1,6 +1,6 @@
 cask 'phoenix' do
-  version '2.6.3'
-  sha256 'e2e6a1577d376d4a313f6133a6c026e2b136b7d1168615f12de58750b3a631db'
+  version '2.6.4'
+  sha256 '11729a1e9abddccc53041ce34969f0b120642df4b94bb1c884409eebe64c75a2'
 
   url "https://github.com/kasper/phoenix/releases/download/#{version}/phoenix-#{version}.tar.gz"
   appcast 'https://github.com/kasper/phoenix/releases.atom'


### PR DESCRIPTION
Upgrade Phoenix to 2.6.4. Thanks!

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
