### PR TITLE
Update mos.rb to 3.1.0

### DIFF
--- a/Casks/mos.rb
+++ b/Casks/mos.rb
@@ -1,6 +1,6 @@
 cask 'mos' do
-  version '2.3.0'
-  sha256 '4f5dc538ec8cea0774b483cf74751ae6062b7cd13bc6e7876a67bb86439f85ef'
+  version '3.1.0'
+  sha256 '8be71fb09749634603ed8c076d852a14ec39146bda9faae08c8d50eece5a5b4b'
 
   # github.com/Caldis/Mos/ was verified as official when first introduced to the cask
   url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.dmg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
