### PR TITLE
Update geneious-prime from 2020.2.2 to 2020.2.3

### DIFF
--- a/Casks/geneious-prime.rb
+++ b/Casks/geneious-prime.rb
@@ -1,6 +1,6 @@
 cask "geneious-prime" do
-  version "2020.2.2"
-  sha256 "056c6f05c49e494a2e7b7011e43aa993e545e26c3d20d948b26beffbd550da02"
+  version "2020.2.3"
+  sha256 "5c2f3e5cee9188bb6009545e4fe533cc5ade1f0e9121c4f8c56ab52ff155b8aa"
 
   url "https://assets.geneious.com/installers/geneious/release/Geneious_Prime_mac64_#{version.dots_to_underscores}_with_jre.dmg"
   appcast "https://www.geneious.com/download/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).