### PR TITLE
Update biscuit from 1.2.8 to 1.2.9

### DIFF
--- a/Casks/biscuit.rb
+++ b/Casks/biscuit.rb
@@ -1,6 +1,6 @@
 cask 'biscuit' do
-  version '1.2.8'
-  sha256 'e12d53f85b3ba74b7897499b5cb2f8f9b98a87170497f4309c75e8bf2e7fa713'
+  version '1.2.9'
+  sha256 '6a8b06f1da66a7cf65b4af30acf678270595b61f2302a37bd6bb19675f08080c'
 
   # github.com/agata/dl.biscuit/ was verified as official when first introduced to the cask
   url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).