### PR TITLE
Update cashnotify from 3.3.1 to 3.3.2

### DIFF
--- a/Casks/cashnotify.rb
+++ b/Casks/cashnotify.rb
@@ -1,6 +1,6 @@
 cask "cashnotify" do
-  version "3.3.1"
-  sha256 "b19ec27da32947788760a64c194d2cb270de65dd452f0272d7b2b233b1cc6523"
+  version "3.3.2"
+  sha256 "7b255a80775d4c5dc3baba55c3039bbaf139f105617e0ab28f64de74e6baf7cb"
 
   url "https://download.cashnotify.com/download/mac/"
   appcast "https://github.com/BaguetteEngineering/download.cashnotify.com/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).