### PR TITLE
Revert installation of miniconda to previous version.

### DIFF
--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -1,27 +1,31 @@
 cask 'miniconda' do
-  version 'py37_4.8.2'
-  sha256 'f3ede3a58d82fb5dcbca52d291a9edb5cd962d84d823a20693dd4bb27506cdd0'
+  version 'py37_4.8.3'
+  sha256 'ccc1bded923a790cd61cd17c83c3dcc374dc0415cfa7fb1f71e6a2438236543d'
 
   # repo.anaconda.com/miniconda/ was verified as official when first introduced to the cask
-  url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.pkg"
+  url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.sh"
   name 'Continuum Analytics Miniconda'
   homepage 'https://conda.io/miniconda.html'
 
   auto_updates true
+  container type: :naked
 
-  pkg "Miniconda3-#{version}-MacOSX-x86_64.pkg"
+  installer script: {
+              executable: "Miniconda3-#{version}-MacOSX-x86_64.sh",
+              args:       ['-b', '-p', "#{caskroom_path}/base"],
+            }
+  binary "#{caskroom_path}/base/condabin/conda"
 
-  uninstall pkgutil: [
-                       'io.continuum.pkg.apreinstall',
-                       'io.continuum.pkg.conda.exe',
-                       'io.continuum.pkg.pathupdate',
-                       'io.continuum.pkg.postextract',
-                       'io.continuum.pkg.preconda',
-                     ]
+  uninstall delete: "#{caskroom_path}/base"
 
   zap trash: [
-               '~/.condarc',
-               '~/.conda',
-               '~/.continuum',
-             ]
+        '~/.condarc',
+        '~/.conda',
+        '~/.continuum',
+      ]
+
+  caveats <<~EOS
+    Please run the following to setup your shell:
+      conda init "$(basename "${SHELL}")"
+  EOS
 end

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -11,18 +11,18 @@ cask 'miniconda' do
   container type: :naked
 
   installer script: {
-              executable: "Miniconda3-#{version}-MacOSX-x86_64.sh",
-              args:       ['-b', '-p', "#{caskroom_path}/base"],
-            }
+                      executable: "Miniconda3-#{version}-MacOSX-x86_64.sh",
+                      args:       ['-b', '-p', "#{caskroom_path}/base"],
+                    }
   binary "#{caskroom_path}/base/condabin/conda"
 
   uninstall delete: "#{caskroom_path}/base"
 
   zap trash: [
-        '~/.condarc',
-        '~/.conda',
-        '~/.continuum',
-      ]
+               '~/.condarc',
+               '~/.conda',
+               '~/.continuum',
+             ]
 
   caveats <<~EOS
     Please run the following to setup your shell:


### PR DESCRIPTION
This reverts the changes made to a previous way to install miniconda. This is more in line with both the instructions on the miniconda website for both installation and uninstallation, and it is more consistent with the Anaconda cask. The current installation method also does not cleanly uninstall. This cask does cleanly uninstall.

This work is not my own. I am reverting to what @xyu has done previously with this cask. @xyu deserves all the credit for creating this cask structure.

@vitorgalvao and I have discussed this change in a previous pull request ([here](https://github.com/Homebrew/homebrew-cask/pull/85456)).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
