### PR TITLE
Update alt-tab from 6.0.0 to 6.1.0

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask "alt-tab" do
-  version "6.0.0"
-  sha256 "a6c92bde6017152dc414e4e2740f8d1dc03ba4a4bb0edb3d6da52a77c83665b5"
+  version "6.1.0"
+  sha256 "6367dae1535976dbd0d2b14d4571c37604dbb93ab425b71ae812cec4c500a9af"
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast "https://github.com/lwouis/alt-tab-macos/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).