### PR TITLE
update emby-server to 4.5.0.50

### DIFF
--- a/Casks/emby-server.rb
+++ b/Casks/emby-server.rb
@@ -1,6 +1,6 @@
 cask "emby-server" do
-  version "4.4.3.0"
-  sha256 "b8d495a3f7703d020a2a9f6370fe802d6bfcc21a13c437c081a7af076ae028cd"
+  version "4.5.0.50"
+  sha256 "83dc5ec97e977b8ce194d99c62b3f33bd1f868b956c49b46ae90c06e5efe4b7f"
 
   # github.com/MediaBrowser/Emby.Releases/ was verified as official when first introduced to the cask
   url "https://github.com/MediaBrowser/Emby.Releases/releases/download/#{version}/embyserver-osx-x64-#{version}.zip"


### PR DESCRIPTION
Released 4 days ago: https://github.com/MediaBrowser/Emby.Releases/releases/tag/4.5.0.50

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
