### PR TITLE
Change to source path.fish.inc as path not works

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,6 +1,3 @@
-# typed: false
-# frozen_string_literal: false
-
 cask "google-cloud-sdk" do
   version :latest # Must remain unversioned, else all installed gcloud components would be lost on upgrade
   sha256 :no_check

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: false
+
 cask "google-cloud-sdk" do
   version :latest # Must remain unversioned, else all installed gcloud components would be lost on upgrade
   sha256 :no_check
@@ -39,6 +42,6 @@ cask "google-cloud-sdk" do
 
       for fish users
         set -g -x "CLOUDSDK_PYTHON" "#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
-        set -g fish_user_paths "#{staged_path}/#{token}/path.fish.inc" $fish_user_paths
+        source "#{staged_path}/#{token}/path.fish.inc"
   EOS
 end


### PR DESCRIPTION
As mentioned in [comment of](https://github.com/Homebrew/homebrew-cask/pull/88182#discussion_r518473429_) #88182 I changed the output to `source .*`

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
