### PR TITLE
Upgrade Zettlr from 1.6 to 1.7.0 release

### DIFF
--- a/Casks/zettlr.rb
+++ b/Casks/zettlr.rb
@@ -1,6 +1,6 @@
 cask 'zettlr' do
-  version '1.6.0'
-  sha256 '51076164403cfaf16cd2fb9f22505303e05f448dfb1d914dfd78e82b20a9f3b2'
+  version '1.7.0'
+  sha256 'ff11bf15e163470b6e9b42bcd1dba42c43052c7b008d94f05163bd88e5442a5c'
 
   # github.com/Zettlr/Zettlr/ was verified as official when first introduced to the cask
   url "https://github.com/Zettlr/Zettlr/releases/download/v#{version}/Zettlr-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


