### PR TITLE
Update eclipse-rcp from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-rcp' do
-  version '4.15.0,2020-03:R'
-  sha256 '570e9088a9bd3522723b573c913c6af9909e1360a12f6cab8c5199a68a233a22'
+  version '4.16.0,2020-06:R'
+  sha256 'a2a0e8c2505e5ab75dd39d275dd16cc99c7e656ee22d6038e2efe54d5e46117e'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-rcp-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for RCP and RAP Developers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.