### PR TITLE
Update dropbox-passwords from 7.2.25 to 7.2.36

### DIFF
--- a/Casks/dropbox-passwords.rb
+++ b/Casks/dropbox-passwords.rb
@@ -1,6 +1,6 @@
 cask "dropbox-passwords" do
-  version "7.2.25"
-  sha256 "8ef1fd2a6d1aac57b5bdcade398fa0bc387a9a079113df66e96fa56817269a06"
+  version "7.2.36"
+  sha256 "51c57af430f2a90ae91c436096e3c09a141fcede5b06838733acd75f6c1b1655"
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/dbx-releng/dropbox_passwords/mac/DropboxPasswords_#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).