### PR TITLE
Update firefox to 78.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,123 +1,123 @@
 cask 'firefox' do
-  version '78.0.1'
+  version '78.0.2'
 
   language 'cs' do
-    sha256 'a98b9fbd811dedeec75f8d9107e9743df6054732c7f325571f8ad06075e42601'
+    sha256 '3ce818085f70c9f345cd8513c8af3945c1797846741fab3a20c8e6df462850c3'
     'cs'
   end
 
   language 'de' do
-    sha256 'bf1645a063900a98b1a2dcb444a96e5cad0d38f86acc46695aade2a3d26a9f4d'
+    sha256 '762a53e3b7ff3a91ffc917b22948666efee31ca28b5bedb4819cc14b41d49309'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '948d77ad3d2dc29c77ce7b13e74a64b82bb3b207fea81733a1f453fa181400bd'
+    sha256 '294c244ccf1150f67a3f128db1b0a55bcc4a1b61443fe9e3c262b76cccb96548'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '9e53e7f712cd209902c479c6f966944b5dbae38a698ad6232f6eeb51f2ff0f3b'
+    sha256 'ca276b896e9adbb99b459ff71d65dbbeb7274436ba4a1733fa805f90f9a181ca'
     'en-US'
   end
 
   language 'eo' do
-    sha256 '45a4a4a53d7249f745a9f9dbbcce343f1c79a5c366b522c8e5f97999d227bbc8'
+    sha256 'cc3507a7fd538d5f44803f49a24f8c6acb69c50d5ebe9a4472d52c4d15385f66'
     'eo'
   end
 
   language 'es-AR' do
-    sha256 '623bb8628427fb52df26b737be7ae62ec54cc2db5dc349fa0fe851d6c67f5579'
+    sha256 '6a58d20fe0c5033eb30808a3abcf4b14629255bd6d25d2b4db6b364e5b410692'
     'es-AR'
   end
 
   language 'es-CL' do
-    sha256 '2e497c71ae079a65cd3beed3439968e0b84aad4a0e50b020db6690621f35fc0f'
+    sha256 'cadb82e5b73ebf7483d17a313cd19cdfdaafdcf6e5e2bd48d42381dac3ea0ae6'
     'es-CL'
   end
 
   language 'es-ES' do
-    sha256 'dde3558ffa019a580aac54e438bf947fbe31e709fd2a391c6e2afbd8f31dee14'
+    sha256 'b0896794ae95282946bbe9203083d24cbd2b40768dd5fe1291694dba3bf166a0'
     'es-ES'
   end
 
   language 'fi' do
-    sha256 '217f10266e0bd5395cafd30c13c7874dca28d359649269d3f0298a361b263b47'
+    sha256 '18cc9f33a85c11ae96066d5ace76b34925ad7d0bc3bf5b1b609c37bb4d99be6a'
     'fi'
   end
 
   language 'fr' do
-    sha256 '99d22159e3dfb02073902178a9bdb7f62d982c1857fcff6f20b9b418c81d1e9a'
+    sha256 '5badf0572c6a085fa34987af39cf29a06229adf58c8b37d80a6072288da3781a'
     'fr'
   end
 
   language 'gl' do
-    sha256 'da4a7873c72a5484e46364850241cfb6ad14c0b208857f119dfea7e7293eb643'
+    sha256 '25ffdf52246a5a2b94ebb04f832f13a0ef331f92555bf3140747b4c7b00af67f'
     'gl'
   end
 
   language 'in' do
-    sha256 'dcd00d43776b72805c1192f30c6c1a87cb29dfd8cb45aa52dbbba82704a7fb68'
+    sha256 '8690ca46c3796f601fd7c059950ce2d243ef66b8b7c7661f8d18b1f1a3276826'
     'hi-IN'
   end
 
   language 'it' do
-    sha256 '98058d70c4a30d6f3820a7cecd322c886b7839d1a4c67470cbc744dce9f48ebf'
+    sha256 '54be0264c181a48ab560ab6198d33ec801c9cffa41a2d590a3d0a8795cdb0a97'
     'it'
   end
 
   language 'ja' do
-    sha256 '7b976b100bec6d0ed1021260119bd4bea4c23b0307fabc32de17135e46819fcf'
+    sha256 '60ce8b32c2c2df1914a1874428a2ff86aff4920de8aac404be7c282b0c477680'
     'ja-JP-mac'
   end
 
   language 'ko' do
-    sha256 '2d7e113c5eef35ca53bc72fc5c464f5b8c18bc39bd1af8532171e48c251d8c7e'
+    sha256 '7956b1703b57b16d3444160d438ec67550795d02e6983539a3a08cd19e8a49f4'
     'ko'
   end
 
   language 'nl' do
-    sha256 'fc9569195c53563aa962b66b73470b5091fea03d837f9d3e713ff590630ca372'
+    sha256 '68c57c9078a62ab77c6defb3b344f5b06c0ead15cef9b52d02d0d3fe2d74aa13'
     'nl'
   end
 
   language 'pl' do
-    sha256 'f92be73ecad383e6d426f20f809671165eb617919cbf154a05e73bdfc6989d91'
+    sha256 'f65369182e5492dc612988e02e3a6b047f03de86cef3eaa7b2dfb9120fb8bf5e'
     'pl'
   end
 
   language 'pt-BR' do
-    sha256 '2b43013dc74e9b4c7d97617daa3751c2ee598500613c1a5323b87f7b522b699a'
+    sha256 '4ff91fd02b1b0db08216fcbaa0b57a46bf5809aa5dc74428676df610ff8fbb7a'
     'pt-BR'
   end
 
   language 'pt' do
-    sha256 'b66df94914515a21421d4b12a786dc374fe9d68386fadc829257bfe21ae86d82'
+    sha256 'b55d87d1eb9b1f959262d13c6a90d12fd58c6f4658399c22969f4d4f9beda71f'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '126e067e0b5c4f64f4d92314d8c2f0a08fc85879afbee4ab3cb34c52fc1a4d06'
+    sha256 '45c30594250b597e8f9ded70af8f9a0e4ca9596c2e24342f44838fbd9267f1db'
     'ru'
   end
 
   language 'tr' do
-    sha256 'f5301d9ea9f09f78e03fe2f9f7d561fdfb3646498fbce42db6c284fe121e0c19'
+    sha256 'df88be61234b968f3c0ba5d3a0bd89b312cf999f8696477af1c3d610e043d451'
     'tr'
   end
 
   language 'uk' do
-    sha256 'e2dcf7004e0ded90b2c9f5e2edce0671718cdf2d99a880cd465d99fbd3619813'
+    sha256 '2862a85b38c375ae5c2150f52bdcda0ae63288deb3561d44a911ef337d65bc78'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'da54b858896d398f2470b2451b06e5bab843dcde90a9938d4b41991072024812'
+    sha256 '80f5b584a8bacbfdf4606d43b02d8d199a4237fe2b5938c0e465ee679f6d9d6f'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '6892b700d44bd5b5c82bdc2d3e3a155fa58b0570f9e5c3809dc4586e477a0a6d'
+    sha256 'f6319048566b9e0bf14c90d1ab737f3e0dbb69f302b633e60d8f66ee790d27dd'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).