### PR TITLE
zoom-for-it-admins: update uninstall and zap

### DIFF
--- a/Casks/zoom-for-it-admins.rb
+++ b/Casks/zoom-for-it-admins.rb
@@ -13,38 +13,27 @@ cask "zoom-for-it-admins" do
 
   pkg "ZoomInstallerIT.pkg"
 
-  postflight do
-    set_ownership "~/Library/Application Support/zoom.us"
-  end
-
-  uninstall quit:       "us.zoom.ZoomOpener",
-            signal:     ["KILL", "us.zoom.xos"],
-            pkgutil:    "us.zoom.pkg.videmeeting",
-            login_item: "ZoomOpener",
-            script:     {
-              executable:   "/usr/bin/defaults",
-              args:         ["delete", "us.zoom.xos"],
-              must_succeed: false,
-              sudo:         true,
-            },
-            delete:     [
+  uninstall signal:  ["KILL", "us.zoom.xos"],
+            pkgutil: "us.zoom.pkg.videmeeting",
+            delete:  [
               "/Applications/zoom.us.app",
               "/Library/Audio/Plug-Ins/HAL/ZoomAudioDevice.driver",
               "/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
               "/Library/Logs/DiagnosticReports/zoom.us*",
-              "~/.zoomus/ZoomOpener.app",
-              "~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
             ]
 
   zap trash: [
+    "/Library/Preferences/us.zoom.config.plist",
     "~/.zoomus",
     "~/Desktop/Zoom",
     "~/Documents/Zoom",
     "~/Library/Application Support/CloudDocs/session/containers/iCloud.us.zoom.videomeetings",
     "~/Library/Application Support/CloudDocs/session/containers/iCloud.us.zoom.videomeetings.plist",
+    "~/Library/Application Support/CrashReporter/zoom.us*",
     "~/Library/Application Support/zoom.us",
     "~/Library/Caches/us.zoom.xos",
     "~/Library/Cookies/us.zoom.xos.binarycookies",
+    "~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
     "~/Library/Logs/zoom.us",
     "~/Library/Logs/zoominstall.log",
     "~/Library/Logs/ZoomPhone",


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-cask/pull/87225#issue-464404953

Note that `/Library/Audio/Plug-Ins/HAL/ZoomAudioDevice.driver` and `/Library/Preferences/us.zoom.config.plist` are specific to the IT-Admins version.