### PR TITLE
Update activedock from 2.41,2041 to 2.42,2042

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,5 +1,5 @@
 cask "activedock" do
-  version "2.41,2041"
+  version "2.42,2042"
   sha256 "72ebf918e7c23118a3f4760080c02aba40dd4cba73d0d8e1fbe3e5636a33df52"
 
   url "https://noteifyapp.com/download/ActiveDock.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).