### PR TITLE
Add usbimager.app 1.0.4

### DIFF
--- a/Casks/usbimager.rb
+++ b/Casks/usbimager.rb
@@ -1,0 +1,12 @@
+cask "usbimager" do
+  version "1.0.4"
+  sha256 "42f85d64baee14b63b45ffcb0a7a24ee3f2a5339f76f2b5cdb767a9f069de432"
+
+  url "https://gitlab.com/bztsrc/usbimager/-/raw/binaries/usbimager_#{version}-intel-macosx-cocoa.zip"
+  appcast "https://gitlab.com/bztsrc/usbimager/-/tags?format=atom"
+  name "USBImager"
+  desc "A simple GUI application that writes compressed disk images to USB drives and creates backups."
+  homepage "https://gitlab.com/bztsrc/usbimager"
+
+  app "USBImager.app"
+end

--- a/Casks/usbimager.rb
+++ b/Casks/usbimager.rb
@@ -5,7 +5,7 @@ cask "usbimager" do
   url "https://gitlab.com/bztsrc/usbimager/-/raw/binaries/usbimager_#{version}-intel-macosx-cocoa.zip"
   appcast "https://gitlab.com/bztsrc/usbimager/-/tags?format=atom"
   name "USBImager"
-  desc "GUI application that writes compressed disk images to USB drives and creates backups"
+  desc "GUI application that writes compressed images to USB drives and creates backups"
   homepage "https://gitlab.com/bztsrc/usbimager"
 
   app "USBImager.app"

--- a/Casks/usbimager.rb
+++ b/Casks/usbimager.rb
@@ -5,7 +5,7 @@ cask "usbimager" do
   url "https://gitlab.com/bztsrc/usbimager/-/raw/binaries/usbimager_#{version}-intel-macosx-cocoa.zip"
   appcast "https://gitlab.com/bztsrc/usbimager/-/tags?format=atom"
   name "USBImager"
-  desc "A simple GUI application that writes compressed disk images to USB drives and creates backups."
+  desc "GUI application that writes compressed disk images to USB drives and creates backups"
   homepage "https://gitlab.com/bztsrc/usbimager"
 
   app "USBImager.app"

--- a/Casks/usbimager.rb
+++ b/Casks/usbimager.rb
@@ -5,7 +5,7 @@ cask "usbimager" do
   url "https://gitlab.com/bztsrc/usbimager/-/raw/binaries/usbimager_#{version}-intel-macosx-cocoa.zip"
   appcast "https://gitlab.com/bztsrc/usbimager/-/tags?format=atom"
   name "USBImager"
-  desc "GUI application that writes compressed images to USB drives and creates backups"
+  desc "Write compressed disk images to USB drives"
   homepage "https://gitlab.com/bztsrc/usbimager"
 
   app "USBImager.app"


### PR DESCRIPTION
### USBImager – A Lightweight Alternative to balenaEtcher

Adds [USBImager by bzt](https://gitlab.com/bztsrc/usbimager) which is a very minimal GUI app that can write compressed disk images to USB drives.

**Publicity**: https://www.cnx-software.com/2020/09/08/usbimager-a-lightweight-alternative-to-balenaetcher

-----
Important: Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] brew cask audit --download {{cask_file}} is error-free.
- [ ] brew cask style --fix {{cask_file}} reports no offenses.
- [x] There are no open pull requests for the same update.
- [x] The submission is for a stable version or documented exception.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] brew cask audit --new-cask {{cask_file}} worked successfully.
- [x] brew cask install {{cask_file}} worked successfully.
- [x] brew cask uninstall {{cask_file}} worked successfully.
- [x] Checked the cask was not already refused.
- [ ] Checked the cask is submitted to the correct repo.