### PR TITLE
Update 115browser from 23.8.0.20 to 23.9.0.4

### DIFF
--- a/Casks/115browser.rb
+++ b/Casks/115browser.rb
@@ -1,6 +1,6 @@
 cask '115browser' do
-  version '23.8.0.20'
-  sha256 '722ea2ff44c69bd541afe689a8e73c3ecbe06520931c8f98775b9d6ee7a4cdf2'
+  version '23.9.0.4'
+  sha256 'c019b756f928cb07c558f447cdd91b4c4d8a17d6f2cca2be323628efa431deed'
 
   url "https://down.115.com/client/mac/115pc_#{version}.dmg"
   appcast 'https://appversion.115.com/1/web/1.0/api/chrome?callback=get_version'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).