### PR TITLE
Upgrade surge-synthesizer.rb to 1.7.0

### DIFF
--- a/Casks/surge-synthesizer.rb
+++ b/Casks/surge-synthesizer.rb
@@ -1,6 +1,6 @@
 cask "surge-synthesizer" do
-  version "1.6.6"
-  sha256 "cd709c3a447bd98f35f1ca5c56be3f50267ccde3c8860fd0e75cf7f3d096aa9c"
+  version "1.7.0"
+  sha256 "7dfa884bc9680c2ba54bc38255528fb9c008ea3ef6f930c920d96db37f2e3a01"
 
   # github.com/surge-synthesizer/releases/ was verified as official when first introduced to the cask
   url "https://github.com/surge-synthesizer/releases/releases/download/#{version}/Surge-#{version}-Setup.dmg"


### PR DESCRIPTION
1.7.0 is a major release of surge; this commit updates
to the newest version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
