### PR TITLE
Update resilio-sync from 2.7.0 to 2.7.1

### DIFF
--- a/Casks/resilio-sync.rb
+++ b/Casks/resilio-sync.rb
@@ -1,6 +1,6 @@
 cask 'resilio-sync' do
-  version '2.7.0'
-  sha256 'ea7b33283c6993c1d6f2ed3e75ba5743bf014b3a19351f5cfeb6dddd8f8cb842'
+  version '2.7.1'
+  sha256 'ac17763ded34445e52ad958279631707ad91604d8fa7a8ff225286c4b43124f5'
 
   url "https://download-cdn.resilio.com/#{version}/osx/Resilio-Sync.dmg"
   appcast "https://help.resilio.com/hc/en-us/articles/206216855-Sync-#{version.major}-x-change-log"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).