### PR TITLE
Set auto_updates flag for kiwi-for-g-suite

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -8,6 +8,8 @@ cask 'kiwi-for-g-suite' do
   name 'Kiwi For G Suite'
   homepage 'https://www.kiwiforgmail.com/'
 
+  auto_updates true
+
   pkg 'Kiwi for G Suite.pkg'
 
   uninstall pkgutil: 'com.zive.kiwi.qb-pkg.gsuite',


### PR DESCRIPTION
Kiwi Fro G Suite now has an auto update functionality.

![Bildschirmfoto 2020-07-22 um 12 54 20](https://user-images.githubusercontent.com/243056/88168294-80c79180-cc1a-11ea-915d-4e6214bda24a.png)
![Bildschirmfoto 2020-07-22 um 12 54 26](https://user-images.githubusercontent.com/243056/88168291-7f966480-cc1a-11ea-9138-ea56cdc443c6.png)

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).