### PR TITLE
Update gitx.rb

### DIFF
--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -1,22 +1,8 @@
-# frozen_string_literal: true
-
 cask "gitx" do
-  if MacOS.version <= :snow_leopard
-    version "0.14.81"
-    sha256 "ba61b4b84cb613a6196e6bd1d3102ad460ec0645a885b1cb94132e5244e1d330"
-  elsif MacOS.version <= :lion
-    version "0.15.1949"
-    sha256 "17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a"
-  elsif MacOS.version <= :mavericks
-    version "0.15.1964"
-    sha256 "d88bcb7f92ca1cdf31cb3f1d2e24c03e2091ab330319aeef2e770c0dbd6f7817"
-  else
-    version "0.16.2327"
-    sha256 "c8dd6dcac8dd85808acdb937f3125bf67b2b1c2b36da5541f20de73628abf544"
-    s="s"
-  end
+  version "0.16.2327"
+  sha256 "c8dd6dcac8dd85808acdb937f3125bf67b2b1c2b36da5541f20de73628abf544"
 
-  url "https://github.com/gitx/gitx/releases/download/build#{s}/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
+  url "https://github.com/gitx/gitx/releases/download/builds/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
   appcast "https://github.com/gitx/gitx/releases.atom"
   name "GitX"
   desc "GUI for git"

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -9,10 +9,7 @@ cask "gitx" do
   desc "GUI for git"
   homepage "https://github.com/gitx/gitx"
 
-  conflicts_with cask: [
-    "laullon-gitx",
-    "rowanj-gitx",
-  ]
+  conflicts_with cask: "rowanj-gitx"
 
   app "GitX.app"
   binary "#{appdir}/GitX.app/Contents/Resources/gitx"

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -19,12 +19,12 @@ cask "gitx" do
   url "https://github.com/gitx/gitx/releases/download/build#{s}/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
   appcast "https://github.com/gitx/gitx/releases.atom"
   name "GitX"
-  desc "Is a native graphical client for the git version control system"
+  desc "GUI for git"
   homepage "https://github.com/gitx/gitx"
 
