### PR TITLE
Update mediathekview from 13.5.1 to 13.6.0

### DIFF
--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -1,6 +1,6 @@
 cask "mediathekview" do
-  version "13.5.1"
-  sha256 "745a965c74bbd449535bdd87e8473d0c0912a0e20abe298f2f174687786f075a"
+  version "13.6.0"
+  sha256 "76a4600190df7ff145f3cf97747f376d9f45318b083a83dbd099b7522b6749f4"
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}-mac.dmg"
   appcast "https://mediathekview.de/changelog/index.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).