### PR TITLE
libreoffice-language-pack 7.0.0

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,493 +1,493 @@
 cask "libreoffice-language-pack" do
-  version "6.4.5"
+  version "7.0.0"
 
   language "af" do
-    sha256 "e5c59d35e577cbb49ae9408d4de67ef99f7c27d946955896cde7b2eb8bfb4e4d"
+    sha256 "406aa72fc4131ff66965233f3e0119ccaf2fbe49eae67274334fbf9924f61af2"
     "af"
   end
 
   language "am" do
-    sha256 "037a2a7a356cb5eddedbe5bbd48b7b1fa2178bf8462e0c621347dd69ccc62ae8"
+    sha256 "1b7383cc7890b72d4ffe6c76dd73b656e5368b4c9b10aa527c3dfab29e00d1bb"
     "am"
   end
 
   language "ar" do
-    sha256 "4653485f08bea0e7c8a3c663643e57ac87501d58650241a1cd0b33f017258792"
+    sha256 "7c8045c9fa95a4c38cd38ac55586c6d74517ba1d661c898dd65b05017d932666"
     "ar"
   end
 
   language "as" do
-    sha256 "db35f789dc64a4c543f1d35263ff2b6ec1b7afdc3841e00d29c2cf2f5092886c"
+    sha256 "2dc439f76330c7bdd00f83272ed40ef0e1052fa2ce798806bc307d975ca8112f"
     "as"
   end
 
   language "be" do
-    sha256 "33c0d958f16832d44502c15929475647a9b2a86b5c49aad7ed0da55b35ab2812"
+    sha256 "33813e0178b40c093c18d2d875bf4f3da9c3bda05bd13641090fd0c8e05d405c"
     "be"
   end
 
   language "bg" do
-    sha256 "cd32dce8a36d59246928b03911cc086e508495a7e971ed6b27090db1e59e31ad"
+    sha256 "ac78e90c3eaef1419c8de62f8aca8574404e7bc92e8bfe221498d6401322eeeb"
     "bg"
   end
 
   language "bn-IN" do
-    sha256 "5e2d3e552122d0671d40ab22615a2a9e702737425b23f05604ef95b490b6e050"
+    sha256 "84786eff0910a225eba43ad124983938f07c7b939b2fb3222fb7265fe88fc440"
     "bn-IN"
   end
 
   language "bn" do
-    sha256 "14b05c7c1b4ff5a971b730b0686e96d26230edbeb6c3708c63d8696e4b47a2c9"
+    sha256 "d8a2c56166c6774c898832245b3ed6a773ef940d4afffcc9ac4a72badcfc0c7d"
     "bn"
   end
 
   language "bo" do
-    sha256 "d474e8722c31766797535c308a141b7a0ca4bcf47938da55dac891d7a7e9b9ca"
+    sha256 "0059b9608df86d187eba8fca9cb882f8f2692e9d47574ee34e364675890e11ce"
     "bo"
   end
 
   language "br" do
-    sha256 "9301f7f73733c14d7bde2d73361dd3d759317cffb9b697cecac30383535db33a"
+    sha256 "e234d7b7e1acc3d1c7b9e5b833bc25e7c8cd1d65636dee503bfc08462c417454"
     "br"
   end
 
   language "bs" do
-    sha256 "d104301be0a1877d6bd6a9c5f8bd12a1a9b55180a8c41ded81b2a41177f3f954"
+    sha256 "1e2eed16faa2cf4cacbbfaf2de4b43e5ab1df1e89a17748b21ba88d96f17a460"
     "bs"
   end
 
   language "ca" do
-    sha256 "4af22f7d1119d9b3930ab680eb277da803a4e5d0622573bfcf586fae331a954e"
+    sha256 "61a6c8bef1c48e803c3704f85b78f24ac1f4d8181ad69f7a099b831f30c020e5"
     "ca"
   end
 
   language "cs" do
-    sha256 "137b90a20a7b96a7259fa7366e9a43ca27bc57427b16e7d02b872a6b3699a687"
+    sha256 "6956c6f74a175ecb742220004f1e8fbdfff22e56aa411b9d1b7fc08036e475f0"
     "cs"
   end
 
   language "cy" do
-    sha256 "046d587b7b2bb434ff4d8a71d973294a28e2f03118e82dea231efeb794bd27ab"
+    sha256 "ade3f0ce090dcbcb34c060b8226dd640de9726a463288c13932189488a7f5f6c"
     "cy"
   end
 
   language "da" do
