### PR TITLE
Update dungeon-crawl-stone-soup-console from 0.25.0 to 0.25.1

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-console.rb
+++ b/Casks/dungeon-crawl-stone-soup-console.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-console' do
-  version '0.25.0'
-  sha256 '8edd26f9255c49f2c7c3a606bff6e9ecca25466313f67ced4bd8a26c2fcc83c1'
+  version '0.25.1'
+  sha256 '3fb8da37afbb276f86dc46b2b28f010c614133a77576a7349222b491fcd946ea'
 
   # github.com/crawl/crawl/releases was verified as official when first introduced to the cask
   url "https://github.com/crawl/crawl/releases/download/#{version}/dcss-#{version}-macos-console.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).