### PR TITLE
Update carbon-copy-cloner from 5.1.19.6027 to 5.1.20.6042

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -1,6 +1,6 @@
 cask 'carbon-copy-cloner' do
-  version '5.1.19.6027'
-  sha256 'f5bb24f88767e3af0e75998dfde5d315de66b376f7d5d5d3931e8c4caacccc79'
+  version '5.1.20.6042'
+  sha256 '198599c60e0988b4dec387772ec4c8cfe13d5e21b419caf1b7249e2a18f6f8aa'
 
   # bombich.scdn1.secure.raxcdn.com/software/files/ was verified as official when first introduced to the cask
   url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).