### PR TITLE
Update stellarium from 0.20.1 to 0.20.2

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,6 +1,6 @@
 cask 'stellarium' do
-  version '0.20.1'
-  sha256 '154e4a61cea2225e93626077fd7d22f49706c84fa7dd56f51bc3bded84f9d0ce'
+  version '0.20.2'
+  sha256 'b45c493d005682b86b9a0773052af549bf0fa32f9379199b01548d5a3d884b38'
 
   # github.com/Stellarium/stellarium/ was verified as official when first introduced to the cask
   url "https://github.com/Stellarium/stellarium/releases/download/v#{version}/Stellarium-#{version}.zip"

--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.13f1,d4ddf0d95db9'
-  sha256 'ef39ecce48455966060ad63b9c543638a5c3fb64ed873c0425fce15372da4624'
+  version '2019.4.1f1,e6c045e14e4e'
+  sha256 '4c8730dcac1140b022a8b87f80d03a30b106a710b5facdfe98eb0de694cf71bd'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.