### PR TITLE
Update activedock from 2.2,2021 to 2.32,2032

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask 'activedock' do
-  version '2.2,2021'
-  sha256 '80de86553afe8b527d8dd4b6734c8ef8c9d21a5bf172617c12596a5e52f47b62'
+  version '2.32,2032'
+  sha256 '28f73ff8a774c3cb8a458789755ad63a3c834f95f22f4ee0716334d71a1eaa5e'
 
   url 'https://noteifyapp.com/download/ActiveDock.dmg'
   appcast 'https://macplus-software.com/downloads/ActiveDock.xml'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).