### PR TITLE
Update XLink Kai.app to v7.4.37

### DIFF
--- a/Casks/xlink-kai.rb
+++ b/Casks/xlink-kai.rb
@@ -1,9 +1,9 @@
 cask 'xlink-kai' do
-  version '7.4.36'
-  sha256 '931b8250de58bf24553e26cb6507186005520d8eec4c6f83d1db63c613693717'
+  version '7.4.37'
+  sha256 'f19d595d94b156a801f12529c95086f20d1c7ca25961f52a025153a2e4d30420'
 
   # github.com/Team-XLink/releases/ was verified as official when first introduced to the cask
-  url "https://github.com/Team-XLink/releases/releases/download/v#{version}/XLink.Kai.app.zip"
+  url "https://github.com/Team-XLink/releases/releases/download/v#{version}/XLinkKai-7.4.37-539579342-macOS.dmg"
   appcast 'https://github.com/Team-XLink/releases/releases.atom'
   name 'XLink Kai'
   homepage 'https://www.teamxlink.co.uk/'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).