### PR TITLE
Update easy-move-plus-resize from 1.3.0 to 1.4.0

### DIFF
--- a/Casks/easy-move-plus-resize.rb
+++ b/Casks/easy-move-plus-resize.rb
@@ -8,5 +8,5 @@ cask "easy-move-plus-resize" do
   desc "Utility to support moving and resizing using a modifier key and mouse drag"
   homepage "https://github.com/dmarcotte/easy-move-resize"
 
-  app "easy-move-resize/Easy Move+Resize.app"
+  app "Easy Move+Resize.app"
 end

--- a/Casks/easy-move-plus-resize.rb
+++ b/Casks/easy-move-plus-resize.rb
@@ -1,8 +1,8 @@
 cask "easy-move-plus-resize" do
-  version "1.3.0"
-  sha256 "da8c7c8e365c348f06c80cdc075271d85d16a954bf5f9494786dcb8251bc27b6"
+  version "1.4.0"
+  sha256 "b68ec37dd8243f20a79d4c80b66bd1fad047074e23f05b22720e2088c4ac6ed1"
 
-  url "https://github.com/dmarcotte/easy-move-resize/releases/download/#{version}/Easy.Move.Resize.app.zip"
+  url "https://github.com/dmarcotte/easy-move-resize/releases/download/#{version}/Easy.Move+Resize.app.zip"
   appcast "https://github.com/dmarcotte/easy-move-resize/releases.atom"
   name "Easy Move+Resize"
   desc "Utility to support moving and resizing using a modifier key and mouse drag"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).