### PR TITLE
Update waltr from 2.6.26 to 2.6.27

### DIFF
--- a/Casks/waltr.rb
+++ b/Casks/waltr.rb
@@ -1,6 +1,6 @@
 cask "waltr" do
-  version "2.6.26"
-  sha256 "47ebc0efeebd56a32b6ce5187e4b20998cf4ac4a9ee03e4af9584dc602147145"
+  version "2.6.27"
+  sha256 "5b1ca23244d060c6ca941f96ca78e91fbff5cde34cdf5d9879468fee6e2929f3"
 
   # dl.devmate.com/com.softorino.waltr2/ was verified as official when first introduced to the cask
   url "https://shining.softorino.com/shine_uploads/waltr#{version.major}mac_#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).