### PR TITLE
Update waterfox-current from 2020.09,6820.9.22 to 2020.10,6820.10.20

### DIFF
--- a/Casks/waterfox-current.rb
+++ b/Casks/waterfox-current.rb
@@ -1,6 +1,6 @@
 cask "waterfox-current" do
-  version "2020.09,6820.9.22"
-  sha256 "f98452eadb537f73354da1787ba535c1ce9a8e3447e97f3431825e8455d9f357"
+  version "2020.10,6820.10.20"
+  sha256 "4bbeb0210e75f33959cb60e4ef8b35176c4f01d9bc684d4f217255d3b7ecfb30"
 
   url "https://cdn.waterfox.net/releases/osx64/installer/Waterfox%20Current%20#{version.before_comma}%20Setup.dmg"
   appcast "https://www.waterfox.net/download/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).