### PR TITLE
Revert "Use `pull_request_target` for CI workflow."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
 on:
-  pull_request_target:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+  - pull_request
 
 jobs:
   syntax:


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#88011