### PR TITLE
Update libreoffice-language-pack from 7.0.0 to 7.0.1

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,396 +1,396 @@
 cask "libreoffice-language-pack" do
-  version "7.0.0"
+  version "7.0.1"
 
   language "af" do
-    sha256 "406aa72fc4131ff66965233f3e0119ccaf2fbe49eae67274334fbf9924f61af2"
+    sha256 "c964581f2c42e4144ec5ba89a198ef47c37bb110d3e39d8952c300ef88e998b3"
     "af"
   end
   language "am" do
-    sha256 "1b7383cc7890b72d4ffe6c76dd73b656e5368b4c9b10aa527c3dfab29e00d1bb"
+    sha256 "ad75fad4e8a202653c74b2ebbea06afa4f7374a8c95e6d25380f02675a7c0e66"
     "am"
   end
   language "ar" do
-    sha256 "7c8045c9fa95a4c38cd38ac55586c6d74517ba1d661c898dd65b05017d932666"
+    sha256 "78ca644428e95f544ea39a581ecf886ba109ce343160cd435b954bf9220a51e3"
     "ar"
   end
   language "as" do
-    sha256 "2dc439f76330c7bdd00f83272ed40ef0e1052fa2ce798806bc307d975ca8112f"
+    sha256 "fc5e60c0d663d600f0b66985a629f724dae50be3d3498b60b2787c64b89ce7fc"
     "as"
   end
   language "be" do
-    sha256 "33813e0178b40c093c18d2d875bf4f3da9c3bda05bd13641090fd0c8e05d405c"
+    sha256 "f8dc364011cc59e1f69063163acdd533c8664dc8f1f2565fd2f14bc86e5251ed"
     "be"
   end
   language "bg" do
-    sha256 "ac78e90c3eaef1419c8de62f8aca8574404e7bc92e8bfe221498d6401322eeeb"
+    sha256 "63b9af359ef01031aae172546a48bc82cccaebcf883540a2efbbbc38e92f6e02"
     "bg"
   end
   language "bn-IN" do
-    sha256 "84786eff0910a225eba43ad124983938f07c7b939b2fb3222fb7265fe88fc440"
+    sha256 "1b5712815b7e521e38c68fdd6977934e325aab0fb0e6d145bee180b26b2b2882"
     "bn-IN"
   end
   language "bn" do
-    sha256 "d8a2c56166c6774c898832245b3ed6a773ef940d4afffcc9ac4a72badcfc0c7d"
+    sha256 "24d180e99df405578752e962fdbde96d75aca5adaf135f5d4e5abe0581bddc2d"
     "bn"
   end
   language "bo" do
-    sha256 "0059b9608df86d187eba8fca9cb882f8f2692e9d47574ee34e364675890e11ce"
+    sha256 "3e05038750ffa1051a832873a408d3e71771418a84e44a0f7d7f7029ace19d9a"
     "bo"
   end
   language "br" do
-    sha256 "e234d7b7e1acc3d1c7b9e5b833bc25e7c8cd1d65636dee503bfc08462c417454"
+    sha256 "18e4dd22b871c7d4aa3a992229d14fb019dd2396414bb9b36f10c054ede2dd89"
     "br"
   end
   language "bs" do
-    sha256 "1e2eed16faa2cf4cacbbfaf2de4b43e5ab1df1e89a17748b21ba88d96f17a460"
+    sha256 "c31028d866f44ca9b8df0f017d24cddf3d914527fdc5d369005e19b204cb1526"
     "bs"
   end
   language "ca" do
-    sha256 "61a6c8bef1c48e803c3704f85b78f24ac1f4d8181ad69f7a099b831f30c020e5"
+    sha256 "bf2e0a50aea120f262ceea7f25b09c901a2c37d84ecaf23e190b586f124f59f2"
     "ca"
   end
   language "cs" do
-    sha256 "6956c6f74a175ecb742220004f1e8fbdfff22e56aa411b9d1b7fc08036e475f0"
+    sha256 "100cfca24aecc517a3da6787f10ac5b528416a500c0aa85d69b3acc958a8c746"
     "cs"
   end
   language "cy" do
