### PR TITLE
Update macdive from 2.12.0 to 2.12.1

### DIFF
--- a/Casks/macdive.rb
+++ b/Casks/macdive.rb
@@ -1,6 +1,6 @@
 cask "macdive" do
-  version "2.12.0"
-  sha256 "6a41df499fba9cf5862287fb0f2e28800115742b658273cf74d9ac44677195b1"
+  version "2.12.1"
+  sha256 "46868ad5fa66ffea156870d1324e8b6dcf60632615e49b4ac56818e996588cf7"
 
   url "https://www.mac-dive.com/downloads/MacDive_#{version}.dmg"
   appcast "https://www.mac-dive.com/shimmer/?appcast&appName=MacDive"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).