### PR TITLE
Update ksdiff url to new one

### DIFF
--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -2,9 +2,9 @@ cask "ksdiff" do
   version "2.2.0,122"
   sha256 "cf32401d631e61cbbc3dc9947626174b45e8317a6cac39380067e7017e8d4c87"
 
-  url "https://cdn.kaleidoscopeapp.com/releases/ksdiff-#{version.after_comma}-#{version.before_comma}.zip"
+  url "https://updates.kaleidoscope.app/v2/prod/ksdiff-#{version.after_comma}-#{version.before_comma}.zip"
   name "ksdiff"
-  homepage "https://www.kaleidoscopeapp.com/ksdiff2"
+  homepage "https://kaleidoscope.app/ksdiff2"
 
   conflicts_with cask: "kaleidoscope"
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Update the urls of the ksdiff cask to the new ones, because the old ones are not working anymore
