### PR TITLE
Update nordvpn identifiers

### DIFF
--- a/Casks/nordvpn.rb
+++ b/Casks/nordvpn.rb
@@ -12,21 +12,27 @@ cask 'nordvpn' do
 
   pkg 'NordVPN.pkg'
 
-  uninstall quit:       'com.nordvpn.NordVPN',
+  uninstall quit:       [
+                          'com.nordvpn.osx',
+                          'com.nordvpn.osx.NordVPNLauncher',
+                        ],
             launchctl:  [
                           'com.nordvpn.osx.helper',
                           'com.nordvpn.NordVPN.Helper',
                         ],
-            delete:     '/Library/PrivilegedHelperTools/com.nordvpn.NordVPN.Helper',
+            delete:     [
+                          '/Library/PrivilegedHelperTools/com.nordvpn.osx.helper',
+                          '/Library/PrivilegedHelperTools/com.nordvpn.osx.ovpnDnsManager',
+                        ],
             login_item: 'NordVPN',
             pkgutil:    'com.nordvpn.osx'
 
   zap trash: [
-               '~/Library/Application Support/com.nordvpn.NordVPN',
-               '~/Library/Caches/com.nordvpn.NordVPN',
+               '~/Library/Application Support/com.nordvpn.osx',
+               '~/Library/Caches/com.nordvpn.osx',
                '~/Library/Logs/NordVPN/',
-               '~/Library/Preferences/com.nordvpn.NordVPN.plist',
-               '~/Library/Saved Application State/com.nordvpn.NordVPN.savedState',
-               '~/Library/Cookies/com.nordvpn.NordVPN.binarycookies',
+               '~/Library/Preferences/com.nordvpn.osx.plist',
+               '~/Library/Saved Application State/com.nordvpn.osx.savedState',
+               '~/Library/Cookies/com.nordvpn.osx.binarycookies',
              ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

The identifier in the formula (com.nordvpn.NordVPN) seems to be outdated and did not match that of the app that was installed (com.nordvpn.osx). The installer also installed /Library/PrivilegedHelperTools/ovpn on my computer. I didn't add it to the uninstall stanza as I thought it might conflict with OpenVPN, based on the name. Please let me know if it should be added to the PR as well.
