### PR TITLE
Add scratch-link cask

### DIFF
--- a/Casks/scratch-link.rb
+++ b/Casks/scratch-link.rb
@@ -2,10 +2,9 @@ cask "scratch-link" do
   version "1.3.57"
   sha256 "58e9e3a5745bc65e6920bed934eb952e29b184022a9c6d8942dfcdf13b644c9d"
 
-  # downloads.scratch.mit.edu was verified as official when first introduced to the cask
   url "https://downloads.scratch.mit.edu/link/mac.zip"
   name "Scratch Link"
-  homepage "https://github.com/LLK/scratch-link"
+  homepage "https://scratch.mit.edu/microbit"
 
   pkg "scratch-link-#{version}.pkg"
 

--- a/Casks/scratch-link.rb
+++ b/Casks/scratch-link.rb
@@ -7,8 +7,6 @@ cask "scratch-link" do
   name "Scratch Link"
   homepage "https://github.com/LLK/scratch-link"
 
-  license :bsd
-
   pkg "scratch-link-#{version}.pkg"
 
   uninstall pkgutil: "edu.mit.scratch.scratch-link"

--- a/Casks/scratch-link.rb
+++ b/Casks/scratch-link.rb
@@ -1,0 +1,15 @@
+cask "scratch-link" do
+  version "1.3.57"
+  sha256 "58e9e3a5745bc65e6920bed934eb952e29b184022a9c6d8942dfcdf13b644c9d"
+
+  # downloads.scratch.mit.edu was verified as official when first introduced to the cask
+  url "https://downloads.scratch.mit.edu/link/mac.zip"
+  name "Scratch Link"
+  homepage "https://github.com/LLK/scratch-link"
+
+  license :bsd
+
+  pkg "scratch-link-#{version}.pkg"
+
+  uninstall pkgutil: "edu.mit.scratch.scratch-link"
+end


### PR DESCRIPTION
version '1.3.57'

Scratch Link is a helper application which allows Scratch 3.0 to communicate with hardware peripherals.
Scratch Link replaces the Scratch Device Manager and Scratch Device Plug-in.
It is open-sourced (BSD) since 2019.

The source code is available here
https://github.com/LLK/scratch-link

To learn more about Scratch & Scratch Link go here
https://scratch.mit.edu/microbit

This is also where the zip/pkg download link is provided
https://downloads.scratch.mit.edu/link/mac.zip

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
