### PR TITLE
secure URLs

### DIFF
--- a/Casks/accurics.rb
+++ b/Casks/accurics.rb
@@ -2,8 +2,8 @@ cask "accurics" do
   version "0.0.4"
   sha256 "74f0f00ac9f8f4ad47f5dcb81eaabad1587eedf458d41ec5d91d54490376b0ae"
 
-  url "http://downloads.accurics.com/cli/#{version}/accurics-cli.dmg"
-  appcast "http://downloads.accurics.com/cli/#{version}/accurics-cli.yml",
+  url "https://downloads.accurics.com/cli/#{version}/accurics-cli.dmg"
+  appcast "https://downloads.accurics.com/cli/#{version}/accurics-cli.yml",
           must_contain: version
   name "Accurics CLI"
   homepage "https://www.accurics.com/"

--- a/Casks/aimersoft-video-converter-ultimate.rb
+++ b/Casks/aimersoft-video-converter-ultimate.rb
@@ -2,7 +2,7 @@ cask "aimersoft-video-converter-ultimate" do
   version "11.6.5.2"
   sha256 "eebe898d4a1b9fe7fcab56ec978b383a4f3d2f2079e29cbc8396552279ff18b7"
 
-  url "http://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full747.dmg"
+  url "https://download.aimersoft.com/cbs_down/aimer-mac-video-converter-ultimate_full747.dmg"
   name "Aimersoft Video Converter Ultimate"
   homepage "https://www.aimersoft.com/video-converter-ultimate.html"
 

--- a/Casks/amorphousdiskmark.rb
+++ b/Casks/amorphousdiskmark.rb
@@ -2,9 +2,9 @@ cask "amorphousdiskmark" do
   version :latest
   sha256 :no_check
 
-  url "http://katsurashareware.com/dl/AmorphousDiskMark.zip"
+  url "https://katsurashareware.com/dl/AmorphousDiskMark.zip"
   name "AmorphousDiskMark"
-  homepage "http://www.katsurashareware.com/pgs/adm.html"
+  homepage "https://katsurashareware.com/pgs/adm.html"
 
   app "AmorphousDiskMark.app"
 

--- a/Casks/cisdem-data-recovery.rb
+++ b/Casks/cisdem-data-recovery.rb
@@ -2,7 +2,7 @@ cask "cisdem-data-recovery" do
   version "6.4.0"
   sha256 "3624f99d258fb7f6af77f5226d8528b08dbc5840069ef38be3c681efcd146cc2"
 
-  url "http://download.cisdem.com/cisdem-datarecovery.dmg"
+  url "https://download.cisdem.com/cisdem-datarecovery.dmg"
   appcast "https://www.cisdem.com/data-recovery-mac/release-notes.html"
   name "Cisdem Data Recovery"
   homepage "https://www.cisdem.com/data-recovery-mac.html"

--- a/Casks/cisdem-document-reader.rb
+++ b/Casks/cisdem-document-reader.rb
@@ -2,7 +2,7 @@ cask "cisdem-document-reader" do
   version "5.2.0"
   sha256 "cd08ba974b7d468751268ccbc42ea00e94c0067a3f7f64d3ea73c2655f44e2de"
 
-  url "http://download.cisdem.com/cisdem-documentreader.dmg"
+  url "https://download.cisdem.com/cisdem-documentreader.dmg"
   appcast "https://www.cisdem.com/document-reader-mac/release-notes.html"
   name "Cisdem Document Reader"
   homepage "https://www.cisdem.com/document-reader-mac.html"

--- a/Casks/cisdem-pdf-converter-ocr.rb
+++ b/Casks/cisdem-pdf-converter-ocr.rb
@@ -2,7 +2,7 @@ cask "cisdem-pdf-converter-ocr" do
   version "7.5.0"
   sha256 "dabdd364beb742094ceabfd153fe160cc070a79f8e87e2c41aec80b5a5158f21"
 
