### PR TITLE
Update boxcryptor from 2.35.1024 to 2.36.1042

### DIFF
--- a/Casks/boxcryptor.rb
+++ b/Casks/boxcryptor.rb
@@ -1,6 +1,6 @@
 cask "boxcryptor" do
-  version "2.35.1024"
-  sha256 "5dded2fc6f5bdcc6ee1d40ab1ff9079b6058342caec76fcf7ca76a2eee308cd0"
+  version "2.36.1042"
+  sha256 "38515f06567cf19a5f4f82ecb690ec55b51e39befa186dcba38cccf59e268192"
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.boxcryptor.com/l/download-macosx"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).