### PR TITLE
zoomus: update uninstall and zap

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -13,27 +13,12 @@ cask "zoomus" do
 
   pkg "Zoom.pkg"
 
-  postflight do
-    set_ownership "~/Library/Application Support/zoom.us"
-  end
-
-  uninstall quit:       "us.zoom.ZoomOpener",
-            signal:     ["KILL", "us.zoom.xos"],
-            pkgutil:    "us.zoom.pkg.videmeeting",
-            login_item: "ZoomOpener",
-            script:     {
-              executable:   "/usr/bin/defaults",
-              args:         ["delete", "us.zoom.xos"],
-              must_succeed: false,
-              sudo:         true,
-            },
-            delete:     [
+  uninstall signal:  ["KILL", "us.zoom.xos"],
+            pkgutil: "us.zoom.pkg.videmeeting",
+            delete:  [
               "/Applications/zoom.us.app",
-              "/Library/Audio/Plug-Ins/HAL/ZoomAudioDevice.driver",
               "/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
               "/Library/Logs/DiagnosticReports/zoom.us*",
-              "~/.zoomus/ZoomOpener.app",
-              "~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
             ]
 
   zap trash: [
@@ -42,9 +27,11 @@ cask "zoomus" do
     "~/Documents/Zoom",
     "~/Library/Application Support/CloudDocs/session/containers/iCloud.us.zoom.videomeetings",
     "~/Library/Application Support/CloudDocs/session/containers/iCloud.us.zoom.videomeetings.plist",
+    "~/Library/Application Support/CrashReporter/zoom.us*",
     "~/Library/Application Support/zoom.us",
     "~/Library/Caches/us.zoom.xos",
     "~/Library/Cookies/us.zoom.xos.binarycookies",
+    "~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
     "~/Library/Logs/zoom.us",
     "~/Library/Logs/zoominstall.log",
     "~/Library/Logs/ZoomPhone",


### PR DESCRIPTION
I recently ran `brew upgrade zoomus --verbose --debug` due to some changes in how `brew upgrade` works (see [here](https://github.com/Homebrew/homebrew-cask/issues/87045) and [here](https://github.com/Homebrew/brew/pull/8227), for example), and noticed some things in the `uninstall` stanza that were no longer required. 

WIth this in mind and after carefully examining the payloads of `Zoom.pkg` and `ZoomInstallerIT.pkg`, I have updated the `uninstall` and `zap` stanzas for `zoomus.rb`; `zoom-for-it-admins.rb` will be taken care of in a separate PR.

Some explanation:

- `~/Library/Application Support/zoom.us` no longer requires a permission change.

- there is no longer any `ZoomOpener` components.

- `signal: "KILL"` removes the ad-hoc launch job definition `us.zoom.xos` if `zoom.us.app` is running and `pkgutil: "us.zoom.pkg.videmeeting"` removes `us.zoom.xos.plist` as it should, so `defaults "delete"` is no longer required. I have left `~/Library/Preferences/us.zoom.xos.plist` in the `zap` stanza, as it does no harm in remaining there. 

For example, this is the output of `brew upgrade zoomus` that I have been seeing for the last several `zoomus` updates:
```
==> Running uninstall script /usr/bin/defaults
Password:
{DATE} {TIME} defaults[{NUM}:{NUM}] 
Domain (us.zoom.xos) not found.
Defaults have not been changed.
```

- `/Library/Audio/Plug-Ins/HAL/ZoomAudioDevice.driver` is specific to the IT-Admins version.

-  `~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin` is a user-generated file created by user modification of the behaviour of `/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin`, and hence I have moved it to the `zap` stanza.