### PR TITLE
Update disk-drill from 3.8.977 to 3.8.975

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,6 +1,6 @@
 cask "disk-drill" do
-  version "3.8.977"
-  sha256 "c87f1d7d016d950396e328fafa237ea4aff5c6cbd2bd62e091c43750f6e0976a"
+  version "3.8.975"
+  sha256 "7681d8b279c772849b770dd01647f34d3ccc2b8df849c1e24d5aa4b97b5bc184"
 
   url "https://www.cleverfiles.com/releases/DiskDrill_#{version}.zip"
   appcast "https://www.cleverfiles.com/releases/auto-update/dd2-newestr.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).