### PR TITLE
Update firefox from 82.0.2 to 82.0.3

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,104 +1,104 @@
 cask "firefox" do
-  version "82.0.2"
+  version "82.0.3"
 
   language "cs" do
-    sha256 "b49efcdc53d95cca7f8b26be7e78bca867fc683922af5618771d91004541551a"
+    sha256 "6037050efb9a57414d76b7616f5aabfe1ccbc7f7a97c2ca099c308239576bb2b"
     "cs"
   end
   language "de" do
-    sha256 "e1903c5bca139c3c25b0f826b2e018915d385f1e2871624724a76d7d28b09183"
+    sha256 "abe0f990e16e131fa3f712e035162074f4299f940767c6c9458bde7846a3d08f"
     "de"
   end
   language "en-CA" do
-    sha256 "068593147a27719cfaa027303ab8738fcf8a454649b06be6eef7c4b94011c657"
+    sha256 "e60dc54bde7d4c8a43bae8c9ee56eb9e497aea8e3adc5f3623e009407e7446d1"
     "en-CA"
   end
   language "en-GB" do
-    sha256 "5739944bc4ad6a2dceb53ab6b40794cec92c855b49b3c89e983e9a45af5e0488"
+    sha256 "cafa14c8cf50bd91faebbc096625fb5b8c2be752046e389a002a175e13ccbbd5"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "09368f133828b3a64748add77b73304f1e53df5102dba919447d6c4654ba0be0"
+    sha256 "c1f74e535db7009e296af03d376a18e54d92c4ad55e9170efd491c2faf595983"
     "en-US"
   end
   language "eo" do
-    sha256 "e30007aab74acaaafbfac9e2195ce5b5443b19903053539936239facee99dd03"
+    sha256 "dd984751c82dfebb3ab2ad66fe65632a18dfd5d8adbdc404f9ef286df6c41b3b"
     "eo"
   end
   language "es-AR" do
-    sha256 "c1062d74e52fd6a7771b31170940d76e72452cce07f62fbf7787a24afc6631a2"
+    sha256 "6f6e6f14ee264a6fef1e49d05baa33d4f1daaee2a0c55ff2929f91c97788e9e4"
     "es-AR"
   end
   language "es-CL" do
-    sha256 "afee2539118474a59dfc53d657aa8bd8596085b3a4413c2a91564e6b38e57747"
+    sha256 "a823cfca81cd5aa8b1189e9c40cc47360f960812bb0e066fc66f4c218b76b006"
     "es-CL"
   end
   language "es-ES" do
-    sha256 "c06b7c958dc4423f634dd1c4924bf4e981f0a17ad96555410c682a2fa1c41635"
+    sha256 "0cb9dd83accf621cffb18762c52b4d41ffa915a913062f8167932c1ae2a0569d"
     "es-ES"
   end
   language "fi" do
-    sha256 "8a5f81c7bb2106be0c52d23fb0349efc814fd0455419fd139deee8a32c853f3a"
+    sha256 "d443a27d0b057b982c85fb9b63d4864198186b01879828f1864e33192705a018"
     "fi"
   end
   language "fr" do
-    sha256 "ef43d805466c22dd111cbdf9c406269c845de1e8dda6054759b4fb3dc6ba1e80"
+    sha256 "9462a25a9c1d042599c74f1748e3b6f4166e2cd8441aaff9b4deec20234885f9"
     "fr"
   end
   language "gl" do
-    sha256 "bfbfccd12efdfbba992710bc6b277f6e489ab9c47d75f155704578757eb89cdb"
+    sha256 "e8b214630eaad537ab37eba9843af5b674bdc85269aaff4cb2531e60d934b497"
     "gl"
   end
   language "in" do
-    sha256 "59bad3462f48b9554b21276035ae7536251e7c8d617a723b1e5cac4858b4c5cb"
+    sha256 "f2d70830463ad5b9eb5ce36fc15b86bdc0afe8aa1fe89ca5c0dead638592ae1f"
     "hi-IN"
   end
   language "it" do
-    sha256 "99e25f886a32b3797f67f584e37664dbd926435b8586810ab090541bde5ae6b5"
+    sha256 "4d77c850164d663f670d4cc88f3c562ffe6097c7dbc350b1b1b126e079c35ea7"
     "it"
   end
   language "ja" do
-    sha256 "5605b277ef85deff342d9ee32001058e2ff3d931575734cee050325b0c72bb49"
+    sha256 "0922c1a8a0b626333ae833ea9f892aeaa68aeafb544229e5b56dbebb59b8ef2c"
     "ja-JP-mac"
   end
   language "ko" do
-    sha256 "9ba87bb9d1c83ab782b1ca8f344305ac3650c40108b4a3ec10ffe12bdc6f932e"
+    sha256 "a473201e899856964a8191fa398ce8c9e6054d6b1ece9e9c19fb8b57696ab7fa"
     "ko"
   end
   language "nl" do
-    sha256 "48ffe8b9446798206ca335fbb19a6265589c6ef72507669b2df5bf9100b8f607"
+    sha256 "2ab4f134b9f1ed07cd61ff6f8bcdfc43c8aa5ed343c452ab9fee17c069eeaa5f"
     "nl"
   end
   language "pl" do
-    sha256 "32475ff55caa8f8bd9d32c8ae94514895a0cad354c1c6a58706f2653ce580423"
+    sha256 "d606163da7b1112fed9707ba305c5a10de857ecd39abb73f55643c46c9f97c1b"
     "pl"
   end
   language "pt-BR" do
-    sha256 "e77f336743c3cc5d98677b93f9ecc55e74275bfa330487f39c502fae9866a7db"
+    sha256 "8566c981870cab0c349f7a4a69814d49429d28f1211864fdbde163c70cd0d3b8"
     "pt-BR"
   end
   language "pt" do
-    sha256 "cc2d634b9db3f66bc86f0d24d25629745c3d45cbbc5b69ef501aa4c02e016f2d"
+    sha256 "09514c16a17538bbde41b0fa76b5455021a498c719400d3123a0f8f0927700c8"
     "pt-PT"
   end
   language "ru" do
-    sha256 "4dab2d076738a8e08d5c324f356156fc7b93601b126531595f51681b85c74e31"
+    sha256 "f00b14b0dba9747f956206d484afe3c41edac021d9be660a5080422cdb247bc5"
     "ru"
   end
   language "tr" do
-    sha256 "ffabd1365860e0ae6e019d956a1ddd643ec3b53c17141ce45c0ced4de0ff8f31"
+    sha256 "ddf0865b156cc0220cfa8a103d31654d852801d7c41509b3f5bbb96192d7882d"
     "tr"
   end
   language "uk" do
-    sha256 "7dfcf7c04225706fcdda5d7044609d21df0eb12c05532de7e640a093665fa942"
+    sha256 "fdb991505a6a3cb46bb64e020404e816f614e7fe7dff3681d332ecabb7be3618"
     "uk"
   end
   language "zh-TW" do
-    sha256 "195090128e40b481bb5cf9fcfd3e62e885d670de2a4cadd302aa36d08c331821"
+    sha256 "a881597aebbf2ce833491ce9ef9053a5114a7ef9793312326936fd70aaa8d33f"
     "zh-TW"
   end
   language "zh" do
-    sha256 "434512f450a98daf7a3863f147e312edcc056776fe86f384a9d17b774dc63756"
+    sha256 "6d53142b21b6ae06659c53c59d14db706b8f23d5415e6b7a92be25ba8d7099b6"
     "zh-CN"
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
