### PR TITLE
Fix Adobe DNG Converter installation on High Sierra

### DIFF
--- a/Casks/adobe-dng-converter.rb
+++ b/Casks/adobe-dng-converter.rb
@@ -1,6 +1,11 @@
 cask "adobe-dng-converter" do
-  version "13.0"
-  sha256 "72c5692e94c4cd2f0f10d2c4ccc0c4dda82578f0fec1c67956458844f95fe78d"
+  if MacOS.version <= :high_sierra
+    version "12.4"
+    sha256 "b3815537877c4b0505e4c5d4cc8739c8cd6cfbbfddf1a9f2dfb223ef322682c9"
+  else
+    version "13.0"
+    sha256 "72c5692e94c4cd2f0f10d2c4ccc0c4dda82578f0fec1c67956458844f95fe78d"
+  end
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"
   appcast "https://supportdownloads.adobe.com/product.jsp?product=106&platform=Macintosh"


### PR DESCRIPTION
Add app version switching based on OS version as latest app version
13.0 requires Mojave or later.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
