### PR TITLE
bricklink-studio: restore S3 subdomain

### DIFF
--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -2,8 +2,8 @@ cask 'bricklink-studio' do
   version '2.1.5_10'
   sha256 'f5d36786aab7590f1415e15682047025718787027797e56d54d206b510345b27'
 
-  # s3.amazonaws.com/blstudio was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/blstudio/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg"
+  # blstudio.s3.amazonaws.com/ was verified as official when first introduced to the cask
+  url "https://blstudio.s3.amazonaws.com/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg"
   appcast 'https://bricklink.com/v3/studio/download.page'
   name 'Studio'
   homepage 'https://bricklink.com/v3/studio/download.page'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---
This open [PR](https://github.com/Homebrew/homebrew-cask/pull/82691), what looks like obsoleted by a more recent commit.