### PR TITLE
Update db-browser-for-sqlite.rb

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -5,14 +5,14 @@ cask "db-browser-for-sqlite" do
   # github.com/sqlitebrowser/sqlitebrowser/ was verified as official when first introduced to the cask
   url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-#{version}.dmg"
   appcast "https://github.com/sqlitebrowser/sqlitebrowser/releases.atom"
-  name "SQLite Database Browser"
+  name "DB Browser for SQLite"
   desc "Database browser for SQLite (DB4S) project"
   homepage "https://sqlitebrowser.org/"
 
   app "DB Browser for SQLite.app"
 
   zap trash: [
-    "~/Library/Preferences/net.sourceforge.sqlitebrowser.plist",
+    "~/Library/Preferences/com.sqlitebrowser.sqlitebrowser.plist",
     "~/Library/Saved Application State/net.sourceforge.sqlitebrowser.savedState",
   ]
 end


### PR DESCRIPTION
We renamed the project 'DB Browser for SQLite' on August 31, 2014.
Also, we no longer save it as `~/Library/Preferences/net.sourceforge.sqlitebrowser.plist`, but save it like this:
`~/Library/Preferences/com.sqlitebrowser.sqlitebrowser.plist`

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
```
$ brew cask style --fix Casks/db-browser-for-sqlite.rb
Casks/db-browser-for-sqlite.rb:1:1: C: Missing frozen string literal comment.
cask "db-browser-for-sqlite" do
^

1 file inspected, 1 offense detected, 1 more offense can be corrected with `rubocop -A`
```
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).