### PR TITLE
Update ringcentral from 20.3.30.2377 to 20.4.10

### DIFF
--- a/Casks/ringcentral.rb
+++ b/Casks/ringcentral.rb
@@ -1,6 +1,6 @@
 cask "ringcentral" do
-  version "20.3.30.2377"
-  sha256 "4a3676241c419e02c2d606cd8c75b4841ada24120513fe337c579d31b12860fe"
+  version "20.4.10"
+  sha256 "7a346f13059a98082f06ee75aca0a3a64c0fdf96b639d5d4f555596e0dcb9728"
 
   url "https://app.ringcentral.com/downloads/RingCentral.pkg"
   appcast "https://app.ringcentral.com/download/latest-mac.yml",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).