### PR TITLE
Update musictube from 1.13 to 1.13.1

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,6 +1,6 @@
 cask "musictube" do
-  version "1.13"
-  sha256 "5f6c9a91d90931f47c5002cca11574339b6cfd6f586adb85c045bb2494d47e54"
+  version "1.13.1"
+  sha256 "30eaa0863be443e3f322ee8369aae074fc0195d7f287ce44924ef7ca9d65e841"
 
   url "https://flavio.tordini.org/files/musictube/musictube.dmg"
   appcast "https://flavio.tordini.org/musictube-ws/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).