### PR TITLE
Update musescore

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -19,7 +19,7 @@ cask "musescore" do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{appdir}/MuseScore #{version_major}.app/Contents/MacOS/mscore' "$@"
+      exec '#{appdir}/MuseScore #{version.major}.app/Contents/MacOS/mscore' "$@"
     EOS
   end
 end

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,6 +1,6 @@
 cask "musescore" do
   version "3.5.1"
-  sha256 "17f02fd50e74c3d2c5c5e7451cb00b21fd7e84e10d5201211b2bed0ebb1a2e55"
+  sha256 "b3316b1ad11ba011e2505691d861287173639644616753ee9525330c2a41dabe"
 
   # github.com/musescore/MuseScore/ was verified as official when first introduced to the cask
   url "https://github.com/musescore/MuseScore/releases/download/v#{version.chomp(".0")}/MuseScore-#{version}.dmg"
@@ -19,7 +19,7 @@ cask "musescore" do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{appdir}/MuseScore #{version}.app/Contents/MacOS/mscore' "$@"
+      exec '#{appdir}/MuseScore #{version_major}.app/Contents/MacOS/mscore' "$@"
     EOS
   end
 end

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -11,7 +11,7 @@ cask "musescore" do
 
   depends_on macos: ">= :yosemite"
 
-  app "MuseScore #{version}.app"
+  app "MuseScore #{version.major}.app"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/mscore.wrapper.sh"
   binary shimscript, target: "mscore"


### PR DESCRIPTION
Seems like MuseScore team updated the file inside the release after my previous pull request was merged (#90469). Check https://github.com/musescore/MuseScore/releases/tag/v3.5.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

