### PR TITLE
Update switchresx from 4.10.0 to 4.10.1 and skip sha256 check

### DIFF
--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -1,6 +1,6 @@
 cask 'switchresx' do
-  version '4.10.0'
-  sha256 '99225a0980b49efaccdbd8ea1f2a8db7e811647c3a1a40440883b9d072cbdb92'
+  version '4.10.1'
+  sha256 :no_check
 
   url "https://www.madrau.com/data/switchresx/SwitchResX#{version.major}.zip"
   appcast "https://www.madrau.com/SRXCurrentVersion#{version.major}"


### PR DESCRIPTION
I’ve switched the cask to use `sha256 :no_check`. According to [the docs](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#special-value-no_check):

> The special value `sha256 :no_check` is used to turn off SHA checking whenever checksumming is impractical due to the upstream configuration.

The download URL (http://www.madrau.com/data/switchresx/SwitchResX4.zip) does not include a minor or point release number, so even if I updated the checksum (to `33b2bec0623f1edd83e32efa2ac1980f9d677211abdfd8a3d62289eb29abf20a`), it would break again the next time the SwitchResX author publishes an update.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free. (ran `brew cask audit --download Casks/switchresx.rb`)
- [x] `brew cask style --fix {{cask_file}}` reports no offenses. (ran `brew cask style --fix Casks/switchresx.rb`)
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update. NB: #85567 also updates to version 4.10.1, but it doesn’t apply `sha256 :no_check`
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**: n/a
