### PR TITLE
Update unity-webgl-support-for-editor from 2019.4.2f1,20b4642a3455 to 2019.4.6f1,a7aea80e3716

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask "unity-webgl-support-for-editor" do
-  version "2019.4.2f1,20b4642a3455"
-  sha256 "1053741f0afecf880309c30599d7897ec86026a9d7c832948c518f92b1abc79a"
+  version "2019.4.6f1,a7aea80e3716"
+  sha256 "c1bd1830d0131ecb14fa8b8eef6e9fe226a0f2be84a76625eca32ffab8060f25"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"

--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,6 +1,6 @@
 cask "unity" do
-  version "2019.4.2f1,20b4642a3455"
-  sha256 "1be916e3c36a8f94c9294daed6805b24890c5f5b9627e0ee84abce6fbb0935c6"
+  version "2019.4.6f1,a7aea80e3716"
+  sha256 "84bd731464cac8fee32474f8627dc7be5b73f68f3f537ce746da5000da332295"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorInstaller/Unity-#{version.before_comma}.pkg"
   appcast "https://unity3d.com/get-unity/download/archive"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).