-  url "http://download.cisdem.com/cisdem-pdfconverterocr.dmg"
+  url "https://download.cisdem.com/cisdem-pdfconverterocr.dmg"
   appcast "https://www.cisdem.com/pdf-converter-ocr-mac/release-notes.html"
   name "Cisdem PDF Converter OCR"
   homepage "https://www.cisdem.com/pdf-converter-ocr-mac.html"

--- a/Casks/cmdtap.rb
+++ b/Casks/cmdtap.rb
@@ -2,10 +2,10 @@ cask "cmdtap" do
   version "1.9.4"
   sha256 "7e31179f044f3a834ea51daf250ad5085d6c8ea4bbabb8c1b193cff103d3f5ea"
 
-  url "http://www.yingdev.com/Content/Projects/CmdTap/Release/#{version}/CmdTap.zip"
-  appcast "http://www.yingdev.com/projects/cmdtap"
+  url "https://www.yingdev.com/Content/Projects/CmdTap/Release/#{version}/CmdTap.zip"
+  appcast "https://www.yingdev.com/projects/cmdtap"
   name "CmdTap"
-  homepage "http://www.yingdev.com/projects/cmdtap"
+  homepage "https://www.yingdev.com/projects/cmdtap"
 
   app "CmdTap.app"
 end

--- a/Casks/dwarf-fortress-lmp.rb
+++ b/Casks/dwarf-fortress-lmp.rb
@@ -3,7 +3,7 @@ cask "dwarf-fortress-lmp" do
   sha256 "7023cb5952172bdb74bda215a7856a0dd769188cc277846fd02a70783e86ea36"
 
   # dffd.bay12games.com/ was verified as official when first introduced to the cask
-  url "http://dffd.bay12games.com/download.php?id=12202&f=Lazy+Mac+Pack.v#{version}.dmg"
+  url "https://dffd.bay12games.com/download.php?id=12202&f=Lazy+Mac+Pack.v#{version}.dmg"
   name "Dwarf Fortress LMP (Lazy Mac Pack)"
   homepage "http://www.bay12forums.com/smf/index.php?topic=158322.0"
 

--- a/Casks/edrawmax.rb
+++ b/Casks/edrawmax.rb
@@ -3,11 +3,11 @@ cask "edrawmax" do
   sha256 :no_check
 
   language "CN" do
-    url "http://cc-download.edrawsoft.cn/edraw-max_cn_full5381.dmg"
+    url "https://cc-download.edrawsoft.cn/edraw-max_cn_full5381.dmg"
     homepage "https://www.edrawsoft.cn/"
   end
   language "en", default: true do
-    url "http://download.edrawsoft.com/edraw-max_full5380.dmg"
+    url "https://download.edrawsoft.com/edraw-max_full5380.dmg"
     homepage "https://www.edrawsoft.com/"
   end
 

--- a/Casks/fl-studio.rb
+++ b/Casks/fl-studio.rb
@@ -2,7 +2,7 @@ cask "fl-studio" do
   version "20.7.2.1170"
   sha256 "d94f6f444b2ea9435d88882ade9a268ae09a83e433e6ea238b0f2ebab6335343"
 
-  url "http://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
+  url "https://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://support.image-line.com/redirect/flstudio20_mac_installer"
   name "FL Studio"
   homepage "https://www.image-line.com/flstudio/"

--- a/Casks/flvcd-bigrats.rb
+++ b/Casks/flvcd-bigrats.rb
@@ -2,9 +2,9 @@ cask "flvcd-bigrats" do
   version "0.5.2.7"
   sha256 "92cd22709e6db9607a2b2292d6ac42cda4f5bf97c7d2511b8a35b1fef0f9688b"
 
-  url "http://app.flvcd.com/flvcd_bigrats_mac#{version.no_dots}.zip"
+  url "https://app.flvcd.com/flvcd_bigrats_mac#{version.no_dots}.zip"
   name "硕鼠MAC"
-  homepage "http://www.flvcd.com/index.htm"
+  homepage "https://www.flvcd.com/index.htm"
 
   app "硕鼠MAC.app"
 end

