### PR TITLE
Update maccy from 0.18.0 to 0.18.1

### DIFF
--- a/Casks/maccy.rb
+++ b/Casks/maccy.rb
@@ -1,6 +1,6 @@
 cask "maccy" do
-  version "0.18.0"
-  sha256 "9c9c10ebee068ab6de965969cd24b552224ebbe6af889b94a2bc9642f81e1f1f"
+  version "0.18.1"
+  sha256 "71a7836f6a381ef34eeae8694cccae10c183a413159cc6810d90fad0ecd777a1"
 
   # github.com/p0deje/Maccy/ was verified as official when first introduced to the cask
   url "https://github.com/p0deje/Maccy/releases/download/#{version}/Maccy.app.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).