### PR TITLE
Update mochi from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask "mochi" do
-  version "1.6.1"
-  sha256 "300f81f5dd367575408e9639326a3f37801bbba5017eb5f63ad4da8cee52d8fb"
+  version "1.6.2"
+  sha256 "9b932d4eb38e1bd8d934eafea52b91972c211a9d3e11e476934dca1fda3f97ee"
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   appcast "https://mochi.cards/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.