### PR TITLE
Add VB-Cable

### DIFF
--- a/Casks/vb-cable.rb
+++ b/Casks/vb-cable.rb
@@ -9,5 +9,7 @@ cask "vb-cable" do
 
   pkg "vb-cable-installer.pkg"
 
-  uninstall pkgutil: "com.vbaudio.vbcable"
+  uninstall launchctl: "com.vbaudio.vbcableagent",
+            pkgutil: "com.vbaudio.vbcable",
+            delete: "/Library/Preferences/com.vbaudio.vbcable.plist"
 end

--- a/Casks/vb-cable.rb
+++ b/Casks/vb-cable.rb
@@ -10,6 +10,6 @@ cask "vb-cable" do
   pkg "vb-cable-installer.pkg"
 
   uninstall launchctl: "com.vbaudio.vbcableagent",
-            pkgutil: "com.vbaudio.vbcable",
-            delete: "/Library/Preferences/com.vbaudio.vbcable.plist"
+            pkgutil:   "com.vbaudio.vbcable",
+            delete:    "/Library/Preferences/com.vbaudio.vbcable.plist"
 end

--- a/Casks/vb-cable.rb
+++ b/Casks/vb-cable.rb
@@ -1,0 +1,13 @@
+cask "vb-cable" do
+  version "107"
+  sha256 "ba0bc4674882f828eeb001540460fee04641fdd4c43da7c08a2360644d3536da"
+
+  url "https://download.vb-audio.com/Download_MAC/VBCable_MACDriver_Pack#{version}.dmg"
+  name "VB-CABLE Virtual Audio Device"
+  desc "Virtual audio cable for routing audio from one application to another"
+  homepage "https://www.vb-audio.com/Cable/index.htm"
+
+  pkg "vb-cable-installer.pkg"
+
+  uninstall pkgutil: "com.vbaudio.vbcable"
+end


### PR DESCRIPTION
Hi, VB-Cable is a virtual audio device which can be used as a "cable" to connect one app to another.

** I need some advice on writing the uninstall stanza. Manual uninstallation steps can be found [here](https://forum.vb-audio.com/viewtopic.php?f=7&t=1063). It seems to work except it does not delete /Library/Preferences/com.vbaudio.vbcable.plist. Should I add that as a `delete:`? I also see that CI is saying I should add some `launchctl:` stuff but don't really understand what it's saying.



After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully. **see above**
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
