### PR TITLE
Rename box-edit to box-tools, install supporting apps

### DIFF
--- a/Casks/box-tools.rb
+++ b/Casks/box-tools.rb
@@ -1,14 +1,23 @@
-cask "box-edit" do
+cask "box-tools" do
   version :latest
   sha256 :no_check
 
   # e3.boxcdn.net/box-installers/boxedit/mac/currentrelease/ was verified as official when first introduced to the cask
   url "https://e3.boxcdn.net/box-installers/boxedit/mac/currentrelease/BoxToolsInstaller.dmg"
-  name "Box Edit"
+  name "Box Tools"
+  desc "Create and edit any file directly from a web browser"
   homepage "https://www.box.com/resources/downloads"
 
-  app "Install Box Tools.app/Contents/Resources/Box Edit.app",
-      target: "#{ENV["HOME"]}/Library/Application Support/Box/Box Edit/Box Edit.app"
+  apps = [
+    "Device Trust",
+    "Edit",
+    "Local Com Server",
+    "Tools Custom Apps",
+  ]
+  apps.each do |a|
+    app "Install Box Tools.app/Contents/Resources/Box #{a}.app",
+        target: "#{ENV["HOME"]}/Library/Application Support/Box/Box Edit/Box #{a}.app"
+  end
 
   uninstall quit: [
     "com.Box.Box-Edit",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Renamed `box-edit` to `box-tools` and it  now installs _exactly_ what would be installed by running `Install Box Tools.app`.

Tested locally, and I have confirmed that the `/Box Edit/` part in:
```
target: "#{ENV["HOME"]}/Library/Application Support/Box/Box Edit/Box #{a}.app"
```
is correct.

Closes https://github.com/Homebrew/homebrew-cask/issues/88637.