### PR TITLE
Update wordpresscom from 6.0.3 to 6.0.2

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask "wordpresscom" do
-  version "6.0.3"
-  sha256 "a79497e7ea7260b5caf012605c97cd0fb1c7b7694eaee48a88aa8afa87238923"
+  version "6.0.2"
+  sha256 "2ce9f5314966ef51f97aa0b1b953d65466f3232921ada4c5a019cab131001f27"
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast "https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).