### PR TITLE
Menumeters move to github infrastructure

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -6,7 +6,7 @@ cask "menumeters" do
   url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version}.zip"
   appcast "https://github.com/yujitach/MenuMeters/releases.atom"
   name "MenuMeters for El Capitan (and later)"
-  desc "Is a set of CPU, memory, disk, and network monitoring tools"
+  desc "Set of CPU, memory, disk, and network monitoring tools"
   homepage "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/"
 
   auto_updates true

--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -2,9 +2,11 @@ cask "menumeters" do
   version "2.0.8"
   sha256 "acb318ef826f1eb66ea5e9d22c5495c2d334157b946a50eb3b60c8f40bc560c8"
 
-  url "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/zips/MenuMeters_#{version}.zip"
-  appcast "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/MenuMeters-Update.xml"
+  # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
+  url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version}.zip"
+  appcast "https://github.com/yujitach/MenuMeters/releases.atom"
   name "MenuMeters for El Capitan (and later)"
+  desc "Is a set of CPU, memory, disk, and network monitoring tools"
   homepage "https://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/"
 
   auto_updates true


### PR DESCRIPTION
Move Menumeters to Github infrastructure for stability and availability behind firewalls.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).