-    sha256 "ade3f0ce090dcbcb34c060b8226dd640de9726a463288c13932189488a7f5f6c"
+    sha256 "4afeefae27622de4f2a5a1ad97a65f9e671c2065874c8e13149c43f1eb5d0529"
     "cy"
   end
   language "da" do
-    sha256 "b2cd366d7b08fb166bf6ec14c5aa63d10d15c971d7e12244dc1fbfec174d81c1"
+    sha256 "606d92b9b402b58758a64b6e82fc4ac223be2cb022b98462b3a060d86eec9a26"
     "da"
   end
   language "de" do
-    sha256 "200bf89260428856312d309dff4fce5c79534716dc3605fe73b1f61ab032819d"
+    sha256 "d6b2cfcda60fdf383dc7c341d67dcc17cc2bfa697cfbc2a4a0865d26a44ad560"
     "de"
   end
   language "dz" do
-    sha256 "c4f81af24249431bf062a1e83d2d4718c0f09cd2af8b7f37d52277ffcad29d90"
+    sha256 "a230af0b554f8140c838f21e76bba871104e670e99d0f7aed23da9c30b26cf5d"
     "dz"
   end
   language "el" do
-    sha256 "02e765c8ddf4723300f222a5531d11a9b43b6ebc7e0f7a86510615856e8171d4"
+    sha256 "7b620c8208bf196a283b2ca6dffb0785d8a9def790b801e367c31830db17eb0d"
     "el"
   end
   language "en-GB", default: true do
-    sha256 "5fa2c8f625e3cf8faa9cb7e05139aea88a269e56f6abef849b468b09d969c783"
+    sha256 "1afec25555aeb7543e20c3063c9fc538fe45888d51240d3e62563c73990ddc9c"
     "en-GB"
   end
   language "en-ZA" do
-    sha256 "55401c558068c980bd5147e2cd30856f88d543e3a7a5cf6a0f8a1152ed9f8306"
+    sha256 "2395652a028253d58bd7551f7f850cfb80b454b25e75825a26a0ede59c7c17ce"
     "en-ZA"
   end
   language "eo" do
-    sha256 "67ac6a233a7bb9424bbfa94aca34437f1ee3972781592dd920ec671b0746a132"
+    sha256 "6062910fe5e9075809412248aeeabf57e5c728721905a8ebde7b912c6d49d91f"
     "eo"
   end
   language "es" do
-    sha256 "edd96a217c7593bbb3ef0e5f5d1b090fdfd7020668a2a0b25e766685af499d14"
+    sha256 "c9fa6681f5158897beaab963eb2b20a534dfe6965dee278e210ca37d21ee6840"
     "es"
   end
   language "et" do
-    sha256 "216c3b91ed7b4235c893136011604252fb6f5ddb319bb22999efdc16c2c1ac86"
+    sha256 "71342f08ddab22f34f310cde7f3cd3c4a2fa726f45135fc617808fff57a46f78"
     "et"
   end
   language "eu" do
-    sha256 "7cd06e539fb6ddc47578072c1f4b35c58e40bfcd12fcd80cc835b4f39209e193"
+    sha256 "25642a9e213e2cf653b2faa388fcec39e68948091f41210136f75d9bf8010a42"
     "eu"
   end
   language "fa" do
-    sha256 "69849780eeafac03d1a9b01eb41e3fe6123e7508cea1279ddd74467864355c32"
+    sha256 "144dd73df0e134321d98c92020ece74537aa4f1e010db09e973b0e37a84534eb"
     "fa"
   end
   language "fi" do
-    sha256 "0a7c5ed1d0a28e4d333ee524aa4e3a7219fd516c4ffc0ddc0781075a998ce577"
+    sha256 "a1a596bf9e2fb778a58bb1a1f79a8a0961fda430fbda658485bdcff730448090"
     "fi"
   end
   language "fr" do
-    sha256 "43b303e46b71de668dbac5dd3942b44068759b067ed8abd2484e16966adb5bd8"
+    sha256 "63aa61b11d729fd764f2558ef137d389fdae15f0414d7e3826cd657ba6316df8"
     "fr"
   end
   language "fy" do
-    sha256 "e79d6e5fa32914381b4e0bbfa88186fdc9d48a569b45e3ac5ee5196a076943ab"
+    sha256 "e124c8753897afa0b4a445a74867f4f24e381918c68522c622ac1fefe5575f82"
     "fy"
   end
   language "ga" do
