### PR TITLE
Link binary makemkvcon in makemkv cask

### DIFF
--- a/Casks/makemkv.rb
+++ b/Casks/makemkv.rb
@@ -8,6 +8,7 @@ cask "makemkv" do
   homepage "https://www.makemkv.com/"
 
   app "MakeMKV.app"
+  binary "#{appdir}/MakeMKV.app/Contents/MacOS/makemkvcon"
 
   zap trash: [
     "~/Library/Preferences/com.makemkv.MakeMKV.plist",


### PR DESCRIPTION
Make the console binary, makemkvcon, accessible when cask is installed.