### PR TITLE
Update maccy from 0.15.0 to 0.15.1

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask "maccy" do
-  version "0.15.0"
-  sha256 "57fe3b4798ac0fb429ba92be1f249e4e744ae43e7346df722db62df28de091ab"
+  version "0.15.1"
+  sha256 "f356624344f569fe96ed90af043dd7704166a579cab7068d4cd36d1b2088eecb"
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).