### PR TITLE
Update alt-tab from 4.12.2 to 4.13.0

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask "alt-tab" do
-  version "4.12.2"
-  sha256 "70d205c92c42978d6cc505cf25a5789685d8ff11e469c2bbb7bde741e6856fca"
+  version "4.13.0"
+  sha256 "e32462ec590d315006d01b6c3d8e844feb6ed515fd48a84a33ff86fad2b91928"
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast "https://github.com/lwouis/alt-tab-macos/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).