### PR TITLE
Update vorta to v0.7.0, add BorgBackup as dependency

### DIFF
--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -1,6 +1,6 @@
 cask "vorta" do
-  version "0.6.26"
-  sha256 "c38c856f4c97fa3fa29296ad5b7a33406588aa4cde055f68ca1099a38bbb3a44"
+  version "0.7.0"
+  sha256 "27ed5fb099578e376a7a46b68cd237de40368f688530cdf3b6d87e002456d6d5"
 
   url "https://github.com/borgbase/vorta/releases/download/v#{version}/vorta-#{version}.dmg"
   appcast "https://github.com/borgbase/vorta/releases.atom"
@@ -9,6 +9,7 @@ cask "vorta" do
 
   auto_updates true
   depends_on macos: ">= :mojave"
+  depends_on formula: "borgbackup"
 
   app "Vorta.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

Some housekeeping for this formula:

- Add BorgBackup as dependency, which was recently [improved](https://github.com/Homebrew/homebrew-core/pull/59717) to better work with Apple Gatekeeper.
- Minor version update to [0.7.0](https://github.com/borgbase/vorta/releases/tag/v0.7.0)