### PR TITLE
Update opera from 70.0.3728.144 to 70.0.3728.154

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask "opera" do
-  version "70.0.3728.144"
-  sha256 "f0e0a0e1c68d1c7360236d189d5a83e87625e6b125a53e701d3a8de11b0de489"
+  version "70.0.3728.154"
+  sha256 "f087875e6ac566a53aa42e0069bf3f406111c015e58ad7f9460eca428bc62017"
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   appcast "https://ftp.opera.com/pub/opera/desktop/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.