### PR TITLE
Update keepassxc from 2.6.2 to 2.6.2-2

### DIFF
--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -3,7 +3,7 @@ cask "keepassxc" do
   sha256 "611b940952d5d51c2865d35e6916954a4ff3454bc8ae4dcc7abed0a4cda7d90d"
 
   # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version.sub(/-\d+\z/, "")}/KeePassXC-#{version}.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version.major_minor_patch}/KeePassXC-#{version}.dmg"
   appcast "https://github.com/keepassxreboot/keepassxc/releases.atom"
   name "KeePassXC"
   desc "Password manager app"

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -1,9 +1,9 @@
 cask "keepassxc" do
-  version "2.6.2"
-  sha256 "29bfaf99f2c8a47063b2da0b67054f10c90cafe248db84411a26ecc974711ba7"
+  version "2.6.2-2"
+  sha256 "611b940952d5d51c2865d35e6916954a4ff3454bc8ae4dcc7abed0a4cda7d90d"
 
   # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version.sub(/-\d+\z/, "")}/KeePassXC-#{version}.dmg"
   appcast "https://github.com/keepassxreboot/keepassxc/releases.atom"
   name "KeePassXC"
   desc "Password manager app"

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -3,7 +3,7 @@ cask "keepassxc" do
   sha256 "611b940952d5d51c2865d35e6916954a4ff3454bc8ae4dcc7abed0a4cda7d90d"
 
   # github.com/keepassxreboot/keepassxc/ was verified as official when first introduced to the cask
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version.major_minor_patch}/KeePassXC-#{version}.dmg"
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version.sub(/-\d+\z/, "")}/KeePassXC-#{version}.dmg"
   appcast "https://github.com/keepassxreboot/keepassxc/releases.atom"
   name "KeePassXC"
   desc "Password manager app"


### PR DESCRIPTION
The "-2" portion of the version needs to be stripped for a portion of the download URL, so I used code that would strip any dash followed by one or more numbers at the end of the version string.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
