### PR TITLE
Update qcad from 3.25.1 to 3.25.2

### DIFF
--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,11 +1,11 @@
 cask "qcad" do
-  version "3.25.1"
+  version "3.25.2"
 
   if MacOS.version <= :high_sierra
     sha256 "600f04ed9524d1d1f8471500e73c456665618e0774f791a562ed080f9cc02e4d"
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   else
-    sha256 "e6b811f9ca060a6e56fe6086a3ebff85cc1d2c9619659c808d2fa382daeceeb7"
+    sha256 "6f3ecfdcfd2411acb5477894a0725ddda8cc7027542e34946b7c33a6cbfd32df"
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14-10.15.dmg"
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).