### PR TITLE
Update gitfinder from 1.5 to 1.5.1

### DIFF
--- a/Casks/gitfinder.rb
+++ b/Casks/gitfinder.rb
@@ -1,6 +1,6 @@
 cask "gitfinder" do
-  version "1.5"
-  sha256 "c6499d0461155947906c890d74c05c4a95f335b6c08c437f6dcca29d3ecaac8d"
+  version "1.5.1"
+  sha256 "d84e83960790d93a9164aaee4450475c2b49789bc24f89b8d472f4f0f27caf89"
 
   # zigz.ag/GitFinder/ was verified as official when first introduced to the cask
   url "https://zigz.ag/GitFinder/updates/GitFinder.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).