### PR TITLE
Revert "Update feishu from 3.24.10 to 3.26.3"

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,6 +1,6 @@
 cask 'feishu' do
-  version '3.26.3'
-  sha256 'ff19ae85b8eb66538bb0ba8616767b9fc3b04a72e8fcc4cda31e38154c7dffcd'
+  version '3.24.10'
+  sha256 '5daa993b5eae47efcd0b88be3886a45e4d49806f26eadd8cf97eb9940fedb234'
 
   # sf3-ttcdn-tos.pstatp.com/ was verified as official when first introduced to the cask
   url "https://sf3-ttcdn-tos.pstatp.com/obj/ee-appcenter/Feishu-#{version}.dmg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#85132
appcast and website download were reverted back to 3.24.10