### PR TITLE
Update clash-for-windows from 0.11.5 to 0.11.6

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,6 +1,6 @@
 cask "clash-for-windows" do
-  version "0.11.5"
-  sha256 "4d59021fadd98b2e63537f9c3b984f4a2c876fd73123acc0d357b3809b0990c8"
+  version "0.11.6"
+  sha256 "fbbab5759864d69a3d963103351f6e52d46cbcbb3644c5a0a93f01ef44b99139"
 
   url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
   appcast "https://github.com/Fndroid/clash_for_windows_pkg/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).