### PR TITLE
unity-hub: move rmdir from uninstall to zap

### DIFF
--- a/Casks/unity-hub.rb
+++ b/Casks/unity-hub.rb
@@ -10,11 +10,11 @@ cask "unity-hub" do
 
   app "Unity Hub.app"
 
-  uninstall quit:  "com.unity3d.unityhub",
-            rmdir: "/Applications/Unity/Hub"
+  uninstall quit:  "com.unity3d.unityhub"
 
   zap trash: [
     "~/Library/Preferences/com.unity3d.unityhub.plist",
     "~/Library/Preferences/com.unity3d.unityhub.helper.plist",
-  ]
+  ],
+      rmdir: "/Applications/Unity/Hub"
 end

--- a/Casks/unity-hub.rb
+++ b/Casks/unity-hub.rb
@@ -10,7 +10,7 @@ cask "unity-hub" do
 
   app "Unity Hub.app"
 
-  uninstall quit:  "com.unity3d.unityhub"
+  uninstall quit: "com.unity3d.unityhub"
 
   zap trash: [
     "~/Library/Preferences/com.unity3d.unityhub.plist",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Closes https://github.com/Homebrew/homebrew-cask/issues/92237.