### PR TITLE
Fix doc about macOS version comparison

### DIFF
--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -51,11 +51,10 @@ depends_on macos: ['10.14', '10.15']
 
 ### Setting a Minimum macOS Release
 
-`depends_on macos:` can also accept a string starting with a comparison operator such as `>=`, followed by an macOS release in the form above. The following are both valid expressions meaning “at least macOS 10.15”:
+`depends_on macos:` can also accept a string starting with a comparison operator such as `>=`, followed by an macOS release in the form above. The following is a valid expression meaning “at least macOS Catalina (10.15)”:
 
 ```ruby
 depends_on macos: '>= :catalina'
-depends_on macos: '>= 10.15'
 ```
 
 A comparison expression cannot be combined with any other form of `depends_on macos:`.

--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -27,11 +27,11 @@ depends_on formula: 'unar'
 
 ### Requiring an Exact macOS Release
 
-The value for `depends_on macos:` may be a symbol, string, or an array, listing the exact compatible macOS releases.
+The value for `depends_on macos:` may be a symbol or an array, listing the exact compatible macOS releases.
 
 The available values for macOS releases are:
 
-| symbol             | corresponding string
+| symbol             | corresponding release
 | -------------------|----------------------
 | `:yosemite`        | `'10.10'`
 | `:el_capitan`      | `'10.11'`
@@ -45,8 +45,6 @@ Only major releases are covered (version numbers containing a single dot). The s
 ```ruby
 depends_on macos: :catalina
 depends_on macos: [:mojave, :catalina]
-depends_on macos: '10.15'
-depends_on macos: ['10.14', '10.15']
 ```
 
 ### Setting a Minimum macOS Release

--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -7,10 +7,10 @@
 
 The value should be another Cask token, needed by the current Cask.
 
-Example use: [`SSHFS`](https://github.com/Homebrew/homebrew-cask/blob/312ae841f1f1b2ec07f4d88b7dfdd7fbdf8d4f94/Casks/sshfs.rb#L12) depends on OSXFUSE:
+Example use: [`cellery`](https://github.com/Homebrew/homebrew-cask/blob/4002df8f6bca93ed6eb40494995fcfa038cf99bf/Casks/cellery.rb#L11) depends on OSXFUSE:
 
 ```ruby
-depends_on cask: 'osxfuse'
+depends_on cask: "osxfuse"
 ```
 
 ## depends_on formula:
@@ -20,31 +20,34 @@ The value should name a Homebrew Formula needed by the Cask.
 Example use: some distributions are contained in archive formats such as `7z` which are not supported by stock Apple tools. For these cases, a more capable archive reader may be pulled in at install time by declaring a dependency on the Homebrew Formula `unar`:
 
 ```ruby
-depends_on formula: 'unar'
+depends_on formula: "unar"
 ```
 
 ## depends_on macos:
 
 ### Requiring an Exact macOS Release
 
-The value for `depends_on macos:` may be a symbol or an array, listing the exact compatible macOS releases.
+The value for `depends_on macos:` may be a symbol or an array of symbols, listing the exact compatible macOS releases.
 
 The available values for macOS releases are:
 
 | symbol             | corresponding release
 | -------------------|----------------------
-| `:yosemite`        | `'10.10'`
-| `:el_capitan`      | `'10.11'`
-| `:sierra`          | `'10.12'`
-| `:high_sierra`     | `'10.13'`
-| `:mojave`          | `'10.14'`
-| `:catalina`        | `'10.15'`
+| `:yosemite`        | `10.10`
+| `:el_capitan`      | `10.11`
+| `:sierra`          | `10.12`
+| `:high_sierra`     | `10.13`
+| `:mojave`          | `10.14`
+| `:catalina`        | `10.15`
 
-Only major releases are covered (version numbers containing a single dot). The symbol form is preferred for readability. The following are all valid ways to enumerate the exact macOS release requirements for a Cask:
+Only major releases are covered (version numbers containing a single dot). The symbol form is used for readability. The following are all valid ways to enumerate the exact macOS release requirements for a Cask:
 
 ```ruby
 depends_on macos: :catalina
-depends_on macos: [:mojave, :catalina]
+depends_on macos: [
+  :mojave,
+  :catalina,
+]
 ```
 
 ### Setting a Minimum macOS Release
@@ -52,7 +55,7 @@ depends_on macos: [:mojave, :catalina]
 `depends_on macos:` can also accept a string starting with a comparison operator such as `>=`, followed by an macOS release in the form above. The following is a valid expression meaning “at least macOS Catalina (10.15)”:
 
 ```ruby
-depends_on macos: '>= :catalina'
+depends_on macos: ">= :catalina"
 ```
 
 A comparison expression cannot be combined with any other form of `depends_on macos:`.


### PR DESCRIPTION
While implementing custom Cask, I found that the following statement doens't work and raises invalid cask errors:

```ruby
  depends_on macos: '>= 10.15'
```

However, this is declared valid in documentaiton.

After digging into [the source code of homebrew](https://github.com/Homebrew/brew/blob/5e09bb256411d8ed9388fa2cd64dcbb8be847bdf/Library/Homebrew/requirements/macos_requirement.rb#L18), I found that it uses `MacOS::Version.from_symbol` to parse the version, and thus confirm that using version code is not valid anymore.

I also found #88467 reported this issue.