### PR TITLE
Update musescore from 3.4.2 to 3.5.0

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,9 +1,15 @@
 cask "musescore" do
-  version "3.4.2"
-  sha256 "59f7ee60d77b63a67a89f998f19ae3434959b6ed2eeb20c9e90ff56f5659f824"
+  version "3.5.0"
+  shortversion = if version.patch.to_s == "0"
+    version.major_minor.to_s
+  else
+    version
+  end
+
+  sha256 "42f67d022604c6da5a31850ffeb0b2adde0bcc8f675aea6acfdc791eefa73047"
 
   # github.com/musescore/MuseScore/ was verified as official when first introduced to the cask
-  url "https://github.com/musescore/MuseScore/releases/download/v#{version}/MuseScore-#{version}.dmg"
+  url "https://github.com/musescore/MuseScore/releases/download/v#{shortversion}/MuseScore-#{version}.dmg"
   appcast "https://github.com/musescore/MuseScore/releases.atom"
   name "MuseScore"
   homepage "https://musescore.org/"

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -24,7 +24,7 @@ cask "musescore" do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{appdir}/MuseScore #{version.major}.app/Contents/MacOS/mscore' "$@"
+      exec '#{appdir}/MuseScore #{version.major_minor}.app/Contents/MacOS/mscore' "$@"
     EOS
   end
 end

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -16,7 +16,7 @@ cask "musescore" do
 
   depends_on macos: ">= :yosemite"
 
-  app "MuseScore #{version.major}.app"
+  app "MuseScore #{version.major_minor}.app"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/mscore.wrapper.sh"
   binary shimscript, target: "mscore"

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,15 +1,9 @@
 cask "musescore" do
   version "3.5.0"
-  shortversion = if version.patch.to_s == "0"
-    version.major_minor.to_s
-  else
-    version
-  end
-
   sha256 "42f67d022604c6da5a31850ffeb0b2adde0bcc8f675aea6acfdc791eefa73047"
 
   # github.com/musescore/MuseScore/ was verified as official when first introduced to the cask
-  url "https://github.com/musescore/MuseScore/releases/download/v#{shortversion}/MuseScore-#{version}.dmg"
+  url "https://github.com/musescore/MuseScore/releases/download/v#{version.chomp(".0")}/MuseScore-#{version}.dmg"
   appcast "https://github.com/musescore/MuseScore/releases.atom"
   name "MuseScore"
   homepage "https://musescore.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).