### PR TITLE
generate_cask_token: use env ruby

### DIFF
--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -1,4 +1,4 @@
-#!usr/bin/env ruby
+#!/usr/bin/env ruby
 #
 # generate_cask_token
 #

--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!usr/bin/env ruby
 #
 # generate_cask_token
 #


### PR DESCRIPTION
This script fails with the Ruby shipped with Mojave.