--- a/Casks/gloomhaven-helper.rb
+++ b/Casks/gloomhaven-helper.rb
@@ -3,7 +3,7 @@ cask "gloomhaven-helper" do
   sha256 "7b2161b1ca159a7584d89355d72b8aae2c7c06c281eee8c26a75da16697dea96"
 
   url "https://esotericsoftware.com/files/ghh/GloomhavenHelper-#{version}.zip"
-  appcast "http://esotericsoftware.com/gloomhaven-helper"
+  appcast "https://esotericsoftware.com/gloomhaven-helper"
   name "Gloomhaven Helper"
   homepage "https://esotericsoftware.com/gloomhaven-helper"
 

--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -4,7 +4,7 @@ cask "imgotv" do
 
   # download.imgo.tv/ was verified as official when first introduced to the cask
   url "https://download.imgo.tv/app/mac/#{version}/mgtv-mango-#{version}.dmg"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?user_agent=Mac%20OS%20X&url=http://pcconf.api.mgtv.com/getPcDownloadUrl?source=mango2"
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?user_agent=Mac%20OS%20X&url=https://pcconf.api.mgtv.com/getPcDownloadUrl?source=mango2"
   name "芒果TV"
   homepage "https://www.mgtv.com/app/"
 

--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -6,7 +6,7 @@ cask "meshlab" do
   url "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-#{version}/MeshLab#{version}-macos.dmg"
   appcast "https://github.com/cnr-isti-vclab/meshlab/releases.atom"
   name "MeshLab"
-  homepage "http://www.meshlab.net/"
+  homepage "https://www.meshlab.net/"
 
   app "meshlab.app"
 

--- a/Casks/mindmaster.rb
+++ b/Casks/mindmaster.rb
@@ -2,7 +2,7 @@ cask "mindmaster" do
   version :latest
   sha256 :no_check
 
-  url "http://download.edrawsoft.com/mindmaster_full5378.dmg"
+  url "https://download.edrawsoft.com/mindmaster_full5378.dmg"
   name "MindMaster"
   homepage "https://www.edrawsoft.com/mindmaster/"
 

--- a/Casks/pdfelement-express.rb
+++ b/Casks/pdfelement-express.rb
@@ -2,7 +2,7 @@ cask "pdfelement-express" do
   version "1.2.1"
   sha256 "dd60c96c53725e1165a951b5b8c6c82acfbf7d47b91f2ab06ed662326df7eb34"
 
-  url "http://download.wondershare.com/cbs_down/mac-pdfelement-express_full4133.dmg"
+  url "https://download.wondershare.com/cbs_down/mac-pdfelement-express_full4133.dmg"
   appcast "https://cbs.wondershare.com/go.php?m=upgrade_info&pid=4133"
   name "PDFelement Express"
   homepage "https://pdf.wondershare.com/pdfelement-express-mac.html"

--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -2,7 +2,7 @@ cask "pdfelement" do
   version "7.6.6"
   sha256 "678f28f3043618b744df5ad588c1a673a9d03064e5301c4a43bc743e0b5c9039"
 
-  url "http://download.wondershare.com/cbs_down/mac-pdfelement_full5237.dmg"
+  url "https://download.wondershare.com/cbs_down/mac-pdfelement_full5237.dmg"
   appcast "https://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237"
   name "Wondershare PDFelement for Mac"
   homepage "https://pdf.wondershare.com/"

--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -1,6 +1,6 @@
 cask "pdfelement" do
   version "7.6.6"
-  sha256 "678f28f3043618b744df5ad588c1a673a9d03064e5301c4a43bc743e0b5c9039"
+  sha256 "8ab259e7c7aef2f291b4d1c04b064fd1fdd663542227ac19cb5619c47ff23b6e"
 
   url "https://download.wondershare.com/cbs_down/mac-pdfelement_full5237.dmg"
   appcast "https://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237"

--- a/Casks/pinegrow.rb
+++ b/Casks/pinegrow.rb
@@ -1,5 +1,5 @@
 cask "pinegrow" do
