### PR TITLE
Fix sqlectron for case-sensitive file systems

### DIFF
--- a/Casks/sqlectron.rb
+++ b/Casks/sqlectron.rb
@@ -8,7 +8,7 @@ cask "sqlectron" do
   name "Sqlectron"
   homepage "https://sqlectron.github.io/"
 
-  app "Sqlectron.app"
+  app "sqlectron.app"
 
   zap trash: [
     "~/.sqlectron.json",


### PR DESCRIPTION
The 1.31.0 release changed capitalization of the app file (from _Sqlectron.app_ to _sqlectron.app_).

A future release may also return to the old capitalization, in which case this will need to be reversed.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
