### PR TITLE
Update freeorion from 0.4.9,2020-02-02.db53471 to 0.4.10,2020-07-10.f3d403e

### DIFF
--- a/Casks/freeorion.rb
+++ b/Casks/freeorion.rb
@@ -1,6 +1,6 @@
 cask 'freeorion' do
-  version '0.4.9,2020-02-02.db53471'
-  sha256 'b90858dd1869166836e77497237b215609577247462b0a54def1e71425f694f7'
+  version '0.4.10,2020-07-10.f3d403e'
+  sha256 'fa9db8fd170915283775ccc052d80f5b4c3a7626ac57f3e00a4b321692b3e040'
 
   # github.com/freeorion/ was verified as official when first introduced to the cask
   url "https://github.com/freeorion/freeorion/releases/download/v#{version.before_comma}/FreeOrion_v#{version.before_comma}_#{version.after_comma}_MacOSX_10.9.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).