### PR TITLE
Revert "Update macvim conflicts_with"

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -8,11 +8,7 @@ cask 'macvim' do
   homepage 'https://github.com/macvim-dev/macvim'
 
   auto_updates true
-  conflicts_with formula: [
-                            'ex-vi',
-                            'macvim',
-                            'vim',
-                          ]
+  conflicts_with formula: 'macvim'
 
   app 'MacVim.app'
 


### PR DESCRIPTION
We can use `--no-binaries` instead.