### PR TITLE
Update julia from 1.5.2 to 1.5.3

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -1,6 +1,6 @@
 cask "julia" do
-  version "1.5.2"
-  sha256 "e6a1eb4f4d26eef968d1e25f7bacf18a1bc1d47c2cc63c35b071825a7d96b966"
+  version "1.5.3"
+  sha256 "802cdb67748bbd8a943604981d4f2a2c4c98899f5bbad0aef8a7ea8bc9b31abd"
 
   url "https://julialang-s3.julialang.org/bin/mac/x64/#{version.major_minor}/julia-#{version}-mac64.dmg"
   appcast "https://github.com/JuliaLang/julia/releases.atom"


### PR DESCRIPTION
`brew bump-cask-pr --version 1.5.3 julia` didn't work for me, unfortunately. It failed in trying to create a PR. Not sure what went wrong.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).