### PR TITLE
Update cutter from 1.11.0 to 1.11.1

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,6 +1,6 @@
 cask "cutter" do
-  version "1.11.0"
-  sha256 "59237d9fd90c4dd932f756eddfe5d27d9d53352d28ba0ec92bfe4ec19b200299"
+  version "1.11.1"
+  sha256 "6f35931d52915ce093825ecad6288c1798ca99af7cffde1592a7e2119deb98b6"
 
   # github.com/radareorg/cutter/ was verified as official when first introduced to the cask
   url "https://github.com/radareorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).