### PR TITLE
Update juicebar from 1.0.66 to 1.0.68

### DIFF
--- a/Casks/juicebar.rb
+++ b/Casks/juicebar.rb
@@ -1,6 +1,6 @@
 cask "juicebar" do
-  version "1.0.66"
-  sha256 "748346b6d32dc35e59465f5f3742761d58ca4e07cb797c007c4480801526753a"
+  version "1.0.68"
+  sha256 "144b413b57396a850ef82886398023d5eb1d3e04154004dfb11086fe6017d343"
 
   url "https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filename.cgi?url=https://mango.get-juicebar.com/v#{version.major}/bundles/macOS/latest"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).