### PR TITLE
Rename raspberry-pi-imager to rpi-imager

### DIFF
--- a/Casks/rpi-imager.rb
+++ b/Casks/rpi-imager.rb
@@ -1,4 +1,4 @@
-cask "raspberry-pi-imager" do
+cask "rpi-imager" do
   version "1.4"
   sha256 "85b337e9ccbec6dd39b0ddbf4b9b4cb1f39fb90f6923a3fea694b2300e936538"
 


### PR DESCRIPTION
Rename the raspberry-pi-imager cask to rpi-imager, the same name use in the apt command.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
