### PR TITLE
anka software casks + anka flow removal

### DIFF
--- a/Casks/anka-build-cloud-registry.rb
+++ b/Casks/anka-build-cloud-registry.rb
@@ -1,0 +1,35 @@
+cask "anka-build-cloud-registry" do
+  version "1.11.0-d43f91c"
+  sha256 "5cd249263b1242a50394c1ee2325aa7e3c53d3b4b4f753e2b78e4c98d7861425"
+
+  # d1efqjhnhbvc57.cloudfront.net/ was verified as official when first introduced to the cask
+  url "https://d1efqjhnhbvc57.cloudfront.net/AnkaRegistry-#{version}.pkg"
+  appcast "https://ankadocs.veertu.com/docs/release-notes/"
+  name "Anka Build Cloud Registry"
+  desc "Store Anka's macOS virtual machines in a central location"
+  homepage "https://veertu.com/"
+
+  depends_on macos: ">= :yosemite"
+
+  pkg "AnkaRegistry-#{version}.pkg"
+
+  uninstall launchctl: [
+    "com.veertu.anka.registry.plist",
+    "com.veertu.anka.registry",
+  ],
+            pkgutil:   "com.veertu.anka.registry.pkg",
+            delete:    [
+              "/Library/Application Support/Veertu/Anka/bin/fvutil",
+              "/Library/Application Support/Veertu/Anka/bin/ankaregctl",
+              "/Library/Application Support/Veertu/Anka/bin/ankaregd",
+              "/Library/Application Support/Veertu/Anka/bin/vmnetproxy",
+              "/Library/Application Support/Veertu/Anka/bin/vlaunchd",
+            ]
+
+  zap trash: "/Library/Logs/Veertu/AnkaController",
+      rmdir: "/Library/Application Support/Veertu/Anka/registry"
+
+  caveats do
+    license "https://veertu.com/terms-and-conditions/"
+  end
+end

--- a/Casks/anka-virtualization.rb
+++ b/Casks/anka-virtualization.rb
@@ -1,12 +1,12 @@
-cask "anka-flow" do
+cask "anka-virtualization" do
   version "2.2.3.118"
   sha256 "3f8937ea296ff16e87940b541e9b8ff67ffa23fe3f8d341c9bf5ff699598f776"
 
   # d1efqjhnhbvc57.cloudfront.net/ was verified as official when first introduced to the cask
-  url "https://d1efqjhnhbvc57.cloudfront.net/Anka-#{version}.pkg",
-      referer: "https://veertu.com/download-anka-run/"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://veertu.com/downloads/anka-virtualization-latest"
-  name "Veertu Anka Flow"
+  url "https://d1efqjhnhbvc57.cloudfront.net/Anka-#{version}.pkg"
+  appcast "https://ankadocs.veertu.com/docs/release-notes/"
+  name "Anka Virtualization"
+  desc "CLI tool for managing and creating macOS virtual machines"
   homepage "https://veertu.com/"
 
   depends_on macos: ">= :yosemite"


### PR DESCRIPTION
Veertu Inc is taking over the management of the casks for our software as well as adding a few.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
```
audit for anka-virtualization: passed
audit for anka-flow: passed
audit for anka-build-cloud-registry: passed
audit for anka-build-cloud-controller-and-registry: passed
```
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
The only problem with this is that my description of the software requires "macOS VM" in it and it's saying `Description shouldn't contain the platform.`
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] `brew cask audit --new-cask {{cask_file}}` worked successfully.
```
audit for anka-virtualization: passed
audit for anka-flow: passed
audit for anka-build-cloud-registry: passed
audit for anka-build-cloud-controller-and-registry: passed
```
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
