### PR TITLE
Update kafka-tool from latest to 2.0.7

### DIFF
--- a/Casks/kafka-tool.rb
+++ b/Casks/kafka-tool.rb
@@ -10,7 +10,6 @@ cask "kafka-tool" do
   installer script: {
     executable: "Kafka Tool #{version.major} Installer.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
-    sudo:       true,
   }
 
   uninstall delete: "/Applications/Kafka Tool.app"

--- a/Casks/kafka-tool.rb
+++ b/Casks/kafka-tool.rb
@@ -8,12 +8,12 @@ cask "kafka-tool" do
   homepage "https://www.kafkatool.com/index.html"
 
   installer script: {
-    executable: "Kafka Tool 2 Installer.app/Contents/MacOS/JavaApplicationStub",
+    executable: "Kafka Tool #{version.major} Installer.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
     sudo:       true,
   }
 
   uninstall delete: "/Applications/Kafka Tool.app"
 
-  zap trash: "~/.kafkatool2"
+  zap trash: "~/.kafkatool#{version.major}"
 end

--- a/Casks/kafka-tool.rb
+++ b/Casks/kafka-tool.rb
@@ -1,21 +1,19 @@
 cask "kafka-tool" do
-  version :latest
-  sha256 :no_check
+  version "2.0.7"
+  sha256 "8f4a008a4d3ce83e274d15796474770165961c6b66b59503e03ccd8c6b93ebbd"
 
   url "https://www.kafkatool.com/download2/kafkatool.dmg"
+  appcast "https://www.kafkatool.com/download.html"
   name "Kafka Tool"
   homepage "https://www.kafkatool.com/index.html"
 
   installer script: {
     executable: "Kafka Tool 2 Installer.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
+    sudo:       true,
   }
 
   uninstall delete: "/Applications/Kafka Tool.app"
 
   zap trash: "~/.kafkatool2"
-
-  caveats do
-    depends_on_java "8"
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

From the `homepage`:

> All versions of Kafka Tool come with a bundled JRE with the exception of the Linux version.

so the `depends_on_java "8"` should not be required.

Addresses https://github.com/Homebrew/homebrew-cask/issues/86628