-    sha256 "53648a30f5c991ddd684ebbfc5fb286b547322e20ab43ec5b7a5b5c31ab4ca1b"
+    sha256 "b2cd366d7b08fb166bf6ec14c5aa63d10d15c971d7e12244dc1fbfec174d81c1"
     "da"
   end
 
   language "de" do
-    sha256 "c4c19e163fb44b18517cf82c9ed3c7e368372a4aca4fa17537ad1520e478c885"
+    sha256 "200bf89260428856312d309dff4fce5c79534716dc3605fe73b1f61ab032819d"
     "de"
   end
 
   language "dz" do
-    sha256 "945aa5dc096e72d1f99b21e138d0d23f446f390c7b28dd2aebf8b2cde325f78f"
+    sha256 "c4f81af24249431bf062a1e83d2d4718c0f09cd2af8b7f37d52277ffcad29d90"
     "dz"
   end
 
   language "el" do
-    sha256 "f1a2e47c9ba72000bbd511f97296c575eff7ed20c45750fa24481b367583f789"
+    sha256 "02e765c8ddf4723300f222a5531d11a9b43b6ebc7e0f7a86510615856e8171d4"
     "el"
   end
 
   language "en-GB", default: true do
-    sha256 "9a1ddeba04b8a2a87ca94e1566edf4427466fcb3b3024d8ed9e22773e050a094"
+    sha256 "5fa2c8f625e3cf8faa9cb7e05139aea88a269e56f6abef849b468b09d969c783"
     "en-GB"
   end
 
   language "en-ZA" do
-    sha256 "4be8c7c30d17c52e8061fb228a11e0fcb6291eca48bf11db266ab16ccbbca9d0"
+    sha256 "55401c558068c980bd5147e2cd30856f88d543e3a7a5cf6a0f8a1152ed9f8306"
     "en-ZA"
   end
 
   language "eo" do
-    sha256 "cfff3bd921ef52205d82b726b6c36d8e1685d918a017960a83c61770b6a7c808"
+    sha256 "67ac6a233a7bb9424bbfa94aca34437f1ee3972781592dd920ec671b0746a132"
     "eo"
   end
 
   language "es" do
-    sha256 "ebc515f4861139596331e5ddb5fd6cdc4fb8286f45d59147ea98cb41e383390b"
+    sha256 "edd96a217c7593bbb3ef0e5f5d1b090fdfd7020668a2a0b25e766685af499d14"
     "es"
   end
 
   language "et" do
-    sha256 "d3643761e07a7baefbf986626dc3480c95cd6a352c1f8459f9d9fd5d8b2b95d6"
+    sha256 "216c3b91ed7b4235c893136011604252fb6f5ddb319bb22999efdc16c2c1ac86"
     "et"
   end
 
   language "eu" do
-    sha256 "829dcfbb4b40b18f49405a06737776be7b9a5920b066292154be8619e7b5cf84"
+    sha256 "7cd06e539fb6ddc47578072c1f4b35c58e40bfcd12fcd80cc835b4f39209e193"
     "eu"
   end
 
   language "fa" do
-    sha256 "0bd41d28e37eed56726e292d0d32b801569255d2432dc0c082174f2f03c74850"
+    sha256 "69849780eeafac03d1a9b01eb41e3fe6123e7508cea1279ddd74467864355c32"
     "fa"
   end
 
   language "fi" do
-    sha256 "9540a930a6576657bcbed0fa39dd0033dc72852c3b867a8a2552a77b952ca549"
+    sha256 "0a7c5ed1d0a28e4d333ee524aa4e3a7219fd516c4ffc0ddc0781075a998ce577"
     "fi"
   end
 
   language "fr" do
-    sha256 "4135c75d7b2708088f616b89439924671e320c9ef1341f59a4f1e53d2bd0b651"
+    sha256 "43b303e46b71de668dbac5dd3942b44068759b067ed8abd2484e16966adb5bd8"
     "fr"
   end
 
   language "fy" do
-    sha256 "d52aac46d63620a03ad7b7c4f77a4d3981ee78f5346501996ba0d68d24e689bf"
+    sha256 "e79d6e5fa32914381b4e0bbfa88186fdc9d48a569b45e3ac5ee5196a076943ab"
     "fy"
   end
 
   language "ga" do
