### PR TITLE
Update uniconverter from 11.6.7.5 to 12.0.0.28

### DIFF
--- a/Casks/uniconverter.rb
+++ b/Casks/uniconverter.rb
@@ -1,6 +1,6 @@
 cask 'uniconverter' do
-  version '11.6.7.5'
-  sha256 '4c5063f2f645821d289f22511c60dc3d3abeff7632f3440ff9c6204622f263ea'
+  version '12.0.0.28'
+  sha256 '9e5769f4d83eaf5ee664da6aa1b0af9c104a9675f6495dc5f0b94db04b536479'
 
   url 'http://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full735.dmg'
   name 'UniConverter'

--- a/Casks/wondershare-uniconverter.rb
+++ b/Casks/wondershare-uniconverter.rb
@@ -1,4 +1,4 @@
-cask 'uniconverter' do
+cask 'wondershare-uniconverter' do
   version '12.0.0.28'
   sha256 '9e5769f4d83eaf5ee664da6aa1b0af9c104a9675f6495dc5f0b94db04b536479'
 
@@ -6,7 +6,7 @@ cask 'uniconverter' do
   name 'UniConverter'
   homepage 'https://videoconverter.wondershare.com/'
 
-  app 'UniConverter.app'
+  app 'Wondershare UniConverter.app'
 
   zap trash: [
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.wondershare.video-converter-ultimate.sfl*',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).