### PR TITLE
add Perimeter81 latest

### DIFF
--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -1,0 +1,15 @@
+cask "perimeter81" do
+  version :latest
+  sha256 :no_check
+
+  url "https://static.perimeter81.com/apps/osx/Perimeter81.pkg"
+  name "Perimeter 81"
+  desc "Zero Trust Network as a Service client"
+  homepage "https://perimeter81.com/"
+
+  pkg "Perimeter81.pkg"
+
+  uninstall pkgutil: [
+    "com.safervpn.osx.smb",
+  ]
+end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -1,3 +1,4 @@
+# typed: false
 cask "perimeter81" do
   version :latest
   sha256 :no_check
@@ -9,12 +10,10 @@ cask "perimeter81" do
 
   pkg "Perimeter81.pkg"
 
-  uninstall pkgutil: [
-    "com.safervpn.osx.smb",
-  ], launchctl: [
-    "com.perimeter81.Perimeter81",
-    "com.perimeter81.osx.HelperTool",
-  ], quit: [
-    "com.safervpn.osx.smb",
-  ]
+  uninstall pkgutil:   "com.safervpn.osx.smb",
+            launchctl: [
+              "com.perimeter81.Perimeter81",
+              "com.perimeter81.osx.HelperTool",
+            ],
+            quit:      "com.safervpn.osx.smb"
 end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -10,13 +10,13 @@ cask "perimeter81" do
 
   pkg "Perimeter81.pkg"
 
-  uninstall quit:      [
-    "com.perimeter81.Perimeter81",
-    "com.safervpn.osx.smb",
-  ],
+  uninstall pkgutil:   "com.safervpn.osx.smb"
+            quit:      [
+              "com.perimeter81.Perimeter81",
+              "com.safervpn.osx.smb",
+            ],
             launchctl: [
               "com.perimeter81.Perimeter81",
               "com.perimeter81.osx.HelperTool",
-            ],
-            pkgutil:   "com.safervpn.osx.smb"
+            ]
 end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -10,7 +10,7 @@ cask "perimeter81" do
 
   pkg "Perimeter81.pkg"
 
-  uninstall pkgutil:   "com.safervpn.osx.smb"
+  uninstall pkgutil:   "com.safervpn.osx.smb",
             quit:      [
               "com.perimeter81.Perimeter81",
               "com.safervpn.osx.smb",

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -13,7 +13,7 @@ cask "perimeter81" do
   uninstall quit:      [
     "com.perimeter81.Perimeter81",
     "com.safervpn.osx.smb",
-  ]
+  ],
             launchctl: [
               "com.perimeter81.Perimeter81",
               "com.perimeter81.osx.HelperTool",

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -11,12 +11,18 @@ cask "perimeter81" do
   pkg "Perimeter81.pkg"
 
   uninstall pkgutil:   "com.safervpn.osx.smb",
-            quit:      [
-              "com.perimeter81.Perimeter81",
-              "com.safervpn.osx.smb",
-            ],
+            signal:    ["TERM", "com.safervpn.osx.smb"],
             launchctl: [
               "com.perimeter81.Perimeter81",
               "com.perimeter81.osx.HelperTool",
-            ]
+            ],
+            delete:    "/Library/PrivilegedHelperTools/com.perimeter81.osx.HelperTool"
+
+  zap trash: [
+    "~/Library/Application Support/com.safervpn.osx.smb",
+    "~/Library/Caches/Perimeter 81",
+    "~/Library/Caches/com.safervpn.osx.smb",
+    "~/Library/Preferences/com.safervpn.osx.smb.plist",
+    "~/Library/Saved Application State/com.safervpn.osx.smb.savedState",
+  ]
 end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -1,19 +1,22 @@
-# typed: false
 cask "perimeter81" do
+  # note: "81" is not a version number, but an intrinsic part of the product name
   version :latest
   sha256 :no_check
 
   url "https://static.perimeter81.com/apps/osx/Perimeter81.pkg"
   name "Perimeter 81"
-  desc "Zero Trust Network as a Service client"
+  desc "Zero trust network as a service client"
   homepage "https://perimeter81.com/"
 
   pkg "Perimeter81.pkg"
 
-  uninstall pkgutil:   "com.safervpn.osx.smb",
+  uninstall quit:      [
+    "com.perimeter81.Perimeter81",
+    "com.safervpn.osx.smb",
+  ]
             launchctl: [
               "com.perimeter81.Perimeter81",
               "com.perimeter81.osx.HelperTool",
             ],
-            quit:      "com.safervpn.osx.smb"
+            pkgutil:   "com.safervpn.osx.smb"
 end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -10,7 +10,10 @@ cask "perimeter81" do
 
   pkg "Perimeter81.pkg"
 
-  uninstall quit:      "com.perimeter81.Perimeter81",
+  uninstall quit:      [
+    "com.perimeter81.Perimeter81",
+    "com.safervpn.osx.smb",
+  ],
             launchctl: [
               "com.perimeter81.Perimeter81",
               "com.perimeter81.osx.HelperTool",

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -11,5 +11,10 @@ cask "perimeter81" do
 
   uninstall pkgutil: [
     "com.safervpn.osx.smb",
+  ], launchctl: [
+    "com.perimeter81.Perimeter81",
+    "com.perimeter81.osx.HelperTool",
+  ], quit: [
+    "com.safervpn.osx.smb",
   ]
 end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -10,10 +10,7 @@ cask "perimeter81" do
 
   pkg "Perimeter81.pkg"
 
-  uninstall quit:      [
-    "com.perimeter81.Perimeter81",
-    "com.safervpn.osx.smb",
-  ],
+  uninstall quit:      "com.perimeter81.Perimeter81",
             launchctl: [
               "com.perimeter81.Perimeter81",
               "com.perimeter81.osx.HelperTool",


### PR DESCRIPTION
Unfortunately, Perimeter 81 doesn't seem to offer versioned downloads, and implemented their own update procedure.

---

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
