### PR TITLE
Update chef-workstation from 20.7.81 to 20.7.96

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask 'chef-workstation' do
-  version '20.7.81'
-  sha256 '1027d55e29c12dcedefe799b8d3a5b1bb19df4224a77eb5e87d0d623570cca63'
+  version '20.7.96'
+  sha256 'b0ab6bba23d3cd5ef2e1e4cad2dbbffd34ac6fe4b3cfe5df62c298c367b7a9cd'
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.dmg"
   appcast 'https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.14&m=x86_64&v=latest'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.

        brew  cask audit --download chef-workstation
        ==> Downloading https://packages.chef.io/files/stable/chef-workstation/20.7.96/mac_os_x/10.14/chef-workstation-20.7.96-1.dmg
        ######################################################################## 100.0%
        ==> Verifying SHA-256 checksum for Cask 'chef-workstation'.
        audit for chef-workstation: passed

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

        brew cask style --fix chef-workstation
        [...SNIP...]
        1 file inspected, no offenses detected

- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
  - [Chef Workstation `20.7.96` is stable](https://downloads.chef.io/products/workstation/)
