### PR TITLE
Updated google-cloud-sdk for python39

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -28,12 +28,12 @@ cask "google-cloud-sdk" do
     #{token} is installed at #{staged_path}/#{token}. Add your profile:
 
       for bash users
-        export "CLOUDSDK_PYTHON=#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
+        export CLOUDSDK_PYTHON="#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         source "#{staged_path}/#{token}/path.bash.inc"
         source "#{staged_path}/#{token}/completion.bash.inc"
 
       for zsh users
-        export "CLOUDSDK_PYTHON=#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
+        export CLOUDSDK_PYTHON="#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         source "#{staged_path}/#{token}/path.zsh.inc"
         source "#{staged_path}/#{token}/completion.zsh.inc"
 

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -9,15 +9,16 @@ cask "google-cloud-sdk" do
 
   depends_on formula: "python@3.8"
 
-  installer script: {
-    executable: "/usr/bin/env",
-    args:       [
-      "CLOUDSDK_PYTHON=#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python",
-      "#{caskroom_path}/latest/google-cloud-sdk/install.sh",
-      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
-      "--rc-path", "false", "--quiet"
-    ],
-  }
+  stage_only true
+
+  postflight do
+    system_command "#{staged_path}/#{token}/install.sh",
+                   args: [
+                     "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
+                     "--rc-path", "false", "--quiet"
+                   ],
+                   env:  { "CLOUDSDK_PYTHON" => "#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python" }
+  end
 
   # Not actually necessary, since it would be deleted anyway.
   # It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -4,20 +4,20 @@ cask "google-cloud-sdk" do
 
   url "https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz"
   name "Google Cloud SDK"
+  desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
 
+  depends_on formula: "python@3.8"
+
   installer script: {
-    executable: "google-cloud-sdk/install.sh",
+    executable: "/usr/bin/env",
     args:       [
+      "CLOUDSDK_PYTHON=#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python",
+      "#{caskroom_path}/latest/google-cloud-sdk/install.sh",
       "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
       "--rc-path", "false", "--quiet"
     ],
   }
-  binary "google-cloud-sdk/bin/bq"
-  binary "google-cloud-sdk/bin/docker-credential-gcloud"
-  binary "google-cloud-sdk/bin/gcloud"
-  binary "google-cloud-sdk/bin/git-credential-gcloud.sh"
-  binary "google-cloud-sdk/bin/gsutil"
 
   # Not actually necessary, since it would be deleted anyway.
   # It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
@@ -27,14 +27,17 @@ cask "google-cloud-sdk" do
     #{token} is installed at #{staged_path}/#{token}. Add your profile:
 
       for bash users
+        export "CLOUDSDK_PYTHON=#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         source "#{staged_path}/#{token}/path.bash.inc"
         source "#{staged_path}/#{token}/completion.bash.inc"
 
       for zsh users
+        export "CLOUDSDK_PYTHON=#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         source "#{staged_path}/#{token}/path.zsh.inc"
         source "#{staged_path}/#{token}/completion.zsh.inc"
 
       for fish users
+        set -g -x "CLOUDSDK_PYTHON" "#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         set -g fish_user_paths "#{staged_path}/#{token}/path.fish.inc" $fish_user_paths
   EOS
 end


### PR DESCRIPTION
Issue #91744

google-cloud-sdk fails to install or work because it doesn't work with
python 3.9 yet and that is the default python3 in homebrew. Please
review this PR closely as I'm new to the inner workings of homebrew/casks 
 and I don't know Ruby or fish shell. These changes may also be a
bit "hacky" but were the best I could come up with under the
circumstances.

These changes require and force usage of python 3.8 for installation
and adds information to the `caveats` section about setting the required
`CLOUDSDK_PYTHON` shell variable.

I removed all the `binary` stanzas as the `caveats` section mentions
that you must source files for your shell that set $PATH to look for the
bins in their unlinked locations.

Additionally, I cleaned up the cask a bit and added a `desc` stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
