### PR TITLE
Update qlcolorcode checksum

### DIFF
--- a/Casks/qlcolorcode.rb
+++ b/Casks/qlcolorcode.rb
@@ -1,6 +1,6 @@
 cask "qlcolorcode" do
   version "3.0.2"
-  sha256 "10cff73fb77f982bf218e24c0a385da31919c8dabf11c75faff876f1722ec9a4"
+  sha256 "7b4b0d51854de546c247895e519d6dbcb3b6722f9d430b18a10a1a898ca7a4ca"
 
   url "https://github.com/anthonygelibert/QLColorCode/releases/download/release-#{version}/QLColorCode.qlgenerator.zip"
   appcast "https://github.com/anthonygelibert/QLColorCode/releases.atom"


### PR DESCRIPTION
<!-- **Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
-->

Looks like they re-uploaded the latest release

https://github.com/Homebrew/homebrew-cask/pull/88935#issuecomment-689370456

> The checksum here seems to be incorrect. When I download the newest version (3.0.2) from https://github.com/anthonygelibert/QLColorCode/releases/tag/release-3.0.2 and calculate the checksum on that, I get `7b4b0d51854de546c247895e519d6dbcb3b6722f9d430b18a10a1a898ca7a4ca` rather than `10cff73fb77f982bf218e24c0a385da31919c8dabf11c75faff876f1722ec9a4` - which obviously leads to an error when trying to upgrade using homebrew.