### PR TITLE
Update opera-gx from 71.0.3770.317 to 71.0.3770.323

### DIFF
--- a/Casks/opera-gx.rb
+++ b/Casks/opera-gx.rb
@@ -1,6 +1,6 @@
 cask "opera-gx" do
-  version "71.0.3770.317"
-  sha256 "c8b3a840d36d3a01410e2ccb88f28cfec5cefe20a0e301d29667928b30dbab0a"
+  version "71.0.3770.323"
+  sha256 "1ad00e160bd6a709d4543f4713259e9cd9127c9fd901dc7e820d5af019c6b6d0"
 
   url "https://get.geo.opera.com/pub/opera_gx/#{version}/mac/Opera_GX_#{version}_Setup.dmg"
   appcast "https://ftp.opera.com/pub/opera_gx/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).