### PR TITLE
Update darktable from 3.0.2 to 3.2.1

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,6 +1,6 @@
 cask "darktable" do
-  version "3.0.2"
-  sha256 "b71dab1b4f0ad796055f6d725a82913ad08f609de6ca96d65dbe6ffbeecb6416"
+  version "3.2.1"
+  sha256 "292b8327fdc2bd6346994d52f904e0d89078100c91eec2a7c6982f71f8dd24ca"
 
   # github.com/darktable-org/darktable/ was verified as official when first introduced to the cask
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).