### PR TITLE
Update securesafe from 2.7.1 to 2.7.2

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,6 +1,6 @@
 cask "securesafe" do
-  version "2.7.1"
-  sha256 "dc501d465214a986c777019b16cef2ee77bd7062a3c23a7839ab6aa62d4b2366"
+  version "2.7.2"
+  sha256 "79cefe64d6c4d6c501496e9b333a9bc785fe8d7a64b473df2216c4e58396d59b"
 
   url "https://www.securesafe.com/downloads/SecureSafe_#{version}.pkg"
   appcast "https://www.securesafe.com/en/downloads/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).