### PR TITLE
Update tandem from 1.5.11 to 1.5.13

### DIFF
--- a/Casks/tandem.rb
+++ b/Casks/tandem.rb
@@ -1,6 +1,6 @@
 cask 'tandem' do
-  version '1.5.11'
-  sha256 '7b89f35377d0166ce5fe522e9861b076e531096b5d02d5adab581b3e6305516a'
+  version '1.5.13'
+  sha256 '05c1ca19b263dbcd8251f6f4eae77a5ef637d9b188bfd1c97cf3a2ef7bdf14ba'
 
   # wisp-app.s3-accelerate.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://wisp-app.s3-accelerate.amazonaws.com/Tandem-#{version}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.