### PR TITLE
Revert "Update beyond-compare from 4.3.5.24893 to 4.3.6.25063 (#89071)"

### DIFF
--- a/Casks/beyond-compare.rb
+++ b/Casks/beyond-compare.rb
@@ -1,6 +1,6 @@
 cask "beyond-compare" do
-  version "4.3.6.25063"
-  sha256 "8502e7970dc616f7c257305d9801fb85a69d0c5a3fa10deebf62b37e4eb0fd35"
+  version "4.3.5.24893"
+  sha256 "36251c332df4e916fba32d40dc72309d395e62f999dd0c41bfedb331fa2698c6"
 
   url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
   appcast "https://www.scootersoftware.com/download.php"


### PR DESCRIPTION
This reverts commit 5833c818c7d9204425bd81555368ca5f1c0e1491.

From Scooter Software:
> We've rolled back Beyond Compare 4.3.6 on Mac to version 4.3.5. Beyond Compare 4.3.6 on Windows and Linux are unaffected. The Mac version of BC was rolled back because a macOS 11.0 Big Sur fix in 4.3.6 inadvertently caused blurry text and slow scrolling performance on all versions of macOS.

Source: https://www.scootersoftware.com/vbulletin/forum/from-scooter-software/news-announcements/84140-bc-4-3-6-mac-rolled-back-to-4-3-5