### PR TITLE
Update iterm2.rb macos version check

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,16 +1,15 @@
 cask "iterm2" do
   # note: "2" is not a version number, but an intrinsic part of the product name
   if MacOS.version <= :high_sierra
-    version '3.3.12'
-    sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167"
-    appcast "https://iterm2.com/appcasts/final_modern.xml" 
+  version "3.3.12"
+  sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167" 
   else
-    version '3.4.0'
-    sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
-    appcast "https://iterm2.com/appcasts/final_modern.xml"
+  version "3.4.0"
+  sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
   end
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
+  appcast "https://iterm2.com/appcasts/final_modern.xml"
   name "iTerm2"
   desc "Terminal emulator as alternative to Apple's Terminal app"
   homepage "https://www.iterm2.com/"

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,11 +1,11 @@
 cask "iterm2" do
   # note: "2" is not a version number, but an intrinsic part of the product name
   if MacOS.version <= :high_sierra
-  version "3.3.12"
-  sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167" 
+    version "3.3.12"
+    sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167" 
   else
-  version "3.4.0"
-  sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
+    version "3.4.0"
+    sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
   end
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -2,7 +2,7 @@ cask "iterm2" do
   # note: "2" is not a version number, but an intrinsic part of the product name
   if MacOS.version <= :high_sierra
     version "3.3.12"
-    sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167" 
+    sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167"
   else
     version "3.4.0"
     sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,10 +1,17 @@
 cask "iterm2" do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version "3.4.0"
-  sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
+  if MacOS.version <= :high_sierra
+    version '3.3.12'
+    sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167"
+    appcast "https://iterm2.com/appcasts/final_modern.xml"
+    url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
+  else
+    version '3.4.0'
+    sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
+    appcast "https://iterm2.com/appcasts/final_modern.xml"
+    url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
+  end
 
-  url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
-  appcast "https://iterm2.com/appcasts/final_modern.xml"
   name "iTerm2"
   desc "Terminal emulator as alternative to Apple's Terminal app"
   homepage "https://www.iterm2.com/"

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -3,15 +3,14 @@ cask "iterm2" do
   if MacOS.version <= :high_sierra
     version '3.3.12'
     sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167"
-    appcast "https://iterm2.com/appcasts/final_modern.xml"
-    url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
+    appcast "https://iterm2.com/appcasts/final_modern.xml" 
   else
     version '3.4.0'
     sha256 "5f78331d4786ead6fff49c86738be8fab3a1777346c3e35e6bb9c6cad52c1a47"
     appcast "https://iterm2.com/appcasts/final_modern.xml"
-    url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   end
 
+  url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   name "iTerm2"
   desc "Terminal emulator as alternative to Apple's Terminal app"
   homepage "https://www.iterm2.com/"


### PR DESCRIPTION
Latest Version 3.4.0 not supporting MacOS 10.12 and 10.13 anymore so it needs to use iterm2 3.3.12.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).