### PR TITLE
Update riot from 1.6.6 to 1.6.7

### DIFF
--- a/Casks/riot.rb
+++ b/Casks/riot.rb
@@ -1,6 +1,6 @@
 cask 'riot' do
-  version '1.6.6'
-  sha256 '15ca39a94d85d7e3dd4e70cecf929455db3c6e6102a0bfffff2189c3b011641a'
+  version '1.6.7'
+  sha256 '97a2413c050df71f293de0ce392aec567de847c18bb3e7f1c11112e1a5504948'
 
   url "https://packages.riot.im/desktop/install/macos/Riot-#{version}.dmg"
   appcast 'https://github.com/vector-im/riot-desktop/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).