### PR TITLE
Update activedock from 2.56,2056 to 2.57,2057

### DIFF
--- a/Casks/activedock.rb
+++ b/Casks/activedock.rb
@@ -1,6 +1,6 @@
 cask "activedock" do
-  version "2.56,2056"
-  sha256 "c8a5c5bdceec8f0623e02250d3557ca5367a1efe3204a2711249c66f1311bbd4"
+  version "2.57,2057"
+  sha256 "42abb31bf56355199991e6f654380e641252ea2af03fe19c1f01800c3dcda2c7"
 
   # macplus-software.com/ was verified as official when first introduced to the cask
   url "https://macplus-software.com/downloads/ActiveDock.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).