### PR TITLE
Update sound-siphon from 3.2.3,5876 to 3.2.4,5876

### DIFF
--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -1,6 +1,6 @@
 cask "sound-siphon" do
-  version "3.2.3,5876"
-  sha256 "0e5e955a2976963580d14d1711263a8d0688a1160e4cbd147f848fa2e098e8f7"
+  version "3.2.4,5876"
+  sha256 "c05ce45e0eb4950926ffdfdca6a49540e562f756475df68aed2d39db53156e3f"
 
   # staticz.net/ was verified as official when first introduced to the cask
   url "https://staticz.com/download/#{version.after_comma}/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).