### PR TITLE
Update react-native-debugger (0.11.5)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,6 +1,6 @@
 cask "react-native-debugger" do
-  version "0.11.4"
-  sha256 "5e7d61729dfcec903636fa2374abcd8bc351433d9b3e141706a4c425ace49fca"
+  version "0.11.5"
+  sha256 "ff58023a5e098329e0e694ba1079b2a287efa36610677136e624cbec496d8e37"
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   appcast "https://github.com/jhen0409/react-native-debugger/releases.atom"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
