### PR TITLE
Update unity-webgl-support-for-editor from 2020.1.1f1,2285c3239188 to 2020.1.6f1,fc477ca6df10

### DIFF
--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -2,10 +2,11 @@ cask "unity-webgl-support-for-editor" do
   version "2020.1.6f1,fc477ca6df10"
   sha256 "b91f1b15e2899aea0ea40e21560bd074ca61d544974d49494643f1fae9e77fef"
 
+  # netstorage.unity3d.com/unity/ was verified as official when first introduced to the cask
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity WebGL Build Support"
-  homepage "https://unity3d.com/unity/"
+  homepage "https://unity.com/products"
 
   depends_on cask: "unity"
 

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -12,5 +12,8 @@ cask "unity-webgl-support-for-editor" do
 
   pkg "UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
 
-  uninstall pkgutil: "com.unity3d.WebGLSupport"
+  uninstall pkgutil: [
+    "com.unity3d.WebGLSupport",
+    "com.unity3d.UnityEditor5.x",
+    ]
 end

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -2,8 +2,8 @@ cask "unity-webgl-support-for-editor" do
   version "2020.1.6f1,fc477ca6df10"
   sha256 "b91f1b15e2899aea0ea40e21560bd074ca61d544974d49494643f1fae9e77fef"
 
-  # netstorage.unity3d.com/unity/ was verified as official when first introduced to the cask
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
+  # download.unity3d.com/download_unity/ was verified as official when first introduced to the cask
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity WebGL Build Support"
   desc "WebGL taget support for Unity"

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask "unity-webgl-support-for-editor" do
-  version "2020.1.1f1,2285c3239188"
-  sha256 "fe30dbb737bbd7efe1420340b6685d431d5a0f8fba8d60abc74c65c5c5acfa2b"
+  version "2020.1.6f1,fc477ca6df10"
+  sha256 "b91f1b15e2899aea0ea40e21560bd074ca61d544974d49494643f1fae9e77fef"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"

--- a/Casks/unity-webgl-support-for-editor.rb
+++ b/Casks/unity-webgl-support-for-editor.rb
@@ -6,14 +6,12 @@ cask "unity-webgl-support-for-editor" do
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity WebGL Build Support"
+  desc "WebGL taget support for Unity"
   homepage "https://unity.com/products"
 
   depends_on cask: "unity"
 
   pkg "UnitySetup-WebGL-Support-for-Editor-#{version.before_comma}.pkg"
 
-  uninstall pkgutil: [
-    "com.unity3d.WebGLSupport",
-    "com.unity3d.UnityEditor5.x",
-    ]
+  uninstall pkgutil: "com.unity3d.WebGLSupport"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).