### PR TITLE
Update vscodium from 1.47.3 to 1.48.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask "vscodium" do
-  version "1.47.3"
-  sha256 "d6576b9c3febdb72e74e038ed3cd69b3e4b30812ad109c984171461dec6708cb"
+  version "1.48.0"
+  sha256 "9259c129d53b15cb832a66f2042beb2bbd764db518e25c0f0b39f9dc620130f1"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{version}.dmg"
   appcast "https://github.com/VSCodium/vscodium/releases.atom"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
