### PR TITLE
Update SciHubEVA from v4.0.1 to v4.1.0

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -1,6 +1,6 @@
 cask "scihubeva" do
-  version "v4.0.1"
-  sha256 "5ba4ea891fa3781612d8c47c550920194e44bb0d4f49a724ab111d3aed35ebd0"
+  version "v4.1.0"
+  sha256 "d6feb6c6632209201e8b0f1e1a811fa073238b6414de40269f6ee2cccc29c0ba"
 
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast "https://github.com/leovan/SciHubEVA/releases.atom"


### PR DESCRIPTION
Update SciHubEVA from v4.0.1 to v4.1.0

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).