### PR TITLE
Update boom to 1.6.11

### DIFF
--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -1,10 +1,10 @@
 cask "boom" do
-  version "1.6.9,1575451705"
-  sha256 "444b5513c92eb0975494509908786a31f087a0af0e58fa5f312a156318be22f8"
+  version "1.6.11"
+  sha256 "624f8f01299d657e677098acfe4df6291136da5cff9949218168f4aced9a3be3"
 
-  # devmate.com/com.globaldelight.Boom2/ was verified as official when first introduced to the cask
-  url "https://dl.devmate.com/com.globaldelight.Boom2/#{version.before_comma}/#{version.after_comma}/Boom2-#{version.before_comma}.dmg"
-  appcast "https://updates.devmate.com/com.globaldelight.Boom2.xml"
+  # d13nae1tw8tdnq.cloudfront.net/Boom2mac/ was verified as official when first introduced to the cask
+  url "https://d13nae1tw8tdnq.cloudfront.net/Boom2mac/webstore/Boom2.dmg"
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_lastmodified.cgi?url=https://d13nae1tw8tdnq.cloudfront.net/Boom2mac/webstore/Boom2.dmg"
   name "Boom"
   desc "Transforms audio input"
   homepage "https://www.globaldelight.com/boom"


### PR DESCRIPTION
ok we have a bit of a problem here. they don't use sparkle anymore, but a homegrown solution. which is difficult to piggyback on even with sophisticated CGIs. basically they do this:

`curl -H 'Host: www.globaldelight.net' -H 'Content-Type: application/octet-stream' -H 'Accept: */*' -H 'User-Agent: Boom%202/1.6.9003 CFNetwork/1200.1 Darwin/20.1.0' -H 'Accept-Language: en-gb' --data-binary "@data.txt" --compressed 'https://www.globaldelight.net/tower/registrationauth/boom/boomCheckUpdateOffer.php'`

where you need a 500 byte binary file. 

=> current output:
`{"ResponseStatus":"1","AppVersionAvailable":"1.6.11","DownloadURL":"https:\/\/d3jbf8nvvpx3fh.cloudfront.net\/Boom2\/Update\/v1.6.11\/Boom_2_Update.dmg","ReleaseNotes":"Boom 2 (v1.6.11) comes with: \n- Minor defect fixes."}%   
`
so the other option is to use and try to observe the static download file from the homepage. lets try that