### PR TITLE
Update Chicken from 2.2b2 to 2.2b3

### DIFF
--- a/Casks/chicken.rb
+++ b/Casks/chicken.rb
@@ -1,11 +1,11 @@
 cask "chicken" do
-  version "2.2b2"
-  sha256 "20e910b6cbf95c3e5dcf6fe8e120d5a0911f19099128981fb95119cee8d5fc6b"
+  version "2.2b3"
+  sha256 "78f05c20e6584d8eb46a30c0f9eb3e90f4e583a0f2d78ad5810370fadec0f323"
 
-  url "https://downloads.sourceforge.net/chicken/Chicken-#{version}.dmg"
-  appcast "https://chicken.sourceforge.io/chicken.xml"
+  url "https://github.com/boecko/chicken/releases/download/v#{version}/Chicken_#{version}.dmg"
+  appcast "https://github.com/boecko/chicken/releases.atom"
   name "Chicken"
-  homepage "https://sourceforge.net/projects/chicken/"
+  homepage "https://github.com/boecko/chicken"
 
   app "Chicken.app"
 


### PR DESCRIPTION
The current chicken cast install a 32-bit application. The installed app can't start on Catalina since apple removed 32bit support.

I saw https://github.com/Homebrew/homebrew-cask/pull/26012, but after 4 year the decision needs to be reviewed since the current cask is defuct/does not work on Catalina.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
