### PR TITLE
Only run `audit` on all casks if individual casks are not tested.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
           brew cask audit ${{ join(matrix.audit_args, ' ') }} '${{ matrix.cask.path }}'
         timeout-minutes: 30
-        if: always()
+        if: always() && !matrix.skip_audit
 
       - name: Gather cask information
         id: info

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -18,7 +18,12 @@ syntax_job = {
 matrix = [syntax_job]
 
 unless labels.include?("ci-syntax-only")
-  matrix += CiMatrix.generate(tap, labels: labels)
+  cask_jobs = CiMatrix.generate(tap, labels: labels)
+
+  # If casks were changed, skip `audit` for all others.
+  syntax_job[:skip_audit] = true if cask_jobs.any?
+
+  matrix += cask_jobs
 end
 
 puts JSON.pretty_generate(matrix)


### PR DESCRIPTION
This should prevent failures from unrelated casks having an impact on regular cask pull requests.