### PR TITLE
texshop: revert to 4.44

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,6 +1,6 @@
 cask "texshop" do
-  version "4.50"
-  sha256 "73231b2a01ac59dce7c0bf985edc0161179a73dce4c005d79d75156fa9467caf"
+  version "4.44"
+  sha256 "67f8f1ea196209a65dd996db875e19307f947e697a5b70dad0571ed88f4fd0ad"
 
   url "https://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   appcast "https://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml"


### PR DESCRIPTION
There is an issue with version 4.50:

> NOTE: TeXShop 4.50 is broken for users who add a Typeset button to the PDF Window. Please wait to download until this message disappears.

and this version had been removed from the `appcast`:
```
|-> curl https://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml
<?xml version="1.0" standalone="yes"?><rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
<channel>
<title>TeXShop</title>
<item>
<title>4.44</title>
<pubDate>Wed, 23 Oct 2019 07:14:44 -0700</pubDate>
<sparkle:minimumSystemVersion>10.10.0</sparkle:minimumSystemVersion>
<enclosure url="https://pages.uoregon.edu/koch/texshop/texshop-64/texshop444.zip" sparkle:version="4.44" sparkle:shortVersionString="4.44" length="46475198" type="application/octet-stream" sparkle:edSignature="hyhdr9AI0A+UP5juGEy6UAo+9YhRvSB5O1uCZmxXV/HZ+X0sjvev3+hl+nhxrp6CFmq68wv4y5s/EsZvqqghDg==" sparkle:dsaSignature="MCwCFFvCyIW/CHa2vTPWNcElrGiNgoyNAhRmAppwy0/Bol1HLnGxGwMbRIizrA=="/>
</item>
</channel></rss>
```