### PR TITLE
Update squeak from 5.2,18229 to 5.3,19435

### DIFF
--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -1,6 +1,6 @@
 cask 'squeak' do
-  version '5.2,18229'
-  sha256 '78191157f46bbcd04f8c7d36190d5e0247a238eac01b26911badd5c622a3300f'
+  version '5.3,19435'
+  sha256 '06c2d22064b2795c6f4a2c03feddd2ebf741aa8222676195f5ce7b9f607411bd'
 
   url "https://files.squeak.org/#{version.before_comma}/Squeak#{version.before_comma}-#{version.after_comma}-64bit/Squeak#{version.before_comma}-#{version.after_comma}-64bit-All-in-One.zip"
   appcast 'https://squeak.org/downloads/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.