### PR TITLE
Update betterzip from 4.2.5 to 5.0

### DIFF
--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -1,6 +1,6 @@
 cask 'betterzip' do
-  version '4.2.5'
-  sha256 '6fda66723dfacba7d7ffbf1817e06031aa7faeec586cd11b9619db28940fa179'
+  version '5.0'
+  sha256 '87c3e5be2fbf9fae630e0e5d307fdb47da81a6a351840fac4db23300fd27a984'
 
   # macitbetter.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://macitbetter.s3.amazonaws.com/BetterZip-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.