### PR TITLE
Update typora from 0.9.9.34 to 0.9.9.34.1

### DIFF
--- a/Casks/typora.rb
+++ b/Casks/typora.rb
@@ -1,6 +1,6 @@
 cask 'typora' do
-  version '0.9.9.34'
-  sha256 '70611aa29dc563ca2985445ee6e8e7f70c436c5fe591a953d76e84807eb6a7de'
+  version '0.9.9.34.1'
+  sha256 'a6908a54a142c4e23b8cf6a316614dca545cca4d67a3abaafa98469b2d094661'
 
   url "https://www.typora.io/download/Typora-#{version}.dmg"
   appcast 'https://www.typora.io/download/dev_update.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).