### PR TITLE
Update intune-company-portal from 2.8.200800 to 2.9.200900

### DIFF
--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -1,6 +1,6 @@
 cask "intune-company-portal" do
-  version "2.8.200800"
-  sha256 "e041f3c2f0c88078579cee41a065c13e2465f6b625831b755abce25fd25301ff"
+  version "2.9.200900"
+  sha256 "8a4c32458a2f41c18508e38cb718628c3a428267cd70dddff0ccca6a9b40e2f4"
 
   url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Installer.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://go.microsoft.com/fwlink/?linkid=853070"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).