-    sha256 "e33e024751a2f023314c84badad98f863f7d969c8d834c6a5a6dff6af01bd915"
+    sha256 "083a09ce8d6166494f6a0c0ba75060e0b47c0df3feee10c7d88d56374c7fbc52"
     "ga"
   end
   language "gd" do
-    sha256 "1034dd3648ac5ae799d0101e755d19459b40c01223ef849ef6c210d1e01a0b6e"
+    sha256 "282da6e91c95c3a5e4e6e02696a0b92f27c2e2aa227e2c290fa1cca4ecef8ab9"
     "gd"
   end
   language "gl" do
-    sha256 "7e4367da014d1491df2c914549165b00983bc22b65582795e2676ccb806182d8"
+    sha256 "f9cbb82a6c1fd6fbbb1caa282bdfba70ce40b52d8a6f39983f4fe5a68c37e677"
     "gl"
   end
   language "gu" do
-    sha256 "60868e1d182e15d302c9b62e2459a052a6445d53e7146e8caef45364320937e9"
+    sha256 "82b53208b2543344178837d655318aae6d5060a10197672b61c37eba624b08a8"
     "gu"
   end
   language "he" do
-    sha256 "ce36ab1654b809ae36ce04ec06f59cadb4a723f8a2f6ced081d5353b7ba08785"
+    sha256 "e7c9cae831b5fca81fdcc0ff7e749639e639534b93209ee3e9c230dc7437cded"
     "he"
   end
   language "hi" do
-    sha256 "5e1b1bbf1936591487b49bde15f275213211a65e2b0c504376cc938f686eacd3"
+    sha256 "975f77ade81a81751634b853a16a3315a14490015720481ac62ecc7bc48f88a8"
     "hi"
   end
   language "hr" do
-    sha256 "9e4c2a68ff8d1375f5edbb504d340e50e148c147b9f2caf1745faa24ea82d4b4"
+    sha256 "2559510056065c1fc5265f77e09759c9e89a5811790f89354a4a7f96909b669c"
     "hr"
   end
   language "hu" do
-    sha256 "0fb3676db1db8c32597b2493fa3d76309aaec0d4d1c18cce32ff8a1dcbb1693a"
+    sha256 "2170bcfc6e93dd01d42e9ff52bd406a5df0b0bf1b0d9ffe33a2ed99a1db092f5"
     "hu"
   end
   language "id" do
-    sha256 "2409f730ab17bbd70be2abb1e654199bad1abee4d8c4fd67161ce5aabd0ecb87"
+    sha256 "a4cb17e9f33346daa8314f412edc74add8a289710e9482da22ae065cc6914338"
     "id"
   end
   language "is" do
-    sha256 "245476eba31728b1cd7cd51dc963ce6ec04215a0f8cc217d2efb157d5864d7bb"
+    sha256 "f69acfa532e9c7970034f63149018ba3c955a2430bc18a775747a6f12f3e4563"
     "is"
   end
   language "it" do
-    sha256 "071cbc5eb19993ec957f2f3f57c332738fdcb6387488b93087b60186d463cbf0"
+    sha256 "6095a4c22a289255ea1ad6884128835bcf71909ac6bc2fe01e8cf8c670eba919"
     "it"
   end
   language "ja" do
-    sha256 "4ae91ed65064006a6f81781425c12d0d9feefaa74fbe2e84710e045bb78b0e18"
+    sha256 "8efedd09f1d4e8833de230b31ac18dddf720b7dc55a788e7a09ebfa4e395fead"
     "ja"
   end
   language "ka" do
-    sha256 "f39f0633acbb1b1e4d6507c92589a7e7c7f11b723623b982c73e86160aae63d2"
+    sha256 "96657cd6b0b1dd23ab159c18f2faad545d58c3a6b3a02e68ec4366a41023c0c2"
     "ka"
   end
   language "kk" do
-    sha256 "28223c831964feffb5fdd57cd72f14b0399286e2bcd15fefbcd444e6e1d0009f"
+    sha256 "c9af90966ad880a8cc7efda5b2d87e4a98a7f916934c9be8d11b5c28a276d126"
     "kk"
   end
   language "km" do
