### PR TITLE
Update copyclip from 2.9.97 to 2.9.98

### DIFF
--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -1,6 +1,6 @@
 cask 'copyclip' do
-  version '2.9.97'
-  sha256 'ef40942a284f8af9484682b28ae9aa922f4b54ebf2b1c1c5d1b0bf3aa95b60fc'
+  version '2.9.98'
+  sha256 '907948736d8872ac831cd92832553e0d4a46fb4f74e9e1f14a3f4fcfbbd2bb21'
 
   # rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379?format=zip'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).