### PR TITLE
Update coqide from 8.11.2 to 8.12.0

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,6 +1,6 @@
 cask "coqide" do
-  version "8.11.2"
-  sha256 "18c09fbafaa2731bb7f6cff0b8e821b57cf6857d1bd1609055d0784d445c6d53"
+  version "8.12.0"
+  sha256 "be5bf7b8009e0693f5da35437a901c58a924c12c9464c5be3ff1ed3ebe495697"
 
   # github.com/coq/coq/ was verified as official when first introduced to the cask
   url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version}-installer-macos.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).