### PR TITLE
Update aircall from 2.5.7 to 2.5.8

### DIFF
--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -10,5 +10,5 @@ cask 'aircall' do
 
   auto_updates true
 
-  app 'mac/Aircall.app'
+  app 'Aircall.app'
 end

--- a/Casks/aircall.rb
+++ b/Casks/aircall.rb
@@ -1,9 +1,9 @@
 cask 'aircall' do
-  version '2.5.7'
-  sha256 'bd7892c7dcf0e39645a12b21f5c8fbb8552313603966e37be05d568af23d25e2'
+  version '2.5.8'
+  sha256 '59501a4466fcd5993bceec3b98afcf6755487e61b8d7a5467b1d86bb41117064'
 
-  # aircall-electron-releases.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url "https://aircall-electron-releases.s3.amazonaws.com/production/Aircall-#{version}-mac.zip"
+  # s3-us-west-1.amazonaws.com/aircall-electron-releases/ was verified as official when first introduced to the cask
+  url "https://s3-us-west-1.amazonaws.com/aircall-electron-releases/production/Aircall-#{version}.zip"
   appcast 'https://electron.aircall.io/update/osx/0.0.0'
   name 'Aircall'
   homepage 'https://aircall.io/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).