### PR TITLE
Update garagebuy from 3.3.2 to 3.3.4b3

### DIFF
--- a/Casks/garagebuy.rb
+++ b/Casks/garagebuy.rb
@@ -1,6 +1,6 @@
 cask 'garagebuy' do
-  version '3.3.2'
-  sha256 'f3a8d32189e8d6f5f051ad014ede279c10c67cbd1d9ccb4c223f9366b62b72fb'
+  version '3.3.4b3'
+  sha256 '262511e8cab08d7e32d81e43a964cc2253468ddf4789318e7c1de2b10ddfaddf'
 
   # iwascoding.de/ was verified as official when first introduced to the cask
   url "https://www.iwascoding.de/downloads/GarageBuy_#{version}.dmg"

--- a/Casks/unity-ios-support-for-editor.rb
+++ b/Casks/unity-ios-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-ios-support-for-editor' do
-  version '2019.3.13f1,d4ddf0d95db9'
-  sha256 'ef39ecce48455966060ad63b9c543638a5c3fb64ed873c0425fce15372da4624'
+  version '2019.4.1f1,e6c045e14e4e'
+  sha256 '4c8730dcac1140b022a8b87f80d03a30b106a710b5facdfe98eb0de694cf71bd'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.