### PR TITLE
Don't re-run workflows on forks.

### DIFF
--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -17,13 +17,15 @@ on:
 jobs:
   rerun-workflow:
     if: >
-      startsWith(github.repository, "Homebrew/") &&
-      (github.event.label.name == 'ci-requeue' ||
-       github.event.label.name == 'ci-retry' ||
-       github.event.label.name == 'ci-skip-appcast' ||
-       github.event.label.name == 'ci-skip-install' ||
-       github.event.label.name == 'ci-syntax-only' ||
-       !github.event.label.name)
+      startsWith(github.repository, "Homebrew/") && 
+      (
+        github.event.label.name == 'ci-requeue' ||
+        github.event.label.name == 'ci-retry' ||
+        github.event.label.name == 'ci-skip-appcast' ||
+        github.event.label.name == 'ci-skip-install' ||
+        github.event.label.name == 'ci-syntax-only' ||
+        !github.event.label.name
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Re-run CI workflow

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -17,12 +17,13 @@ on:
 jobs:
   rerun-workflow:
     if: >
-      github.event.label.name == 'ci-requeue' ||
-      github.event.label.name == 'ci-retry' ||
-      github.event.label.name == 'ci-skip-appcast' ||
-      github.event.label.name == 'ci-skip-install' ||
-      github.event.label.name == 'ci-syntax-only' ||
-      !github.event.label.name
+      startsWith(github.repository, "Homebrew/") &&
+      (github.event.label.name == 'ci-requeue' ||
+       github.event.label.name == 'ci-retry' ||
+       github.event.label.name == 'ci-skip-appcast' ||
+       github.event.label.name == 'ci-skip-install' ||
+       github.event.label.name == 'ci-syntax-only' ||
+       !github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - name: Re-run CI workflow


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

~~After making all changes to a cask, verify:~~  

- [ ] ~~`brew cask audit --download {{cask_file}}` is error-free.~~
- [ ] ~~`brew cask style --fix {{cask_file}}` reports no offenses.~~
- [ ] ~~There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.~~  
- [ ] ~~The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).~~

(N/A; not modifying any casks.)  

~~Additionally, **if adding a new cask**:~~  

- [ ] ~~Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).~~  
- [ ] ~~`brew cask audit --new-cask {{cask_file}}` worked successfully.~~  
- [ ] ~~`brew cask install {{cask_file}}` worked successfully.~~  
- [ ] ~~`brew cask uninstall {{cask_file}}` worked successfully.~~  
- [ ] ~~Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).~~  
- [ ] ~~Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).~~  

(N/A; not adding any new casks.)  

Please verify:  

- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same change.  

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;After:  

 - Coming back to working with Homebrew and Homebrew Cask after an extended hiatus, 
 - Pulling any new changes down from GitHub, and
 - Pushing them to my personal forks, 

I noticed CI jobs were getting triggered on my personal Homebrew Cask fork by the 'rerun-workflow' Actions workflow.  This PR is a naïve attempt at fixing that; feel free to request or add changes or supersede as needed/desired.  