### PR TITLE
Update mochi from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask 'mochi' do
-  version '1.5.2'
-  sha256 '4b9d2d96610939e211c5c17b2e6880b31e35a7537e5da4cf255107185b78e138'
+  version '1.5.3'
+  sha256 '0a386fce803ccd56335a23098dc9d0134c52a9a7fdab4ac4545074c4d3500798'
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   appcast 'https://mochi.cards/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.