### PR TITLE
Update the zap given example with one following current styling rules

### DIFF
--- a/doc/cask_language_reference/stanzas/zap.md
+++ b/doc/cask_language_reference/stanzas/zap.md
@@ -21,4 +21,4 @@ $ brew cask zap td-toolbelt             # also removes org.ruby-lang.installer
 
 The form of `zap` stanza follows the [`uninstall` stanza](uninstall.md). All of the same directives are available. The `trash:` key is preferred over `delete:`.
 
-Example: [dropbox.rb](https://github.com/Homebrew/homebrew-cask/blob/31cd96cc0e00dab1bff74d622e32d816bafd1f6f/Casks/dropbox.rb#L17-L35)
+Example: [dropbox.rb](https://github.com/Homebrew/homebrew-cask/blob/fa4d9da31b557cba0fb9f983b7ea9e75af1a5f9e/Casks/dropbox.rb#L21-L43)


### PR DESCRIPTION
This PR is updating the zap documentation, hopefully avoiding future styling issues (see [my experience](https://github.com/Homebrew/homebrew-cask/pull/91304#discussion_r514277888)) by using a too old example.

# Default template

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
