### PR TITLE
Update termius from 5.13.2 to 6.0.0

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '5.13.2'
-  sha256 'a89044fd048ca3d0b9393b0722f7fb0526b4c1fab5a6f8653c63b5e6eaaa0241'
+  version '6.0.0'
+  sha256 '4f4c2e99a0ba2a3b12de6316a0f7ed8ec572b2af883ea9e7c4c9f9650fce0a78'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac/ was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).