### PR TITLE
Secure URLs

### DIFF
--- a/Casks/helium.rb
+++ b/Casks/helium.rb
@@ -3,7 +3,7 @@ cask "helium" do
   sha256 :no_check
 
   # download.clockworkmod.com/carbon/ was verified as official when first introduced to the cask
-  url "http://download.clockworkmod.com/carbon/carbon-mac.zip"
+  url "https://download.clockworkmod.com/carbon/carbon-mac.zip"
   name "Helium"
   homepage "https://github.com/koush/support-wiki/wiki/Helium-Desktop-Installer-and-Android-App"
 

--- a/Casks/meshmixer.rb
+++ b/Casks/meshmixer.rb
@@ -2,10 +2,10 @@ cask "meshmixer" do
   version "3p5"
   sha256 "ec13996680ea8636c0f4a82386824e73eea8c6a2145f4b16383f167ab5777281"
 
-  url "http://www.meshmixer.com/downloads/Autodesk_Meshmixer_v#{version}_MacOS.pkg"
-  appcast "http://meshmixer.com/download.html"
+  url "https://meshmixer.com/downloads/Autodesk_Meshmixer_v#{version}_MacOS.pkg"
+  appcast "https://meshmixer.com/download.html"
   name "MeshMixer"
-  homepage "http://meshmixer.com/"
+  homepage "https://meshmixer.com/"
 
   pkg "Autodesk_Meshmixer_v#{version}_macOS.pkg"
 

--- a/Casks/td-agent.rb
+++ b/Casks/td-agent.rb
@@ -2,8 +2,8 @@ cask "td-agent" do
   version "3.1.1-0"
   sha256 "aea92474070fc973315228dde287a32111d29cb52f4a94bc7f73cfa73d88afc8"
 
-  # packages.treasuredata.com.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url "http://packages.treasuredata.com.s3.amazonaws.com/#{version.major}/macosx/td-agent-#{version}.dmg"
+  # s3.amazonaws.com/packages.treasuredata.com/ was verified as official when first introduced to the cask
+  url "https://s3.amazonaws.com/packages.treasuredata.com/#{version.major}/macosx/td-agent-#{version}.dmg"
   appcast "https://td-agent-package-browser.herokuapp.com/#{version.major}/macosx"
   name "td-agent"
   homepage "https://www.fluentd.org/"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://download.clockworkmod.com/carbon/carbon-mac.zip
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
==> No SHA-256 checksum defined for Cask 'helium', skipping verification.
audit for helium: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://meshmixer.com/downloads/Autodesk_Meshmixer_v3p5_MacOS.pk
==> Verifying SHA-256 checksum for Cask 'meshmixer'.
audit for meshmixer: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://s3.amazonaws.com/packages.treasuredata.com/3/macosx/td-a
==> Verifying SHA-256 checksum for Cask 'td-agent'.
audit for td-agent: passed
```
