### PR TITLE
Remove `--force` from issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -25,7 +25,7 @@ about: Create a report to help us improve
 {{replace this}}
 ```
 
-#### Output of command with `--force --verbose --debug`
+#### Output of command with `--verbose --debug`
 
 ```
 {{replace this}}


### PR DESCRIPTION
Many times people will run commands which don't support `--force`, resulting in an irrelevant error for the actual issue.