### PR TITLE
Update rhinoceros from 6.27.20176.04592 to 6.28.20199.17132

### DIFF
--- a/Casks/rhinoceros.rb
+++ b/Casks/rhinoceros.rb
@@ -1,6 +1,6 @@
 cask "rhinoceros" do
-  version "6.27.20176.04592"
-  sha256 "f665af12b4915a8570e60d243d0637071a90b492a6154472c546def21c718a7e"
+  version "6.28.20199.17132"
+  sha256 "303c6ce8463aaca47262586aa7aab2e4981138cfcea9ce4103a0f82227516272"
 
   # mcneel.com/ was verified as official when first introduced to the cask
   url "https://files.mcneel.com/rhino/#{version.major}/mac/releases/rhino_#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).