### PR TITLE
Update refined-github-safari from 2.1.21 to 2.1.22

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask "refined-github-safari" do
-  version "2.1.21"
-  sha256 "cdbbe885d9f750ee3f6b4ef4b16906ae59906a0f8b3d29b3339d619aa554d0dc"
+  version "2.1.22"
+  sha256 "9f3e222ffacadfba34427808a5bcde76157399bf448d56646db4f8e697334772"
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast "https://github.com/lautis/refined-github-safari/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).