### PR TITLE
Update and rename imgur.rb to zbuc-imgur.rb

### DIFF
--- a/Casks/zbuc-imgur.rb
+++ b/Casks/zbuc-imgur.rb
@@ -1,4 +1,4 @@
-cask "imgur" do
+cask "zbuc-imgur" do
   version :latest
   sha256 :no_check
 

--- a/Casks/zbuc-imgur.rb
+++ b/Casks/zbuc-imgur.rb
@@ -3,7 +3,8 @@ cask "zbuc-imgur" do
   sha256 :no_check
 
   url "https://github.com/zbuc/imgurBar/raw/master/imgur.dmg"
-  name "imgur"
+  name "imgurBar"
+  desc "Menubar application to upload images to imgur"
   homepage "https://github.com/zbuc/imgurBar"
 
   app "imgur.app"

--- a/Casks/zbuc-imgur.rb
+++ b/Casks/zbuc-imgur.rb
@@ -4,7 +4,7 @@ cask "zbuc-imgur" do
 
   url "https://github.com/zbuc/imgurBar/raw/master/imgur.dmg"
   name "imgurBar"
-  desc "Menubar application to upload images to imgur"
+  desc "Upload images to imgur from the menubar"
   homepage "https://github.com/zbuc/imgurBar"
 
   app "imgur.app"


### PR DESCRIPTION
Cask looks official from the name. Our rules predict this case.

It’s unpopular so the renaming won’t cause much disruption.

```
imgur
30 days: 5 (#3310)
90 days: 13 (#3715)
365 days: 98 (#3130)
Age: 2115 days (added 2014, November 17)
```