### PR TITLE
Update adguard from 2.5.0.902 to 2.5.1.916

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -1,6 +1,6 @@
 cask "adguard" do
-  version "2.5.0.902"
-  sha256 "cd72eb1a01e4e338a86ac33167f6cf73d96cfda3c9128d2c65f7ca8812155710"
+  version "2.5.1.916"
+  sha256 "8b042f4a600704ff57e751d027df9e5c2039fcf9a2213dba50af22117a9e2955"
 
   url "https://static.adguard.com/mac/release/AdGuard-#{version}.dmg"
   appcast "https://static.adguard.com/mac/adguard-release-appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).