### PR TITLE
Use explicit timeout in `brew cask ci`.

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -171,7 +171,6 @@ class Check
                    .select { |id| id.match?(/\.\d+\Z/) }
                    .map { |id| id.sub(/\.\d+\Z/, "") }, stanza: stanza)
 
-
     loaded_launchjobs = filter_exceptions(diff[:loaded_launchjobs]
                         .added
                         .reject { |id| id.match?(/\.\d+\Z/) }, stanza: stanza)


### PR DESCRIPTION
This should help to avoid things like https://github.com/Homebrew/homebrew-cask/pull/87166 clogging up CI.