-  conflicts_with cask: %w[
-    laullon-gitx
-    rowanj-gitx
+  conflicts_with cask: [
+    "laullon-gitx",
+    "rowanj-gitx",
   ]
 
   app "GitX.app"

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -1,21 +1,30 @@
-cask "gitx" do
-  version "0.7.1"
-  sha256 "d28a2cc1a1d0b83908e7b7fa47706c4e4fab3570277b2a7eae0324b1d86a4b87"
+cask 'gitx' do
+  if MacOS.version <= :snow_leopard
+    version '0.14.81'
+    sha256 'ba61b4b84cb613a6196e6bd1d3102ad460ec0645a885b1cb94132e5244e1d330'
+  elsif MacOS.version <= :lion
+    version '0.15.1949'
+    sha256 '17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a'
+  elsif MacOS.version <= :mavericks
+    version '0.15.1964'
+    sha256 'd88bcb7f92ca1cdf31cb3f1d2e24c03e2091ab330319aeef2e770c0dbd6f7817'
+  else
+    version '0.16.2327'
+    sha256 'c8dd6dcac8dd85808acdb937f3125bf67b2b1c2b36da5541f20de73628abf544'
+    s='s'
+  end
 
-  url "http://frim.frim.nl/GitXStable.app.zip"
-  appcast "http://gitx.frim.nl/Downloads/appcast.xml"
-  name "GitX"
-  homepage "http://gitx.frim.nl/"
+  url "https://github.com/gitx/gitx/releases/download/build#{s}/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
 
-  conflicts_with cask: ["laullon-gitx", "rowanj-gitx"]
+  appcast 'https://github.com/gitx/gitx/releases.atom'
+  name 'GitX-dev'
+  homepage 'https://github.com/gitx/gitx'
 
-  app "GitX.app"
-  binary "#{appdir}/GitX.app/Contents/Resources/gitx"
-
-  zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/nl.frim.gitx.sfl*",
-    "~/Library/Caches/nl.frim.GitX",
-    "~/Library/Preferences/nl.frim.GitX.plist",
-    "~/Library/Saved Application State/nl.frim.GitX.savedState",
+  conflicts_with cask: %w[
+    laullon-gitx
+    rowanj-gitx
   ]
+
+  app 'GitX.app'
+  binary "#{appdir}/GitX.app/Contents/Resources/gitx"
 end

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -1,4 +1,6 @@
 cask 'gitx' do
+  desc "GitX is an OS X (MacOS) native graphical client for the git version control system."
+
   if MacOS.version <= :snow_leopard
     version '0.14.81'
     sha256 'ba61b4b84cb613a6196e6bd1d3102ad460ec0645a885b1cb94132e5244e1d330'

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -1,32 +1,32 @@
-cask 'gitx' do
-  desc "GitX is an OS X (MacOS) native graphical client for the git version control system."
+# frozen_string_literal: true
 
+cask "gitx" do
   if MacOS.version <= :snow_leopard
-    version '0.14.81'
-    sha256 'ba61b4b84cb613a6196e6bd1d3102ad460ec0645a885b1cb94132e5244e1d330'
+    version "0.14.81"
+    sha256 "ba61b4b84cb613a6196e6bd1d3102ad460ec0645a885b1cb94132e5244e1d330"
   elsif MacOS.version <= :lion
-    version '0.15.1949'
-    sha256 '17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a'
+    version "0.15.1949"
+    sha256 "17301ee1209bd4b12c126d7a58405efdb366f99f70b4f923a9c96e16c334ce2a"
   elsif MacOS.version <= :mavericks
-    version '0.15.1964'
-    sha256 'd88bcb7f92ca1cdf31cb3f1d2e24c03e2091ab330319aeef2e770c0dbd6f7817'
+    version "0.15.1964"
+    sha256 "d88bcb7f92ca1cdf31cb3f1d2e24c03e2091ab330319aeef2e770c0dbd6f7817"
   else
-    version '0.16.2327'
-    sha256 'c8dd6dcac8dd85808acdb937f3125bf67b2b1c2b36da5541f20de73628abf544'
-    s='s'
+    version "0.16.2327"
+    sha256 "c8dd6dcac8dd85808acdb937f3125bf67b2b1c2b36da5541f20de73628abf544"
+    s="s"
   end
 
   url "https://github.com/gitx/gitx/releases/download/build#{s}/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
-
-  appcast 'https://github.com/gitx/gitx/releases.atom'
-  name 'GitX-dev'
-  homepage 'https://github.com/gitx/gitx'
+  appcast "https://github.com/gitx/gitx/releases.atom"
+  name "GitX"
+  desc "Is a native graphical client for the git version control system"
+  homepage "https://github.com/gitx/gitx"
 
   conflicts_with cask: %w[
     laullon-gitx
     rowanj-gitx
   ]
 
-  app 'GitX.app'
+  app "GitX.app"
   binary "#{appdir}/GitX.app/Contents/Resources/gitx"
 end

--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -2,8 +2,9 @@ cask "gitx" do
   version "0.16.2327"
   sha256 "c8dd6dcac8dd85808acdb937f3125bf67b2b1c2b36da5541f20de73628abf544"
 
-  url "https://github.com/gitx/gitx/releases/download/builds/#{version.major_minor}/#{version.patch}/GitX-dev-#{version.patch}.dmg"
-  appcast "https://github.com/gitx/gitx/releases.atom"
+  url "https://github.com/gitx/gitx/releases/download/build%2F#{version.major_minor}%2F#{version.patch}/GitX-dev-#{version.patch}.dmg"
+  appcast "https://github.com/gitx/gitx/releases.atom",
+          must_contain: "#{version.major_minor}%2F#{version.patch}"
   name "GitX"
   desc "GUI for git"
   homepage "https://github.com/gitx/gitx"


### PR DESCRIPTION
The old version of gitx has been unmaintained for years (Thu, 29 Jan 2009 23:54:01 GMT according to the appcast).

The maintained version has moved to github.com/gitx/git, this pr updates to the modern versions and points to the new home.

gitx/gitx#113

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:
> --download didn't work so I ran it locally, hope this is ok! bug tracked here https://github.com/Homebrew/brew/issues/7444
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
