### PR TITLE
Update stretchly from 0.21.1 to 1.0.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,6 +1,6 @@
 cask 'stretchly' do
-  version '0.21.1'
-  sha256 'b3c36fcabbc33b13f9aca772c674301a3f13b1263318399bbb298565170030dd'
+  version '1.0.0'
+  sha256 'ba2123a394c424a7cf2e4e812937ac231c8c972c789c0857dd861ecf30ad3e6b'
 
   # github.com/hovancik/stretchly/ was verified as official when first introduced to the cask
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).