### PR TITLE
Update kitematic from 0.17.11 to 0.17.12

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -1,6 +1,6 @@
 cask 'kitematic' do
-  version '0.17.11'
-  sha256 '52906fd3fc98d8ce94ff24e19714879024fb7d07a2daae4e59187ec969cd2ddc'
+  version '0.17.12'
+  sha256 '39e673d2760529fe05e57c213e7f0a5cbaaef1ea76911a3f8514276972f6579f'
 
   # github.com/docker/kitematic/ was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).