### PR TITLE
Update robo-3t from 1.4.0 to 1.4.1

### DIFF
--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -1,9 +1,9 @@
 cask "robo-3t" do
-  version "1.4.0,12e54cc"
-  sha256 "a95ef2029a0d430b935dcd29dc18d48c86b3ccc92e26855db1afd256ef0ccf5b"
+  version "1.4.1,122dbd9"
+  sha256 "02cf60fd969e7c2f7037bb567f558e436618f9a707904f786d1f03f97193a263"
 
-  # download.studio3t.com was verified as official when first introduced to the cask
-  url "https://download.studio3t.com/robomongo/mac/robo3t-#{version.before_comma}-darwin-x86_64-#{version.after_comma}.dmg"
+  # github.com/Studio3T/robomongo/releases was verified as official when first introduced to the cask
+  url "https://github.com/Studio3T/robomongo/releases/download/v#{version.before_comma}/robo3t-#{version.before_comma}-darwin-x86_64-#{version.after_comma}.dmg"
   appcast "https://robomongo.org/download"
   name "Robo 3T (formerly Robomongo)"
   desc "MongoDB management tool (formerly Robomongo)"


### PR DESCRIPTION
1.4.0 Has some pretty terrible UI bugs, and a 1.4.1 patch version was released on their GitHub page. It's even mentioned in the comments on their 1.4 release blog: https://blog.robomongo.org/robo-3t-1-4/#Download

Changed the url to their GitHub release version, due to the main download page having an email registration wall (and possibly doesn't contain the patch release, judging by the official advice to download the patch version from GitHub).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions)
