### PR TITLE
Update maccy from 0.16.0 to 0.17.0

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask "maccy" do
-  version "0.16.0"
-  sha256 "568816395407db5f2cbce25791df86c571d14c1b1f0d3c0869577e365394b160"
+  version "0.17.0"
+  sha256 "4124d36eadf67db0fd3d6cf1d378d2e7871aeb536254b922d5ae30de62787dbc"
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).