### PR TITLE
Update unity from 2019.4.0f1,0af376155913 to 2019.4.1f1,e6c045e14e4e

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.4.0f1,0af376155913'
-  sha256 '643e08d88c737f2c1326aac3802593fd0ffa774ebb3edf6384e8b0c96f22bbe3'
+  version '2019.4.1f1,e6c045e14e4e'
+  sha256 '4acc0627ae12d2430e8fb2a27f22bf821695866657331a3e20b82ac560075f90'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.