### PR TITLE
Update workflowy from 1.3.5-9115 to 1.3.5-9401

### DIFF
--- a/Casks/workflowy.rb
+++ b/Casks/workflowy.rb
@@ -1,6 +1,6 @@
 cask 'workflowy' do
-  version '1.3.5-9115'
-  sha256 '27fb7619a340cc070333f832558cd5b21ae58f3c5be072e1bdafbce9496bc7d7'
+  version '1.3.5-9401'
+  sha256 'c3d0be6a0bb64fa9721f6cb8f192f2f3b48da1915f5510e7ef3b23cceb6e04a2'
 
   # github.com/workflowy/desktop/ was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop/releases/download/v#{version}/WorkFlowy.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).