### PR TITLE
Remove auto_updates stanza from pycharm-ce

### DIFF
--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -8,8 +8,6 @@ cask 'pycharm-ce' do
   name 'PyCharm CE'
   homepage 'https://www.jetbrains.com/pycharm/'
 
-  auto_updates true
-
   app 'PyCharm CE.app'
 
   uninstall_postflight do


### PR DESCRIPTION
Although PyCharm CE automatically checks for updates, pressing the update button just brings you to a webpage where you can download the new version. According to [this page in the Homebrew Cask documentation](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/all_stanzas.md#optional-stanzas), this means that this Cask does not qualify for the auto_updates stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).