### PR TITLE
Don't automerge when there are outstanding requests.

### DIFF
--- a/.github/actions/automerge/automerge.rb
+++ b/.github/actions/automerge/automerge.rb
@@ -94,9 +94,6 @@ def merge_pull_request(pr, check_runs = GitHub.check_runs(pr: pr).fetch("check_r
 
     out, _ = system_command! 'git', args: ['-C', tap.path, 'log', '--pretty=format:', '-G', '\s+version\s+\'', '--follow', '--patch', '--', diff.cask_path]
 
-    # Workaround until https://github.com/anolson/git_diff/pull/16 is merged and released.
-    out.gsub!(/^copy (from|to)/, 'rename \1')
-
     version_diff = GitDiff.from_string(out)
     previous_versions = version_diff.additions.select { |l| l.version? }.map { |l| l.version }.uniq
 

--- a/.github/actions/automerge/automerge.rb
+++ b/.github/actions/automerge/automerge.rb
@@ -77,6 +77,9 @@ def merge_pull_request(pr, check_runs = GitHub.check_runs(pr: pr).fetch("check_r
 
   skip "Pull request #{pr_name} has labels." if pr.fetch("labels").any?
 
+  reviews = GitHub.open_api("#{pr.fetch("url")}/reviews")
+  skip "Pull request #{pr_name} has reviews." if reviews.any?
+
   diff = diff_for_pull_request(pr)
   skip "Pull request #{pr_name} is not a “simple” version bump." unless diff.simple?
 


### PR DESCRIPTION
Don't automerge PRs which have any review comments.

Fixes https://github.com/Homebrew/homebrew-cask/issues/81923.