### PR TITLE
Update whoozle-android-file-transfer from 3.9 to 4.0

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -1,6 +1,6 @@
 cask "whoozle-android-file-transfer" do
-  version "3.9"
-  sha256 "d0ccedbd2d5e67c2cfbec0bddf7a5696833531e36809ca6162e69dbfc4308d43"
+  version "4.0"
+  sha256 "5bd55683d71d3c3ced260705da4b4b4c4fccf34865f5d006468156f3355a2b9b"
 
   # github.com/whoozle/android-file-transfer-linux/ was verified as official when first introduced to the cask
   url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version}/AndroidFileTransferForLinux.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).