### PR TITLE
Update electron from 9.0.3 to 9.0.5

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,12 +1,12 @@
 cask 'electron' do
-  version '9.0.3'
-  sha256 '7d4061b0217f922c50ebdc924cbbe55faa4104d0f733aebe6e04079ee3c4eca6'
+  version '9.0.5'
+  sha256 '4897b6121ad2792fd7c0b71f37967d1a251425c3e68d35e293e8f8ccf4166a5e'
 
   # github.com/electron/electron/ was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom'
   name 'Electron'
-  homepage 'https://electron.atom.io/'
+  homepage 'hhttps://electronjs.org/'
 
   app 'Electron.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.