### PR TITLE
Update qcad from 3.25.0 to 3.25.1

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,11 +1,11 @@
 cask "qcad" do
-  version "3.25.0"
+  version "3.25.1"
 
   if MacOS.version <= :high_sierra
-    sha256 "f904031d67ee95adadc773d314ca154c448324447b628527df51d213f90e2c70"
+    sha256 "600f04ed9524d1d1f8471500e73c456665618e0774f791a562ed080f9cc02e4d"
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 "6ceb9145f8646d5a2c5c9de59e952b68bbdf1f544275b7ada95d0173eed84ea4"
+    sha256 "e6b811f9ca060a6e56fe6086a3ebff85cc1d2c9619659c808d2fa382daeceeb7"
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14-10.15.dmg"
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).