### PR TITLE
Update wpsoffice from 2.5.0,4141 to 2.6.0,4284

### DIFF
--- a/Casks/wpsoffice.rb
+++ b/Casks/wpsoffice.rb
@@ -1,6 +1,6 @@
 cask "wpsoffice" do
-  version "2.5.0,4141"
-  sha256 "abd8a54aff7ea06a068fa0fcc2789b422d898483d897bebd48d3b5c01efb169c"
+  version "2.6.0,4284"
+  sha256 "d9b8fb2da3903c7c2ed409142cd2046653c692d90d56497b33705443aad7996f"
 
   # wdl1.pcfg.cache.wpscdn.com/ was verified as official when first introduced to the cask
   url "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/macwpsoffice/download/#{version.before_comma}.#{version.after_comma}/WPSOffice_#{version.before_comma}(#{version.after_comma}).dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).