### PR TITLE
RescueTime sha256 update

### DIFF
--- a/Casks/rescuetime.rb
+++ b/Casks/rescuetime.rb
@@ -1,6 +1,6 @@
 cask "rescuetime" do
   version "2.16.4.2"
-  sha256 "41f0f340ec75b8296756e4129f6df8743279ddfd77f581d825839c7d7725088f"
+  sha256 "ac9650230c820a2e270cd05c65e6e1d16c03f24a4fcbbf0b8b6434980f523723"
 
   url "https://www.rescuetime.com/installers/RescueTimeInstaller.pkg"
   appcast "https://www.rescuetime.com/installers/appcast"


### PR DESCRIPTION
Fixing this issue:

Error: Checksum for Cask 'rescuetime' does not match.
Expected: 41f0f340ec75b8296756e4129f6df8743279ddfd77f581d825839c7d7725088f
  Actual: ac9650230c820a2e270cd05c65e6e1d16c03f24a4fcbbf0b8b6434980f523723
    File: /Users/vs/Library/Caches/Homebrew/downloads/6c16425385932119cb691c50100bf4fe56fbd2c9979a4db3433801a155ebf112--RescueTimeInstaller.pkg

Verified that version is still 2.16.4.2

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).