### PR TITLE
Use Backblaze Uninstaller and switch to latest version as Backblaze downloads are unversioned

### DIFF
--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -8,14 +8,7 @@ cask "backblaze" do
 
   installer manual: "Backblaze Installer.app"
 
-  uninstall launchctl: [
-    "com.backblaze.bzserv",
-    "com.backblaze.bzbmenu",
-  ],
-            delete:    [
-              "#{appdir}/Backblaze.app",
-              "/Library/PreferencePanes/BackblazeBackup.prefPane",
-            ]
+  uninstall script: "#{staged_path}/Backblaze Uninstaller.app/Contents/MacOS/Backblaze Uninstaller"
 
   zap trash: [
     "/Library/Backblaze.bzpkg",

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,10 +1,8 @@
 cask "backblaze" do
-  version "7.0.2.464"
-  sha256 "4956a72674d1901a6ec5a98ec0089ebfde743c5bb63e7644c3103e113e26d6d8"
+  version :latest
+  sha256 :no_check
 
   url "https://secure.backblaze.com/mac/install_backblaze.dmg"
-  appcast "https://secure.backblaze.com/api/clientversion.xml",
-          must_contain: "mac_version=\"#{version}\""
   name "Backblaze"
   homepage "https://backblaze.com/"
 


### PR DESCRIPTION
Backblaze [do not offer versioned downloads of their installer](https://secure.backblaze.com/download.htm) so attempting to upgrade the Cask causes issues with mismatched checksums if the previous installer is still cached.
    
This means we lose the ability to detect updates but forcibly upgrading the Cask (e.g. with `brew cask upgrade backblaze`) should now work as expected.

Rather than having to manually delete the various applications, preference panes and `launchctl` jobs installed by the Backblaze Installer ourselves, use the included Backblaze Uninstaller script instead.
    
Note that the Uninstaller will not delete user-specific files so we retain the existing zap stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).