### PR TITLE
Update crystalmaker from 10.5.2 to 10.5.3

### DIFF
--- a/Casks/crystalmaker.rb
+++ b/Casks/crystalmaker.rb
@@ -1,6 +1,6 @@
 cask 'crystalmaker' do
-  version '10.5.2'
-  sha256 '3bff8e69a8edc992b65d38d934161206121fe2df1d1e0799566f402947d9a4f0'
+  version '10.5.3'
+  sha256 '9d1814f19a712deaea1adb15ad75d60437e3d8ca067710de49d9c4fd083f7b30'
 
   url 'http://crystalmaker.com/downloads/crystalmaker_mac.zip'
   appcast "http://crystalmaker.com/crystalmaker/release-notes/mac/#{version.major}/index.html"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.