### PR TITLE
Update vuescan from 9.7.30 to 9.7.31

### DIFF
--- a/Casks/vuescan.rb
+++ b/Casks/vuescan.rb
@@ -1,5 +1,5 @@
 cask "vuescan" do
-  version "9.7.30"
+  version "9.7.31"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.hamrick.com/files/vuex64#{version.major_minor.no_dots}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).