### PR TITLE
Update copyclip from 2.9.98 to 2.9.98.3

### DIFF
--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -1,5 +1,5 @@
 cask "copyclip" do
-  version "2.9.98"
+  version "2.9.98.3"
   sha256 "907948736d8872ac831cd92832553e0d4a46fb4f74e9e1f14a3f4fcfbbd2bb21"
 
   # rink.hockeyapp.net/api/2/apps/ffb436060eb379c0cb23097402e92379 was verified as official when first introduced to the cask


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).