### PR TITLE
Update free-download-manager from 6.10.1 to 6.10.2

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -1,5 +1,5 @@
 cask 'free-download-manager' do
-  version '6.10.1'
+  version '6.10.2'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dn3.freedownloadmanager.org/#{version.major}/latest/fdm.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).