### PR TITLE
Run cache workflow on schedule instead of on every push.

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -20,7 +20,7 @@ puts 'Detecting changes…'
   '.github/*.yml',
   '.github/actions/{automerge}/**/*',
   '.github/ISSUE_TEMPLATE/*.md',
-  '.github/workflows/{automerge,ci,dispatch-command,rebase,rerun-workflow,review,self-approve}.yml',
+  '.github/workflows/{automerge,cache,ci,dispatch-command,rebase,rerun-workflow,review,self-approve}.yml',
   '.gitignore',
   '.travis.yml',
   'Casks/.rubocop.yml',

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -3,8 +3,9 @@ name: Cache
 on:
   push:
     branches:
-      - master
       - debug-cache
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours
 
 jobs:
   cancel-previous-runs:


### PR DESCRIPTION
Otherwise bulk cask updates will result in a constant backlog of cache workflow runs.