### PR TITLE
Update eclipse-modeling from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-modeling' do
-  version '4.15.0,2020-03:R'
-  sha256 'fdc20ca5813e6b196d764b13b5cda2f0fd057ff8b1b1374397e3049359c9901e'
+  version '4.16.0,2020-06:R'
+  sha256 '74ae00bfcb12c2bda36b16f0af536140d199c841c8b8aa597381a0a283b19f70'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-modeling-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse Modeling Tools'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.