-  version "5.972"
+  version "5.973"
   sha256 "acef11695cedd16b53bf74a06d696631329e73f9bc7a439d70547fb28a7750a1"
 
   url "https://download.pinegrow.com/PinegrowMac.#{version}.dmg"

--- a/Casks/pinegrow.rb
+++ b/Casks/pinegrow.rb
@@ -1,6 +1,6 @@
 cask "pinegrow" do
   version "5.973"
-  sha256 "acef11695cedd16b53bf74a06d696631329e73f9bc7a439d70547fb28a7750a1"
+  sha256 "18dc7c55b32327adea54c2eee9133da8636774fccb97bdce1bcab7e6cd3637f0"
 
   url "https://download.pinegrow.com/PinegrowMac.#{version}.dmg"
   appcast "https://pinegrow.com/"

--- a/Casks/pinegrow.rb
+++ b/Casks/pinegrow.rb
@@ -2,7 +2,7 @@ cask "pinegrow" do
   version "5.972"
   sha256 "acef11695cedd16b53bf74a06d696631329e73f9bc7a439d70547fb28a7750a1"
 
-  url "http://download.pinegrow.com/PinegrowMac.#{version}.dmg"
+  url "https://download.pinegrow.com/PinegrowMac.#{version}.dmg"
   appcast "https://pinegrow.com/"
   name "Pinegrow"
   homepage "https://pinegrow.com/"

--- a/Casks/skyfonts.rb
+++ b/Casks/skyfonts.rb
@@ -2,7 +2,7 @@ cask "skyfonts" do
   version "5.9.5.6"
   sha256 "b2526d96898895db1c3f2caf3b1ab825898408b097e1efd88fbf33dd6bf9515f"
 
-  url "http://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
+  url "https://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_#{version}.dmg"
   appcast "https://api.skyfonts.com/api/SkyFontsAppCast?osid=3"
   name "SkyFonts"
   homepage "https://skyfonts.com/"

--- a/Casks/stageplotpro.rb
+++ b/Casks/stageplotpro.rb
@@ -2,8 +2,8 @@ cask "stageplotpro" do
   version "2.9.9.2"
   sha256 "748786ecec45adb5a506be89d5875573a3269ccb8dbaa729938d4986496c16da"
 
-  url "http://www.stageplot.com/download/StagePlotPro_#{version}.dmg"
-  appcast "http://www.stageplot.com/DownloadPage.html"
+  url "https://www.stageplot.com/download/StagePlotPro_#{version}.dmg"
+  appcast "https://www.stageplot.com/DownloadPage.html"
   name "StagePlotPro"
   homepage "https://www.stageplot.com/"
 

--- a/Casks/sunloginclient.rb
+++ b/Casks/sunloginclient.rb
@@ -2,7 +2,7 @@ cask "sunloginclient" do
   version "10.2.0.28522"
   sha256 "3b854bff658cf6c514ff007dbb73c61b48187d32b353ff637ed9b25fff7dd78e"
 
-  url "http://dl-cdn.oray.com/sunlogin/mac/SunloginClient_#{version}.dmg"
+  url "https://dl-cdn.oray.com/sunlogin/mac/SunloginClient_#{version}.dmg"
   name "Sunlogin X"
   name "向日葵 X"
   homepage "https://sunlogin.oray.com/"

--- a/Casks/tickeys.rb
+++ b/Casks/tickeys.rb
@@ -6,7 +6,7 @@ cask "tickeys" do
   url "https://github.com/yingDev/Tickeys/releases/download/#{version}/Tickeys-#{version}-yosemite.dmg"
   appcast "https://github.com/yingDev/Tickeys/releases.atom"
   name "Tickeys"
-  homepage "http://www.yingdev.com/projects/tickeys"
+  homepage "https://www.yingdev.com/projects/tickeys"
 
   app "Tickeys.app"
 end

--- a/Casks/wondershare-filmora.rb
+++ b/Casks/wondershare-filmora.rb
@@ -1,6 +1,6 @@
 cask "wondershare-filmora" do
   version "9.5.2.7"
