### PR TITLE
Update oracle-jdk-javadoc from 14.0.2,12:205943a0976c4ed48cb16f1043c5c647 to 15,36:779bf45e88a44cbd9ea6621d33e33db1

### DIFF
--- a/Casks/oracle-jdk-javadoc.rb
+++ b/Casks/oracle-jdk-javadoc.rb
@@ -1,6 +1,6 @@
 cask "oracle-jdk-javadoc" do
-  version "14.0.2,12:205943a0976c4ed48cb16f1043c5c647"
-  sha256 "de553f6c490da58748f6a334335434667ea1844d06a62b93407bb2f244d5c816"
+  version "15,36:779bf45e88a44cbd9ea6621d33e33db1"
+  sha256 "ecf31c3f366069300517999971982fba900effec6999931cb587e97aaaa0052a"
 
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_doc-all.zip",
       cookies: {


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).