### PR TITLE
Update beekeeper-studio from 1.7.5 to 1.8.5

### DIFF
--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,6 +1,6 @@
 cask "beekeeper-studio" do
-  version "1.7.5"
-  sha256 "ecd99632a6cb5eada14de1594c3033fe796db1cb19d5cfd92ecd0af9bd3db7a7"
+  version "1.8.5"
+  sha256 "79dbbcfd1b20422276cb9c24cca22a4d8848f719e227973924d2e7354043df5f"
 
   # github.com/beekeeper-studio/beekeeper-studio/ was verified as official when first introduced to the cask
   url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).