### PR TITLE
Update packetsender from 6.2.3 to 7.0.5

### DIFF
--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -1,6 +1,6 @@
 cask 'packetsender' do
-  version '6.2.3'
-  sha256 '4a886b351ef7d30906e20d05ea002a6ae2308c28dd1246957bcaa361e054ee2b'
+  version '7.0.5'
+  sha256 '30281225ee4e2baf3ca365123832c2931342aaf1011038268eab13ec73375fad'
 
   # github.com/dannagle/PacketSender/ was verified as official when first introduced to the cask
   url "https://github.com/dannagle/PacketSender/releases/download/v#{version}/PacketSender_v#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).