### PR TITLE
Update qsync-client from 3.3.7.0514 to 3.5.0.0612

### DIFF
--- a/Casks/qsync-client.rb
+++ b/Casks/qsync-client.rb
@@ -1,6 +1,6 @@
 cask 'qsync-client' do
-  version '3.3.7.0514'
-  sha256 '97d7813e1c2a171d07355969236719e7a70e5e475522ea840e87594ab8ea478b'
+  version '3.5.0.0612'
+  sha256 '9595c63bd5debce7e872435e991365358c18dda801fc8488427153a1b6a03383'
 
   url "https://download.qnap.com/Storage/Utility/QNAPQsyncClientMac-#{version}.dmg"
   appcast 'https://update.qnap.com/SoftwareRelease.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).