### PR TITLE
Update uberconference from 2.0.4 to 2.2.2

### DIFF
--- a/Casks/uberconference.rb
+++ b/Casks/uberconference.rb
@@ -1,6 +1,6 @@
 cask "uberconference" do
-  version "2.0.4"
-  sha256 "4cf47171b3065c5dd6bb20e3e6419b7233ffe4d2f3979b259a21e2e217f44fb5"
+  version "2.2.2"
+  sha256 "3c9d39c239aca2e292d17221656bcd20347bbfaabaaa777c76e92e7ab80dfff2"
 
   # See https://help.uberconference.com/hc/en-us/articles/360033352091-Use-the-Desktop-App
   # storage.googleapis.com/ was verified as official when first introduced to the cask


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).