### PR TITLE
Create convert3dgui.rb

### DIFF
--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -1,6 +1,6 @@
 cask "convert3dgui" do
   version "1.0.0"
-  sha256 "73fb4bce06f4194bba3a6bd6302ce34dfc13b939d01ea370173113a63ef04e4b"
+  sha256 "f90fc3732578e9c9378e6d9340611ab93955f8ee182af1a59edac55f8df4b728"
   
   url "https://downloads.sourceforge.net/c3d/c3d-#{version}-MacOS-x86_64.dmg"
   appcast "https://sourceforge.net/projects/c3d/rss?path=/c3d/#{version}"

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -5,7 +5,7 @@ cask "convert3dgui" do
   url "https://master.dl.sourceforge.net/project/c3d/c3d/Nightly/c3d-nightly-MacOS-.dmg"
   name "Convert3DGUI"
   desc "A command-line tool for converting 3D images between common file formats"
-  homepage "http://www.itksnap.org/pmwiki/pmwiki.php?n=Convert3D.Documentation"
+  homepage "https://sourceforge.net/projects/c3d"
 
   app "Convert3DGUI.app"
 

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -14,7 +14,5 @@ cask "convert3dgui" do
   binary "#{appdir}/Convert3DGUI.app/Contents/bin/c3d_affine_tool"
   binary "#{appdir}/Convert3DGUI.app/Contents/bin/c4d"
 
-  zap trash: [
-    "~/Library/Saved Application State/org.itksnap.c3dgui.savedState",
-  ]
+  zap trash: "~/Library/Saved Application State/org.itksnap.c3dgui.savedState"
 end

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -9,6 +9,10 @@ cask "convert3dgui" do
   homepage "https://sourceforge.net/projects/c3d"
 
   app "Convert3DGUI.app"
+  binary "#{appdir}/Convert3DGUI.app/Contents/bin/c2d"
+  binary "#{appdir}/Convert3DGUI.app/Contents/bin/c3d"
+  binary "#{appdir}/Convert3DGUI.app/Contents/bin/c3d_affine_tool"
+  binary "#{appdir}/Convert3DGUI.app/Contents/bin/c4d"
 
   zap trash: [
     "~/Library/Saved Application State/org.itksnap.c3dgui.savedState",

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -1,8 +1,15 @@
 cask "convert3dgui" do
-  version :latest
-  sha256 :no_check
+  version "1.0.0"
+  sha256 "73fb4bce06f4194bba3a6bd6302ce34dfc13b939d01ea370173113a63ef04e4b"
+  
+  url do
+    require 'open-uri'
+    project_name = "c3d"
+    filename = "c3d-#{version}-MacOS-x86_64"
+    ext = "dmg"
+    "https://master.dl.sourceforge.net/project/#{project_name}/#{project_name}/#{version}/#{filename}.#{ext}"
+  end
 
-  url "https://master.dl.sourceforge.net/project/c3d/c3d/Nightly/c3d-nightly-MacOS-.dmg"
   name "Convert3DGUI"
   desc "A command-line tool for converting 3D images between common file formats"
   homepage "https://sourceforge.net/projects/c3d"

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -1,0 +1,15 @@
+cask "convert3dgui" do
+  version :latest
+  sha256 :no_check
+
+  url "https://master.dl.sourceforge.net/project/c3d/c3d/Nightly/c3d-nightly-MacOS-.dmg"
+  name "Convert3DGUI"
+  desc "A command-line tool for converting 3D images between common file formats"
+  homepage "http://www.itksnap.org/pmwiki/pmwiki.php?n=Convert3D.Documentation"
+
+  app "Convert3DGUI.app"
+
+  zap trash: [
+    "~/Library/Saved Application State/org.itksnap.c3dgui.savedState",
+  ]
+end

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -9,9 +9,9 @@ cask "convert3dgui" do
     ext = "dmg"
     "https://master.dl.sourceforge.net/project/#{project_name}/#{project_name}/#{version}/#{filename}.#{ext}"
   end
-
+  appcast "https://sourceforge.net/projects/c3d/rss?path=/c3d/1.0.0"
   name "Convert3DGUI"
-  desc "A command-line tool for converting 3D images between common file formats"
+  desc "Command-line tool for converting 3D images between common file formats"
   homepage "https://sourceforge.net/projects/c3d"
 
   app "Convert3DGUI.app"

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -9,7 +9,7 @@ cask "convert3dgui" do
     ext = "dmg"
     "https://master.dl.sourceforge.net/project/#{project_name}/#{project_name}/#{version}/#{filename}.#{ext}"
   end
-  appcast "https://sourceforge.net/projects/c3d/rss?path=/c3d/1.0.0"
+  appcast "https://sourceforge.net/projects/c3d/rss?path=/c3d/#{version}"
   name "Convert3DGUI"
   desc "Command-line tool for converting 3D images between common file formats"
   homepage "https://sourceforge.net/projects/c3d"

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -1,7 +1,7 @@
 cask "convert3dgui" do
   version "1.0.0"
   sha256 "f90fc3732578e9c9378e6d9340611ab93955f8ee182af1a59edac55f8df4b728"
-  
+
   url "https://downloads.sourceforge.net/c3d/c3d-#{version}-MacOS-x86_64.dmg"
   appcast "https://sourceforge.net/projects/c3d/rss?path=/c3d/#{version}"
   name "Convert3DGUI"

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -3,7 +3,7 @@ cask "convert3dgui" do
   sha256 "73fb4bce06f4194bba3a6bd6302ce34dfc13b939d01ea370173113a63ef04e4b"
   
   url do
-    require 'open-uri'
+    require "open-uri"
     project_name = "c3d"
     filename = "c3d-#{version}-MacOS-x86_64"
     ext = "dmg"

--- a/Casks/convert3dgui.rb
+++ b/Casks/convert3dgui.rb
@@ -2,13 +2,7 @@ cask "convert3dgui" do
   version "1.0.0"
   sha256 "73fb4bce06f4194bba3a6bd6302ce34dfc13b939d01ea370173113a63ef04e4b"
   
-  url do
-    require "open-uri"
-    project_name = "c3d"
-    filename = "c3d-#{version}-MacOS-x86_64"
-    ext = "dmg"
-    "https://master.dl.sourceforge.net/project/#{project_name}/#{project_name}/#{version}/#{filename}.#{ext}"
-  end
+  url "https://downloads.sourceforge.net/c3d/c3d-#{version}-MacOS-x86_64.dmg"
   appcast "https://sourceforge.net/projects/c3d/rss?path=/c3d/#{version}"
   name "Convert3DGUI"
   desc "Command-line tool for converting 3D images between common file formats"


### PR DESCRIPTION
It is the official c3d module powered by itk-snap with gui function. It could provide a smooth experience than Docker.

It is an indivudal module. It does not require itk-snap but I would strongly recommend users to have an x11 environment. I would suggest users use fslview by oxford or freeview by harvard. The c3d module is a requirement for most of clinical deep learning. For example, HippMapper and VentMapper are using c3d for neuroimaging preprocessing. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
