### PR TITLE
Turning auto_updates on for Amazon Chime

### DIFF
--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -6,9 +6,8 @@ cask "amazon-chime" do
   appcast "https://clients.chime.aws/mac/appcast"
   name "Amazon Chime"
   homepage "https://chime.aws/"
-  
-  auto_updates true
 
+  auto_updates true
   depends_on macos: ">= :el_capitan"
 
   app "Amazon Chime.app"

--- a/Casks/amazon-chime.rb
+++ b/Casks/amazon-chime.rb
@@ -6,6 +6,8 @@ cask "amazon-chime" do
   appcast "https://clients.chime.aws/mac/appcast"
   name "Amazon Chime"
   homepage "https://chime.aws/"
+  
+  auto_updates true
 
   depends_on macos: ">= :el_capitan"
 


### PR DESCRIPTION
Amazon Chime has an in-built auto update mechanism so turning on the
flag to stop it being updated twice.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
