### PR TITLE
Update nomachine-enterprise-client from 6.10.12_8 to 6.11.2_14

### DIFF
--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -1,6 +1,6 @@
 cask 'nomachine-enterprise-client' do
-  version '6.10.12_8'
-  sha256 '1cc40bccd4b86f789177d213f9a7be4fb19a48d794f56885064176ad58f7f21e'
+  version '6.11.2_14'
+  sha256 'bd2cf69fab6e74d87b0a6442e8d7700278128be9c1bf22628ded923be89ed147'
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine-enterprise-client_#{version}.dmg"
   appcast 'https://www.nomachine.com/download/download&id=15'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).