### PR TITLE
Update gnucash from 3.10,1 to 3.11,1

### DIFF
--- a/Casks/gnucash.rb
+++ b/Casks/gnucash.rb
@@ -1,6 +1,6 @@
 cask 'gnucash' do
-  version '3.10,1'
-  sha256 '053764da1b4f87e2851372912ad503447bf96cd111b819a92f02319343f592f6'
+  version '3.11,1'
+  sha256 '840eb08731a58e463efaf640bd011637d3f23a6125ee313c167de1f1640424dd'
 
   # github.com/Gnucash/gnucash/ was verified as official when first introduced to the cask
   url "https://github.com/Gnucash/gnucash/releases/download/#{version.before_comma}/Gnucash-Intel-#{version.before_comma.chomp('b')}-#{version.after_comma}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).