### PR TITLE
Update ableton-live-standard from 10.1.15 to 10.1.17

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-standard" do
-  version "10.1.15"
-  sha256 "5fb22be292e64f84915bbe26be89f242ba53f3f54a1fb5d90fc0d25d367e5cee"
+  version "10.1.17"
+  sha256 "1c8220c39196fd3358d4e8196e0b399a6b36315eaf348dab9b548eb7365eba0f"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).