### PR TITLE
Update musescore from 3.5.1 to 3.5.2.312126096

### DIFF
--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -4,7 +4,8 @@ cask "musescore" do
 
   # github.com/musescore/MuseScore/ was verified as official when first introduced to the cask
   url "https://github.com/musescore/MuseScore/releases/download/v#{version.major_minor_patch}/MuseScore-#{version}.dmg"
-  appcast "https://github.com/musescore/MuseScore/releases.atom"
+  appcast "https://github.com/musescore/MuseScore/releases.atom",
+          must_contain: version.major_minor_patch
   name "MuseScore"
   desc "Open-source music notation software"
   homepage "https://musescore.org/"

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -1,9 +1,9 @@
 cask "musescore" do
-  version "3.5.1"
-  sha256 "4c9f4daac8486b61be4cf31d75d078141fc5c97a71e6b7ddbc7dbaed8167cd5f"
+  version "3.5.2.312126096"
+  sha256 "1179534be80e528f22eb3927e1939263e67127265c69e312356d4dceb7ecad0d"
 
   # github.com/musescore/MuseScore/ was verified as official when first introduced to the cask
-  url "https://github.com/musescore/MuseScore/releases/download/v#{version.chomp(".0")}/MuseScore-#{version}.dmg"
+  url "https://github.com/musescore/MuseScore/releases/download/v#{version.major_minor_patch}/MuseScore-#{version}.dmg"
   appcast "https://github.com/musescore/MuseScore/releases.atom"
   name "MuseScore"
   desc "Open-source music notation software"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).