### PR TITLE
Update dcp-o-matic-player from 2.14.36 to 2.14.37

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask "dcp-o-matic-player" do
-  version "2.14.36"
-  sha256 "6a1b5b4fba17293c94d0e32174a371c0cef59af142bbe802a94aec788f78a42b"
+  version "2.14.37"
+  sha256 "fc0d5a8d536611fc144afc134fb18596ecda61baa6283eabe28a6e865385b842"
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-player&version=#{version}"
   appcast "https://dcpomatic.com/download"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).