### PR TITLE
Bumping chef-workstation to 20.8.111

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask "chef-workstation" do
-  version "20.7.96"
-  sha256 "b0ab6bba23d3cd5ef2e1e4cad2dbbffd34ac6fe4b3cfe5df62c298c367b7a9cd"
+  version "20.8.111"
+  sha256 "0cfac31ad71cb5c84244137bb4976da426d4f2c61f9d534cc1bc08b8f390a4ec"
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.dmg"
   appcast "https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.14&m=x86_64&v=latest"


### PR DESCRIPTION
After making all changes to the cask:

- [x] \`brew cask audit --download {{cask_file}}\` is error-free.
- [x] \`brew cask style --fix {{cask_file}}\` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for stable version.

Most of the file changes were from running `brew cask style --fix`. I only changed the version and the SHA

Signed-off-by: tyler-ball <tball@chef.io>