### PR TITLE
Update jellyfin.rb

### DIFF
--- a/Casks/jellyfin.rb
+++ b/Casks/jellyfin.rb
@@ -1,6 +1,6 @@
 cask "jellyfin" do
-  version "10.6.0"
-  sha256 "42cb7ce3813ba1d2f2f0bd7694dfd59aaf812e4357d0418680a17168f1bad6aa"
+  version "10.6.1"
+  sha256 "0d7b562f0b799302db417a9ab5eb2bf07fdc8ca19b28649798ebcf266c949c1e"
 
   url "https://repo.jellyfin.org/releases/server/macos/stable/combined/Jellyfin_#{version}.dmg"
   appcast "https://repo.jellyfin.org/releases/server/macos/stable/"


### PR DESCRIPTION

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
