### PR TITLE
Make LuLu 1.2.3 installer case sensitive

### DIFF
--- a/Casks/lulu.rb
+++ b/Casks/lulu.rb
@@ -11,13 +11,13 @@ cask "lulu" do
   depends_on macos: ">= :sierra"
 
   installer script: {
-    executable: "#{staged_path}/Lulu Installer.app/Contents/MacOS/LuLu Installer",
+    executable: "#{staged_path}/LuLu Installer.app/Contents/MacOS/LuLu Installer",
     args:       ["-install"],
     sudo:       true,
   }
 
   uninstall script: {
-    executable: "#{staged_path}/Lulu Installer.app/Contents/MacOS/LuLu Installer",
+    executable: "#{staged_path}/LuLu Installer.app/Contents/MacOS/LuLu Installer",
     args:       ["-uninstall"],
     sudo:       true,
   }


### PR DESCRIPTION
On MacOS with case-sensitive filesystem installer fails due to wrong filename of installer package. This PR fixes it.

- [*] `brew cask audit --download {{cask_file}}` is error-free.
- [*] `brew cask style --fix {{cask_file}}` reports no offenses.
- [*] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [*] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
