### PR TITLE
Update bitwarden from 1.20.0 to 1.20.1

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,6 +1,6 @@
 cask "bitwarden" do
-  version "1.20.0"
-  sha256 "08303b34acd6aca122f7c4f7ce44ffdb7946906ea530d74b41e3dd1bc1891b44"
+  version "1.20.1"
+  sha256 "890973fc10926151ff069b506900f65e304c9def238281005ccd2170f3d37f91"
 
   # github.com/bitwarden/desktop/ was verified as official when first introduced to the cask
   url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).