### PR TITLE
Update loaf from 1.1.5 to 1.1.6

### DIFF
--- a/Casks/loaf.rb
+++ b/Casks/loaf.rb
@@ -1,6 +1,6 @@
 cask "loaf" do
-  version "1.1.5"
-  sha256 "3c248b2587cd78f670c83a55e1b1eee6b7be33864fda3135313b26920e3178e6"
+  version "1.1.6"
+  sha256 "8d84a74b17352cbe51f9a93507a2cbeeed30379bdf0180d1551794f7657a34af"
 
   # github.com/philipardeljan/getloaf/ was verified as official when first introduced to the cask
   url "https://github.com/philipardeljan/getloaf/releases/download/v#{version}/loaf.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).