### PR TITLE
Add ffmpeg-static v4.3

### DIFF
--- a/Casks/ffmpeg-static.rb
+++ b/Casks/ffmpeg-static.rb
@@ -1,0 +1,14 @@
+cask 'ffmpeg-static' do
+  version '4.3'
+  sha256 'b29347ba16984ae943f0a05b14be03f533e95b2eb41ad9ea14a37b7ba507260b'
+
+  url "https://ffmpeg.zeranoe.com/builds/macos64/static/ffmpeg-#{version}-macos64-static.zip"
+  name 'FFmpeg'
+  homepage 'https://ffmpeg.zeranoe.com/builds/'
+
+  conflicts_with formula: 'ffmpeg'
+
+  binary "ffmpeg-#{version}-macos64-static/bin/ffmpeg"
+  binary "ffmpeg-#{version}-macos64-static/bin/ffprobe"
+  binary "ffmpeg-#{version}-macos64-static/bin/ffplay"
+end


### PR DESCRIPTION
A statically compiled version of FFmpeg.

This is the static build linked from the official FFmpeg download page:

  http://ffmpeg.org/download.html#build-mac

I realize there is an `ffmpeg` formula in `Homebrew/homebrew-core`, but installing that requires installing a *lot* of dependencies (60 in my case) that I do not need for anything else.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
