### PR TITLE
Set auto_updates to true for tiles

### DIFF
--- a/Casks/tiles.rb
+++ b/Casks/tiles.rb
@@ -9,6 +9,8 @@ cask "tiles" do
   desc "Window manager"
   homepage "https://www.sempliva.com/tiles/"
 
+  auto_updates true
+
   app "Tiles.app"
 
   uninstall launchctl: "com.sempliva.TilesHelper",

--- a/Casks/tiles.rb
+++ b/Casks/tiles.rb
@@ -10,6 +10,7 @@ cask "tiles" do
   homepage "https://www.sempliva.com/tiles/"
 
   auto_updates true
+  depends_on macos: ">= :el_capitan"
 
   app "Tiles.app"
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/435284/98365868-55cf4500-2033-11eb-9789-79225761d8b6.png)

Tiles has auto update and it's enabled by default.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
