### PR TITLE
Revert "Update naver-whale from 2.8.105.22 to 2.8.107.7"

### DIFF
--- a/Casks/naver-whale.rb
+++ b/Casks/naver-whale.rb
@@ -1,5 +1,5 @@
 cask "naver-whale" do
-  version "2.8.107.7"
+  version "2.8.105.22"
   sha256 "7c68a5c58f8852db829f1ffdc5a2f592c36a818630b15e78fbcc42464d79615a"
 
   # update.whale.naver.net/downloads/installers/ was verified as official when first introduced to the cask


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#89813

version is still at "2.8.105.22" 