### PR TITLE
Rename FreeType to freetype for case-sensitive filesystems for dwarf-fortress

### DIFF
--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -11,7 +11,11 @@ cask 'dwarf-fortress' do
   binary shimscript, target: 'dwarf-fortress'
 
   preflight do
-    FileUtils.mv(staged_path.join('df_osx/libs/SDL_ttf.framework/Frameworks/FreeType.framework'), staged_path.join('df_osx/libs/SDL_ttf.framework/Frameworks/freetype.framework'))
+    begin
+      FileUtils.mv(staged_path.join('df_osx/libs/SDL_ttf.framework/Frameworks/FreeType.framework'), staged_path.join('df_osx/libs/SDL_ttf.framework/Frameworks/freetype.framework'))
+    rescue SystemCallError
+      # Ignore failed renames (occurs on case-insensitive drives).
+    end
     IO.write shimscript, <<~EOS
       #!/bin/sh
       exec '#{staged_path}/df_osx/df' "$@"

--- a/Casks/dwarf-fortress.rb
+++ b/Casks/dwarf-fortress.rb
@@ -11,6 +11,7 @@ cask 'dwarf-fortress' do
   binary shimscript, target: 'dwarf-fortress'
 
   preflight do
+    FileUtils.mv(staged_path.join('df_osx/libs/SDL_ttf.framework/Frameworks/FreeType.framework'), staged_path.join('df_osx/libs/SDL_ttf.framework/Frameworks/freetype.framework'))
     IO.write shimscript, <<~EOS
       #!/bin/sh
       exec '#{staged_path}/df_osx/df' "$@"


### PR DESCRIPTION
Note that this is a fix for an underlying bug in dwarf-fortress (http://www.bay12games.com/dwarves/mantisbt/view.php?id=11136) - if that is outside the scope of homebrew, feel free to close out 👍

Fix is documented at http://dwarffortresswiki.org/index.php/DF2014:Installation#Mac - there's also a command to clear the `com.apple.quarantine` attribute, but that seems to not be the general pattern for homebrew, so didn't include.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
