### PR TITLE
ci.yml: Run style before CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
           PR_URL: ${{ github.event.pull_request._links.html.href }}
           HOMEBREW_COLOR: 1
           HOMEBREW_DEVELOPER: 1
+      - name: brew cask style
+        run: |
+          # don't care about `brew cask style` here.
+          brew untap adoptopenjdk/openjdk
+
+          brew cask style
       - name: brew cask ci
         run: |
           cd "$(brew --repository "${GITHUB_REPOSITORY}")"
@@ -57,9 +63,3 @@ jobs:
         env:
           HOMEBREW_COLOR: 1
           HOMEBREW_DEVELOPER: 1
-      - name: brew cask style
-        run: |
-          # don't care about `brew cask style` here.
-          brew untap adoptopenjdk/openjdk
-
-          brew cask style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,6 @@ jobs:
           PR_URL: ${{ github.event.pull_request._links.html.href }}
           HOMEBREW_COLOR: 1
           HOMEBREW_DEVELOPER: 1
-      - name: brew cask style
-        run: |
-          # don't care about `brew cask style` here.
-          brew untap adoptopenjdk/openjdk
-
-          brew cask style
       - name: brew cask ci
         run: |
           cd "$(brew --repository "${GITHUB_REPOSITORY}")"
@@ -63,3 +57,10 @@ jobs:
         env:
           HOMEBREW_COLOR: 1
           HOMEBREW_DEVELOPER: 1
+      - name: brew cask style
+        run: |
+          # don't care about `brew cask style` here.
+          brew untap adoptopenjdk/openjdk
+
+          brew cask style
+        if: always()


### PR DESCRIPTION
`style` should be run first because that always works, unlike CI which sometimes points errors that aren’t there (e.g. asking to remove a `launchctl` that’s already covered in the cask, or a checking an outdated appcast).