### PR TITLE
Update sha, url and appcast in masterway-note.rb

### DIFF
--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -4,7 +4,7 @@ cask "masterway-note" do
 
   # prota.oss-cn-beijing.aliyuncs.com/ was verified as official when first introduced to the cask
   url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/latest/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0masterwaynote.pkg"
-  appcast "https://masterwaynote.com/changelog/desktopapp"
+  appcast "https://masterwaynote.com/autoupdate/darwin?bundleId=1"
   name "Masterway Note"
   name "大师笔记"
   homepage "https://masterwaynote.com/"

--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -1,5 +1,5 @@
 cask "masterway-note" do
-  version "1.2.0"
+  version "1.2.0,59"
   sha256 "303f2f63a01da52ac17e8a37bbdd227269a43a66d43d7f0b2debad132b848411"
 
   # prota.oss-cn-beijing.aliyuncs.com/ was verified as official when first introduced to the cask

--- a/Casks/masterway-note.rb
+++ b/Casks/masterway-note.rb
@@ -1,11 +1,10 @@
 cask "masterway-note" do
   version "1.2.0"
-  sha256 "dc65476d865f52bab13396c608e233c3f6399d63b65dddde4ffba5fdf6721d46"
+  sha256 "303f2f63a01da52ac17e8a37bbdd227269a43a66d43d7f0b2debad132b848411"
 
   # prota.oss-cn-beijing.aliyuncs.com/ was verified as official when first introduced to the cask
-  url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/#{version.major_minor}/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0masterwaynote.pkg"
-  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://masterwaynote.com/download/macos",
-          must_contain: version.major_minor
+  url "https://prota.oss-cn-beijing.aliyuncs.com/downloads/latest/%E5%A4%A7%E5%B8%88%E7%AC%94%E8%AE%B0masterwaynote.pkg"
+  appcast "https://masterwaynote.com/changelog/desktopapp"
   name "Masterway Note"
   name "大师笔记"
   homepage "https://masterwaynote.com/"


### PR DESCRIPTION
the download link changed to "latest" - so the appcast isn't working anymore 
I just found this javascript generated changelog site that doesn't really contain the version 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
