### PR TITLE
Update big-mean-folder-machine from 2.41 to 2.42

### DIFF
--- a/Casks/big-mean-folder-machine.rb
+++ b/Casks/big-mean-folder-machine.rb
@@ -1,6 +1,6 @@
 cask "big-mean-folder-machine" do
-  version "2.41"
-  sha256 "d5ac6ccdc6dc01d518b69576b0d969a1d784f7170746ddccd343e8f2977204fa"
+  version "2.42"
+  sha256 "5324a4904a5559edf587ffd3f5af70aa0a46744631721a8761463c792f755004"
 
   url "https://www.publicspace.net/download/BMFM.dmg"
   appcast "https://www.publicspace.net/app/bmfm#{version.major}.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).