### PR TITLE
Add Home Assistant.app v2020.7,1

### DIFF
--- a/Casks/home-assistant.rb
+++ b/Casks/home-assistant.rb
@@ -10,4 +10,10 @@ cask "home-assistant" do
   homepage "https://companion.home-assistant.io/"
 
   app "Home Assistant.app"
+
+  zap trash: [
+               '~/Library/Application Scripts/io.robbie.HomeAssistant',
+               '~/Library/Group Containers/group.io.robbie.homeassistant',
+               '~/Library/Containers/io.robbie.HomeAssistant',
+             ]
 end

--- a/Casks/home-assistant.rb
+++ b/Casks/home-assistant.rb
@@ -1,0 +1,13 @@
+cask "home-assistant" do
+  version "2020.7,1"
+  sha256 "118fb5a137784c0f546157a08d04d02925e94da0d804bd6aa17458a246df247a"
+
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/home-assistant/iOS/releases/download/mac/#{version.before_comma}/#{version.after_comma}/home-assistant-mac.zip"
+  appcast "https://github.com/home-assistant/iOS/releases.atom"
+  name "Home Assistant"
+  desc "Companion app for Home Assistant home automation software"
+  homepage "https://companion.home-assistant.io/"
+
+  app "Home Assistant.app"
+end

--- a/Casks/home-assistant.rb
+++ b/Casks/home-assistant.rb
@@ -2,7 +2,7 @@ cask "home-assistant" do
   version "2020.7,1"
   sha256 "118fb5a137784c0f546157a08d04d02925e94da0d804bd6aa17458a246df247a"
 
-  # github.com was verified as official when first introduced to the cask
+  # github.com/home-assistant/iOS/ was verified as official when first introduced to the cask
   url "https://github.com/home-assistant/iOS/releases/download/mac/#{version.before_comma}/#{version.after_comma}/home-assistant-mac.zip"
   appcast "https://github.com/home-assistant/iOS/releases.atom"
   name "Home Assistant"

--- a/Casks/home-assistant.rb
+++ b/Casks/home-assistant.rb
@@ -12,8 +12,8 @@ cask "home-assistant" do
   app "Home Assistant.app"
 
   zap trash: [
-               '~/Library/Application Scripts/io.robbie.HomeAssistant',
-               '~/Library/Group Containers/group.io.robbie.homeassistant',
-               '~/Library/Containers/io.robbie.HomeAssistant',
-             ]
+    "~/Library/Application Scripts/io.robbie.HomeAssistant",
+    "~/Library/Group Containers/group.io.robbie.homeassistant",
+    "~/Library/Containers/io.robbie.HomeAssistant",
+  ]
 end


### PR DESCRIPTION
Cask for the Home Assistant companion app. Fixes home-assistant/iOS#1037, fixes home-assistant/iOS#1039.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or **[documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version)**.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
