### PR TITLE
Update ringcentral-classic from 20.3.10 to 20.4.10

### DIFF
--- a/Casks/ringcentral-classic.rb
+++ b/Casks/ringcentral-classic.rb
@@ -1,6 +1,6 @@
 cask "ringcentral-classic" do
-  version "20.3.10"
-  sha256 "c555c9f06cd424a2a8e00e10bf3b39103f069e8438ecb2f11de7dcfabeb72fdc"
+  version "20.4.10"
+  sha256 "41a072a9d5da4d0a6e9c8313f6f8dc09722d1819d6d8bc3a993607397909ca01"
 
   url "https://downloads.ringcentral.com/glip/rc/#{version}/mac/RingCentral%20Classic-#{version}.dmg"
   name "RingCentral Classic"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).