### PR TITLE
.github/workflows: run `brew cask style`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,9 @@ jobs:
         env:
           HOMEBREW_COLOR: 1
           HOMEBREW_DEVELOPER: 1
+      - name: brew cask style
+        run: |
+          # don't care about `brew cask style` here.
+          brew untap adoptopenjdk/openjdk
+
+          brew cask style


### PR DESCRIPTION
Do this for all casks instead of a single cask.

As-of https://github.com/Homebrew/brew/pull/7867 we will need to ensure that this never fails to avoid breaking Homebrew/brew CI (and vice versa)