### PR TITLE
Update openzfs.rb

### DIFF
--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -6,6 +6,18 @@ cask "openzfs" do
   name "OpenZFS on OS X"
   homepage "https://openzfsonosx.org/"
 
+  if MacOS.version <= :el_capitan
+    pkg "OpenZFS on OS X #{version.major_minor_patch} El Capitan.pkg"
+  elsif MacOS.version <= :sierra
+    pkg "OpenZFS on OS X #{version.major_minor_patch} Sierra.pkg"
+  elsif MacOS.version <= :high_sierra
+    pkg "OpenZFS on OS X #{version.major_minor_patch} High Sierra.pkg"
+  elsif MacOS.version <= :mojave
+    pkg "OpenZFS on OS X #{version.major_minor_patch} Mojave.pkg"
+  elsif MacOS.version <= :catalina
+    pkg "OpenZFS on OS X #{version.major_minor_patch} Catalina.pkg"
+  end
+
   # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
   depends_on macos: [
     :el_capitan,
@@ -14,19 +26,6 @@ cask "openzfs" do
     :mojave,
     :catalina,
   ]
-
-  case MacOS.version
-  when :el_capitan
-    pkg "OpenZFS on OS X #{version.major_minor_patch} El Capitan.pkg"
-  when :sierra
-    pkg "OpenZFS on OS X #{version.major_minor_patch} Sierra.pkg"
-  when :high_sierra
-    pkg "OpenZFS on OS X #{version.major_minor_patch} High Sierra.pkg"
-  when :mojave
-    pkg "OpenZFS on OS X #{version.major_minor_patch} Mojave.pkg"
-  when :catalina
-    pkg "OpenZFS on OS X #{version.major_minor_patch} Catalina.pkg"
-  end
 
   uninstall_preflight do
     uninstall_zfs = "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -26,7 +26,7 @@ cask "openzfs" do
   elsif MacOS.version <= :catalina
     pkg "OpenZFS on OS X #{version.major_minor_patch} Catalina.pkg"
   end
-  
+
   uninstall_preflight do
     uninstall_zfs = "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"
     IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub("$(which zpool)", "/usr/local/bin/zpool"))

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -6,6 +6,15 @@ cask "openzfs" do
   name "OpenZFS on OS X"
   homepage "https://openzfsonosx.org/"
 
+  # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
+  depends_on macos: [
+    :el_capitan,
+    :sierra,
+    :high_sierra,
+    :mojave,
+    :catalina,
+  ]
+
   if MacOS.version <= :el_capitan
     pkg "OpenZFS on OS X #{version.major_minor_patch} El Capitan.pkg"
   elsif MacOS.version <= :sierra
@@ -17,16 +26,7 @@ cask "openzfs" do
   elsif MacOS.version <= :catalina
     pkg "OpenZFS on OS X #{version.major_minor_patch} Catalina.pkg"
   end
-
-  # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
-  depends_on macos: [
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-    :mojave,
-    :catalina,
-  ]
-
+  
   uninstall_preflight do
     uninstall_zfs = "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"
     IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub("$(which zpool)", "/usr/local/bin/zpool"))


### PR DESCRIPTION
get rid of non-standard syntax, similar to onyx/saoimageds9


also, while we are at at, the 'unusual case' thing is *below* the version numbers in all other cases. it seems to be one of the few things that the style check doesn't care about