### PR TITLE
Update eloston-chromium from 81.0.4044.138-1 to 83.0.4103.116-1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,6 +1,6 @@
 cask 'eloston-chromium' do
-  version '81.0.4044.138-1'
-  sha256 '3d6c402573a77e26b3572fabda3613523cdce19f334ae503629285dc7b4c79b8'
+  version '83.0.4103.116-1'
+  sha256 '0537a4f8e1a7f8d51fc0b45ca0b4102de3380853a685ab9dff387b1db37a5188'
 
   # github.com/kramred/ungoogled-chromium-binaries/ was verified as official when first introduced to the cask
   url "https://github.com/kramred/ungoogled-chromium-binaries/releases/download/#{version}/ungoogled-chromium_#{version}.1_macos.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).