### PR TITLE
Update touchosc-bridge from 1.5.0 to 1.6.0

### DIFF
--- a/Casks/touchosc-bridge.rb
+++ b/Casks/touchosc-bridge.rb
@@ -1,6 +1,6 @@
 cask 'touchosc-bridge' do
-  version '1.5.0'
-  sha256 '53ce1e920e05b844c3fa2bb1e891fec2b8de9e4917ec0fa01feecfcb772cd767'
+  version '1.6.0'
+  sha256 '2a9d20a033e18cf27af61a65d29d02dedadb23e6e2ece346586f860a2bc239f0'
 
   url "https://hexler.net/pub/touchosc/touchosc-bridge-#{version}-macos.zip"
   appcast 'https://hexler.net/software/touchosc'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).