### PR TITLE
Add Transcriptions.app 1.3

### DIFF
--- a/Casks/transcriptions.rb
+++ b/Casks/transcriptions.rb
@@ -1,0 +1,21 @@
+cask "transcriptions" do
+  version "1.3"
+  sha256 "c0aa6654c16dc05195cc88113323f2cfe2ce2a0a5ea85e95e42692d0b144205e"
+
+  # github.com/soleil-alpin was verified as official when first introduced to the cask
+  url "https://github.com/soleil-alpin/Transcriptions/releases/download/v#{version}/Transcriptions.app.zip"
+  appcast "https://github.com/soleil-alpin/Transcriptions/releases.atom"
+  name "Transcriptions"
+  desc "Text editor for fast manual transcription"
+  homepage "https://soleil-alpin.com/Transcriptions/"
+
+  depends_on macos: ">= :catalina"
+
+  app "Transcriptions.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.davidhas.transcriptions.sfl2",
+    "~/Library/Application Scripts/com.davidhas.Transcriptions",
+    "~/Library/Containers/com.davidhas.Transcriptions",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Note: while this cask is not notable enough, I'm submitting for consideration to be included as it is a newly-established replacement/upgrade for the Mac App Store version of Transcriptions.app. (The App Store version is 1.2).

```
$ brew cask audit --new-cask transcriptions
==> Downloading https://github.com/soleil-alpin/Transcriptions/releases/download/v1.3/Transcriptions.app.zip
Already downloaded: /Users/agamemnon/Library/Caches/Homebrew/downloads/f465a56738127bb445a799abdcaf17b6464d9cf5e070b05aba5fa8d8a563da99--Transcriptions.app.zip
==> Verifying SHA-256 checksum for Cask 'transcriptions'.
audit for transcriptions: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: audit failed for casks: transcriptions
```