### PR TITLE
Update easy-move-plus-resize from 1.2.0 to 1.3.0

### DIFF
--- a/Casks/easy-move-plus-resize.rb
+++ b/Casks/easy-move-plus-resize.rb
@@ -7,5 +7,5 @@ cask "easy-move-plus-resize" do
   name "Easy Move+Resize"
   homepage "https://github.com/dmarcotte/easy-move-resize"
 
-  app "Easy Move+Resize.app"
+  app "easy-move-resize/Easy Move+Resize.app"
 end

--- a/Casks/easy-move-plus-resize.rb
+++ b/Casks/easy-move-plus-resize.rb
@@ -1,6 +1,6 @@
 cask "easy-move-plus-resize" do
-  version "1.2.0"
-  sha256 "2060d10fedaf7e52b762645ef36716ce9a370d9d6895b7464faf7d79f3c0afd4"
+  version "1.3.0"
+  sha256 "da8c7c8e365c348f06c80cdc075271d85d16a954bf5f9494786dcb8251bc27b6"
 
   url "https://github.com/dmarcotte/easy-move-resize/releases/download/#{version}/Easy.Move.Resize.app.zip"
   appcast "https://github.com/dmarcotte/easy-move-resize/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).