### PR TITLE
Update swiftformat-for-xcode from 0.44.15 to 0.44.17

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask 'swiftformat-for-xcode' do
-  version '0.44.15'
-  sha256 '8f35ef12db703e21aa4b030f791970a167b1f86536e2aab835ea13abbb83e2fa'
+  version '0.44.17'
+  sha256 'd6b03aa4df9d483b26a8f07ad395b518a4b7c9f123c8ec5766de8d47c06c80b3'
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   appcast 'https://github.com/nicklockwood/SwiftFormat/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.