### PR TITLE
freecad: add depends_on and conflicts_with

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -9,5 +9,8 @@ cask "freecad" do
   desc "3D parametric modeler"
   homepage "https://www.freecadweb.org/"
 
+  conflicts_with cask: "homebrew/cask-versions/freecad-pre"
+  depends_on macos: ">= :sierra"
+
   app "FreeCAD.app"
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
