### PR TITLE
Update Webex Teams download URL

### DIFF
--- a/Casks/webex-teams.rb
+++ b/Casks/webex-teams.rb
@@ -2,8 +2,9 @@ cask "webex-teams" do
   version :latest
   sha256 :no_check
 
-  url "https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg" 
+  url "https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg"
   name "Webex Teams"
+  desc "Video communication and virtual meeting platform"
   homepage "https://www.webex.com/"
 
   app "Webex Teams.app"

--- a/Casks/webex-teams.rb
+++ b/Casks/webex-teams.rb
@@ -2,7 +2,7 @@ cask "webex-teams" do
   version :latest
   sha256 :no_check
 
-  url "https://www.webex.com/downloads/WebexTeams.dmg"
+  url "https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg" 
   name "Webex Teams"
   homepage "https://www.webex.com/"
 


### PR DESCRIPTION
Existing URL used by Homebrew installs an outdated version that then needs to self-update itself which takes some time.  Updated URL is what is used on the website currently. 
https://www.webex.com/downloads.html and https://help.webex.com/en-us/krgc3ab/Webex-Teams-Download-the-App


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
