### PR TITLE
Revert "Update joplin from 1.0.233 to 1.0.237"

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,11 +1,12 @@
 cask "joplin" do
-  version "1.0.237"
-  sha256 "4bf306ea8a4a02eaced2f62fffb550ed09c90f316f504f4e6146431ab05d3ea6"
+  version "1.0.233"
+  sha256 "f8734de24064f8dfd088d9df2e2f72f8aeaee4391e907e5ed70d37c939cdd2ca"
 
   # github.com/laurent22/joplin/ was verified as official when first introduced to the cask
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg"
   appcast "https://github.com/laurent22/joplin/releases.atom"
   name "Joplin"
+  desc "Note taking and to-do application with synchronization capabilities"
   homepage "https://joplin.cozic.net/"
 
   app "Joplin.app"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#88528

The stable release is version 1.0.233.

@laurent22 there is an [open PR in `homebrew-core`](https://github.com/Homebrew/homebrew-core/pull/59053) updating the [formula for `joplin`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/joplin.rb) to version 1.0.166, but the tests are failing I am at a bit of a loss to understand why -- your valuable input would be most appreciated, thank you.