### PR TITLE
Update ibm-cloud-cli from 0.21.0 to 1.1.0

### DIFF
--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -1,13 +1,12 @@
 cask "ibm-cloud-cli" do
-  version "0.21.0"
-  sha256 "2ff070a944fd9516a72bf7659513f8351acd09eb5d434601e754b33b2e411faa"
+  version "1.1.0"
+  sha256 "5fabea7058974f14c19417c3b66dd8ad71f421f1acfb2a4d8d2580735fcc20ee"
 
-  # public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/ was verified as official when first introduced to the cask
   url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/IBM_Cloud_CLI_#{version}.pkg"
   appcast "https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases.atom"
   name "Bluemix-CLI"
   name "IBM Cloud CLI"
-  homepage "https://clis.ng.bluemix.net/ui/home.html"
+  homepage "https://cloud.ibm.com/docs/cli/index.html"
 
   depends_on cask: "docker"
   depends_on formula: "kubectl"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
