### PR TITLE
Update visicut from 1.9-80-g65b7f094 to 1.9.83-2dc5fd7f

### DIFF
--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,10 +1,11 @@
 cask "visicut" do
-  version "1.9.83-2dc5fd7f"
-  sha256 "07b01fd9afb3a4f82c5c9fecae6fd9dc88aa75007415bc4d5a8d0c738285d9de"
+  version "1.9-83-g2dc5fd7f"
+  sha256 "a0d5cb13f9e4133b8721ce94603fb0ea6b9eeb7943fab79ab2f82cae6df4982a"
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast "https://download.visicut.org"
   name "VisiCut"
+  desc "Prepare, save and send jobs to Lasercutters"
   homepage "https://visicut.org/"
 
   app "VisiCut.app"

--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -1,6 +1,6 @@
 cask "visicut" do
-  version "1.9-80-g65b7f094"
-  sha256 "26247e3e785a491b64ab186e48ba9f8734c2a5c2d847068dcd78d826e48420e8"
+  version "1.9.83-2dc5fd7f"
+  sha256 "07b01fd9afb3a4f82c5c9fecae6fd9dc88aa75007415bc4d5a8d0c738285d9de"
 
   url "https://download.visicut.org/files/master/MacOSX/VisiCutMac-#{version}.zip"
   appcast "https://download.visicut.org"

--- a/Casks/visicut.rb
+++ b/Casks/visicut.rb
@@ -9,4 +9,8 @@ cask "visicut" do
   homepage "https://visicut.org/"
 
   app "VisiCut.app"
+
+  caveats do
+    depends_on_java "11+"
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).