### PR TITLE
Update nvidia-geforce-now from 2.0.21.106,96AA0E to 2.0.22.96,34C0E3

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,6 +1,6 @@
 cask "nvidia-geforce-now" do
-  version "2.0.21.106,96AA0E"
-  sha256 "7419d4ed88cf8230b97edc74770a6d701528aedc47602a38d535e896d9f7aa95"
+  version "2.0.22.96,34C0E3"
+  sha256 "f4be911d0f5f0af825ad91eeb595b8da29bb7306ea0ba6ff4c8221f8d748dbd4"
 
   url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release_#{version.after_comma}.dmg"
   appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).