### PR TITLE
Update eloston-chromium from 85.0.4183.121-1.1 to 85.0.4183.121-1.2

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,6 +1,6 @@
 cask "eloston-chromium" do
-  version "85.0.4183.121-1.1"
-  sha256 "36aa35551f17a086ece90c459d1f1a7d2ed18f323953202942b77986c689d7d5"
+  version "85.0.4183.121-1.2"
+  sha256 "fe05848463379136ba7089a751d2660474157a4ae3e00898f789001027e92cf5"
 
   # github.com/kramred/ungoogled-chromium-macos/ was verified as official when first introduced to the cask
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}_macos.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).