### PR TITLE
Update openphone from 1.9.1 to 1.9.2

### DIFF
--- a/Casks/openphone.rb
+++ b/Casks/openphone.rb
@@ -1,6 +1,6 @@
 cask "openphone" do
-  version "1.9.1"
-  sha256 "a06985ee79cd2561a90e9d7c18b5d9a564321d4b18130a13d4969a6e276b20e5"
+  version "1.9.2"
+  sha256 "55fb295959ce82840872c9226cac106305048030e4035047e78d6ecd4e95af83"
 
   url "https://download.openphone.co/OpenPhone-#{version}.dmg"
   appcast "https://s3-us-west-2.amazonaws.com/download.openphone.co/latest-mac.yml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.