### PR TITLE
Update masterway-note from 1.1.0.88242909 to 1.2.0

### DIFF
--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -13,6 +13,6 @@ cask "masterway-note" do
   auto_updates true
 
   pkg "大师笔记masterwaynote.pkg"
-  
-  uninstall pkgutil: 'YQ.Masterway.macOS'
+
+  uninstall pkgutil: "YQ.Masterway.macOS"
 end

--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -1,9 +1,9 @@
 cask "masterway-note" do
-  version "1.1.0.88242909"
-  sha256 "f6a7e718f7f1c18dc5302ee1f9b320b9ef64d926dc2980f470529cd948c819c4"
+  version "1.2.0"
+  sha256 "dc65476d865f52bab13396c608e233c3f6399d63b65dddde4ffba5fdf6721d46"
 
   # prota.oss-cn-beijing.aliyuncs.com/ was verified as official when first introduced to the cask
-  url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/#{version.major_minor}/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0-#{version}.dmg"
+  url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/#{version.major_minor}/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0masterwaynote.pkg"
   appcast "https://masterwaynote.com/mac",
           must_contain: version.major_minor
   name "Masterway Note"

--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -4,7 +4,7 @@ cask "masterway-note" do
 
   # prota.oss-cn-beijing.aliyuncs.com/ was verified as official when first introduced to the cask
   url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/#{version.major_minor}/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0masterwaynote.pkg"
-  appcast "https://masterwaynote.com/mac",
+  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://masterwaynote.com/download/macos",
           must_contain: version.major_minor
   name "Masterway Note"
   name "大师笔记"
@@ -12,5 +12,7 @@ cask "masterway-note" do
 
   auto_updates true
 
-  app "大师笔记.app"
+  pkg "大师笔记masterwaynote.pkg"
+  
+  uninstall pkgutil: 'YQ.Masterway.macOS'
 end

--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -14,5 +14,6 @@ cask "masterway-note" do
 
   pkg "大师笔记masterwaynote.pkg"
 
-  uninstall pkgutil: "YQ.Masterway.macOS"
+  uninstall pkgutil: "YQ.Masterway.macOS",
+            quit:    "YQ.Masterway.macOS"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.