### PR TITLE
Update maccy from 0.11.0 to 0.12.0

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask 'maccy' do
-  version '0.11.0'
-  sha256 '6aa9f596ee23a420f37a94ba9f2dc7f260d0f9d4e2974a79b3207daf8041d145'
+  version '0.12.0'
+  sha256 '8a10dff4762620008e0166abfd1eb3b14eb94e261dc0b5ff54dbca46b87ca505'
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.