### PR TITLE
Update loaf from 1.0.2 to 1.0.3

### DIFF
--- a/Casks/loaf.rb
+++ b/Casks/loaf.rb
@@ -1,6 +1,6 @@
 cask 'loaf' do
-  version '1.0.2'
-  sha256 'f4581b2bdb6050244cbbc9ad150db5d46cf654c6bd4c24980889d5f8a7b8cf7a'
+  version '1.0.3'
+  sha256 'fe8967b30889d96de1eef3927bee732530b4da821b0e4f8e94c57ab5dcd8a5dc'
 
   # github.com/philipardeljan/getloaf/ was verified as official when first introduced to the cask
   url "https://github.com/philipardeljan/getloaf/releases/download/v#{version}/loaf.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).