### PR TITLE
logisim-evolution 3.3.0

### DIFF
--- a/Casks/logisim-evolution.rb
+++ b/Casks/logisim-evolution.rb
@@ -1,25 +1,20 @@
 cask "logisim-evolution" do
-  version "2.15.0"
-  sha256 "2d56d01a692e26dd2e5c19a6139ed66d9352fb4bc2c81171b2153b9099cfd91d"
+  version "3.3.0"
+  sha256 "55a9ed8069fd677b0caa9cccc39ce5f64be4d16293b4daddb8c54d2082f2a847"
 
-  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution.jar"
+  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution-#{version}-all.jar"
   appcast "https://github.com/reds-heig/logisim-evolution/releases.atom"
   name "Logisim Evolution"
+  desc "Digital logic designer and simulator"
   homepage "https://github.com/reds-heig/logisim-evolution"
 
   container type: :naked
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/logisim-evolution.wrapper.sh"
-  binary shimscript, target: "logisim-evolution"
-
-  preflight do
-    IO.write shimscript, <<~EOS
-      #!/bin/bash
-      cd "$(dirname "$(readlink -n "${0}")")" && \
-        java "${@}" -jar 'logisim-evolution.jar'
-    EOS
-  end
+  app "logisim-evolution-#{version}-all.jar", target: "logisim-evolution.jar"
 
   zap trash: "~/Library/Preferences/com.cburch.logisim.plist"
+
+  caveats do
+    depends_on_java "9+"
+  end
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

See https://github.com/Homebrew/homebrew-cask/pull/90647 for background.