### PR TITLE
Update jclasslib-bytecode-viewer from 5.5.1 to 5.6

### DIFF
--- a/Casks/jclasslib-bytecode-viewer.rb
+++ b/Casks/jclasslib-bytecode-viewer.rb
@@ -1,6 +1,6 @@
 cask 'jclasslib-bytecode-viewer' do
-  version '5.5.1'
-  sha256 'dd158ca2c71dacaeec163851c5b6473d7213dc2bb3d1b2e0437f9a4e73bd1bfe'
+  version '5.6'
+  sha256 '9fd02a64ac969c81861da25fc71541507053dedfebec680c23cb97b4d9b5f7f7'
 
   url "https://github.com/ingokegel/jclasslib/releases/download/#{version}/jclasslib_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/ingokegel/jclasslib/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).