### PR TITLE
Update godot-mono to 3.2.2

### DIFF
--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -1,6 +1,6 @@
 cask 'godot-mono' do
-  version '3.2.1'
-  sha256 'aaede8ad074da8cfe39f179af2eb7d2fe7776391a06d9236c65e426af87a8392'
+  version '3.2.2'
+  sha256 '84c99d3dbd151a9f088c5cf3dd99f2185c43af2ab650bb11ec37404907e76ec6'
 
   # downloads.tuxfamily.org/godotengine/ was verified as official when first introduced to the cask
   url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_osx.64.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download godot-mono.rb` is error-free.
- [x] `brew cask style --fix godot-mono.rb` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Base cask updated in #85085
