### PR TITLE
Change download url to use Google's edge cache.

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -2,8 +2,8 @@ cask 'android-studio' do
   version '4.0.0.16,193.6514223'
   sha256 '61b71dd3274085c16c597ea4a51a5d6c1e39957f358a3434eda79ecc332235ee'
 
-  # google.com/dl/android/studio/ was verified as official when first introduced to the cask
-  url "https://dl.google.com/dl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"
+  # redirector.gvt1.com/edgedl/android/studio/ is Google's edge cache url for dl.google.com/android/studio/
+  url "https://redirector.gvt1.com/edgedl/android/studio/install/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.dmg"
   appcast 'https://dl.google.com/android/studio/patches/updates.xml',
           must_contain: version.major_minor_patch
   name 'Android Studio'


### PR DESCRIPTION
For immutable files, `dl.google.com` has an edge cache with the corresponding path `redirector.gvt1.com/edgedl` which tends to be faster when users are not close to Google data centers. `updates.xml` will still need to use `dl.google.com`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
