### PR TITLE
Update opera-gx from 71.0.3770.302 to 71.0.3770.310

### DIFF
--- a/Casks/opera-gx.rb
+++ b/Casks/opera-gx.rb
@@ -1,6 +1,6 @@
 cask "opera-gx" do
-  version "71.0.3770.302"
-  sha256 "bfc7f97bbb96091b15dce4cdbf8eae40b610299fa579c13688ff9bd135af74c7"
+  version "71.0.3770.310"
+  sha256 "b8ffe09c006b653126aa45c9b3a4bb6f91ae5ccc4edab7797725fd64d0c492c7"
 
   url "https://get.geo.opera.com/pub/opera_gx/#{version}/mac/Opera_GX_#{version}_Setup.dmg"
   appcast "https://ftp.opera.com/pub/opera_gx/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).