### PR TITLE
Update cctalk from 7.7.1-1082 to 7.7.2.2

### DIFF
--- a/Casks/cctalk.rb
+++ b/Casks/cctalk.rb
@@ -1,9 +1,9 @@
 cask "cctalk" do
-  version "7.7.1-1082"
-  sha256 "73311cac88f85c3dfaa8cda4dabef2253a4674eabf2120d0476e999bf26782d8"
+  version "7.7.2.2"
+  sha256 "00f7e6be63b26ddb4ba5d565b5b85a8bc4139188d0215c80080985d90b736b6f"
 
   # cc.hjfile.cn/ was verified as official when first introduced to the cask
-  url "https://cc.hjfile.cn/cc/CCtalk.#{version}/8/1/103/CCtalk.#{version}.dmg"
+  url "https://cc.hjfile.cn/cc/#{version}/8/1/103/#{version}.dmg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://www.cctalk.com/webapi/basic/v1.1/version/down%3Fapptype=1%26terminalType=8%26versionType=103"
   name "CCtalk"
   homepage "https://www.cctalk.com/download/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).