### PR TITLE
Update libreoffice-language-pack from 7.0.2 to 7.0.3

### DIFF
--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,396 +1,396 @@
 cask "libreoffice-language-pack" do
-  version "7.0.2"
+  version "7.0.3"
 
   language "af" do
-    sha256 "6d7887abe15f7a463de6f8417f5e81d7941a23792b9005572b95a884d389486c"
+    sha256 "2cc4cd07d63fc8eda574fdd05b30f438b8499d790c2f07274a95a8d38df3bee7"
     "af"
   end
   language "am" do
-    sha256 "3120ecaa9a65639dfe05b999aeeca2a57543bd3904a24ec4ad57bd21730b45cf"
+    sha256 "8a3ae24cb2c2bf3aa2931e0f9dafe3ccbf2f6fef6d69f102e7ba0a6f7e680697"
     "am"
   end
   language "ar" do
-    sha256 "8825b9be7c1ade3772d953c4adcb430a2879a24922a2a5091b2e6237db647a68"
+    sha256 "446cc03319fa1f33ed6c7f33be7b708759403d522b7ba37a1979cb6d92747f4a"
     "ar"
   end
   language "as" do
-    sha256 "a4fdf8ffa05f5953111ad97b0cc4e6df3a3d98ca6c775e98cede89b2a2495e11"
+    sha256 "418da3669939084c37453f9e37ffdbf71f88920b9adf348ae5b637284bf45805"
     "as"
   end
   language "be" do
-    sha256 "0d4148f75737b3a2f85fa384ad3d44192ed0e08d3ba8502844a614b2de95450f"
+    sha256 "5d66a1c3dbbb8579e225b8506060d8f3bb7029ff4a5fbc4ecdf206ea73123832"
     "be"
   end
   language "bg" do
-    sha256 "46fdbf03cf7e1d4e94985c1cca699c4bc02f08d62bd3e6d8c90e2d472e1592e4"
+    sha256 "14411c24b40fd0c4f977e4cf245da041cf78e9bc48554685b04749e1c8de74cd"
     "bg"
   end
   language "bn-IN" do
-    sha256 "7d3c266696418035f314e922832a75b71b13c173742a5d9c426e278905331b56"
+    sha256 "312d441f4892ef4829bf6e41bb55a747df7c338c9506c9f7cf615a311a98513a"
     "bn-IN"
   end
   language "bn" do
-    sha256 "80913375be377e767b707b2fc5eb4b590c19b57c37c4f33b83747e3b33e79d2d"
+    sha256 "d7a5fd187d97df356a376ef9d6c1555a42370abf21b140de29750561170d31b8"
     "bn"
   end
   language "bo" do
-    sha256 "88a172a7d5a246977510b49af4902d22f9bd5bd3e0e139d3d8e5af7cac91d2ac"
+    sha256 "af7a598a7bd305994b7059db36083eb7835ff07900a150b65532145a06462dbd"
     "bo"
   end
   language "br" do
-    sha256 "99268dce3595a6ea75a5166474c949c56fcb2ec8823a8fc3e61d01c3ba4cd515"
+    sha256 "6c1e4233a9a4c56235798d7445edc5af1aae595e41d58867dea898c35b2f412c"
     "br"
   end
   language "bs" do
-    sha256 "f22780a21679f7f1a7c6a1e4451154fa80ccc420052cb90de7d75ca0758a672d"
+    sha256 "f41e6ab4d21249231a58539c631db4552ded00c400a113584bf8beeb9df2608c"
     "bs"
   end
   language "ca" do
-    sha256 "cb335e26eca12b0227f8c5a2d07dfd1c359b5a54725afc161e20ab582a0162d8"
+    sha256 "c3146727fe1a028deff49308bddd09ef6a5c7276349369bc0a3e84bf192aa301"
     "ca"
   end
   language "cs" do
-    sha256 "c32e1344b4eac061190d7d135431fc9578b679f00021ef1f64d34171e66cafd1"
+    sha256 "fc4cf10c279b96207d0f148304f268974e35c92b15d5da932bab6d071d1d87aa"
     "cs"
   end
   language "cy" do
