### PR TITLE
Update vscodium from 1.47.1 to 1.47.2

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask 'vscodium' do
-  version '1.47.1'
-  sha256 'c22029dc23a334a7f7517cffd65b55f71e5f0f6c863ecd940d6a6de33a95b63f'
+  version '1.47.2'
+  sha256 '63984ea7fd5ed3fa210273e2372dde75cfa06c63dd1f32640cd161d4fd8d7e91'
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{version}.dmg"
   appcast 'https://github.com/VSCodium/vscodium/releases.atom'


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
