### PR TITLE
Bump chef-workstation to 20.7.81

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask 'chef-workstation' do
-  version '20.6.62'
-  sha256 'd13d6dcdb69c0c7843e2e0f07765138d6eb17aa47854b3b721ecc97e2e7911e7'
+  version '20.7.81'
+  sha256 '1027d55e29c12dcedefe799b8d3a5b1bb19df4224a77eb5e87d0d623570cca63'
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.dmg"
   appcast 'https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.14&m=x86_64&v=latest'


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for stable version.

Signed-off-by: tyler-ball <tball@chef.io>
