### PR TITLE
Update eclipse-testing from 4.15.0,2020-03:R to 4.16.0,2020-06:R

### DIFF
--- a/Casks/eclipse-testing.rb
+++ b/Casks/eclipse-testing.rb
@@ -1,6 +1,6 @@
 cask 'eclipse-testing' do
-  version '4.15.0,2020-03:R'
-  sha256 'bbaf313028ce4dc0c65c9efb1d2cdb6c323c9b396e8739d91b6f56a09e570b64'
+  version '4.16.0,2020-06:R'
+  sha256 'b9998ea9a897c70366a37560658ec718c97ffdf78015556dcc867df87504eb4c'
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.after_comma.before_colon}/#{version.after_colon}/eclipse-testing-#{version.after_comma.before_colon}-#{version.after_colon}-macosx-cocoa-x86_64.dmg&r=1"
   name 'Eclipse for Testers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.