### PR TITLE
Update listen1 from 2.14.0 to 2.15.1

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,7 +1,7 @@
 cask "listen1" do
   # note: "1" is not a version number, but an intrinsic part of the product name
-  version "2.14.0"
-  sha256 "1690ff0d136a164590293b7a53ab271b52b5a48abde7b586bfc5171e361507a7"
+  version "2.15.1"
+  sha256 "d395bb1ef924f98c91299b099de3a6857861161d626d5352579232c08cc5f622"
 
   # github.com/listen1/listen1_desktop/ was verified as official when first introduced to the cask
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"

--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -7,6 +7,7 @@ cask "listen1" do
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac.dmg"
   appcast "https://github.com/listen1/listen1_desktop/releases.atom"
   name "Listen 1"
+  desc "Search and play songs from a variety of online sources"
   homepage "https://listen1.github.io/listen1/"
 
   app "Listen1.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).