### PR TITLE
Update get-backup-pro from 3.5.8 to 3.5.9

### DIFF
--- a/Casks/get-backup-pro.rb
+++ b/Casks/get-backup-pro.rb
@@ -1,6 +1,6 @@
 cask "get-backup-pro" do
-  version "3.5.8"
-  sha256 "115f35aabc153d76529f959cd04b89195f6e0b61d1671f4e6222065aa851ff74"
+  version "3.5.9"
+  sha256 "1a93a51f8064a1cdc5645ab0530ec73c97dfd27c6d55425883c9afab4f2e6328"
 
   # belightsoft.s3.amazonaws.com/updates/ was verified as official when first introduced to the cask
   url "https://belightsoft.s3.amazonaws.com/updates/Get+Backup+Pro+#{version.major}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).