### PR TITLE
Update nosqlbooster-for-mongodb from 6.0.4 to 6.0.5

### DIFF
--- a/Casks/nosqlbooster-for-mongodb.rb
+++ b/Casks/nosqlbooster-for-mongodb.rb
@@ -1,6 +1,6 @@
 cask "nosqlbooster-for-mongodb" do
-  version "6.0.4"
-  sha256 "4375c1477f0036ac0f3e355eb525bc6875854e8291a38009a19a9c4c277ee6a0"
+  version "6.0.5"
+  sha256 "4baa73242fd38bfe537e2abd24a0565c92cde7cad0080389e1ad713cf5544239"
 
   url "https://nosqlbooster.com/s3/download/releasesv#{version.major}/nosqlbooster4mongo-#{version}.dmg"
   appcast "https://nosqlbooster.com/downloads"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).