### PR TITLE
Update jamf-migrator from 5.2.8 to 5.3.1

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -1,6 +1,6 @@
 cask "jamf-migrator" do
-  version "5.2.8"
-  sha256 "4909bfee8dab3df999f8e328a946c7f7d46293e23eb5485ed4ec317047bfc316"
+  version "5.3.1"
+  sha256 "d73a6e813d4d01501afedefe0bdd7b8419ac264f052513431e0e3a18b8e8c8c7"
 
   url "https://github.com/jamf/JamfMigrator/releases/download/current/jamf-migrator.zip"
   appcast "https://github.com/jamf/JamfMigrator/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).