### PR TITLE
Update telavox-flow from 1.102.3 to 1.103.0

### DIFF
--- a/Casks/telavox-flow.rb
+++ b/Casks/telavox-flow.rb
@@ -1,9 +1,9 @@
 cask 'telavox-flow' do
-  version '1.102.3'
-  sha256 '2d8d35a3e07a4b048ae809647e303a0eacb31ea7630ee55b7b0a28c4ab0a008c'
+  version '1.103.0'
+  sha256 '88adaaf442fe73946c268bc404d922f0d853db119e5d01dc6867f24ac8124083'
 
   # s3.eu-west-2.amazonaws.com/flow-desktop/ was verified as official when first introduced to the cask
-  url "https://s3.eu-west-2.amazonaws.com/flow-desktop/Flow-#{version}.dmg"
+  url "https://s3.eu-west-2.amazonaws.com/flow-desktop/Telavox-#{version}.dmg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://deopappmanager.telavox.com/flow/download/mac/latest'
   name 'Telavox Flow'
   homepage 'https://telavox.com/en/apps/'

--- a/Casks/telavox-flow.rb
+++ b/Casks/telavox-flow.rb
@@ -10,7 +10,7 @@ cask 'telavox-flow' do
 
   auto_updates true
 
-  app 'Flow.app'
+  app 'Telavox.app'
 
   zap trash: [
                '~/Library/Application Support/Flow',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).