### PR TITLE
Update juicebar from 1.0.63 to 1.0.66

### DIFF
--- a/Casks/juicebar.rb
+++ b/Casks/juicebar.rb
@@ -1,10 +1,11 @@
 cask "juicebar" do
-  version "1.0.63"
-  sha256 "0947fe502aace9e0472c14bada8c4ad4a4698a56d2a2e3ee389534849100cd74"
+  version "1.0.66"
+  sha256 "748346b6d32dc35e59465f5f3742761d58ca4e07cb797c007c4480801526753a"
 
   url "https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"
   name "JuiceBar"
+  desc "Marketplace for Resolume"
   homepage "https://get-juicebar.com/"
 
   app "JuiceBar.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).

I have confirmed that the `.app` inside the `.dmg` is indeed at version 1.0.66.

Closes https://github.com/Homebrew/homebrew-cask/pull/89047