### PR TITLE
Update kaleidoscope from 2.3.1,1441-apr-7-2020 to 2.3.4,1444-nov-6-2020

### DIFF
--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -1,9 +1,9 @@
 cask "kaleidoscope" do
-  version "2.3.1,1441-apr-7-2020"
-  sha256 "720abc4bc1a5cdb0d58fb1794d16c9d4e00d82a570d428ff7b44e36fa45212bd"
+  version "2.3.4,1444-nov-6-2020"
+  sha256 "8dd95241d5ee02674c78bc7a4b2dc19adbb81c6db16d1d59dc5c9cf9440891fd"
 
-  # appcasts.hypergiant.com/ks/prod/ was verified as official when first introduced to the cask
-  url "https://appcasts.hypergiant.com/ks/prod/Kaleidoscope-#{version.before_comma}-build-#{version.after_comma}.zip"
+  # updates.kaleidoscope.app was verified as official when first introduced to the cask
+  url "https://updates.kaleidoscope.app/v2/prod/Kaleidoscope-#{version.before_comma}-build-#{version.after_comma}.app.zip"
   appcast "https://appcasts.hypergiant.com/ks/prod/updates"
   name "Kaleidoscope"
   desc "Spots differences in text and image files"

--- a/Casks/kaleidoscope.rb
+++ b/Casks/kaleidoscope.rb
@@ -2,7 +2,7 @@ cask "kaleidoscope" do
   version "2.3.4,1444-nov-6-2020"
   sha256 "8dd95241d5ee02674c78bc7a4b2dc19adbb81c6db16d1d59dc5c9cf9440891fd"
 
-  # updates.kaleidoscope.app was verified as official when first introduced to the cask
+  # updates.kaleidoscope.app/ was verified as official when first introduced to the cask
   url "https://updates.kaleidoscope.app/v2/prod/Kaleidoscope-#{version.before_comma}-build-#{version.after_comma}.app.zip"
   appcast "https://appcasts.hypergiant.com/ks/prod/updates"
   name "Kaleidoscope"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download kaleidoscope` is error-free.
- [x] `brew cask style --fix kaleidoscope ` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
