### PR TITLE
Update swiftformat-for-xcode from 0.44.13 to 0.44.14

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask 'swiftformat-for-xcode' do
-  version '0.44.13'
-  sha256 '8b649bb3f4f25bfe874d5264d6aaf1f3210be45027aa14e7897d4e9925883b90'
+  version '0.44.14'
+  sha256 '9c04404d8742b40e6c024e22cce42b8ee2730b92c8706ebd1b1f03387a34fb66'
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   appcast 'https://github.com/nicklockwood/SwiftFormat/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.