### PR TITLE
Update isyncr from 5.14.10 to 5.14.11, removing 5.6.5, adding 5.0.8 and 6.0.3

### DIFF
--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -1,14 +1,17 @@
 cask 'isyncr' do
-  if MacOS.version <= :sierra
-    version '5.6.5'
+  if MacOS.version <= :lion
+    version '5.0.8'
     sha256 '8cd6b1c96a902d8810e52aab6a980424370237617bfd3ff574367ff1ce8d4f4e'
-  else
-    version '5.14.10'
+    elseif MacOS.version <= :mojave
+    version '5.14.11'
     sha256 '3952db5c64873cf63a5bfb6b308fd992f2eeb67cf838955fc200cd59640803aa'
+  else
+    version '6.0.3'
+    sha256 'c7033eb946a6a6104a75cc5c182506f47a0399b54f3b4ce486e82a1c7d040154'
   end
 
   url "https://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"
-  appcast 'https://www.jrtstudio.com/files/SlashiSyncr36.js'
+  appcast 'https://www.jrtstudio.com/files/SlashiSyncr38.js'
   name 'iSyncr Desktop'
   homepage 'https://www.jrtstudio.com/iSyncr-iTunes-for-Android'
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).