### PR TITLE
Upgrade BrowserStack Local to app

### DIFF
--- a/Casks/browserstacklocal.rb
+++ b/Casks/browserstacklocal.rb
@@ -2,9 +2,19 @@ cask 'browserstacklocal' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip'
+  url 'https://www.browserstack.com/BrowserStackLocal.dmg'
   name 'BrowserStack Local'
   homepage 'https://www.browserstack.com/'
 
-  binary 'BrowserStackLocal'
+  app 'BrowserStackLocal.app'
+  binary 'BrowserStackLocal.app/Contents/Resources/public/BrowserStackLocal'
+
+  uninstall launchctl: 'com.browserstack.local'
+
+  zap trash: [
+               '/tmp/BrowserStackLocal.dmg',
+               '/tmp/bstack-local-app.log',
+               '~/.bstack',
+               '~/Library/Caches/com.browserstack.Local',
+             ]
 end

--- a/Casks/browserstacklocal.rb
+++ b/Casks/browserstacklocal.rb
@@ -12,8 +12,6 @@ cask 'browserstacklocal' do
   uninstall launchctl: 'com.browserstack.local'
 
   zap trash: [
-               '/tmp/BrowserStackLocal.dmg',
-               '/tmp/bstack-local-app.log',
                '~/.bstack',
                '~/Library/Caches/com.browserstack.Local',
              ]


### PR DESCRIPTION
The BrowserStack Local app is now distributed as an app inside a disk image (see https://www.browserstack.com/docs/app-live/local-testing#macOS).

Note that the binary version is still available (see https://www.browserstack.com/local-testing/releases/v8.0) so we might want to split this into two formulae: one for the BrowserStack Local Binary and one for BrowserStack Local, what's the best way to achieve this?

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).