### PR TITLE
Update rcloneosx from 2.2.1 to 2.2.5

### DIFF
--- a/Casks/rcloneosx.rb
+++ b/Casks/rcloneosx.rb
@@ -1,6 +1,6 @@
 cask "rcloneosx" do
-  version "2.2.1"
-  sha256 "38d1f45614e6b4541e31eaafdf7126178dbb3de6ef8389efe1bb13ee846078d7"
+  version "2.2.5"
+  sha256 "dc44945e81c66ce9238212a4878cb35c507d364069e2361cd76b333bf0e0ab0c"
 
   url "https://github.com/rsyncOSX/rcloneosx/releases/download/v#{version}/rcloneosx.#{version}.dmg"
   appcast "https://github.com/rsyncOSX/rcloneosx/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).