### PR TITLE
Update dcp-o-matic-encode-server from 2.14.38 to 2.14.40

### DIFF
--- a/Casks/dcp-o-matic-encode-server.rb
+++ b/Casks/dcp-o-matic-encode-server.rb
@@ -1,6 +1,6 @@
 cask "dcp-o-matic-encode-server" do
-  version "2.14.38"
-  sha256 "85e5ee995923cda7790f6c1157487609db2e632e0b6d9a52203e190564b08cac"
+  version "2.14.40"
+  sha256 "2bc7778d0862f8b84017a61c7eca389019e2aa9b77fd0a2a84d947d25dac9f0c"
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-server&version=#{version}"
   appcast "https://dcpomatic.com/download"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).