### PR TITLE
updated OpenVPN Connect Client (openvpn-connect) from 2.7.1.107 to 3.2.0

### DIFF
--- a/Casks/openvpn-connect.rb
+++ b/Casks/openvpn-connect.rb
@@ -1,16 +1,23 @@
 cask 'openvpn-connect' do
-  version '2.7.1.107'
-  sha256 '058a8d2c5b3817722a0474eb004e77d551726e710a4fb17c4fa34a81faa6fa2a'
+  version '3.2.0,1426'
+  sha256 '1a67cf9cfc87079e02d32d8f8fbd6f83be245f2a7401c8234cd0f400deb2a88e'
 
-  url "https://swupdate.openvpn.net/as/clients/openvpn-connect-#{version}_signed.dmg"
+  url "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-#{version.before_comma}.#{version.after_comma}_signed.dmg"
   appcast 'https://openvpn.net/client-connect-vpn-for-mac-os/'
   name 'OpenVPN Connect client'
   homepage 'https://openvpn.net/client-connect-vpn-for-mac-os/'
 
-  pkg 'OpenVPN_Connect_Installer_signed.pkg'
+  pkg "OpenVPN_Connect_#{version.before_comma.dots_to_underscores}(#{version.after_comma})_Installer_signed.pkg"
 
-  uninstall script: {
-                      executable: '/Applications/OpenVPN/Uninstall OpenVPN Connect.app/Contents/Resources/remove.sh',
-                      sudo:       true,
-                    }
+  uninstall launchctl: 'org.openvpn.client',
+            script:    {
+                         executable: '/Applications/OpenVPN Connect/Uninstall OpenVPN Connect.app/Contents/Resources/remove.sh',
+                         sudo:       true,
+                       },
+            pkgutil:   [
+                         'org.openvpn.client.pkg',
+                         'org.openvpn.client_framework.pkg',
+                         'org.openvpn.client_launch.pkg',
+                         'org.openvpn.client_uninstall.pkg',
+                       ]
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

----

`3.2.0` is the first stable release of version 3.
