### PR TITLE
Update listen1 from 2.10.0 to 2.11.0

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask "listen1" do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version "2.10.0"
-  sha256 "ba72e323a7ad41897a5625d8555b0a45160038ddd7546237bc498ad24da25ebc"
+  version "2.11.0"
+  sha256 "7c4b60bf4baf48879ba57b6daf080a9d6e71bfb2546714a527b928730cbc17a4"
 
   # github.com/listen1/listen1_desktop/ was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] The commit message includes the cask’s name and version.