### PR TITLE
Update hubstaff from 1.5.12,2388 to 1.5.15,2652

### DIFF
--- a/Casks/hubstaff.rb
+++ b/Casks/hubstaff.rb
@@ -1,6 +1,6 @@
 cask "hubstaff" do
-  version "1.5.12,2388"
-  sha256 "6f486c41c06d26dd70ea6b6077d5d2a91b36efb1ab6b38c9fc18464af4c8a9b3"
+  version "1.5.15,2652"
+  sha256 "abea6948da97884d2f9890ffca45a75408d2a750681eae0212f79a202c77b429"
 
   url "https://app.hubstaff.com/download/#{version.after_comma}-mac-os-x-#{version.before_comma.dots_to_hyphens}-release"
   appcast "https://app.hubstaff.com/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).