### PR TITLE
Revert "Update dictionaries from 1.4,322:1577018334 to 1.5,344:1590512627"

### DIFF
--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -1,6 +1,6 @@
 cask 'dictionaries' do
-  version '1.5,344:1590512627'
-  sha256 'ddf7dbc5b4998c594579c855dac3738c21a422319b6258f7c6e0136bca9504e8'
+  version '1.4,322:1577018334'
+  sha256 'fefdddd3165a0cd53f201058b28ba365ced4f7be54bfcb7e6f0b41aa48e10143'
 
   # dl.devmate.com/io.dictionaries.Dictionaries/ was verified as official when first introduced to the cask
   url "https://dl.devmate.com/io.dictionaries.Dictionaries/#{version.after_comma.before_colon}/#{version.after_colon}/Dictionaries-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#83316
I think they downgraded this app - the website and feed contains again 1.4 