### PR TITLE
Update podman.rb to install manpages

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -1,14 +1,30 @@
 cask 'podman' do
   version '1.9.3'
-  sha256 '221bab2f343252aaa465712a3873faad958f24bd66436ba09c36e329a74de030'
+  sha256 '8c5d96ee0a30a3b00dec726d7e660cc75999831a9082325d501b0d25bc347abc'
 
-  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-remote-darwin.tar.gz"
+  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-remote-darwin.zip"
   appcast 'https://github.com/containers/libpod/releases.atom'
   name 'podman'
   homepage 'https://github.com/containers/libpod/'
 
-  # Renamed for consistency with previous releases
-  binary 'podman-remote-darwin', target: 'podman'
+  binary 'podman-remote-darwin/podman'
+
+  postflight do
+    man1 = Dir["#{staged_path}/podman-remote-darwin/docs/*.1"]
+    FileUtils.mv(man1, "#{HOMEBREW_PREFIX}/share/man/man1/")
+
+    man5 = Dir["#{staged_path}/podman-remote-darwin/docs/*.5"]
+    FileUtils.mkdir("#{HOMEBREW_PREFIX}/share/man/man5/") unless File.exist?("#{HOMEBREW_PREFIX}/share/man/man5/")
+    FileUtils.mv(man5, "#{HOMEBREW_PREFIX}/share/man/man5/")
+  end
+
+  uninstall_postflight do
+    man1 = Dir["#{HOMEBREW_PREFIX}/share/man/man1/podman*.1"]
+    FileUtils.rm(man1)
+
+    man5 = Dir["#{HOMEBREW_PREFIX}/share/man/man5/podman*.5"]
+    FileUtils.rm(man5)
+  end
 
   zap trash: '~/.config/containers/podman-remote.config'
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Submitting to cask instead of core because https://github.com/Homebrew/homebrew-cask/pull/64042#issuecomment-496993261
