### PR TITLE
Update thunderbird from 78.0 to 78.0.1

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -1,83 +1,83 @@
 cask 'thunderbird' do
-  version '78.0'
+  version '78.0.1'
 
   language 'cs' do
-    sha256 'a8e174323bcdd19427be949aefb4bae0c05441b4db51e638438f921f2f2c3efd'
+    sha256 'ad7d112b593fa2f32220c9996e6d7676f6099f0f548839af8abca3cb8ee24ecf'
     'cs'
   end
 
   language 'de' do
-    sha256 '3b4bf61a635ce66f8511121d15323bd52ca7692200d85ddd0727d6e4f5148ba9'
+    sha256 'f6aca97a348d49484a34e246be6cacb0b66268f2145ead9817085c26244e1cb4'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '0fd9a3eca9d0c4f2d4fda4e58265b09ffee7bf9f8eb3b266c7a4a7bb53008a2d'
+    sha256 'a17a28ea4bfdcfab87987363414fe6711e6a1334cea8285b6f7361be32ac977c'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'ce7f6b89cf5db15bd61679e9fd9f6ae268ebdd6811fb3b36383894b439b785fd'
+    sha256 '859d138390c9a73970cdc6b70b69179f04f9740b48967d75993535731981de15'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'd5cf3cb703137bbb0ee89b84fdd127633336d8ccae74e3bead4c5c15a0708826'
+    sha256 'dcd934c090522ba78865293ee428951c39c156751b58cad55514b86e3076be0f'
     'fr'
   end
 
   language 'gl' do
-    sha256 '302fb97d773b2a2c20bd35b889f6925d766804c4c7d45541d038e32f07d9e59a'
+    sha256 '1d229bb99353fb7127444190d679dac620642fb1c9b1370b0f29ac020ced8514'
     'gl'
   end
 
   language 'it' do
-    sha256 '02e677c9dbd126bf28c82763f0164928e6f23da36a5e513e6b7223d02a937209'
+    sha256 'a9d581d6e3bb0affd2d1e942bb89178d24e6be5194ca036bf639ea83c33e153a'
     'it'
   end
 
   language 'ja' do
-    sha256 '506d4568b32f600c10d5f0730d6581efafca4dc16a71046a94c065c24d43c1e7'
+    sha256 'e62e315b8a0aaba6b58a38605886bc38ce295d6337e8fc3ab606bdd38436c725'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'a20203776d1eb90e88dcae009a88fab73c2e4c2495d36fa48afe29ec9cf78509'
+    sha256 'd27c4c646d4b482139324617d7a91b49784c215ed903ed28c2190ad683b43e41'
     'nl'
   end
 
   language 'pl' do
-    sha256 'e97d27c87f9d7b120fcabcd8af3b49c1d58c0d6f5e256ceb8e481c8e6f138d17'
+    sha256 'bf3d5074ca14ebd63418b6fa4626311e238cc4201c22530c32552c93a481f9bf'
     'pl'
   end
 
   language 'pt' do
-    sha256 '9d01a66ed37296fcd43c74776156cff10fcf594158d5d3dfc9730474fd5ad30d'
+    sha256 '00fb6565128fc62600ac891c803f2f647ddb68ceca25098cbdaf948d5f67afab'
     'pt-PT'
   end
 
   language 'pt-BR' do
-    sha256 '8f532ea577603a73a2d18a99144a04a76b5c05cdc1cde0e1ab12248081088a5a'
+    sha256 '25f9b57565a8d282309770ee45e851f62a7329651c86905f1e66baafbce44901'
     'pt-BR'
   end
 
   language 'ru' do
-    sha256 '9e7ea68bc432e3f4deff668f53f924ee55835cdfb07b59e0097bcc740da4f659'
+    sha256 '183cfca926008eee2ce2a9ec76bad7c43ddac87a8c96a900d569c52f4bcdee3c'
     'ru'
   end
 
   language 'uk' do
-    sha256 '5766e73226001c4bf3ec4bd585433a53b0869622860c5e52afb19dea1abe5e57'
+    sha256 'e69eb67071ff82751a101d52fd557b1e01ce37d4605494c60ed4aeead3b3ce8b'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'e73ebf77cfda0583630657a373246cce3b5291c9c6af6f8bf90df455605ec476'
+    sha256 '265b65f8700635b801b74dc1a0202a63fe96e52dc9b140048a4d65ec57ec48a3'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'd1acbe69f96b01d69d905863165d317e6c9f40256105c1d191563dd7fd61e6f1'
+    sha256 'bb52f95faab53b2f1c0559253a18a8e153883efdf04cd7ee85f9d19f504871d9'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
