### PR TITLE
Bumping chef-workstation to 20.9.136

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask "chef-workstation" do
-  version "20.8.125"
-  sha256 "c2efc11084fd5f409a551cfcaf489b5c85e6e035e998cd0db448764038d42277"
+  version "20.9.136"
+  sha256 "72cacf3591508e8e7aaa75f011274c8539dc0d7b168eb265a0c544d238927e88"
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.15/chef-workstation-#{version}-1.dmg"
   appcast "https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.15&m=x86_64&v=latest"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for stable version.

Signed-off-by: tyler-ball <tball@chef.io>