### PR TITLE
Update seadrive from 2.0.3 to 2.0.4

### DIFF
--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -1,6 +1,6 @@
 cask 'seadrive' do
-  version '2.0.3'
-  sha256 'd15832a8e76fdb2126d2c81a497fc9e30b8d14cc8d0f32f68a340e6c5fad12b5'
+  version '2.0.4'
+  sha256 '51e6b7588a2c3d1a3b8141890edf3ae4ae237b1162eeee7f7becff66a6aac6da'
 
   # download.seadrive.org/ was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seadrive-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).