### PR TITLE
Update popo from 3.4.5 to 3.4.7

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask "popo" do
-  version "3.4.5"
-  sha256 "4646511179f3d6f80f87e7922c9b9f93b54c516f569ce3c8a8fac7b4bc3694e0"
+  version "3.4.7"
+  sha256 "99b87db706a44923a5e9e1c2aa845f7c925d25b49c46cda710cddd16b0f69270"
 
   url "https://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   appcast "http://http.popo.netease.com:8080/api/open/jsonp/check_version?device=4",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.