### PR TITLE
Bumped fldigi version and added a zap stanza

### DIFF
--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -11,7 +11,5 @@ cask "fldigi" do
   app "fldigi-#{version.before_comma}.app"
   app "flarq-#{version.after_comma}.app"
 
-  zap trash: [
-    "~/.fldigi",
-  ]
+  zap trash: "~/.fldigi"
 end

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -1,6 +1,6 @@
 cask "fldigi" do
-  version "4.1.15,4.3.7"
-  sha256 "d4d6e158192c614ca1c0b940fe85847149cf278d2ff200202eff67c3f07f7088"
+  version "4.1.16,4.3.7"
+  sha256 "9aefd9935a335c796c6dd8c64430ae5599f86d74564b49f2d4c3944e364a502a"
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/fldigi-#{version.before_comma}_x86_64.dmg"
   appcast "https://sourceforge.net/projects/fldigi/rss?path=/fldigi"
@@ -10,4 +10,8 @@ cask "fldigi" do
 
   app "fldigi-#{version.before_comma}.app"
   app "flarq-#{version.after_comma}.app"
+
+  zap trash: [
+    "~/.fldigi",
+  ]
 end


### PR DESCRIPTION
Bumped fldigi to version 4.1.16, flarq remains the same version
Added zap stanza to cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
