### PR TITLE
Update media-center from 26.0.107 to 27.00.15

### DIFF
--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -1,8 +1,8 @@
 cask "media-center" do
-  version "26.0.107"
-  sha256 "8865b68f48fca629729b50175498cfae7d782a078bb948fa1a54f349615f35a0"
+  version "27.00.15"
+  sha256 "1fc547cd95d9c51cb78f0f1885b7fa1e29a3bc8031d1527a000aa5273688e72b"
 
-  url "https://files.jriver.com/mediacenter/channels/v#{version.major}/latest/MediaCenter#{version.no_dots}.dmg"
+  url "https://files.jriver.com/mediacenter/channels/v#{version.major}/stable/MediaCenter#{version.no_dots}.dmg"
   appcast "https://www.jriver.com/download.html",
           must_contain: version.no_dots
   name "JRiver Media Center"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).