### PR TITLE
Update webcatalog from 25.10.0 to 25.11.0

### DIFF
--- a/Casks/webcatalog.rb
+++ b/Casks/webcatalog.rb
@@ -1,6 +1,6 @@
 cask "webcatalog" do
-  version "25.10.0"
-  sha256 "c0bcbb785749a83983f1476f8caff7ce53a10f8fb6452f1b629b49ff7255f171"
+  version "25.11.0"
+  sha256 "53cede335fa66c7c56868194b98f4076e489645027ca668bc72b7089c497a92e"
 
   # github.com/webcatalog/webcatalog-app/ was verified as official when first introduced to the cask
   url "https://github.com/webcatalog/webcatalog-app/releases/download/v#{version}/WebCatalog-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).