### PR TITLE
Update wrike from 3.3.5 to 3.3.6

### DIFF
--- a/Casks/wrike.rb
+++ b/Casks/wrike.rb
@@ -1,6 +1,6 @@
 cask "wrike" do
-  version "3.3.5"
-  sha256 "6c6b720e64815f87a02914d253a77b3642fb61d212e6a4470d1c044b8803f6e3"
+  version "3.3.6"
+  sha256 "ad9aed232603dc184cceba30b192f771fd81582ca52d8ce9af6d5d8bde4b9c7b"
 
   url "https://dl.wrike.com/download/WrikeDesktopApp.v#{version}.dmg"
   appcast "https://www.wrike.com/frontend/electron-app/changelog.json"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).