### PR TITLE
Use `pull_request_target` for CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  - pull_request
+  pull_request_target:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
 
 jobs:
   syntax:


### PR DESCRIPTION
This should make it possible to unbreak CI without having people need to rebase their PRs.