### PR TITLE
Update eclipse-ide from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-ide' do
-  version '4.15.0,2020-03:R'
-  sha256 '2bd854713770bf52dbcc46fb860a09a2117178e33502c30652c584f62f5ec493'
+  version '4.16.0,2020-06:R'
+  sha256 'a2b7097702af90f200731773e8eb5e7867d382197bab5b4eaca68bb90d6ca7c0'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-committers-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Eclipse Committers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.