-    sha256 "8784193fbc604bdc07894d9723fc6082442462a7226da43c454ae87e141fb621"
+    sha256 "e33e024751a2f023314c84badad98f863f7d969c8d834c6a5a6dff6af01bd915"
     "ga"
   end
 
   language "gd" do
-    sha256 "7b970bf89cd3d896bdbb06516bf49398d6ef273d8e390866abd8548c9044f44e"
+    sha256 "1034dd3648ac5ae799d0101e755d19459b40c01223ef849ef6c210d1e01a0b6e"
     "gd"
   end
 
   language "gl" do
-    sha256 "6ffa31118dd8b50f5d027ccc97e4d4a11f16b12441c29d9c506fb503e8d8f688"
+    sha256 "7e4367da014d1491df2c914549165b00983bc22b65582795e2676ccb806182d8"
     "gl"
   end
 
   language "gu" do
-    sha256 "a7f190ab566b8a49b61ccaa4e1893445479593ab342426bf4b629e29d20e3709"
+    sha256 "60868e1d182e15d302c9b62e2459a052a6445d53e7146e8caef45364320937e9"
     "gu"
   end
 
   language "he" do
-    sha256 "851a0403e48b58b90e2044c798281bf670b228e842b0db5bd34d60924520aee1"
+    sha256 "ce36ab1654b809ae36ce04ec06f59cadb4a723f8a2f6ced081d5353b7ba08785"
     "he"
   end
 
   language "hi" do
-    sha256 "055cc88a707f1fc5fdf8da40843ecc619d7a19db4a3db7dee5b3d4bedcfd3d7e"
+    sha256 "5e1b1bbf1936591487b49bde15f275213211a65e2b0c504376cc938f686eacd3"
     "hi"
   end
 
   language "hr" do
-    sha256 "960ff8331c370ebc1e43d3445960743f9e7c1659ad2ac5e1cd92c8bd028b0168"
+    sha256 "9e4c2a68ff8d1375f5edbb504d340e50e148c147b9f2caf1745faa24ea82d4b4"
     "hr"
   end
 
   language "hu" do
-    sha256 "3ae353ba26bf1c94562217443fb39f280e3e69eeca228c1859bd856555a1d917"
+    sha256 "0fb3676db1db8c32597b2493fa3d76309aaec0d4d1c18cce32ff8a1dcbb1693a"
     "hu"
   end
 
   language "id" do
-    sha256 "87dc1385d05993e98bb642140f4f531d202906a6df2e9ee9005622376f69b1e8"
+    sha256 "2409f730ab17bbd70be2abb1e654199bad1abee4d8c4fd67161ce5aabd0ecb87"
     "id"
   end
 
   language "is" do
-    sha256 "4da9560d8044c1ab0d48bb8a59c724c00adf29da2e05bad6f8b814cf2db180e9"
+    sha256 "245476eba31728b1cd7cd51dc963ce6ec04215a0f8cc217d2efb157d5864d7bb"
     "is"
   end
 
   language "it" do
-    sha256 "3987dee84499321949bb0329b409e8221baaacd98f1e9c52197efb1af6ece7fa"
+    sha256 "071cbc5eb19993ec957f2f3f57c332738fdcb6387488b93087b60186d463cbf0"
     "it"
   end
 
   language "ja" do
-    sha256 "527f905f503e156c18cbea7b66c89243b2ce5d90ed170b4cee6b2b39a2e31f81"
+    sha256 "4ae91ed65064006a6f81781425c12d0d9feefaa74fbe2e84710e045bb78b0e18"
     "ja"
   end
 
   language "ka" do
-    sha256 "fedd2471e4b94f0a74d92d6bc83dc6588702fd0bbfbe4b2e9ef12cd92b48af8b"
+    sha256 "f39f0633acbb1b1e4d6507c92589a7e7c7f11b723623b982c73e86160aae63d2"
     "ka"
   end
 
   language "kk" do
-    sha256 "3915efecfa54f5969192479e28fb177b088b1a8dc8d8e17e572fe69da648f525"
+    sha256 "28223c831964feffb5fdd57cd72f14b0399286e2bcd15fefbcd444e6e1d0009f"
     "kk"
   end
 
   language "km" do
