### PR TITLE
Update vienna from 3.5.10 to 3.6.0

### DIFF
--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -1,6 +1,6 @@
 cask "vienna" do
-  version "3.5.10"
-  sha256 "9422869412b22c132e9acfd8809a8633876cab0b8b5b09d293c196646d461548"
+  version "3.6.0"
+  sha256 "1ad5fb5f41e4fe4e5f54e7fd121d8b89f114454d6e72056f17832d9e9b82da1b"
 
   # bintray.com/viennarss/ was verified as official when first introduced to the cask
   url "https://dl.bintray.com/viennarss/vienna-rss/Vienna#{version}.tar.gz"


### PR DESCRIPTION


- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