-    sha256 "fca6672e319e178541bde89b752e984b63936d3a44dbf6486fd300933379bebf"
+    sha256 "4b8b8d7288f988a3224cd67b7a8002ee96df7a7856ef139eb8452167f78a7a39"
     "cy"
   end
   language "da" do
-    sha256 "f1916bf2a5a98c5b3bea8217e04a44f83b4eee18d4f9e870b4feda64b5e8c40c"
+    sha256 "e12dbee45d66b9f727906c30a81e4d24a529fd5482802ddaddd0dbeaacf27a98"
     "da"
   end
   language "de" do
-    sha256 "f3daccff5f89d939e50f79506d612c34359b2b0a65cb6b54012f81c50290525b"
+    sha256 "e66e527d84e46e482f0e189607b91ba5d2ef1feb2ade07c7f1d2a3059eba5847"
     "de"
   end
   language "dz" do
-    sha256 "8145beb35be82daf95f57212d877303d83add920f7dea271076f95612b2ff87a"
+    sha256 "f9f1f7cac6a2517f38be99f3bbf31dc6f232972c6a77a59d8ff36b1b189b5ab2"
     "dz"
   end
   language "el" do
-    sha256 "2cbc786e1f6a1b71c6a0b705819703e1e804858b12346005d06a81ccb51ccfe5"
+    sha256 "74e2293066aa59bc4a5a8aa9f16545a6df5adf1cc91bf66111c58337af8ec300"
     "el"
   end
   language "en-GB", default: true do
-    sha256 "44b09cadde80c3d91679c74f27efbb15b08813d013975c92b6d9c279cb92a0b5"
+    sha256 "a68af956925c7b9fc21b606e218a3eed62c92a0731ab9039189c2e3115bc5b1e"
     "en-GB"
   end
   language "en-ZA" do
-    sha256 "9370118181899084952ae2a7b0d289ccfbff08b75f22147db4f38a3137ab0074"
+    sha256 "d12532af39fe6739f06179f78abe99aaeae5592dc7c458d16d3d3df43d45903e"
     "en-ZA"
   end
   language "eo" do
-    sha256 "a582052412248aea2f1c0ae30bb33d67c429f80019613ec833aeb829dcdb2a5f"
+    sha256 "c14ad1f65fb461a5f73b9ecc060f661432689a57d7a718eea128c9f048ab6e78"
     "eo"
   end
   language "es" do
-    sha256 "77756dcbb925c012c55b641d53e37068e88f2e4011787a7314252484fe44a6af"
+    sha256 "894efc1fbbbd0e05afb17993c5d0d533651ae8b7188b780a9a4001ae8c61a716"
     "es"
   end
   language "et" do
-    sha256 "a3909f4de33b9ab2e8e9d08879dd27b37882920ac01a2301a1e71f9a91431135"
+    sha256 "251cd0b74da33d498b0ec1efe6ab9a87364e533c5ca16c09ea4d3ee6b51ffc0c"
     "et"
   end
   language "eu" do
-    sha256 "d38493fb7cb583768bd2b04a25bbcf4d720efefb4570695c0a6df0a3996ccccd"
+    sha256 "86b81bf8d09f7276a1393d522a7d39d6015528de5ca776f788328effb61eb46d"
     "eu"
   end
   language "fa" do
-    sha256 "02cfd1357fdec3d8def9dde170d3e8f2e3555398ef24f66c3e2bd266b7a1a540"
+    sha256 "d494f6c249b92f3f3238d0d6bad7e5bdd1f27f2a19076815eda6adf21f8aa249"
     "fa"
   end
   language "fi" do
-    sha256 "f80fea3d703a41c703b1b6db84727c3b9254ad0a2ce791923b14dfa3eeb49335"
+    sha256 "101a4cc365382213c6e374b46c9b60a20327f88ba6192bf15e9195a65abedec6"
     "fi"
   end
   language "fr" do
-    sha256 "bd795e89104ca7a936e08a5226b7c23fe7557fbd6f4e5a2f3fc13af8f3afa989"
+    sha256 "bad1df5775798f62919a0cb7545f22b117a1f5a73b308eabd6abe5a449c5a818"
     "fr"
   end
   language "fy" do
