### PR TITLE
Update breaktimer from 0.7.3 to 0.7.4

### DIFF
--- a/Casks/breaktimer.rb
+++ b/Casks/breaktimer.rb
@@ -1,6 +1,6 @@
 cask 'breaktimer' do
-  version '0.7.3'
-  sha256 '07f2ce6e31304dabd0b35a0b4897d08d4ac462e814d3c4ffbd8bc765d8ccbaea'
+  version '0.7.4'
+  sha256 '6b8e2d1506787c7f7ccec38652f623b01ab47c1133f5d6fabf7515fde590fd7a'
 
   # github.com/tom-james-watson/breaktimer-app/ was verified as official when first introduced to the cask
   url "https://github.com/tom-james-watson/breaktimer-app/releases/download/v#{version}/BreakTimer.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).