### PR TITLE
Update diskcatalogmaker from 8.2.5 to 8.2.6

### DIFF
--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -1,6 +1,6 @@
 cask "diskcatalogmaker" do
-  version "8.2.5"
-  sha256 "a559f5e08863cb77da41d6dd7dcd09ac86c7e3477d0746cb58fb4e175d30a6f5"
+  version "8.2.6"
+  sha256 "a7ddac6285371e572c51ee34bc6aa30c8a3ddb4060d25265f536eda0019fd9b7"
 
   url "https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).