### PR TITLE
Add Warzone 2100 v3.4.0

### DIFF
--- a/Casks/warzone-2100.rb
+++ b/Casks/warzone-2100.rb
@@ -2,7 +2,7 @@ cask 'warzone-2100' do
   version '3.4.0'
   sha256 'c74ffe361f41965ea46a4e1e63685210584cba3281c7a85e7ce92d2bd7fef490'
 
-  # github.com/Warzone2100 was verified as official when first introduced to the cask
+  # github.com/Warzone2100/warzone2100/ was verified as official when first introduced to the cask
   url "https://github.com/Warzone2100/warzone2100/releases/download/#{version}/warzone2100_macOS.zip"
   appcast 'https://github.com/Warzone2100/warzone2100/releases.atom'
   name 'Warzone 2100'

--- a/Casks/warzone-2100.rb
+++ b/Casks/warzone-2100.rb
@@ -1,0 +1,17 @@
+cask 'warzone-2100' do
+  version '3.4.0'
+  sha256 'c74ffe361f41965ea46a4e1e63685210584cba3281c7a85e7ce92d2bd7fef490'
+
+  # github.com/Warzone2100 was verified as official when first introduced to the cask
+  url "https://github.com/Warzone2100/warzone2100/releases/download/#{version}/warzone2100_macOS.zip"
+  appcast 'https://github.com/Warzone2100/warzone2100/releases.atom'
+  name 'Warzone 2100'
+  homepage 'https://wz2100.net/'
+
+  app 'Warzone 2100.app'
+
+  zap trash: [
+               '~/Library/Application Support/Warzone 2100*',
+               '~/Library/Saved Application State/net.wz2100.Warzone2100.savedState',
+             ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Note: first line of zap stanza may be `~/Library/Application Support/Warzone 2100 #{version}`, but I think that mask is better here for future. Because if user will upgrade to a new version e.g. `3.4.1`, then old profile will not be removed with zap.