### PR TITLE
Update app-tamer from 2.5.1 to 2.5.2

### DIFF
--- a/Casks/app-tamer.rb
+++ b/Casks/app-tamer.rb
@@ -1,6 +1,6 @@
 cask 'app-tamer' do
-  version '2.5.1'
-  sha256 'dc705190efa7658652202e0cb50293b2c8fa02443da943d61641405db7ecd4b0'
+  version '2.5.2'
+  sha256 'b184e87e6465502485760a1fe5a535d8d9534fe7731e3f6d777b9983ebf1e861'
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   appcast 'https://www.stclairsoft.com/cgi-bin/sparkle.cgi?AT'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).