### PR TITLE
Update jitsi-meet from 2.4.0 to 2.4.1

### DIFF
--- a/Casks/jitsi-meet.rb
+++ b/Casks/jitsi-meet.rb
@@ -1,6 +1,6 @@
 cask "jitsi-meet" do
-  version "2.4.0"
-  sha256 "8eef8348a041ade8806323aa448bd5fe79b78031360b6d739a17f84ec4ff07e6"
+  version "2.4.1"
+  sha256 "904e37f124bbf40ce9bcb60a85fd85d3bb25ec3ae15cf62b6f0c5d9e1d391db4"
 
   url "https://github.com/jitsi/jitsi-meet-electron/releases/download/v#{version}/jitsi-meet.dmg"
   appcast "https://github.com/jitsi/jitsi-meet-electron/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).