### PR TITLE
Update KiCad from 5.1.6-0 to 5.1.7-0

### DIFF
--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -1,17 +1,14 @@
 cask "kicad" do
-  version "5.1.6-0"
+  version "5.1.7-0"
 
-  if MacOS.version <= :high_sierra
-    sha256 "cb2baef00e877509996eb89e5b0addc99298db53bd4bd6c8dc4d8797fd22d809"
-    url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-#{version}.dmg"
-  else
-    sha256 "8e262b653209776ad32393566be0a0b1c560ade8cb9877bfcf5289dde21b99dd"
-    url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-#{version}-10_14.dmg"
-  end
+  sha256 "7f136cf18fbea59b2bae22e08ca55e198994baf1c3ad57875d3e59ad295304c0"
+  url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-#{version}-10_14.dmg"
 
   appcast "https://kicad-downloads.s3.cern.ch/?delimiter=/&prefix=osx/stable/"
   name "KiCad"
   homepage "https://kicad-pcb.org/"
+  
+  depends_on macos: '>= 10.14'
 
   app "KiCad/kicad.app",            target: "KiCad/KiCad.app"
   app "KiCad/bitmap2component.app", target: "KiCad/bitmap2component.app"


### PR DESCRIPTION
Update KiCad to 5.1.7-0, add dependancy for macOS >= 10.14 per updated system requirements from KiCad

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
