### PR TITLE
mysqlworkbench: add mojave version

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -7,6 +7,10 @@ cask "mysqlworkbench" do
     version "8.0.16"
     sha256 "3478800290e2797d294e3721fdaea4c41ddc1917f2b59ec94a935e16c18dc5d2"
     url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
+  elsif MacOS.version <= :mojave
+    version "8.0.21"
+    sha256 "7d812551cc1cc38e1d5f588e6c91b07f1778c78a04bfe94dafac3a23ea425e88"
+    url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   else
     version "8.0.22"
     sha256 "4e27de82d869043cf80e803f1a57cc041a91cabddf0aa6a6c054d68af1837d48"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

https://www.mysql.com/support/eol-notice.html:

> October 19, 2020
>
> Support EOL for macOS v10.14
>
> Due to very low demand, MySQL has stopped development and support for macOS 10.14. Users are requested to upgrade to recent versions of macOS. Source and binaries for previously released versions will continue to be available from the archives.

Closes https://github.com/Homebrew/homebrew-cask/issues/91416.