### PR TITLE
Update qt-creator from 4.12.3 to 4.12.4

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator' do
-  version '4.12.3'
-  sha256 '3fb78c748fffaceb5fd2658dcac358987ac297b364b2a6ef75be7d1911484dd1'
+  version '4.12.4'
+  sha256 '7710ba09dad8a554e525625b2e261c163ad3db6ff2bc79764529923deae5c1a9'
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   appcast 'https://download.qt.io/official_releases/qtcreator/',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).