### PR TITLE
Move to using an upstream installer script in yandex-cloud-cli

### DIFF
--- a/Casks/yandex-cloud-cli.rb
+++ b/Casks/yandex-cloud-cli.rb
@@ -1,11 +1,32 @@
 cask 'yandex-cloud-cli' do
-  version '0.57.0'
-  sha256 '0c80606fb67fbe28d62ff583b971bc391d403e568fcca2192109760c3ff4c9cd'
+  version :latest # Must remain unversioned, else all installed yandex-cloud components would be lost on upgrade
+  sha256 :no_check
 
   # yandexcloud.net/yandexcloud-yc/ was verified as official when first introduced to the cask
-  url "https://storage.yandexcloud.net/yandexcloud-yc/release/#{version}/darwin/amd64/yc"
+  url 'https://storage.yandexcloud.net/yandexcloud-yc/install.sh'
   name 'Yandex Cloud CLI'
   homepage 'https://cloud.yandex.com/docs/cli/'
 
-  binary 'yc'
+  installer script: {
+                      executable: 'install.sh',
+                      args:       ['-i', "#{staged_path}/#{token}", '-n'],
+                    }
+  installer script: {
+                      executable: 'yandex-cloud-cli/bin/yc',
+                      args:       ['components', 'post-update'],
+                    }
+  binary 'yandex-cloud-cli/bin/docker-credential-yc'
+  binary 'yandex-cloud-cli/bin/yc'
+
+  uninstall delete: "#{staged_path}/#{token}" # Not actually necessary, since it would be deleted anyway. It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
+
+  caveats <<~EOS
+    To install shell completions add this to your profile:
+
+      for bash users
+        source "#{staged_path}/#{token}/completion.bash.inc"
+
+      for zsh users
+        source "#{staged_path}/#{token}/completion.zsh.inc"
+  EOS
 end


### PR DESCRIPTION
Move to using installer script provided by Yandex which allows for the installation of all components of the CLI with `brew` without the need to execute additional commands after that (which are poorly documented on their part). It is also should be less brittle in case of the upstream changes and make shell completions available for the user.

In the same time, make the cask unversioned so it won't conflict with `yc` self-update and component management mechanism (the same situation as in https://github.com/Homebrew/homebrew-cask/blob/master/Casks/google-cloud-sdk.rb)

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
