### PR TITLE
Update refined-github-safari from 2.1.2 to 2.1.3

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask "refined-github-safari" do
-  version "2.1.2"
-  sha256 "f3e67532f0d80b88e5161d2af3ed2f1450589234e52eb57eb01e871a2cc031eb"
+  version "2.1.3"
+  sha256 "0c4f9d97bf754bb22f005f92a480e1603d1d698a36be9d237c13d35f81ea03ab"
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast "https://github.com/lautis/refined-github-safari/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).