-    sha256 "0ad61a9dd80fdfafb0094f7fe4c1e841e9fdb96cef66beac8a419e89f87952b2"
+    sha256 "94e05ffb8d81863436476a21ac7c66558b179c6de3548015e01ebe5b08cd1593"
     "km"
   end
   language "kn" do
-    sha256 "7267a7cdc51d134318488e05cbd76ed9013a286e6f52af996aa000cb3cd02fd9"
+    sha256 "e2ca0a80e2c1c040aa6c40522018f945caba3270f8a122d335471e0b5f99bd92"
     "kn"
   end
   language "ko" do
-    sha256 "7a0e0ccb33226c2372e861dd1291e6f3f58b29e4f4e89a93d1a12cb79ee8289e"
+    sha256 "4c237d0eae1406391fa9ccf32b07a2b52f9454e05c6de43baf639558e6e3b9b8"
     "ko"
   end
   language "ks" do
-    sha256 "159016d3cad86a777db654b80fd988bb70d887a2a9f8e1b42ff37fa436cbc39d"
+    sha256 "9e91a0f68c935255998c2db096e8941d36caf9eec8f6031c614a80a2f6d55b3f"
     "ks"
   end
   language "lb" do
-    sha256 "e857a9ff77ca0f620482a4739d84029509c66bc28e8dfbcd196137ecea0d2974"
+    sha256 "cfb20090f8b1298a75e8eae21492431ae326cbda59a436ff91c460d6679d9021"
     "lb"
   end
   language "lo" do
-    sha256 "f7281d3a7800bb6182b259c90ff90ad91123b5e0a0a38ef775ffd71777f5804a"
+    sha256 "5571ec361707d2764aed00e2a79c39ab0864d554413f3f8534263a2c6af3bbb2"
     "lo"
   end
   language "lt" do
-    sha256 "9c83a155e22d6c44a02431ece2be1ff213e7fd3dd0729c1002fada9ea2dc6d2b"
+    sha256 "067b2ba33cc7017a6f47ac2a8bb678eb43c1fe705d97ca8fc9df8c9160c7f416"
     "lt"
   end
   language "lv" do
-    sha256 "a3da6960ae12584c46b2f59d07f7327ee58f528b8812b20db1cf18188953d338"
+    sha256 "1110c611a58816736a97c8dee4dd645477b613f7f1f1496481f59aab1dfe38e8"
     "lv"
   end
   language "mk" do
-    sha256 "a4e733c753229280796a113598acc259d18cded1a741bcbc7d67c75e6f3bd861"
+    sha256 "cdcbec60ca3e26fdb0f28bb203aa9c49c555f4494418efc6b2de11fac6a8e5b4"
     "mk"
   end
   language "ml" do
-    sha256 "8723cba284282301612b46d211949a465b0f00960c0b746bb5ff65503d335e04"
+    sha256 "751e1cb6479e4cab589eb399fce83029b409ca04538bde3ea6e9b1f6537ff5b7"
     "ml"
   end
   language "mn" do
-    sha256 "653d7be68597b68109f987e6c8e0183115d76670cf075d9c61ee95671adaca71"
+    sha256 "919f53bb63319e97eab0ad8c6815c26cdd2cb4268d4ebdceaab0cec9621ee47f"
     "mn"
   end
   language "mr" do
-    sha256 "3d28cd5db1be5421e92c62f6949f922e6cc93ac31e9617c6b48818e4a566a786"
+    sha256 "3cdc89d20c8cede023bdbcd8082cbde026fa2c5449225be6999cf666b6835c8c"
     "mr"
   end
   language "my" do
-    sha256 "5b46f5bf4c9ff546523679284e64282f116978d97e8934a3c9b9c59291f246c2"
+    sha256 "41c203513e675a237235a574d96e80152b5bef41d0d393fb9922600fc5ab0816"
     "my"
   end
   language "nb" do
-    sha256 "7d222d266e0a7809d287703ebea776921032db4b250f0d2f4f1e948a4b1641bd"
+    sha256 "dcddc1e52d9caef1bf2d4a99218479cb8cf97d73969a10f5ce965a83c520cebe"
     "nb"
   end
   language "ne" do
