### PR TITLE
Update lightproxy from 1.1.36 to 1.1.38

### DIFF
--- a/Casks/lightproxy.rb
+++ b/Casks/lightproxy.rb
@@ -1,6 +1,6 @@
 cask "lightproxy" do
-  version "1.1.36"
-  sha256 "9d19c02a6db9c54a45436c0bd43cbaceeab0ba4da787f13cc43b8f9d85a12781"
+  version "1.1.38"
+  sha256 "f576fae36ce6b25efca5fa53fbd1f13e3c593e60641d26f64a00b8b2fc4b9b5b"
 
   # github.com/alibaba/lightproxy/ was verified as official when first introduced to the cask
   url "https://github.com/alibaba/lightproxy/releases/download/v#{version}/LightProxy-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).