### PR TITLE
Update pycharm-ce-with-anaconda-plugin to 2020.2.3,202.7660.27

### DIFF
--- a/Casks/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/pycharm-ce-with-anaconda-plugin.rb
@@ -6,6 +6,7 @@ cask "pycharm-ce-with-anaconda-plugin" do
   appcast "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release"
   name "Jetbrains PyCharm Community Edition with Anaconda plugin"
   name "PyCharm CE with Anaconda plugin"
+  desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
 
   auto_updates true

--- a/Casks/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/pycharm-ce-with-anaconda-plugin.rb
@@ -1,8 +1,8 @@
 cask "pycharm-ce-with-anaconda-plugin" do
-  version "2020.2.3"
+  version "2020.2.3,202.7660.27"
   sha256 "dac8c3468fb164220fedab3f94051b0d500ecfd294b9310bc4b952ab699c4000"
 
-  url "https://download.jetbrains.com/python/pycharm-community-anaconda-#{version}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-community-anaconda-#{version.before_comma}.dmg"
   appcast "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release"
   name "Jetbrains PyCharm Community Edition with Anaconda plugin"
   name "PyCharm CE with Anaconda plugin"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This PR has been created fully automatically with the [jetbrains-cask-bot](https://github.com/leipert/jetbrains-cask-bot)

Apparently jetbrains changed the download URL for pycharm-ce-with-anaconda-plugin@2020.2.3,202.7660.27.
This PR adjusts the URL for pycharm-ce-with-anaconda-plugin.

/cc @leipert