### PR TITLE
Update sqlworkbenchj.rb from 124 to 126

### DIFF
--- a/Casks/sqlworkbenchj.rb
+++ b/Casks/sqlworkbenchj.rb
@@ -1,8 +1,8 @@
 cask "sqlworkbenchj" do
-  version "124"
-  sha256 "2173c7f00172bef3fed23e7f57e168a9d156c72c311af032ba469139f80d9fe9"
+  version "126"
+  sha256 "1ae9bfbde5642aab3a5fe0372be92d34293a59edfc74a743b1a4318015be5cb9"
 
-  url "https://www.sql-workbench.eu/Workbench-Build#{version}-Mac.tgz"
+  url "https://www.sql-workbench.eu/Workbench-Build#{version}-with-optional-libs.zip"
   appcast "https://www.sql-workbench.eu/wb_news.xml"
   name "SQL Workbench/J"
   homepage "https://www.sql-workbench.eu/"


### PR DESCRIPTION
there are two different downloads of sqlworkbenchj - not sure which one we prefer - I've added the "… including all optional libraries" package:  https://www.sql-workbench.eu/downloads.html

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
