### PR TITLE
Update geotag-photos-pro from 1.6.2 to 1.6.3

### DIFF
--- a/Casks/geotag-photos-pro.rb
+++ b/Casks/geotag-photos-pro.rb
@@ -1,6 +1,6 @@
 cask 'geotag-photos-pro' do
-  version '1.6.2'
-  sha256 '5506bf8b4fa2f63dc448ebce1d9d33daa4d18cddf58ff39852becbd4e31d02b5'
+  version '1.6.3'
+  sha256 '78b0d269c11c4e65b42108197ce97dd875247ea0f4c7d86aeec6f6d3d5acad0b'
 
   # github.com/tappytaps/geotag-desktop-app/ was verified as official when first introduced to the cask
   url "https://github.com/tappytaps/geotag-desktop-app/releases/download/v#{version}/Geotag-Photos-Pro-2-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).