### PR TITLE
Update unity-download-assistant from 2019.4.2f1,20b4642a3455 to 2019.4.6f1,a7aea80e3716

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask "unity-download-assistant" do
-  version "2019.4.2f1,20b4642a3455"
-  sha256 "732a59b3c664eee3b05063aa13922898be3e51544d0510e19533c9afbb107c4d"
+  version "2019.4.6f1,a7aea80e3716"
+  sha256 "cddbcf4ff11ba5b75c7983dbb2eaf7fb0d8e94d1900db930e0edbdd43b4a6169"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast "https://unity3d.com/get-unity/download/archive"

--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask "unity" do
-  version "2019.4.2f1,20b4642a3455"
-  sha256 "1be916e3c36a8f94c9294daed6805b24890c5f5b9627e0ee84abce6fbb0935c6"
+  version "2019.4.6f1,a7aea80e3716"
+  sha256 "84bd731464cac8fee32474f8627dc7be5b73f68f3f537ce746da5000da332295"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast "https://unity3d.com/get-unity/download/archive"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).