### PR TITLE
Update remember-the-milk from 1.2.1 to 1.2.2

### DIFF
--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -1,6 +1,6 @@
 cask 'remember-the-milk' do
-  version '1.2.1'
-  sha256 '80f9d66b19822c619d25d920e1d2415f17d7086a23fa4f4631d5a9de56f8fe29'
+  version '1.2.2'
+  sha256 '056b74352c82306572275801f527d062edf04d50ffc7337d65c30543920da333'
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}.zip"
   appcast 'https://www.rememberthemilk.com/services/mac/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).