### PR TITLE
Update barrier from 2.3.2 to 2.3.3

### DIFF
--- a/Casks/barrier.rb
+++ b/Casks/barrier.rb
@@ -1,6 +1,6 @@
 cask 'barrier' do
-  version '2.3.2'
-  sha256 'b5ebc59c4152f827a0551f265c026d3d78d7bc0d2d8ad1bd9ad0961d1815a2d0'
+  version '2.3.3'
+  sha256 'fc6a002d796453eba7a77b9df107af0f972b6e807268e880c88950bde819a40d'
 
   url "https://github.com/debauchee/barrier/releases/download/v#{version}/Barrier-#{version}-Release.dmg"
   appcast 'https://github.com/debauchee/barrier/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).