-  sha256 "a5d72be65c12e158aeee05e4266d0af1ab956c7cb5fe65b18bde7b54b7457eac"
+  sha256 "9ab5a7ab7172c47d4bcccf94b0cb7ca07d7a35cd2f58c3214b4ceeb34767e9ae"
 
   url "https://download.wondershare.com/filmora#{version.major}-mac_full718.dmg"
   name "Wondershare Filmora9"

--- a/Casks/wondershare-filmora.rb
+++ b/Casks/wondershare-filmora.rb
@@ -2,7 +2,7 @@ cask "wondershare-filmora" do
   version "9.5.2.7"
   sha256 "a5d72be65c12e158aeee05e4266d0af1ab956c7cb5fe65b18bde7b54b7457eac"
 
-  url "http://download.wondershare.com/filmora#{version.major}-mac_full718.dmg"
+  url "https://download.wondershare.com/filmora#{version.major}-mac_full718.dmg"
   name "Wondershare Filmora9"
   homepage "https://filmora.wondershare.com/video-editor/"
 

--- a/Casks/wondershare-uniconverter.rb
+++ b/Casks/wondershare-uniconverter.rb
@@ -2,7 +2,7 @@ cask "wondershare-uniconverter" do
   version "12.0.3.17"
   sha256 "f16c7777c6a9fa6b33835af15651130ced84dedd9b95c1a999d1cc0a922baf82"
 
-  url "http://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full735.dmg"
+  url "https://download.wondershare.com/cbs_down/video-converter-ultimate-mac_full735.dmg"
   name "UniConverter"
   homepage "https://videoconverter.wondershare.com/"
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---

The two checksum errors are the same regardless of the protocol, and not the result of this commit.