-    sha256 "609f44290c3cec618e5e45d0d0e6e72442e2577aeb41c7ce2769a3235920d4a5"
+    sha256 "4b17abb853d23a3c51105a206fedea438e7739583d8d7487455750bca8079571"
     "fy"
   end
   language "ga" do
-    sha256 "0b7e5828b1d952823a829a5f6a929383010f7898670dbd312b0e121bdd87088a"
+    sha256 "2e78b3ffc080c05e9bdd28a9626c1139e0951daa2da11e7ae517f32d893e7933"
     "ga"
   end
   language "gd" do
-    sha256 "3b962be036aee22efcb9a6f7cbc9a6e48489368c427279651a0d94ef487c5461"
+    sha256 "135021504d5d28f4be1b194f7aed361f37502755c84cb9c1bfffa44185d1cd58"
     "gd"
   end
   language "gl" do
-    sha256 "104c3b08683899bbe5d704591d56004f43804482d72d36a16c070f750af895f8"
+    sha256 "29d4e5a96a228111ef4cab3ef8c353f98a3c1a45d4bfb1e9f7bfe4d7c2ad633f"
     "gl"
   end
   language "gu" do
-    sha256 "6884245d8b5a0b91ebf71adb1807943c21a0d50183d72e9061b6c737f1a05521"
+    sha256 "d811d98dc2977e66174ebd2317023a23d46244900c07f9aaf9d97c579669369b"
     "gu"
   end
   language "he" do
-    sha256 "be9b5de10a37bfd638282f38c7fd7b5fa7f4d939f579a5da562c31ed15db735b"
+    sha256 "440865245e1d66950b4da9a06558da273c2fb7ebac5d88a2522b89b152a0ff2e"
     "he"
   end
   language "hi" do
-    sha256 "f74ebe4119b182f16b0718ac9cd749b12a2c1ca08738ae5659858df7843aaab5"
+    sha256 "bd9a0b562df51b27508e620cbff6a20938c4129bb5efdb69839c9f643ae061ff"
     "hi"
   end
   language "hr" do
-    sha256 "806a8b2092f33a797d89ca2f6339a59287592865133cf3a3c868d64523c0e93d"
+    sha256 "551d63ce3772986c3e86ea7f36491a6b5028d054a753fad6c19665ab64f11a93"
     "hr"
   end
   language "hu" do
-    sha256 "4c4abe7f8fcd9d39e1a8e6a7fd69ddb9b5245d69a531bac5e14505064779011b"
+    sha256 "317feea153ff790770c4be875347a75a11c0ac803b5df03219eb6acc3a2f2c2b"
     "hu"
   end
   language "id" do
-    sha256 "21ed8011698847a539c6a6f7ceda4517ae6f835131a36abb783d9b3dddc7a6d2"
+    sha256 "f42b8f5f3a2fb47aa81ded37c1322a293f188098136ccca21d4ea7b0bf0643ed"
     "id"
   end
   language "is" do
-    sha256 "303e26ba91f2b23387edebfd1e4048941ff53688112b9e5d363b9b8a66218aae"
+    sha256 "2e1b0b609ca22006f015054d8e187ca00376194f80b7bc432dbe3a52bc241a76"
     "is"
   end
   language "it" do
-    sha256 "c89a04b7bc1550a8eef97b3c4c66d575b05792dd68179ff6d6a8647b2f6a6c0e"
+    sha256 "362a0d641c365b98402a1448e922bddfd3e48e62f1c2facf39b6d85b40721794"
     "it"
   end
   language "ja" do
-    sha256 "dba6f8477f401411749d9bbb5b5a39f4c5d5efed73f3d1d5b038970f7dea031c"
+    sha256 "0bb3897d176ca8e49a04fa6d6a98c602f0c0cbbec2dfffcfdc45754e699143d2"
     "ja"
   end
   language "ka" do
-    sha256 "882781438bc36dc6e8c26ed81b567f414defdb3d2ffa778573fbcc6f2f7d362c"
+    sha256 "287d90a7f9fd5e6851e973da9176ccc77d086a3e181147987cad63b98c02d225"
     "ka"
   end
   language "kk" do
