### PR TITLE
Update eclipse-platform from 4.15,202003050155 to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
   version '4.16,202006040540'
-  sha256 '00bf1b44639bd24b38708eb90f32b43c9f96133d9f7c48cd056c26045f9f9744'
+  sha256 'fec0b72ca606bba458cb431a00dafd33fa4d1347b8748bf4d9f4f994b1807e00'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-platform' do
-  version '4.16.0,2020-06:R'
+  version '4.16.0,202006040540'
   sha256 '00bf1b44639bd24b38708eb90f32b43c9f96133d9f7c48cd056c26045f9f9744'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-platform' do
-  version '4.15,202003050155'
-  sha256 '41a4ab3d88895129d07ff702eac85542795967b8128c98a5e9204ffbb4f3395e'
+  version '4.16.0,2020-06:R'
+  sha256 '00bf1b44639bd24b38708eb90f32b43c9f96133d9f7c48cd056c26045f9f9744'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse SDK'

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -1,5 +1,5 @@
 cask 'eclipse-platform' do
-  version '4.16.0,202006040540'
+  version '4.16,202006040540'
   sha256 '00bf1b44639bd24b38708eb90f32b43c9f96133d9f7c48cd056c26045f9f9744'
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.before_comma}-#{version.after_comma}/eclipse-SDK-#{version.before_comma}-macosx-cocoa-x86_64.dmg&r=1"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.