### PR TITLE
Update webots from R2020b to R2020b-rev1

### DIFF
--- a/Casks/webots.rb
+++ b/Casks/webots.rb
@@ -1,6 +1,6 @@
 cask "webots" do
-  version "R2020b"
-  sha256 "84ebf8f401045918323e9fc60a25ebffaacfe4869f92b5d5084dac6cf8d48841"
+  version "R2020b-rev1"
+  sha256 "b131e2e98193a7977633d415bba2ca854cb16a7b95b32a853aa8588f69592c03"
 
   # github.com/cyberbotics/webots was verified as official when first introduced to the cask
   url "https://github.com/cyberbotics/webots/releases/download/#{version}/webots-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).