### PR TITLE
Update airserver from 7.2.5 to 7.2.6

### DIFF
--- a/Casks/airserver.rb
+++ b/Casks/airserver.rb
@@ -1,6 +1,6 @@
 cask 'airserver' do
-  version '7.2.5'
-  sha256 '75f9d31bb093cf191f6d954a2aaf2f754add058dc69d9fbc958dfab2e78269b6'
+  version '7.2.6'
+  sha256 'fc7c7562654ffd47c46e4ffe0a8fc1565d0fa76297ad2e6105cab3c8ab125568'
 
   url "https://dl.airserver.com/mac/AirServer-#{version}.dmg"
   appcast 'https://www.airserver.com/downloads/mac/appcast.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).