### PR TITLE
google-chrome: remove conflicts_with

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -9,10 +9,6 @@ cask "google-chrome" do
   homepage "https://www.google.com/chrome/"
 
   auto_updates true
-  conflicts_with cask: [
-    "homebrew/cask-versions/google-chrome-beta",
-    "homebrew/cask-versions/google-chrome-dev",
-  ]
   depends_on macos: ">= :yosemite"
 
   app "Google Chrome.app"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

https://github.com/Homebrew/homebrew-cask-versions/pull/9867