### PR TITLE
turbo-boost-switcher: update SHA-256 checksum of downloaded file

### DIFF
--- a/Casks/turbo-boost-switcher.rb
+++ b/Casks/turbo-boost-switcher.rb
@@ -1,6 +1,6 @@
 cask "turbo-boost-switcher" do
   version "2.10.1"
-  sha256 "edc40e912008c39bd3e9b69e20931c46cc15ee016d49972eeda7216d0a602f1f"
+  sha256 "a1647590b9458bf27adc3749438a98e317fc137960329cf935f91c34753f0fa8"
 
   # turbo-boost-switcher.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://turbo-boost-switcher.s3.amazonaws.com/Turbo_Boost_Switcher_v#{version}.dmg"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

I'm receiving the following error running `brew cask upgrade`:

```text
==> Upgrading turbo-boost-switcher
==> Caveats
turbo-boost-switcher requires a kernel extension to work.
If the installation fails, retry after you enable it in:
  System Preferences → Security & Privacy → General

For more information, refer to vendor documentation or this Apple Technical Note:
  https://developer.apple.com/library/content/technotes/tn2459/_index.html

==> Downloading https://turbo-boost-switcher.s3.amazonaws.com/Turbo_Boost_Switcher_v2.10.1.dmg
/usr/bin/curl --disable --globoff --show-error --user-agent Homebrew/2.5.11\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.15.7\)\ curl/7.64.1 --header Accept-Language:\ en --fail --retry 3 --location --remote-time --continue-at 0 --output /Users/parkr/Library/Caches/Homebrew/downloads/b417294c43856254cf9e10a6b9ebc20035055fe42f0ed1382aee453912373c2d--Turbo_Boost_Switcher_v2.10.1.dmg.incomplete https://turbo-boost-switcher.s3.amazonaws.com/Turbo_Boost_Switcher_v2.10.1.dmg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2437k  100 2437k    0     0   446k      0  0:00:05  0:00:05 --:--:--  470k
==> Verifying SHA-256 checksum for Cask 'turbo-boost-switcher'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
==> Purging files for version 2.10.1 of Cask turbo-boost-switcher
Error: Checksum for Cask 'turbo-boost-switcher' does not match.
Expected: edc40e912008c39bd3e9b69e20931c46cc15ee016d49972eeda7216d0a602f1f
  Actual: a1647590b9458bf27adc3749438a98e317fc137960329cf935f91c34753f0fa8
    File: /Users/parkr/Library/Caches/Homebrew/downloads/b417294c43856254cf9e10a6b9ebc20035055fe42f0ed1382aee453912373c2d--Turbo_Boost_Switcher_v2.10.1.dmg
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/reporting_bugs/checksum_does_not_match_error.md
```

Upon manually downloading the file from the website, I get the `Actual` SHA-256 sum:

```text
~/Downloads$ shasum -a 256 Turbo_Boost_Switcher_v2.10.1.dmg
a1647590b9458bf27adc3749438a98e317fc137960329cf935f91c34753f0fa8  Turbo_Boost_Switcher_v2.10.1.dmg
```
