### PR TITLE
Update plex.rb from 1.22.0.1421-be6a7c42 to 1.23.0.1435-e10e14cf

### DIFF
--- a/Casks/plex.rb
+++ b/Casks/plex.rb
@@ -1,6 +1,6 @@
 cask "plex" do
-  version "1.22.0.1421-be6a7c42"
-  sha256 "4714a6799dbd7454c5047d9ca350fa0dbbdc7940955e439a0d0df405e2527e9c"
+  version "1.23.0.1435-e10e14cf"
+  sha256 "d0270e50028eb56f3d366f82ce39e715c13af5a6213cc7b70e48c0f3eacda392"
 
   url "https://downloads.plex.tv/plex-desktop/#{version}/macos/Plex-#{version}-x86_64.zip"
   appcast "https://plex.tv/api/downloads/6.json"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).