### PR TITLE
Update virtualbox-extension-pack from 6.1.14 to 6.1.16

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -5,6 +5,7 @@ cask "virtualbox-extension-pack" do
   url "https://download.virtualbox.org/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   appcast "https://download.virtualbox.org/virtualbox/LATEST.TXT"
   name "Oracle VirtualBox Extension Pack"
+  desc "x86 and AMD64/Intel64 virtualization"
   homepage "https://www.virtualbox.org/"
 
   conflicts_with cask: "virtualbox-extension-pack-beta"

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -5,7 +5,7 @@ cask "virtualbox-extension-pack" do
   url "https://download.virtualbox.org/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   appcast "https://download.virtualbox.org/virtualbox/LATEST.TXT"
   name "Oracle VirtualBox Extension Pack"
-  desc "x86 and AMD64/Intel64 virtualization"
+  desc "AMD64/Intel64 and x86 virtualization"
   homepage "https://www.virtualbox.org/"
 
   conflicts_with cask: "virtualbox-extension-pack-beta"

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,6 +1,6 @@
 cask "virtualbox-extension-pack" do
-  version "6.1.14"
-  sha256 "b224e796e886b19bce69f0aaedf6ca82bad0ca29c61fb0ed86166efb84356942"
+  version "6.1.16"
+  sha256 "9802482b77b95a954cb5111793da10d009009a4e9a9c4eaa4bd1ae5dafe9db46"
 
   url "https://download.virtualbox.org/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   appcast "https://download.virtualbox.org/virtualbox/LATEST.TXT"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).