### PR TITLE
desc.md: remove link to code

### DIFF
--- a/doc/cask_language_reference/stanzas/desc.md
+++ b/doc/cask_language_reference/stanzas/desc.md
@@ -1,5 +1,5 @@
 # desc
 
-`desc` accepts a single-line UTF-8 string (max. 80 characters) containing a short description of the software, and is used to help with searchability and disambiguation.
+`desc` accepts a single-line UTF-8 string containing a short description of the software. It’s used to help with searchability and disambiguation.
 
-It should start with a capital letter, and avoid including the Cask [name](name.md). The full list of rules is described [here](https://github.com/homebrew/brew/blob/master/Library/Homebrew/rubocops/shared/desc_helper.rb).
+It should start with an uppercase letter, avoid including the Cask’s [name](name.md), and have no more than 80 characters.


### PR DESCRIPTION
We shouldn’t ask our users to read source code to understand a list of rules for a phrase—most of our contributors aren’t versed in Ruby. We don’t need to include everything, just the most important and let the checks catch the rare outliers.