### PR TITLE
Update libreoffice from 6.4.5 to 7.0.0

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,10 +1,9 @@
 cask "libreoffice" do
-  version "7.0.0"
+  version "7.0.0.3"
   sha256 "74700ce918278b78464a4cd0e16d929e4af7b0447c42b400f61a2555818584e9"
 
-  version_full = "7.0.0.3"
   # documentfoundation.org/ was verified as official when first introduced to the cask
-  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version_full}_MacOS_x86-64.dmg"
+  url "https://download.documentfoundation.org/libreoffice/stable/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast "https://download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice"
   homepage "https://www.libreoffice.org/"

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,9 +1,10 @@
 cask "libreoffice" do
-  version "6.4.5"
-  sha256 "8f8561085a93186ddb5d7d7b5f990e9effbb3305b1197768960bf6c688bef678"
+  version "7.0.0"
+  sha256 "74700ce918278b78464a4cd0e16d929e4af7b0447c42b400f61a2555818584e9"
 
+  version_full = "7.0.0.3"
   # documentfoundation.org/ was verified as official when first introduced to the cask
-  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
+  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version_full}_MacOS_x86-64.dmg"
   appcast "https://download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice"
   homepage "https://www.libreoffice.org/"

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -4,7 +4,8 @@ cask "libreoffice" do
 
   # documentfoundation.org/ was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/stable/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
-  appcast "https://download.documentfoundation.org/libreoffice/stable/"
+  appcast "https://download.documentfoundation.org/libreoffice/stable/",
+          must_contain: version.major_minor_patch
   name "LibreOffice"
   homepage "https://www.libreoffice.org/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).