### PR TITLE
Update Geany dmg to a 1.37-2 build for macOS

### DIFF
--- a/Casks/geany.rb
+++ b/Casks/geany.rb
@@ -1,8 +1,8 @@
 cask "geany" do
   version "1.37"
-  sha256 "4ad3a8ac715f6a12fb13cbdc972f2dfe0362a84998c00a0d2b43bf805220890b"
+  sha256 "223edf07ef5eb3404a953a1c93af9737fe097668160327a94e41133e3ded4dcc"
 
-  url "https://download.geany.org/geany-#{version}_osx.dmg"
+  url "https://download.geany.org/geany-#{version}_osx-2.dmg"
   appcast "https://github.com/geany/geany/releases.atom"
   name "Geany"
   desc "Fast and lightweight IDE"


### PR DESCRIPTION
The used Xcode produced binaries that were not able to run on macOS 10.14 due to usage of not yet available symbols. The new build was done with an older Xcode and tested (the dmg itself, not the cask) on macOS 10.14, 10.15 and macOS 11 on the ARM prototype

The bug was raised at upstream project within geany/geany#2637

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
