### PR TITLE
Update papyrus from 4.5.0,2019-09 to 4.8.0,2020-06

### DIFF
--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -1,6 +1,6 @@
 cask 'papyrus' do
-  version '4.5.0,2019-09'
-  sha256 '8fb94209c2bed5a0978cd77cdd8e0870dc343c38575f600fa5762b39a0fea2ab'
+  version '4.8.0,2020-06'
+  sha256 '4b653cc5689a896bb94a4fa767584838318672123dde864853f1316ef7e3a132'
 
   url "https://www.eclipse.org/downloads/download.php?file=/modeling/mdt/papyrus/rcp/#{version.after_comma}/#{version.before_comma}/papyrus-#{version.after_comma}-#{version.before_comma}-macosx64.tar.gz&r=1"
   appcast 'https://mirrors.dotsrc.org/eclipse//modeling/mdt/papyrus/rcp/',


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).