-    sha256 "a6e87456f36899b4c4cf0345d128a7e0ae55e888cbd88070c3e01c0e85cbcaba"
+    sha256 "0ad61a9dd80fdfafb0094f7fe4c1e841e9fdb96cef66beac8a419e89f87952b2"
     "km"
   end
 
   language "kn" do
-    sha256 "e74467cb647610e45963c7a0849e4c573bd394e527cdbf8cbbfde025d43cf2b3"
+    sha256 "7267a7cdc51d134318488e05cbd76ed9013a286e6f52af996aa000cb3cd02fd9"
     "kn"
   end
 
   language "ko" do
-    sha256 "73e64c06b99adb44a4c70450edad0457462cc34f247389bb877c1a41186a586d"
+    sha256 "7a0e0ccb33226c2372e861dd1291e6f3f58b29e4f4e89a93d1a12cb79ee8289e"
     "ko"
   end
 
   language "ks" do
-    sha256 "b3dd4fee9f6b9516f7f06e7c38dba67824459b605226852e349f06924c089a00"
+    sha256 "159016d3cad86a777db654b80fd988bb70d887a2a9f8e1b42ff37fa436cbc39d"
     "ks"
   end
 
   language "lb" do
-    sha256 "9589f577af616957628b4f6f0d2f3530ffb8d531bcd4e191e22d17786e12f94b"
+    sha256 "e857a9ff77ca0f620482a4739d84029509c66bc28e8dfbcd196137ecea0d2974"
     "lb"
   end
 
   language "lo" do
-    sha256 "b88065836c02d21ae28fe30a5fffd96cbcf27a7d867df088073bf2a28ea92f87"
+    sha256 "f7281d3a7800bb6182b259c90ff90ad91123b5e0a0a38ef775ffd71777f5804a"
     "lo"
   end
 
   language "lt" do
-    sha256 "1e2838b4ab26394294b67cf89414719b64ee453c6da6324c16f04f421d286b08"
+    sha256 "9c83a155e22d6c44a02431ece2be1ff213e7fd3dd0729c1002fada9ea2dc6d2b"
     "lt"
   end
 
   language "lv" do
-    sha256 "e34969c3d82a31bce52de2e75396edc6b4137e2b6299c4a2c578b418d6fb1617"
+    sha256 "a3da6960ae12584c46b2f59d07f7327ee58f528b8812b20db1cf18188953d338"
     "lv"
   end
 
   language "mk" do
-    sha256 "165af78dda096b8b7789c083ca08d83ddd7c30c4423a5a977e512aa6cbd0c935"
+    sha256 "a4e733c753229280796a113598acc259d18cded1a741bcbc7d67c75e6f3bd861"
     "mk"
   end
 
   language "ml" do
-    sha256 "3670509d4325f5f29f7c215162b83e5269ee876adab424c2de2303772260fa66"
+    sha256 "8723cba284282301612b46d211949a465b0f00960c0b746bb5ff65503d335e04"
     "ml"
   end
 
   language "mn" do
-    sha256 "7b7378d6a9c739ed09abd1b164e5deebac5f2b3ef6eb5ff8114a2e64ee8b6a66"
+    sha256 "653d7be68597b68109f987e6c8e0183115d76670cf075d9c61ee95671adaca71"
     "mn"
   end
 
   language "mr" do
-    sha256 "33b743973a5207e9b901a1d073445044ae4ab8602dd45cc42bbde4f4874eeeaa"
+    sha256 "3d28cd5db1be5421e92c62f6949f922e6cc93ac31e9617c6b48818e4a566a786"
     "mr"
   end
 
   language "my" do
-    sha256 "e9e8ea44287631b81b034645bda6b8eee76721d1d875cf853fced67c7f64a902"
+    sha256 "5b46f5bf4c9ff546523679284e64282f116978d97e8934a3c9b9c59291f246c2"
     "my"
   end
 
   language "nb" do
-    sha256 "d3f628dd4f8f3cc392c3fc4146d2b17e2e9e2d459c83e3646d90191e60b68350"
+    sha256 "7d222d266e0a7809d287703ebea776921032db4b250f0d2f4f1e948a4b1641bd"
     "nb"
   end
 
   language "ne" do
-    sha256 "b1dc2b1d2a2870d5d8c9bb21e63f3e8bd914df246af83c40758018daf104395b"
+    sha256 "670fea6658eca5bda401cd6d089cc3b76eaad178328fc30e2f9a973628dfd36c"
     "ne"
   end
 
   language "nl" do
