### PR TITLE
Add Pitch.app v1.2.2

### DIFF
--- a/Casks/pitch.rb
+++ b/Casks/pitch.rb
@@ -1,0 +1,19 @@
+cask "pitch" do
+  version "1.2.2"
+  sha256 "0bbb116f7a36e5247a48e4e336b06f71e6d40f7e3ac14601e2bd8d991b0d9030"
+
+  url "https://desktop-app-builds.pitch.com/Pitch-#{version}.dmg"
+  appcast "https://desktop-app-builds.pitch.com/latest-mac.yml"
+  name "Pitch"
+  desc "Collaborative presentation software"
+  homepage "https://pitch.com/"
+
+  app "Pitch.app"
+
+  zap trash: [
+    "~/Library/Application Support/Pitch",
+    "~/Library/Logs/Pitch",
+    "~/Library/Preferences/io.pitch.pitch-macos.plist",
+    "~/Library/Saved Application State/io.pitch.pitch-macos.savedState",
+  ]
+end


### PR DESCRIPTION
This commit adds v1.2.2 of [Pitch][1]: "collaborative presentation software for modern teams".

The cask downloads a `.dmg` and extracts the `Pitch.app` file.

[1]: https://pitch.com

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
