### PR TITLE
Update prudent from 79.0.3945.88,21 to 22.0.43.3,22

### DIFF
--- a/Casks/prudent.rb
+++ b/Casks/prudent.rb
@@ -1,6 +1,6 @@
 cask 'prudent' do
-  version '79.0.3945.88,21'
-  sha256 '2ae056b051f72e31b1ba39c23d2ec8d7f5192f53ad19fdd7630df74d9e89c1d9'
+  version '22.0.43.3,22'
+  sha256 '6169cad58f68b4115c768812a76ae015496da3ff197161e63d382891c04f7746'
 
   # github.com/PrudentMe/main/ was verified as official when first introduced to the cask
   url "https://github.com/PrudentMe/main/releases/download/#{version.after_comma}/Prudent.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.