### PR TITLE
Update use-engine from 2.2.5.4 to 2.2.5.5

### DIFF
--- a/Casks/use-engine.rb
+++ b/Casks/use-engine.rb
@@ -1,6 +1,6 @@
 cask "use-engine" do
-  version "2.2.5.4"
-  sha256 "f66b1a6ca65a0cfb3f5a85902651b6311d9cb274763dac3ac82c7f7bb0ca4253"
+  version "2.2.5.5"
+  sha256 "1f10b0e793099c8e55b88927bf31bf8b97997174249fda001c0bc834fc3d1d89"
 
   url "https://repository.use-together.com/stable/use-engine/macos/#{version.major}.x/#{version}/use-engine.dmg"
   name "USE Engine"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).