### PR TITLE
Update swiftstack-client from 1.26.0 to 1.27.1

### DIFF
--- a/Casks/swiftstack-client.rb
+++ b/Casks/swiftstack-client.rb
@@ -1,6 +1,6 @@
 cask "swiftstack-client" do
-  version "1.26.0"
-  sha256 "736ded795ab06519fbadf2fac8b2c2defa6461cd5a223134e1cd9335a82a1beb"
+  version "1.27.1"
+  sha256 "d91cd9da8470954978ee3cdcd74faaf4be3c128c5895d28b46b00778d8b7558e"
 
   # storage.googleapis.com/swiftstack/ was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/swiftstack/swiftstackclient-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).