### PR TITLE
Update freeorion from 0.4.10,2020-07-10.f3d403e to 0.4.10.1,2020-09-25.39cfe10

### DIFF
--- a/Casks/freeorion.rb
+++ b/Casks/freeorion.rb
@@ -1,6 +1,6 @@
 cask "freeorion" do
-  version "0.4.10,2020-07-10.f3d403e"
-  sha256 "fa9db8fd170915283775ccc052d80f5b4c3a7626ac57f3e00a4b321692b3e040"
+  version "0.4.10.1,2020-09-25.39cfe10"
+  sha256 "ca31a2a35878df0059589cf88f50cd1168d5f493b8ccbcaece88ae3a2e5331a7"
 
   # github.com/freeorion/ was verified as official when first introduced to the cask
   url "https://github.com/freeorion/freeorion/releases/download/v#{version.before_comma}/FreeOrion_v#{version.before_comma}_#{version.after_comma}_MacOSX_10.9.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).