### PR TITLE
Upgrade XcodeClangFormat.app to v1.2.0

### DIFF
--- a/Casks/xcodeclangformat.rb
+++ b/Casks/xcodeclangformat.rb
@@ -1,8 +1,8 @@
 cask 'xcodeclangformat' do
-  version '1.1.0'
-  sha256 'd6fd1a1af949bbc99e0e0a3e15c8c5b3ce4d138b6b8943ee17459dc2dbc4f583'
+  version '1.2.0'
+  sha256 'bd6e0c78230a4912741356d96d69753f5fb911193c40168f3a0978096eb2c4a3'
 
-  url "https://github.com/mapbox/XcodeClangFormat/releases/download/v#{version}/XcodeClangFormat-v#{version}.zip"
+  url "https://github.com/mapbox/XcodeClangFormat/releases/download/v#{version}/XcodeClangFormat.zip"
   appcast 'https://github.com/mapbox/XcodeClangFormat/releases.atom'
   name 'XcodeClangFormat'
   homepage 'https://github.com/mapbox/XcodeClangFormat'


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download xcodeclangformat` is error-free.
- [x] `brew cask style --fix xcodeclangformat` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

App developed by @mapbox (mainly by @kkaefer)