### PR TITLE
Update voov-meeting from 1.6.0 to 1.6.0.520,1410000198

### DIFF
--- a/Casks/voov-meeting.rb
+++ b/Casks/voov-meeting.rb
@@ -1,9 +1,10 @@
 cask 'voov-meeting' do
-  version '1.6.0'
+  version '1.6.0.520,1410000198'
   sha256 '581aeaa2004e8ab4df26a5383ff89fdb6886e1fcdcced9c60e96be2d49e4aa55'
 
-  # 4e0bb836a1be819870c428989fb03550.dlied1.cdntips.com/dlied1.qq.com/ was verified as official when first introduced to the cask
-  url 'https://4e0bb836a1be819870c428989fb03550.dlied1.cdntips.com/dlied1.qq.com/download/VooVMeeting_1410000198_1.6.0.520.publish.dmg?mkey=5f106b283b3b0043&f=1ea2&proto=https&access_type=$header_ApolloNet'
+  # down.qq.com/download/ was verified as official when first introduced to the cask
+  url "https://down.qq.com/download/VooVMeeting_#{version.after_comma}_#{version.before_comma}.publish.dmg"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://voovmeeting.com/download/darwin'
   name 'VooV Meeting'
   name 'Tencent Meeting International Version'
   homepage 'https://voovmeeting.com/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).