### PR TITLE
Sync `self-approve` workflow.

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -20,7 +20,7 @@ puts 'Detecting changes…'
   '.github/*.yml',
   '.github/actions/{automerge}/**/*',
   '.github/ISSUE_TEMPLATE/*.md',
-  '.github/workflows/{automerge,ci,rebase,rerun-workflow,review}.yml',
+  '.github/workflows/{automerge,ci,rebase,rerun-workflow,review,self-approve}.yml',
   '.gitignore',
   '.travis.yml',
   'Casks/.rubocop.yml',


### PR DESCRIPTION
As noticed in https://github.com/Homebrew/homebrew-cask/pull/88947#issuecomment-691490611.