### PR TITLE
Fix for `any_version_installed?` undefined

### DIFF
--- a/cmd/brewcask-ci.rb
+++ b/cmd/brewcask-ci.rb
@@ -132,7 +132,7 @@ module Cask
             ensure
               cask_and_formula_dependencies.reverse.each do |cask_or_formula|
                 next unless cask_or_formula.is_a?(Cask)
-                Installer.new(cask_or_formula, verbose: true).uninstall if cask_or_formula.any_version_installed?
+                Installer.new(cask_or_formula, verbose: true).uninstall if cask_or_formula.installed?
               end
             end
 


### PR DESCRIPTION
Related: #84037, #83523, #85841

- https://github.com/Homebrew/brew/blob/ea47dce/Library/Homebrew/formula.rb#L490-L492
	- `any_version_installed?` is a Formula method
- https://github.com/Homebrew/brew/blob/ea47dce/Library/Homebrew/cask/cask.rb#L77-L79
	- `Cask#installed?` is a valid Cask method
- https://github.com/Homebrew/brew/blob/ea47dce/Library/Homebrew/compat/formula.rb#L5-L9
	- Only `Formula#installed?` is deprecated

Fixes this error:

```
Error: undefined method any_version_installed?
```

This error is fixed by Homebrew/brew#7988:

```
Error: Calling Formula#installed? is deprecated! Use Formula#latest_version_installed? (or Formula#any_version_installed? ) instead.
```