### PR TITLE
Revert "Update wordpresscom from 6.0.2 to 6.0.3"

### DIFF
--- a/Casks/wordpresscom.rb
+++ b/Casks/wordpresscom.rb
@@ -1,6 +1,6 @@
 cask "wordpresscom" do
-  version "6.0.3"
-  sha256 "a79497e7ea7260b5caf012605c97cd0fb1c7b7694eaee48a88aa8afa87238923"
+  version "6.0.2"
+  sha256 "2ce9f5314966ef51f97aa0b1b953d65466f3232921ada4c5a019cab131001f27"
 
   url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
   appcast "https://public-api.wordpress.com/rest/v1.1/desktop/osx/version?compare=0.1.0&channel=stable"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#88877
not working -> https://github.com/Homebrew/homebrew-cask/pull/89314