### PR TITLE
Update Multipass to 1.4.0

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask "multipass" do
-  version "1.3.0"
-  sha256 "10334a00061e2fb09c3d134b307b762166811f889d9f477c7ba35acf2e50eb41"
+  version "1.4.0"
+  sha256 "ff34ce741367f77a9fc25f10ccb0a67c0bd4aa62328722a573454dd42fed6132"
 
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast "https://github.com/CanonicalLtd/multipass/releases.atom"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

NB: CI will fail on this due to lacking CPU features, since it's a VM manager.
