### PR TITLE
Update clash-for-windows from 0.11.10 to 0.12.0

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,6 +1,6 @@
 cask "clash-for-windows" do
-  version "0.11.10"
-  sha256 "c9eb80c6abb8e85322aea577f6d086c0b70a9ce73d855bfd93e97f2002486abe"
+  version "0.12.0"
+  sha256 "45d62846384b459e59d8616bd566e163ebd65753111b84386d1bd9742d4e2aa6"
 
   url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
   appcast "https://github.com/Fndroid/clash_for_windows_pkg/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).