### PR TITLE
Update subler from 1.6.8 to 1.6.9

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask "subler" do
-  version "1.6.8"
-  sha256 "d9d0c84725d8f2abccdbccc42d5ad1fd563b590a238df657c5d11e28dfbdfcdc"
+  version "1.6.9"
+  sha256 "1e5ed973059bca998e089d51b6f350390325ea537f095542161d9dda31d9603d"
 
   # bitbucket.org/galad87/subler/ was verified as official when first introduced to the cask
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).