### PR TITLE
Flipper: update to v0.47.0

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask 'flipper' do
-  version '0.46.0'
-  sha256 '575556890dfeda947ca1cea888f3810072861770688ac4bcde06f04c9c16e70b'
+  version '0.47.0'
+  sha256 'e7449125301bca9fab1a0389c9d5055f686645189c912cd7e5a8bea59d1e23dc'
 
   # github.com/facebook/flipper/ was verified as official when first introduced to the cask
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.zip"


### PR DESCRIPTION
Sorry about the `"` in the commit message. Fat fingers compared to my keyboard, I guess.