### PR TITLE
Update 1password-cli from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask '1password-cli' do
-  version '1.1.0'
-  sha256 'b4f4287c98dca3bde4f223df02e6c14a3d3abbd3db0a84b33bfdbbb4a4587ef3'
+  version '1.1.1'
+  sha256 'f55e62a140a714542249346037c793af5d35110d2aab7d32e59df89967e7369a'
 
   # cache.agilebits.com/dist/1P/op/pkg/ was verified as official when first introduced to the cask
   url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_darwin_amd64_v#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).