### PR TITLE
Add BoostNoteNext v0.9.0

### DIFF
--- a/Casks/boost-note-next.rb
+++ b/Casks/boost-note-next.rb
@@ -1,0 +1,23 @@
+cask "boost-note-next" do
+  version "0.9.0"
+  sha256 "7ec52d8dc2a7a0746b2e5efc5703fb16d1fc3ed6f8c170277d502580a1bf7331"
+
+  # github.com/BoostIO/BoostNote.next/ was verified as official when first introduced to the cask
+  url "https://github.com/BoostIO/BoostNote.next/releases/download/v#{version}/boost-note-mac.dmg"
+  appcast "https://github.com/BoostIO/BoostNote.next/releases.atom"
+  name "Boostnote.Next"
+  desc "Intuitive and stylish markdown note app for the developers"
+  homepage "https://boostnote.io/"
+
+  app "Boost Note.app"
+
+  uninstall signal: [
+    ["TERM", "com.boostio.boostnote"],
+  ]
+
+  zap trash: [
+    "~/Library/Application Support/Boost Note",
+    "~/Library/Preferences/com.boostio.boostnote.plist",
+    "~/Library/Saved Application State/com.boostio.boostnote.savedState",
+  ]
+end

--- a/Casks/boost-note-next.rb
+++ b/Casks/boost-note-next.rb
@@ -6,14 +6,12 @@ cask "boost-note-next" do
   url "https://github.com/BoostIO/BoostNote.next/releases/download/v#{version}/boost-note-mac.dmg"
   appcast "https://github.com/BoostIO/BoostNote.next/releases.atom"
   name "Boostnote.Next"
-  desc "Intuitive and stylish markdown note app for the developers"
+  desc "Markdown note editor for developers"
   homepage "https://boostnote.io/"
 
   app "Boost Note.app"
 
-  uninstall signal: [
-    ["TERM", "com.boostio.boostnote"],
-  ]
+  uninstall signal: ["TERM", "com.boostio.boostnote"]
 
   zap trash: [
     "~/Library/Application Support/Boost Note",

--- a/Casks/boost-note.rb
+++ b/Casks/boost-note.rb
@@ -1,4 +1,4 @@
-cask "boost-note-next" do
+cask "boost-note" do
   version "0.9.0"
   sha256 "7ec52d8dc2a7a0746b2e5efc5703fb16d1fc3ed6f8c170277d502580a1bf7331"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download boost-note-next` is error-free.
- [x] `brew cask style --fix boost-note-next` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask boost-note-next` worked successfully.
- [x] `brew cask install boost-note-next` worked successfully.
- [x] `brew cask uninstall boost-note-next` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

NOTE: 
I did not name it accorting to the token reference, because it would lead to `boost-note`. 
Actually there already is `boostnote`, which is the old version. To my understanding `boostnote`should be named boost-note and the added one is named BoostNode.Nextm which doesn't seem to have an Naming convention? Happy to get enlightened.

