### PR TITLE
Update istat-menus from 6.40 to 6.50

### DIFF
--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,5 +1,5 @@
 cask "istat-menus" do
-  version "6.40"
+  version "6.50"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://files.bjango.com/istatmenus#{version.major}/istatmenus#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).