### PR TITLE
Update plex.rb from 1.21.0.1410-50a34597 to 1.22.0.1421-be6a7c42

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask "plex" do
-  version "1.21.0.1410-50a34597"
-  sha256 "7daf8eb0faf843d697fc0d63a65d4ee9db51de3bb2e36d404c4e79a8e12d91af"
+  version "1.22.0.1421-be6a7c42"
+  sha256 "4714a6799dbd7454c5047d9ca350fa0dbbdc7940955e439a0d0df405e2527e9c"
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast "https://plex.tv/api/downloads/6.json"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
