### PR TITLE
Expose the usage of MiniZinc executables from MiniZincIDE Cask

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -6,7 +6,10 @@ cask "minizincide" do
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg"
   appcast "https://github.com/MiniZinc/MiniZincIDE/releases.atom"
   name "MiniZincIDE"
-  homepage "https://www.minizinc.org/ide/index.html"
+  desc "Open-source constraint modeling language and IDE"
+  homepage "https://www.minizinc.org/index.html"
 
   app "MiniZincIDE.app"
+  binary "#{appdir}/MiniZincIDE.app/Contents/Resources/minizinc"
+  binary "#{appdir}/MiniZincIDE.app/Contents/Resources/mzn2doc"
 end

--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -9,6 +9,9 @@ cask "minizincide" do
   desc "Open-source constraint modeling language and IDE"
   homepage "https://www.minizinc.org/index.html"
 
+  conflicts_with formula: "unrar"
+  depends_on macos: ">= :sierra"
+
   app "MiniZincIDE.app"
   binary "#{appdir}/MiniZincIDE.app/Contents/Resources/minizinc"
   binary "#{appdir}/MiniZincIDE.app/Contents/Resources/mzn2doc"

--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -9,7 +9,7 @@ cask "minizincide" do
   desc "Open-source constraint modeling language and IDE"
   homepage "https://www.minizinc.org/index.html"
 
-  conflicts_with formula: "unrar"
+  conflicts_with formula: "minizinc"
   depends_on macos: ">= :sierra"
 
   app "MiniZincIDE.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

### Proposed Changes

This PR exposes the MiniZinc executables from the bundled package. This allows users to use `minizinc` directly from command-line.

Although the binary would currently conflict with the current `minizinc` formula in the Homebrew core packages., it should be mentioned that this binary is an incomplete version of MiniZinc. The official MiniZinc bundle links against the CoinBC and Gecode solvers and is compiled with the headers for the CPlex, Gurobi, SCIP, and XPress solvers to allow users to load these solvers at runtime. This means that users of the `minizinc` formula do not have access to various features of the MiniZinc compiler, both during compilation of the MiniZinc language and in the solving of the produced models. Therefore, I would suggest that once this cask can expose the executables from within this cask, we have a look at deprecating the `minizinc` formula and aliasing `minizinc` to this cask.
