### PR TITLE
Add Intent Drive.app v1.1.9

### DIFF
--- a/Casks/internxt-drive.rb
+++ b/Casks/internxt-drive.rb
@@ -4,6 +4,7 @@ cask "internxt-drive" do
 
   # github.com/internxt/drive-desktop was verified as official when first introduced to the cask
   url "https://github.com/internxt/drive-desktop/releases/download/v#{version}/internxt-drive-#{version}.dmg"
+  appcast "https://github.com/internxt/drive-desktop/releases.atom"
   name "Internxt Drive"
   desc "End-to-end encrypted, free, open source cloud storage"
   homepage "https://internxt.com/drive"

--- a/Casks/internxt-drive.rb
+++ b/Casks/internxt-drive.rb
@@ -1,0 +1,12 @@
+cask "internxt-drive" do
+  version "1.1.9"
+  sha256 "31b8266747f286cdaeb021a84a804cbe952e2445950f4ab220869c1d343ed49d"
+
+  # github.com/internxt/drive-desktop was verified as official when first introduced to the cask
+  url "https://github.com/internxt/drive-desktop/releases/download/v#{version}/internxt-drive-#{version}.dmg"
+  name "Internxt Drive"
+  desc "End-to-end encrypted, free, open source cloud storage"
+  homepage "https://internxt.com/drive"
+
+  app "Internxt Drive.app"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

`brew cask audit --download` Failed because of:
- The URL https://internxt.com/drive is not reachable (HTTP status code 500)
The page get yesterday update, they currently fix the issue

`brew cask audit --new-cask` Failed because of:
 - The URL https://internxt.com/drive is not reachable (HTTP status code 500)
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
See above