### PR TITLE
Update gitkraken from 7.1.0 to 7.2.0

### DIFF
--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -1,6 +1,6 @@
 cask "gitkraken" do
-  version "7.1.0"
-  sha256 "884ef780db02a033e59a937f64784bd0caf8e273997bcb980da2bd8efc58aa92"
+  version "7.2.0"
+  sha256 "95e2dd16c7d6b0c18e910f0c72116fe59ff9ef7b2ba4dedd494fa86d1dd53591"
 
   # release.axocdn.com/darwin/ was verified as official when first introduced to the cask
   url "https://release.gitkraken.com/darwin/installGitKraken.dmg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).