### PR TITLE
Update mailbutler from 2,3007-13895 to 2,3020-13965

### DIFF
--- a/Casks/mailbutler.rb
+++ b/Casks/mailbutler.rb
@@ -1,6 +1,6 @@
 cask 'mailbutler' do
-  version '2,3007-13895'
-  sha256 'a8876a4732167e285888fc6a29495f19ae645ec48e04ca10e3cfd8f5c840cbff'
+  version '2,3020-13965'
+  sha256 '2d67fb2d1c348d506e15626fb51a04ce9b5c4cad8653da0d1f72d7b2a23b5a34'
 
   url "https://downloads.mailbutler.io/sparkle/public/Mailbutler_#{version.after_comma}.zip"
   appcast "https://www.mailbutler.io/appcast#{version.major}.php"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).