-    sha256 "34ac39976c52ea41bd7275f37e6c78775b72f8de6185c7f4e68001166d4e8e16"
+    sha256 "6732c2504f4206b3c6edd214a172efdcce4d517f31fed3514047b1445b821109"
     "nl"
   end
 
   language "nn" do
-    sha256 "33921e397aafa84d98e16bafb9a927fd2948e4f361aa39b5c6944504d1b053ea"
+    sha256 "427bcfae67f75d06bfd57320e56e7c3d33899b80c3b71aa40eabc40615fcf3c0"
     "nn"
   end
 
   language "nr" do
-    sha256 "d53825e360fb8bb56a4ea1a1d34af9a3227d95bc58d13884dc0f44178e551431"
+    sha256 "8b905519c33fcd26e31d32dfa927f968db48616be828588c51d939d40da4b944"
     "nr"
   end
 
   language "oc" do
-    sha256 "1862592eb14cac59ae4a76cfe79d8166a2bb834503f755f521d15d489c2aa541"
+    sha256 "a38fa35a1ab21bd200ac8e6f5f6baffbcaad1ec0c52600c400ec11001c54877e"
     "oc"
   end
 
   language "om" do
-    sha256 "df6300b10777776db05f93a4b0e18a3df92d213913aa0513ad71c3a630dcfc9d"
+    sha256 "7157f3bc020a83df2c895621fd3abaedb10a69d9f236a014f780c022d7754fdb"
     "om"
   end
 
   language "or" do
-    sha256 "92e0c4b9fe5b817567433545769e1b9bc032cebd5329a3520022d0b03103de48"
+    sha256 "40eb8b4bad0657c434625cfb757ed77c14eb85bfad4146351b9e4482cffa50c9"
     "or"
   end
 
   language "pa-IN" do
-    sha256 "458de8ee63110a7e942c2d265713ab2aa6294537cd2b81bf47d36ac8a105977f"
+    sha256 "e6da8f55b2534efb6218ff330fedd248477afac1f899c71892d90467309fcc86"
     "pa-IN"
   end
 
   language "pl" do
-    sha256 "61f3370cd99b0df59450a43657eae686f4c5ba574ef5fc04b43f577146edf314"
+    sha256 "0d089e5a0dd41817f7f5ea73a8d009663fa7a74bf32eee66f48a366911ef080e"
     "pl"
   end
 
   language "pt-BR" do
-    sha256 "893a6c380fe110770d0cc8b8b29bbadff39e62d23f495b553d34187f787443b2"
+    sha256 "236a964f655a6d3badff19eade39bc0280720d07cf3426cf4b153cc3904eaf98"
     "pt-BR"
   end
 
   language "pt" do
-    sha256 "73af110c37dc5e275fd355a3cebcb1ee549648e39784a060e9072581541a1e56"
+    sha256 "e8d380b81b37fa36d6c5da47e64f8627c857e12f7c20973e5f52e1070ff6fde0"
     "pt"
   end
 
   language "ro" do
-    sha256 "f7726aeff3f31094ecc60d45696e7a9ea1d0339f046b67b723634fc463ef0723"
+    sha256 "8d826c647f7c6bd34f0f1f9e94b2a57f7346e5814015570277c320cbd99c292d"
     "ro"
   end
 
   language "ru" do
-    sha256 "b6d935e89b86797df366b18ca71b63e797bae3fd89d48a2d10a5b68c62bb7573"
+    sha256 "1c68c99166f4fe95bac1ab54ca63b44154bd1ce2314c772a42791ec9c57dee6e"
     "ru"
   end
 
   language "rw" do
-    sha256 "50451075a924b69a8fdd197cdc8c1be3d8984d1d17e40241f04db2c6b6eb7dc1"
+    sha256 "fd1d86079e9eb65fd72768a46e9021f5002eca4fb264540ebd9424e785b0cf34"
     "rw"
   end
 
   language "sa-IN" do
-    sha256 "826b188af5d1f90c0b7e9cfe79853dead0eef66f01987ac0a33f9cec0fb2a905"
+    sha256 "8bf1e28272230e1d1f8da3b155a09c57afe27e4efeae661df46a4f99f663b5a0"
     "sa-IN"
   end
 
   language "sd" do
