### PR TITLE
Update seadrive from 2.0.4 to 2.0.5

### DIFF
--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -1,6 +1,6 @@
 cask "seadrive" do
-  version "2.0.4"
-  sha256 "51e6b7588a2c3d1a3b8141890edf3ae4ae237b1162eeee7f7becff66a6aac6da"
+  version "2.0.5"
+  sha256 "71cb10d98b9f2bb9680d641b68ccf73f7972d3276b6f42df299cc040230d7ba1"
 
   # download.seadrive.org/ was verified as official when first introduced to the cask
   url "https://download.seadrive.org/seadrive-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).