### PR TITLE
Update beekeeper-studio from 1.5.1 to 1.5.2

### DIFF
--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,6 +1,6 @@
 cask 'beekeeper-studio' do
-  version '1.5.1'
-  sha256 '9c03213d368f0cfafc7b9b9377536ae86d85b254f177265332b01413ec23cb93'
+  version '1.5.2'
+  sha256 'ecabab1e8cb27577d576b5fd7d180ce0a664637a9edfe8c20d8980e851ce94e9'
 
   # github.com/beekeeper-studio/beekeeper-studio/ was verified as official when first introduced to the cask
   url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).