### PR TITLE
Update apple-juice from 1.10.2 to 2020.11

### DIFF
--- a/Casks/apple-juice.rb
+++ b/Casks/apple-juice.rb
@@ -1,6 +1,6 @@
 cask "apple-juice" do
-  version "1.10.2"
-  sha256 "dedbbf56a4d972ed0ad987be5b2577f2c59c55b0b9e4effd05c60f3c29773677"
+  version "2020.11"
+  sha256 "cdbfc948c76ad5777e5780c0411236c29c30ad606865a4e0c7a53c98cf5a60dc"
 
   url "https://github.com/raphaelhanneken/apple-juice/releases/download/#{version}/Apple.Juice.dmg"
   appcast "https://github.com/raphaelhanneken/apple-juice/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).