### PR TITLE
Update yandex-cloud-cli to 0.57.0

### DIFF
--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -1,6 +1,6 @@
 cask 'yandex-cloud-cli' do
-  version '0.56.0'
-  sha256 'bdff86cb0917a47dff5ef8c299d81f7f85e14e132a62de1291061cc701138d85'
+  version '0.57.0'
+  sha256 '0c80606fb67fbe28d62ff583b971bc391d403e568fcca2192109760c3ff4c9cd'
 
   # yandexcloud.net/yandexcloud-yc/ was verified as official when first introduced to the cask
   url "https://storage.yandexcloud.net/yandexcloud-yc/release/#{version}/darwin/amd64/yc"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).