### PR TITLE
Update buildsettingextractor from 1.4.1 to 1.4.2

### DIFF
--- a/Casks/buildsettingextractor.rb
+++ b/Casks/buildsettingextractor.rb
@@ -1,6 +1,6 @@
 cask "buildsettingextractor" do
-  version "1.4.1"
-  sha256 "2df87f5a23ef63f151b37b71c513c598cf612ffac113ee65f9f677281a26280b"
+  version "1.4.2"
+  sha256 "0ec12a9897178d643120d48403bc6b946fef3ea690c25eaa54d40fb57ab49e6c"
 
   url "https://github.com/dempseyatgithub/BuildSettingExtractor/releases/download/v#{version}/BuildSettingExtractor_#{version}.dmg"
   appcast "https://github.com/dempseyatgithub/BuildSettingExtractor/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).