### PR TITLE
Update mediainfo to 20.08

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,19 +1,19 @@
-cask "mediainfo" do
-  version "20.03"
-  sha256 "8bc9aa24da2b78c15027c93afe0f078dab8ab32983ee14157ddaa86198a0bdd2"
+cask 'mediainfo' do
+  version '20.08'
+  sha256 '753c24f51349cde35f58f46f5e04c3e052ff9857c1d6c24a5329d341b7113525'
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
-  appcast "https://mediaarea.net/rss/mediainfo_updates.xml"
-  name "MediaInfo"
-  homepage "https://mediaarea.net/en/MediaInfo"
+  appcast 'https://mediaarea.net/rss/mediainfo_updates.xml'
+  name 'MediaInfo'
+  homepage 'https://mediaarea.net/en/MediaInfo'
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: '>= :high_sierra'
 
-  app "MediaInfo.app"
+  app 'MediaInfo.app'
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mediaarea.mediainfo.mac-old.sfl*",
-    "~/Library/Preferences/net.mediaarea.mediainfo.mac-old.plist",
-    "~/Library/Saved Application State/net.mediaarea.mediainfo.mac-old.savedState",
-  ]
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mediaarea.mediainfo.mac-old.sfl*',
+               '~/Library/Preferences/net.mediaarea.mediainfo.mac-old.plist',
+               '~/Library/Saved Application State/net.mediaarea.mediainfo.mac-old.savedState',
+             ]
 end

--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,19 +1,19 @@
 cask 'mediainfo' do
-  version '20.08'
-  sha256 '753c24f51349cde35f58f46f5e04c3e052ff9857c1d6c24a5329d341b7113525'
+  version "20.08"
+  sha256 "753c24f51349cde35f58f46f5e04c3e052ff9857c1d6c24a5329d341b7113525"
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
-  appcast 'https://mediaarea.net/rss/mediainfo_updates.xml'
-  name 'MediaInfo'
-  homepage 'https://mediaarea.net/en/MediaInfo'
+  appcast "https://mediaarea.net/rss/mediainfo_updates.xml"
+  name "MediaInfo"
+  homepage "https://mediaarea.net/en/MediaInfo"
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: ">= :high_sierra"
 
-  app 'MediaInfo.app'
+  app "MediaInfo.app"
 
   zap trash: [
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mediaarea.mediainfo.mac-old.sfl*',
-               '~/Library/Preferences/net.mediaarea.mediainfo.mac-old.plist',
-               '~/Library/Saved Application State/net.mediaarea.mediainfo.mac-old.savedState',
+               "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mediaarea.mediainfo.mac-old.sfl*",
+               "~/Library/Preferences/net.mediaarea.mediainfo.mac-old.plist",
+               "~/Library/Saved Application State/net.mediaarea.mediainfo.mac-old.savedState",
              ]
 end

--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,4 +1,4 @@
-cask 'mediainfo' do
+cask "mediainfo" do
   version "20.08"
   sha256 "753c24f51349cde35f58f46f5e04c3e052ff9857c1d6c24a5329d341b7113525"
 
@@ -12,8 +12,8 @@ cask 'mediainfo' do
   app "MediaInfo.app"
 
   zap trash: [
-               "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mediaarea.mediainfo.mac-old.sfl*",
-               "~/Library/Preferences/net.mediaarea.mediainfo.mac-old.plist",
-               "~/Library/Saved Application State/net.mediaarea.mediainfo.mac-old.savedState",
-             ]
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.mediaarea.mediainfo.mac-old.sfl*",
+    "~/Library/Preferences/net.mediaarea.mediainfo.mac-old.plist",
+    "~/Library/Saved Application State/net.mediaarea.mediainfo.mac-old.savedState",
+  ]
 end


### PR DESCRIPTION
+ Fix `brew cask style`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
