### PR TITLE
Update beyond-compare from 4.3.5.24893 to 4.3.6.25063

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,6 +1,6 @@
 cask "beyond-compare" do
-  version "4.3.5.24893"
-  sha256 "36251c332df4e916fba32d40dc72309d395e62f999dd0c41bfedb331fa2698c6"
+  version "4.3.6.25063"
+  sha256 "8502e7970dc616f7c257305d9801fb85a69d0c5a3fa10deebf62b37e4eb0fd35"
 
   url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "https://www.scootersoftware.com/download.php"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).