### PR TITLE
Update vivi from 2.19.1 to 2.20.1

### DIFF
--- a/Casks/vivi.rb
+++ b/Casks/vivi.rb
@@ -1,6 +1,6 @@
 cask "vivi" do
-  version "2.19.1"
-  sha256 "c6dc9400d3d5649db62ae07f6545c23fd35f3534528f0fdc13321d5c2c98353c"
+  version "2.20.1"
+  sha256 "179d9fce75179f4cad550c2b823bb2254ad255b3e684e4bac987bccf78d65719"
 
   url "https://downloads.vivi.io/app/#{version}/Vivi.pkg"
   name "Vivi"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).