### PR TITLE
Update prosys-opc-ua-browser from 4.0.4-247 to 4.0.6-268

### DIFF
--- a/Casks/prosys-opc-ua-browser.rb
+++ b/Casks/prosys-opc-ua-browser.rb
@@ -1,6 +1,6 @@
 cask "prosys-opc-ua-browser" do
-  version "4.0.4-247"
-  sha256 "9d9e7156cc06dab6bc8fcc20d29dc8a357946d40ec6616a21a7d5d7cf5b0c601"
+  version "4.0.6-268"
+  sha256 "ebcbd868c2ff4d14607dcb7d9db4fd26cbcedc368ac8b8ee43fff6c13a00fe0e"
 
   url "https://www.prosysopc.com/opcua/apps/UaBrowser/dist/#{version}/prosys-opc-ua-browser-macos-#{version}.dmg"
   appcast "https://downloads.prosysopc.com/opc-ua-browser-downloads.php"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).