### PR TITLE
CONTRIBUTING: Update to use ssh for remote

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ For manual updates, you'll need to fork the repository and add your copy as a re
 ```bash
 $ github_user='<my-github-username>'
 $ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
-$ git remote add "${github_user}" "https://github.com/${github_user}/homebrew-cask"
+$ git remote add "${github_user}" "git@github.com:${github_user}/homebrew-cask.git"
 ```
 
 3: If you have already added your GitHub fork as a remote for your homebrew-cask Tap, ensure your fork is [up-to-date](https://help.github.com/articles/merging-an-upstream-repository-into-your-fork/).


### PR DESCRIPTION
Using ssh as opposed to HTTPs is a better choice for working with git repositories.
Contributor has to have ssh keys configured, but that must be assumed at this point. The use of git is a requirement anyway :)