### PR TITLE
Update ueli from 8.7.1 to 8.8.0

### DIFF
--- a/Casks/ueli.rb
+++ b/Casks/ueli.rb
@@ -1,6 +1,6 @@
 cask 'ueli' do
-  version '8.7.1'
-  sha256 'caa7722348cdd4cb5e2eafa17777efec5fcfa35abbb8057319d13d6b328c299a'
+  version '8.8.0'
+  sha256 'ce24b8e1de20e19d168b7d6337db5648d0eec9d64726cd9b2ca031b011f516d8'
 
   # github.com/oliverschwendener/ueli/ was verified as official when first introduced to the cask
   url "https://github.com/oliverschwendener/ueli/releases/download/v#{version}/ueli-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).