### PR TITLE
Update kodelife from 0.9.3.135 to 0.9.5.138

### DIFF
--- a/Casks/kodelife.rb
+++ b/Casks/kodelife.rb
@@ -1,9 +1,9 @@
 cask "kodelife" do
-  version "0.9.3.135"
-  sha256 "db29fbd6b8cadcae9cd438f73d8c236e2f6cca859dab42b76fde01a8b1305c31"
+  version "0.9.5.138"
+  sha256 "ce7820a85db2e8d37cec89f8c5940a9afc8b7747be40ec9f9c8a8331f609a8da"
 
   url "https://hexler.net/pub/kodelife/kodelife-#{version}-macos.zip"
-  appcast "https://hexler.net/pub/kodelife/appcast.hex"
+  appcast "https://hexler.net/pub/kodelife/appcast.xml"
   name "KodeLife"
   homepage "https://hexler.net/software/kodelife"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.