### PR TITLE
Update ringcentral-classic from 20.2.30 to 20.3.10

### DIFF
--- a/Casks/ringcentral-classic.rb
+++ b/Casks/ringcentral-classic.rb
@@ -1,6 +1,6 @@
 cask "ringcentral-classic" do
-  version "20.2.30"
-  sha256 "4f5789eda68ba05a6a76ab03246352c52039dce27db9d9bf2c68c214feb830e2"
+  version "20.3.10"
+  sha256 "c555c9f06cd424a2a8e00e10bf3b39103f069e8438ecb2f11de7dcfabeb72fdc"
 
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral%20Classic-#{version}.dmg"
   name "RingCentral Classic"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).