### PR TITLE
Update subsync from 0.15.0 to 0.16.0

### DIFF
--- a/Casks/subsync.rb
+++ b/Casks/subsync.rb
@@ -1,6 +1,6 @@
 cask 'subsync' do
-  version '0.15.0'
-  sha256 '0e6f54806e30db861acc88592de474e026fa54e8b1d636e52be5fa2a5e941c0d'
+  version '0.16.0'
+  sha256 '0483b43faf4a1645d0763bba7b3a229e43d0ef870be18e43f3bc76f60cfb9fc5'
 
   # github.com/sc0ty/subsync was verified as official when first introduced to the cask
   url "https://github.com/sc0ty/subsync/releases/download/#{version.major_minor}/subsync-#{version}-mac-x86_64.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
