### PR TITLE
sf-symbols: update checksum

### DIFF
--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -1,7 +1,7 @@
 cask "sf-symbols" do
   if MacOS.version <= :mojave
     version "1.1"
-    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 "eddca84dde246f358429e47a8a7906b026d892dba97e556b555b27e7070de04e"
     url "https://devimages-cdn.apple.com/design/resources/download/SF-Symbols.dmg"
   else
     version "2.0"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

------

`brew cask install sf-symbols` failed for me on macOS 10.14.6, with the result:
```
==> Downloading https://devimages-cdn.apple.com/design/resources/download/SF-Symbols.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'sf-symbols'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
Error: Checksum for Cask 'sf-symbols' does not match.
Expected: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  Actual: eddca84dde246f358429e47a8a7906b026d892dba97e556b555b27e7070de04e
    File: /Users/muneeb/Library/Caches/Homebrew/downloads/6197ca22ac4d1dee3137deaee3697d9e494dd05b9eca55b2fef3a0725394a23d--SF-Symbols.dmg
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/reporting_bugs/checksum_does_not_match_error.md
```
After downloading `SF-Symbols.dmg` from [Apple's website](https://developer.apple.com/sf-symbols/), I confirmed the checksum:
```
$ sha256sum ~/Downloads/SF-Symbols.dmg
eddca84dde246f358429e47a8a7906b026d892dba97e556b555b27e7070de04e  /Users/muneeb/Downloads/SF-Symbols.dmg
```
I also confirmed the checksum for SF Symbols 2.0, which is the same value as in the formula.