### PR TITLE
(re)add marathon2 and marathon-infinity casks

### DIFF
--- a/Casks/marathon-infinity.rb
+++ b/Casks/marathon-infinity.rb
@@ -1,0 +1,13 @@
+cask "marathon-infinity" do
+  version "20200830"
+  sha256 "b191070a8116b5081870c8673995589b450cc1183bbf88b1b865b5d251459f7a"
+
+  # github.com/Aleph-One-Marathon/alephone/ was verified as official when first introduced to the cask
+  url "https://github.com/Aleph-One-Marathon/alephone/releases/download/release-#{version}/MarathonInfinity-#{version}-Mac.dmg"
+  appcast "https://github.com/Aleph-One-Marathon/alephone/releases.atom"
+  name "Marathon Infinity"
+  desc "First-person shooter, third in a trilogy"
+  homepage "https://alephone.lhowon.org/"
+
+  app "Marathon Infinity.app"
+end

--- a/Casks/marathon2.rb
+++ b/Casks/marathon2.rb
@@ -1,0 +1,14 @@
+cask "marathon2" do
+  # note: "2" is not a version number, but an intrinsic part of the product name
+  version "20200830"
+  sha256 "a4c56cc2e837cec92bcded8406f5cb4cc7ddb7ce4472ac19e088120a47f18e50"
+
+  # github.com/Aleph-One-Marathon/alephone/ was verified as official when first introduced to the cask
+  url "https://github.com/Aleph-One-Marathon/alephone/releases/download/release-#{version}/Marathon2-#{version}-Mac.dmg"
+  appcast "https://github.com/Aleph-One-Marathon/alephone/releases.atom"
+  name "Marathon 2"
+  desc "First-person shooter, second in a trilogy"
+  homepage "https://alephone.lhowon.org/"
+
+  app "Marathon 2.app"
+end


### PR DESCRIPTION
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

----

Both were removed in analytics purges, but I propose to re-add them to match/parallel the `marathon` and `aleph-one` casks.

*marathon2: Removed in #63338 (cc482d5ffa)
*marathon-infinity: Removed in #72428 (3d28779db4)

It's a little bit of a weird case, as while it is an active project with several alpha releases over the years, it was just officially updated for the first time in 5 years.  All four casks are from the same repo (https://github.com/Aleph-One-Marathon/alephone), but that repo appear to meet the [https://github.com/Homebrew/homebrew-cask/blob/master/doc/faq/rejected_casks.md popularity recommendations].  I'm obviously not privy to the stats when they were purged, but I do think it makes sense to have these two for completion.  Obviously happy to discuss (cc @vitorgalvao) if views differ, although I think this aligns with https://github.com/Homebrew/homebrew-cask/pull/63053#issuecomment-656669308 and https://github.com/Homebrew/homebrew-cask/pull/63053#issuecomment-656807630.