### PR TITLE
sapmachine-jdk: add cask description

### DIFF
--- a/Casks/sapmachine-jdk.rb
+++ b/Casks/sapmachine-jdk.rb
@@ -6,6 +6,7 @@ cask "sapmachine-jdk" do
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "An OpenJDK release maintained and supported by SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-jdk-#{version}.jdk"

--- a/Casks/sapmachine-jdk.rb
+++ b/Casks/sapmachine-jdk.rb
@@ -6,7 +6,7 @@ cask "sapmachine-jdk" do
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
-  desc "An OpenJDK release maintained and supported by SAP"
+  desc "OpenJDK release maintained and supported by SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-jdk-#{version}.jdk"


### PR DESCRIPTION
As the bot suggested on [the last bump-cask-pr](https://github.com/Homebrew/homebrew-cask/pull/89790):

https://github.com/Homebrew/homebrew-cask/actions/runs/270056420

> Casks/sapmachine-jdk.rb#L1
Cask should have a description. Please add a `desc` stanza.