### PR TITLE
remove line with wildcard for launchctl from boom cask

### DIFF
--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -15,7 +15,6 @@ cask "boom" do
 
   uninstall kext:      "com.globaldelight.driver.Boom2Device",
             launchctl: [
-              "com.globaldelight.Boom2.*",
               "com.globaldelight.Boom2Daemon",
             ],
             signal:    ["TERM", "com.globaldelight.Boom2"]

--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -14,9 +14,7 @@ cask "boom" do
   app "Boom 2.app"
 
   uninstall kext:      "com.globaldelight.driver.Boom2Device",
-            launchctl: [
-              "com.globaldelight.Boom2Daemon",
-            ],
+            launchctl: "com.globaldelight.Boom2Daemon",
             signal:    ["TERM", "com.globaldelight.Boom2"]
 
   zap trash: [


### PR DESCRIPTION
Removing another instance from the casks listed in this issue https://github.com/Homebrew/homebrew-cask/issues/79661

I followed the instructions given in the issue conversation.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

