### PR TITLE
Update softmaker-freeoffice from 2018,976 to 2018,978

### DIFF
--- a/Casks/softmaker-freeoffice.rb
+++ b/Casks/softmaker-freeoffice.rb
@@ -1,6 +1,6 @@
 cask "softmaker-freeoffice" do
-  version "2018,976"
-  sha256 "a93564f66b1c5748dea3cd3672226dedb3d6c1f9126c3c73eaa843c222336b56"
+  version "2018,978"
+  sha256 "db69c25b69f486947d2694f730fcf62a830ca4b1d9188e3c43a9a9827e8aeb79"
 
   # softmaker.net/ was verified as official when first introduced to the cask
   url "https://www.softmaker.net/down/softmaker-freeoffice-#{version.before_comma}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).