### PR TITLE
Update wifi-explorer from 2.6.1 to 2.6.2

### DIFF
--- a/Casks/wifi-explorer.rb
+++ b/Casks/wifi-explorer.rb
@@ -1,6 +1,6 @@
 cask 'wifi-explorer' do
-  version '2.6.1'
-  sha256 'e282dc6d2dc631a9801866f9ef9ca4457aeaec32d37775191b084289b3151679'
+  version '2.6.2'
+  sha256 '6405bbb84fe5dcc1c7fb7689cdfba7e8025efc665a0d3aa348eba4002f537584'
 
   url "https://www.intuitibits.com/downloads/WiFiExplorer_#{version}.dmg"
   appcast 'https://www.intuitibits.com/appcasts/wifiexplorercast.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).