### PR TITLE
Update packetproxy from 2.1.4 to 2.1.5

### DIFF
--- a/Casks/packetproxy.rb
+++ b/Casks/packetproxy.rb
@@ -1,6 +1,6 @@
 cask 'packetproxy' do
-  version '2.1.4'
-  sha256 '82087d0f0aee7420887c3e4a2da0f86ea522ff38ca064518ad31f4dbd0e0fb81'
+  version '2.1.5'
+  sha256 '3deacdd72c1fb252239bf8c6935328ff271f62a3a2607e7ea4a33523d08b3116'
 
   url "https://github.com/DeNA/PacketProxy/releases/download/#{version}/PacketProxy-#{version}-Installer-Mac-Signed.dmg"
   appcast 'https://github.com/DeNA/PacketProxy/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).