### PR TITLE
Pull the specified version of NordVPN.

### DIFF
--- a/Casks/nordvpn.rb
+++ b/Casks/nordvpn.rb
@@ -3,7 +3,7 @@ cask "nordvpn" do
   sha256 "3ed6d0413c72b79293584dc0430a982c018a1950ece570529e43d66e8576a35f"
 
   # downloads.nordcdn.com/ was verified as official when first introduced to the cask
-  url "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg"
+  url "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/#{version}/NordVPN.pkg"
   appcast "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/update_pkg.xml"
   name "NordVPN"
   desc "VPN client for secure internet access and private browsing"


### PR DESCRIPTION
Downloading from the "latest" URL can cause a different version to be downloaded. The hash check stops it from being installed but it's pretty annoying.

Currently the cask specifies v5.9.1 but v5.8.1 is being served from the "latest" URL.

This may conflict with #91355. I suggest merging that first and then I'll resolve any conflicts.

---

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
