### PR TITLE
Update flightgear.rb from 2018.3.2 to 2018.3.6

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask "flightgear" do
   version "2018.3.6"
-  sha256 "cfc8667d68f2a08323f1abfa172e6a7bcbf465fa4f00a6576309066332974306"
+  sha256 "43b82f3319cdb2eb09b742a5988faa389a9a25cf0be2f0aa77430c573ca3482a"
 
   # sourceforge.net/project/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/project/flightgear/release-#{version.major_minor}/FlightGear-#{version}.dmg"

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -2,8 +2,8 @@ cask "flightgear" do
   version "2018.3.6"
   sha256 "cfc8667d68f2a08323f1abfa172e6a7bcbf465fa4f00a6576309066332974306"
 
-  # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
+  # sourceforge.net/project/flightgear/ was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/project/flightgear/release-#{version.major_minor}/FlightGear-#{version}.dmg"
   appcast "https://sourceforge.net/projects/flightgear/rss"
   name "FlightGear"
   homepage "https://www.flightgear.org/"

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask "flightgear" do
   version "2018.3.6"
-  sha256 "dc7a40e19f64b80fdf7171be1516fd877dc7934981268ee72dfb974b53849b9a"
+  sha256 "cb3fddf800d6473aea5191f2e579e85a6aa4ff6bd35058f963b327a7612ca26d"
 
   # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,5 +1,5 @@
 cask "flightgear" do
-  version "2018.3.2"
+  version "2018.3.6"
   sha256 "dc7a40e19f64b80fdf7171be1516fd877dc7934981268ee72dfb974b53849b9a"
 
   # sourceforge.net/flightgear/ was verified as official when first introduced to the cask

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask "flightgear" do
   version "2018.3.6"
-  sha256 "cb3fddf800d6473aea5191f2e579e85a6aa4ff6bd35058f963b327a7612ca26d"
+  sha256 "cfc8667d68f2a08323f1abfa172e6a7bcbf465fa4f00a6576309066332974306"
 
   # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -2,8 +2,8 @@ cask "flightgear" do
   version "2018.3.6"
   sha256 "cfc8667d68f2a08323f1abfa172e6a7bcbf465fa4f00a6576309066332974306"
 
-  # sourceforge.net/project/flightgear/ was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/project/flightgear/release-#{version.major_minor}/FlightGear-#{version}.dmg"
+  # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"
   appcast "https://sourceforge.net/projects/flightgear/rss"
   name "FlightGear"
   homepage "https://www.flightgear.org/"

--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask "flightgear" do
   version "2018.3.6"
-  sha256 "43b82f3319cdb2eb09b742a5988faa389a9a25cf0be2f0aa77430c573ca3482a"
+  sha256 "cfc8667d68f2a08323f1abfa172e6a7bcbf465fa4f00a6576309066332974306"
 
   # sourceforge.net/project/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/project/flightgear/release-#{version.major_minor}/FlightGear-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
