### PR TITLE
Update typinator from 8.4.1 to 8.5

### DIFF
--- a/Casks/typinator.rb
+++ b/Casks/typinator.rb
@@ -1,6 +1,6 @@
 cask "typinator" do
-  version "8.4.1"
-  sha256 "4175671b56683c0edebe832c0d1430f5b60c3dd2c2e7f57db73c2c6ecbe47950"
+  version "8.5"
+  sha256 "670df1830fa7893baf892e37008741c54c46d3e9e989d6933ac030352207342f"
 
   url "https://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
       user_agent: :fake


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).