### PR TITLE
Update nomachine-enterprise-client from 6.11.2_14 to 6.12.3_8

### DIFF
--- a/Casks/nomachine-enterprise-client.rb
+++ b/Casks/nomachine-enterprise-client.rb
@@ -1,6 +1,6 @@
 cask "nomachine-enterprise-client" do
-  version "6.11.2_14"
-  sha256 "bd2cf69fab6e74d87b0a6442e8d7700278128be9c1bf22628ded923be89ed147"
+  version "6.12.3_8"
+  sha256 "ef8ba9d97652799128cb0ba409508a8984fa15fbe72c3236ad3d3d6501267851"
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine-enterprise-client_#{version}.dmg"
   appcast "https://www.nomachine.com/download/download&id=15"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).