### PR TITLE
Update jellyfin from 10.6.1 to 10.6.2

### DIFF
--- a/Casks/jellyfin.rb
+++ b/Casks/jellyfin.rb
@@ -1,8 +1,8 @@
 cask "jellyfin" do
-  version "10.6.1"
-  sha256 "0d7b562f0b799302db417a9ab5eb2bf07fdc8ca19b28649798ebcf266c949c1e"
+  version "10.6.2"
+  sha256 "5553490ef591114102de0dd8c5305685bb0d07cb2e28419d83760d116cc17aaa"
 
-  url "https://repo.jellyfin.org/releases/server/macos/stable/combined/Jellyfin_#{version}.dmg"
+  url "https://repo.jellyfin.org/releases/server/macos/stable/installer/Jellyfin_#{version}.dmg"
   appcast "https://repo.jellyfin.org/releases/server/macos/stable/"
   name "Jellyfin"
   homepage "https://jellyfin.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).