### PR TITLE
Update tinkerwell from 2.8.1 to 2.8.2

### DIFF
--- a/Casks/tinkerwell.rb
+++ b/Casks/tinkerwell.rb
@@ -1,6 +1,6 @@
 cask 'tinkerwell' do
-  version '2.8.1'
-  sha256 'cb31fd29dcf57306374302afdf3ba9880f85e0efb2af8be5f1f8a8df9cd59f5a'
+  version '2.8.3'
+  sha256 '9e9269e6b8b7cc9ccccf9705080b8f414ef7a690b87775f181a600c09157fb68'
 
   # tinkerwell.fra1.digitaloceanspaces.com/ was verified as official when first introduced to the cask
   url "https://tinkerwell.fra1.digitaloceanspaces.com/tinkerwell/Tinkerwell-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).