### PR TITLE
EurKEY: Switch to system-wide installation

### DIFF
--- a/Casks/eurkey.rb
+++ b/Casks/eurkey.rb
@@ -5,8 +5,9 @@ cask "eurkey" do
   # github.com/jonasdiemer/EurKEY-Mac/ was verified as official when first introduced to the cask
   url "https://github.com/jonasdiemer/EurKEY-Mac/archive/master.zip"
   name "EurKEY keyboard layout"
+  desc "Keyboard Layout for Europeans, Coders and Translators"
   homepage "https://eurkey.steffen.bruentjen.eu/"
 
-  artifact "EurKEY-Mac-master/EurKEY.icns", target: "#{ENV["HOME"]}/Library/Keyboard Layouts/EurKEY.icns"
-  artifact "EurKEY-Mac-master/EurKEY.keylayout", target: "#{ENV["HOME"]}/Library/Keyboard Layouts/EurKEY.keylayout"
+  artifact "EurKEY-Mac-master/EurKEY.icns", target: "/Library/Keyboard Layouts/EurKEY.icns"
+  artifact "EurKEY-Mac-master/EurKEY.keylayout", target: "/Library/Keyboard Layouts/EurKEY.keylayout"
 end


### PR DESCRIPTION
This makes EurKEY also available in VmWare, the Lock screen and
probably other places and is the recommended way [1].

Also see [2].

sha256sum was added on this occasion.

[1] https://github.com/jonasdiemer/EurKEY-Mac
[2] https://superuser.com/questions/99172/how-to-stop-os-x-from-switching-input-method-keyboard-layout-automatically/561613#561613

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
