### PR TITLE
Add zap stanza to gloomhaven-helper

### DIFF
--- a/Casks/gloomhaven-helper.rb
+++ b/Casks/gloomhaven-helper.rb
@@ -19,7 +19,10 @@ cask "gloomhaven-helper" do
     EOS
   end
 
-  zap trash: "~/.ghh"
+  zap trash: [
+    "~/.ghh",
+    "~/.prefs/ghh",
+  ]
 
   caveats do
     depends_on_java "8+"

--- a/Casks/gloomhaven-helper.rb
+++ b/Casks/gloomhaven-helper.rb
@@ -19,6 +19,8 @@ cask "gloomhaven-helper" do
     EOS
   end
 
+  zap trash: "~/.ghh"
+
   caveats do
     depends_on_java "8+"
   end


### PR DESCRIPTION
Running Gloomhaven Helper creates a folder `~/.ghh` in which it stores the current state, settings and log files. It also adds a file `~/.prefs/ghh`. Adding this zap stanza enables users to easily remove that.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).