### PR TITLE
Re-Add Bitlord.app 2.4.6,348

### DIFF
--- a/Casks/bitlord.rb
+++ b/Casks/bitlord.rb
@@ -1,6 +1,6 @@
 cask 'bitlord' do
   version '2.4.6,348'
-  sha256 '35b4c5c6d880973f05c1ef2fa16b996b7c82aca88a4412c17d2f50e24f51ca09'
+  sha256 '081ec26228213772ca9655f6e469529e7932d628efb10beda72405ad87cfbc39'
 
   url "https://www.bitlord.com/osx/BitLord-ver#{version.after_comma}.dmg"
   name 'BitLord'

--- a/Casks/bitlord.rb
+++ b/Casks/bitlord.rb
@@ -1,0 +1,10 @@
+cask 'bitlord' do
+  version '2.4.6,348'
+  sha256 '35b4c5c6d880973f05c1ef2fa16b996b7c82aca88a4412c17d2f50e24f51ca09'
+
+  url "https://www.bitlord.com/osx/BitLord-ver#{version.after_comma}.dmg"
+  name 'BitLord'
+  homepage 'https://www.bitlord.com/'
+
+  app 'BitLord.app'
+end

--- a/Casks/bitlord.rb
+++ b/Casks/bitlord.rb
@@ -1,11 +1,11 @@
-cask 'bitlord' do
-  version '2.4.6,348'
-  sha256 '081ec26228213772ca9655f6e469529e7932d628efb10beda72405ad87cfbc39'
+cask "bitlord" do
+  version "2.4.6,348"
+  sha256 "081ec26228213772ca9655f6e469529e7932d628efb10beda72405ad87cfbc39"
 
   url "https://www.bitlord.com/osx/BitLord-ver#{version.after_comma}.dmg"
-  name 'BitLord'
-  desc 'Torrent downloader and streamer'
-  homepage 'https://www.bitlord.com/'
+  name "BitLord"
+  desc "Torrent downloader and streamer"
+  homepage "https://www.bitlord.com/"
 
-  app 'BitLord.app'
+  app "BitLord.app"
 end

--- a/Casks/bitlord.rb
+++ b/Casks/bitlord.rb
@@ -4,6 +4,7 @@ cask 'bitlord' do
 
   url "https://www.bitlord.com/osx/BitLord-ver#{version.after_comma}.dmg"
   name 'BitLord'
+  desc 'Torrent downloader and streamer'
   homepage 'https://www.bitlord.com/'
 
   app 'BitLord.app'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues). Bitlord was removed due to the latest version installer being adware. However, the bitlord installer for the newest macOS version is now clean, and I think Bitlord deserves a re-add.
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
