### PR TITLE
Update unity-windows-support-for-editor from 2020.1.1f1,2285c3239188 to 2020.1.6f1,fc477ca6df10

### DIFF
--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -2,8 +2,8 @@ cask "unity-windows-support-for-editor" do
   version "2020.1.6f1,fc477ca6df10"
   sha256 "db8e9dc12552ea3c65f73ac4711c5d122496bbfc32e628d880180f8c27b40c13"
 
-  # netstorage.unity3d.com/unity/ was verified as official when first introduced to the cask
-  url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
+  # download.unity3d.com/download_unity/ was verified as official when first introduced to the cask
+  url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity Windows (Mono) Build Support"
   desc "Windows (Mono) taget support for Unity"

--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -6,6 +6,7 @@ cask "unity-windows-support-for-editor" do
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity Windows (Mono) Build Support"
+  desc "Windows (Mono) taget support for Unity"
   homepage "https://unity.com/products"
 
   depends_on cask: "unity"

--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -2,10 +2,11 @@ cask "unity-windows-support-for-editor" do
   version "2020.1.6f1,fc477ca6df10"
   sha256 "db8e9dc12552ea3c65f73ac4711c5d122496bbfc32e628d880180f8c27b40c13"
 
+  # netstorage.unity3d.com/unity/ was verified as official when first introduced to the cask
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity Windows (Mono) Build Support"
-  homepage "https://unity3d.com/unity/"
+  homepage "https://unity.com/products"
 
   depends_on cask: "unity"
 

--- a/Casks/unity-windows-support-for-editor.rb
+++ b/Casks/unity-windows-support-for-editor.rb
@@ -1,6 +1,6 @@
 cask "unity-windows-support-for-editor" do
-  version "2020.1.1f1,2285c3239188"
-  sha256 "ce6ce9dd7c2738d20307b80791ac9f478cb8e1d373447fdbe5e7a28899b0a83a"
+  version "2020.1.6f1,fc477ca6df10"
+  sha256 "db8e9dc12552ea3c65f73ac4711c5d122496bbfc32e628d880180f8c27b40c13"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-#{version.before_comma}.pkg"
   appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).