### PR TITLE
Use correct IINA download path

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -2,7 +2,7 @@ cask "iina" do
   version "1.0.7"
   sha256 "1b1938b3a9640b4c26960aefab1ebe077bfaaf4b7a62ccfce5a7e138c9c56d75"
 
-  url "https://dl.iina.io/IINA.v#{version}.dmg"
+  url "https://dl-portal.iina.io/IINA.v#{version}.dmg"
   appcast "https://iina.io/appcast.xml"
   name "IINA"
   homepage "https://iina.io/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Hi, I'm one of the IINA developers. We should use `dl-portal.iina.io` since it redirects to a proper mirror.