### PR TITLE
Update windows95 from 2.2.1 to 2.2.2

### DIFF
--- a/Casks/windows95.rb
+++ b/Casks/windows95.rb
@@ -1,9 +1,9 @@
 cask "windows95" do
   # note: "95" is not a version number, but an intrinsic part of the product name
-  version "2.2.1"
-  sha256 "bee0c1a0b142b8a096e14567948f0ce36a156e21d9d3ed055dfd17e701ba8b35"
+  version "2.2.2"
+  sha256 "70deb71aa540fceeddec8815f308710f9ca991bd78cf84d8512aa8035d781c2c"
 
-  url "https://github.com/felixrieseberg/windows95/releases/download/v#{version}/windows95-macos-#{version}.zip"
+  url "https://github.com/felixrieseberg/windows95/releases/download/v#{version}/windows95-darwin-x64-#{version}.zip"
   appcast "https://github.com/felixrieseberg/windows95/releases.atom"
   name "Windows 95"
   homepage "https://github.com/felixrieseberg/windows95"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).