### PR TITLE
Update macx-dvd-ripper-pro from 6.5.4,20201015 to 6.5.4,20201021

### DIFF
--- a/Casks/macx-dvd-ripper-pro.rb
+++ b/Casks/macx-dvd-ripper-pro.rb
@@ -1,5 +1,5 @@
 cask "macx-dvd-ripper-pro" do
-  version "6.5.4,20201015"
+  version "6.5.4,20201021"
   sha256 "fc7ad20e55eedac7f1c864658ef8fe65e89a8bb227a68a829c06a83e1882f81a"
 
   url "https://www.macxdvd.com/download/macx-dvd-ripper-pro.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).