-    sha256 "670fea6658eca5bda401cd6d089cc3b76eaad178328fc30e2f9a973628dfd36c"
+    sha256 "bc3b5da106a08a4bddd0130086b8ced166f5be1bee2ead25e5f4e8842e6635bd"
     "ne"
   end
   language "nl" do
-    sha256 "6732c2504f4206b3c6edd214a172efdcce4d517f31fed3514047b1445b821109"
+    sha256 "b200341cd39d582285dc007605e681dcdee90ca70d415d6bc984c7bf26026dbb"
     "nl"
   end
   language "nn" do
-    sha256 "427bcfae67f75d06bfd57320e56e7c3d33899b80c3b71aa40eabc40615fcf3c0"
+    sha256 "9109486528083c2154c9a5e4cc9c808f4293cbc35e1b0f0d5ed9d5c94ad06dfc"
     "nn"
   end
   language "nr" do
-    sha256 "8b905519c33fcd26e31d32dfa927f968db48616be828588c51d939d40da4b944"
+    sha256 "0d0c9b6c6fad3ef58bbf97669d5f1ab3632023888aeb030142a40d45995dfec1"
     "nr"
   end
   language "oc" do
-    sha256 "a38fa35a1ab21bd200ac8e6f5f6baffbcaad1ec0c52600c400ec11001c54877e"
+    sha256 "4d736f3396ef328f63a5b05f63a07532f7046c683b4992d12b43e4bcc99e8d80"
     "oc"
   end
   language "om" do
-    sha256 "7157f3bc020a83df2c895621fd3abaedb10a69d9f236a014f780c022d7754fdb"
+    sha256 "180f96201bffa323280de553789e4358fa2da0f299937a31d994f23913cf421d"
     "om"
   end
   language "or" do
-    sha256 "40eb8b4bad0657c434625cfb757ed77c14eb85bfad4146351b9e4482cffa50c9"
+    sha256 "459291c5e8b0dbc777c76c0759ee78be8e8af19d43a6992601f2af1f9c2b7236"
     "or"
   end
   language "pa-IN" do
-    sha256 "e6da8f55b2534efb6218ff330fedd248477afac1f899c71892d90467309fcc86"
+    sha256 "f261772864bc490ab6802a9f185670620075e23178e2f9ee84f95ebe2dbe4b58"
     "pa-IN"
   end
   language "pl" do
-    sha256 "0d089e5a0dd41817f7f5ea73a8d009663fa7a74bf32eee66f48a366911ef080e"
+    sha256 "dadcc9554bdd92771dc6e5424e84cde1181efa33da275f8cf3b16fe96d6f1e99"
     "pl"
   end
   language "pt-BR" do
-    sha256 "236a964f655a6d3badff19eade39bc0280720d07cf3426cf4b153cc3904eaf98"
+    sha256 "cb0728f0bbc21fce688df297e2cd0d772aa4c6cf2977cd1d60642eacf771ad88"
     "pt-BR"
   end
   language "pt" do
-    sha256 "e8d380b81b37fa36d6c5da47e64f8627c857e12f7c20973e5f52e1070ff6fde0"
+    sha256 "ee0e4ddd79d169aabcf4753c3fbc167d871c39d108cfb6258706c99e01c2b5f3"
     "pt"
   end
   language "ro" do
-    sha256 "8d826c647f7c6bd34f0f1f9e94b2a57f7346e5814015570277c320cbd99c292d"
+    sha256 "335fc623f0520aad305fe1fde8d446b7010aed1af69ea63bcbd3dd8a4a8ce18b"
     "ro"
   end
   language "ru" do
-    sha256 "1c68c99166f4fe95bac1ab54ca63b44154bd1ce2314c772a42791ec9c57dee6e"
+    sha256 "d8119a3c4c772bfc3b172cbf42194d077f43bd5ac9ba996bc4e748ab0ba04cf6"
     "ru"
   end
   language "rw" do
-    sha256 "fd1d86079e9eb65fd72768a46e9021f5002eca4fb264540ebd9424e785b0cf34"
+    sha256 "38ca7a08b7562b2fd036ebf67a64d483c399c053def2fe86996fb07fe448a3f1"
     "rw"
   end
   language "sa-IN" do
