### PR TITLE
Add `auto_updates` flag to fontlab 7.1.4.7515

### DIFF
--- a/Casks/fontlab.rb
+++ b/Casks/fontlab.rb
@@ -8,5 +8,7 @@ cask "fontlab" do
   name "Fontlab"
   homepage "https://www.fontlab.com/font-editor/fontlab/"
 
+  auto_updates true
+
   app "FontLab #{version.major}.app"
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).