### PR TITLE
Update dangerzone from 0.1.1 to 0.1.3

### DIFF
--- a/Casks/dangerzone.rb
+++ b/Casks/dangerzone.rb
@@ -1,6 +1,6 @@
 cask "dangerzone" do
-  version "0.1.1"
-  sha256 "5de17c9713940cce761562dec3c3e7ffba8b1dabde957aa17c8b8fe3193771b4"
+  version "0.1.3"
+  sha256 "01b8f8b1315d43ce01695d20803d43d98dccf0dff6c3a12b53c009bed4d906c6"
 
   # github.com/firstlookmedia/dangerzone/ was verified as official when first introduced to the cask
   url "https://github.com/firstlookmedia/dangerzone/releases/download/v#{version}/Dangerzone.#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).