### PR TITLE
Update runjs from 1.10.1 to 1.11.0

### DIFF
--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -1,6 +1,6 @@
 cask "runjs" do
-  version "1.10.1"
-  sha256 "05c6f9581c33adc73601b959e24d5a294cf62f245d2e3823a0c9972fec74c568"
+  version "1.11.0"
+  sha256 "b77b403534562884b4338e406c36df6089b448eb43e085bc92f328414a9e9234"
 
   # github.com/lukehaas/runjs/ was verified as official when first introduced to the cask
   url "https://github.com/lukehaas/runjs/releases/download/v#{version}/RunJS-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).