### PR TITLE
Update firefox from 81.0 to 81.0.1

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,100 +1,100 @@
 cask "firefox" do
-  version "81.0"
+  version "81.0.1"
 
   language "cs" do
-    sha256 "b1fcb872074a9c04ec291fffeed4a5d44376a78700a0df3998b44ecdcec56f67"
+    sha256 "dba48f3fd65c4587e1eea2c7a14961123a7417d87aa004299c51611325c492e1"
     "cs"
   end
   language "de" do
-    sha256 "a3d3e360c4e8eb7ffa38b89d19f6aa5c77cada687bfacc9b24f19c68b4d36ca6"
+    sha256 "4ae1f92b5abd75464cec4791af57bca84d29f0ff3a76a3469efa6c7f8d10ce19"
     "de"
   end
   language "en-GB" do
-    sha256 "484880e53d9e5e3690f7c8f2b231127bc7d2c56f4b5d7a0795bf64c63e7d9768"
+    sha256 "44ce4070461daa344cb5ed17b507542d573eb8e27f0d6a3cb06e40beba135736"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "c4975a1a73dd1976e1f58cf5822921d25f2fb4a0e092897037e039d7ac6b8a67"
+    sha256 "ab23191e777ce46deee5869807ecfd63ebcf33a78fd7aeb9fe8e326d4748a428"
     "en-US"
   end
   language "eo" do
-    sha256 "7a436d832a26d5914835a60cbe8c50eab5e33e6381a35b2d9274e805354df273"
+    sha256 "ff4687c5e850a09efe9dc05c17f4b03e4cc33d1e5e4c9c2d2b8c85923b0cf492"
     "eo"
   end
   language "es-AR" do
-    sha256 "6e178055dedcbf10e9a50f3eff2498b5ab605b4e7378a1df379c8fc3b3c24bee"
+    sha256 "3f649809a2572813f9ee36e4224290aa11321ac44a24325c80cc201dc58d2ba7"
     "es-AR"
   end
   language "es-CL" do
-    sha256 "0a12cd6e23a3bca5adbec32d95c1f2d2776f9d2098ef6c88b80e18e4a24d2507"
+    sha256 "3886c58ff407a7e78354b23cb26911d11204e0cb2a07ba38ed1cd215d5b0f9d9"
     "es-CL"
   end
   language "es-ES" do
-    sha256 "2c1bd174572ff1dac95fcdbc19c97b6a8e2de3dd397dfe8ea0172a8352550073"
+    sha256 "af414599528d3aed987a5d4b72c29ea5014b86e59617c4ab6468221cbf973ba0"
     "es-ES"
   end
   language "fi" do
-    sha256 "21461392237940b8e6092b319a4475d412429a1ae46bf06400189c6be9f646f4"
+    sha256 "b8e265d6b1c0df5fa6675d973bd6321c0f885907c2d5d69772889e2385bc6a14"
     "fi"
   end
   language "fr" do
-    sha256 "b66aa3ac120646ec854b3ece8fe5de59f0848c9700afe8715c4bcb459547bc45"
+    sha256 "4ccb10434ba6216be6d50ad9b235d96f03cfc7cb8112d8a46c73a08865684357"
     "fr"
   end
   language "gl" do
-    sha256 "8373218406838ed367fdd4a0c601a3239b501453ccc6d1c88ee1a23d262640d9"
+    sha256 "b932ba80e0cbe63ff454b3b1fdf16afa0dbdfbf129109f342a296351390a68a7"
     "gl"
   end
   language "in" do
-    sha256 "243f537281c8a050c4e42c8f8afe344c68c2a5f8541dbf3830bf090194f4a8ba"
+    sha256 "62510d547baf1c394a427544d02a96935e3d64e4bff39959e2ec19de44f20d9c"
     "hi-IN"
   end
   language "it" do
-    sha256 "c4b6b5ed8c2d53dd2ea5658c462a054fa66f497c1dee2709d124792a22a39316"
+    sha256 "97a6a240013bcb8f0ea2e3c320c7dd37fd269be0e2d6fd2a6c30c2b17268e8ce"
     "it"
   end
   language "ja" do
-    sha256 "e19879ee2206c06e115ad14669d67ff41c26a6dd5dd59f2f408420f5d92b2e99"
+    sha256 "a07334dfb62067aaac4f8b92b6dffd75908c93a439ac80e8ac17033e4ef2361a"
     "ja-JP-mac"
   end
   language "ko" do
-    sha256 "535f2cca4e190c5a7b86733a154e2941c0e7fd62162b67c3a57185ee0abf57be"
+    sha256 "69ee42a5e6047af39fa5d5373b713c08415e936369f57cf08f47a61f5f99aa8f"
     "ko"
   end
   language "nl" do
-    sha256 "9ec7ccbc2433c23eae414445ea5b6ffb980922d7c57102d306f99740c0a119d2"
+    sha256 "2ec29239240cca52ecb823c19c8d59fb7650e4f509e10a529f93b4dc8d6fc8c1"
     "nl"
   end
   language "pl" do
-    sha256 "b28633a8af76c8c52d03afad3c66d08da42f73bde74e3f1cb9f883643c9ac2ac"
+    sha256 "c2ab0d63315f852abf71b04f79e056d3aab0297df1ef7e8ce3ef636aa7fb9e0f"
     "pl"
   end
   language "pt-BR" do
-    sha256 "92360ca53890560573d8763ea6e2552ff836a6696e12fb415da4c1f20d23e0d5"
+    sha256 "e871467394fe786e6f4d75cd1668f745f519a239255ecbd19ccfcf998055563a"
     "pt-BR"
   end
   language "pt" do
-    sha256 "89f203c46d2d527bd5be2eef28fadee47b1c09832a2f98cf1ba2702edf3d041e"
+    sha256 "bd2b95a5db68e24e43abe32b1c687d18b8e28c408b6aa9dd4db4ab002a245afd"
     "pt-PT"
   end
   language "ru" do
-    sha256 "f2a6505d0d7d28e5b7737147b86b175572995e007ee7f2f913a775a221bf91f0"
+    sha256 "d6a609a90da8859c2614613ab49cf9eb990fdaf22c5a8f8c0727c7af6cd5e061"
     "ru"
   end
   language "tr" do
-    sha256 "d4c5ac7dd273824a21ab6658a6112e4155ac2e3abbeccb4580abfb07cb4e65d4"
+    sha256 "379322314ed69e8e1630186da5542855cf23f386a5f04ee5f0f82ac799467865"
     "tr"
   end
   language "uk" do
-    sha256 "7a96ffde9f55e75f974221c0825a371becd2c3518e4985d3fa47d9afe893cd90"
+    sha256 "1a6f82291d995dd0a70c0e883a473944fa02680d512aa5ddb5a797ee6e00d97b"
     "uk"
   end
   language "zh-TW" do
-    sha256 "d737be9a4678e15c48473f392c779d26bd426ab6d68115ca8932136d01c17ba1"
+    sha256 "aa11d2f941e8b73a36745aae706a8d10943d9afe10dad3ebc0310f5cc2887633"
     "zh-TW"
   end
   language "zh" do
-    sha256 "7713d2f38f8dab17bf2f20358f55cb578e425fa243a19ef5fec4fbe64e069677"
+    sha256 "147d40cda6fe3baa6896f92ba322cdb2144bdbd3535060eaf6b746a3439b4058"
     "zh-CN"
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
