### PR TITLE
Update electron-fiddle from 0.15.1 to 0.16.0

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,6 +1,6 @@
 cask "electron-fiddle" do
-  version "0.15.1"
-  sha256 "876a72cf8d05e182f3c4ce9901c84dc94213fbe412467e52561e38277c366fb4"
+  version "0.16.0"
+  sha256 "b3a70530aa6422b208663e025ec25a1047f40e08f970e6d6a84fa65ad978b251"
 
   # github.com/electron/fiddle/ was verified as official when first introduced to the cask
   url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).