### PR TITLE
Update Emacs from 26.3 to 27.1

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,6 +1,6 @@
 cask "emacs" do
-  version "26.3"
-  sha256 "310f34b3890584b08fd6de9f422d0747ed3405910120ecfd2eb2cbf8921986a6"
+  version "27.1"
+  sha256 "0ab20c654a21d78b85a4a1d89e53808e67ad558d94f1f22a4339df11cd5b866b"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast "https://emacsformacosx.com/atom/release"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).