### PR TITLE
Update eclipse-dsl from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-dsl.rb
+++ b/Casks/eclipse-dsl.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-dsl' do
-  version '4.15.0,2020-03:R'
-  sha256 '94d5c1212d36e2ed5f6e5eeecc757307507b36c37223405a26d90ad62ecb0824'
+  version '4.16.0,2020-06:R'
+  sha256 '0041186fb72520a1d87586be11324ea7d450a9887329307f2c39c8dd8bd07ad8'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-dsl-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java and DSL Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.