### PR TITLE
Update wiznote from 2.8.5,2020-04-22 to 2.8.6,2020-06-15

### DIFF
--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -1,6 +1,6 @@
 cask 'wiznote' do
-  version '2.8.5,2020-04-22'
-  sha256 'fc851924922d6a655e1c47091471024247d25c79a677638d5f940e3a986de988'
+  version '2.8.6,2020-06-15'
+  sha256 '64d4e6bc8cfdd96d62384cf741a3c6b4c6323b0c38da8ebc857890f377521151'
 
   url "https://get.wiz.cn/wiznote-macos-#{version.after_comma}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://url.wiz.cn/u/mac',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.