### PR TITLE
Update wkhtmltopdf from 0.12.6-1 to 0.12.6-2

### DIFF
--- a/Casks/wkhtmltopdf.rb
+++ b/Casks/wkhtmltopdf.rb
@@ -1,6 +1,6 @@
 cask 'wkhtmltopdf' do
-  version '0.12.6-1'
-  sha256 '6ddc677c0f86c354fdd221b888f7dff48ff85ca587bc1564dbf5fe7cdb4c65b5'
+  version '0.12.6-2'
+  sha256 '81a66b77b508fede8dbcaa67127203748376568b3673a17f6611b6d51e9894f8'
 
   # github.com/wkhtmltopdf/packaging/ was verified as official when first introduced to the cask
   url "https://github.com/wkhtmltopdf/packaging/releases/download/#{version}/wkhtmltox-#{version}.macos-cocoa.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This fixes compatibility for older macOS versions.