### PR TITLE
Update clockify from 2.5.6 to 2.5.8

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,6 +1,6 @@
 cask "clockify" do
-  version "2.5.6"
-  sha256 "4b47a46231819f805a9fd6124c343f6a5e5887769cb1ce6c5c949b142e375687"
+  version "2.5.8"
+  sha256 "84297c0f98e2a3a80f0d57f1aa11cdf23e1c4226fb086dfc8b43f65948530597"
 
   # clockify-resources.s3.eu-central-1.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).