### PR TITLE
Export Wireshark CLI tools from formula

### DIFF
--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -14,7 +14,26 @@ cask "wireshark" do
 
   app "Wireshark.app"
   pkg "Install ChmodBPF.pkg"
-  pkg "Add Wireshark to the system path.pkg"
+  pkg "Add Wireshark to the system path.pkg"  
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/capinfos"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/captype"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/dftest"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/dumpcap"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/editcap"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/idl2wrs"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/mergecap"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/mmdbresolve"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/randpkt"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/rawshark"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/reordercap"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/sharkd"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/text2pcap"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/tshark"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/extcap/androiddump"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/extcap/ciscodump"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/extcap/randpktdump"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/extcap/sshdump"
+  binary "#{appdir}/Wireshark.app/Contents/MacOS/extcap/udpdump"
 
   uninstall_preflight do
     system_command "/usr/sbin/installer",

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,3 +1,4 @@
+# typed: false
 cask "wireshark" do
   version "3.2.7"
   sha256 "1347138534c6d9adb2ee1af7898cac2248b63bfb1ac6afee54e17725ab333106"
@@ -14,7 +15,7 @@ cask "wireshark" do
 
   app "Wireshark.app"
   pkg "Install ChmodBPF.pkg"
-  pkg "Add Wireshark to the system path.pkg"  
+  pkg "Add Wireshark to the system path.pkg"
   binary "#{appdir}/Wireshark.app/Contents/MacOS/capinfos"
   binary "#{appdir}/Wireshark.app/Contents/MacOS/captype"
   binary "#{appdir}/Wireshark.app/Contents/MacOS/dftest"

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,4 +1,3 @@
-# typed: false
 cask "wireshark" do
   version "3.2.7"
   sha256 "1347138534c6d9adb2ee1af7898cac2248b63bfb1ac6afee54e17725ab333106"
@@ -11,6 +10,7 @@ cask "wireshark" do
 
   auto_updates true
   conflicts_with cask: "wireshark-chmodbpf"
+  conflicts_with formula: "wireshark"
   depends_on macos: ">= :sierra"
 
   app "Wireshark.app"

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -9,8 +9,8 @@ cask "wireshark" do
   homepage "https://www.wireshark.org/"
 
   auto_updates true
-  conflicts_with cask: "wireshark-chmodbpf"
-  conflicts_with formula: "wireshark"
+  conflicts_with cask:    "wireshark-chmodbpf",
+                 formula: "wireshark"
   depends_on macos: ">= :sierra"
 
   app "Wireshark.app"


### PR DESCRIPTION
Wireshark comes with several bundled CLI tools, which currently are not
exposed through the cask, and people have to manually alias or link them.

This makes the Wireshark cask work more in line with what other casks
that bundle CLI binaries (e.g. `julia` or `visual-studio-code`) do.

The following command was used to extract the available binaries from
`Wireguard.app` if needed for future reference (needs `fd` and `rg`):

```bash
fd --type=executable . /Applications/Wireshark.app/ | \
rg -F Wireshark.app/Contents/MacOS | rg -v 'Wireshark$' | \
rg -F /Applications --replace='binary "#{appdir}' | awk '{print $0 "\""}'
```

The outputs of it are in line with the documentation currently hosted at:
https://www.wireshark.org/docs/man-pages/

A great follow up addition to this would be adding the `man` pages (e.g.
`/Applications/Wireshark.app/Contents/Resources/share/man/man1/tshark.1`)
automatically to `man`'s path through the Cask formula, but I am not sure
how to accomplish this **(I'll gladly make another PR  for this if a maintainer
can point me to an example from another formula that does this)**.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).