### PR TITLE
Update macx-dvd-ripper-pro from 6.5.3,20200630 to 6.5.3,20200927

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,7 +3,7 @@ cask "macx-dvd-ripper-pro" do
   sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
           must_contain: ""
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,6 +3,7 @@ cask "macx-dvd-ripper-pro" do
   sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,7 +3,7 @@ cask "macx-dvd-ripper-pro" do
   sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_sizeandmodified.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
           must_contain: ""
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -4,6 +4,7 @@ cask "macx-dvd-ripper-pro" do
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
+          must_contain: ""
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,8 +3,8 @@ cask "macx-dvd-ripper-pro" do
   sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_sizeandmodified.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
-          must_contain: " "
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
+          must_contain: ""
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,8 +3,8 @@ cask "macx-dvd-ripper-pro" do
   sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
-  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_filesize.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
-          must_contain: ""
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_sizeandmodified.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
+          must_contain: "GMT"
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -4,7 +4,7 @@ cask "macx-dvd-ripper-pro" do
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_sizeandmodified.cgi?url=https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg",
-          must_contain: ""
+          must_contain: " "
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -3,7 +3,6 @@ cask "macx-dvd-ripper-pro" do
   sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
-  appcast "https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro"
   name "MacX DVD Ripper Pro"
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"

--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,6 +1,6 @@
 cask "macx-dvd-ripper-pro" do
-  version "6.5.3,20200630"
-  sha256 "147b66ed1946dea61bb15a08b0c4e92875f82ed9e838e4db1495acf1180019cb"
+  version "6.5.3,20200927"
+  sha256 "049e143d60b42b6e77b590749a9d258d9a005a7e182ee155a35e419080f6dfa0"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"
   appcast "https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).