### PR TITLE
Update pd-l2ork from 2.11.0 to 2.12.0

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,6 +1,6 @@
 cask 'pd-l2ork' do
-  version '2.11.0'
-  sha256 'b30ee278d8417ee0edab353004e9f4b47edeb725357ca1598d2a0117b0c8c95b'
+  version '2.12.0'
+  sha256 '47245085cb38ebe460e36432034f86bdbc8b478340db268a5799959c6ec43c25'
 
   # github.com/agraef/purr-data/ was verified as official when first introduced to the cask
   url "https://github.com/agraef/purr-data/releases/download/#{version}/osx_10.11-x86_64-dmg.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).