### PR TITLE
Update vmware-horizon-client from 5.4.2-15910566,CART21FQ1 to 5.4.3-16499473,CART21FQ1

### DIFF
--- a/Casks/vmware-horizon-client.rb
+++ b/Casks/vmware-horizon-client.rb
@@ -1,6 +1,6 @@
 cask 'vmware-horizon-client' do
-  version '5.4.2-15910566,CART21FQ1'
-  sha256 '2d5668402ef372656b487e8e868a8a5a139ec4b8ff88b10d15772231f0988c26'
+  version '5.4.3-16499473,CART21FQ1'
+  sha256 '3fe45ce4f1a84049ed9d7e445fdc0397da7c8b420ae870e686fd66876b2003d6'
 
   url "https://download3.vmware.com/software/view/viewclients/#{version.after_comma}/VMware-Horizon-Client-#{version.before_comma}.dmg"
   appcast 'https://docs.vmware.com/en/VMware-Horizon-Client-for-Mac/',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).