### PR TITLE
Update maccy from 0.12.0 to 0.13.0

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask 'maccy' do
-  version '0.12.0'
-  sha256 '8a10dff4762620008e0166abfd1eb3b14eb94e261dc0b5ff54dbca46b87ca505'
+  version '0.13.0'
+  sha256 '82024126a7a17f3f5359d8e531e3db67e13707e59e1aa0320372b4eaf3025bf8'
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).