### PR TITLE
Update pycharm from 2020.1.4,201.8743.11 to 2020.2,202.6397.98

### DIFF
--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -1,6 +1,6 @@
 cask "pycharm" do
-  version "2020.1.4,201.8743.11"
-  sha256 "42187e76d16bacb79beff546d46e608b9e5d752edd6de7ec543772e7ffade333"
+  version "2020.2,202.6397.98"
+  sha256 "bb69c7043e707ab36e63b4183d4e812711bd1c703784c3fcde930c4d8bc992a5"
 
   url "https://download.jetbrains.com/python/pycharm-professional-#{version.before_comma}.dmg"
   appcast "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).