### PR TITLE
Revert "Update vagrant from 2.2.10 to 2.2.11"

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,6 +1,6 @@
 cask "vagrant" do
-  version "2.2.11"
-  sha256 "36a83de54330ee621b5fcfea4a6c98b54af23764adec24e4dc3c35c34bd2da9b"
+  version "2.2.10"
+  sha256 "913d959455d37a0bb410c89ba3aedc886ccc76ce06bae7b228ba7454294325da"
 
   # hashicorp.com/vagrant/ was verified as official when first introduced to the cask
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"

--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -6,6 +6,7 @@ cask "vagrant" do
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg"
   appcast "https://github.com/hashicorp/vagrant/releases.atom"
   name "Vagrant"
+  desc "Development environment"
   homepage "https://www.vagrantup.com/"
 
   pkg "vagrant.pkg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#92098

Vagrant 2.2.11 fails to start VMWare VMs with the newest update. See also https://github.com/hashicorp/vagrant/issues/12022