### PR TITLE
Update nteract from 0.25.1 to 0.26.0

### DIFF
--- a/Casks/nteract.rb
+++ b/Casks/nteract.rb
@@ -1,6 +1,6 @@
 cask "nteract" do
-  version "0.25.1"
-  sha256 "553c7e9d1ef9f27c920000498fb0b388a6168a2e708490797099e71fe37e2764"
+  version "0.26.0"
+  sha256 "8cf33c99cdfdd9bd1623aac9ac0ea51f9b6043a4be28b4520429413a79af5856"
 
   url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
   appcast "https://github.com/nteract/nteract/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).