### PR TITLE
Update ableton-live-suite from 10.1.17 to 10.1.18

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-suite" do
-  version "10.1.17"
-  sha256 "988fa3d292b2e3316a90264010228007364ba57305834889f9439066f0d8fb12"
+  version "10.1.18"
+  sha256 "0c829423259382fd4fa756024fc5498cb67db91f0709d23f475cd3835e083ab1"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).