### PR TITLE
Update OpenInTerminal from 2.2.2 to 2.2.3

### DIFF
--- a/Casks/openinterminal.rb
+++ b/Casks/openinterminal.rb
@@ -1,6 +1,6 @@
 cask "openinterminal" do
-  version "2.2.2"
-  sha256 "ba95e668eb6aa70b97299e19d5e0b6031478f9342669c89c5ca4e05d14d73e94"
+  version "2.2.3"
+  sha256 "192a01d0d7978175f99ff438e2cc2db9b3959700d8ef4f8f71af21c42e323ac0"
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/#{version}/OpenInTerminal.app.zip"
   appcast "https://github.com/Ji4n1ng/OpenInTerminal/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).