### PR TITLE
Update final-cut-library-manager from 3.80 to 3.82

### DIFF
--- a/Casks/final-cut-library-manager.rb
+++ b/Casks/final-cut-library-manager.rb
@@ -1,6 +1,6 @@
 cask "final-cut-library-manager" do
-  version "3.80"
-  sha256 "6559de714cc8e226ddaff82f360002b491afafb70f2074176e8c0e7033f2accf"
+  version "3.82"
+  sha256 "175538d3d9b654274a4a59b43bf279b533b2c5f82a9a99d0fed15499a5a11ba0"
 
   url "http://cdn.arcticwhiteness.com/finalcutlibrarymanager/download/zips/FinalCutLibraryManager_#{version}.zip"
   appcast "https://www.arcticwhiteness.com/finalcutlibrarymanager/download/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).