### PR TITLE
Revert "Update anydesk.rb"

### DIFF
--- a/Casks/anydesk.rb
+++ b/Casks/anydesk.rb
@@ -1,9 +1,8 @@
 cask "anydesk" do
-  version "5.6.0"
-  sha256 "bc5606943ad25155651c5fe6a17562bae9088d092e1b8cf7c1bc2eaeb9cbe219"
+  version :latest
+  sha256 :no_check
 
   url "https://download.anydesk.com/anydesk.dmg"
-  appcast "https://anydesk.com/en/downloads/mac-os"
   name "AnyDesk"
   homepage "https://anydesk.com/remote-desktop"
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#87008

anydesk does not provide versioned downloads. Also, the appcast is just a link to the download page for the Mac-version.