### PR TITLE
Update rubitrack-pro from 5.3.1 to 5.3.2

### DIFF
--- a/Casks/rubitrack-pro.rb
+++ b/Casks/rubitrack-pro.rb
@@ -1,6 +1,6 @@
 cask 'rubitrack-pro' do
-  version '5.3.1'
-  sha256 'af53b5047ce9fcc47b9bd0316b58f35a96b8a0635c2db4b02e54fa7b014edfae'
+  version '5.3.2'
+  sha256 '789ec84384b2e5ce8187d4e957b98892b4c830a3b9abb513ed9747ee3ba22136'
 
   url "https://www.rubitrack.com/files/rubiTrack-#{version}.dmg"
   appcast "https://www.rubitrack.com/autoupdate/sparkle#{version.major}.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).