### PR TITLE
Restore HTTPS for URLs downgraded to HTTP

### DIFF
--- a/Casks/securityspy.rb
+++ b/Casks/securityspy.rb
@@ -2,7 +2,7 @@ cask "securityspy" do
   version "5.2.4"
   sha256 "25bb6f7e74a5876e42c94b3015c9040d96df9f3ea70b22853851f0d676ff88d4"
 
-  url "http://www.bensoftware.com/securityspy/SecuritySpy.dmg"
+  url "https://www.bensoftware.com/securityspy/SecuritySpy.dmg"
   appcast "https://www.bensoftware.com/securityspy/versionhistory.html",
           must_contain: version.chomp(".0")
   name "SecuritySpy"

--- a/Casks/ximalaya.rb
+++ b/Casks/ximalaya.rb
@@ -3,7 +3,7 @@ cask "ximalaya" do
   sha256 "fcc76ea2971a623967f7d0bc149692c599ba9ddb8ad1c782447a06c8ac8db9d0"
 
   # s1.xmcdn.com/ was verified as official when first introduced to the cask
-  url "http://s1.xmcdn.com/yx/ximalaya-pc/#{version.before_comma}/download/Ximalaya-#{version.before_comma}_#{version.after_comma}.dmg"
+  url "https://s1.xmcdn.com/yx/ximalaya-pc/#{version.before_comma}/download/Ximalaya-#{version.before_comma}_#{version.after_comma}.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.ximalaya.com/down/lite?client=mac"
   name "ximalaya"
   name "喜马拉雅"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
1 file inspected, no offenses detected
==> Downloading https://www.bensoftware.com/securityspy/SecuritySpy.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'securityspy'.
audit for securityspy: passed

1 file inspected, no offenses detected
==> Downloading https://s1.xmcdn.com/yx/ximalaya-pc/1.2.21/download/Ximalaya-1.2
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'ximalaya'.
audit for ximalaya: passed
```