### PR TITLE
Update BetterZip 5.0 depends_on macos

### DIFF
--- a/Casks/betterzip.rb
+++ b/Casks/betterzip.rb
@@ -9,7 +9,7 @@ cask 'betterzip' do
   homepage 'https://macitbetter.com/'
 
   auto_updates true
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :high_sierra'
 
   app 'BetterZip.app'
 


### PR DESCRIPTION
According to the official version history (https://macitbetter.com/version-history/), High Sierra is the minimum macOS version for BetterZip 5.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).