### PR TITLE
Update master-password uninstall

### DIFF
--- a/Casks/master-password.rb
+++ b/Casks/master-password.rb
@@ -8,8 +8,7 @@ cask 'master-password' do
 
   app 'Master Password.app'
 
-  uninstall quit:      'com.lyndir.lhunath.MasterPassword.Mac',
-            launchctl: 'com.lyndir.lhunath.MasterPassword.Mac.LoginHelper'
+  uninstall quit:      'com.lyndir.lhunath.MasterPassword.Mac'
 
   zap trash: [
                '~/Library/Application Scripts/com.lyndir.lhunath.MasterPassword.Mac',

--- a/Casks/master-password.rb
+++ b/Casks/master-password.rb
@@ -8,7 +8,7 @@ cask 'master-password' do
 
   app 'Master Password.app'
 
-  uninstall quit:      'com.lyndir.lhunath.MasterPassword.Mac'
+  uninstall quit: 'com.lyndir.lhunath.MasterPassword.Mac'
 
   zap trash: [
                '~/Library/Application Scripts/com.lyndir.lhunath.MasterPassword.Mac',


### PR DESCRIPTION
This `app` does not actually write a launch job definition that is stored on one's hard drive -- it launches the job ad-hoc via the Service Management Framework daemon (`smd` or `otherbsd`), and as such does not need to be uninstalled via `launchctl:`.