### PR TITLE
Update dropbox-passwords from 5.2.4 to 7.2.25

### DIFF
--- a/Casks/dropbox-passwords.rb
+++ b/Casks/dropbox-passwords.rb
@@ -1,6 +1,6 @@
 cask "dropbox-passwords" do
-  version "5.2.4"
-  sha256 "74d41ac8296c4dfa71cda236320173c83856b1d99fcc6bcc9de820d669cd85ba"
+  version "7.2.25"
+  sha256 "8ef1fd2a6d1aac57b5bdcade398fa0bc387a9a079113df66e96fa56817269a06"
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/dbx-releng/dropbox_passwords/mac/DropboxPasswords_#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).