### PR TITLE
Update codeexpander from 3.3.6 to 3.5.0

### DIFF
--- a/Casks/codeexpander.rb
+++ b/Casks/codeexpander.rb
@@ -1,6 +1,6 @@
 cask 'codeexpander' do
-  version '3.3.6'
-  sha256 '54bf88b5da08f75ec5b93677860f0a284984d83db5f92446e4937b4c56af9f07'
+  version '3.5.0'
+  sha256 '835032d575715f57f1949156d2a7a441165ae17c398c45f30d6d58179faa3f02'
 
   url "https://github.com/oncework/codeexpander/releases/download/#{version.major_minor}.x/CodeExpander-#{version}.dmg"
   appcast 'https://github.com/oncework/codeexpander/releases.atom',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).