### PR TITLE
Update splashtop-streamer from 3.3.8.0 to 3.4.0.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,6 +1,6 @@
 cask 'splashtop-streamer' do
-  version '3.3.8.0'
-  sha256 '37e9c3bc2ea19f078b010e2c0c2dd897981dd649cbbd0d55a39c6f3de36ebae5'
+  version '3.4.0.0'
+  sha256 'b0ec92daf4ac3a6b0da2e02f7cb6fdbf1dba456021be7fca5750f8fb3bdc0a4c'
 
   # d17kmd0va0f0mp.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).