### PR TITLE
Updated ableton-live and adobe-creative-cloud casks, added 'auto_updates true'.

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -7,6 +7,7 @@ cask 'ableton-live-intro' do
   name 'Ableton Live Intro'
   homepage 'https://www.ableton.com/en/live/'
 
+  auto_updates true
   depends_on macos: '>= :el_capitan'
 
   app "Ableton Live #{version.major} Intro.app"

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -7,6 +7,7 @@ cask 'ableton-live-lite' do
   name 'Ableton Live Lite'
   homepage 'https://www.ableton.com/en/products/live-lite/'
 
+  auto_updates true
   depends_on macos: '>= :el_capitan'
 
   app "Ableton Live #{version.major} Lite.app"

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -7,6 +7,8 @@ cask 'ableton-live-standard' do
   name 'Ableton Live Standard'
   homepage 'https://www.ableton.com/en/live/'
 
+  auto_updates true
+
   app "Ableton Live #{version.major} Standard.app"
 
   zap trash: '~/Library/*/*[Aa]bleton*',

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -7,6 +7,7 @@ cask 'ableton-live-suite' do
   name 'Ableton Live Suite'
   homepage 'https://www.ableton.com/en/live/'
 
+  auto_updates true
   depends_on macos: '>= :el_capitan'
 
   app "Ableton Live #{version.major} Suite.app"

--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -6,6 +6,8 @@ cask 'adobe-creative-cloud' do
   name 'Adobe Creative Cloud'
   homepage 'https://creative.adobe.com/products/creative-cloud'
 
+  auto_updates true
+
   installer script: {
                       executable:   "#{staged_path}/Install.app/Contents/MacOS/Install",
                       args:         ['--mode=silent'],


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).