### PR TITLE
Update suitcase-fusion from 21.2.0 to 21.2.1

### DIFF
--- a/Casks/suitcase-fusion.rb
+++ b/Casks/suitcase-fusion.rb
@@ -1,6 +1,6 @@
 cask "suitcase-fusion" do
-  version "21.2.0"
-  sha256 "71f73a1338e5776f0ecedf89bbb1b1925982769b5e30461e075a36ae7bd09465"
+  version "21.2.1"
+  sha256 "851db1e4030aee1fe82e0f2c2a411266ada957f2f9682ea4c91c455967b767d4"
 
   url "https://bin.extensis.com/SuitcaseFusion-M-#{version.dots_to_hyphens}.dmg"
   appcast "https://www.extensis.com/support/suitcase-fusion-#{version.major}/release-notes/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).