### PR TITLE
Add workaround for Visual Studio.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ jobs:
   ci:
     runs-on: macos-latest
     steps:
+      - name: Clean up CI machine
+        run: |
+          if ! brew cask ls visual-studio &>/dev/null; then
+            if ! rm -r '/Applications/Visual Studio.app'; then
+              echo '::warning::Workaround for Visual Studio is no longer needed.'
+            fi
+          fi
       - name: Update Homebrew
         id: update_homebrew
         run: |

--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -1,6 +1,6 @@
 cask "visual-studio" do
-  version "8.6.8.2"
-  sha256 "efdc300cc5a3261b2851c081d06b462862282e7abf748eaa650d3b9591e49a41"
+  version "8.7.0.2037"
+  sha256 "8d0bd1b5badcceb71a8d1e65c35f5852bc84d67841086efc989db9be03cb2c5b"
 
   # dl.xamarin.com/VsMac/ was verified as official when first introduced to the cask
   url "https://dl.xamarin.com/VsMac/VisualStudioForMac-#{version}.dmg"


### PR DESCRIPTION
Remove `Visual Studio.app` which is not installed via Homebrew Cask.