### PR TITLE
Update rsyncosx from 6.3.5 to 6.4.0

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -1,6 +1,6 @@
 cask 'rsyncosx' do
-  version '6.3.5'
-  sha256 '47ff64b3a1936c5d6920719a4d1b2e3f621448114176d7822961f6bf128a3b49'
+  version '6.4.0'
+  sha256 '4c02aa7c6e01083fd45d939ca97df19a18c46e506bb407fa4cc8ed22f1bc884b'
 
   url "https://github.com/rsyncOSX/RsyncOSX/releases/download/v#{version}/RsyncOSX.#{version}.dmg"
   appcast 'https://github.com/rsyncOSX/RsyncOSX/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).