### PR TITLE
Update edfbrowser from 1.76 to 1.77

### DIFF
--- a/Casks/edfbrowser.rb
+++ b/Casks/edfbrowser.rb
@@ -1,6 +1,6 @@
 cask 'edfbrowser' do
-  version '1.76,87e7b6e7565cce3453f85e78bebfd759'
-  sha256 '9cbbf181604f10628242f720732cf730a90d04244864a94dc296be1340613cc7'
+  version '1.77,d46af4a00350581592aff8e210fe8295'
+  sha256 'd51f87e1d08fac2f6144219833a60e9fa59deab4d7bc0b260c29d57169784fe5'
 
   # gitlab.com/whitone/EDFbrowser/ was verified as official when first introduced to the cask
   url "https://gitlab.com/whitone/EDFbrowser/uploads/#{version.after_comma}/EDFbrowser-#{version.before_comma}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).