### PR TITLE
Revert "Rectangle: remove launchd service when uninstalling"

### DIFF
--- a/Casks/rectangle.rb
+++ b/Casks/rectangle.rb
@@ -13,8 +13,7 @@ cask 'rectangle' do
 
   app 'Rectangle.app'
 
-  uninstall quit:      'com.knollsoft.Rectangle',
-            launchctl: 'com.knollsoft.RectangleLauncher'
+  uninstall quit: 'com.knollsoft.Rectangle'
 
   zap trash: [
                '~/Library/Application Scripts/com.knollsoft.RectangleLauncher',


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#85907

Please see https://github.com/Homebrew/homebrew-cask/pull/84809 for an explanation.