### PR TITLE
Update dungeon-crawl-stone-soup-tiles from 0.25.0 to 0.25.1

### DIFF
--- a/Casks/dungeon-crawl-stone-soup-tiles.rb
+++ b/Casks/dungeon-crawl-stone-soup-tiles.rb
@@ -1,6 +1,6 @@
 cask 'dungeon-crawl-stone-soup-tiles' do
-  version '0.25.0'
-  sha256 '81034a2a22bab5d727d0c8e160e53b8b4e22d6cc76441bfc64455f61d870da5a'
+  version '0.25.1'
+  sha256 'c24f556de6ad767c8fbfc545dda62e57a0f965d8748f427f72e9dd5c0d4d0f3d'
 
   # github.com/crawl/crawl/releases was verified as official when first introduced to the cask
   url "https://github.com/crawl/crawl/releases/download/#{version}/dcss-#{version}-macos-tiles.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).