### PR TITLE
Update intune-company-portal from 2.6.200600 to 2.7.200700

### DIFF
--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -1,6 +1,6 @@
 cask 'intune-company-portal' do
-  version '2.6.200600'
-  sha256 'e2ee7fbb0e9c04c126f22c6d30142c6e87506908fb7432f876c01125e28982f1'
+  version '2.7.200700'
+  sha256 'd6a293dd298ba6041858fb17859a1cfdc0bb27c6bc7c86e8bbd9d9ccb737c4de'
 
   url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Installer.pkg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://go.microsoft.com/fwlink/?linkid=853070'

--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -14,6 +14,7 @@ cask 'intune-company-portal' do
 
   uninstall pkgutil:   [
                          'com.microsoft.package.Microsoft_AutoUpdate.app',
+                         'com.microsoft.CompanyPortalMac',
                          'com.microsoft.CompanyPortal',
                        ],
             delete:    [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).