### PR TITLE
Update qobuz from 5.4.4-b017 to 5.4.4-b018

### DIFF
--- a/Casks/qobuz.rb
+++ b/Casks/qobuz.rb
@@ -1,6 +1,6 @@
 cask "qobuz" do
-  version "5.4.4-b017"
-  sha256 "00b77f4334688f483652f63a5a4446f4c5319ea424c8f02c13267b602f391ca7"
+  version "5.4.4-b018"
+  sha256 "1d7d750db9f21a5fd6ff01b92b53cf3db186b11dcd7b6aa839ef8cbac0650955"
 
   url "https://desktop.qobuz.com/releases/darwin/x64/elCapitan_sierra/#{version}/Qobuz.dmg"
   name "Qobuz"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).