### PR TITLE
Update tagspaces from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -1,6 +1,6 @@
 cask "tagspaces" do
-  version "3.6.1"
-  sha256 "1e39b3138e0b1e92ef1d33a39d22c757b4b4c0619bc45eb82adf899560aa4a0b"
+  version "3.6.2"
+  sha256 "44af73dfd63eac6b943cc8fc0234a13eb0861f78e3a4bf11b986997c56bba5de"
 
   # github.com/tagspaces/tagspaces/ was verified as official when first introduced to the cask
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).