### PR TITLE
Update psi-plus from 1.4.1426-macOS10.13 to 1.4.1439-macOS10.13

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,6 +1,6 @@
 cask 'psi-plus' do
-  version '1.4.1426-macOS10.13'
-  sha256 'b1edb4baddd66af7ca4332786605f3e034bbaa563fae687ba568749a4d9b232a'
+  version '1.4.1439-macOS10.13'
+  sha256 'cb8e38c3b22b2c1727aa714da96634f239edf355d189d5d3d2c8741b31490f79'
 
   # downloads.sourceforge.net/psiplus/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/psiplus/Psi+-#{version}-x86_64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.