### PR TITLE
Update orange from 3.24.1 to 3.26.0

### DIFF
--- a/Casks/orange.rb
+++ b/Casks/orange.rb
@@ -1,8 +1,8 @@
 cask "orange" do
-  version "3.24.1"
-  sha256 "4f31193260c4f2d9f0a495d664e8fbc7438aebfadc7e83f1d950c1c672873887"
+  version "3.26.0"
+  sha256 "21388b5e62c5c8e22bd15696f974901e918b718a7ae4e874d569781ffaddb80c"
 
-  url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}.dmg"
+  url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}-Python37.dmg"
   appcast "https://github.com/biolab/orange3/releases.atom"
   name "Orange"
   homepage "https://orange.biolab.si/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.