### PR TITLE
Update diskcatalogmaker from 8.2 to 8.2.0

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,5 +1,5 @@
 cask 'diskcatalogmaker' do
-  version '8.2'
+  version '8.2.0'
   sha256 'a3c5434bd2e48ae7f538a0f2d5511afab2c5fb4c9382f8eb0c88166aa0b38b39'
 
   url 'https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).