### PR TITLE
Update alt-tab from 6.8.0 to 6.9.0

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,6 +1,6 @@
 cask "alt-tab" do
-  version "6.8.0"
-  sha256 "e871fd8833600fdc0655c6c096c1937b969341ed3ce5c19cc0125f0b87359266"
+  version "6.9.0"
+  sha256 "b1c522054d554e86254bccd4f4e8591612e47f57788c342b859ff003a67f9574"
 
   url "https://github.com/lwouis/alt-tab-macos/releases/download/v#{version}/AltTab-#{version}.zip"
   appcast "https://github.com/lwouis/alt-tab-macos/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).