### PR TITLE
Update permute from 3.5.4,2300 to 3.5.5,2305

### DIFF
--- a/Casks/permute.rb
+++ b/Casks/permute.rb
@@ -1,6 +1,6 @@
 cask "permute" do
-  version "3.5.4,2300"
-  sha256 "8ed158c730d91a0f034fa8634f40cb07303c11ed1a9d4beaefa7e1d6f8ffbdec"
+  version "3.5.5,2305"
+  sha256 "dc2c6002a6f067aa250e0f383cbcf46cd66b4f963d96cdab3f9706e9c1bf165a"
 
   url "https://trial.charliemonroe.net/permute/v#{version.major}/Permute_#{version.major}_#{version.after_comma}.dmg"
   appcast "https://trial.charliemonroe.net/permute/updates_#{version.major}.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).