### PR TITLE
Add PB for Desktop.app v11.0.2

### DIFF
--- a/Casks/pb-for-desktop.rb
+++ b/Casks/pb-for-desktop.rb
@@ -1,0 +1,40 @@
+cask "pb-for-desktop" do
+  version "11.0.2"
+  sha256 "fdf0f2e7b820e5efbc9b0c7e69dfdcb4ac3caa3012ed7086d59a62c190f7c3e2"
+
+  # github.com/sidneys/pb-for-desktop/ was verified as official when first introduced to the cask
+  url "https://github.com/sidneys/pb-for-desktop/releases/download/v#{version}/pb-for-desktop-#{version}-mac.zip"
+  appcast "https://github.com/sidneys/pb-for-desktop/releases.atom"
+  name "PB for Desktop"
+  desc "Powerful Pushbullet desktop app. Get push notifications on Windows, Mac & Linux"
+  homepage "https://sidneys.github.io/pb-for-desktop"
+
+  auto_updates true
+
+  app "PB for Desktop.app"
+
+  uninstall launchctl: "PB for Desktop",
+            quit:      [
+              "de.sidneys.pb-for-desktop",
+              "de.sidneys.pb-for-desktop.helper",
+              "de.sidneys.pb-for-desktop.helper.GPU",
+              "de.sidneys.pb-for-desktop.helper.Plugin",
+              "de.sidneys.pb-for-desktop.helper.Renderer",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/PB for Desktop",
+    "~/Library/Application Support/ShipIt_stderr.log",
+    "~/Library/Application Support/ShipIt_stdout.log",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/de.sidneys.pb-for-desktop.sfl*",
+    "~/Library/Application Support/de.sidneys.pb-for-desktop.ShipIt",
+    "~/Library/Caches/de.sidneys.pb-for-desktop",
+    "~/Library/Caches/de.sidneys.pb-for-desktop.ShipIt",
+    "~/Library/Logs/PB for Desktop",
+    "~/Library/Preferences/ByHost/de.sidneys.pb-for-desktop.ShipIt.*.plist",
+    "~/Library/Preferences/de.sidneys.pb-for-desktop.helper.plist",
+    "~/Library/Preferences/de.sidneys.pb-for-desktop.plist",
+    "~/Library/Saved Application State/de.sidneys.pb-for-desktop.savedState",
+    "~/Library/WebKit/de.sidneys.pb-for-desktop",
+  ]
+end

--- a/Casks/pb.rb
+++ b/Casks/pb.rb
@@ -6,7 +6,7 @@ cask "pb" do
   url "https://github.com/sidneys/pb-for-desktop/releases/download/v#{version}/pb-for-desktop-#{version}-mac.zip"
   appcast "https://github.com/sidneys/pb-for-desktop/releases.atom"
   name "PB for Desktop"
-  desc "Powerful Pushbullet desktop app. Get push notifications on Windows, Mac & Linux"
+  desc "Unofficial Pushbullet desktop app to get push notifications on Mac"
   homepage "https://sidneys.github.io/pb-for-desktop"
 
   auto_updates true

--- a/Casks/pb.rb
+++ b/Casks/pb.rb
@@ -6,7 +6,7 @@ cask "pb" do
   url "https://github.com/sidneys/pb-for-desktop/releases/download/v#{version}/pb-for-desktop-#{version}-mac.zip"
   appcast "https://github.com/sidneys/pb-for-desktop/releases.atom"
   name "PB for Desktop"
-  desc "Unofficial Pushbullet desktop app to get push notifications on Mac"
+  desc "Unofficial Pushbullet desktop app to get push notifications"
   homepage "https://sidneys.github.io/pb-for-desktop"
 
   auto_updates true

--- a/Casks/pb.rb
+++ b/Casks/pb.rb
@@ -1,4 +1,4 @@
-cask "pb-for-desktop" do
+cask "pb" do
   version "11.0.2"
   sha256 "fdf0f2e7b820e5efbc9b0c7e69dfdcb4ac3caa3012ed7086d59a62c190f7c3e2"
 


### PR DESCRIPTION
# Checklist 

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

# Notes

The cask token contains the term "desktop" because of the app name.
That prevents `brew cask audit --new-cask` from working without warning:

```bash
$> brew cask audit --new-cask "pb-for-desktop"
audit for pb-for-desktop: warning
 - cask token mentions desktop
```