### PR TITLE
Update prudent from 79.0.3945.88,21 to 22.0.43.3

### DIFF
--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -1,11 +1,11 @@
 cask 'prudent' do
-  version '79.0.3945.88,21'
-  sha256 '2ae056b051f72e31b1ba39c23d2ec8d7f5192f53ad19fdd7630df74d9e89c1d9'
+  version '22.0.43.3'
+  sha256 '6169cad58f68b4115c768812a76ae015496da3ff197161e63d382891c04f7746'
 
   # github.com/PrudentMe/main/ was verified as official when first introduced to the cask
-  url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"
+  url "https://github.com/PrudentMe/main/releases/download/#{version.major}/Prudent.zip"
   appcast 'https://github.com/PrudentMe/main/releases.atom',
-          must_contain: version.after_comma
+          must_contain: version.major
   name 'Prudent'
   homepage 'https://prudent.me/'
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).