### PR TITLE
add kdiff3 v1.8.3

### DIFF
--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -1,5 +1,5 @@
 cask "kdiff3" do
-  # note: "3" is not a version number, but an intrinsic part of the product name (3-way diff)
+  # note: "3" is not a version number, but an intrinsic part of the product name
   version "1.8.3"
   sha256 "b6ad193fb01392f6dd05b99989c86c578054d97961753b97a20855453e33708a"
 

--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -1,0 +1,32 @@
+cask "kdiff3" do
+  # note: "3" is not a version number, but an intrinsic part of the product name (3-way diff)
+  version "1.8.3"
+  sha256 "b6ad193fb01392f6dd05b99989c86c578054d97961753b97a20855453e33708a"
+
+  url "https://download.kde.org/stable/kdiff3/kdiff3-#{version}-macos-64.dmg"
+  appcast "https://invent.kde.org/sdk/kdiff3/-/tags?format=atom"
+  name "KDiff3"
+  homepage "https://invent.kde.org/sdk/kdiff3"
+
+  app "kdiff3.app"
+  shimscript = "#{staged_path}/kdiff3.wrapper.sh"
+  binary shimscript, target: "kdiff3"
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/bash
+      '#{appdir}/kdiff3.app/Contents/MacOS/kdiff3' "$@"
+    EOS
+  end
+
+  zap trash: "~/.kdiff3rc"
+
+  caveats <<~END
+    kdiff3 is not signed, so you will need to reauthorize the app to run every
+    time the app is updated.
+
+    Run the app once. If macOS blocks it from running, go to:
+      System Preferences → Security & Privacy → General
+    To re-enable, click Open Anyway.
+  END
+end

--- a/Casks/kdiff3.rb
+++ b/Casks/kdiff3.rb
@@ -20,13 +20,4 @@ cask "kdiff3" do
   end
 
   zap trash: "~/.kdiff3rc"
-
-  caveats <<~END
-    kdiff3 is not signed, so you will need to reauthorize the app to run every
-    time the app is updated.
-
-    Run the app once. If macOS blocks it from running, go to:
-      System Preferences → Security & Privacy → General
-    To re-enable, click Open Anyway.
-  END
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

[KDiff3 was removed](https://github.com/Homebrew/homebrew-cask/pull/67726) when the project was not publishing binaries, but [version 1.8.3 has a published macOS binary](https://download.kde.org/stable/kdiff3/) now.

I copied the old cask and updated it. KDiff3 won't run on Catalina by default because it's not signed, so it has to be allowed in Security & Privacy. None of the predefined caveats explained this situation, but since `unsigned_accessibilty` exists, it seems like unsigned binaries are acceptable.