### PR TITLE
Update the-battle-for-wesnoth.rb

### DIFF
--- a/Casks/the-battle-for-wesnoth.rb
+++ b/Casks/the-battle-for-wesnoth.rb
@@ -3,8 +3,8 @@ cask "the-battle-for-wesnoth" do
   sha256 "e79a1dede6b8da6d3726ea87ff39a4c895e83fcd1dd0114201e3503dd37b5090"
 
   # sourceforge.net/wesnoth/ was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/wesnoth/Wesnoth_#{version}.dmg"
-  appcast "https://sourceforge.net/projects/wesnoth/rss"
+  url "https://downloads.sourceforge.net/wesnoth/wesnoth-#{version.major_minor}/wesnoth-#{version}/Wesnoth_#{version}.dmg"
+  appcast "https://sourceforge.net/projects/wesnoth/rss?path=/wesnoth-#{version.major_minor}"
   name "The Battle for Wesnoth"
   homepage "https://wesnoth.org/"
 


### PR DESCRIPTION
Use version specific appcast.
Use enhance download link.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).