### PR TITLE
Update menutube from 1.6.1 to 1.7.2

### DIFF
--- a/Casks/menutube.rb
+++ b/Casks/menutube.rb
@@ -1,6 +1,6 @@
 cask 'menutube' do
-  version '1.6.1'
-  sha256 'b50a106a88b96e9ce98feb99502446ad9ce8fcd610dfb3f479e40030e16a7d42'
+  version '1.7.2'
+  sha256 '3553cd053f622837fac6e365c19daa5946ce72c8ba10eadae4afb11c7fa57851'
 
   # github.com/edanchenkov/MenuTube/ was verified as official when first introduced to the cask
   url "https://github.com/edanchenkov/MenuTube/releases/download/#{version}/MenuTube-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).