### PR TITLE
Update 01_bug_report.md: `brew cask doctor` -> `brew doctor --verbose`

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -31,7 +31,7 @@ about: Create a report to help us improve
 {{replace this}}
 ```
 
-#### Output of `brew cask doctor`
+#### Output of `brew doctor --verbose`
 
 ```
 {{replace this}}


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/issues/88679

```
|-> brew cask doctor
Error: Calling brew cask doctor is deprecated! Use brew doctor --verbose instead.
```