### PR TITLE
Update paperspace from 8.4.1.0 to 9.2.2.1040

### DIFF
--- a/Casks/paperspace.rb
+++ b/Casks/paperspace.rb
@@ -1,9 +1,9 @@
 cask 'paperspace' do
-  version '8.4.1.0'
-  sha256 '6b425ada9f9a9696a1925e7fc8ccfaca4e1db2d7fc2077618cc3e58626bede34'
+  version '9.2.2.1040'
+  sha256 'ae4999785de90c465638772266b1a401f11db4c2ec6aa0472611ac9265bcfe95'
 
   # ps-receiver.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url "https://ps-receiver.s3.amazonaws.com/darwin/Paperspace-#{version}.dmg"
+  url "https://ps-receiver.s3.amazonaws.com/prod/darwin/Paperspace-#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/extract_text/extract_text_split_easy.cgi?url=https://www.paperspace.com/download&user_agent=Mozilla/5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X%2010_14_5)'
   name 'Paperspace'
   homepage 'https://www.paperspace.com/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).