### PR TITLE
Add Autenticacao.gov.pt v3.1.2

### DIFF
--- a/Casks/autenticacao.gov.pt.rb
+++ b/Casks/autenticacao.gov.pt.rb
@@ -1,0 +1,13 @@
+cask 'autenticacao.gov.pt' do
+  version '3.1.2'
+  sha256 '1fddce88483125d520530f71ebc06b5737aa40e867b3567c119292fc222d7c82'
+
+  url 'https://www.autenticacao.gov.pt/documents/20126/78595/Autenticacao.gov_MacOS.pkg'
+  name 'Autenticacao.gov.pt'
+  homepage 'https://www.autenticacao.gov.pt/web/guest/cc-aplicacao'
+
+  pkg 'Autenticacao.gov_MacOS.pkg'
+
+  uninstall pkgutil: ['pt.cartaodecidadao.lib', 'pt.cartaodecidadao.bin', 'pt.cartaodecidadao.certs', 'pt.cartaodecidadao.apps'],
+            signal:  ['TERM', 'pt.gov.autenticacao']
+end


### PR DESCRIPTION
Application allows Portuguese citizens to use their ID to authenticate with authorities

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
