### PR TITLE
Update keepassxc to 2.6.1, set keepassxc Sierra verison to 2.5.4 

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,5 +1,5 @@
 cask "keepassxc" do
-  version "2.6.0"
+  version "2.6.1"
 
   if MacOS.version <= :sierra
     # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
@@ -8,7 +8,7 @@ cask "keepassxc" do
   else
     # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
     url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
-    sha256 "2224047775b0184b78c252e97cc9c7487aada3a26d24701e45114ea32868f403"
+    sha256 "ac0a74369f4009a6d5922840c3df8fe4641c11af8643cc60b9ba6103ff1eceda"
   end
 
   appcast "https://github.com/keepassxreboot/keepassxc/releases.atom"

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -8,8 +8,6 @@ cask "keepassxc" do
   name "KeePassXC"
   homepage "https://keepassxc.org/"
 
-  depends_on macos: ">= :sierra"
-
   app "KeePassXC.app"
   binary "#{appdir}/KeePassXC.app/Contents/MacOS/keepassxc-cli"
 

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -8,6 +8,8 @@ cask "keepassxc" do
   name "KeePassXC"
   homepage "https://keepassxc.org/"
 
+  depends_on macos: ">= :high_sierra"
+
   app "KeePassXC.app"
   binary "#{appdir}/KeePassXC.app/Contents/MacOS/keepassxc-cli"
 

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -3,6 +3,7 @@ cask "keepassxc" do
 
   if MacOS.version <= :sierra
     # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
+    version "2.5.4"
     url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-Sierra.dmg"
     sha256 "7cd8dc34022091c240e538f7a9889afd7dc8f9f3957a66bca9d70c067045ade4"
   else

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,17 +1,9 @@
 cask "keepassxc" do
   version "2.6.1"
+  sha256 "ac0a74369f4009a6d5922840c3df8fe4641c11af8643cc60b9ba6103ff1eceda"
 
-  if MacOS.version <= :sierra
-    # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
-    version "2.5.4"
-    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-Sierra.dmg"
-    sha256 "7cd8dc34022091c240e538f7a9889afd7dc8f9f3957a66bca9d70c067045ade4"
-  else
-    # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
-    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
-    sha256 "ac0a74369f4009a6d5922840c3df8fe4641c11af8643cc60b9ba6103ff1eceda"
-  end
-
+  # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
   appcast "https://github.com/keepassxreboot/keepassxc/releases.atom"
   name "KeePassXC"
   homepage "https://keepassxc.org/"


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
