### PR TITLE
Update corretto from 11.0.7.10.1 to 11.0.8.10.1

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,6 +1,6 @@
 cask 'corretto' do
-  version '11.0.7.10.1'
-  sha256 'efd6cba4404041ef6ac3e882042f12c76b844d918f83b56493187df3bae3815e'
+  version '11.0.8.10.1'
+  sha256 'd87c677c3f2d5b323112aa8e028cd4dbaad0e37fb378ffac87f7e447996476cb'
 
   url "https://corretto.aws/downloads/resources/#{version.sub(%r{-\d+}, '')}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.