### PR TITLE
Update browserosaurus from 10.12.2 to 11.0.1

### DIFF
--- a/Casks/browserosaurus.rb
+++ b/Casks/browserosaurus.rb
@@ -1,6 +1,6 @@
 cask "browserosaurus" do
-  version "10.12.2"
-  sha256 "807d4d4480dc4f10d2413df353bfe8c0a398a6ecb276e8903c09241b19aea74e"
+  version "11.0.1"
+  sha256 "d95057ccb8303c66dc42d40aaacbaf7751f3c63cb59fd85a4150b07219c48b6c"
 
   # github.com/will-stone/browserosaurus/ was verified as official when first introduced to the cask
   url "https://github.com/will-stone/browserosaurus/releases/download/v#{version}/Browserosaurus-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).