### PR TITLE
Update unity-download-assistant from 2020.1.1f1,2285c3239188 to 2020.1.9f1,145f5172610f

### DIFF
--- a/Casks/unity-download-assistant.rb
+++ b/Casks/unity-download-assistant.rb
@@ -1,6 +1,6 @@
 cask "unity-download-assistant" do
-  version "2020.1.1f1,2285c3239188"
-  sha256 "c40fe051a57f0d8d04a724b8374207434450d3e52ae7abc5c138668b6941a6f8"
+  version "2020.1.9f1,145f5172610f"
+  sha256 "2b3dc80bf80b3f82c4b949b7db189096b681e0ccd883000f9e8940f56e5b9abf"
 
   url "https://netstorage.unity3d.com/unity/#{version.after_comma}/UnityDownloadAssistant-#{version.before_comma}.dmg"
   appcast "https://unity3d.com/get-unity/download/archive"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).