### PR TITLE
Update flightgear from 2018.3.6 to 2020.3.1

### DIFF
--- a/Casks/flightgear.rb
+++ b/Casks/flightgear.rb
@@ -1,6 +1,6 @@
 cask "flightgear" do
-  version "2018.3.6"
-  sha256 "cfc8667d68f2a08323f1abfa172e6a7bcbf465fa4f00a6576309066332974306"
+  version "2020.3.1"
+  sha256 "0f5ed23e455201c3a055663263d8abc51929f17534e1b5de65ecc5bb526c7097"
 
   # sourceforge.net/flightgear/ was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/flightgear/FlightGear-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).