### PR TITLE
Update sim-daltonism from 2.0.4 to 2.0.5

### DIFF
--- a/Casks/sim-daltonism.rb
+++ b/Casks/sim-daltonism.rb
@@ -1,6 +1,6 @@
 cask 'sim-daltonism' do
-  version '2.0.4'
-  sha256 'c5c930be3f4ba613f780f4877f8555e92d2bc0a30bd0b12913a04226b0eef0d0'
+  version '2.0.5'
+  sha256 'f094aa0fbcd7b9b29c4a0af34f1e6b4789467946d3b1eadcacb1085fccb6da72'
 
   url "https://littoral.michelf.ca/apps/sim-daltonism/sim-daltonism-#{version}.zip"
   appcast 'https://littoral.michelf.ca/apps/sim-daltonism/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.