### PR TITLE
Update ringcentral from 20.2.30 to 20.2.31

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask 'ringcentral' do
-  version '20.2.30'
-  sha256 'a163e5cec8734052967392eb8cd9ddd52a72f985a8abce27eb2380ea0926ad95'
+  version '20.2.31'
+  sha256 'acbf0577337546da9275a602a13f79c1482cf287e17cde2774b2cc4df82d464b'
 
   url 'https://app.ringcentral.com/downloads/RingCentral.pkg'
   appcast 'https://app.ringcentral.com/download/latest-mac.yml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).