### PR TITLE
Add appcast to gloomhaven-helper

### DIFF
--- a/Casks/gloomhaven-helper.rb
+++ b/Casks/gloomhaven-helper.rb
@@ -3,6 +3,7 @@ cask "gloomhaven-helper" do
   sha256 "7b2161b1ca159a7584d89355d72b8aae2c7c06c281eee8c26a75da16697dea96"
 
   url "https://esotericsoftware.com/files/ghh/GloomhavenHelper-#{version}.zip"
+  appcast "http://esotericsoftware.com/gloomhaven-helper"
   name "Gloomhaven Helper"
   homepage "https://esotericsoftware.com/gloomhaven-helper"
 


### PR DESCRIPTION
As per comment in #86626, add homepage URL as appcast

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).