### PR TITLE
Update keysmith from 0.5.22 to 1.0.1

### DIFF
--- a/Casks/keysmith.rb
+++ b/Casks/keysmith.rb
@@ -1,6 +1,6 @@
 cask "keysmith" do
-  version "0.5.22"
-  sha256 "97fa32b003eaa99feb423080afeef2ddb520dacac3c642ca402d5b76815edc5a"
+  version "1.0.1"
+  sha256 "a1c5ac590da2940073a9ec8779213a8758efd82e39ddd8d983d2414adb0fd2c7"
 
   url "https://keysmith.app/versions/Keysmith-#{version}.dmg"
   appcast "https://www.keysmith.app/versions/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).