### PR TITLE
Update vidrio from 1.20 to 1.21

### DIFF
--- a/Casks/vidrio.rb
+++ b/Casks/vidrio.rb
@@ -3,8 +3,8 @@ cask "vidrio" do
     version "1.19.1"
     sha256 "abd03be4d007d414e0ace47ea6fffb4c2b049b30e2fef0fc65601f1c976cc4be"
   else
-    version "1.20"
-    sha256 "442af94727bcfc89bd330842342fc7857a13bf9c6153384325905d0109445553"
+    version "1.21"
+    sha256 "898a2777af79559c4c75ac7e072354267329de770d80e3bcb858cfae6b1d8b7b"
   end
 
   url "https://vidr.io/releases/macos/Vidrio-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).