### PR TITLE
Update gpg-suite-pinentry.rb

### DIFF
--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -5,6 +5,7 @@ cask "gpg-suite-pinentry" do
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast "https://gpgtools.org/releases/gka/appcast.xml"
   name "GPG Suite Pinentry"
+  desc "A GUI pinentry program from the GPG Suite for GPG"
   homepage "https://gpgtools.org/"
 
   auto_updates true

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -5,7 +5,7 @@ cask "gpg-suite-pinentry" do
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast "https://gpgtools.org/releases/gka/appcast.xml"
   name "GPG Suite Pinentry"
-  desc "A GUI pinentry program from the GPG Suite for GPG"
+  desc "Pinentry GUI for GPG Suite"
   homepage "https://gpgtools.org/"
 
   auto_updates true

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -106,5 +106,12 @@ cask "gpg-suite-pinentry" do
 
   caveats do
     files_in_usr_local
+
+    <<~EOS
+      You can now set this as your pinentry program like
+
+      ~/.gnupg/gpg-agent.conf
+          pinentry-program #{HOMEBREW_PREFIX}/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
+    EOS
   end
 end

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -108,9 +108,7 @@ cask "gpg-suite-pinentry" do
     files_in_usr_local
 
     <<~EOS
-      You can now set this as your pinentry program like
-
-      ~/.gnupg/gpg-agent.conf
+      You may need to set "pinentry-gram" in `~/.gnupg/gpg-agent.conf` as follows:
           pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
     EOS
   end

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -109,7 +109,7 @@ cask "gpg-suite-pinentry" do
     files_in_usr_local
 
     <<~EOS
-      You may need to set "pinentry-gram" in `~/.gnupg/gpg-agent.conf` as follows:
+      You may need to set "pinentry-program" in `~/.gnupg/gpg-agent.conf` as follows:
 
         pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
     EOS

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -109,7 +109,8 @@ cask "gpg-suite-pinentry" do
 
     <<~EOS
       You may need to set "pinentry-gram" in `~/.gnupg/gpg-agent.conf` as follows:
-          pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
+
+        pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
     EOS
   end
 end

--- a/Casks/gpg-suite-pinentry.rb
+++ b/Casks/gpg-suite-pinentry.rb
@@ -111,7 +111,7 @@ cask "gpg-suite-pinentry" do
       You can now set this as your pinentry program like
 
       ~/.gnupg/gpg-agent.conf
-          pinentry-program #{HOMEBREW_PREFIX}/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
+          pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
     EOS
   end
 end


### PR DESCRIPTION
Add a reminder for `~/.gnupg/gpg-agent.conf` settings.
Refer to the description of `caveats` in [pinentry-mac.rb](https://github.com/Homebrew/homebrew-core/blob/5e6b22d05db84553765213aa8bbb73dfa5ae4b24/Formula/pinentry-mac.rb#L35).


After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
