### PR TITLE
Update kid3 from 3.8.3 to 3.8.4

### DIFF
--- a/Casks/kid3.rb
+++ b/Casks/kid3.rb
@@ -1,7 +1,7 @@
 cask "kid3" do
   # note: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
-  version "3.8.3"
-  sha256 "ef4adf153bd7e52088021eae4f51d92c6de14b4953bcd6352b75b9482d486894"
+  version "3.8.4"
+  sha256 "18c893879bf20f376480b2062beb0ee7a0c7e2ad4663d11bffff994990568c4d"
 
   # downloads.sourceforge.net/kid3/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).