### PR TITLE
Update fing-desktop from 2.0.0 to 2.1.0, fix style

### DIFF
--- a/Casks/fing-desktop.rb
+++ b/Casks/fing-desktop.rb
@@ -1,19 +1,19 @@
-cask 'fing-desktop' do
-  version '2.0.0'
-  sha256 'fceb7cf920214f447333e80bf7b141f67661a423eda03041bc651e3323763810'
+cask "fing-desktop" do
+  version "2.1.0"
+  sha256 "4a9bb7c0fb8531cacc60fd4247c55ae322224cf300ecb67de303710bf9773631"
 
-  url 'https://get.fing.com/fing-desktop-releases/mac/Fing.dmg'
-  appcast 'https://get.fing.com/fing-desktop-releases/mac/latest-mac.yml'
-  name 'Fing Desktop'
-  homepage 'https://www.fing.com/products/fing-desktop'
+  url "https://get.fing.com/fing-desktop-releases/mac/Fing.dmg"
+  appcast "https://get.fing.com/fing-desktop-releases/mac/latest-mac.yml"
+  name "Fing Desktop"
+  homepage "https://www.fing.com/products/fing-desktop"
 
-  app 'Fing.app'
+  app "Fing.app"
 
-  uninstall launchctl: 'com.fing.service'
+  uninstall launchctl: "com.fing.service"
 
   zap trash: [
-               '~/Library/Application Support/Fing',
-               '~/Library/Preferences/com.fing.app.plist',
-               '~/Library/Saved Application State/com.fing.app.savedState',
-             ]
+    "~/Library/Application Support/Fing",
+    "~/Library/Preferences/com.fing.app.plist",
+    "~/Library/Saved Application State/com.fing.app.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
