### PR TITLE
Update webcatalog from 25.4.1 to 25.4.2

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask "webcatalog" do
-  version "25.4.1"
-  sha256 "b01aa120dcbbb610ce713353d9e94eb10dcb3157d4ae76fe31113c5419016eef"
+  version "25.4.2"
+  sha256 "e191a677398a1971bf215e5b5329226ca08f675aabbdd971347ae3107e030e15"
 
   # github.com/atomery/webcatalog/ was verified as official when first introduced to the cask
   url "https://github.com/atomery/webcatalog/releases/download/v#{version}/WebCatalog-#{version}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).