### PR TITLE
Update rectangle uninstall

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -13,7 +13,7 @@ cask 'rectangle' do
 
   app 'Rectangle.app'
 
-  uninstall quit:      'com.knollsoft.Rectangle'
+  uninstall quit: 'com.knollsoft.Rectangle'
 
   zap trash: [
                '~/Library/Application Scripts/com.knollsoft.RectangleLauncher',

--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -13,8 +13,7 @@ cask 'rectangle' do
 
   app 'Rectangle.app'
 
-  uninstall quit:      'com.knollsoft.Rectangle',
-            launchctl: 'com.knollsoft.RectangleLauncher'
+  uninstall quit:      'com.knollsoft.Rectangle'
 
   zap trash: [
                '~/Library/Application Scripts/com.knollsoft.RectangleLauncher',


### PR DESCRIPTION
This `app` does not actually write a launch job definition that is stored on one's hard drive -- it launches the job ad-hoc via the Service Management Framework daemon (`smd` or `otherbsd`), and as such does not need to be uninstalled via `launchctl:`.