### PR TITLE
Revert "Dozer: v4.2.0"

### DIFF
--- a/Casks/dozer.rb
+++ b/Casks/dozer.rb
@@ -1,6 +1,6 @@
 cask 'dozer' do
-  version '4.2.0'
-  sha256 '8998bc850a86a9812a3930cc23fb77f71ae4ca72619fc5b8ee335acdf2f9ab32'
+  version '4.0.0'
+  sha256 'd8d37a114c9dab2f16a56e60d8a977115ba34fe408ff7947d0d74028f1f22843'
 
   url "https://github.com/Mortennn/Dozer/releases/download/v#{version}/Dozer.#{version}.dmg"
   appcast 'https://github.com/Mortennn/Dozer/releases.atom'


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#85873

4.2.0 is a pre-release: https://github.com/Mortennn/Dozer/releases