### PR TITLE
Update koodo-reader from 1.1.6 to 1.1.7

### DIFF
--- a/Casks/koodo-reader.rb
+++ b/Casks/koodo-reader.rb
@@ -1,6 +1,6 @@
 cask "koodo-reader" do
-  version "1.1.6"
-  sha256 "5b8c9d148945a6711ee49139b969c1f1adba83d0b1161b1ca857feddf2fab580"
+  version "1.1.7"
+  sha256 "9b6cbe00b16f17774b2753374468c1e8b8465a72f9f2c525f3a1a37e68a9c2af"
 
   # github.com/troyeguo/koodo-reader was verified as official when first introduced to the cask
   url "https://github.com/troyeguo/koodo-reader/releases/download/v#{version}/Koodo-Reader-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).