### PR TITLE
[WIP] Add list_associated_files developer script

### DIFF
--- a/cmd/brewcask-find-bundle-id.rb
+++ b/cmd/brewcask-find-bundle-id.rb
@@ -1,0 +1,33 @@
+ARGV.shift
+
+raise 'A cask-token or App Name argument is required' if ARGV.empty?
+
+def bundle_id_from(app)
+  stdout = `/usr/bin/osascript -e 'id of app "#{File.basename app}"'` ||
+           `/usr/bin/mdls -raw -name kMDItemCFBundleIdentifier "#{app}"`
+  stdout.chomp
+end
+
+case ARGV.join ' '
+when %r{^[a-z0-9][a-z0-9/-]+$}
+  begin
+    cask = Cask::CaskLoader.load ARGV.first
+    cask.artifacts.find do |artifact|
+      directives = :launchctl, :quit, :signal, :delete, :trash, :rmdir
+      directives = artifact.directives.values_at(*directives).flatten.compact
+
+      bundle_ids = directives.grep(%r{\w+\.\w+\.\w+}) { $& }
+
+      break puts bundle_ids unless bundle_ids.empty?
+
+      app = directives.find { %r{\.app$} }
+      break puts(*bundle_id_from(app)) if app
+    end
+  end
+when %r{/.+\.app}
+  puts bundle_id_from ARGV.join(' ').split(%r{\b}).map(&:capitalize).join
+else
+  basename = File.basename ARGV.join('*'), '.app'
+  pattern = "{,#{Dir.home}}/Applications/{*/,}*#{basename}*.app"
+  puts Dir.glob(pattern, File::FNM_CASEFOLD).map(&method(:bundle_id_from))
+end

--- a/developer/bin/list_associated_files
+++ b/developer/bin/list_associated_files
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+raise 'A cask token, bundle ID, or app name argument is required, or a combination thereof' if ARGV.empty?
+
+raise 'A cask-token, bundle.ID, or App Name argument is required' if ARGV.empty?
+
+args = ARGV.join ' '
+
+search = [
+  '/Library',
+  '/Library/*',
+  "#{Dir.home}/Library",
+  "#{Dir.home}/Library/*",
+  "#{Dir.home}/Documents",
+  "#{Dir.home}/Documents/*",
+  '/Users/Shared',
+  '/private/var/**',
+]
+
+if %r{^\w+\.\w+\.\w+$}.match? args
+  ids = ARGV
+else
+  stdout, = Open3.capture2 'brew', 'cask', 'find-bundle-id', *args
+  ids = stdout.lines.map(&:chomp).reject(&:empty?)
+end
+ids += ids.map { |id| id.split('.').drop 1 }.flatten.compact.uniq
+
+name = File.basename(args, '.app').split(%r{\W}).join '*'
+names = [name] + ids
+
+pattern = "{,#{Dir.home}}/{#{search.join ','}}/*{#{names.join ','}}*"
+
+associated = Dir.glob pattern, File::FNM_CASEFOLD
+
+puts associated.map { |path| path.sub Dir.home, '~' }.uniq.sort


### PR DESCRIPTION
- [x] `brew cask style --fix {{commands}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.

Add `list_associated_files` developer helper script to list all associated files of a given app name, Bundle ID, or Cask token… 

A major pain point is rummaging through Finder trying to find all of the associated files with a given app, when creating or even updating a Cask… This script should help with `uninstall`, and `zap` stanzas in particular.