### PR TITLE
Update jettison from 1.8 to 1.8.1

### DIFF
--- a/Casks/jettison.rb
+++ b/Casks/jettison.rb
@@ -1,6 +1,6 @@
 cask "jettison" do
-  version "1.8"
-  sha256 "d181859e8e54286e4a3747d6d22f47a390fb3e2aeba7449bc62a7fa83b8bc7df"
+  version "1.8.1"
+  sha256 "40aef2e9cc2b5fd5615c56c2b355705e185945c580e0c940eaa48493165c62fe"
 
   url "https://stclairsoft.com/download/Jettison-#{version}.dmg"
   appcast "https://stclairsoft.com/cgi-bin/sparkle.cgi?JT"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).