### PR TITLE
wireshark: Add shim script

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -14,6 +14,16 @@ cask 'wireshark' do
   app 'Wireshark.app'
   pkg 'Install ChmodBPF.pkg'
   pkg 'Add Wireshark to the system path.pkg'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/wireshark.wrapper.sh"
+  binary shimscript, target: 'wireshark'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec #{appdir}/Wireshark.app/Contents/MacOS/Wireshark "$@"
+    EOS
+  end
 
   uninstall_preflight do
     system_command '/usr/sbin/installer',


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

Prompted by https://github.com/eldadru/ksniff/issues/63, it seems that the `wireshark` CLI script was removed somewhere along the line when the cask was upgraded from v2 to v3.

This adds a shim script in the same way it's done in other Casks to address the issue.