-    sha256 "9e9cd71bee966cd1cf057e975e1431f0e682434f150ed6e4a45a9817202261e3"
+    sha256 "58cbcb5027bccac9e3fd48a2bea6ac73673028c16588bd89190975396229e055"
     "kk"
   end
   language "km" do
-    sha256 "46ced8a4dc8999897d73e6ec3b748fadeb4b1c3323f8bbc248fdfc86586096e7"
+    sha256 "4cafbbf3fe3a8edaec7783a8fbdeb2369a7b96f15edacfcf023d304889041848"
     "km"
   end
   language "kn" do
-    sha256 "d7f543ca47814db2649ec00ee91b616a259f6b3526cd42c8163c3ee782a04356"
+    sha256 "716058ccccdda9bd843d95d4419c70d096a022f45aa31c28f377154660dab0a7"
     "kn"
   end
   language "ko" do
-    sha256 "5a0671059ca003d1366717d9f475710cf6431596dee84acd5f6055c7d4294ca9"
+    sha256 "dd98c4fb75995fd9a61d30378fbff4fe120b400b0aa4599071511622c5096fb9"
     "ko"
   end
   language "ks" do
-    sha256 "ea053606a476e6df50d34f3197924d51d80ecb0a444cc1920c76af84fec1c5b6"
+    sha256 "062e13b56f51501c2f70e15471ba64321269227cb32f10cce427ee9b7b12c695"
     "ks"
   end
   language "lb" do
-    sha256 "3c01fe218d76056664e5bbabc0bfb2e89fdba3ed8f323ae7d76e93fa37bfe9bc"
+    sha256 "5c8d2154b1093fd5e89543747c9158790b618b4e005cb146c51713c3c2a0e864"
     "lb"
   end
   language "lo" do
-    sha256 "837c159b6a29a9fe6e19f5c73cc3ae4903e7d7b72e18265d140e05078d246dfa"
+    sha256 "0354becaf5efb3e580b33756520238874bd0d4c5d71c596406f1c2b03d444311"
     "lo"
   end
   language "lt" do
-    sha256 "420826f832d4846e54354a7d54ff7983007697bd3b4f1dbde5a03673f522b79f"
+    sha256 "4bf22c104ce3f977b62565126f8bd6082a9554750407584e49304243a5aff380"
     "lt"
   end
   language "lv" do
-    sha256 "d870eda2c70f046c10262ef06eae8ae0537dd874680f89c63d67089b2738925c"
+    sha256 "de7e658a20cab5d600386bae3db2c92ebca834fde46b0f33f1e722351e557086"
     "lv"
   end
   language "mk" do
-    sha256 "4406b8f2f4bc4d6565d0cc436feb4f53d3838654142763d926080b7a7cdd1f13"
+    sha256 "d42abd6fa102b3f9e3d213880d957d0bf0a2eaaf5ea4a9870389b81ec7534136"
     "mk"
   end
   language "ml" do
-    sha256 "485915089e0c3ff88611512fe1a7dc279d72fe9a8fc712feb85cd3fbe77c9c73"
+    sha256 "ff02717aca09b3acc0f2030f0a2fcbac0c4535aa8b9193bfd45f4d8b8b085237"
     "ml"
   end
   language "mn" do
-    sha256 "f04e09283a6edaca56ca751eb9ba4c716413ca8311854f73a9e79bb4f6458965"
+    sha256 "295be2cfb7d24c04eb1563f982f2da341aa3e15ad3e381b5571d8e111cacc1a2"
     "mn"
   end
   language "mr" do
-    sha256 "9116503e2a5d3b41e04c36a211443440ada18c6039eb876c4e8e6e3608a71386"
+    sha256 "cad90fb7ab561584575095a32017cb88814bc00bbc6f35ebe1fd42191e2e2598"
     "mr"
   end
   language "my" do
-    sha256 "aa7db75562df84fb3419f92dfbf7e9afee03d88f79532ced50579cbdfb400c71"
+    sha256 "8ab4bd91d9b71848cb2a6f779b2c52089f02148a6aa6fd437bb2d744f37d8027"
     "my"
   end
   language "nb" do
-    sha256 "5dc22b371125a6dd1bc4a6911ba4929156507a1b943d86466acb1b239b6bbad1"
+    sha256 "af5d99918dca59f9b97f04fd7e70e072d50aaa2d213cd694dc68b21ae645e0db"
     "nb"
   end
   language "ne" do
