### PR TITLE
Update macvim conflicts_with

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -8,7 +8,11 @@ cask 'macvim' do
   homepage 'https://github.com/macvim-dev/macvim'
 
   auto_updates true
-  conflicts_with formula: 'macvim'
+  conflicts_with formula: [
+                            'ex-vi',
+                            'macvim',
+                            'vim',
+                          ]
 
   app 'MacVim.app'
 


### PR DESCRIPTION
Updated `conflicts_with`:

- Conflicts with formula [`ex-vi`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ex-vi.rb) since `ex-vi` also installs a `bin/view` binary.
- Conflicts with formula [`macvim`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/macvim.rb), obviously.
- Conflicts with formula [`vim`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/vim.rb) since `vim` also installs `bin/vi*` binaries.

Adresses https://github.com/Homebrew/homebrew-cask/issues/86221