### PR TITLE
Add flrig.app v1.3.52

### DIFF
--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -1,0 +1,12 @@
+cask "flrig" do
+  version "1.3.52"
+  sha256 "2cb4e59e92f27fb32c9514ad2cc51f5430d9fa1cfb61023ba8a330dbaf176b89"
+
+  url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version.before_comma}_x86_64.dmg"
+  appcast "https://sourceforge.net/projects/fldigi/rss?path=/flrig"
+  name "flrig"
+  desc "Ham radio rig control program cooperates with fldigi"
+  homepage "https://sourceforge.net/projects/fldigi/files/flrig/"
+
+  app "flrig-#{version.before_comma}.app"
+end

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -5,7 +5,7 @@ cask "flrig" do
   url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version.before_comma}_x86_64.dmg"
   appcast "https://sourceforge.net/projects/fldigi/rss?path=/flrig"
   name "flrig"
-  desc "Ham radio rig control program cooperates with fldigi"
+  desc "Ham radio rig control"
   homepage "https://sourceforge.net/projects/fldigi/files/flrig/"
 
   app "flrig-#{version.before_comma}.app"

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -11,6 +11,6 @@ cask "flrig" do
   app "flrig-#{version.before_comma}.app"
 
   zap trash: [
-    "~/.flrig"
+    "~/.flrig",
   ]
 end

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -9,4 +9,8 @@ cask "flrig" do
   homepage "https://sourceforge.net/projects/fldigi/files/flrig/"
 
   app "flrig-#{version.before_comma}.app"
+
+  zap trash: [
+    "~/.flrig"
+  ]
 end

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -10,7 +10,5 @@ cask "flrig" do
 
   app "flrig-#{version.before_comma}.app"
 
-  zap trash: [
-    "~/.flrig",
-  ]
+  zap trash: "~/.flrig"
 end


### PR DESCRIPTION
flrig.app partners with fldigi.app which already has a cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
