### PR TITLE
Update arq appcast

### DIFF
--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -3,7 +3,7 @@ cask "arq" do
   sha256 "137f1e366220e2cc06e7bb3006df2cb1cb79d614b980b161b956974f26912aff"
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version.major}.pkg"
-  appcast "https://www.arqbackup.com/download/arqbackup/arq#{version.major}_release_notes.html"
+  appcast "https://www.arqbackup.com"
   name "Arq"
   desc "Multi-cloud backup application"
   homepage "https://www.arqbackup.com/"


### PR DESCRIPTION
this should prevent another update to a beta version of a new generation as here

https://github.com/Homebrew/homebrew-cask/pull/90193

in general i question the wisdom of using version interpolation in appcasts URLs. the new URLs often come online before the release is official and we need something to prevent bad auto-merges