### PR TITLE
Update xlink-kai from 7.4.37 to 7.4.38

### DIFF
--- a/Casks/xlink-kai.rb
+++ b/Casks/xlink-kai.rb
@@ -1,6 +1,6 @@
 cask "xlink-kai" do
-  version "7.4.37"
-  sha256 "bd9fad75377aaade3cfa3d0ed83538ff970bf688c11bee5e8408707f7c52d7bd"
+  version "7.4.38"
+  sha256 "67e9b35ef505671812c5ee48b7fe6888ebc6d3e62d12b51a10ed1df1ac9cfd63"
 
   # github.com/Team-XLink/releases/ was verified as official when first introduced to the cask
   url "https://github.com/Team-XLink/releases/releases/download/v#{version}/XLink.Kai.macOS.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).