### PR TITLE
Update jcryptool from 0.9.10 to 1.0.0,2020-11-01

### DIFF
--- a/Casks/jcryptool.rb
+++ b/Casks/jcryptool.rb
@@ -1,12 +1,12 @@
 cask "jcryptool" do
-  version "0.9.10"
-  sha256 "8c6e6b3fe803f40e7c5e9a910a47e6c3c5f0f5a8884932dd253e63f8b83194af"
+  version "1.0.0,2020-11-01"
+  sha256 "4284466b7cee5e0d3f14a4b134d70dec197752b77c34fd4c38dd5d15033d51c2"
 
-  url "https://www.cryptool.org/jctdownload/Builds/downloads/stable/jcryptool-#{version}-macosx.cocoa.x86_64.tar.gz"
-  appcast "https://www.cryptool.org/en/jct-downloads",
-          must_contain: version.major_minor
+  # github.com/jcryptool/core was verified as official when first introduced to the cask
+  url "https://github.com/jcryptool/core/releases/download/Weekly-Build--#{version.after_comma}/jcryptool-#{version.before_comma}-macosx.cocoa.x86_64.tar.gz"
+  appcast "https://github.com/jcryptool/core/releases.atom"
   name "JCrypTool"
-  homepage "https://www.cryptool.org/en/jcryptool"
+  homepage "https://www.cryptool.org/en/jct/downloads"
 
   app "jcryptool.app"
 

--- a/Casks/jcryptool.rb
+++ b/Casks/jcryptool.rb
@@ -2,15 +2,17 @@ cask "jcryptool" do
   version "1.0.0,2020-11-01"
   sha256 "4284466b7cee5e0d3f14a4b134d70dec197752b77c34fd4c38dd5d15033d51c2"
 
-  # github.com/jcryptool/core was verified as official when first introduced to the cask
+  # github.com/jcryptool/core/ was verified as official when first introduced to the cask
   url "https://github.com/jcryptool/core/releases/download/Weekly-Build--#{version.after_comma}/jcryptool-#{version.before_comma}-macosx.cocoa.x86_64.tar.gz"
-  appcast "https://github.com/jcryptool/core/releases.atom"
+  appcast "https://github.com/jcryptool/core/releases.atom",
+          must_contain: version.after_comma
   name "JCrypTool"
+  desc "Apply and analyze cryptographic algorithms"
   homepage "https://www.cryptool.org/en/jct/downloads"
 
-  app "jcryptool.app"
+  app "JCrypTool.app"
 
   caveats do
-    depends_on_java("8")
+    depends_on_java("11")
   end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).