### PR TITLE
Update deezer from 4.20.0 to 4.20.21

### DIFF
--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -1,6 +1,6 @@
 cask 'deezer' do
-  version '4.20.0'
-  sha256 'b3e2b2f95d1facc3fbf6f0c0cfa1e3a8becaad25ec48f011924a5b253e2fecb8'
+  version '4.20.21'
+  sha256 '35931075e287da7e0fc52890a55526f1b284342908d2b96babfef55c2bc2c06c'
 
   url "https://www.deezer.com/desktop/download/artifact/darwin/x64/#{version}"
   appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.deezer.com/desktop/download%3Fplatform%3Ddarwin%26architecture=x64'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.