### PR TITLE
Update unity-webgl-support-for-editor from 2019.4.0f1,0af376155913 to 2019.4.1f1,e6c045e14e4e

### DIFF
--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.13f1,d4ddf0d95db9'
-  sha256 'ef39ecce48455966060ad63b9c543638a5c3fb64ed873c0425fce15372da4624'
+  version '2019.4.1f1,e6c045e14e4e'
+  sha256 '4c8730dcac1140b022a8b87f80d03a30b106a710b5facdfe98eb0de694cf71bd'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-webgl-support-for-editor' do
-  version '2019.4.0f1,0af376155913'
-  sha256 '9e175116e70cb7293b85a86bd80647124a6cdae8b191a3c9c3535ae077358630'
+  version '2019.4.1f1,e6c045e14e4e'
+  sha256 '338e94887bef4fe4ae6cb6cb2d07d1e5e5e194cfc4f2a82403ff36bfa13e7029'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.