-    sha256 "ee3b4554a65292415a567735863aad2ba457973402f7f8191025a78b239c74c4"
+    sha256 "f30013ca1987a0ea46be6e028a3e87e446bb689762ddbd588c2cc70aa18a1ae7"
     "ne"
   end
   language "nl" do
-    sha256 "5a80119f4cd145859a768b953146f623f183282835aeb95cb9dfa3c97968a9b3"
+    sha256 "08790f4efc67916a7a96d8ab6f204100ea3719aa0ff2f6863c11597e32a9a683"
     "nl"
   end
   language "nn" do
-    sha256 "06da4dc18581e8c01d1c9ea956f81c65815864b2edbabed03eb5524b21628940"
+    sha256 "a9f2e9555b75aa4e01803c080959de8088bc679114c1896553ca17de79737e08"
     "nn"
   end
   language "nr" do
-    sha256 "0b0a37e1c5df6177994483bedb2084d9c151b5233ec153b635db463d33f47515"
+    sha256 "62e7c440c1ba4b54da50b99c1727e0e34150b7c6876956804fbf48bb5d828c92"
     "nr"
   end
   language "oc" do
-    sha256 "a1df1f405131e025387a9a4f7dbcaf33613ffd4f986263f3eccbe763e946bc68"
+    sha256 "0c6555745b0ab40c0ac88fc6b45a9668fddf3a455bd71c28b27db5ae73206958"
     "oc"
   end
   language "om" do
-    sha256 "9ef9b012186ba93f17bbb4f1ef9ca0e6a4e8f09cc76a0691f38d50656131e6bc"
+    sha256 "9f2e4f7ab99d1518926db5f609cea19b95322a20e5c38425e2e6672514508a51"
     "om"
   end
   language "or" do
-    sha256 "ba37ed60e03dce1c37ba5a7021a715267aa830516f6c02085980799f10e101bb"
+    sha256 "f4f51ff5c67777d58de1a4e5d4ef7691ec77cfa431e31ac7e230b4f98e441f33"
     "or"
   end
   language "pa-IN" do
-    sha256 "41c3f117a3de4318ae95972844c322316c2780afb71925eb8090f266427657b7"
+    sha256 "8658329e4a4173b0aafbd13d10fe90d358796f8f5eb58a7b8f9d2b2fc2d0188b"
     "pa-IN"
   end
   language "pl" do
-    sha256 "62119441b970e76899113c51931a810ba753a199c656f0f51e058f297f12d12d"
+    sha256 "fce7338e761c0f3dedc824f13766d9eee79ac39595a749fa1752124a2dce8e63"
     "pl"
   end
   language "pt-BR" do
-    sha256 "4b430e201c7884f8b04724f97848cb6c627501269ba581718efd03cafb66a0a1"
+    sha256 "cd342cd4d997182def1865e0d3910b2d401bcbd971dd889dc51137ebb57ea321"
     "pt-BR"
   end
   language "pt" do
-    sha256 "a35681e9df8f9fa03044036a7ded71a6b831cd975836b23fe95611f2b93a98c4"
+    sha256 "1f85b8243fb229ead17e71e05c9a9f204bf4fa6883257b93f7db1fd212841d3d"
     "pt"
   end
   language "ro" do
-    sha256 "ec17fcc9ec85f6e0ad111d285f14010e09c09c3cc24728bf665e0ed55925d370"
+    sha256 "dd8c7a65d29ec4f77a6e15fc59e8679aa0e77945efd1c548332fbd48425d5107"
     "ro"
   end
   language "ru" do
-    sha256 "7327bc75386a468de8a774306fbab4fad54154e3ca6c1566a397a0b24441e840"
+    sha256 "74792c9a55296ce27d6e2b6cd9e7280e89b32f47d4175bcb38794c434923b8d6"
     "ru"
   end
   language "rw" do
-    sha256 "a59b6ae52f157ebf7274138c062a90dfdb0985d0d945cb0308136fe91e78070b"
+    sha256 "57c162f1a786e54a3d40e39af7c43926f7068114c1580eef276ad00355adecfd"
     "rw"
   end
   language "sa-IN" do
