### PR TITLE
Update virtualc64 from 3.3.2 to 3.4

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,7 +1,7 @@
 cask 'virtualc64' do
   # note: "64" is not a version number, but an intrinsic part of the product name
-  version '3.3.2'
-  sha256 'ffe82a07306c56065e6e76b212ee4918308c93b72ba73e3ef7be8f6b5cd579ac'
+  version '3.4'
+  sha256 '542145ec4d6b71b5a05a5bfe55b30fc7792dd8eaf363e666a426eb6e045e8af4'
 
   url "http://www.dirkwhoffmann.de/virtualc64/VirtualC64_#{version}.zip"
   appcast 'http://dirkwhoffmann.de/virtualc64/VirtualC64Appcast.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).