### PR TITLE
Update pingplotter from 5.18.2 to 5.18.3

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -1,6 +1,6 @@
 cask "pingplotter" do
-  version "5.18.2"
-  sha256 "d12e65bd71ecedb6c2e61b324af4438ff1cb28b38ef9f292d6b83738af089b88"
+  version "5.18.3"
+  sha256 "3c9319636bd3eb4ded9bf5475bcc55d2bdb4a8f822ffa679a1c87b8527e3941f"
 
   url "https://www.pingplotter.com/downloads/pingplotter_osx.zip"
   appcast "https://www.pingplotter.com/download"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).