### PR TITLE
Update unity-windows-support-for-editor from 2019.4.1f1,e6c045e14e4e to 2019.4.2f1,20b4642a3455

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask 'unity-windows-support-for-editor' do
-  version '2019.4.1f1,e6c045e14e4e'
-  sha256 '82670699f61ed625453859cc34a3474cf8bca5f0cbb5eeafd4be748c18410043'
+  version '2019.4.2f1,20b4642a3455'
+  sha256 'fad4e7c58c9c4f7e477fd41ab8d71b54fa33ed53ac516cb3042bd507d9b4f5d4'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json'

--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask 'unity' do
-  version '2019.4.1f1,e6c045e14e4e'
-  sha256 '4acc0627ae12d2430e8fb2a27f22bf821695866657331a3e20b82ac560075f90'
+  version '2019.4.2f1,20b4642a3455'
+  sha256 '1be916e3c36a8f94c9294daed6805b24890c5f5b9627e0ee84abce6fbb0935c6'
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast 'https://unity3d.com/get-unity/download/archive'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).