### PR TITLE
Update kiwi-for-g-suite from 2.0.36v to 2.0.37v

### DIFF
--- a/Casks/kiwi-for-g-suite.rb
+++ b/Casks/kiwi-for-g-suite.rb
@@ -1,6 +1,6 @@
 cask "kiwi-for-g-suite" do
-  version "2.0.36v"
-  sha256 "d477c9bf0f51b2edaab26b3ffcb9d423fc6d66941d36c3d15989b255d7e288e9"
+  version "2.0.37v"
+  sha256 "23b687d41e9db1a2aeb81efe82c78fcdb47bf27b8bf20f46fdcadb4e5b38d550"
 
   # kiwiforgsuite.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://kiwiforgsuite.s3.amazonaws.com/mac/release/Kiwi+for+G+Suite.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).