### PR TITLE
Update netnewswire from 5.1.1 to 5.1.2

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -1,6 +1,6 @@
 cask "netnewswire" do
-  version "5.1.1"
-  sha256 "5cd3e7631011233c1016f234379eca7baa971befd88862816d440c2fe2fc9b48"
+  version "5.1.2"
+  sha256 "bd67df55c08ee255a5d8ccaeb5779b82e55e504d0cadfb15a13b2ceb6bc4cda6"
 
   # github.com/brentsimmons/NetNewsWire/ was verified as official when first introduced to the cask
   url "https://github.com/brentsimmons/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).