### PR TITLE
Update refined-github-safari from 2.1.18 to 2.1.20

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask "refined-github-safari" do
-  version "2.1.18"
-  sha256 "162dfcb24a45e1b8d95e2d0f186f5523e2a896d0c9517023fb69ffc85d010b5d"
+  version "2.1.20"
+  sha256 "a8621ada8a048782d5bf585a195d5e432b0fc57c280ed62d65ed9b64ab76eebc"
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast "https://github.com/lautis/refined-github-safari/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).