### PR TITLE
Add dosbox-staging 0.75.0

### DIFF
--- a/Casks/dosbox-staging.rb
+++ b/Casks/dosbox-staging.rb
@@ -1,0 +1,12 @@
+cask 'dosbox-staging' do
+  version '0.75.0'
+  sha256 'a0038c7401d239934d25517ca5e8e6006cc3f4cb7060f6ace56609d36bca12ef'
+
+  # github.com/dosbox-staging/dosbox-staging/ was verified as official when first introduced to the cask
+  url "https://github.com/dosbox-staging/dosbox-staging/releases/download/v#{version}/dosbox-staging-macOS-v#{version}.dmg"
+  appcast 'https://github.com/dosbox-staging/dosbox-staging/releases.atom'
+  name 'dosbox-staging'
+  homepage 'https://dosbox-staging.github.io/'
+
+  app 'dosbox-staging.app'
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Audit failure:

```
audit for dosbox-staging: warning
 - possible duplicate, cask token conflicts with Homebrew core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/dosbox-staging.rb
Error: audit failed for casks: dosbox-staging
```

This is different from the formula in that it installs the .app instead of a terminal command