### PR TITLE
Fix incorrect auto_update method call in ableton*

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -9,7 +9,7 @@ cask 'ableton-live-intro' do
 
   depends_on macos: '>= :el_capitan'
 
-  auto_update true
+  auto_updates true
 
   app "Ableton Live #{version.major} Intro.app"
 

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -9,7 +9,7 @@ cask 'ableton-live-lite' do
 
   depends_on macos: '>= :el_capitan'
 
-  auto_update true
+  auto_updates true
 
   app "Ableton Live #{version.major} Lite.app"
 

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -7,7 +7,7 @@ cask 'ableton-live-standard' do
   name 'Ableton Live Standard'
   homepage 'https://www.ableton.com/en/live/'
 
-  auto_update true
+  auto_updates true
 
   app "Ableton Live #{version.major} Standard.app"
 

--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -9,7 +9,7 @@ cask 'ableton-live' do
 
   depends_on macos: '>= :el_capitan'
 
-  auto_update true
+  auto_updates true
 
   app "Ableton Live #{version.major} Trial.app"
 


### PR DESCRIPTION
Casks definitions were using `auto_update` instead of `auto_updates`.