### PR TITLE
Update eclipse-jee from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-jee' do
-  version '4.15.0,2020-03:R'
-  sha256 '9fbe1d6b52f84ded8ee9dec0faf740f9934225abbc40262c1ef8c576c50bf830'
+  version '4.16.0,2020-06:R'
+  sha256 'f795b689a2cce4c10739daa1ba00688ae0362cdc579052d9c34f866ff3542343'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-jee-#{version.after_comma.before_colon}-#{version.after_colon}-incubation-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse IDE for Java EE Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.