```
1 file inspected, no offenses detected
==> Downloading https://downloads.accurics.com/cli/0.0.4/accurics-cli.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'accurics'.
audit for accurics: passed

1 file inspected, no offenses detected
==> Downloading https://download.aimersoft.com/cbs_down/aimer-mac-video-converte
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'aimersoft-video-converter-ultimate'.
audit for aimersoft-video-converter-ultimate: passed

1 file inspected, no offenses detected
==> Downloading https://katsurashareware.com/dl/AmorphousDiskMark.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'amorphousdiskmark', skipping verificat
audit for amorphousdiskmark: passed

1 file inspected, no offenses detected
==> Downloading https://download.cisdem.com/cisdem-datarecovery.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cisdem-data-recovery'.
audit for cisdem-data-recovery: passed

1 file inspected, no offenses detected
==> Downloading https://download.cisdem.com/cisdem-documentreader.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cisdem-document-reader'.
audit for cisdem-document-reader: passed

1 file inspected, no offenses detected
==> Downloading https://download.cisdem.com/cisdem-pdfconverterocr.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cisdem-pdf-converter-ocr'.
audit for cisdem-pdf-converter-ocr: passed

1 file inspected, no offenses detected
==> Downloading https://www.yingdev.com/Content/Projects/CmdTap/Release/1.9.4/Cm
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'cmdtap'.
audit for cmdtap: passed

1 file inspected, no offenses detected
==> Downloading https://dffd.bay12games.com/download.php?id=12202&f=Lazy+Mac+Pac
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'dwarf-fortress-lmp'.
audit for dwarf-fortress-lmp: passed

1 file inspected, no offenses detected
==> Auditing language: 'CN'
==> Downloading https://cc-download.edrawsoft.cn/edraw-max_cn_full5381.dmg
==> Downloading from https://cc-download.edrawsoft.cn/cbs_down/edraw-max_cn_full
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'edrawmax', skipping verification.
audit for edrawmax: passed
==> Auditing language: 'en'
==> Downloading https://download.edrawsoft.com/edraw-max_full5380.dmg
==> Downloading from https://download.edrawsoft.com/cbs_down/edraw-max_full5380.
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'edrawmax', skipping verification.

audit for edrawmax: passed

1 file inspected, no offenses detected
==> Downloading https://demodownload.image-line.com/flstudio/flstudio_mac_20.7.2
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'fl-studio'.
audit for fl-studio: passed

1 file inspected, no offenses detected
==> Downloading https://app.flvcd.com/flvcd_bigrats_mac0527.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'flvcd-bigrats'.
audit for flvcd-bigrats: passed

1 file inspected, no offenses detected
==> Downloading https://esotericsoftware.com/files/ghh/GloomhavenHelper-8.4.6.zi
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'gloomhaven-helper'.
audit for gloomhaven-helper: passed

1 file inspected, no offenses detected
==> Downloading https://download.imgo.tv/app/mac/6.3.2/mgtv-mango-6.3.2.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'imgotv'.
audit for imgotv: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/cnr-isti-vclab/meshlab/releases/download/Mesh
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'meshlab'.
audit for meshlab: passed

1 file inspected, no offenses detected
==> Downloading https://download.edrawsoft.com/mindmaster_full5378.dmg
==> Downloading from https://download.edrawsoft.com/cbs_down/mindmaster_full5378
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'mindmaster', skipping verification.
audit for mindmaster: passed

1 file inspected, no offenses detected
==> Downloading https://download.wondershare.com/cbs_down/mac-pdfelement-express
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'pdfelement-express'.
audit for pdfelement-express: passed

1 file inspected, no offenses detected
==> Downloading https://download.wondershare.com/cbs_down/mac-pdfelement_full5237.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'pdfelement'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
audit for pdfelement: failed
 - download not possible: Checksum for Cask 'pdfelement' does not match.
Expected: 678f28f3043618b744df5ad588c1a673a9d03064e5301c4a43bc743e0b5c9039
  Actual: 8ab259e7c7aef2f291b4d1c04b064fd1fdd663542227ac19cb5619c47ff23b6e

1 file inspected, no offenses detected
==> Downloading https://download.pinegrow.com/PinegrowMac.5.972.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'pinegrow'.
audit for pinegrow: passed

1 file inspected, no offenses detected
==> Downloading https://www.bensoftware.com/securityspy/SecuritySpy.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'securityspy'.
audit for securityspy: passed

1 file inspected, no offenses detected
==> Downloading https://cdn1.skyfonts.com/client/Monotype_SkyFonts_Mac64_5.9.5.6
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'skyfonts'.
audit for skyfonts: passed

1 file inspected, no offenses detected
==> Downloading https://www.stageplot.com/download/StagePlotPro_2.9.9.2.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'stageplotpro'.
audit for stageplotpro: passed

1 file inspected, no offenses detected
==> Downloading https://dl-cdn.oray.com/sunlogin/mac/SunloginClient_10.2.0.28522
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'sunloginclient'.
audit for sunloginclient: passed

1 file inspected, no offenses detected
==> Downloading https://github.com/yingDev/Tickeys/releases/download/0.5.0/Ticke
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'tickeys'.
audit for tickeys: passed

1 file inspected, no offenses detected
==> Downloading https://download.wondershare.com/filmora9-mac_full718.dmg
==> Downloading from https://download.wondershare.com/cbs_down/filmora9-mac_full718.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'wondershare-filmora'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
audit for wondershare-filmora: failed
 - download not possible: Checksum for Cask 'wondershare-filmora' does not match.
Expected: a5d72be65c12e158aeee05e4266d0af1ab956c7cb5fe65b18bde7b54b7457eac
  Actual: 9ab5a7ab7172c47d4bcccf94b0cb7ca07d7a35cd2f58c3214b4ceeb34767e9ae

1 file inspected, no offenses detected
==> Downloading https://download.wondershare.com/cbs_down/video-converter-ultima
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'wondershare-uniconverter'.
audit for wondershare-uniconverter: passed

1 file inspected, no offenses detected
==> Downloading https://s1.xmcdn.com/yx/ximalaya-pc/1.2.21/download/Ximalaya-1.2
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'ximalaya'.
audit for ximalaya: passed
```
