### PR TITLE
Update jedit from 5.5.0 to 5.6.0

### DIFF
--- a/Casks/jedit.rb
+++ b/Casks/jedit.rb
@@ -1,6 +1,6 @@
 cask "jedit" do
-  version "5.5.0"
-  sha256 "2573720e6b36dca2105d3b16bc2245b3d1dadcd7e84d40f2c41c3c285386d122"
+  version "5.6.0"
+  sha256 "7fc6bcf042401899915793e038bab826546d91b593b6f3855e9f29d4101aab61"
 
   # sourceforge.net/jedit/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/jedit/jedit#{version}install.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.