### PR TITLE
Update ringcentral-classic from 20.2.21 to 20.2.30

### DIFF
--- a/Casks/ringcentral-classic.rb
+++ b/Casks/ringcentral-classic.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral-classic' do
-  version '20.2.21'
-  sha256 'd28982a802c531469779a9912fca10a4f97c1c1684b1c18339d4d8de8ef28d36'
+  version '20.2.30'
+  sha256 '4f5789eda68ba05a6a76ab03246352c52039dce27db9d9bf2c68c214feb830e2'
 
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral%20Classic-#{version}.dmg"
   name 'RingCentral Classic'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).