### PR TITLE
Update hex-fiend from 2.13.1 to 2.14.0

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -1,9 +1,9 @@
 cask "hex-fiend" do
-  version "2.13.1"
-  sha256 "8434067ac0c41d68346e8abea807bff0cc3eba61619ef39ad8f437407848cf98"
+  version "2.14.0"
+  sha256 "5ddb0f43e014fe6963f0a60776ab3fccac2da3e973be252ebddd664ca1954a7f"
 
   # github.com/ridiculousfish/HexFiend/ was verified as official when first introduced to the cask
-  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version}.dmg"
+  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"
   appcast "https://github.com/ridiculousfish/HexFiend/releases.atom"
   name "Hex Fiend"
   desc "Hex editor focussing on speed"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).