### PR TITLE
Update obsidian from 0.8.14 to 0.8.15

### DIFF
--- a/Casks/obsidian.rb
+++ b/Casks/obsidian.rb
@@ -1,6 +1,6 @@
 cask "obsidian" do
-  version "0.8.14"
-  sha256 "234a9793a210229da1b29a4558c199ea47a4c62159b2101e70260ab9e895df13"
+  version "0.8.15"
+  sha256 "ee5394c69e5e6f5dff96131c8a4982d545abf79a461ef4777d8404e73d46a9b8"
 
   # github.com/obsidianmd/ was verified as official when first introduced to the cask
   url "https://github.com/obsidianmd/obsidian-releases/releases/download/v#{version}/Obsidian-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).