### PR TITLE
Update trojan-qt5 from 1.2.0 to 1.3.0

### DIFF
--- a/Casks/trojan-qt5.rb
+++ b/Casks/trojan-qt5.rb
@@ -1,7 +1,7 @@
 cask 'trojan-qt5' do
   # note: "5" is not a version number, but an intrinsic part of the product name
-  version '1.2.0'
-  sha256 'd99e2f49f76b4a103fc9e7faf6d57afd824b4e0e91cae48b8832bc0cf8d60c43'
+  version '1.3.0'
+  sha256 'f5cbad7e6a31671b1ee76eea6800fcbea52fb6e691adfee1152f7241499a6980'
 
   url "https://github.com/TheWanderingCoel/Trojan-Qt5/releases/download/v#{version}/Trojan-Qt5-macOS.dmg"
   appcast 'https://github.com/TheWanderingCoel/Trojan-Qt5/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).