### PR TITLE
Update vienna from 3.5.6 to 3.5.7

### DIFF
--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,6 +1,6 @@
 cask "vienna" do
-  version "3.5.6"
-  sha256 "81f6b6f9721d435dc73898e3629c8b477bd1a904614d5048c53e02e9ddd8f7fb"
+  version "3.5.7"
+  sha256 "59e3d7b8983cbf27e467d81fb5aa3be3664736c2020e4b651890ea490e279c55"
 
   # bintray.com/viennarss/ was verified as official when first introduced to the cask
   url "https://dl.bintray.com/viennarss/vienna-rss/Vienna#{version}.tar.gz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.