### PR TITLE
Upgrade Azgaar's Fantasy Map Generator to v1.3

### DIFF
--- a/Casks/fantasy-map-generator.rb
+++ b/Casks/fantasy-map-generator.rb
@@ -1,12 +1,12 @@
 cask 'fantasy-map-generator' do
-  version '1.2'
-  sha256 'c8c64c031afe5423c83f8ad38e39da7b41a551ca248705b5b23c7718967b07da'
+  version '1.3'
+  sha256 '6aba1ba5b3c358fe4b09d2cbd7449bc603213cbc52de622250eaabaf8eae6d6d'
 
   # github.com/Azgaar/Fantasy-Map-Generator/ was verified as official when first introduced to the cask
-  url "https://github.com/Azgaar/Fantasy-Map-Generator/releases/download/v#{version}/FMG-darwin-x64.zip"
+  url "https://github.com/Azgaar/Fantasy-Map-Generator/releases/download/v#{version}/FMG-macos-x64.dmg"
   appcast 'https://github.com/Azgaar/Fantasy-Map-Generator/releases.atom'
   name "Azgaar's Fantasy Map Generator"
   homepage 'https://azgaar.github.io/Fantasy-Map-Generator'
 
-  app "Azgaar's Fantasy Map Generator-darwin-x64/Azgaar's Fantasy Map Generator.app"
+  app "Azgaar's Fantasy Map Generator.app"
 end


### PR DESCRIPTION
Starting with v1.3, Azgaar's Fantasy Map Generator switched to using
.dmg rather than .zip releases, which necessitated the change in the
cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
