### PR TITLE
Add archi 4.7.1

### DIFF
--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -10,11 +10,6 @@ cask "archi" do
 
   app "Archi/Archi.app"
 
-  preflight do
-    # https://github.com/archimatetool/archi/issues/555
-    Quarantine.release! download_path: "#{staged_path}/Archi/Archi.app"
-  end
-
   zap trash: [
     "~/Library/Application Support/Archi#{version.major}",
     "~/Library/Caches/com.archimatetool.editor",

--- a/Casks/archi.rb
+++ b/Casks/archi.rb
@@ -1,0 +1,24 @@
+cask "archi" do
+  version "4.7.1"
+  sha256 "19fa57ef812949963e1af5cc2516fc5f544f6e86dd69bd5608794e11935ee07d"
+
+  url "https://www.archimatetool.com/downloads/archi/Archi-Mac-#{version}.zip"
+  appcast "https://github.com/archimatetool/archi/releases.atom"
+  name "Archi"
+  desc "Toolkit for the ArchiMate modelling language"
+  homepage "https://www.archimatetool.com/"
+
+  app "Archi/Archi.app"
+
+  preflight do
+    # https://github.com/archimatetool/archi/issues/555
+    Quarantine.release! download_path: "#{staged_path}/Archi/Archi.app"
+  end
+
+  zap trash: [
+    "~/Library/Application Support/Archi#{version.major}",
+    "~/Library/Caches/com.archimatetool.editor",
+    "~/Library/Preferences/com.archimatetool.editor.plist",
+    "~/Library/Saved Application State/com.archimatetool.editor.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
  - _(See below explanation for re-adding this cask)_
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

This cask was removed in #90364 for the following reason:

> They keep changing the `after_comma` value without any other changes, as some kind of download protection we have to keep fighting and isn’t worth it.

For example: https://www.archimatetool.com/downloads/71cb57dc/Archi-Mac-71cb57dc.zip, where `71cb57dc` is the `after_comma` value

However, this doesn't appear to be the case anymore, e.g. https://www.archimatetool.com/downloads/archi/Archi-Mac-4.7.1.zip