### PR TITLE
Update macbreakz from 5.35 to 5.36

### DIFF
--- a/Casks/macbreakz.rb
+++ b/Casks/macbreakz.rb
@@ -1,6 +1,6 @@
 cask "macbreakz" do
-  version "5.35"
-  sha256 "1a3cc6c0506bdd5b5b15ef0eb34013d367c9f3edb8354c5d087a5fc7177d2083"
+  version "5.36"
+  sha256 "a50ab71a5582912966835108c5ae5d6364bdde02c15f173fe5e70dd33c5d7429"
 
   url "https://www.publicspace.net/download/MacBreakZ#{version.major}.dmg"
   appcast "https://www.publicspace.net/app/signed_mb#{version.major}.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).