-    sha256 "dacaeb7d7c85405ccabbf8da8cf24141074a49cd2781e09c2e07e93ae8cf5d19"
+    sha256 "355d995dd59969499a73e0bf9f50145c192011de731275b22ff7f27c32105de8"
     "sd"
   end
 
   language "si" do
-    sha256 "fcb620775bf8ac2474fdfe4c26273c7064445fee1d496b522777c4e5d9ea1bc8"
+    sha256 "1dc5d5c4266382246eb460317128b2dc9602bfc4411a5bb714ec93e4c518f84f"
     "si"
   end
 
   language "sk" do
-    sha256 "9644cad80aba5d6811dbff2ff94f649578e79e03ac53fcc0952d30cae425de67"
+    sha256 "4fbe0a05ca2ed91d2af78da37113b661a609fde3f018da819c175260841409df"
     "sk"
   end
 
   language "sl" do
-    sha256 "ac0eb4cb9feaa96f12bfaf18303f367865e9b06bc666546bd5d1641c7d8b57b0"
+    sha256 "8fb88fc7e565704fe649b628727bf171a800488f43b35924623eb929ad2364ad"
     "sl"
   end
 
   language "sq" do
-    sha256 "105ada43ce637cca2cbde4e8a241086f9acadffa8fcf44bbd4a025a1c34879a2"
+    sha256 "43c753cf61b56908a38bde44316d4ffba4ed14193bef5cca545342d419d1ddde"
     "sq"
   end
 
   language "sr" do
-    sha256 "6b75aaf46be6fdc053e417c15276e43a1c90c8db41071ede46daebf1a510b0d6"
+    sha256 "176c9341af0db3e97029f50b7eeffb2524ee4f82844622bbfd145c579d1567d8"
     "sr"
   end
 
   language "ss" do
-    sha256 "5f1eb79e62ce17110915158e9d2d743ec4bc7dafac99105c8665c741a97ac191"
+    sha256 "0793f2b5b77d0001f4cbfba6b6a3c6182174d85f6be44c01f2f34eca2059a69a"
     "ss"
   end
 
   language "st" do
-    sha256 "baea20cc46f51df9402226a433c707f753554d468a9239d9caea718e026d4d0a"
+    sha256 "375c7265361fc650bb3f8382e4116fc82b0b2715f831a1eead0d815ce62a3b85"
     "st"
   end
 
   language "sv" do
-    sha256 "c7828a6627db579b6b0429368e69171c11c44bd610cea65b6057c6252c42fa45"
+    sha256 "a6023ac360ce07c4d507f4d0c9f5a6f4f8878522715ee26493bdfb7a4bf7b1b7"
     "sv"
   end
 
   language "sw-TZ" do
-    sha256 "3c844d0b23745a5eb76af4cdf10a52e6f7e4b14b04af0970897384c8211bd5d9"
+    sha256 "bfe39c9e4764da0370be5af6a2423d31f2d79e3920a95146eba245954423fd8f"
     "sw-TZ"
   end
 
   language "ta" do
-    sha256 "7d0c2c0ded244fcc02fcfef8c8bd53612fbc49ed39902dd355c1f89793d75eaf"
+    sha256 "7018f3d9bc82b51f906ea140a78be2d691921ebd4376a4b65df8b4c5e286ad0d"
     "ta"
   end
 
   language "te" do
-    sha256 "d11e5957db7c9f7d4c6468d944ce48a8e1b1492b4cb6589dd0d38417269ab555"
+    sha256 "19463276cadd4911ca788929d03cd5875b24132a7b50e6145766800c93cde885"
     "te"
   end
 
   language "tg" do
-    sha256 "fb4a94fd46d7ac453e26dff8820e636a61ed2cf5486b76e84f6f59cf327927ca"
+    sha256 "21519cc4bb95ba5e749688c55f2e0f5bea17a0504f6c01dfb61a78d8b1be3b8e"
     "tg"
   end
 
   language "th" do
-    sha256 "14d23f26d7ffc21871f6837e0cd6c3578f89cdaf363ef75d2706a67e90c1bd03"
+    sha256 "bef7ee8b215901f2188828f5ad177571a12dae1a045cd4dc2073cf2ddd978ae0"
     "th"
   end
 
   language "tn" do
-    sha256 "248681843ce3bc05f8c1e6698179ce4139070e17d952e62c92c0461d4d51d4a2"
+    sha256 "ed07d61d3cbc429e9de35c7b067c790f9ba4795c7698b7ff10111cc4f1e00991"
     "tn"
   end
 
   language "tr" do
