### PR TITLE
Update chromium from 789773 to 791416

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask 'chromium' do
-  version '789773'
-  sha256 '19a09bc564e56a302c1d4ccb575d950c382a7795263a2ffba1cbc38e9da8fc88'
+  version '791416'
+  sha256 'f1edc2b618a3ad9016c6f1ebc24861be451edb4d5d24755bb88435ac6f0d7489'
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).