### PR TITLE
Update phpstorm from 2020.1.4,201.8743.18 to 2020.2,202.6397.115

### DIFF
--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -1,6 +1,6 @@
 cask "phpstorm" do
-  version "2020.1.4,201.8743.18"
-  sha256 "f068cdd6697779dca853393ff785a72e18236ebb578b847e5fa007bc0592203e"
+  version "2020.2,202.6397.115"
+  sha256 "cdab2c47c5b2ed8d10e13c1476ad0ee1231a1f130abfb1e08a1db7742850ebcb"
 
   url "https://download.jetbrains.com/webide/PhpStorm-#{version.before_comma}.dmg"
   appcast "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).