### PR TITLE
Update jellyfin from 10.6.3 to 10.6.4

### DIFF
--- a/Casks/jellyfin.rb
+++ b/Casks/jellyfin.rb
@@ -1,6 +1,6 @@
 cask "jellyfin" do
-  version "10.6.3"
-  sha256 "66e55f9112b0d4c38128baafd7fa56919bd80a0314bb953f557b5297c7d4c95a"
+  version "10.6.4"
+  sha256 "0ddfda5c16930202adc719cce89703ee5c27c2490fb36b59fe513188245ccffa"
 
   url "https://repo.jellyfin.org/releases/server/macos/stable/installer/Jellyfin_#{version}.dmg"
   appcast "https://repo.jellyfin.org/releases/server/macos/stable/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).