### PR TITLE
Update kiwi-for-g-suite from 2.0.35v to 2.0.36v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask 'kiwi-for-g-suite' do
-  version '2.0.35v'
-  sha256 '7ee568b3651dc6a71830d379a6c69c9548083581528a7553984e0bade3b7243a'
+  version '2.0.36v'
+  sha256 'd477c9bf0f51b2edaab26b3ffcb9d423fc6d66941d36c3d15989b255d7e288e9'
 
   # kiwiforgsuite.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url 'https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).