### PR TITLE
Update avidemux from 2.7.4 to 2.7.6

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,9 +1,9 @@
 cask 'avidemux' do
-  version '2.7.4'
-  sha256 'a5c5028ecc954b6658b4c0e6b04c1c186c42a12530e66a5379f51fe7a3ebfcd8'
+  version '2.7.6'
+  sha256 '91a4d9757173c261eac01a79019aed38a1185951ff2b67352e6ecbac2ea5f56f'
 
   # sourceforge.net/avidemux/ was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Mojava_64Bits_Qt5.dmg"
+  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Catalina_64Bits_Qt5.dmg"
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'

--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,9 +1,18 @@
 cask 'avidemux' do
-  version '2.7.6'
-  sha256 '91a4d9757173c261eac01a79019aed38a1185951ff2b67352e6ecbac2ea5f56f'
+  if MacOS.version <= :mojave
+    version '2.7.4'
+    sha256 'a5c5028ecc954b6658b4c0e6b04c1c186c42a12530e66a5379f51fe7a3ebfcd8'
 
-  # sourceforge.net/avidemux/ was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Catalina_64Bits_Qt5.dmg"
+    # sourceforge.net/avidemux/ was verified as official when first introduced to the cask
+    url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Mojava_64Bits_Qt5.dmg"
+  else
+    version '2.7.6'
+    sha256 '91a4d9757173c261eac01a79019aed38a1185951ff2b67352e6ecbac2ea5f56f'
+
+    # sourceforge.net/avidemux/ was verified as official when first introduced to the cask
+    url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Catalina_64Bits_Qt5.dmg"
+  end
+
   appcast 'https://sourceforge.net/projects/avidemux/rss?path=/avidemux'
   name 'Avidemux'
   homepage 'https://www.avidemux.org/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).