### PR TITLE
Don't automerge pull requests which have any labels.

### DIFF
--- a/.github/actions/automerge/automerge.rb
+++ b/.github/actions/automerge/automerge.rb
@@ -137,7 +137,8 @@ def passed_ci?(check_runs, cask_name)
   ]
 
   check_runs.all? { |_name, check_run| check_run["conclusion"] == "success" } &&
-    (check_runs.dig("test (#{cask_name})", "conclusion") == "success")
+    (check_runs.dig("test (#{cask_name})", "conclusion") == "success") &&
+    (check_runs.dig("conclusion", "conclusion") == "success")
 end
 
 begin

--- a/.github/actions/automerge/automerge.rb
+++ b/.github/actions/automerge/automerge.rb
@@ -75,6 +75,8 @@ def merge_pull_request(pr, check_runs = GitHub.check_runs(pr: pr).fetch("check_r
   tap = Tap.fetch(repo)
   pr_name = "#{tap.name}##{number}"
 
+  skip "Pull request #{pr_name} has labels." if pr.fetch("labels").any?
+
   diff = diff_for_pull_request(pr)
   skip "Pull request #{pr_name} is not a “simple” version bump." unless diff.simple?
 


### PR DESCRIPTION
PRs which have any labels applied should always be reviewed manually.