### PR TITLE
Update perforce from 20.1,1953492 to 20.1,1991450

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,5 +1,5 @@
 cask "perforce" do
-  version "20.1,1953492"
+  version "20.1,1991450"
   sha256 "e93b556b4824afa3b9c1b7e328a53c605c8953cc9facd6c12d7a3b3451434ea6"
 
   url "https://cdist2.perforce.com/perforce/r#{version.before_comma}/bin.macosx1010x86_64/helix-core-server.tgz"


### PR DESCRIPTION
Just upgraded to macOS Catalina, and it doesn't trust the `p4` without this upgrade

<img width="398" alt="image" src="https://user-images.githubusercontent.com/6885889/90575171-b014e400-e16f-11ea-853d-32c484c3706c.png">

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).