### PR TITLE
Update vimr from 0.33.1-354 to 0.34.0-355

### DIFF
--- a/Casks/vimr.rb
+++ b/Casks/vimr.rb
@@ -1,6 +1,6 @@
 cask "vimr" do
-  version "0.33.1-354"
-  sha256 "71a8cfc371f7c117e4aea7b671e66f6840539089de2d4dde09e38bb989578e93"
+  version "0.34.0-355"
+  sha256 "e4e5db59146993fa01ad9999ff0cab9effe209c6827cf6eabe4a54a92d9f987c"
 
   # github.com/qvacua/vimr/ was verified as official when first introduced to the cask
   url "https://github.com/qvacua/vimr/releases/download/v#{version}/VimR-v#{version}.tar.bz2"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).