### PR TITLE
Update altair-graphql-client from 2.4.12 to 2.4.13

### DIFF
--- a/Casks/altair-graphql-client.rb
+++ b/Casks/altair-graphql-client.rb
@@ -1,6 +1,6 @@
 cask "altair-graphql-client" do
-  version "2.4.12"
-  sha256 "743836a8159da30c699034679c860be6c6be9e9be6400c6c515314a1302c1cc8"
+  version "2.4.13"
+  sha256 "c128814eae89b15320d2591ce3c8c1558fdbc526fe0f2831d25895e5eb8f5d04"
 
   # github.com/imolorhe/altair/ was verified as official when first introduced to the cask
   url "https://github.com/imolorhe/altair/releases/download/v#{version}/altair_#{version}_mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).