### PR TITLE
Update menumeters from 2.0.8.2 to 2.0.8.3

### DIFF
--- a/Casks/menumeters.rb
+++ b/Casks/menumeters.rb
@@ -1,6 +1,6 @@
 cask "menumeters" do
-  version "2.0.8.2"
-  sha256 "85d284e080251558fc840d54ee343ae004ab89594b1941a90f2a2cc4bcec198b"
+  version "2.0.8.3"
+  sha256 "02dec390291b36046780499b58dafa4a8cfcd6bb6786f94b676ce479565aa5b4"
 
   # github.com/yujitach/MenuMeters was verified as official when first introduced to the cask
   url "https://github.com/yujitach/MenuMeters/releases/download/#{version}/MenuMeters_#{version}.zip"


### PR DESCRIPTION
Version 2.0.8.2 increased problems with accessing the preferences. This should be fixed in 2.0.8.3 (cp. https://github.com/yujitach/MenuMeters/releases/tag/2.0.8.3)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).