### PR TITLE
Update default-folder-x from 5.4.6 to 5.5

### DIFF
--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -1,6 +1,6 @@
 cask "default-folder-x" do
-  version "5.4.6"
-  sha256 "617da236112e84f7eeb00285001e277c5a9c60bb3f4bde9230516d32750ca7b4"
+  version "5.5"
+  sha256 "1649beb6f419e8978055fdf07a3ca15abced1b02723f9ddafd32b22acda7d88a"
 
   url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   appcast "https://www.stclairsoft.com/cgi-bin/sparkle.cgi?DX5"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).