### PR TITLE
Update lyricsx from 1.5.5,2309 to 1.5.6,2322

### DIFF
--- a/Casks/lyricsx.rb
+++ b/Casks/lyricsx.rb
@@ -1,6 +1,6 @@
 cask "lyricsx" do
-  version "1.5.5,2309"
-  sha256 "ceb833a473521a14983e471bd49ff71195ac8983db961a73c8087af361e1ca4b"
+  version "1.5.6,2322"
+  sha256 "a23c6098bde8a57c3cbc32fdff499a7615ff5b9dcbc84f4e122add13552731b1"
 
   url "https://github.com/ddddxxx/LyricsX/releases/download/v#{version.before_comma}/LyricsX_#{version.before_comma}+#{version.after_comma}.zip"
   appcast "https://github.com/ddddxxx/LyricsX/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).