### PR TITLE
Rectangle: remove launchd service when uninstalling

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -13,7 +13,8 @@ cask 'rectangle' do
 
   app 'Rectangle.app'
 
-  uninstall quit: 'com.knollsoft.Rectangle'
+  uninstall quit:      'com.knollsoft.Rectangle',
+            launchctl: 'com.knollsoft.RectangleLauncher'
 
   zap trash: [
                '~/Library/Application Scripts/com.knollsoft.RectangleLauncher',


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).