### PR TITLE
Using a 64-bit build of ZipCleaner

### DIFF
--- a/Casks/zipcleaner.rb
+++ b/Casks/zipcleaner.rb
@@ -3,6 +3,7 @@ cask "zipcleaner" do
   sha256 "bfdb7d451bc2b0e8f65711e09690dc4527ed924f0d187e4c7eacd0d824e24c58"
 
   url "https://github.com/AmigaAbattoir/ZipCleaner/releases/download/V#{version}/ZipCleaner.app.zip"
+  appcast "https://github.com/AmigaAbattoir/ZipCleaner/releases.atom"
   name "ZipCleaner"
   homepage "https://github.com/AmigaAbattoir/ZipCleaner"
 

--- a/Casks/zipcleaner.rb
+++ b/Casks/zipcleaner.rb
@@ -1,10 +1,10 @@
 cask "zipcleaner" do
   version :latest
-  sha256 :no_check
+  sha256 "bfdb7d451bc2b0e8f65711e09690dc4527ed924f0d187e4c7eacd0d824e24c58"
 
-  url "https://roger-jolly.nl/software/downloads/zipcleaner/ZipCleaner.zip"
+  url "https://github.com/AmigaAbattoir/ZipCleaner/releases/download/V1.1.0/ZipCleaner.app.zip"
   name "ZipCleaner"
-  homepage "https://roger-jolly.nl/software/#zipcleaner"
+  homepage "https://github.com/AmigaAbattoir/ZipCleaner"
 
   app "ZipCleaner.app"
 end

--- a/Casks/zipcleaner.rb
+++ b/Casks/zipcleaner.rb
@@ -1,8 +1,8 @@
 cask "zipcleaner" do
-  version :latest
+  version "1.1.0"
   sha256 "bfdb7d451bc2b0e8f65711e09690dc4527ed924f0d187e4c7eacd0d824e24c58"
 
-  url "https://github.com/AmigaAbattoir/ZipCleaner/releases/download/V1.1.0/ZipCleaner.app.zip"
+  url "https://github.com/AmigaAbattoir/ZipCleaner/releases/download/V#{version}/ZipCleaner.app.zip"
   name "ZipCleaner"
   homepage "https://github.com/AmigaAbattoir/ZipCleaner"
 


### PR DESCRIPTION
ZipCleaner has been mostly [abandoned](https://roger-jolly.nl/software/) from its maintainer, and while the code still works, it's never been re-compiled for 64-bit. Because of that, it stopped working on Catalina.

This updates the link to ZipCleaner's builds to use the ones by @AmigaAbattoir: https://github.com/AmigaAbattoir/ZipCleaner/releases

(Note: I have no relationship with either ZipCleaner nor the maintainer of the repo above)