### PR TITLE
tunnelbear: remove privileged helper on uninstall

### DIFF
--- a/Casks/tunnelbear.rb
+++ b/Casks/tunnelbear.rb
@@ -12,7 +12,8 @@ cask "tunnelbear" do
   app "TunnelBear.app"
 
   uninstall quit:      "com.tunnelbear.mac.TunnelBear",
-            launchctl: "com.tunnelbear.mac.tbeard"
+            launchctl: "com.tunnelbear.mac.tbeard",
+            delete:    "/Library/PrivilegedHelperTools/com.tunnelbear.mac.tbeard"
 
   zap trash: [
     "~/Library/Preferences/com.tunnelbear.mac.TunnelBear.plist",


### PR DESCRIPTION
Tunnelbear installs a tool to `/Library/PrivilegedHelperTools` which was not removed on uninstall by homebrew cask. I added a delete stanza to remove this tool. Unfortunately, the trash stanza did not work for me. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).