### PR TITLE
Update pingplotter from 5.18.1 to 5.18.2

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -1,6 +1,6 @@
 cask "pingplotter" do
-  version "5.18.1"
-  sha256 "f70b5ad6c32cac19a2f31304c435009b56c2bb101af71dfc55e79ade36e9c784"
+  version "5.18.2"
+  sha256 "d12e65bd71ecedb6c2e61b324af4438ff1cb28b38ef9f292d6b83738af089b88"
 
   url "https://www.pingplotter.com/downloads/pingplotter_osx.zip"
   appcast "https://www.pingplotter.com/download"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).