### PR TITLE
Update ibm-cloud-cli from 1.1.0 to 1.2.0

### DIFF
--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -1,6 +1,6 @@
 cask "ibm-cloud-cli" do
-  version "1.1.0"
-  sha256 "5fabea7058974f14c19417c3b66dd8ad71f421f1acfb2a4d8d2580735fcc20ee"
+  version "1.2.0"
+  sha256 "4b6791bc30bc6a893845078d29c762967679eb7671b02d421e3a0f5a4170094d"
 
   url "https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/#{version}/IBM_Cloud_CLI_#{version}.pkg"
   appcast "https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases.atom"


### PR DESCRIPTION
Upgrade `ibm-cloud-cli` to [v1.2.0](https://github.com/IBM-Cloud/ibm-cloud-cli-release/releases/tag/v1.2.0).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
