### PR TITLE
Update zeplin from 3.6,918 to 3.7,951

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,6 +1,6 @@
 cask 'zeplin' do
-  version '3.6,918'
-  sha256 'ac26a1945797ff0d57277db3c858227f9523d40cb0536ddb979eb42fee5e2089'
+  version '3.7,951'
+  sha256 'adb32b61abd4349c8eb6060ee229262965efe61edea271eaae620a211282c479'
 
   url 'https://api.zeplin.io/urls/download-mac'
   appcast 'https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).