### PR TITLE
Update airy from 3.15,283 to 3.15,286

### DIFF
--- a/Casks/airy.rb
+++ b/Casks/airy.rb
@@ -1,6 +1,6 @@
 cask 'airy' do
-  version '3.15,283'
-  sha256 '3efb32bf817876802fa88d8b72def106c783a07efd600d89322261d8fbb9610e'
+  version '3.15,286'
+  sha256 'e8277d777f0897ac5639d4c3e5f602936f78789839f18756e817af23f9a6b014'
 
   url 'https://cdn.eltima.com/download/airy.dmg'
   appcast 'https://cdn.eltima.com/download/airy-update/airy.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.