### PR TITLE
Uninstalling Unity Hub should not remove Unity installations

### DIFF
--- a/Casks/unity-hub.rb
+++ b/Casks/unity-hub.rb
@@ -10,7 +10,8 @@ cask "unity-hub" do
 
   app "Unity Hub.app"
 
-  uninstall quit:   "com.unity3d.unityhub"
+  uninstall quit:  "com.unity3d.unityhub",
+            rmdir: "/Applications/Unity/Hub"
 
   zap trash: [
     "~/Library/Preferences/com.unity3d.unityhub.plist",

--- a/Casks/unity-hub.rb
+++ b/Casks/unity-hub.rb
@@ -10,8 +10,7 @@ cask "unity-hub" do
 
   app "Unity Hub.app"
 
-  uninstall quit:   "com.unity3d.unityhub",
-            delete: "/Applications/Unity/Hub"
+  uninstall quit:   "com.unity3d.unityhub"
 
   zap trash: [
     "~/Library/Preferences/com.unity3d.unityhub.plist",


### PR DESCRIPTION
Don't delete `~/Applications/Unity/Hub` when uninstalling, as this would also delete any installed versions of Unity.
This is especially a problem when updating Unity Hub, as it will uninstall all already installed versions of Unity, forcing the user to reinstall them.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
