### PR TITLE
Update Maccy to 0.15.0

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask "maccy" do
-  version "0.14.1"
-  sha256 "d9512f737b5ac14620cafca286adc95f7036d5fc9c4fab07da563e42bc0b4002"
+  version "0.15.0"
+  sha256 "57fe3b4798ac0fb429ba92be1f249e4e744ae43e7346df722db62df28de091ab"
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"
@@ -16,5 +16,8 @@ cask "maccy" do
   uninstall quit: "org.p0deje.Maccy"
 
   zap login_item: "Maccy",
-      trash:      "~/Library/Preferences/org.p0deje.Maccy.plist"
+      trash: [
+        "~/Library/Application Scripts/org.p0deje.Maccy",
+        "~/Library/Containers/org.p0deje.Maccy",
+  ]
 end

--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -16,7 +16,7 @@ cask "maccy" do
   uninstall quit: "org.p0deje.Maccy"
 
   zap login_item: "Maccy",
-      trash: [
+      trash:      [
         "~/Library/Application Scripts/org.p0deje.Maccy",
         "~/Library/Containers/org.p0deje.Maccy",
       ]

--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -19,5 +19,5 @@ cask "maccy" do
       trash: [
         "~/Library/Application Scripts/org.p0deje.Maccy",
         "~/Library/Containers/org.p0deje.Maccy",
-  ]
+      ]
 end

--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -17,6 +17,7 @@ cask "maccy" do
 
   zap login_item: "Maccy",
       trash:      [
+        "~/Library/Preferences/org.p0deje.Maccy.plist",
         "~/Library/Application Scripts/org.p0deje.Maccy",
         "~/Library/Containers/org.p0deje.Maccy",
       ]


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).