### PR TITLE
Update db-browser-for-sqlite from 3.11.2 to 3.12.0

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,9 +1,9 @@
 cask 'db-browser-for-sqlite' do
-  version '3.11.2'
-  sha256 '022536d420dca87285864a4a948b699d01430721b511722bcf9c8713ab946776'
+  version '3.12.0'
+  sha256 '4a7aaac7554c43ecec330d0631f356510dcad11e49bb01986ba683b6dfb59530'
 
   # github.com/sqlitebrowser/sqlitebrowser/ was verified as official when first introduced to the cask
-  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version.major_minor_patch}/DB.Browser.for.SQLite-#{version}.dmg"
+  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/#{version}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast 'https://github.com/sqlitebrowser/sqlitebrowser/releases.atom'
   name 'SQLite Database Browser'
   homepage 'https://sqlitebrowser.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.