### PR TITLE
Update cutter from 1.10.3 to 1.11.0

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask 'cutter' do
-  version '1.10.3'
-  sha256 'af01ca5da120afbc8666c5a029996435226ac3d72448cb48b02fd8a4853e6c80'
+  version '1.11.0'
+  sha256 '59237d9fd90c4dd932f756eddfe5d27d9d53352d28ba0ec92bfe4ec19b200299'
 
   # github.com/radareorg/cutter/ was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
After making all changes to the cask:

* [x] `brew cask audit --download {{cask_file}}` is error-free.
* [x] `brew cask style --fix {{cask_file}}` reports no offenses.
* [x] The commit message includes the cask’s name and version.
* [x] The submission is for a stable version or documented exception.