### PR TITLE
Update intune-company-portal from 2.7.200700 to 2.8.200800

### DIFF
--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -1,6 +1,6 @@
 cask "intune-company-portal" do
-  version "2.7.200700"
-  sha256 "d6a293dd298ba6041858fb17859a1cfdc0bb27c6bc7c86e8bbd9d9ccb737c4de"
+  version "2.8.200800"
+  sha256 "e041f3c2f0c88078579cee41a065c13e2465f6b625831b755abce25fd25301ff"
 
   url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Installer.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://go.microsoft.com/fwlink/?linkid=853070"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.