-    sha256 "72a35e5a39cf40bc2e7231b3658aac7861a82fdae206f072f964f2def5213035"
+    sha256 "8399f3802cf39a7f0de79fe6c32d611fa4d155b924023b72dc2bd4d32a222492"
     "sa-IN"
   end
   language "sd" do
-    sha256 "9d15ebac716ad717e143f30cbf7b2cd89cbf21bd9abd1fcf3c0df2c8ddf17d00"
+    sha256 "a7ec6ababdde3aed6b867618fae0264fb4c925291880d445a091ef815c3ee270"
     "sd"
   end
   language "si" do
-    sha256 "338fc6ef228c826f0e52184a12d5f4c9b5e164854033a788fe5ac32c732c4fd1"
+    sha256 "f77cbf698496e69325fe3bbdceaaac899e6a450c2e97a7310749f2fdb0bfc14f"
     "si"
   end
   language "sk" do
-    sha256 "de44cacd8a0ecaa0d41dce6153abc89f514d301bd630cf113a0a05b92321dfb5"
+    sha256 "179550c5f9676456c92054cc93c689ddab6a74c20bb347a68cfd2c0cd9f1731a"
     "sk"
   end
   language "sl" do
-    sha256 "ecdbbeb660e7e954a9e3cb9452b6404806b9f7023cd75c996ebfd6a3b77cdf36"
+    sha256 "08ea8f55deec5228102c4a9f34236155dea4388c2b5137d3f7ec3803353b321d"
     "sl"
   end
   language "sq" do
-    sha256 "9bdcdbcb52ebc981f84982df4f6e49a20a202d19359cb7284804f40a446abde6"
+    sha256 "1c9be27ebfe871d24924fb38def6c238ada0724f815d344082c90481dbcd0c5a"
     "sq"
   end
   language "sr" do
-    sha256 "e0282239680e734530db0d4051fc98a6e39e63356a70081dab2e3f6844c90211"
+    sha256 "80436307bca89a4671cf862650773f87692465e3a7b709b244567106925894b0"
     "sr"
   end
   language "ss" do
-    sha256 "da619ae02042a2de59556a54046d7e85e87c7082de38a281fce90bdccdae8157"
+    sha256 "603ccfbf5fb7af5601dd4aeb49f5cad708940622a3ffe70cb347ead0149c53a5"
     "ss"
   end
   language "st" do
-    sha256 "aa4d453a755f5d69c86e7f096455a42b3837608a05f3bd530a86710fe838e0da"
+    sha256 "888eba2cbccdabaed5b433cdb9febff28682a034d6cb92892bf7ceeb59235226"
     "st"
   end
   language "sv" do
-    sha256 "0d303020515dd5a532cc6d48e416ed2338c53a9facff7d0ce080976212d6fa58"
+    sha256 "f0362a20e7e8ec7e382f14f4657ece51a37b50739d89dd0db5b0a1d1e4716c5f"
     "sv"
   end
   language "sw-TZ" do
-    sha256 "69b794863d8e026eeeaf3aadaefa84779b4e73dd54406dc3cd696379a2b2f263"
+    sha256 "05e29ec23f7ea1f71cde29c5b5f55235157a0211cde37b3d478550397b9745c6"
     "sw-TZ"
   end
   language "ta" do
-    sha256 "394715b7b3fbc85ba226d153bdb89326742746f85638fbc6bea554c197f4029e"
+    sha256 "854bed3b2cfa30ca2adb884a4e8aef7e0deaed164e285da32e8f2911eac6bb8c"
     "ta"
   end
   language "te" do
-    sha256 "f60e39bf8cc3f238363cc6f2ff101e5ecf922a4d09697c4ddf3e01207aaab447"
+    sha256 "bab024586e07ede277d3a99cc2452ff3906b3a8627fad2f9b6811154b89c050c"
     "te"
   end
   language "tg" do
-    sha256 "6aaef00f8d933c8faaf0ee219f46b6e070788f4b3edde9e3a18e1a0711ca4fc6"
+    sha256 "c4a81cd674e46f0a986937b12e9ed84c9b6f86435779a2993e0500742d9c2cfd"
     "tg"
   end
   language "th" do
