### PR TITLE
Update termius from 6.0.1 to 6.1.1

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,6 +1,6 @@
 cask 'termius' do
-  version '6.0.1'
-  sha256 '04bd264c9bae3adf2df65cb425d0d0520c4ab17adeddcb9cb922bc6862b12a04'
+  version '6.1.1'
+  sha256 '26e0e2a618d9c0f84519b37505a408a2bc7e2dcb736ffe9d9b8d7ff0034d8cab'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac/ was verified as official when first introduced to the cask
   url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac/Termius.dmg'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).