### PR TITLE
Update mochi from 1.5.7 to 1.5.9

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask 'mochi' do
-  version '1.5.7'
-  sha256 'cc021ef6e6cd1cd1e06462c7377d3d0411a606023caf58167eb58914d1edb733'
+  version '1.5.9'
+  sha256 '4eac36200305344efbe905924dcba378a90ef27248732d87ea6737aa933146df'
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   appcast 'https://mochi.cards/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.