### PR TITLE
Update raspberry-pi-imager from latest to 1.4

### DIFF
--- a/Casks/raspberry-pi-imager.rb
+++ b/Casks/raspberry-pi-imager.rb
@@ -1,8 +1,9 @@
 cask 'raspberry-pi-imager' do
-  version :latest
-  sha256 :no_check
+  version '1.4'
+  sha256 '85b337e9ccbec6dd39b0ddbf4b9b4cb1f39fb90f6923a3fea694b2300e936538'
 
-  url 'https://downloads.raspberrypi.org/imager/imager.dmg'
+  url "https://downloads.raspberrypi.org/imager/imager_#{version}.dmg"
+  appcast 'https://github.com/raspberrypi/rpi-imager/releases.atom'
   name 'Raspberry Pi Imager'
   homepage 'https://www.raspberrypi.org/downloads/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.