### PR TITLE
Update activedock from 2.38,2038 to 2.39,2039

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask "activedock" do
-  version "2.38,2038"
-  sha256 "2d7d5d3b151fc4c36b406fddeb16ed304adf44f6d8ceaabceaeec154f21d8a98"
+  version "2.39,2039"
+  sha256 "bcc56e36fdccdcc597e28d6f76bb40d2097ed9fa9eedc1eca23eab6700ba46ba"
 
   url "https://noteifyapp.com/download/ActiveDock.dmg"
   appcast "https://macplus-software.com/downloads/ActiveDock.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.