### PR TITLE
Update obsidian from 0.7.6 to 0.8.0

### DIFF
--- a/Casks/obsidian.rb
+++ b/Casks/obsidian.rb
@@ -1,6 +1,6 @@
 cask 'obsidian' do
-  version '0.7.6'
-  sha256 '12a7c4b92203e4dd13a3527885a05354e8a33cb5c127ce7f25b7a375ad9645ba'
+  version '0.8.0'
+  sha256 '4837599e8ea49e8fde7fe3d6247930ddc9258aaef6321679a14825ddcc63d798'
 
   # github.com/obsidianmd/ was verified as official when first introduced to the cask
   url "https://github.com/obsidianmd/obsidian-releases/releases/download/v#{version}/Obsidian-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).