### PR TITLE
Update splashtop-streamer from 3.4.0.0 to 3.4.2.0

### DIFF
--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -1,6 +1,6 @@
 cask "splashtop-streamer" do
-  version "3.4.0.0"
-  sha256 "b0ec92daf4ac3a6b0da2e02f7cb6fdbf1dba456021be7fca5750f8fb3bdc0a4c"
+  version "3.4.2.0"
+  sha256 "7dbd3c0246b6835bd929b17b5f1c2d3c5738feb30a861502930d2d10792ce781"
 
   # d17kmd0va0f0mp.cloudfront.net/ was verified as official when first introduced to the cask
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"

--- a/Casks/splashtop-streamer.rb
+++ b/Casks/splashtop-streamer.rb
@@ -6,6 +6,7 @@ cask "splashtop-streamer" do
   url "https://d17kmd0va0f0mp.cloudfront.net/mac/Splashtop_Streamer_Mac_INSTALLER_v#{version}.dmg"
   appcast "https://www.splashtop.com/wp-content/themes/responsive/downloadx.php?platform=mac"
   name "Splashtop Streamer"
+  desc "Connect to and control computers from desktop and mobile devices"
   homepage "https://www.splashtop.com/downloads"
 
   auto_updates true
@@ -15,8 +16,9 @@ cask "splashtop-streamer" do
   uninstall quit:      "com.splashtop.Splashtop-Streamer",
             launchctl: [
               "com.splashtop.streamer-daemon",
+              "com.splashtop.streamer-for-root",
               "com.splashtop.streamer-for-user",
               "com.splashtop.streamer-srioframebuffer",
             ],
-            pkgutil:   "com.splashtop.splashtopStreamer.*"
+            pkgutil:   "com.splashtop.Splashtop-Streamer"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).