### PR TITLE
Update flash-player-debugger-ppapi from 32.0.0.414 to 32.0.0.433

### DIFF
--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -3,8 +3,7 @@ cask "flash-player-debugger-ppapi" do
   sha256 "e262d5644e078f6fbe78b384f659e1899038f18be8fc92911e1167a6c2cb7d04"
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
-  appcast "https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml",
-          must_contain: version.tr(".", ",")
+  appcast "https://www.adobe.com/support/flashplayer/debug_downloads.html"
   name "Adobe Flash Player PPAPI (plugin for Opera and chromium) content debugger"
   homepage "https://www.adobe.com/support/flashplayer/debug_downloads.html"
 

--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -1,6 +1,6 @@
 cask "flash-player-debugger-ppapi" do
-  version "32.0.0.414"
-  sha256 "818b60fe6e85d2b8d5bbfbc83665e1ba601a4d3c8b88df57cf1ec86b77704d3b"
+  version "32.0.0.433"
+  sha256 "e262d5644e078f6fbe78b384f659e1899038f18be8fc92911e1167a6c2cb7d04"
 
   url "https://fpdownload.adobe.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"
   appcast "https://fpdownload.adobe.com/pub/flashplayer/update/current/xml/version_en_mac_pep.xml",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).