### PR TITLE
Update zappy from 2.5.4 to 2.5.5

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,6 +1,6 @@
 cask "zappy" do
-  version "2.5.4"
-  sha256 "c168ad7db84edaf1412cb14b951b238e5cd6eac92e2fa9822619a98672484f19"
+  version "2.5.5"
+  sha256 "51dcd3d361040802b2b89f6daffb016acbc26faf5c9769a0de055f71caa6c186"
 
   url "https://zappy.zapier.com/releases/zappy-#{version}.zip"
   appcast "https://zappy.zapier.com/releases/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).