### PR TITLE
Add Unclutter 2.1.22d

### DIFF
--- a/Casks/unclutter.rb
+++ b/Casks/unclutter.rb
@@ -8,4 +8,12 @@ cask 'unclutter' do
   homepage 'https://unclutterapp.com/'
 
   app 'Unclutter.app'
+
+  zap trash: [
+               '~/Library/Application Support/Unclutter',
+               '~/Library/Caches/com.softwareambience.Unclutter',
+               '~/Library/Containers/com.softwareambience.Unclutter',
+               '~/Library/Group Containers/*.com.softwareanbience.Unclutter',
+               '~/Library/Preferences/com.softwareambience.Unclutter.plist',
+             ]
 end

--- a/Casks/unclutter.rb
+++ b/Casks/unclutter.rb
@@ -1,0 +1,10 @@
+cask 'unclutter' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://unclutterapp.com/files/Unclutter.zip'
+  name 'Unclutter'
+  homepage 'https://unclutterapp.com/'
+
+  app 'Unclutter.app'
+end

--- a/Casks/unclutter.rb
+++ b/Casks/unclutter.rb
@@ -1,5 +1,5 @@
 cask 'unclutter' do
-  version '2.1.22d'
+  version '2.1.2200'
   sha256 'f2a60f896e8c8c1f21a1beb3b9c5a833343a2932ab423ebc8b791eb8db1cca1b'
 
   url 'https://unclutterapp.com/files/Unclutter.zip'

--- a/Casks/unclutter.rb
+++ b/Casks/unclutter.rb
@@ -1,8 +1,9 @@
 cask 'unclutter' do
-  version :latest
-  sha256 :no_check
+  version '2.1.22d'
+  sha256 'f2a60f896e8c8c1f21a1beb3b9c5a833343a2932ab423ebc8b791eb8db1cca1b'
 
   url 'https://unclutterapp.com/files/Unclutter.zip'
+  appcast 'https://unclutterapp.com/updates/'
   name 'Unclutter'
   homepage 'https://unclutterapp.com/'
 


### PR DESCRIPTION
This cask has been submitted a few times before but rejected because it was unclear if the app could be purchased from within the app and not requiring a download: #46823 #37546

I have bought the app and it is possible to activate it with an activation link from the e-mail you receive afterwards. The app also mentions activation using a license file. It does not require a re-download, clicking the link brings you back to Unclutter which then activates and removes the trial restrictions. Therefore I don't think it differs from apps like Little Snitch or Alfred which are included in the repo.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
