### PR TITLE
Update meshcommander from 0.8.5 to 0.88

### DIFF
--- a/Casks/meshcommander.rb
+++ b/Casks/meshcommander.rb
@@ -1,9 +1,9 @@
 cask "meshcommander" do
-  version "0.8.5"
-  sha256 "a161ab200bfa30e9550fcfcf9d8e19da867b5171a5a8260d36884b752b6eb69a"
+  version "0.88"
+  sha256 "97ba03d3f9c4eadc306efc619fa0196c7e9c97d240bff89cfd0e4da719c40fb5"
 
   # bintray.com/gomesjj/APPS/ was verified as official when first introduced to the cask
-  url "https://bintray.com/gomesjj/APPS/download_file?file_path=#{version.no_dots}%2FMeshCommander.dmg.zip"
+  url "https://bintray.com/gomesjj/APPS/download_file?file_path=#{version}%2FMeshCommander.dmg-#{version.no_dots}.zip"
   appcast "https://dl.bintray.com/gomesjj/APPS/",
           must_contain: version.no_dots
   name "MeshCommander"

--- a/Casks/meshcommander.rb
+++ b/Casks/meshcommander.rb
@@ -4,8 +4,7 @@ cask "meshcommander" do
 
   # bintray.com/gomesjj/APPS/ was verified as official when first introduced to the cask
   url "https://bintray.com/gomesjj/APPS/download_file?file_path=#{version}%2FMeshCommander.dmg-#{version.no_dots}.zip"
-  appcast "https://dl.bintray.com/gomesjj/APPS/",
-          must_contain: version.no_dots
+  appcast "https://dl.bintray.com/gomesjj/APPS/"
   name "MeshCommander"
   homepage "https://www.devtty.uk/apple/Intel_Mesh_Commander_on_Mac_OS_X/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).