### PR TITLE
Update colour-contrast-analyser from 3.1.1 to 3.1.2

### DIFF
--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -1,6 +1,6 @@
 cask "colour-contrast-analyser" do
-  version "3.1.1"
-  sha256 "4beb8e9582b1b75fb7114a31b03d7a00147028993ea78f24590d6e183779ccd0"
+  version "3.1.2"
+  sha256 "fbc56bf2d07fc6500fa28c30b292b058a3f360c5bad55da3262bb40452100294"
 
   # github.com/ThePacielloGroup/CCAe was verified as official when first introduced to the cask
   url "https://github.com/ThePacielloGroup/CCAe/releases/download/v#{version}/CCA-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).