### PR TITLE
Update chrome-remote-desktop-host: Fix broken homepage link

### DIFF
--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -14,16 +14,16 @@ cask "chrome-remote-desktop-host" do
     args:       ["--no-ui"],
     sudo:       true,
   },
+            launchctl: [
+              "com.google.keystone.daemon",
+              "com.google.keystone.system.xpcservice",
+              "org.chromium.chromoting",
+            ],
             pkgutil:   [
               "com.google.pkg.ChromeRemoteDesktopHost",
               "com.google.pkg.ChromeRemoteDesktopHostService",
               "com.google.pkg.ChromeRemoteDesktopHostUninstaller",
               "com.google.pkg.Keystone",
-            ],
-            launchctl: [
-              "com.google.keystone.daemon",
-              "com.google.keystone.system.xpcservice",
-              "org.chromium.chromoting",
             ]
 
   caveats do

--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -4,6 +4,7 @@ cask "chrome-remote-desktop-host" do
 
   url "https://dl.google.com/chrome-remote-desktop/chromeremotedesktop.dmg"
   name "Chrome Remote Desktop"
+  desc "Remotely access another computer through the Chrome browser"
   homepage "https://chrome.google.com/webstore/detail/chrome-remote-desktop/inomeogfingihgjfjlpeplalcfajhgai"
 
   pkg "Chrome Remote Desktop Host.pkg"
@@ -11,8 +12,13 @@ cask "chrome-remote-desktop-host" do
   uninstall script:  {
     executable: "/Applications/Chrome Remote Desktop Host Uninstaller.app/Contents/MacOS/remoting_host_uninstaller",
     args:       ["--no-ui"],
+    sudo:       true,
   },
-            pkgutil: "com.google.pkg.ChromeRemoteDesktopHost"
+            pkgutil: [
+              "com.google.pkg.ChromeRemoteDesktopHost",
+              "com.google.pkg.ChromeRemoteDesktopHostService",
+              "com.google.pkg.ChromeRemoteDesktopHostUninstaller",
+            ]
 
   caveats do
     logout

--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -4,7 +4,7 @@ cask "chrome-remote-desktop-host" do
 
   url "https://dl.google.com/chrome-remote-desktop/chromeremotedesktop.dmg"
   name "Chrome Remote Desktop"
-  homepage "https://chrome.google.com/webstore/detail/chrome-remote-desktop/gbchcmhmhahfdphkhkmpfmihenigjmpp"
+  homepage "https://chrome.google.com/webstore/detail/chrome-remote-desktop/inomeogfingihgjfjlpeplalcfajhgai"
 
   pkg "Chrome Remote Desktop Host.pkg"
 

--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -9,21 +9,15 @@ cask "chrome-remote-desktop-host" do
 
   pkg "Chrome Remote Desktop Host.pkg"
 
-  uninstall script:    {
+  uninstall script:  {
     executable: "/Applications/Chrome Remote Desktop Host Uninstaller.app/Contents/MacOS/remoting_host_uninstaller",
     args:       ["--no-ui"],
     sudo:       true,
   },
-            launchctl: [
-              "com.google.keystone.daemon",
-              "com.google.keystone.system.xpcservice",
-              "org.chromium.chromoting",
-            ],
-            pkgutil:   [
+            pkgutil: [
               "com.google.pkg.ChromeRemoteDesktopHost",
               "com.google.pkg.ChromeRemoteDesktopHostService",
               "com.google.pkg.ChromeRemoteDesktopHostUninstaller",
-              "com.google.pkg.Keystone",
             ]
 
   caveats do

--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -18,6 +18,7 @@ cask "chrome-remote-desktop-host" do
               "com.google.pkg.ChromeRemoteDesktopHost",
               "com.google.pkg.ChromeRemoteDesktopHostService",
               "com.google.pkg.ChromeRemoteDesktopHostUninstaller",
+              "com.google.pkg.Keystone",
             ]
 
   caveats do

--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -9,16 +9,21 @@ cask "chrome-remote-desktop-host" do
 
   pkg "Chrome Remote Desktop Host.pkg"
 
-  uninstall script:  {
+  uninstall script:    {
     executable: "/Applications/Chrome Remote Desktop Host Uninstaller.app/Contents/MacOS/remoting_host_uninstaller",
     args:       ["--no-ui"],
     sudo:       true,
   },
-            pkgutil: [
+            pkgutil:   [
               "com.google.pkg.ChromeRemoteDesktopHost",
               "com.google.pkg.ChromeRemoteDesktopHostService",
               "com.google.pkg.ChromeRemoteDesktopHostUninstaller",
               "com.google.pkg.Keystone",
+            ],
+            launchctl: [
+              "com.google.keystone.daemon",
+              "com.google.keystone.system.xpcservice",
+              "org.chromium.chromoting",
             ]
 
   caveats do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.