### PR TITLE
Secure URLs

### DIFF
--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -6,7 +6,7 @@ cask "snes9x" do
   url "http://www.s9x-w32.de/dl/snes9x-#{version}-macosx-i386.zip"
   appcast "http://www.s9x-w32.de/dl/"
   name "Snes9x"
-  homepage "http://www.snes9x.com/"
+  homepage "https://www.snes9x.com/"
 
   app "snes9x-#{version}-macosx-i386/Snes9x.app"
 end

--- a/Casks/ubersicht.rb
+++ b/Casks/ubersicht.rb
@@ -2,10 +2,10 @@ cask "ubersicht" do
   version "1.4.61"
   sha256 "0e5090b99d48eb6c4b3dbcea67c32018079285015996ff2bb4cc68d383b7d019"
 
-  url "http://tracesof.net/uebersicht/releases/Uebersicht-#{version}.app.zip"
-  appcast "http://tracesof.net/uebersicht/updates.xml.rss"
+  url "https://tracesof.net/uebersicht/releases/Uebersicht-#{version}.app.zip"
+  appcast "https://tracesof.net/uebersicht/updates.xml.rss"
   name "Übersicht"
-  homepage "http://tracesof.net/uebersicht/"
+  homepage "https://tracesof.net/uebersicht/"
 
   auto_updates true
   depends_on macos: ">= :yosemite"

--- a/Casks/watchguard-mobile-vpn-with-ssl.rb
+++ b/Casks/watchguard-mobile-vpn-with-ssl.rb
@@ -8,5 +8,9 @@ cask "watchguard-mobile-vpn-with-ssl" do
 
   pkg "WatchGuard Mobile VPN with SSL Installer V#{version.after_comma}.mpkg"
 
-  uninstall pkgutil: "com.watchguard.*"
+  uninstall pkgutil: "com.watchguard.*",
+            delete:  [
+              "/Applications/WatchGuard/Uninstall WG SSL VPN.app",
+              "/Applications/WatchGuard/WatchGuard Mobile VPN with SSL.app",
+            ]
 end

--- a/Casks/watchguard-mobile-vpn-with-ssl.rb
+++ b/Casks/watchguard-mobile-vpn-with-ssl.rb
@@ -2,7 +2,7 @@ cask "watchguard-mobile-vpn-with-ssl" do
   version "12.5.3,615421"
   sha256 "b8a4f9ce908f19df6122fdf24445fdb233d812f2f6b5f08261ca2e4cca0c3784"
 
-  url "http://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.before_comma.dots_to_underscores}/WG-MVPN-SSL_#{version.before_comma.dots_to_underscores}.dmg"
+  url "https://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/#{version.before_comma.dots_to_underscores}/WG-MVPN-SSL_#{version.before_comma.dots_to_underscores}.dmg"
   name "WatchGuard Mobile VPN with SSL"
   homepage "https://www.watchguard.com/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading http://www.s9x-w32.de/dl/snes9x-1.60-macosx-i386.zip
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'snes9x'.
audit for snes9x: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://tracesof.net/uebersicht/releases/Uebersicht-1.4.61.app.z
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'ubersicht'.
audit for ubersicht: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://cdn.watchguard.com/SoftwareCenter/Files/MUVPN_SSL/12_5_3
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'watchguard-mobile-vpn-with-ssl'.
audit for watchguard-mobile-vpn-with-ssl: passed
```
