### PR TITLE
Update menubar-countdown from 1.2 to 2.1

### DIFF
--- a/Casks/menubar-countdown.rb
+++ b/Casks/menubar-countdown.rb
@@ -8,5 +8,7 @@ cask "menubar-countdown" do
   desc "Countdown timer for the menu bar"
   homepage "https://github.com/kristopherjohnson/MenubarCountdown"
 
+  depends_on macos: ">= :mojave"
+
   app "Menubar Countdown.app"
 end

--- a/Casks/menubar-countdown.rb
+++ b/Casks/menubar-countdown.rb
@@ -1,12 +1,12 @@
 cask "menubar-countdown" do
-  version "1.2"
-  sha256 "4ee0a7a87dbd4013c461b59316c749a5f9a92160bdf6d90afb1ff029f9381c01"
+  version "2.1"
+  sha256 "9b72a2c3544c7e3e9c9cb60feb9be2ff7905184c9e988f921bea5269a60fb805"
 
-  # capablehands.s3.amazonaws.com/ was verified as official when first introduced to the cask
-  url "https://capablehands.s3.amazonaws.com/downloads/MenubarCountdown-#{version}.zip"
+  url "https://github.com/kristopherjohnson/MenubarCountdown/releases/download/#{version}/Menubar_Countdown_#{version}.zip"
+  appcast "https://github.com/kristopherjohnson/MenubarCountdown/releases.atom"
   name "Menubar Countdown"
   desc "Countdown timer for the menu bar"
   homepage "https://github.com/kristopherjohnson/MenubarCountdown"
 
-  app "MenubarCountdown-#{version}/Menubar Countdown.app"
+  app "Menubar Countdown.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The old version is 32-bit and does not run on latest macOS.