### PR TITLE
Update mucommander from 0.9.4-2 to 0.9.5-1

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,6 +1,6 @@
 cask 'mucommander' do
-  version '0.9.4-2'
-  sha256 '1f0dee9c1a4713b462d5ccae5799ca3bb48178c1877715dd34213183d0fc960a'
+  version '0.9.5-1'
+  sha256 '476ffd9e271163513d9fde2d015d1da3f2777e54b913b10d4ef49ac7e016bae1'
 
   # github.com/mucommander/mucommander/ was verified as official when first introduced to the cask
   url "https://github.com/mucommander/mucommander/releases/download/#{version}/mucommander-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).