### PR TITLE
Update colour-contrast-analyser to 3.1.0

### DIFF
--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -1,12 +1,12 @@
 cask 'colour-contrast-analyser' do
-  version '2.4'
-  sha256 'bf8559d329675e776d4b5be382d789b2c94087d8f5f88386112406e6e59f02c9'
+  version '3.1.0'
+  sha256 '0e47c4be616b95b4ce262e225e4775e5951590f3a0ad98a51dae0d220f2f1fe6'
 
-  # github.com/ThePacielloGroup/CCA-OSX/ was verified as official when first introduced to the cask
-  url "https://github.com/ThePacielloGroup/CCA-OSX/releases/download/#{version}/Colour.Contrast.Analyser.app.zip"
-  appcast 'https://github.com/ThePacielloGroup/CCA-OSX/releases.atom'
-  name 'Colour Contrast Analyser'
-  homepage 'https://www.paciellogroup.com/resources/contrastanalyser/'
+  # github.com/ThePacielloGroup/CCAe was verified as official when first introduced to the cask
+  url "https://github.com/ThePacielloGroup/CCAe/releases/download/v#{version}/CCA-#{version}.dmg"
+  appcast 'https://github.com/ThePacielloGroup/CCAe/releases.atom'
+  name 'Colour Contrast Analyser (CCA)'
+  homepage 'https://developer.paciellogroup.com/resources/contrastanalyser/'
 
-  app 'Colour Contrast Analyser.app'
+  app 'Colour Contrast Analyser (CCA).app'
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).