### PR TITLE
Update Steermouse from 5.4.5 to 5.5.1

### DIFF
--- a/Casks/steermouse.rb
+++ b/Casks/steermouse.rb
@@ -1,6 +1,6 @@
 cask "steermouse" do
-  version "5.4.5"
-  sha256 "a2ad5821b923673ca5ee6ac27c0ee543127b3ec9c61dfd053f820246aa47417f"
+  version "5.5.1"
+  sha256 "985ad80baa7d40248d2d66eda436f88580e3a017ac112a06d29eb6f098982c0f"
 
   url "https://plentycom.jp/ctrl/files_sm/SteerMouse#{version}.dmg"
   appcast "https://plentycom.jp/en/steermouse/download.php"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).