### PR TITLE
Secure URLs

### DIFF
--- a/Casks/jamulus.rb
+++ b/Casks/jamulus.rb
@@ -2,10 +2,11 @@ cask "jamulus" do
   version "3.5.11"
   sha256 "6aed7335fc97f709e5e494d5a1ae909203026a33011dd6d88c76ce3d8dac025e"
 
+  # downloads.sourceforge.net/llcon/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/llcon/Jamulus-#{version}-installer-mac.dmg"
   appcast "https://sourceforge.net/projects/llcon/rss"
   name "Jamulus"
-  homepage "http://llcon.sourceforge.net/"
+  homepage "https://llcon.sourceforge.io/"
 
   auto_updates true
 

--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -7,7 +7,7 @@ cask "praat" do
   appcast "https://github.com/praat/praat/releases.atom"
   name "Praat"
   desc "Doing phonetics by computer"
-  homepage "http://www.fon.hum.uva.nl/praat/"
+  homepage "https://www.fon.hum.uva.nl/praat/"
 
   app "Praat.app"
   binary "#{appdir}/Praat.app/Contents/MacOS/Praat", target: "praat"

--- a/Casks/tracks-live.rb
+++ b/Casks/tracks-live.rb
@@ -2,7 +2,7 @@ cask "tracks-live" do
   version "1.3.0-6"
   sha256 "bf7dac4be365ce865b447fc390146ab9dc4cc422523bd2af84e6ec1356e7c4ec"
 
-  url "http://cf-installers.waves.com/TracksLive/Tracks-Live-Install-#{version}.dmg"
+  url "https://cf-installers.waves.com/TracksLive/Tracks-Live-Install-#{version}.dmg"
   name "Tracks Live"
   homepage "https://www.waves.com/mixers-racks/tracks-live"
 

--- a/Casks/waves-central.rb
+++ b/Casks/waves-central.rb
@@ -2,7 +2,7 @@ cask "waves-central" do
   version :latest
   sha256 :no_check
 
-  url "http://cf-installers.waves.com/WavesCentral/Install_Waves_Central.dmg"
+  url "https://cf-installers.waves.com/WavesCentral/Install_Waves_Central.dmg"
   name "Waves Central"
   desc "Client to install and activate Waves products"
   homepage "https://www.waves.com/"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://downloads.sourceforge.net/llcon/Jamulus-3.5.11-installer
==> Downloading from https://deac-riga.dl.sourceforge.net/project/llcon/Jamulus/
==> Verifying SHA-256 checksum for Cask 'jamulus'.
audit for jamulus: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://github.com/praat/praat/releases/download/v6.1.21/praat61
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws
==> Verifying SHA-256 checksum for Cask 'praat'.
audit for praat: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://cf-installers.waves.com/TracksLive/Tracks-Live-Install-1
==> Verifying SHA-256 checksum for Cask 'tracks-live'.
audit for tracks-live: passed
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://cf-installers.waves.com/WavesCentral/Install_Waves_Centr
==> No SHA-256 checksum defined for Cask 'waves-central', skipping verification.
audit for waves-central: passed
```
