### PR TITLE
Update remote-desktop-manager-free from 2020.2.2.0 to 2020.2.3.0

### DIFF
--- a/Casks/remote-desktop-manager-free.rb
+++ b/Casks/remote-desktop-manager-free.rb
@@ -1,6 +1,6 @@
 cask "remote-desktop-manager-free" do
-  version "2020.2.2.0"
-  sha256 "d586a98e635f7548da2b021b641487791359f398080522d5a43296072730f922"
+  version "2020.2.3.0"
+  sha256 "6313b94d6de5f9c2b9a3ddf925b692b4ac37a6263281882de6254d4c89b2552b"
 
   # devolutions.net/ was verified as official when first introduced to the cask
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).