-    sha256 "a6932537bfd8820325e79cc4fdc98dfc373dcf228bb64a2befe95559c8cc2a8d"
+    sha256 "124ed0070929ae1a352c3bc932f668541b67e21fe60d2b6f6caf358aa3dd683f"
     "th"
   end
   language "tn" do
-    sha256 "d890ef3fb6dd5d0815ed17bbdf53b58bf8d8e75594626a6b0e24162a07ce3459"
+    sha256 "4352afcfdf534e4e3eb7a531ceb04c2978a0c7ea8b8f9ce85c3f113fbf661867"
     "tn"
   end
   language "tr" do
-    sha256 "bd70f0d05f21e1bf5c9ab8879b3a80bbc14d08b40abb451e736b1746689ac60f"
+    sha256 "7b1314160a2c16956b225a6b2a81a7661f823955b7275647ab5eebb4c734b772"
     "tr"
   end
   language "ts" do
-    sha256 "c4b994276da8b001952123cf1d0ab977eb2dfdaf45aefe27e9aab3b1199d4a82"
+    sha256 "f81a5110aae2879dcb2c286d94ec8f2bbe00eb3846a10a87f6cf6c9d073e6767"
     "ts"
   end
   language "tt" do
-    sha256 "ea389a096e73bf2202f75ea03b7d7e97c41b8c5e8b96b261f5f120063405a85f"
+    sha256 "51946e25cb63253a795bd58cdff36bdbee85c696d327bec18460d94af958a3e2"
     "tt"
   end
   language "ug" do
-    sha256 "43ed2bacbe911f63b75213b22034d7c4a5f8806db3f5d6f7733443ddb584de98"
+    sha256 "426f023aa425d90a30b0325f8169c8fd6a9e267beb30abffd104ebc3835afd78"
     "ug"
   end
   language "uk" do
-    sha256 "df18385c360a5eb9a17cf550ed95492eb673d979b23ed3723c022d3e969c47c2"
+    sha256 "fca4932f21be156f781202afa6feede5698f42ae553b68230cdbdba6c1fbbea8"
     "uk"
   end
   language "uz" do
-    sha256 "2e841906c0b5ea9fb9c6926b6b439f757f9531d835d525032e3094ee1293e09f"
+    sha256 "61f5a42cdd4641a0a95f799b8904de37e6812733c677f375d057d45c2c906598"
     "uz"
   end
   language "ve" do
-    sha256 "910411db37fff167bc38b377aca2011e2c812f1b434e055489126d3c78fc0cac"
+    sha256 "8a9e9a2c36592928cca5ceb70920d656a0afaae596059aa966c3e392fd5a055f"
     "ve"
   end
   language "vi" do
-    sha256 "8bc0ab1ee48971caaaf519a4cf694a4c80f95ca43e59429b6a48a81f15f5e2b7"
+    sha256 "a4adfe1cb90edbe17866a6dd39b5f84bd308227df7eee7f4683f2b062f87dd83"
     "vi"
   end
   language "xh" do
-    sha256 "3c42aeea2e910c69db4ac1f1bce316c92e1eabac8447a4141dc573cc8e2193b7"
+    sha256 "29b67ec4cd3b6d84858742c09dd14334ffd07a19e4a2723564e8f6d3a1edc819"
     "xh"
   end
   language "zh-CN" do
-    sha256 "9964e785a50988eebe91a157607f0b6bf0afc893c5d84c6517b8848d6271f068"
+    sha256 "b4610beb4384ffae2d01675e812fa5f87816ed024b7ef226aab4b3742b2023d9"
     "zh-CN"
   end
   language "zh-TW" do
-    sha256 "98d2dee629b4b0aa89ebde8758dd2403ad1d9e7a01217e8d3217da74092e905f"
+    sha256 "bdf35ef2f0023a9ba891ce562dfc35201e54932a48788ee43b3e366a01a993db"
     "zh-TW"
   end
   language "zu" do
-    sha256 "e029c324471d9ef82e88c1cc0eeb29e3ee343282fb5987febe0fee47954e0772"
+    sha256 "3e813905e96af0278e75ce63c80616edd11b3058f23de53fe7cb78d17a83d5dc"
     "zu"
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
