### PR TITLE
istat-menus: Remove U+2069 (Unicode POP DIRECTIONAL ISOLATE) from LaunchDaemons path

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -15,6 +15,8 @@ cask "istat-menus" do
 
   uninstall delete:    [
     "/Library/Application Support/iStat Menus #{version.major}",
+    "/Library/LaunchDaemons/com.bjango.istatmenus.fans.plist",
+    "/Library/Logs/iStat Menus",
     "/Library/PrivilegedHelperTools/com.bjango.istatmenus.installerhelper",
   ],
             launchctl: [
@@ -47,8 +49,6 @@ cask "istat-menus" do
     "~/Library/Preferences/com.bjango.istatmenus.plist",
     "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
     "~/Library/Preferences/com.bjango.istatmenus.status.plist",
-    "/Library/Logs/iStat Menus",
-    "/Library/LaunchDaemons/com.bjango.istatmenus.fans.plist",
     "/Users/Shared/.iStatMenus",
   ]
 end

--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -48,7 +48,7 @@ cask "istat-menus" do
     "~/Library/Preferences/com.bjango.istatmenus#{version.major}.extras.plist",
     "~/Library/Preferences/com.bjango.istatmenus.status.plist",
     "/Library/Logs/iStat Menus",
-    "/Library⁩/LaunchDaemons⁩/com.bjango.istatmenus.fans.plist",
+    "/Library/LaunchDaemons/com.bjango.istatmenus.fans.plist",
     "/Users/Shared/.iStatMenus",
   ]
 end


### PR DESCRIPTION
Cask file for `istat-menus` currently has a couple of unnecessary Unicode PDI characters, i.e. the following is shown in `less`:

```
51          "/Library<U+2069>/LaunchDaemons<U+2069>/com.bjango.istatmenus.fans.plist",
```

This pull request removes these characters.

***

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask** ... (N/A)
