### PR TITLE
Update pd-l2ork from 2.14.2 to 2.15.0

### DIFF
--- a/Casks/pd-l2ork.rb
+++ b/Casks/pd-l2ork.rb
@@ -1,6 +1,6 @@
 cask "pd-l2ork" do
-  version "2.14.2"
-  sha256 "b0ad9b2660eac9387b52b448b2bf8348423221488219e757db8f7d33a3bd4ab1"
+  version "2.15.0"
+  sha256 "6d0665df170e570e7d0ebb97115bc3ff0f17e3a6aa5ceaf90229748cc9dbeb73"
 
   # github.com/agraef/purr-data/ was verified as official when first introduced to the cask
   url "https://github.com/agraef/purr-data/releases/download/#{version}/osx_10.11-x86_64-dmg.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).