-    sha256 "8bf1e28272230e1d1f8da3b155a09c57afe27e4efeae661df46a4f99f663b5a0"
+    sha256 "4866d4bfd0cdd18dd173fb51a430873a2756eadb79a0838bdb51bbcdbbcaed6d"
     "sa-IN"
   end
   language "sd" do
-    sha256 "355d995dd59969499a73e0bf9f50145c192011de731275b22ff7f27c32105de8"
+    sha256 "99e0666915563d76a5033f6300367804e21a82b1900dd863aa4fcea589d1d1a6"
     "sd"
   end
   language "si" do
-    sha256 "1dc5d5c4266382246eb460317128b2dc9602bfc4411a5bb714ec93e4c518f84f"
+    sha256 "e24b748a4ee8d474eaccc3b20dbea2b19b33c36ac34fcdf5454e8f71c239b643"
     "si"
   end
   language "sk" do
-    sha256 "4fbe0a05ca2ed91d2af78da37113b661a609fde3f018da819c175260841409df"
+    sha256 "36f6500f4a249a797e334870c0fbd8b82ef7016f68f95508fb033b34dd5223b1"
     "sk"
   end
   language "sl" do
-    sha256 "8fb88fc7e565704fe649b628727bf171a800488f43b35924623eb929ad2364ad"
+    sha256 "d95bc2d4a79c6268dfcbe6534561c59d632d197d5f1e88ea790162dde5cf540a"
     "sl"
   end
   language "sq" do
-    sha256 "43c753cf61b56908a38bde44316d4ffba4ed14193bef5cca545342d419d1ddde"
+    sha256 "7a6cdd3a6f6fb76d943586e77068e518f02b13504ccf281cf1d0eb6b2ce475a6"
     "sq"
   end
   language "sr" do
-    sha256 "176c9341af0db3e97029f50b7eeffb2524ee4f82844622bbfd145c579d1567d8"
+    sha256 "1b0b6990ddc1a11517497129f3e3bd66d0be0ff68342d2a6145f76a1f603e348"
     "sr"
   end
   language "ss" do
-    sha256 "0793f2b5b77d0001f4cbfba6b6a3c6182174d85f6be44c01f2f34eca2059a69a"
+    sha256 "00eeac6724835f1e4591f8c9d8d24a64a8ede76ddfc4b5d4e24ebf24f451325a"
     "ss"
   end
   language "st" do
-    sha256 "375c7265361fc650bb3f8382e4116fc82b0b2715f831a1eead0d815ce62a3b85"
+    sha256 "76f846b78d63d237a87292fdb90b0a256fa5c84df4cc49691a33daa1993e9aaa"
     "st"
   end
   language "sv" do
-    sha256 "a6023ac360ce07c4d507f4d0c9f5a6f4f8878522715ee26493bdfb7a4bf7b1b7"
+    sha256 "cbd676a739a01621c0e8f51e8de1b550a0eb2bc414a64928fb96e5981c063569"
     "sv"
   end
   language "sw-TZ" do
-    sha256 "bfe39c9e4764da0370be5af6a2423d31f2d79e3920a95146eba245954423fd8f"
+    sha256 "8bbdd2c47d70f9e4a32c2f421a13b624cf631e217e9d25d80e01f2290f852b81"
     "sw-TZ"
   end
   language "ta" do
-    sha256 "7018f3d9bc82b51f906ea140a78be2d691921ebd4376a4b65df8b4c5e286ad0d"
+    sha256 "09775e1a98781c10bb6e60752ab7c601033868c81fabe1568b9f98065f1d0ef0"
     "ta"
   end
   language "te" do
-    sha256 "19463276cadd4911ca788929d03cd5875b24132a7b50e6145766800c93cde885"
+    sha256 "b64625bc1ff5e7b527020a9ce16c017b444988385f82a2a125082055259c8fac"
     "te"
   end
   language "tg" do
-    sha256 "21519cc4bb95ba5e749688c55f2e0f5bea17a0504f6c01dfb61a78d8b1be3b8e"
+    sha256 "8612c802729ebdcd07b78836faad25d889b0499b209cdc490915516cbf6bedb8"
     "tg"
   end
   language "th" do
