### PR TITLE
Update chromium from 799881 to 800858

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -6,7 +6,7 @@ cask "chromium" do
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
   appcast "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2FLAST_CHANGE?alt=media"
   name "Chromium"
-  desc "Free and open-source web browser project from Google"
+  desc "Free and open-source web browser"
   homepage "https://www.chromium.org/Home"
 
   conflicts_with cask: [

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,11 +1,12 @@
 cask "chromium" do
-  version "799881"
-  sha256 "10567247579e50751b950189a27eee21747d8363134d534d4107f1bf9d6506c8"
+  version "800852"
+  sha256 "1b3ccbf116f37d6961a75b2fe05af301d018b2e2bbedc1b8f15896d7639e3b7e"
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"
   appcast "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2FLAST_CHANGE?alt=media"
   name "Chromium"
+  desc "Free and open-source web browser project from Google"
   homepage "https://www.chromium.org/Home"
 
   conflicts_with cask: [

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,5 +1,5 @@
 cask "chromium" do
-  version "800852"
+  version "800858"
   sha256 "1b3ccbf116f37d6961a75b2fe05af301d018b2e2bbedc1b8f15896d7639e3b7e"
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask "chromium" do
   version "800858"
-  sha256 "1b3ccbf116f37d6961a75b2fe05af301d018b2e2bbedc1b8f15896d7639e3b7e"
+  sha256 "0e5620e2c206c3a9ba023227b54cfeaf21096a09b19548d2bd4d3de8a1edd577"
 
   # commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/ was verified as official when first introduced to the cask
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).