### PR TITLE
Update insync from 3.1.9.40821 to 3.2.0.40833

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask 'insync' do
-  version '3.1.9.40821'
-  sha256 '8f3d84ec6bb8a83c53b0457eeed04b56968ed5729a1a4c6a0a236c253e89811c'
+  version '3.2.0.40833'
+  sha256 '5a797d90eaa43e8e5a107419e9cce3f50285f64926bb4fb1efbec70907752ffe'
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   appcast 'https://www.insynchq.com/downloads?start=true'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).