### PR TITLE
Update frhelper from 3.9.10,2020-08-21 to 3.9.10,2020-10-14

### DIFF
--- a/Casks/frhelper.rb
+++ b/Casks/frhelper.rb
@@ -1,5 +1,5 @@
 cask "frhelper" do
-  version "3.9.10,2020-08-21"
+  version "3.9.10,2020-10-14"
   sha256 "42a4f6a89c3491be96d5bc883f92f0dcac949cf4b4b0ad63117faf7c071a16e9"
 
   # static.frdic.com/ was verified as official when first introduced to the cask


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).