-    sha256 "bef7ee8b215901f2188828f5ad177571a12dae1a045cd4dc2073cf2ddd978ae0"
+    sha256 "52f9805f4048cf35f385221bfc946ba5d0281352c15738ab764b329741769542"
     "th"
   end
   language "tn" do
-    sha256 "ed07d61d3cbc429e9de35c7b067c790f9ba4795c7698b7ff10111cc4f1e00991"
+    sha256 "bb8795ccbb01aa88285a586f4155520fa53221077340500988d43e4fde15e85d"
     "tn"
   end
   language "tr" do
-    sha256 "2e9b8a33b89ce6fec866fd43fdf5d791148e6636df4461ba7e7683ff6bd1745d"
+    sha256 "e69c43e95cf58bbe3e85ad45a1ee925f977c2c999c55359a576b5e2918aa87c1"
     "tr"
   end
   language "ts" do
-    sha256 "ee4fad0d98c6f4430013f5a288ec4ab3116d02d1ad58e2f740abf769eab37bf3"
+    sha256 "437b903ac7f74ec0e07f71b61fd10d0c32acf3ea5076c211eafc69f1ea564919"
     "ts"
   end
   language "tt" do
-    sha256 "e93d4d761fbdd58ca93f31ca62e68eede4a0f641f1628c6956a3e5ddcf7f5387"
+    sha256 "169f088aa0d743be12e0ae8758628d8a1466fcddb07b8c7f7019ef82b635381b"
     "tt"
   end
   language "ug" do
-    sha256 "78b5a121056102434da9b65a44a8d2b059f53704550739ceb3abd75a5fa641d0"
+    sha256 "9b3ef217e26007cdd8102209946dc2734a98013e8f079fb7792f94e0a95b7557"
     "ug"
   end
   language "uk" do
-    sha256 "5958f53259672289678c00f787ecc23d312f26e8d170af8f438b830781bbea6b"
+    sha256 "419a4e28931241a1103a7dc3d27bc2b06468299cca32c98b3b027313603aa547"
     "uk"
   end
   language "uz" do
-    sha256 "ecf9b27da369a8ccfdc49195e9ac79774f10010e5e7ecd14d8d6e4543202b3da"
+    sha256 "486ec8d9a4a3ed5bc0eb007683b03a77628bca067fa6139a568ab45e1cdb1bad"
     "uz"
   end
   language "ve" do
-    sha256 "d146872a99c2d0465ee360ca1d8f7708f76f2083d47f20823094bcfb4cb96d4c"
+    sha256 "ba7a4c6577c3e5bfd4950b2541d9231fd4bfc065928181e0ec508a52eb20935d"
     "ve"
   end
   language "vi" do
-    sha256 "786a2ee62b2e5ba903aa6b88395073152c8f2e779abe29be28241bea81c8e556"
+    sha256 "ee29308a5c12e8cb44acb17a591d497bd29c548c67570320b4fee6832ac2bed4"
     "vi"
   end
   language "xh" do
-    sha256 "14dee77cb800d1a65a38719e62f05227527d5ee7c89972fe5c8c8e9341a012ae"
+    sha256 "9b96dfefd1bbe9a966ce195f3b27f04e7cf5e8636d444dddcaf421443015976b"
     "xh"
   end
   language "zh-CN" do
-    sha256 "fe3246f610af478e94d1448c85527a93aa09c41cfeee9415bdb3c0bc74555102"
+    sha256 "a98c6fb7a103e88a4be5c88a59c6538795c076a9537690e3538a94dae0f4ca0b"
     "zh-CN"
   end
   language "zh-TW" do
-    sha256 "5cd6d07e5bed5c88ab347bc14dda62945647c4d9b4fcdcd2f0df246efefbb199"
+    sha256 "200bfaadcb37572f53a9001d27a0ab5d13e203531e5525ba3530f3fbb23ecdbc"
     "zh-TW"
   end
   language "zu" do
-    sha256 "9aaffd68e36e60ad6cae009849e25d9f4d47f9ca784b397eb0fe512120fdca79"
+    sha256 "6ebbd00364737dfcc77efb528fc3fa369cf2b796220a99beca38fd9097ec55af"
     "zu"
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
