### PR TITLE
Update protopie from 4.3.3 to 5.0.0

### DIFF
--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -1,6 +1,6 @@
 cask 'protopie' do
-  version '4.3.3'
-  sha256 '4079a25137ecf854154270cb6a9e6f9bedbdcfd37df869e20547fc5fcb9bc107'
+  version '5.0.0'
+  sha256 'e0b1ace8506eba1d9c08c0532282c00e533dadd9114fcbc05829ac9928995a51'
 
   url "https://release.protopie.io/ProtoPie-#{version}.dmg"
   appcast 'https://www.protopie.io/support/updates/'

--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -3,8 +3,7 @@ cask 'protopie' do
   sha256 'e0b1ace8506eba1d9c08c0532282c00e533dadd9114fcbc05829ac9928995a51'
 
   url "https://release.protopie.io/ProtoPie-#{version}.dmg"
-  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.protopie.io/darwin/latest
-'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.protopie.io/darwin/latest'
   name 'ProtoPie'
   homepage 'https://www.protopie.io/'
 

--- a/Casks/protopie.rb
+++ b/Casks/protopie.rb
@@ -3,7 +3,8 @@ cask 'protopie' do
   sha256 'e0b1ace8506eba1d9c08c0532282c00e533dadd9114fcbc05829ac9928995a51'
 
   url "https://release.protopie.io/ProtoPie-#{version}.dmg"
-  appcast 'https://www.protopie.io/support/updates/'
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.protopie.io/darwin/latest
+'
   name 'ProtoPie'
   homepage 'https://www.protopie.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.