### PR TITLE
Update eclipse-installer from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-installer' do
-  version '4.15.0,2020-03:R'
-  sha256 'c5c748789ff9329d31fab103c887204bb138dd91fb13d4a7800fd28eb0ade46a'
+  version '4.16.0,2020-06:R'
+  sha256 '523ba12b8499397f991f249ba981a531420ce132a96cd16f386a6222555290e0'
 
   url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-inst-mac64.tar.gz&r=1"
   name 'Eclipse Installer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.