### PR TITLE
Update pycharm-with-anaconda-plugin to 2020.2.3,202.7660.27

### DIFF
--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -5,6 +5,7 @@ cask "pycharm-with-anaconda-plugin" do
   url "https://download.jetbrains.com/python/pycharm-professional-anaconda-#{version.before_comma}.dmg"
   appcast "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release"
   name "Jetbrains PyCharm with Anaconda plugin"
+  desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
 
   auto_updates true

--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -1,8 +1,8 @@
 cask "pycharm-with-anaconda-plugin" do
-  version "2020.2.3"
+  version "2020.2.3,202.7660.27"
   sha256 "eaa04d83e5bd4daf01d3db0430b26269a2bcb0710cf7d862ab282e2f5f660ceb"
 
-  url "https://download.jetbrains.com/python/pycharm-professional-anaconda-#{version}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-professional-anaconda-#{version.before_comma}.dmg"
   appcast "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release"
   name "Jetbrains PyCharm with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This PR has been created fully automatically with the [jetbrains-cask-bot](https://github.com/leipert/jetbrains-cask-bot)

Apparently jetbrains changed the download URL for pycharm-with-anaconda-plugin@2020.2.3,202.7660.27.
This PR adjusts the URL for pycharm-with-anaconda-plugin.

/cc @leipert