### PR TITLE
Update liclipse from 6.2.0,ua5e9iiglndk16n to 6.3.0,7tlqxhknfqih3fs

### DIFF
--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -1,6 +1,6 @@
 cask "liclipse" do
-  version "6.2.0,ua5e9iiglndk16n"
-  sha256 "1fd1f0c4692c16f62b97decfd7ce872b8826805e9d87ea7c922820a870edd967"
+  version "6.3.0,7tlqxhknfqih3fs"
+  sha256 "8ddf6eee0ffe9fe58c8c2144078689b53c1d154a033aace913c5c0f25f6502b2"
 
   # mediafire.com/file/ was verified as official when first introduced to the cask
   url "https://www.mediafire.com/file/#{version.after_comma}/liclipse_#{version.before_comma}_macosx.cocoa.x86_64.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).