### PR TITLE
Update hazeover from 1.8.5-900 to 1.8.6-970

### DIFF
--- a/Casks/hazeover.rb
+++ b/Casks/hazeover.rb
@@ -1,6 +1,6 @@
 cask 'hazeover' do
-  version '1.8.5-900'
-  sha256 '759f08636ef5668612c34049e482a1bd1cfbab83d38a38ae597d7f10e8085e11'
+  version '1.8.6-970'
+  sha256 '4d18a833babc96bcf19982a413d2d9c3b3334b1057cddc87d4c804acff6acafa'
 
   url 'https://hazeover.com/HazeOver.dmg'
   appcast 'https://hazeover.com/updates.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).