### PR TITLE
Update checksum of DeepGit 4.0.1

### DIFF
--- a/Casks/deepgit.rb
+++ b/Casks/deepgit.rb
@@ -1,6 +1,6 @@
 cask 'deepgit' do
   version '4.0.1'
-  sha256 'cabc3a8c4e8b507fa3f999052a3cc1f6f8ddb06e4cfcdeb9c1d9c2ca6c34351f'
+  sha256 'e1905388c46e1e73e27fdc260350c95923186d962ef5bdc9c59ebba155f53041'
 
   url "https://www.syntevo.com/downloads/deepgit/deepgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://syntevo.com/deepgit/download'


### PR DESCRIPTION
DeepGit 4.0.1 was initially published in a broken state, which the authors then fixed and re-uploaded as still v4.0.1, see the discussion under commit https://github.com/Homebrew/homebrew-cask/commit/b14fcec9e63f7f8ea05beca91a72e4966cf0faf6.

This PR updates the checksum to what I see in the `Actual:` field of the [error message](https://github.com/Homebrew/homebrew-cask/commit/b14fcec9e63f7f8ea05beca91a72e4966cf0faf6#commitcomment-40346950).

---

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

