### PR TITLE
Update musictube from 1.13.2 to 1.14

### DIFF
--- a/Casks/musictube.rb
+++ b/Casks/musictube.rb
@@ -1,6 +1,6 @@
 cask "musictube" do
-  version "1.13.2"
-  sha256 "ed93e0a63871bf224a661f7dade67340f40dfdacc2067913ccdfc1fe5e99357e"
+  version "1.14"
+  sha256 "572cb5e30475f16ada886cc7fe21a409c5775c9c788e1469c1a7d337f8218446"
 
   url "https://flavio.tordini.org/files/musictube/musictube.dmg"
   appcast "https://flavio.tordini.org/musictube-ws/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).