### PR TITLE
Update electerm from 1.3.42 to 1.3.45

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask 'electerm' do
-  version '1.3.42'
-  sha256 '0f8a1eebc983e7fae3ae4b40731832b977e00406910f1afe36a33166ee0f1d39'
+  version '1.3.45'
+  sha256 'e83ee994991a2980d563d3cfaa96f782f5abf11ea6c87e17a7b21714430f3b08'
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   appcast 'https://github.com/electerm/electerm/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).