### PR TITLE
Update dropbox-passwords from 5.1.4 to 5.2.4

### DIFF
--- a/Casks/dropbox-passwords.rb
+++ b/Casks/dropbox-passwords.rb
@@ -1,10 +1,10 @@
 cask "dropbox-passwords" do
-  version "5.1.4"
-  sha256 "3e586ee75ff0b846371f37e17a12569a2683df112d3cd7f70931e60d53482c15"
+  version "5.2.4"
+  sha256 "74d41ac8296c4dfa71cda236320173c83856b1d99fcc6bcc9de820d669cd85ba"
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/dbx-releng/dropbox_passwords/mac/DropboxPasswords_#{version}.dmg"
-  appcast "https://www.dropbox.com/dropbox-passwords-download/mac/beta"
+  appcast "https://www.dropbox.com/dropbox-passwords-download/mac/stable"
   name "Dropbox Passwords"
   desc "Password manager that syncs across devices"
   homepage "https://www.dropbox.com/features/security/passwords"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).