### PR TITLE
Add zprint 1.0.0

### DIFF
--- a/Casks/zprint.rb
+++ b/Casks/zprint.rb
@@ -1,0 +1,12 @@
+cask "zprint" do
+  version "1.0.0"
+  sha256 "b707f1188c175c2028c014f0ae88cb384283aa6d097bb31298d66852162581b1"
+
+  url "https://github.com/kkinnear/zprint/releases/download/#{version}/zprintm-#{version}"
+  appcast "https://github.com/kkinnear/zprint/releases.atom"
+  name "zprint"
+  desc "Library to reformat Clojure and Clojurescript source code and s-expressions"
+  homepage "https://github.com/kkinnear/zprint"
+
+  binary "zprintm-#{version}", target: "zprint"
+end


### PR DESCRIPTION
From [the zprint repo](https://github.com/kkinnear/zprint):

> zprint is a library and command line tool providing a variety of pretty
printing capabilities for both Clojure code and Clojure/EDN structures.
It can meet almost anyone's needs. As such, it supports a number of
major source code formattng approaches.

Submitted as a Cask because building a performant native image requires
GraalVM, which is not available in Homebrew.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download zprint` is error-free.
- [x] `brew cask style --fix zprint` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask zprint` worked successfully.
- [x] `brew cask install zprint` worked successfully.
- [x] `brew cask uninstall zprint` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
