### PR TITLE
Update breaktimer from 0.7.6 to 0.7.7

### DIFF
--- a/Casks/breaktimer.rb
+++ b/Casks/breaktimer.rb
@@ -1,6 +1,6 @@
 cask "breaktimer" do
-  version "0.7.6"
-  sha256 "a62d46779216a08fd03884375c7d961521b9ac32efd8874dca2377c27aa82053"
+  version "0.7.7"
+  sha256 "01fb90a307e2ffb59bb38c683032856aeeff8b5b8b7b0923d4ee307bb34cf2dd"
 
   # github.com/tom-james-watson/breaktimer-app/ was verified as official when first introduced to the cask
   url "https://github.com/tom-james-watson/breaktimer-app/releases/download/v#{version}/BreakTimer.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).