### PR TITLE
Update securesafe from 2.7.2 to 2.8.0

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,8 +1,9 @@
 cask "securesafe" do
-  version "2.7.2"
-  sha256 "79cefe64d6c4d6c501496e9b333a9bc785fe8d7a64b473df2216c4e58396d59b"
+  version "2.8.0"
+  sha256 "1e193ae806896b304fc4ce4c62e1bb3b0c3db07650924f94b7baed7803f5e372"
 
-  url "https://www.securesafe.com/downloads/SecureSafe_#{version}.pkg"
+  # dswiss.com/userdata/downloads was verified as official when first introduced to the cask
+  url "https://www.dswiss.com/userdata/downloads/securesafe-#{version}.pkg"
   appcast "https://www.securesafe.com/en/downloads/"
   name "SecureSafe"
   homepage "https://www.securesafe.com/"

--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -6,6 +6,7 @@ cask "securesafe" do
   url "https://www.dswiss.com/userdata/downloads/securesafe-#{version}.pkg"
   appcast "https://www.securesafe.com/en/downloads/"
   name "SecureSafe"
+  desc "Secure online storage"
   homepage "https://www.securesafe.com/"
 
   depends_on macos: ">= :sierra"

--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -10,7 +10,7 @@ cask "securesafe" do
 
   depends_on macos: ">= :sierra"
 
-  pkg "SecureSafe_#{version}.pkg"
+  pkg "SecureSafe-#{version}.pkg"
 
   uninstall pkgutil: [
     "com.dswiss.securesafe.pkg.sync",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).