### PR TITLE
Update electronmail from 4.5.1 to 4.6.0

### DIFF
--- a/Casks/electronmail.rb
+++ b/Casks/electronmail.rb
@@ -1,6 +1,6 @@
 cask 'electronmail' do
-  version '4.5.1'
-  sha256 '09ce89205d2e90a641bb523b23441e7a88886740eb130e01481704c14fd35da6'
+  version '4.6.0'
+  sha256 '4f5e11ad6e11f78cb7b419c7e5391a00e2433aa1832a592af3663252a430acf2'
 
   url "https://github.com/vladimiry/ElectronMail/releases/download/v#{version}/electron-mail-#{version}-mac-mojave.dmg"
   appcast 'https://github.com/vladimiry/ElectronMail/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).