-    sha256 "270bbe3f3826ec289aaf42d5c19617c78820cdfc4abdb771c0181ff39a650c6d"
+    sha256 "2e9b8a33b89ce6fec866fd43fdf5d791148e6636df4461ba7e7683ff6bd1745d"
     "tr"
   end
 
   language "ts" do
-    sha256 "3112ad9d44ad5aa6299e59a18ced4f45f3e31316f417947d4cf9dcb3eb0d4ec9"
+    sha256 "ee4fad0d98c6f4430013f5a288ec4ab3116d02d1ad58e2f740abf769eab37bf3"
     "ts"
   end
 
   language "tt" do
-    sha256 "752a8c7c63a557328d257b101670489f8a7c84d81700c2644be63be68b6db90a"
+    sha256 "e93d4d761fbdd58ca93f31ca62e68eede4a0f641f1628c6956a3e5ddcf7f5387"
     "tt"
   end
 
   language "ug" do
-    sha256 "bb996ea8cf6203407424b278933c41b41ec535883d4271ca844f4794ddff1fed"
+    sha256 "78b5a121056102434da9b65a44a8d2b059f53704550739ceb3abd75a5fa641d0"
     "ug"
   end
 
   language "uk" do
-    sha256 "868f86db565d81a6b02f7e29bda59c12a464c1407a9386ed05ed29affad12719"
+    sha256 "5958f53259672289678c00f787ecc23d312f26e8d170af8f438b830781bbea6b"
     "uk"
   end
 
   language "uz" do
-    sha256 "4912f94df54c584320f57974c9b2c3ba776b699af49ee100e4864098942c9c09"
+    sha256 "ecf9b27da369a8ccfdc49195e9ac79774f10010e5e7ecd14d8d6e4543202b3da"
     "uz"
   end
 
   language "ve" do
-    sha256 "01152d0de5de7c425a9236ba01260e4b0aa6c1a997916350b0182c56e45cb776"
+    sha256 "d146872a99c2d0465ee360ca1d8f7708f76f2083d47f20823094bcfb4cb96d4c"
     "ve"
   end
 
   language "vi" do
-    sha256 "ed51aea48f5be8ecefccf6b67cfd8274dbe614b122336834ab65edd9e13111cb"
+    sha256 "786a2ee62b2e5ba903aa6b88395073152c8f2e779abe29be28241bea81c8e556"
     "vi"
   end
 
   language "xh" do
-    sha256 "ed14a77b2dcf35a993e0bccc29044f894eefbbfe6941086a8690ce0bddff5f29"
+    sha256 "14dee77cb800d1a65a38719e62f05227527d5ee7c89972fe5c8c8e9341a012ae"
     "xh"
   end
 
   language "zh-CN" do
-    sha256 "1d1f8676b03b685748779c30db52f531db48f67a69509110604d1081f9224fdc"
+    sha256 "fe3246f610af478e94d1448c85527a93aa09c41cfeee9415bdb3c0bc74555102"
     "zh-CN"
   end
 
   language "zh-TW" do
-    sha256 "5171a374a40a0c894137d214c3e261efb1c7bad75fb41707c23ce3a497cd58f2"
+    sha256 "5cd6d07e5bed5c88ab347bc14dda62945647c4d9b4fcdcd2f0df246efefbb199"
     "zh-TW"
   end
 
   language "zu" do
-    sha256 "4223ae6543df6ff228d63df24d312ae8e0f1f2f72fb7c0f07dd904f129dcefde"
+    sha256 "9aaffd68e36e60ad6cae009849e25d9f4d47f9ca784b397eb0fe512120fdca79"
     "zu"
   end
 
@@ -498,6 +498,7 @@ cask "libreoffice-language-pack" do
   homepage "https://www.libreoffice.org/"
 
   depends_on cask: "libreoffice"
+  depends_on macos: ">= :sierra"
 
   installer manual: "LibreOffice Language Pack.app"
 


### PR DESCRIPTION
Updated `version` and added `depends_on macos: ">= :sierra"` as per the [release notes](https://wiki.documentfoundation.org/ReleaseNotes/7.0#Mac).

```
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/developer/bin/update_multilangual_casks /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/libreoffice-language-pack.rb 7.0.0
```