### PR TITLE
Update gzdoom from 4.4.2 to 4.5.0

### DIFF
--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -1,6 +1,6 @@
 cask "gzdoom" do
-  version "4.4.2"
-  sha256 "1de3ed755232e36cf85fccee8fb1f5236f1427713b1086d88f8162c68f2cabc4"
+  version "4.5.0"
+  sha256 "b7a8056e63fa0a14497e8d1767bbbae2da1ebe9f47e4f87df613106f9ebe3522"
 
   # github.com/coelckers/gzdoom/ was verified as official when first introduced to the cask
   url "https://github.com/coelckers/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).