### PR TITLE
Update keepingyouawake uninstall

### DIFF
--- a/Casks/keepingyouawake.rb
+++ b/Casks/keepingyouawake.rb
@@ -12,8 +12,7 @@ cask 'keepingyouawake' do
 
   app 'KeepingYouAwake.app'
 
-  uninstall launchctl: 'info.marcel-dierkes.KeepingYouAwake.Launcher',
-            quit:      'info.marcel-dierkes.KeepingYouAwake'
+  uninstall quit: 'info.marcel-dierkes.KeepingYouAwake'
 
   zap trash: [
                '~/Library/Application Scripts/info.marcel-dierkes.KeepingYouAwake',


### PR DESCRIPTION
This `app` does not actually write a launch job definition that is stored on one's hard drive -- it launches the job ad-hoc via the Service Management Framework daemon (`smd` or `otherbsd`), and as such does not need to be uninstalled via `launchctl:`.