### PR TITLE
Update fontlab from 7.1.2.7436 to 7.1.3.7493

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -1,6 +1,6 @@
 cask 'fontlab' do
-  version '7.1.2.7436'
-  sha256 '9cfb1e0c8e815dd4bde71896b4d35457ac00ab71cbb53af561a5a67da8f593c6'
+  version '7.1.3.7493'
+  sha256 'b2505d9cc5af04ca9f2a7ea18ee81e278e40ae891075df0e23a2d96968c89f61'
 
   # fontlab.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://fontlab.s3.amazonaws.com/fontlab-#{version.major}/#{version.split('.').last}/FontLab-#{version.major}-Mac-Install-#{version.split('.').last}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).