### PR TITLE
Update provisionql from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/provisionql.rb
+++ b/Casks/provisionql.rb
@@ -1,6 +1,6 @@
 cask "provisionql" do
-  version "1.6.1"
-  sha256 "3b545d71bbf2afc50719204071ffb57bc5b782881ace153807bea060b5300b27"
+  version "1.6.2"
+  sha256 "762075acffde7c2aad376bbd946c4533ca81f214ef0e88eaab85d94551cc497a"
 
   url "https://github.com/ealeksandrov/ProvisionQL/releases/download/#{version}/ProvisionQL.zip"
   appcast "https://github.com/ealeksandrov/ProvisionQL/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).