### PR TITLE
Update breaktimer from 0.7.4 to 0.7.5

### DIFF
--- a/Casks/breaktimer.rb
+++ b/Casks/breaktimer.rb
@@ -1,6 +1,6 @@
 cask 'breaktimer' do
-  version '0.7.4'
-  sha256 '6b8e2d1506787c7f7ccec38652f623b01ab47c1133f5d6fabf7515fde590fd7a'
+  version '0.7.5'
+  sha256 'd549ce3694888f10f656ab38700e492b37eaaad7248ca6ccec0a27ec0be8c76e'
 
   # github.com/tom-james-watson/breaktimer-app/ was verified as official when first introduced to the cask
   url "https://github.com/tom-james-watson/breaktimer-app/releases/download/v#{version}/BreakTimer.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).