### PR TITLE
Update splashtop-personal from 2.6.8.0 to 3.4.0.1

### DIFF
--- a/Casks/splashtop-personal.rb
+++ b/Casks/splashtop-personal.rb
@@ -1,6 +1,6 @@
 cask "splashtop-personal" do
-  version "2.6.8.0"
-  sha256 "8c867a3969399db29b4f7aa6abb2f70f06535503f35db7eb5ff58358f3cb91dd"
+  version "3.4.0.1"
+  sha256 "466fa2dd26e41f43e43019f1c817e703e1e29cd9451fbd5c4c0d48da58df3825"
 
   # d17kmd0va0f0mp.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/macclient/STP/Splashtop_Personal_v#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).