### PR TITLE
Add minimum Java version to Gloomhaven-Helper

### DIFF
--- a/Casks/gloomhaven-helper.rb
+++ b/Casks/gloomhaven-helper.rb
@@ -19,6 +19,6 @@ cask 'gloomhaven-helper' do
   end
 
   caveats do
-    depends_on_java
+    depends_on_java '8+'
   end
 end


### PR DESCRIPTION
According to the website, Java 8+ is required to run this application.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
