### PR TITLE
Change container image for `BrewTestBot`

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   automerge:
     if: startsWith( github.repository, 'Homebrew/' )
-    runs-on: ubuntu-latest
+    runs-on: homebrew/ubuntu16.04:master
     steps:
       - uses: actions/checkout@master
       - uses: ./.github/actions/automerge


### PR DESCRIPTION
This fixes the `BrewTestBot` failure because the GitHub Action runs as the `root` user by default; which isn't permitted by Homebrew any longer.

```shell
...
 Step 4/9 : RUN brew update-reset
 ---> Running in 86e8e5610ff9
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
The command '/bin/sh -c brew update-reset' returned a non-zero code: 1

##[error]Docker build failed with exit code 1
```