### PR TITLE
Update bluestacks from 4.210.0.2820,c172aa8a06c3c61d313ee9acf0e6c8b8 to 4.230.10.2820,37a27c1765e16b22ca7c3bddc42177bd

### DIFF
--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -14,7 +14,7 @@ cask "bluestacks" do
   installer manual: "BlueStacks Installer.app"
 
   uninstall_preflight do
-    set_ownership "#{appdir}/BlueStacks.app"
+    set_ownership "/Applications/BlueStacks.app"
   end
 
   uninstall launchctl: [
@@ -23,7 +23,10 @@ cask "bluestacks" do
     "com.BlueStacks.AppPlayer.UninstallWatcher",
     "com.BlueStacks.AppPlayer.Updater",
   ],
-            delete:    "/Library/PrivilegedHelperTools/com.BlueStacks.AppPlayer.bstservice_helper"
+            delete:    [
+              "/Applications/BlueStacks.app",
+              "/Library/PrivilegedHelperTools/com.BlueStacks.AppPlayer.bstservice_helper",
+            ]
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.bluestacks.bluestacks.sfl*",

--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -1,6 +1,6 @@
 cask "bluestacks" do
-  version "4.210.0.2820,c172aa8a06c3c61d313ee9acf0e6c8b8"
-  sha256 "39ff9fd6393bcb326644f0e16f6eed5ed8c96345eabae01248c94f43246b8ce1"
+  version "4.230.10.2820,37a27c1765e16b22ca7c3bddc42177bd"
+  sha256 "9af74c675d4161593c6537b350a7ce0d4de3def535b652bac918f815fc48266e"
 
   url "https://cdn3.bluestacks.com/downloads/mac/bgp64_mac/#{version.before_comma}/#{version.after_comma}/x64/BlueStacksInstaller_#{version.before_comma}.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://cloud.bluestacks.com/api/getdownloadnow?platform=mac",


### PR DESCRIPTION
Replaces https://github.com/Homebrew/homebrew-cask/pull/89715.