### PR TITLE
Update mirrorop from 2.5.2.70 to 2.5.3.78

### DIFF
--- a/Casks/mirrorop.rb
+++ b/Casks/mirrorop.rb
@@ -1,6 +1,6 @@
 cask 'mirrorop' do
-  version '2.5.2.70'
-  sha256 '95b72c5ceeed6a04bcc17515bab8fa4338702e0ed6686975de62e34e8709a6df'
+  version '2.5.3.78'
+  sha256 '59279a53f344ec0b6edb36015164497107a3fea1d55d337d2bf7185ee3bb5b01'
 
   url "https://www.barco.com/services/website/en/TdeFiles/Download?FileNumber=R33050100&TdeType=3&MajorVersion=#{version.major}&MinorVersion=#{version.minor}&PatchVersion=#{version.patch}&BuildVersion=#{version.split('.')[-1]}"
   appcast 'https://www.barco.com/en/support/software/R33050100'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).