### PR TITLE
Update gemini from 2.6.11,348.1:1602851645 to 2.6.12,348.2:1603294703

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,6 +1,6 @@
 cask "gemini" do
-  version "2.6.11,348.1:1602851645"
-  sha256 "5ed9c0b9293b6a8d873a39f59931e4de3798441aeb7e4203c4007c90579c8786"
+  version "2.6.12,348.2:1603294703"
+  sha256 "31d5e44a5b456f1196e7df3a73f857e595feff57a4802e94291f8d9902d16fac"
 
   # dl.devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_comma.before_colon}/#{version.after_colon}/Gemini#{version.major}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).