### PR TITLE
Update swiftformat-for-xcode from 0.45.3 to 0.45.4

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "swiftformat-for-xcode" do
-  version "0.45.3"
-  sha256 "c2d4ff08fdb5aa4026d4f2839a6f72bf1e5accac3857c7165c85ccf4a36d76c2"
+  version "0.45.4"
+  sha256 "0445a10083f422b812def5f59c03560892ff9744118581a39d7fa96af04d0679"
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   appcast "https://github.com/nicklockwood/SwiftFormat/releases.atom"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.