### PR TITLE
Bump chef-workstation to 20.8.125

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,23 +1,23 @@
-cask "chef-workstation" do
-  version "20.8.125"
-  sha256 "c2efc11084fd5f409a551cfcaf489b5c85e6e035e998cd0db448764038d42277"
+cask 'chef-workstation' do
+  version '20.8.125'
+  sha256 'c2efc11084fd5f409a551cfcaf489b5c85e6e035e998cd0db448764038d42277'
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.15/chef-workstation-#{version}-1.dmg"
-  appcast "https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.15&m=x86_64&v=latest"
-  name "Chef Workstation"
-  homepage "https://docs.chef.io/workstation/"
+  appcast 'https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.15&m=x86_64&v=latest'
+  name 'Chef Workstation'
+  homepage 'https://docs.chef.io/workstation/'
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: '>= :high_sierra'
 
   pkg "chef-workstation-#{version}-1.pkg"
 
-  uninstall quit:      "sh.chef.chef-workstation",
-            pkgutil:   "com.getchef.pkg.chef-workstation",
-            launchctl: "io.chef.chef-workstation.app",
+  uninstall quit:      'sh.chef.chef-workstation',
+            pkgutil:   'com.getchef.pkg.chef-workstation',
+            launchctl: 'io.chef.chef-workstation.app',
             script:    {
-              executable: "/opt/chef-workstation/bin/uninstall_chef_workstation",
-              sudo:       true,
-            }
+                         executable: '/opt/chef-workstation/bin/uninstall_chef_workstation',
+                         sudo:       true,
+                       }
 
-  zap trash: "~/.chef-workstation/"
+  zap trash: '~/.chef-workstation/'
 end


### PR DESCRIPTION
After making all changes to the cask:
 - [x] `brew cask audit --download Casks/chef-workstation.rb` is error-free.
 - [x] `brew cask style --fix Casks/chef-workstation.rb` reports no offenses.
 - [x] The commit message includes the cask’s name and version.
 - [x] The submission is for stable version.
