### PR TITLE
Update obsidian from 0.8.1 to 0.8.2

### DIFF
--- a/Casks/obsidian.rb
+++ b/Casks/obsidian.rb
@@ -1,6 +1,6 @@
 cask "obsidian" do
-  version "0.8.1"
-  sha256 "c2a4c2f58ce6621eb7af470d01bec8833c4aec4f7fc83e3566fbd2454cf23827"
+  version "0.8.2"
+  sha256 "ba3e470e0cd370652d4e3254e8f7c405f2a90a9c474ee302f71a606e3c9d25be"
 
   # github.com/obsidianmd/ was verified as official when first introduced to the cask
   url "https://github.com/obsidianmd/obsidian-releases/releases/download/v#{version}/Obsidian-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).