### PR TITLE
Update securesafe from 2.7.0 to 2.7.1

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,6 +1,6 @@
 cask 'securesafe' do
-  version '2.7.0'
-  sha256 '85da709463cea53b41b2609eb650ce85be90178c123bd815c1c3f1f5da558529'
+  version '2.7.1'
+  sha256 'dc501d465214a986c777019b16cef2ee77bd7062a3c23a7839ab6aa62d4b2366'
 
   url "https://www.securesafe.com/downloads/SecureSafe_#{version}.pkg"
   appcast 'https://www.securesafe.com/en/downloads/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).