### PR TITLE
Update Eddie sha256 hash

### DIFF
--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -1,6 +1,6 @@
 cask 'eddie' do
   version '2.18.9'
-  sha256 'fd795535ab519e7de25e2ddfef96a5b6313c81af9c950d05dbc0337852573afd'
+  sha256 '4b6e233496f8d63d1cbab01a2f24e46c480741746c1b1b6e7468442d41c648c1'
 
   # eddie.website/ was verified as official when first introduced to the cask
   url "https://eddie.website/download/?platform=macos&arch=x64&ui=ui&format=disk.dmg&version=#{version}"


### PR DESCRIPTION
The hash changed with version 2.18.9, causing problems while downloading.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
