### PR TITLE
Update plex from 1.15.1.1358-43550df5 to 1.16.0.1364-da192ff7

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask "plex" do
-  version "1.15.1.1358-43550df5"
-  sha256 "221e390c66c93c0d0618249d03338af5f4e11b5949f0aec34cdf7c7ac0d758d5"
+  version "1.16.0.1364-da192ff7"
+  sha256 "c835dd1bc104a65cea74561f1fd4b5f758f2f4a22d36c53e71d9a43680749e87"
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast "https://plex.tv/api/downloads/6.json"
@@ -8,7 +8,7 @@ cask "plex" do
   homepage "https://www.plex.tv/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "Plex.app"
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
