### PR TITLE
Update codeexpander from 3.5.0 to 3.5.3

### DIFF
--- a/Casks/codeexpander.rb
+++ b/Casks/codeexpander.rb
@@ -1,6 +1,6 @@
 cask "codeexpander" do
-  version "3.5.0"
-  sha256 "835032d575715f57f1949156d2a7a441165ae17c398c45f30d6d58179faa3f02"
+  version "3.5.3"
+  sha256 "f36cdc441635343f892d53292f88ecef6f3fee9bd40c6060f4bf47c35200a109"
 
   url "https://github.com/oncework/codeexpander/releases/download/#{version.major_minor}.x/CodeExpander-#{version}.dmg"
   appcast "https://github.com/oncework/codeexpander/releases.atom",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).