### PR TITLE
Add version and sha256 for android-file-transfer

### DIFF
--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -4,6 +4,8 @@ cask "android-file-transfer" do
 
   # google.com/dl/androidjumper/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/androidjumper/mtp/#{version.after_comma}/androidfiletransfer.dmg"
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://dl.google.com/dl/androidjumper/mtp/current/androidfiletransfer.dmg",
+          must_contain: version.after_comma
   name "Android File Transfer"
   desc "Transfer files from and to an Android smartphone"
   homepage "https://www.android.com/filetransfer/"

--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -1,9 +1,9 @@
 cask "android-file-transfer" do
-  version :latest
-  sha256 :no_check
+  version "1.0.12,5071136"
+  sha256 "b9249399a351e8146358ff1ddb546c68a63134b780be795ae64e0a4c2258bc61"
 
   # google.com/dl/androidjumper/ was verified as official when first introduced to the cask
-  url "https://dl.google.com/dl/androidjumper/mtp/current/androidfiletransfer.dmg"
+  url "https://dl.google.com/dl/androidjumper/mtp/#{version.after_comma}/androidfiletransfer.dmg"
   name "Android File Transfer"
   desc "Transfer files from and to an Android smartphone"
   homepage "https://www.android.com/filetransfer/"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).