### PR TITLE
Fix change the package name of Melonbooks Viewer

### DIFF
--- a/Casks/melonbooksviewer.rb
+++ b/Casks/melonbooksviewer.rb
@@ -7,7 +7,7 @@ cask 'melonbooksviewer' do
   name 'メロンブックス 電子書籍'
   homepage 'https://www.melonbooks.co.jp/ebook/list.php?category_id=77'
 
-  pkg 'installer-signed.pkg'
+  pkg 'installer-signed-melon.pkg'
 
   uninstall pkgutil: 'jp.co.melonbooks.viewer'
 end


### PR DESCRIPTION
This fix for a problem where melonbooksviewer could not be installed.
The name of the package files in the zip file had been changed, so it is now fixed.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
