### PR TITLE
Update hoststool from 2.6.1 to 2.7.0

### DIFF
--- a/Casks/hoststool.rb
+++ b/Casks/hoststool.rb
@@ -1,6 +1,6 @@
 cask "hoststool" do
-  version "2.6.1"
-  sha256 "c9c3c6769ae922c28e49634fecd4d97aafe6ea2d40cf16f4812552905e1fa7a6"
+  version "2.7.0"
+  sha256 "52a8c777210dff249e5d37c839ec711910e3c87f68dfe127cb0b9b4719736782"
 
   url "https://github.com/ZzzM/HostsToolforMac/releases/download/#{version}/HostsToolForMac.zip"
   appcast "https://github.com/ZzzM/HostsToolforMac/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).