### PR TITLE
Update podman fron 1.9.3 to 2.0.0

### DIFF
--- a/Casks/podman.rb
+++ b/Casks/podman.rb
@@ -1,30 +1,21 @@
 cask 'podman' do
-  version '1.9.3'
-  sha256 '8c5d96ee0a30a3b00dec726d7e660cc75999831a9082325d501b0d25bc347abc'
+  version '2.0.0'
+  sha256 'ac759d224ef10f8e28f60c6ee514f716361fe183c236985f552b727b5101e3c7'
 
-  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-remote-darwin.zip"
+  url "https://github.com/containers/libpod/releases/download/v#{version}/podman-remote-release-darwin.zip"
   appcast 'https://github.com/containers/libpod/releases.atom'
   name 'podman'
   homepage 'https://github.com/containers/libpod/'
 
-  binary 'podman-remote-darwin/podman'
+  binary 'podman'
 
   postflight do
-    man1 = Dir["#{staged_path}/podman-remote-darwin/docs/*.1"]
+    man1 = Dir["#{staged_path}/docs/*.1"]
     FileUtils.mv(man1, "#{HOMEBREW_PREFIX}/share/man/man1/")
-
-    man5 = Dir["#{staged_path}/podman-remote-darwin/docs/*.5"]
-    FileUtils.mkdir("#{HOMEBREW_PREFIX}/share/man/man5/") unless File.exist?("#{HOMEBREW_PREFIX}/share/man/man5/")
-    FileUtils.mv(man5, "#{HOMEBREW_PREFIX}/share/man/man5/")
   end
 
   uninstall_postflight do
     man1 = Dir["#{HOMEBREW_PREFIX}/share/man/man1/podman*.1"]
     FileUtils.rm(man1)
-
-    man5 = Dir["#{HOMEBREW_PREFIX}/share/man/man5/podman*.5"]
-    FileUtils.rm(man5)
   end
-
-  zap trash: '~/.config/containers/podman-remote.config'
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Submitting to cask instead of core because https://github.com/Homebrew/homebrew-cask/pull/64042#issuecomment-496993261