### PR TITLE
Update miniconda from py37_4.8.3 to py38_4.8.3

### DIFF
--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -1,6 +1,6 @@
 cask "miniconda" do
-  version "py37_4.8.3"
-  sha256 "ccc1bded923a790cd61cd17c83c3dcc374dc0415cfa7fb1f71e6a2438236543d"
+  version "py38_4.8.3"
+  sha256 "9b9a353fadab6aa82ac0337c367c23ef842f97868dcbb2ff25ec3aa463afc871"
 
   # repo.anaconda.com/miniconda/ was verified as official when first introduced to the cask
   url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.sh"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---
Per https://github.com/Homebrew/homebrew-cask/pull/83359#issuecomment-635183417, we choose the `py37` version instead of `py38` because it's identical to `latest`. But now, 
1. In https://repo.anaconda.com/miniconda/, `Miniconda3-latest-MacOSX-x86_64.sh` is identical to `Miniconda3-py38_4.8.3-MacOSX-x86_64.sh`.
2. In https://docs.conda.io/en/latest/miniconda.html, it shows only Python 3.8 version.

I think it's time to move to `py38`.

Cc @b0ttle @ran-dall .

