### PR TITLE
Box Drive: remove wildcard from launchctl

### DIFF
--- a/Casks/box-drive.rb
+++ b/Casks/box-drive.rb
@@ -5,6 +5,7 @@ cask "box-drive" do
   # e3.boxcdn.net/ was verified as official when first introduced to the cask
   url "https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg"
   name "Box Drive"
+  desc "Box Drive is an enterprise cloud drive"
   homepage "https://www.box.com/drive"
 
   conflicts_with cask: "box-sync"

--- a/Casks/box-drive.rb
+++ b/Casks/box-drive.rb
@@ -12,7 +12,7 @@ cask "box-drive" do
   pkg "Box.pkg"
 
   uninstall pkgutil:   "com.box.desktop.installer.*",
-            launchctl: "com.box.desktop.*",
+            launchctl: "com.box.desktop.helper",
             script:    "/Library/Application Support/Box/uninstall_box_drive",
             quit:      [
               "com.box.Box-Local-Com-Server",

--- a/Casks/box-drive.rb
+++ b/Casks/box-drive.rb
@@ -5,7 +5,7 @@ cask "box-drive" do
   # e3.boxcdn.net/ was verified as official when first introduced to the cask
   url "https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg"
   name "Box Drive"
-  desc "Box Drive is an enterprise cloud drive"
+  desc "Client for the Box cloud storage service"
   homepage "https://www.box.com/drive"
 
   conflicts_with cask: "box-sync"


### PR DESCRIPTION
Fixing the launchctl issue with wildcards for box-drive from the casks listed in this issue #79661

I followed the instructions given in the issue conversation.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
