### PR TITLE
Update freesmug-chromium from 84.0.4147.135 to 85.0.4183.83

### DIFF
--- a/Casks/freesmug-chromium.rb
+++ b/Casks/freesmug-chromium.rb
@@ -1,6 +1,6 @@
 cask "freesmug-chromium" do
-  version "84.0.4147.135"
-  sha256 "d2011c452cb50aa9546860dede8a490263dc776fe385095bb11bcb4cd54bd10b"
+  version "85.0.4183.83"
+  sha256 "03676baff11bad7927459c5e183e251a1b4a4245aabd34aaa8f5adc02a5e1cab"
 
   # sourceforge.net/osxportableapps/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/osxportableapps/Chromium_OSX_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.