### PR TITLE
Update unity-android-support-for-editor from 2020.1.1f1,2285c3239188 to 2020.1.6f1,fc477ca6df10

### DIFF
--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -2,10 +2,11 @@ cask "unity-android-support-for-editor" do
   version "2020.1.6f1,fc477ca6df10"
   sha256 "21fe02a3c57e94fc4cc479fede6d509e975e7b72e7fcee8295916e14d998c9c0"
 
+  # netstorage.unity3d.com/unity/ was verified as official when first introduced to the cask
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity Android Build Support"
-  homepage "https://unity3d.com/unity/"
+  homepage "https://unity.com/products"
 
   depends_on cask: "unity"
 

--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -2,8 +2,8 @@ cask "unity-android-support-for-editor" do
   version "2020.1.6f1,fc477ca6df10"
   sha256 "21fe02a3c57e94fc4cc479fede6d509e975e7b72e7fcee8295916e14d998c9c0"
 
-  # netstorage.unity3d.com/unity/ was verified as official when first introduced to the cask
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
+  # download.unity3d.com/download_unity/ was verified as official when first introduced to the cask
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity Android Build Support"
   desc "Android taget support for Unity"

--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -6,6 +6,7 @@ cask "unity-android-support-for-editor" do
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity Android Build Support"
+  desc "Android taget support for Unity"
   homepage "https://unity.com/products"
 
   depends_on cask: "unity"

--- a/Casks/unity-android-support-for-editor.rb
+++ b/Casks/unity-android-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask "unity-android-support-for-editor" do
-  version "2020.1.1f1,2285c3239188"
-  sha256 "b5ba15492f91bad92058384e3d0619aaaa7b8fea9ae1c85fe6f117f7161393f7"
+  version "2020.1.6f1,fc477ca6df10"
+  sha256 "21fe02a3c57e94fc4cc479fede6d509e975e7b72e7fcee8295916e14d998c9c0"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).