### PR TITLE
downgrade the-the-battle-for-wesnoth.rb

### DIFF
--- a/Casks/the-battle-for-wesnoth.rb
+++ b/Casks/the-battle-for-wesnoth.rb
@@ -1,6 +1,6 @@
 cask "the-battle-for-wesnoth" do
-  version "1.15.3"
-  sha256 "cc20b350b6f91db207a6a1f2be16e4574f81eb8fc597111dd1470acfdf79e77f"
+  version "1.14.13"
+  sha256 "3824a6c2828a866ede7caab81287382d5e95969e240d9e22364500a83291b8de"
 
   # sourceforge.net/wesnoth/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"

--- a/Casks/the-battle-for-wesnoth.rb
+++ b/Casks/the-battle-for-wesnoth.rb
@@ -1,6 +1,6 @@
 cask "the-battle-for-wesnoth" do
   version "1.14.13"
-  sha256 "3824a6c2828a866ede7caab81287382d5e95969e240d9e22364500a83291b8de"
+  sha256 "e79a1dede6b8da6d3726ea87ff39a4c895e83fcd1dd0114201e3503dd37b5090"
 
   # sourceforge.net/wesnoth/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"


### PR DESCRIPTION
Version 1.15.3 is a development release, downgrading to 1.14.13.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
