### PR TITLE
Update vscodium from 1.49.1 to 1.49.2

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask "vscodium" do
-  version "1.49.1"
-  sha256 "0b3af0c0c2ee64a0318208fbecd97d31c659a5e7229d350b217ae54d3abb9104"
+  version "1.49.2"
+  sha256 "5cf519f665d93219ad8774ff439be2a89e14c143f012cba3347bb93b3bc4f055"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{version}.dmg"
   appcast "https://github.com/VSCodium/vscodium/releases.atom"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
