### PR TITLE
Update subler from 1.6.5 to 1.6.6

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask "subler" do
-  version "1.6.5"
-  sha256 "7f57f7433dedf273b6e14d2d9d38518609027369f95a56e6f8284433b7a88b13"
+  version "1.6.6"
+  sha256 "0844888aa83e619221dddcedecde63ecb88b92a88811d231dacab755939aa8a7"
 
   # bitbucket.org/galad87/subler/ was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).