### PR TITLE
Update loaf from 1.0.3 to 1.1.0

### DIFF
--- a/Casks/loaf.rb
+++ b/Casks/loaf.rb
@@ -1,6 +1,6 @@
 cask "loaf" do
-  version "1.0.3"
-  sha256 "fe8967b30889d96de1eef3927bee732530b4da821b0e4f8e94c57ab5dcd8a5dc"
+  version "1.1.0"
+  sha256 "4499ace77b0500ebfd3199ea73e7a3fa6c2a14359056489f30dc67caf170c8ee"
 
   # github.com/philipardeljan/getloaf/ was verified as official when first introduced to the cask
   url "https://github.com/philipardeljan/getloaf/releases/download/v#{version}/loaf.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).